### PR TITLE
Support iPad orientations on iPadOS 26

### DIFF
--- a/Conduit/Info.plist
+++ b/Conduit/Info.plist
@@ -90,6 +90,12 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
 	<key>UIRequiresFullScreen</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/Conduit/Info.plist
+++ b/Conduit/Info.plist
@@ -93,11 +93,10 @@
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>UIRequiresFullScreen</key>
-	<true/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/ConduitTests/InterfaceOrientationTests.swift
+++ b/ConduitTests/InterfaceOrientationTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import XCTest
+
+final class InterfaceOrientationTests: XCTestCase {
+    private let appBundleIdentifier = "com.milim.relay"
+
+    private func appInfoDictionary() throws -> [String: Any] {
+        let bundle = try XCTUnwrap(Bundle(identifier: appBundleIdentifier))
+        let infoData = try Data(contentsOf: bundle.bundleURL.appendingPathComponent("Info.plist"))
+        return try XCTUnwrap(
+            PropertyListSerialization.propertyList(from: infoData, options: [], format: nil) as? [String: Any]
+        )
+    }
+
+    func testUniversalOrientationsRemainPortraitOnlyForIPhone() throws {
+        let info = try appInfoDictionary()
+        XCTAssertEqual(
+            info["UISupportedInterfaceOrientations"] as? [String],
+            ["UIInterfaceOrientationPortrait"]
+        )
+    }
+
+    func testIPadOrientationsIncludeBothLandscapeDirections() throws {
+        let info = try appInfoDictionary()
+        XCTAssertEqual(
+            info["UISupportedInterfaceOrientations~ipad"] as? [String],
+            [
+                "UIInterfaceOrientationPortrait",
+                "UIInterfaceOrientationLandscapeLeft",
+                "UIInterfaceOrientationLandscapeRight"
+            ]
+        )
+    }
+}

--- a/ConduitTests/InterfaceOrientationTests.swift
+++ b/ConduitTests/InterfaceOrientationTests.swift
@@ -26,9 +26,11 @@ final class InterfaceOrientationTests: XCTestCase {
             info["UISupportedInterfaceOrientations~ipad"] as? [String],
             [
                 "UIInterfaceOrientationPortrait",
+                "UIInterfaceOrientationPortraitUpsideDown",
                 "UIInterfaceOrientationLandscapeLeft",
                 "UIInterfaceOrientationLandscapeRight"
             ]
         )
+        XCTAssertNil(info["UIRequiresFullScreen"])
     }
 }

