### PR TITLE
Fix Xcode 26.2 parser type-checking failure

### DIFF
--- a/Conduit/Services/StreamEventParser.swift
+++ b/Conduit/Services/StreamEventParser.swift
@@ -19,13 +19,20 @@ enum StreamEventParser {
             return .messageDelta(sessionId: sessionId, text: text)
 
         case "reasoning.delta", "message.reasoning", "message.reasoning.delta":
-            let text = payload?["reasoning"]?.stringValue
-                ?? payload?["reasoning_content"]?.stringValue
-                ?? payload?["text"]?.stringValue
-                ?? payload?["content"]?.stringValue
-                ?? obj["reasoning"]?.stringValue
-                ?? obj["text"]?.stringValue
-                ?? ""
+            let text: String
+            if let reasoning = payload?["reasoning"]?.stringValue {
+                text = reasoning
+            } else if let reasoningContent = payload?["reasoning_content"]?.stringValue {
+                text = reasoningContent
+            } else if let payloadText = payload?["text"]?.stringValue {
+                text = payloadText
+            } else if let content = payload?["content"]?.stringValue {
+                text = content
+            } else if let reasoning = obj["reasoning"]?.stringValue {
+                text = reasoning
+            } else {
+                text = obj["text"]?.stringValue ?? ""
+            }
             if text.isEmpty { return nil }
             return .reasoningDelta(sessionId: sessionId, text: text)
 


### PR DESCRIPTION
Fixes #14

## Summary

- Replace the reasoning-delta lookup chain with ordered `if let` statements.
- Keep the existing lookup order and parser result.
- Limit the change to `StreamEventParser`.

## Root cause

Xcode 26.2 cannot type-check the seven-part optional lookup chain in reasonable time. The compiler stops before Xcode builds the app or the test target.

Xcode 26.6 accepts the seven-part expression in the upstream CI job. The ordered statements preserve parser behavior and let Xcode 26.2 compile the parser.

## Lookup order

The parser continues to use the first available value in this order:

1. `payload.reasoning`
2. `payload.reasoning_content`
3. `payload.text`
4. `payload.content`
5. `reasoning`
6. `text`
7. An empty string

## Validation

- `StreamEventParserTests` passed with Xcode 26.2.
- A clean Conduit simulator build passed with Xcode 26.2.
- `git diff --check` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of streamed reasoning and text content.
  * Preserved the correct priority when content is available in multiple response fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->