### PR TITLE
Fix unresolved CI workflow merge marker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-<<<<<<< HEAD
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

- Remove the committed `<<<<<<< HEAD` merge-conflict marker from the CI workflow.

## Why

The workflow was being parsed without a valid job definition, so GitHub Actions created a failed run with zero jobs and no job log.

## Validation

- Confirmed the unresolved-marker contract failed before the change.
- Confirmed no conflict markers remain.
- Ruby YAML parse passed.
- `git diff --check` passed.
- The change is limited to one line in `.github/workflows/ci.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up the CI workflow by removing a leftover merge-conflict marker.
  * Continuous integration configuration now parses correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->