--- a/docs/superpowers/plans/2026-08-08-ipad-landscape-support.md
+++ b/docs/superpowers/plans/2026-08-08-ipad-landscape-support.md
@@ -1,0 +1,205 @@
+# iPad Landscape Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow iPad to rotate between portrait and landscape while keeping iPhone portrait-only.
+
+**Architecture:** Keep orientation policy declarative in the checked-in app `Info.plist`. The universal orientation key remains the iPhone contract, while the `~ipad` idiom-specific key overrides it for iPad. No runtime orientation APIs or SwiftUI layout changes are needed.
+
+**Tech Stack:** iOS 17, SwiftUI, XcodeGen, XCTest, `xcodebuild`.
+
+## Global Constraints
+
+- iPhone remains portrait-only.
+- iPad supports portrait, landscape-left, and landscape-right with automatic rotation.
+- `UIRequiresFullScreen` remains unchanged.
+- Do not change production SwiftUI views for this orientation-only feature.
+- Preserve the existing user changes in the main checkout; work in `/tmp/hermes-conduit-ipad-orientation`.
+
+---
+
+### Task 1: Add the failing orientation contract tests
+
+**Files:**
+- Create: `ConduitTests/InterfaceOrientationTests.swift`
+
+**Interfaces:**
+- Consumes: the built app bundle identified by `com.milim.relay`.
+- Produces: XCTest coverage for the universal and iPad-specific orientation arrays.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `ConduitTests/InterfaceOrientationTests.swift`:
+
+```swift
+import XCTest
+
+final class InterfaceOrientationTests: XCTestCase {
+    private let appBundleIdentifier = "com.milim.relay"
+
+    func testUniversalOrientationsRemainPortraitOnlyForIPhone() throws {
+        let info = try XCTUnwrap(Bundle(identifier: appBundleIdentifier)?.infoDictionary)
+        XCTAssertEqual(
+            info["UISupportedInterfaceOrientations"] as? [String],
+            ["UIInterfaceOrientationPortrait"]
+        )
+    }
+
+    func testIPadOrientationsIncludeBothLandscapeDirections() throws {
+        let info = try XCTUnwrap(Bundle(identifier: appBundleIdentifier)?.infoDictionary)
+        XCTAssertEqual(
+            info["UISupportedInterfaceOrientations~ipad"] as? [String],
+            [
+                "UIInterfaceOrientationPortrait",
+                "UIInterfaceOrientationLandscapeLeft",
+                "UIInterfaceOrientationLandscapeRight"
+            ]
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests to verify the expected failure**
+
+Run after regenerating the project:
+
+```bash
+xcodegen generate
+SIMULATOR=$(xcrun simctl list devices available -j | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+for runtime, devices in data["devices"].items():
+    if "iOS" not in runtime:
+        continue
+    for device in devices:
+        if "iPhone" in device["name"]:
+            print(device["udid"])
+            sys.exit(0)
+sys.exit(1)
+')
+xcodebuild test \
+  -project Conduit.xcodeproj \
+  -scheme Conduit \
+  -destination "platform=iOS Simulator,id=$SIMULATOR" \
+  -only-testing:ConduitTests/InterfaceOrientationTests \
+  CODE_SIGN_IDENTITY='' \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  DEVELOPMENT_TEAM='' \
+  PROVISIONING_PROFILE_SPECIFIER=''
+```
+
+Expected: `testUniversalOrientationsRemainPortraitOnlyForIPhone` passes and
+`testIPadOrientationsIncludeBothLandscapeDirections` fails because the
+iPad-specific plist key does not exist yet.
+
+### Task 2: Add the iPad-specific plist declaration
+
+**Files:**
+- Modify: `Conduit/Info.plist` near `UISupportedInterfaceOrientations`
+
+**Interfaces:**
+- Consumes: the failing bundle contract from Task 1.
+- Produces: a shipped plist whose base key is portrait-only and whose iPad
+  override contains all three supported orientations.
+
+- [ ] **Step 1: Add the minimal production configuration**
+
+Keep the existing universal key unchanged and add this sibling key immediately
+after its array:
+
+```xml
+<key>UISupportedInterfaceOrientations~ipad</key>
+<array>
+    <string>UIInterfaceOrientationPortrait</string>
+    <string>UIInterfaceOrientationLandscapeLeft</string>
+    <string>UIInterfaceOrientationLandscapeRight</string>
+</array>
+```
+
+- [ ] **Step 2: Run the targeted tests to verify they pass**
+
+Regenerate the project and rerun the Task 1 command. Expected: both orientation
+tests pass with zero failures.
+
+- [ ] **Step 3: Validate the plist and commit the implementation**
+
+Run:
+
+```bash
+plutil -lint Conduit/Info.plist
+git diff --check
+git add Conduit/Info.plist ConduitTests/InterfaceOrientationTests.swift
+git commit -m "Add iPad landscape orientation support"
+```
+
+Expected: `plutil` reports `OK`, the diff has no whitespace errors, and the
+commit contains only the plist declaration and its regression tests.
+
+### Task 3: Verify the complete merged application
+
+**Files:**
+- Verify: generated `Conduit.xcodeproj` and built app `Info.plist`
+
+**Interfaces:**
+- Consumes: the committed orientation declaration and tests from Task 2.
+- Produces: evidence that the full app still builds and all tests pass.
+
+- [ ] **Step 1: Run the full simulator suite**
+
+Use the existing dynamic iPhone simulator selection and run:
+
+```bash
+set -o pipefail
+SIMULATOR=$(xcrun simctl list devices available -j | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+for runtime, devices in data["devices"].items():
+    if "iOS" not in runtime:
+        continue
+    for device in devices:
+        if "iPhone" in device["name"]:
+            print(device["udid"])
+            sys.exit(0)
+sys.exit(1)
+')
+xcodebuild test \
+  -project Conduit.xcodeproj \
+  -scheme Conduit \
+  -destination "platform=iOS Simulator,id=$SIMULATOR" \
+  -configuration Debug \
+  -derivedDataPath /tmp/hermes-conduit-ipad-tests-derived \
+  -resultBundlePath /tmp/hermes-conduit-ipad-tests.xcresult \
+  CODE_SIGN_IDENTITY='' \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  DEVELOPMENT_TEAM='' \
+  PROVISIONING_PROFILE_SPECIFIER=''
+```
+
+Expected: `Executed 207 tests, with 0 failures` and `** TEST SUCCEEDED **`.
+
+- [ ] **Step 2: Inspect the generated app plist**
+
+Run:
+
+```bash
+plutil -p \
+  /tmp/hermes-conduit-ipad-tests-derived/Build/Products/Debug-iphonesimulator/Conduit.app/Info.plist \
+  | sed -n '/UISupportedInterfaceOrientations/,+12p'
+```
+
+Expected: the built app contains the portrait-only universal array and the
+three-entry `UISupportedInterfaceOrientations~ipad` array.
+
+- [ ] **Step 3: Confirm the worktree is clean and report the evidence**
+
+Run:
+
+```bash
+git status --short --branch
+git log -2 --format='%h %an <%ae> %s'
+```
+
+Expected: a clean feature worktree with the implementation commit on top of
+the approved design-spec commit.

--- a/docs/superpowers/plans/2026-08-08-ipados-26-window-migration.md
+++ b/docs/superpowers/plans/2026-08-08-ipados-26-window-migration.md
@@ -1,0 +1,182 @@
+# iPadOS 26 Window Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the iPadOS 26 full-screen compatibility behavior that can leave Conduit in a non-maximized, visually stale orientation window while preserving portrait-only behavior on iPhone.
+
+**Architecture:** Keep orientation policy in the idiom-specific `Info.plist` keys. Remove the deprecated `UIRequiresFullScreen` compatibility flag so iPadOS can manage a resizable SwiftUI `WindowGroup` scene normally, and declare all four iPad orientations required by the iPadOS 26 windowing model. No runtime orientation override or scene delegate is needed for this migration.
+
+**Tech Stack:** SwiftUI, XcodeGen, XCTest, iOS/iPadOS simulator, `xcodebuild`.
+
+## Global Constraints
+
+- The universal `UISupportedInterfaceOrientations` key remains exactly portrait-only for iPhone.
+- The iPad-specific orientation key includes portrait, portrait-upside-down, landscape-left, and landscape-right.
+- `UIRequiresFullScreen` is absent from the shipped app plist.
+- `UIApplicationSupportsMultipleScenes` remains unchanged.
+- Do not change unrelated SwiftUI layout or networking behavior in this migration.
+
+### Task 1: Lock the iPadOS 26 plist contract with a failing test
+
+**Files:**
+- Modify: `ConduitTests/InterfaceOrientationTests.swift`
+
+**Interfaces:**
+- Consumes: the raw shipped `Conduit.app/Info.plist` parser already used by `InterfaceOrientationTests`.
+- Produces: a regression contract asserting the iPad orientation set and absence of `UIRequiresFullScreen`.
+
+- [ ] **Step 1: Update the existing iPad contract test before changing production configuration**
+
+Change `testIPadOrientationsIncludeBothLandscapeDirections()` so its expected array is:
+
+```swift
+[
+    "UIInterfaceOrientationPortrait",
+    "UIInterfaceOrientationPortraitUpsideDown",
+    "UIInterfaceOrientationLandscapeLeft",
+    "UIInterfaceOrientationLandscapeRight"
+]
+```
+
+Then add this assertion to the same test:
+
+```swift
+XCTAssertNil(info["UIRequiresFullScreen"])
+```
+
+- [ ] **Step 2: Run the targeted test and verify it fails for the missing migration**
+
+Run from `/tmp/hermes-conduit-ipad-orientation`:
+
+```bash
+xcodegen=/tmp/xcodegen-device116-source/.build/arm64-apple-macosx/release/xcodegen
+"$xcodegen" generate
+simulator="$(xcrun simctl list devices available | awk -F '[()]' '/iPhone/ && /Booted/ {print $2; exit}')"
+if [ -z "$simulator" ]; then
+  simulator="$(xcrun simctl list devices available | awk -F '[()]' '/iPhone/ {print $2; exit}')"
+fi
+xcodebuild test \
+  -project Conduit.xcodeproj \
+  -scheme Conduit \
+  -destination "platform=iOS Simulator,id=$simulator" \
+  -derivedDataPath /tmp/hermes-conduit-ipados26-red-derived \
+  -only-testing:ConduitTests/InterfaceOrientationTests
+```
+
+Expected: `testIPadOrientationsIncludeBothLandscapeDirections` fails because the current plist omits `UIInterfaceOrientationPortraitUpsideDown` and still contains `UIRequiresFullScreen`.
+
+- [ ] **Step 3: Commit the failing contract test**
+
+```bash
+git add ConduitTests/InterfaceOrientationTests.swift
+git commit -m "Test iPadOS 26 windowing contract"
+```
+
+### Task 2: Remove the deprecated compatibility mode
+
+**Files:**
+- Modify: `Conduit/Info.plist:93-101`
+
+**Interfaces:**
+- Consumes: the failing plist contract from Task 1.
+- Produces: idiom-specific orientation metadata compatible with iPadOS 26 dynamic scenes.
+
+- [ ] **Step 1: Add portrait-upside-down to the iPad orientation array and remove `UIRequiresFullScreen`**
+
+The resulting section must be:
+
+```xml
+<key>UISupportedInterfaceOrientations</key>
+<array>
+    <string>UIInterfaceOrientationPortrait</string>
+</array>
+<key>UISupportedInterfaceOrientations~ipad</key>
+<array>
+    <string>UIInterfaceOrientationPortrait</string>
+    <string>UIInterfaceOrientationPortraitUpsideDown</string>
+    <string>UIInterfaceOrientationLandscapeLeft</string>
+    <string>UIInterfaceOrientationLandscapeRight</string>
+</array>
+<key>UIApplicationSceneManifest</key>
+```
+
+Leave `UIApplicationSceneManifest` and all other plist entries unchanged.
+
+- [ ] **Step 2: Run the targeted orientation tests and plist lint**
+
+```bash
+xcodegen=/tmp/xcodegen-device116-source/.build/arm64-apple-macosx/release/xcodegen
+"$xcodegen" generate
+simulator="$(xcrun simctl list devices available | awk -F '[()]' '/iPhone/ && /Booted/ {print $2; exit}')"
+if [ -z "$simulator" ]; then
+  simulator="$(xcrun simctl list devices available | awk -F '[()]' '/iPhone/ {print $2; exit}')"
+fi
+xcodebuild test \
+  -project Conduit.xcodeproj \
+  -scheme Conduit \
+  -destination "platform=iOS Simulator,id=$simulator" \
+  -derivedDataPath /tmp/hermes-conduit-ipados26-green-derived \
+  -only-testing:ConduitTests/InterfaceOrientationTests
+plutil -lint Conduit/Info.plist
+git diff --check
+```
+
+Expected: both orientation tests pass, `plutil` reports `OK`, and `git diff --check` is clean.
+
+- [ ] **Step 3: Commit the production configuration**
+
+```bash
+git add Conduit/Info.plist
+git commit -m "Migrate iPad orientation support for iPadOS 26"
+```
+
+### Task 3: Verify the built app and orientation transitions
+
+**Files:**
+- Verify: generated `Conduit.app/Info.plist` and simulator-installed app; no source edits expected.
+
+**Interfaces:**
+- Consumes: the migrated plist and orientation contract.
+- Produces: evidence that iPhone remains portrait-only, iPad supports all orientations, and repeated iPad transitions keep the app full-size and foregrounded.
+
+- [ ] **Step 1: Run the complete iPhone simulator test suite**
+
+Run `xcodegen generate`, then:
+
+```bash
+xcodebuild test \
+  -project Conduit.xcodeproj \
+  -scheme Conduit \
+  -destination "platform=iOS Simulator,id=$simulator" \
+  -derivedDataPath /tmp/hermes-conduit-ipados26-full-derived \
+  -resultBundlePath /tmp/hermes-conduit-ipados26-full-tests.xcresult
+```
+
+Expected: all existing tests pass with zero failures.
+
+- [ ] **Step 2: Build for the iPad simulator and inspect the shipped plist**
+
+```bash
+xcodebuild build \
+  -project Conduit.xcodeproj \
+  -scheme Conduit \
+  -destination "platform=iOS Simulator,id=0A743B4B-B5DE-4974-8263-D867D98329F0" \
+  -derivedDataPath /tmp/hermes-conduit-ipados26-ui-derived
+plutil -p /tmp/hermes-conduit-ipados26-ui-derived/Build/Products/Debug-iphonesimulator/Conduit.app/Info.plist
+```
+
+Expected: the built plist has no `UIRequiresFullScreen`, has four iPad orientations, and keeps the universal portrait-only array.
+
+- [ ] **Step 3: Exercise repeated iPad rotations**
+
+Install and launch the built app on the booted iPad Pro 13-inch simulator. Use the Simulator Rotate control for at least twelve portrait/landscape transitions, recording the rendered frame after each transition. Expected: the app alternates between portrait and landscape, remains foregrounded, and does not settle into a smaller compatibility window.
+
+- [ ] **Step 4: Confirm repository state**
+
+```bash
+git diff --check
+git status --short --branch
+git log --oneline --decorate -6
+```
+
+Expected: no uncommitted changes and only the intended test/configuration commits on `agent/ipad-landscape-support`.

--- a/docs/superpowers/specs/2026-08-08-ipad-landscape-support-design.md
+++ b/docs/superpowers/specs/2026-08-08-ipad-landscape-support-design.md
@@ -1,0 +1,47 @@
+# iPad Landscape Support Design
+
+## Goal
+
+Allow Conduit to rotate between portrait and landscape on iPad while keeping
+iPhone portrait-only. This is an orientation declaration change, not a
+landscape-specific redesign of the chat UI.
+
+## Current behavior
+
+The app currently declares `UIInterfaceOrientationPortrait` in the universal
+`UISupportedInterfaceOrientations` key. There is no iPad-specific override, so
+iPad inherits the portrait-only restriction.
+
+## Chosen approach
+
+Use idiom-specific keys in the app's explicit `Conduit/Info.plist`:
+
+- Keep `UISupportedInterfaceOrientations` as portrait-only. iPhone continues to
+  accept only portrait.
+- Add `UISupportedInterfaceOrientations~ipad` containing portrait,
+  landscape-left, and landscape-right. iPad then rotates automatically between
+  all three orientations.
+
+This keeps platform policy declarative, avoids runtime orientation APIs, and
+does not introduce device checks or orientation state into SwiftUI views.
+`UIRequiresFullScreen` remains unchanged because multitasking behavior is
+outside this request.
+
+## Alternatives considered
+
+1. Runtime orientation selection in the app delegate. Rejected: more code and
+   lifecycle timing risk for a static platform policy.
+2. Xcode build-setting-only configuration. Rejected: less explicit than the
+   existing checked-in plist and harder to test as the shipped bundle
+   contract.
+
+## Testing and acceptance criteria
+
+- Add a bundle-level regression test that verifies the base orientation array
+  contains only portrait.
+- Verify the iPad-specific array contains portrait, landscape-left, and
+  landscape-right.
+- Regenerate the Xcode project and run the complete iOS simulator test suite.
+- Confirm the generated app plist preserves the two orientation arrays.
+- No production SwiftUI view or iPhone behavior changes are required.
+


### PR DESCRIPTION
## Summary

- Support portrait, upside-down portrait, and both landscape orientations on iPad.
- Keep iPhone portrait-only.
- Remove the deprecated `UIRequiresFullScreen` compatibility-mode setting.
- Add a plist contract test covering the iPadOS 26 windowing configuration.

## Root cause

`UIRequiresFullScreen` can force iPadOS 26 into compatibility behavior that prevents normal dynamic resizing and can leave orientation transitions in a reduced-size window.

## Validation

- Targeted orientation tests: passed.
- Full simulator suite: 207 tests, 0 failures.
- iPad simulator build: passed.
- Repeated iPad orientation stress test: 12 flips, clean portrait/landscape alternation with no stuck or reduced-size window observed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added iPad support for portrait and both landscape orientations.
  - iPhone orientation behavior remains portrait-only.
  - Removed the full-screen-only restriction to support modern iPad windowing and multitasking.

- **Tests**
  - Added automated checks confirming the supported orientations and full-screen setting across iPhone and iPad configurations.

- **Documentation**
  - Added design and implementation documentation covering iPad landscape support, windowing behavior, and validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->