### PR TITLE
Add manual session rename

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -1412,10 +1412,10 @@ final class AppState: ObservableObject {
         let operations = SessionRenameOperation.Operations(
             renameRuntime: activeClient.map { client in
                 { [weak self, weak client] sessionID, title in
-                    guard let self, let client else { throw CancellationError() }
+                    guard let self, let client else { throw SessionRenameOperation.ContextChanged() }
                     try await client.setSessionTitle(sessionID, title: title)
                     guard profile == self.activeProfile, self.client === client else {
-                        throw CancellationError()
+                        throw SessionRenameOperation.ContextChanged()
                     }
                 }
             },
@@ -1423,7 +1423,7 @@ final class AppState: ObservableObject {
                 guard let self, let dashboardTicketBridge,
                       profile == self.activeProfile,
                       !runtimeRenameExpected || self.client === activeClient else {
-                    throw CancellationError()
+                    throw SessionRenameOperation.ContextChanged()
                 }
                 _ = try await dashboardTicketBridge.requestJSON(
                     path: self.dashboardPath(
@@ -1445,7 +1445,7 @@ final class AppState: ObservableObject {
             ), profile == activeProfile else { return false }
             applyRecoveredSessionTitle(result.title, sessionIDs: result.sessionIDs)
             return true
-        } catch is CancellationError {
+        } catch is SessionRenameOperation.ContextChanged {
             return false
         } catch {
             guard profile == activeProfile else { return false }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -234,6 +234,8 @@ final class AppState: ObservableObject {
     /// profile's database. Keep a small, one-per-session recovery task for a
     /// secondary profile, then stand down as soon as Hermes has written one.
     private var secondaryProfileTitleRecoveryTasks: [String: Task<Void, Never>] = [:]
+    private var secondaryProfileTitleRecoveryTokens: [String: UUID] = [:]
+    private var secondaryProfileTitleRecoverySuppressedKeys = Set<String>()
     private var reconnectAttempts = 0
     private var connectedAt: Date?
     private var profileSessionCache: [String: [SessionSummary]] = [:]
@@ -1395,8 +1397,16 @@ final class AppState: ObservableObject {
         let profile = activeProfile
         let knownIDs = [session.id] + session.alternateIds
         let runtimeID = activeSessionId.flatMap { knownIDs.contains($0) ? $0 : nil }
+        let titleRecoveryTaskKeys = Set(knownIDs.filter { !$0.isEmpty }.map { "\(profile)|\($0)" })
+        secondaryProfileTitleRecoverySuppressedKeys.formUnion(titleRecoveryTaskKeys)
         sessionMutationID = session.id
-        defer { sessionMutationID = nil }
+        defer {
+            sessionMutationID = nil
+            secondaryProfileTitleRecoverySuppressedKeys.subtract(titleRecoveryTaskKeys)
+        }
+
+        await cancelSecondaryProfileTitleRecovery(profile: profile, sessionIDs: knownIDs)
+        guard profile == activeProfile else { return false }
 
         do {
             var renamedViaRPC = false
@@ -3302,6 +3312,20 @@ final class AppState: ObservableObject {
     private func cancelSecondaryProfileTitleRecovery() {
         secondaryProfileTitleRecoveryTasks.values.forEach { $0.cancel() }
         secondaryProfileTitleRecoveryTasks.removeAll()
+        secondaryProfileTitleRecoveryTokens.removeAll()
+    }
+
+    private func cancelSecondaryProfileTitleRecovery(
+        profile: String,
+        sessionIDs: [String]
+    ) async {
+        let taskKeys = Set(sessionIDs.filter { !$0.isEmpty }.map { "\(profile)|\($0)" })
+        let tasks = taskKeys.compactMap { taskKey -> Task<Void, Never>? in
+            secondaryProfileTitleRecoveryTokens.removeValue(forKey: taskKey)
+            return secondaryProfileTitleRecoveryTasks.removeValue(forKey: taskKey)
+        }
+        tasks.forEach { $0.cancel() }
+        for task in tasks { await task.value }
     }
 
     private func titleGenerationSettings(for profile: String) async -> TitleGenerationSettings? {
@@ -3369,9 +3393,17 @@ final class AppState: ObservableObject {
               !assistantMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
 
         let taskKey = "\(profile)|\(sessionId)"
-        guard secondaryProfileTitleRecoveryTasks[taskKey] == nil else { return }
+        guard !secondaryProfileTitleRecoverySuppressedKeys.contains(taskKey),
+              secondaryProfileTitleRecoveryTasks[taskKey] == nil else { return }
+        let token = UUID()
+        secondaryProfileTitleRecoveryTokens[taskKey] = token
         secondaryProfileTitleRecoveryTasks[taskKey] = Task { [weak self, weak client] in
-            defer { self?.secondaryProfileTitleRecoveryTasks.removeValue(forKey: taskKey) }
+            defer {
+                if self?.secondaryProfileTitleRecoveryTokens[taskKey] == token {
+                    self?.secondaryProfileTitleRecoveryTasks.removeValue(forKey: taskKey)
+                    self?.secondaryProfileTitleRecoveryTokens.removeValue(forKey: taskKey)
+                }
+            }
             do {
                 try await Task.sleep(nanoseconds: 2_500_000_000)
             } catch {
@@ -3380,12 +3412,17 @@ final class AppState: ObservableObject {
             guard let self,
                   let client,
                   !Task.isCancelled,
+                  self.secondaryProfileTitleRecoveryTokens[taskKey] == token,
                   self.activeProfile == profile,
                   self.client === client else { return }
 
             do {
                 // Give Hermes' built-in asynchronous title task precedence.
                 if let existingTitle = try await client.sessionTitle(sessionId) {
+                    guard !Task.isCancelled,
+                          self.secondaryProfileTitleRecoveryTokens[taskKey] == token,
+                          self.activeProfile == profile,
+                          self.client === client else { return }
                     self.applyRecoveredSessionTitle(existingTitle, sessionIDs: [sessionId])
                     titleGenerationLog.notice(
                         "Used Hermes title for \(sessionId, privacy: .public) in \(profile, privacy: .public)"
@@ -3395,6 +3432,7 @@ final class AppState: ObservableObject {
                 guard let settings = await self.titleGenerationSettings(for: profile),
                       settings.enabled,
                       !Task.isCancelled,
+                      self.secondaryProfileTitleRecoveryTokens[taskKey] == token,
                       self.activeProfile == profile,
                       self.client === client else { return }
                 guard let generated = try await client.generateSessionTitle(
@@ -3402,10 +3440,17 @@ final class AppState: ObservableObject {
                     userMessage: userMessage,
                     assistantMessage: assistantMessage,
                     language: settings.language
-                ), let title = Self.normalizedGeneratedSessionTitle(generated), !Task.isCancelled,
-                      self.activeProfile == profile, self.client === client else { return }
+                ), let title = Self.normalizedGeneratedSessionTitle(generated),
+                      !Task.isCancelled,
+                      self.secondaryProfileTitleRecoveryTokens[taskKey] == token,
+                      self.activeProfile == profile,
+                      self.client === client else { return }
 
                 try await client.setSessionTitle(sessionId, title: title)
+                guard !Task.isCancelled,
+                      self.secondaryProfileTitleRecoveryTokens[taskKey] == token,
+                      self.activeProfile == profile,
+                      self.client === client else { return }
                 self.applyRecoveredSessionTitle(title, sessionIDs: [sessionId])
                 titleGenerationLog.notice(
                     "Generated title for \(sessionId, privacy: .public) in \(profile, privacy: .public)"

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -1383,6 +1383,32 @@ final class AppState: ObservableObject {
             return false
         }
     }
+    @discardableResult
+    func renameSession(_ session: SessionSummary, to title: String) async -> Bool {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty,
+              trimmedTitle != session.title,
+              sessionMutationID == nil,
+              sessionBelongsToProfile(session, profile: activeProfile),
+              let client else { return false }
+
+        let profile = activeProfile
+        let knownIDs = [session.id] + session.alternateIds
+        let requestID = activeSessionId.flatMap { knownIDs.contains($0) ? $0 : nil } ?? session.id
+        sessionMutationID = session.id
+        defer { sessionMutationID = nil }
+
+        do {
+            try await client.setSessionTitle(requestID, title: trimmedTitle)
+            guard profile == activeProfile, self.client === client else { return false }
+            applyRecoveredSessionTitle(trimmedTitle, sessionIDs: knownIDs)
+            return true
+        } catch {
+            guard profile == activeProfile, self.client === client else { return false }
+            errorMessage = "Could not rename this conversation: \(error.localizedDescription)"
+            return false
+        }
+    }
 
     func deleteSession(_ session: SessionSummary) async -> Bool {
         guard sessionMutationID == nil,

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -1390,21 +1390,39 @@ final class AppState: ObservableObject {
               trimmedTitle != session.title,
               sessionMutationID == nil,
               sessionBelongsToProfile(session, profile: activeProfile),
-              let client else { return false }
+              let dashboardTicketBridge else { return false }
 
         let profile = activeProfile
         let knownIDs = [session.id] + session.alternateIds
-        let requestID = activeSessionId.flatMap { knownIDs.contains($0) ? $0 : nil } ?? session.id
+        let runtimeID = activeSessionId.flatMap { knownIDs.contains($0) ? $0 : nil }
         sessionMutationID = session.id
         defer { sessionMutationID = nil }
 
         do {
-            try await client.setSessionTitle(requestID, title: trimmedTitle)
-            guard profile == activeProfile, self.client === client else { return false }
+            var renamedViaRPC = false
+            if let runtimeID, let client {
+                do {
+                    try await client.setSessionTitle(runtimeID, title: trimmedTitle)
+                    guard profile == activeProfile, self.client === client else { return false }
+                    renamedViaRPC = true
+                } catch {
+                    guard profile == activeProfile, self.client === client else { return false }
+                }
+            }
+
+            if !renamedViaRPC {
+                _ = try await dashboardTicketBridge.requestJSON(
+                    path: dashboardPath("/api/sessions/\(encodedSessionID(session.id))", profile: profile),
+                    method: "PATCH",
+                    body: ["title": trimmedTitle]
+                )
+            }
+
+            guard profile == activeProfile else { return false }
             applyRecoveredSessionTitle(trimmedTitle, sessionIDs: knownIDs)
             return true
         } catch {
-            guard profile == activeProfile, self.client === client else { return false }
+            guard profile == activeProfile else { return false }
             errorMessage = "Could not rename this conversation: \(error.localizedDescription)"
             return false
         }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -234,6 +234,8 @@ final class AppState: ObservableObject {
     /// profile's database. Keep a small, one-per-session recovery task for a
     /// secondary profile, then stand down as soon as Hermes has written one.
     private let sessionTitleRecoveryTracker = SessionTitleRecoveryTracker()
+    private let sessionRenameOperationsOverride: SessionRenameOperation.Operations?
+    private let sessionCatalogLoaderOverride: ((Bool) async throws -> [SessionSummary])?
     private var reconnectAttempts = 0
     private var connectedAt: Date?
     private var profileSessionCache: [String: [SessionSummary]] = [:]
@@ -364,7 +366,13 @@ final class AppState: ObservableObject {
         return (try? JSONDecoder().decode([ReviewSummaryRecord].self, from: data)) ?? []
     }
 
-    init() {
+    init(
+        sessionRenameOperations: SessionRenameOperation.Operations? = nil,
+        sessionCatalogLoader: ((Bool) async throws -> [SessionSummary])? = nil,
+        restoreSavedConnection: Bool = true
+    ) {
+        sessionRenameOperationsOverride = sessionRenameOperations
+        sessionCatalogLoaderOverride = sessionCatalogLoader
         defaultProfileName = ProfileAppearanceStore.loadDefaultName()
         profileAvatarURLs = ProfileAppearanceStore.loadAvatarURLs()
         appIconChoice = UIApplication.shared.alternateIconName == AppIconChoice.light.alternateIconName ? .light : .dark
@@ -390,7 +398,7 @@ final class AppState: ObservableObject {
         migrateLegacyActiveSessionStateIfNeeded()
         restoreActiveSessionState(for: activeProfile)
         restorePinnedSessions(for: activeProfile)
-        loadSavedConnection()
+        if restoreSavedConnection { loadSavedConnection() }
     }
 
     /// Session IDs are only meaningful within their Hermes profile. The first
@@ -1285,23 +1293,42 @@ final class AppState: ObservableObject {
     // MARK: - Session management
 
     func loadSessions(forceRefresh: Bool = false) async {
-        guard let client else { return }
+        let activeClient = client
+        guard activeClient != nil || sessionCatalogLoaderOverride != nil else { return }
         let profile = activeProfile
         let retainedActiveTurn = activeTurnCatalogSession()
         do {
-            let loadedSessions = try await profileSessions(using: client, forceRefresh: forceRefresh)
-            guard profile == activeProfile, self.client === client else { return }
+            let loadedSessions: [SessionSummary]
+            if let sessionCatalogLoaderOverride {
+                loadedSessions = try await sessionCatalogLoaderOverride(forceRefresh)
+            } else if let activeClient {
+                loadedSessions = try await profileSessions(
+                    using: activeClient,
+                    forceRefresh: forceRefresh
+                )
+            } else {
+                return
+            }
+            guard profile == activeProfile else { return }
+            if sessionCatalogLoaderOverride == nil {
+                guard let activeClient, self.client === activeClient else { return }
+            }
             let allSessions = uniqueSessions(
                 [retainedActiveTurn].compactMap { $0 } + loadedSessions
             )
             sessions = allSessions.filter { $0.source != .cron }
             cronSessions = allSessions.filter { $0.source == .cron }
             if let activeSessionId { updateActiveSessionTitle(for: activeSessionId) }
-            Task { [weak self] in
-                await self?.loadProjects(using: client, profile: profile)
+            if let activeClient {
+                Task { [weak self] in
+                    await self?.loadProjects(using: activeClient, profile: profile)
+                }
             }
         } catch {
-            guard profile == activeProfile, self.client === client else { return }
+            guard profile == activeProfile else { return }
+            if sessionCatalogLoaderOverride == nil {
+                guard let activeClient, self.client === activeClient else { return }
+            }
             errorMessage = "Failed to load sessions: \(error.localizedDescription)"
         }
     }
@@ -1391,7 +1418,7 @@ final class AppState: ObservableObject {
         ),
               sessionMutationID == nil,
               sessionBelongsToProfile(session, profile: activeProfile),
-              let dashboardTicketBridge else { return false }
+              sessionRenameOperationsOverride != nil || dashboardTicketBridge != nil else { return false }
 
         let profile = activeProfile
         let knownIDs = [session.id] + session.alternateIds
@@ -1406,35 +1433,43 @@ final class AppState: ObservableObject {
         await sessionTitleRecoveryTracker.cancel(titleRecoveryTaskKeys)
         guard profile == activeProfile else { return false }
 
-        let activeClient = client
-        let runtimeRenameExpected = activeClient != nil
-            && activeSessionId.map { knownIDs.contains($0) } == true
-        let operations = SessionRenameOperation.Operations(
-            renameRuntime: activeClient.map { client in
-                { [weak self, weak client] sessionID, title in
-                    guard let self, let client else { throw SessionRenameOperation.ContextChanged() }
-                    try await client.setSessionTitle(sessionID, title: title)
-                    guard profile == self.activeProfile, self.client === client else {
+        let operations: SessionRenameOperation.Operations
+        if let sessionRenameOperationsOverride {
+            operations = sessionRenameOperationsOverride
+        } else {
+            guard let dashboardTicketBridge else { return false }
+            let activeClient = client
+            let runtimeRenameExpected = activeClient != nil
+                && activeSessionId.map { knownIDs.contains($0) } == true
+            operations = SessionRenameOperation.Operations(
+                renameRuntime: activeClient.map { client in
+                    { [weak self, weak client] sessionID, title in
+                        guard let self, let client else {
+                            throw SessionRenameOperation.ContextChanged()
+                        }
+                        try await client.setSessionTitle(sessionID, title: title)
+                        guard profile == self.activeProfile, self.client === client else {
+                            throw SessionRenameOperation.ContextChanged()
+                        }
+                    }
+                },
+                renameStored: { [weak self, weak dashboardTicketBridge] sessionID, title in
+                    guard let self, let dashboardTicketBridge,
+                          profile == self.activeProfile,
+                          !runtimeRenameExpected || self.client === activeClient else {
                         throw SessionRenameOperation.ContextChanged()
                     }
+                    _ = try await dashboardTicketBridge.requestJSON(
+                        path: self.dashboardPath(
+                            "/api/sessions/\(self.encodedSessionID(sessionID))",
+                            profile: profile
+                        ),
+                        method: "PATCH",
+                        body: ["title": title]
+                    )
                 }
-            },
-            renameStored: { [weak self, weak dashboardTicketBridge] sessionID, title in
-                guard let self, let dashboardTicketBridge,
-                      profile == self.activeProfile,
-                      !runtimeRenameExpected || self.client === activeClient else {
-                    throw SessionRenameOperation.ContextChanged()
-                }
-                _ = try await dashboardTicketBridge.requestJSON(
-                    path: self.dashboardPath(
-                        "/api/sessions/\(self.encodedSessionID(sessionID))",
-                        profile: profile
-                    ),
-                    method: "PATCH",
-                    body: ["title": title]
-                )
-            }
-        )
+            )
+        }
 
         do {
             guard let result = try await SessionRenameOperation.perform(

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -3497,7 +3497,7 @@ final class AppState: ObservableObject {
         let result = SessionRenameOperation.Result(title: title, sessionIDs: sessionIDs)
         let titleSessionIDs = Set(sessionIDs.filter { !$0.isEmpty })
         guard !titleSessionIDs.isEmpty else { return }
-        var matchesActiveSession = activeSessionId.map { titleSessionIDs.contains($0) } ?? false
+        var matchesActiveSession = result.matches(sessionID: activeSessionId)
         func updated(_ session: SessionSummary) -> SessionSummary {
             let updated = result.updating(session)
             guard updated != session else { return session }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -233,9 +233,7 @@ final class AppState: ObservableObject {
     /// Hermes currently starts its automatic title task against the launch
     /// profile's database. Keep a small, one-per-session recovery task for a
     /// secondary profile, then stand down as soon as Hermes has written one.
-    private var secondaryProfileTitleRecoveryTasks: [String: Task<Void, Never>] = [:]
-    private var secondaryProfileTitleRecoveryTokens: [String: UUID] = [:]
-    private var secondaryProfileTitleRecoverySuppressedKeys = Set<String>()
+    private let sessionTitleRecoveryTracker = SessionTitleRecoveryTracker()
     private var reconnectAttempts = 0
     private var connectedAt: Date?
     private var profileSessionCache: [String: [SessionSummary]] = [:]
@@ -1387,53 +1385,71 @@ final class AppState: ObservableObject {
     }
     @discardableResult
     func renameSession(_ session: SessionSummary, to title: String) async -> Bool {
-        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedTitle.isEmpty,
-              trimmedTitle != session.title,
+        guard let trimmedTitle = SessionRenameOperation.normalizedTitle(
+            title,
+            currentTitle: session.title
+        ),
               sessionMutationID == nil,
               sessionBelongsToProfile(session, profile: activeProfile),
               let dashboardTicketBridge else { return false }
 
         let profile = activeProfile
         let knownIDs = [session.id] + session.alternateIds
-        let runtimeID = activeSessionId.flatMap { knownIDs.contains($0) ? $0 : nil }
         let titleRecoveryTaskKeys = Set(knownIDs.filter { !$0.isEmpty }.map { "\(profile)|\($0)" })
-        secondaryProfileTitleRecoverySuppressedKeys.formUnion(titleRecoveryTaskKeys)
+        sessionTitleRecoveryTracker.suppress(titleRecoveryTaskKeys)
         sessionMutationID = session.id
         defer {
             sessionMutationID = nil
-            secondaryProfileTitleRecoverySuppressedKeys.subtract(titleRecoveryTaskKeys)
+            sessionTitleRecoveryTracker.unsuppress(titleRecoveryTaskKeys)
         }
 
-        await cancelSecondaryProfileTitleRecovery(profile: profile, sessionIDs: knownIDs)
+        await sessionTitleRecoveryTracker.cancel(titleRecoveryTaskKeys)
         guard profile == activeProfile else { return false }
 
-        do {
-            var renamedViaRPC = false
-            if let runtimeID, let client {
-                do {
-                    try await client.setSessionTitle(runtimeID, title: trimmedTitle)
-                    guard profile == activeProfile, self.client === client else { return false }
-                    renamedViaRPC = true
-                } catch {
-                    guard profile == activeProfile, self.client === client else { return false }
+        let activeClient = client
+        let runtimeRenameExpected = activeClient != nil
+            && activeSessionId.map { knownIDs.contains($0) } == true
+        let operations = SessionRenameOperation.Operations(
+            renameRuntime: activeClient.map { client in
+                { [weak self, weak client] sessionID, title in
+                    guard let self, let client else { throw CancellationError() }
+                    try await client.setSessionTitle(sessionID, title: title)
+                    guard profile == self.activeProfile, self.client === client else {
+                        throw CancellationError()
+                    }
                 }
-            }
-
-            if !renamedViaRPC {
+            },
+            renameStored: { [weak self, weak dashboardTicketBridge] sessionID, title in
+                guard let self, let dashboardTicketBridge,
+                      profile == self.activeProfile,
+                      !runtimeRenameExpected || self.client === activeClient else {
+                    throw CancellationError()
+                }
                 _ = try await dashboardTicketBridge.requestJSON(
-                    path: dashboardPath("/api/sessions/\(encodedSessionID(session.id))", profile: profile),
+                    path: self.dashboardPath(
+                        "/api/sessions/\(self.encodedSessionID(sessionID))",
+                        profile: profile
+                    ),
                     method: "PATCH",
-                    body: ["title": trimmedTitle]
+                    body: ["title": title]
                 )
             }
+        )
 
-            guard profile == activeProfile else { return false }
-            applyRecoveredSessionTitle(trimmedTitle, sessionIDs: knownIDs)
+        do {
+            guard let result = try await SessionRenameOperation.perform(
+                session: session,
+                activeSessionID: activeSessionId,
+                title: trimmedTitle,
+                operations: operations
+            ), profile == activeProfile else { return false }
+            applyRecoveredSessionTitle(result.title, sessionIDs: result.sessionIDs)
             return true
+        } catch is CancellationError {
+            return false
         } catch {
             guard profile == activeProfile else { return false }
-            errorMessage = "Could not rename this conversation: \(error.localizedDescription)"
+            errorMessage = SessionRenameOperation.failureMessage(error)
             return false
         }
     }
@@ -3310,9 +3326,7 @@ final class AppState: ObservableObject {
     // MARK: - Secondary profile title recovery
 
     private func cancelSecondaryProfileTitleRecovery() {
-        secondaryProfileTitleRecoveryTasks.values.forEach { $0.cancel() }
-        secondaryProfileTitleRecoveryTasks.removeAll()
-        secondaryProfileTitleRecoveryTokens.removeAll()
+        sessionTitleRecoveryTracker.cancelAll()
     }
 
     private func cancelSecondaryProfileTitleRecovery(
@@ -3320,12 +3334,7 @@ final class AppState: ObservableObject {
         sessionIDs: [String]
     ) async {
         let taskKeys = Set(sessionIDs.filter { !$0.isEmpty }.map { "\(profile)|\($0)" })
-        let tasks = taskKeys.compactMap { taskKey -> Task<Void, Never>? in
-            secondaryProfileTitleRecoveryTokens.removeValue(forKey: taskKey)
-            return secondaryProfileTitleRecoveryTasks.removeValue(forKey: taskKey)
-        }
-        tasks.forEach { $0.cancel() }
-        for task in tasks { await task.value }
+        await sessionTitleRecoveryTracker.cancel(taskKeys)
     }
 
     private func titleGenerationSettings(for profile: String) async -> TitleGenerationSettings? {
@@ -3393,16 +3402,12 @@ final class AppState: ObservableObject {
               !assistantMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
 
         let taskKey = "\(profile)|\(sessionId)"
-        guard !secondaryProfileTitleRecoverySuppressedKeys.contains(taskKey),
-              secondaryProfileTitleRecoveryTasks[taskKey] == nil else { return }
+        guard !sessionTitleRecoveryTracker.isSuppressed(taskKey),
+              !sessionTitleRecoveryTracker.hasTask(for: taskKey) else { return }
         let token = UUID()
-        secondaryProfileTitleRecoveryTokens[taskKey] = token
-        secondaryProfileTitleRecoveryTasks[taskKey] = Task { [weak self, weak client] in
+        let task = Task { [weak self, weak client] in
             defer {
-                if self?.secondaryProfileTitleRecoveryTokens[taskKey] == token {
-                    self?.secondaryProfileTitleRecoveryTasks.removeValue(forKey: taskKey)
-                    self?.secondaryProfileTitleRecoveryTokens.removeValue(forKey: taskKey)
-                }
+                self?.sessionTitleRecoveryTracker.finish(token, for: taskKey)
             }
             do {
                 try await Task.sleep(nanoseconds: 2_500_000_000)
@@ -3412,7 +3417,7 @@ final class AppState: ObservableObject {
             guard let self,
                   let client,
                   !Task.isCancelled,
-                  self.secondaryProfileTitleRecoveryTokens[taskKey] == token,
+                  self.sessionTitleRecoveryTracker.isCurrent(token, for: taskKey),
                   self.activeProfile == profile,
                   self.client === client else { return }
 
@@ -3420,7 +3425,7 @@ final class AppState: ObservableObject {
                 // Give Hermes' built-in asynchronous title task precedence.
                 if let existingTitle = try await client.sessionTitle(sessionId) {
                     guard !Task.isCancelled,
-                          self.secondaryProfileTitleRecoveryTokens[taskKey] == token,
+                          self.sessionTitleRecoveryTracker.isCurrent(token, for: taskKey),
                           self.activeProfile == profile,
                           self.client === client else { return }
                     self.applyRecoveredSessionTitle(existingTitle, sessionIDs: [sessionId])
@@ -3432,7 +3437,7 @@ final class AppState: ObservableObject {
                 guard let settings = await self.titleGenerationSettings(for: profile),
                       settings.enabled,
                       !Task.isCancelled,
-                      self.secondaryProfileTitleRecoveryTokens[taskKey] == token,
+                      self.sessionTitleRecoveryTracker.isCurrent(token, for: taskKey),
                       self.activeProfile == profile,
                       self.client === client else { return }
                 guard let generated = try await client.generateSessionTitle(
@@ -3442,13 +3447,13 @@ final class AppState: ObservableObject {
                     language: settings.language
                 ), let title = Self.normalizedGeneratedSessionTitle(generated),
                       !Task.isCancelled,
-                      self.secondaryProfileTitleRecoveryTokens[taskKey] == token,
+                      self.sessionTitleRecoveryTracker.isCurrent(token, for: taskKey),
                       self.activeProfile == profile,
                       self.client === client else { return }
 
                 try await client.setSessionTitle(sessionId, title: title)
                 guard !Task.isCancelled,
-                      self.secondaryProfileTitleRecoveryTokens[taskKey] == token,
+                      self.sessionTitleRecoveryTracker.isCurrent(token, for: taskKey),
                       self.activeProfile == profile,
                       self.client === client else { return }
                 self.applyRecoveredSessionTitle(title, sessionIDs: [sessionId])
@@ -3463,6 +3468,7 @@ final class AppState: ObservableObject {
                 )
             }
         }
+        sessionTitleRecoveryTracker.register(task, token: token, for: taskKey)
     }
 
     static func normalizedGeneratedSessionTitle(_ value: String) -> String? {
@@ -3488,18 +3494,18 @@ final class AppState: ObservableObject {
     }
 
     private func applyRecoveredSessionTitle(_ title: String, sessionIDs: [String]) {
+        let result = SessionRenameOperation.Result(title: title, sessionIDs: sessionIDs)
         let titleSessionIDs = Set(sessionIDs.filter { !$0.isEmpty })
         guard !titleSessionIDs.isEmpty else { return }
         var matchesActiveSession = activeSessionId.map { titleSessionIDs.contains($0) } ?? false
         func updated(_ session: SessionSummary) -> SessionSummary {
-            let summaryIDs = Set([session.id] + session.alternateIds)
-            guard !summaryIDs.isDisjoint(with: titleSessionIDs) else { return session }
-            if let activeSessionId, summaryIDs.contains(activeSessionId) {
+            let updated = result.updating(session)
+            guard updated != session else { return session }
+            if let activeSessionId,
+               Set([session.id] + session.alternateIds).contains(activeSessionId) {
                 matchesActiveSession = true
             }
-            var copy = session
-            copy.title = title
-            return copy
+            return updated
         }
         sessions = sessions.map(updated)
         cronSessions = cronSessions.map(updated)
@@ -3512,7 +3518,7 @@ final class AppState: ObservableObject {
     private func handleStreamEvent(_ event: StreamEvent) {
         if case .sessionTitle(let runtimeSessionId, let storedSessionId, let title) = event {
             let taskKey = "\(activeProfile)|\(runtimeSessionId)"
-            secondaryProfileTitleRecoveryTasks[taskKey]?.cancel()
+            sessionTitleRecoveryTracker.cancel(taskKey)
             applyRecoveredSessionTitle(
                 title,
                 sessionIDs: [runtimeSessionId, storedSessionId]

--- a/Conduit/Services/HermesClient.swift
+++ b/Conduit/Services/HermesClient.swift
@@ -553,6 +553,8 @@ final class HermesClient: ObservableObject {
                 // Hermes' established React Native client uses WebSocket text
                 // frames (`socket.send(JSON.stringify(...))`). The gateway accepts
                 // the connection but does not dispatch binary JSON-RPC frames.
+                // JSONEncoder output is valid UTF-8; keep this transport conversion nonfailable.
+                // swiftlint:disable:next optional_data_string_conversion
                 let text = String(decoding: body, as: UTF8.self)
                 socket.send(.string(text)) { [weak self] error in
                     if let error {

--- a/Conduit/Services/HermesClient.swift
+++ b/Conduit/Services/HermesClient.swift
@@ -532,32 +532,45 @@ final class HermesClient: ObservableObject {
         let body = try JSONEncoder().encode(request)
         logger.notice("Sending RPC id \(id) method \(method, privacy: .public)")
 
-        return try await withCheckedThrowingContinuation { continuation in
-            // Timeout
-            let timer = Timer.scheduledTimer(withTimeInterval: timeout, repeats: false) { [weak self] _ in
-                Task { @MainActor in
-                    if let pending = self?.pending.removeValue(forKey: id) {
-                        pending.continuation.resume(throwing: HermesError.timeout(method))
-                    }
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                if Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                    return
                 }
-            }
 
-            pending[id] = PendingRequest(continuation: continuation, timer: timer)
-
-            // Hermes' established React Native client uses WebSocket text
-            // frames (`socket.send(JSON.stringify(...))`). The gateway accepts
-            // the connection but does not dispatch binary JSON-RPC frames.
-            let text = String(decoding: body, as: UTF8.self)
-            socket.send(.string(text)) { [weak self] error in
-                if let error {
-                    self?.logger.error("RPC send failed for \(method, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                // Timeout
+                let timer = Timer.scheduledTimer(withTimeInterval: timeout, repeats: false) { [weak self] _ in
                     Task { @MainActor in
                         if let pending = self?.pending.removeValue(forKey: id) {
-                            pending.timer?.invalidate()
-                            pending.continuation.resume(throwing: error)
+                            pending.continuation.resume(throwing: HermesError.timeout(method))
                         }
                     }
                 }
+
+                pending[id] = PendingRequest(continuation: continuation, timer: timer)
+
+                // Hermes' established React Native client uses WebSocket text
+                // frames (`socket.send(JSON.stringify(...))`). The gateway accepts
+                // the connection but does not dispatch binary JSON-RPC frames.
+                let text = String(decoding: body, as: UTF8.self)
+                socket.send(.string(text)) { [weak self] error in
+                    if let error {
+                        self?.logger.error("RPC send failed for \(method, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                        Task { @MainActor in
+                            if let pending = self?.pending.removeValue(forKey: id) {
+                                pending.timer?.invalidate()
+                                pending.continuation.resume(throwing: error)
+                            }
+                        }
+                    }
+                }
+            }
+        } onCancel: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let pending = self?.pending.removeValue(forKey: id) else { return }
+                pending.timer?.invalidate()
+                pending.continuation.resume(throwing: CancellationError())
             }
         }
     }

--- a/Conduit/Services/SessionRenameOperation.swift
+++ b/Conduit/Services/SessionRenameOperation.swift
@@ -55,6 +55,8 @@ enum SessionRenameOperation {
             do {
                 try await renameRuntime(runtimeID, normalized)
                 return Result(title: normalized, sessionIDs: sessionIDs)
+            } catch let error as ContextChanged {
+                throw error
             } catch {
                 // A stored-session PATCH is the supported fallback when the
                 // active runtime no longer accepts the title RPC.

--- a/Conduit/Services/SessionRenameOperation.swift
+++ b/Conduit/Services/SessionRenameOperation.swift
@@ -7,6 +7,8 @@ enum SessionRenameOperation {
         var renameStored: (String, String) async throws -> Void
     }
 
+    struct ContextChanged: Error {}
+
     struct Result: Equatable {
         let title: String
         let sessionIDs: [String]

--- a/Conduit/Services/SessionRenameOperation.swift
+++ b/Conduit/Services/SessionRenameOperation.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+@MainActor
+enum SessionRenameOperation {
+    struct Operations {
+        var renameRuntime: ((String, String) async throws -> Void)?
+        var renameStored: (String, String) async throws -> Void
+    }
+
+    struct Result: Equatable {
+        let title: String
+        let sessionIDs: [String]
+
+        func matches(_ session: SessionSummary) -> Bool {
+            let knownIDs = Set(sessionIDs)
+            let candidateIDs = Set([session.id] + session.alternateIds)
+            return !knownIDs.isDisjoint(with: candidateIDs)
+        }
+
+        func updating(_ session: SessionSummary) -> SessionSummary {
+            guard matches(session) else { return session }
+            var updated = session
+            updated.title = title
+            return updated
+        }
+    }
+
+    static func normalizedTitle(_ title: String, currentTitle: String) -> String? {
+        let normalized = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty, normalized != currentTitle else { return nil }
+        return normalized
+    }
+    static func failureMessage(_ error: Error) -> String {
+        "Could not rename this conversation: \(error.localizedDescription)"
+    }
+
+    static func perform(
+        session: SessionSummary,
+        activeSessionID: String?,
+        title: String,
+        operations: Operations
+    ) async throws -> Result? {
+        guard let normalized = normalizedTitle(title, currentTitle: session.title) else { return nil }
+        let sessionIDs = [session.id] + session.alternateIds
+        let runtimeID = activeSessionID.flatMap { sessionIDs.contains($0) ? $0 : nil }
+
+        if let runtimeID, let renameRuntime = operations.renameRuntime {
+            do {
+                try await renameRuntime(runtimeID, normalized)
+                return Result(title: normalized, sessionIDs: sessionIDs)
+            } catch {
+                // A stored-session PATCH is the supported fallback when the
+                // active runtime no longer accepts the title RPC.
+            }
+        }
+
+        try await operations.renameStored(session.id, normalized)
+        return Result(title: normalized, sessionIDs: sessionIDs)
+    }
+}
+
+@MainActor
+final class SessionTitleRecoveryTracker {
+    private var tasks: [String: Task<Void, Never>] = [:]
+    private var tokens: [String: UUID] = [:]
+    private var suppressedKeys = Set<String>()
+
+    func isSuppressed(_ key: String) -> Bool {
+        suppressedKeys.contains(key)
+    }
+
+    func hasTask(for key: String) -> Bool {
+        tasks[key] != nil
+    }
+
+    func suppress(_ keys: Set<String>) {
+        suppressedKeys.formUnion(keys)
+    }
+
+    func unsuppress(_ keys: Set<String>) {
+        suppressedKeys.subtract(keys)
+    }
+
+    func register(_ task: Task<Void, Never>, token: UUID, for key: String) {
+        tokens[key] = token
+        tasks[key] = task
+    }
+
+    func isCurrent(_ token: UUID, for key: String) -> Bool {
+        tokens[key] == token
+    }
+
+    func finish(_ token: UUID, for key: String) {
+        guard tokens[key] == token else { return }
+        tasks.removeValue(forKey: key)
+        tokens.removeValue(forKey: key)
+    }
+
+    func cancel(_ key: String) {
+        tokens.removeValue(forKey: key)
+        tasks.removeValue(forKey: key)?.cancel()
+    }
+
+    func cancelAll() {
+        tasks.values.forEach { $0.cancel() }
+        tasks.removeAll()
+        tokens.removeAll()
+    }
+
+    func cancel(_ keys: Set<String>) async {
+        let pending = keys.compactMap { key -> Task<Void, Never>? in
+            tokens.removeValue(forKey: key)
+            return tasks.removeValue(forKey: key)
+        }
+        pending.forEach { $0.cancel() }
+        for task in pending { await task.value }
+    }
+}

--- a/Conduit/Services/SessionRenameOperation.swift
+++ b/Conduit/Services/SessionRenameOperation.swift
@@ -17,6 +17,11 @@ enum SessionRenameOperation {
             return !knownIDs.isDisjoint(with: candidateIDs)
         }
 
+        func matches(sessionID: String?) -> Bool {
+            guard let sessionID else { return false }
+            return sessionIDs.contains(sessionID)
+        }
+
         func updating(_ session: SessionSummary) -> SessionSummary {
             guard matches(session) else { return session }
             var updated = session

--- a/Conduit/Views/SidebarView.swift
+++ b/Conduit/Views/SidebarView.swift
@@ -149,6 +149,8 @@ struct SessionList: View {
     @State private var showArchivedSessions = false
     @State private var showProjectCreator = false
     @State private var sessionPendingDeletion: SessionSummary?
+    @State private var sessionPendingRename: SessionSummary?
+    @State private var sessionRenameTitle = ""
     @State private var selectedProject: ProjectSummary?
     @AppStorage("conduit.sessionSourceFilter") private var selectedSourceRaw: String = "all"
     @AppStorage("conduit.sessionPresentation") private var sessionPresentationRaw = "sessions"
@@ -328,6 +330,25 @@ struct SessionList: View {
         } message: {
             Text("This permanently deletes the conversation and cannot be undone.")
         }
+        .alert("Rename conversation", isPresented: Binding(
+            get: { sessionPendingRename != nil },
+            set: { if !$0 { sessionPendingRename = nil } }
+        )) {
+            TextField("Conversation title", text: $sessionRenameTitle)
+            Button("Rename") {
+                guard let session = sessionPendingRename else { return }
+                let title = sessionRenameTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !title.isEmpty, title != session.title else { return }
+                sessionPendingRename = nil
+                Task { await appState.renameSession(session, to: title) }
+            }
+            .disabled(
+                sessionRenameTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    || sessionRenameTitle.trimmingCharacters(in: .whitespacesAndNewlines) == (sessionPendingRename?.title ?? "")
+            )
+            Button("Cancel", role: .cancel) { sessionPendingRename = nil }
+        }
+
     }
 
     private var allSessions: [SessionSummary] {
@@ -444,6 +465,15 @@ struct SessionList: View {
         .buttonStyle(.plain)
         .accessibilityHint("Swipe or touch and hold for conversation actions.")
         .contextMenu {
+            Button {
+                Haptics.selection()
+                sessionRenameTitle = session.title
+                sessionPendingRename = session
+            } label: {
+                Label("Rename…", systemImage: "pencil")
+            }
+            .disabled(appState.isSessionMutationInFlight(session))
+
             Button {
                 Haptics.selection()
                 appState.toggleSessionPinned(session)

--- a/Conduit/Views/SidebarView.swift
+++ b/Conduit/Views/SidebarView.swift
@@ -336,16 +336,18 @@ struct SessionList: View {
         )) {
             TextField("Conversation title", text: $sessionRenameTitle)
             Button("Rename") {
-                guard let session = sessionPendingRename else { return }
-                let title = sessionRenameTitle.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !title.isEmpty, title != session.title else { return }
+                guard let session = sessionPendingRename,
+                      let title = SessionRenameOperation.normalizedTitle(
+                          sessionRenameTitle,
+                          currentTitle: session.title
+                      ) else { return }
                 sessionPendingRename = nil
                 Task { await appState.renameSession(session, to: title) }
             }
-            .disabled(
-                sessionRenameTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                    || sessionRenameTitle.trimmingCharacters(in: .whitespacesAndNewlines) == (sessionPendingRename?.title ?? "")
-            )
+            .disabled(SessionRenameOperation.normalizedTitle(
+                sessionRenameTitle,
+                currentTitle: sessionPendingRename?.title ?? ""
+            ) == nil)
             Button("Cancel", role: .cancel) { sessionPendingRename = nil }
         }
 

--- a/ConduitTests/SessionRenameTests.swift
+++ b/ConduitTests/SessionRenameTests.swift
@@ -159,6 +159,26 @@ final class SessionRenameTests: XCTestCase {
         XCTAssertEqual(errorMessage, "Could not rename this conversation: Gateway rejected rename")
     }
 
+    func testTransportCancellationRemainsAUserVisibleFailure() async {
+        do {
+            _ = try await SessionRenameOperation.perform(
+                session: makeSession(),
+                activeSessionID: nil,
+                title: "Renamed",
+                operations: .init(
+                    renameRuntime: nil,
+                    renameStored: { _, _ in throw CancellationError() }
+                )
+            )
+            XCTFail("Expected transport cancellation to propagate")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+            XCTAssertTrue(SessionRenameOperation.failureMessage(error).hasPrefix(
+                "Could not rename this conversation:"
+            ))
+        }
+    }
+
     func testManualRenameCancelsAndInvalidatesPendingTitleRecovery() async {
         let tracker = SessionTitleRecoveryTracker()
         let key = "research|stored-id"

--- a/ConduitTests/SessionRenameTests.swift
+++ b/ConduitTests/SessionRenameTests.swift
@@ -89,19 +89,17 @@ final class SessionRenameTests: XCTestCase {
         XCTAssertEqual(result?.title, "Renamed")
     }
 
-    func testSuccessfulRenameUpdatesEveryProjectionAndPersistsThroughRefresh() async throws {
+    func testSuccessfulRenameUpdatesEveryIdentityProjection() async throws {
         let session = makeSession()
-        var persistedTitle = session.title
         let operationResult = try await SessionRenameOperation.perform(
             session: session,
             activeSessionID: "runtime-id",
             title: "Renamed",
             operations: .init(
-                renameRuntime: { sessionID, title in
+                renameRuntime: { sessionID, _ in
                     XCTAssertEqual(sessionID, "runtime-id")
-                    persistedTitle = title
                 },
-                renameStored: { _, title in persistedTitle = title }
+                renameStored: { _, _ in XCTFail("Active rename must use the runtime RPC") }
             )
         )
         let result = try XCTUnwrap(operationResult)
@@ -118,14 +116,78 @@ final class SessionRenameTests: XCTestCase {
             title: "Old archived title"
         ))
         let unrelatedEntry = result.updating(makeSession(id: "unrelated", alternateIDs: []))
-        let refreshedEntry = makeSession(title: persistedTitle)
 
         XCTAssertEqual(storedEntry.title, "Renamed")
         XCTAssertEqual(runtimeEntry.title, "Renamed")
         XCTAssertEqual(archivedEntry.title, "Renamed")
         XCTAssertTrue(result.matches(sessionID: "runtime-id"), "The active title must receive the rename")
         XCTAssertEqual(unrelatedEntry.title, "Original")
-        XCTAssertEqual(refreshedEntry.title, "Renamed", "The authoritative refreshed catalog must retain the rename")
+    }
+
+    func testContextChangeDoesNotFallBackToStoredSession() async {
+        var storedRequestCount = 0
+
+        do {
+            _ = try await SessionRenameOperation.perform(
+                session: makeSession(),
+                activeSessionID: "runtime-id",
+                title: "Renamed",
+                operations: .init(
+                    renameRuntime: { _, _ in throw SessionRenameOperation.ContextChanged() },
+                    renameStored: { _, _ in storedRequestCount += 1 }
+                )
+            )
+            XCTFail("Expected the context change to terminate the rename")
+        } catch is SessionRenameOperation.ContextChanged {
+            // Expected: a stale client or profile must not mutate stored state.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(storedRequestCount, 0)
+    }
+
+    func testInactiveRenameSurvivesAppStateCatalogRefresh() async {
+        var remoteCatalog: [SessionSummary] = []
+        var forcedRefresh = false
+        let appState = AppState(
+            sessionRenameOperations: .init(
+                renameRuntime: { _, _ in XCTFail("Inactive rename must not use the runtime RPC") },
+                renameStored: { sessionID, title in
+                    remoteCatalog = remoteCatalog.map { session in
+                        guard session.id == sessionID else { return session }
+                        var updated = session
+                        updated.title = title
+                        return updated
+                    }
+                }
+            ),
+            sessionCatalogLoader: { forceRefresh in
+                forcedRefresh = forceRefresh
+                return remoteCatalog
+            },
+            restoreSavedConnection: false
+        )
+        let target = makeSession(profile: appState.activeProfile)
+        let active = makeSession(
+            id: "active-id",
+            alternateIDs: [],
+            title: "Active",
+            profile: appState.activeProfile
+        )
+        remoteCatalog = [target, active]
+        appState.sessions = remoteCatalog
+        appState.activeSessionId = active.id
+
+        let didRename = await appState.renameSession(target, to: "Renamed")
+        XCTAssertTrue(didRename)
+        XCTAssertEqual(appState.sessions.first { $0.id == target.id }?.title, "Renamed")
+
+        await appState.refreshSessionCatalog()
+
+        XCTAssertTrue(forcedRefresh)
+        XCTAssertEqual(appState.sessions.first { $0.id == target.id }?.title, "Renamed")
+        XCTAssertEqual(appState.sessions.first { $0.id == active.id }?.title, "Active")
     }
 
     func testTerminalFailurePreservesCatalogAndSurfacesExistingError() async {
@@ -238,7 +300,8 @@ final class SessionRenameTests: XCTestCase {
     private func makeSession(
         id: String = "stored-id",
         alternateIDs: [String] = ["runtime-id"],
-        title: String = "Original"
+        title: String = "Original",
+        profile: String? = "default"
     ) -> SessionSummary {
         SessionSummary(
             id: id,
@@ -246,7 +309,7 @@ final class SessionRenameTests: XCTestCase {
             title: title,
             model: "test-model",
             updatedLabel: "now",
-            profile: "default",
+            profile: profile,
             source: .chat,
             isActive: false,
             isArchived: false

--- a/ConduitTests/SessionRenameTests.swift
+++ b/ConduitTests/SessionRenameTests.swift
@@ -190,35 +190,28 @@ final class SessionRenameTests: XCTestCase {
         XCTAssertEqual(appState.sessions.first { $0.id == active.id }?.title, "Active")
     }
 
-    func testTerminalFailurePreservesCatalogAndSurfacesExistingError() async {
-        let session = makeSession()
-        var catalog = [session]
-        var activeTitle = session.title
-        var errorMessage: String?
+    func testTerminalFailurePreservesAppStateAndSurfacesExistingError() async {
+        let appState = AppState(
+            sessionRenameOperations: .init(
+                renameRuntime: { _, _ in throw TestError.rejected },
+                renameStored: { _, _ in throw TestError.rejected }
+            ),
+            restoreSavedConnection: false
+        )
+        let session = makeSession(profile: appState.activeProfile)
+        appState.sessions = [session]
+        appState.activeSessionId = "runtime-id"
+        let previousActiveTitle = appState.activeSessionTitle
 
-        do {
-            if let result = try await SessionRenameOperation.perform(
-                session: session,
-                activeSessionID: nil,
-                title: "Renamed",
-                operations: .init(
-                    renameRuntime: nil,
-                    renameStored: { _, _ in throw TestError.rejected }
-                )
-            ) {
-                catalog = catalog.map(result.updating)
-                if result.matches(sessionID: "runtime-id") {
-                    activeTitle = result.title
-                }
-            }
-            XCTFail("Expected the stored rename to fail")
-        } catch {
-            errorMessage = SessionRenameOperation.failureMessage(error)
-        }
+        let didRename = await appState.renameSession(session, to: "Renamed")
 
-        XCTAssertEqual(catalog.map(\.title), ["Original"])
-        XCTAssertEqual(activeTitle, "Original")
-        XCTAssertEqual(errorMessage, "Could not rename this conversation: Gateway rejected rename")
+        XCTAssertFalse(didRename)
+        XCTAssertEqual(appState.sessions.map(\.title), ["Original"])
+        XCTAssertEqual(appState.activeSessionTitle, previousActiveTitle)
+        XCTAssertEqual(
+            appState.errorMessage,
+            "Could not rename this conversation: Gateway rejected rename"
+        )
     }
 
     func testTransportCancellationRemainsAUserVisibleFailure() async {

--- a/ConduitTests/SessionRenameTests.swift
+++ b/ConduitTests/SessionRenameTests.swift
@@ -89,16 +89,19 @@ final class SessionRenameTests: XCTestCase {
         XCTAssertEqual(result?.title, "Renamed")
     }
 
-    func testSuccessfulRenameUpdatesStoredRuntimeAndActiveCatalogEntries() async throws {
+    func testSuccessfulRenameUpdatesEveryProjectionAndPersistsThroughRefresh() async throws {
         let session = makeSession()
-        var serverTitle = session.title
+        var persistedTitle = session.title
         let operationResult = try await SessionRenameOperation.perform(
             session: session,
             activeSessionID: "runtime-id",
             title: "Renamed",
             operations: .init(
-                renameRuntime: { _, title in serverTitle = title },
-                renameStored: { _, title in serverTitle = title }
+                renameRuntime: { sessionID, title in
+                    XCTAssertEqual(sessionID, "runtime-id")
+                    persistedTitle = title
+                },
+                renameStored: { _, title in persistedTitle = title }
             )
         )
         let result = try XCTUnwrap(operationResult)
@@ -109,20 +112,30 @@ final class SessionRenameTests: XCTestCase {
             alternateIDs: ["stored-id"],
             title: "Old runtime title"
         ))
+        let archivedEntry = result.updating(makeSession(
+            id: "archived-id",
+            alternateIDs: ["runtime-id"],
+            title: "Old archived title"
+        ))
         let unrelatedEntry = result.updating(makeSession(id: "unrelated", alternateIDs: []))
+        let refreshedEntry = makeSession(title: persistedTitle)
 
         XCTAssertEqual(storedEntry.title, "Renamed")
         XCTAssertEqual(runtimeEntry.title, "Renamed")
-        XCTAssertTrue(result.matches(runtimeEntry), "The active runtime alias must receive the title")
+        XCTAssertEqual(archivedEntry.title, "Renamed")
+        XCTAssertTrue(result.matches(sessionID: "runtime-id"), "The active title must receive the rename")
         XCTAssertEqual(unrelatedEntry.title, "Original")
-        XCTAssertEqual(serverTitle, "Renamed", "The authoritative title used by a subsequent refresh must be renamed")
+        XCTAssertEqual(refreshedEntry.title, "Renamed", "The authoritative refreshed catalog must retain the rename")
     }
 
-    func testTerminalFailureLeavesExistingCatalogTitleUnchanged() async {
+    func testTerminalFailurePreservesCatalogAndSurfacesExistingError() async {
         let session = makeSession()
+        var catalog = [session]
+        var activeTitle = session.title
+        var errorMessage: String?
 
         do {
-            _ = try await SessionRenameOperation.perform(
+            if let result = try await SessionRenameOperation.perform(
                 session: session,
                 activeSessionID: nil,
                 title: "Renamed",
@@ -130,15 +143,20 @@ final class SessionRenameTests: XCTestCase {
                     renameRuntime: nil,
                     renameStored: { _, _ in throw TestError.rejected }
                 )
-            )
+            ) {
+                catalog = catalog.map(result.updating)
+                if result.matches(sessionID: "runtime-id") {
+                    activeTitle = result.title
+                }
+            }
             XCTFail("Expected the stored rename to fail")
         } catch {
-            XCTAssertEqual(session.title, "Original")
-            XCTAssertEqual(
-                SessionRenameOperation.failureMessage(error),
-                "Could not rename this conversation: Gateway rejected rename"
-            )
+            errorMessage = SessionRenameOperation.failureMessage(error)
         }
+
+        XCTAssertEqual(catalog.map(\.title), ["Original"])
+        XCTAssertEqual(activeTitle, "Original")
+        XCTAssertEqual(errorMessage, "Could not rename this conversation: Gateway rejected rename")
     }
 
     func testManualRenameCancelsAndInvalidatesPendingTitleRecovery() async {
@@ -173,6 +191,28 @@ final class SessionRenameTests: XCTestCase {
 
         tracker.unsuppress(keys)
         XCTAssertFalse(tracker.isSuppressed(key))
+    }
+
+    func testStaleRecoveryCompletionCannotRemoveReplacementTask() async {
+        let tracker = SessionTitleRecoveryTracker()
+        let key = "research|stored-id"
+        let staleToken = UUID()
+        let currentToken = UUID()
+        let staleTask = Task<Void, Never> {}
+
+        tracker.register(staleTask, token: staleToken, for: key)
+        tracker.cancel(key)
+
+        let currentTask = Task<Void, Never> {
+            try? await Task.sleep(nanoseconds: 10_000_000_000)
+        }
+        tracker.register(currentTask, token: currentToken, for: key)
+        tracker.finish(staleToken, for: key)
+
+        XCTAssertTrue(tracker.hasTask(for: key))
+        XCTAssertTrue(tracker.isCurrent(currentToken, for: key))
+
+        await tracker.cancel([key])
     }
 
     private func makeSession(

--- a/ConduitTests/SessionRenameTests.swift
+++ b/ConduitTests/SessionRenameTests.swift
@@ -1,0 +1,195 @@
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class SessionRenameTests: XCTestCase {
+    private enum TestError: LocalizedError {
+        case rejected
+
+        var errorDescription: String? { "Gateway rejected rename" }
+    }
+
+    func testInvalidAndUnchangedTitlesDoNotIssueRequests() async throws {
+        let session = makeSession(title: "Existing")
+        var requestCount = 0
+        let operations = SessionRenameOperation.Operations(
+            renameRuntime: { _, _ in requestCount += 1 },
+            renameStored: { _, _ in requestCount += 1 }
+        )
+
+        for title in ["", "   \n", "Existing", "  Existing  "] {
+            let result = try await SessionRenameOperation.perform(
+                session: session,
+                activeSessionID: "runtime-id",
+                title: title,
+                operations: operations
+            )
+            XCTAssertNil(result)
+        }
+        XCTAssertEqual(requestCount, 0)
+    }
+
+    func testActiveSessionUsesRuntimeRPC() async throws {
+        let session = makeSession()
+        var runtimeRequest: (String, String)?
+        var storedRequest: (String, String)?
+
+        let result = try await SessionRenameOperation.perform(
+            session: session,
+            activeSessionID: "runtime-id",
+            title: "  Renamed  ",
+            operations: .init(
+                renameRuntime: { runtimeRequest = ($0, $1) },
+                renameStored: { storedRequest = ($0, $1) }
+            )
+        )
+
+        XCTAssertEqual(runtimeRequest?.0, "runtime-id")
+        XCTAssertEqual(runtimeRequest?.1, "Renamed")
+        XCTAssertNil(storedRequest)
+        XCTAssertEqual(result?.title, "Renamed")
+    }
+
+    func testInactiveSessionUsesStoredSessionPATCH() async throws {
+        let session = makeSession()
+        var runtimeRequest: (String, String)?
+        var storedRequest: (String, String)?
+
+        _ = try await SessionRenameOperation.perform(
+            session: session,
+            activeSessionID: "another-session",
+            title: "Renamed",
+            operations: .init(
+                renameRuntime: { runtimeRequest = ($0, $1) },
+                renameStored: { storedRequest = ($0, $1) }
+            )
+        )
+
+        XCTAssertNil(runtimeRequest)
+        XCTAssertEqual(storedRequest?.0, "stored-id")
+        XCTAssertEqual(storedRequest?.1, "Renamed")
+    }
+
+    func testFailedRuntimeRPCFallsBackToStoredSessionPATCH() async throws {
+        let session = makeSession()
+        var storedRequest: (String, String)?
+
+        let result = try await SessionRenameOperation.perform(
+            session: session,
+            activeSessionID: "runtime-id",
+            title: "Renamed",
+            operations: .init(
+                renameRuntime: { _, _ in throw TestError.rejected },
+                renameStored: { storedRequest = ($0, $1) }
+            )
+        )
+
+        XCTAssertEqual(storedRequest?.0, "stored-id")
+        XCTAssertEqual(storedRequest?.1, "Renamed")
+        XCTAssertEqual(result?.title, "Renamed")
+    }
+
+    func testSuccessfulRenameUpdatesStoredRuntimeAndActiveCatalogEntries() async throws {
+        let session = makeSession()
+        var serverTitle = session.title
+        let operationResult = try await SessionRenameOperation.perform(
+            session: session,
+            activeSessionID: "runtime-id",
+            title: "Renamed",
+            operations: .init(
+                renameRuntime: { _, title in serverTitle = title },
+                renameStored: { _, title in serverTitle = title }
+            )
+        )
+        let result = try XCTUnwrap(operationResult)
+
+        let storedEntry = result.updating(session)
+        let runtimeEntry = result.updating(makeSession(
+            id: "runtime-id",
+            alternateIDs: ["stored-id"],
+            title: "Old runtime title"
+        ))
+        let unrelatedEntry = result.updating(makeSession(id: "unrelated", alternateIDs: []))
+
+        XCTAssertEqual(storedEntry.title, "Renamed")
+        XCTAssertEqual(runtimeEntry.title, "Renamed")
+        XCTAssertTrue(result.matches(runtimeEntry), "The active runtime alias must receive the title")
+        XCTAssertEqual(unrelatedEntry.title, "Original")
+        XCTAssertEqual(serverTitle, "Renamed", "The authoritative title used by a subsequent refresh must be renamed")
+    }
+
+    func testTerminalFailureLeavesExistingCatalogTitleUnchanged() async {
+        let session = makeSession()
+
+        do {
+            _ = try await SessionRenameOperation.perform(
+                session: session,
+                activeSessionID: nil,
+                title: "Renamed",
+                operations: .init(
+                    renameRuntime: nil,
+                    renameStored: { _, _ in throw TestError.rejected }
+                )
+            )
+            XCTFail("Expected the stored rename to fail")
+        } catch {
+            XCTAssertEqual(session.title, "Original")
+            XCTAssertEqual(
+                SessionRenameOperation.failureMessage(error),
+                "Could not rename this conversation: Gateway rejected rename"
+            )
+        }
+    }
+
+    func testManualRenameCancelsAndInvalidatesPendingTitleRecovery() async {
+        let tracker = SessionTitleRecoveryTracker()
+        let key = "research|stored-id"
+        let keys: Set = [key]
+        let token = UUID()
+        var title = "Original"
+        var recoveryFinished = false
+
+        let recovery = Task { @MainActor in
+            do {
+                try await Task.sleep(nanoseconds: 10_000_000_000)
+            } catch {
+                // Cancellation resumes the recovery so it can observe its stale token.
+            }
+            if tracker.isCurrent(token, for: key) {
+                title = "Automatic title"
+            }
+            recoveryFinished = true
+        }
+        tracker.register(recovery, token: token, for: key)
+        tracker.suppress(keys)
+
+        await tracker.cancel(keys)
+        title = "Manual title"
+
+        XCTAssertTrue(recoveryFinished, "Manual rename must await pending recovery termination")
+        XCTAssertFalse(tracker.isCurrent(token, for: key))
+        XCTAssertEqual(title, "Manual title")
+        XCTAssertTrue(tracker.isSuppressed(key))
+
+        tracker.unsuppress(keys)
+        XCTAssertFalse(tracker.isSuppressed(key))
+    }
+
+    private func makeSession(
+        id: String = "stored-id",
+        alternateIDs: [String] = ["runtime-id"],
+        title: String = "Original"
+    ) -> SessionSummary {
+        SessionSummary(
+            id: id,
+            alternateIds: alternateIDs,
+            title: title,
+            model: "test-model",
+            updatedLabel: "now",
+            profile: "default",
+            source: .chat,
+            isActive: false,
+            isArchived: false
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Add a `Rename...` action to each session row context menu.
- Show an alert that contains the current session title.
- Reject an empty title or an unchanged title.
- Update the session catalog after Hermes accepts the new title.

## Persistence behavior

Conduit uses the `session.title` RPC when Conduit knows the active runtime session ID.

A stored session can have a catalog ID that differs from its runtime ID. When the IDs differ, Conduit sends a profile-scoped `PATCH` request to the session API. Hermes Desktop uses the same session rename flow.

After a successful request, Conduit updates all entries that use the primary or alternate session IDs. The update includes the active session title.

If the request fails, Conduit keeps the old title and uses the existing error presentation.

## User interface

- Long-press a session row to open the context menu.
- Select `Rename...`.
- Edit the current title.
- Select `Rename` to save the title.
- Select `Cancel` to keep the current title.

The `Rename` button is not available when the title is empty or unchanged. Conduit also prevents another session mutation during the request.

## Validation

Completed simulator check:

- After #15 merged, I rebased this branch onto upstream `main`.
- The full simulator test suite passed with Xcode 26.2 after the rebase.

Completed physical-device checks:

- A signed post-rebase build installed and started on a physical iPhone.
- Active and inactive session titles changed and remained changed after a session-list refresh.
- Cancel kept the old title.
- An empty title disabled Rename.
- An unchanged title disabled Rename. Rename stayed disabled after I made and then undid an edit.
- I disabled Wi-Fi before I confirmed an inactive rename. Conduit showed an error and kept the old title. I restored Wi-Fi and refreshed the session list. The old title remained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to rename sessions from the session context menu.
  * Users can enter a new title, with validation for empty or unchanged names.
  * Updated session titles are reflected throughout the app after a successful rename.
  * Session renaming is temporarily disabled while another session update is in progress.

* **Bug Fixes**
  * Improved title recovery so newer results and explicit renames are preserved.
  * Added more reliable handling when renaming fails or a session becomes unavailable.
  * Improved cancellation of interrupted session requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->