### PR TITLE
Support partial chat selection and restore scroll position

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -36,8 +36,12 @@ final class AppState: ObservableObject {
 
     // MARK: - Session
 
-    @Published var sessions: [SessionSummary] = []
-    @Published var cronSessions: [SessionSummary] = []
+    @Published var sessions: [SessionSummary] = [] {
+        didSet { refreshActiveChatScrollSessionIdentity() }
+    }
+    @Published var cronSessions: [SessionSummary] = [] {
+        didSet { refreshActiveChatScrollSessionIdentity() }
+    }
     @Published private(set) var projects: [ProjectSummary] = []
     @Published private(set) var supportsProjects = false
     @Published private(set) var projectsLoading = false
@@ -45,7 +49,10 @@ final class AppState: ObservableObject {
     @Published private(set) var pinnedSessionIDs: [String] = []
     @Published private(set) var sessionMutationID: String?
     @Published private(set) var isRefreshingSessionCatalog = false
-    @Published var activeSessionId: String?
+    @Published var activeSessionId: String? {
+        didSet { refreshActiveChatScrollSessionIdentity() }
+    }
+    @Published private(set) var activeChatScrollSessionIdentity = ChatScrollSessionIdentity.none
     @Published var messages: [ChatMessage] = []
     @Published private(set) var activeSessionTitle = "New conversation"
     @Published private(set) var isChatRefreshing = false
@@ -204,6 +211,7 @@ final class AppState: ObservableObject {
 
     private var reconciliationToken = UUID()
     private var reconciliation: Reconciliation?
+    private var chatScrollIdentityProfile = "default"
     private var activeClientEpoch = UUID()
     private var activeAssistantMessageId: String?
     private var activeReasoningMessageId: String?
@@ -475,6 +483,93 @@ final class AppState: ObservableObject {
     private func persistActiveSessionState() {
         defaults.set(activeSessionIDsByProfile, forKey: activeSessionIDsByProfileKey)
         defaults.set(activeSessionTitlesByProfile, forKey: activeSessionTitlesByProfileKey)
+    }
+
+    private func refreshActiveChatScrollSessionIdentity(
+        isReconciling: Bool? = nil,
+        advanceSettledRevision: Bool = false
+    ) {
+        let current = activeChatScrollSessionIdentity
+        let previous = chatScrollIdentityProfile == activeProfile
+            ? current
+            : ChatScrollSessionIdentity(
+                canonicalSessionID: nil,
+                equivalentSessionIDs: [],
+                isReconciling: current.isReconciling,
+                settledRevision: current.settledRevision
+            )
+        let catalog = sessions + cronSessions
+        func identifiers(for session: SessionSummary) -> Set<String> {
+            Set(([session.id] + session.alternateIds).compactMap(Self.normalizedSessionIdentityID))
+        }
+        func matchingSession(for ids: Set<String>) -> SessionSummary? {
+            guard !ids.isEmpty else { return nil }
+            return catalog.first { !identifiers(for: $0).isDisjoint(with: ids) }
+        }
+
+        let activeID = Self.normalizedSessionIdentityID(activeSessionId)
+        let reconciliationIDs = Set([
+            reconciliation?.requestedSessionId,
+            reconciliation?.resolvedSessionId
+        ].compactMap(Self.normalizedSessionIdentityID))
+        let reconciliationSession = matchingSession(for: reconciliationIDs)
+        let reconciliationCatalogIDs = reconciliationSession.map(identifiers) ?? []
+        let reconciliationContinuesPrevious = reconciliationIDs.isEmpty
+            || reconciliationIDs.contains(where: previous.contains)
+            || !reconciliationCatalogIDs.isDisjoint(with: previous.equivalentSessionIDs)
+            || activeID.map(reconciliationCatalogIDs.contains) == true
+
+        var candidates = reconciliationIDs
+        if reconciliationIDs.isEmpty || reconciliationContinuesPrevious,
+           let activeID {
+            candidates.insert(activeID)
+        }
+        let matchedSession = reconciliationSession ?? matchingSession(for: candidates)
+        let continuesPreviousIdentity = candidates.contains(where: previous.contains)
+
+        let canonicalSessionID: String?
+        if let matchedSession {
+            canonicalSessionID = matchedSession.id
+        } else if continuesPreviousIdentity {
+            canonicalSessionID = previous.canonicalSessionID
+        } else if !reconciliationIDs.isEmpty {
+            canonicalSessionID = Self.normalizedSessionIdentityID(reconciliation?.requestedSessionId)
+                ?? Self.normalizedSessionIdentityID(reconciliation?.resolvedSessionId)
+                ?? activeID
+        } else {
+            canonicalSessionID = activeID
+        }
+
+        var equivalentSessionIDs = candidates
+        if let matchedSession {
+            equivalentSessionIDs.formUnion(
+                ([matchedSession.id] + matchedSession.alternateIds)
+                    .compactMap(Self.normalizedSessionIdentityID)
+            )
+        }
+        if continuesPreviousIdentity {
+            equivalentSessionIDs.formUnion(previous.equivalentSessionIDs)
+        }
+
+        let revision = advanceSettledRevision
+            ? current.settledRevision &+ 1
+            : current.settledRevision
+        let updated = ChatScrollSessionIdentity(
+            canonicalSessionID: canonicalSessionID,
+            equivalentSessionIDs: equivalentSessionIDs,
+            isReconciling: isReconciling ?? current.isReconciling,
+            settledRevision: revision
+        )
+        chatScrollIdentityProfile = activeProfile
+        if updated != current {
+            activeChatScrollSessionIdentity = updated
+        }
+    }
+
+    private static func normalizedSessionIdentityID(_ sessionID: String?) -> String? {
+        guard let value = sessionID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else { return nil }
+        return value
     }
 
     func makeSettingsSnapshot() -> SettingsSnapshot {
@@ -795,12 +890,26 @@ final class AppState: ObservableObject {
     /// The only entry point for cold start, foreground refresh, reconnect, and
     /// manual refresh. It never derives liveness from transcript shape.
     func syncSession() async {
-        guard let client else { return }
+        await syncSession(using: nil)
+    }
+
+    private func syncSession(using existingReconciliationToken: UUID?) async {
+        guard let client else {
+            if let existingReconciliationToken {
+                settleReconciliation(existingReconciliationToken)
+            }
+            return
+        }
         // A notification destination always wins over automatic restoration of
         // the previously active/newest session. Check both before and after
         // the catalog fetch because a notification tap can arrive mid-launch.
-        guard PushNotificationService.shared.pendingTarget == nil else { return }
-        let token = beginReconciliation()
+        guard PushNotificationService.shared.pendingTarget == nil else {
+            if let existingReconciliationToken {
+                settleReconciliation(existingReconciliationToken)
+            }
+            return
+        }
+        let token = existingReconciliationToken ?? beginReconciliation()
         let profile = activeProfile
         let retainedActiveTurn = activeTurnCatalogSession()
         turnState = .synchronizing
@@ -817,8 +926,14 @@ final class AppState: ObservableObject {
             guard token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
-                  activeClient === client else { return }
-            guard PushNotificationService.shared.pendingTarget == nil else { return }
+                  activeClient === client else {
+                settleReconciliation(token)
+                return
+            }
+            guard PushNotificationService.shared.pendingTarget == nil else {
+                settleReconciliation(token)
+                return
+            }
             sessions = allSessions.filter { $0.source != .cron }
             cronSessions = allSessions.filter { $0.source == .cron }
 
@@ -838,9 +953,13 @@ final class AppState: ObservableObject {
             guard token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
-                  activeClient === client else { return }
+                  activeClient === client else {
+                settleReconciliation(token)
+                return
+            }
             turnState = .reconnecting
             errorMessage = "Failed to load gateway sessions: \(error.localizedDescription)"
+            settleReconciliation(token)
         }
     }
 
@@ -848,17 +967,34 @@ final class AppState: ObservableObject {
         let token = UUID()
         reconciliationToken = token
         reconciliation = nil
+        refreshActiveChatScrollSessionIdentity(isReconciling: true)
         return token
     }
 
     private func invalidateReconciliation() {
+        let wasReconciling = activeChatScrollSessionIdentity.isReconciling
         reconciliationToken = UUID()
         reconciliation = nil
+        refreshActiveChatScrollSessionIdentity(
+            isReconciling: false,
+            advanceSettledRevision: wasReconciling
+        )
+    }
+
+    private func settleReconciliation(_ token: UUID) {
+        guard token == reconciliationToken else { return }
+        let wasReconciling = activeChatScrollSessionIdentity.isReconciling
+        reconciliation = nil
+        refreshActiveChatScrollSessionIdentity(
+            isReconciling: false,
+            advanceSettledRevision: wasReconciling
+        )
     }
 
     @discardableResult
     private func reconcile(sessionId: String, using client: HermesClient, token: UUID) async -> Bool {
         reconciliation = Reconciliation(token: token, requestedSessionId: sessionId)
+        refreshActiveChatScrollSessionIdentity(isReconciling: true)
         turnState = .synchronizing
         let profile = activeProfile
 
@@ -880,11 +1016,15 @@ final class AppState: ObservableObject {
             guard token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
-                  activeClient === client else { return false }
+                  activeClient === client else {
+                settleReconciliation(token)
+                return false
+            }
 
             var context = reconciliation
             context?.resolvedSessionId = result.sessionId
             reconciliation = context
+            refreshActiveChatScrollSessionIdentity(isReconciling: true)
 
             // Do not replace a live/in-flight projection with a database read
             // that may be a few events behind. Once the turn is settled, the
@@ -925,18 +1065,21 @@ final class AppState: ObservableObject {
             await refreshContextUsage(sessionId: result.sessionId, using: client)
 
             let bufferedEvents = reconciliation?.token == token ? reconciliation?.bufferedEvents ?? [] : []
-            reconciliation = nil
             bufferedEvents.forEach(applyStreamEvent)
+            settleReconciliation(token)
             return true
 
         } catch {
             guard token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
-                  activeClient === client else { return false }
-            reconciliation = nil
+                  activeClient === client else {
+                settleReconciliation(token)
+                return false
+            }
             turnState = .reconnecting
             errorMessage = "Failed to restore this conversation: \(error.localizedDescription)"
+            settleReconciliation(token)
             return false
         }
     }
@@ -956,11 +1099,15 @@ final class AppState: ObservableObject {
             guard token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
-                  activeClient === client else { return }
+                  activeClient === client else {
+                settleReconciliation(token)
+                return
+            }
             if let returnedProfile = created.profile,
                !profilesMatch(returnedProfile, profile) {
                 turnState = .idle
                 errorMessage = "Hermes created this conversation in \(profileDisplayName(returnedProfile)), not \(profileDisplayName(profile)). It was not opened."
+                settleReconciliation(token)
                 await loadSessions(forceRefresh: true)
                 return
             }
@@ -968,6 +1115,7 @@ final class AppState: ObservableObject {
             guard !runtimeSessionID.isEmpty else {
                 turnState = .idle
                 errorMessage = "Hermes created a conversation without a session ID."
+                settleReconciliation(token)
                 return
             }
 
@@ -1011,13 +1159,18 @@ final class AppState: ObservableObject {
                 await self.loadSlashCommands()
                 await self.loadSessions()
             }
+            settleReconciliation(token)
         } catch {
             guard token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
-                  activeClient === client else { return }
+                  activeClient === client else {
+                settleReconciliation(token)
+                return
+            }
             turnState = .idle
             errorMessage = "Failed to create session: \(error.localizedDescription)"
+            settleReconciliation(token)
         }
     }
 
@@ -1248,17 +1401,23 @@ final class AppState: ObservableObject {
             voiceConversationController.setForegroundActive(true)
             guard connection != nil else { return }
             scenePhaseTask?.cancel()
+            // Publish the foreground reconciliation boundary synchronously.
+            // ChatView may receive the same scene transition before the health
+            // check task runs, so geometry alone must not restore stale rows.
+            let token = beginReconciliation()
             scenePhaseTask = Task { @MainActor [weak self] in
                 guard let self else { return }
                 if let client = self.client, client.isConnected {
                     do {
                         try await client.healthCheck()
-                        await self.syncSession()
+                        await self.syncSession(using: token)
                     } catch {
                         await self.reconnect()
+                        self.settleReconciliation(token)
                     }
                 } else {
                     await self.reconnect()
+                    self.settleReconciliation(token)
                 }
             }
 
@@ -1472,13 +1631,13 @@ final class AppState: ObservableObject {
         // through `eventBelongsToActiveSession` and repopulating the
         // cleared message array while reconciliation is in flight.
         flushPendingPresentationCache()
+        let token = beginReconciliation()
         setActiveSessionState(id: sessionId)
         messages = []
         clearStreamingText()
         activeAssistantMessageId = nil
         activeReasoningMessageId = nil
         updateActiveSessionTitle(for: sessionId)
-        let token = beginReconciliation()
         return await reconcile(sessionId: sessionId, using: client, token: token)
     }
 

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -26,7 +26,9 @@ final class AppState: ObservableObject {
     @Published var isConnecting = false
     @Published var profiles: [String] = []
     @Published private(set) var sessionFilterOrder: [SessionSource] = [.chat, .discord, .telegram, .api, .webhook, .other]
-    @Published private(set) var activeProfile: String = "default"
+    @Published private(set) var activeProfile: String = "default" {
+        didSet { refreshActiveChatScrollSessionIdentity() }
+    }
     @Published private(set) var defaultProfileName: String
     @Published private(set) var profileAvatarURLs: [String: URL]
     @Published private(set) var isProfileSwitching = false
@@ -211,7 +213,6 @@ final class AppState: ObservableObject {
 
     private var reconciliationToken = UUID()
     private var reconciliation: Reconciliation?
-    private var chatScrollIdentityProfile = "default"
     private var activeClientEpoch = UUID()
     private var activeAssistantMessageId: String?
     private var activeReasoningMessageId: String?
@@ -490,86 +491,26 @@ final class AppState: ObservableObject {
         advanceSettledRevision: Bool = false
     ) {
         let current = activeChatScrollSessionIdentity
-        let previous = chatScrollIdentityProfile == activeProfile
-            ? current
-            : ChatScrollSessionIdentity(
-                canonicalSessionID: nil,
-                equivalentSessionIDs: [],
-                isReconciling: current.isReconciling,
-                settledRevision: current.settledRevision
-            )
-        let catalog = sessions + cronSessions
-        func identifiers(for session: SessionSummary) -> Set<String> {
-            Set(([session.id] + session.alternateIds).compactMap(Self.normalizedSessionIdentityID))
-        }
-        func matchingSession(for ids: Set<String>) -> SessionSummary? {
-            guard !ids.isEmpty else { return nil }
-            return catalog.first { !identifiers(for: $0).isDisjoint(with: ids) }
-        }
-
-        let activeID = Self.normalizedSessionIdentityID(activeSessionId)
-        let reconciliationIDs = Set([
-            reconciliation?.requestedSessionId,
-            reconciliation?.resolvedSessionId
-        ].compactMap(Self.normalizedSessionIdentityID))
-        let reconciliationSession = matchingSession(for: reconciliationIDs)
-        let reconciliationCatalogIDs = reconciliationSession.map(identifiers) ?? []
-        let reconciliationContinuesPrevious = reconciliationIDs.isEmpty
-            || reconciliationIDs.contains(where: previous.contains)
-            || !reconciliationCatalogIDs.isDisjoint(with: previous.equivalentSessionIDs)
-            || activeID.map(reconciliationCatalogIDs.contains) == true
-
-        var candidates = reconciliationIDs
-        if reconciliationIDs.isEmpty || reconciliationContinuesPrevious,
-           let activeID {
-            candidates.insert(activeID)
-        }
-        let matchedSession = reconciliationSession ?? matchingSession(for: candidates)
-        let continuesPreviousIdentity = candidates.contains(where: previous.contains)
-
-        let canonicalSessionID: String?
-        if let matchedSession {
-            canonicalSessionID = matchedSession.id
-        } else if continuesPreviousIdentity {
-            canonicalSessionID = previous.canonicalSessionID
-        } else if !reconciliationIDs.isEmpty {
-            canonicalSessionID = Self.normalizedSessionIdentityID(reconciliation?.requestedSessionId)
-                ?? Self.normalizedSessionIdentityID(reconciliation?.resolvedSessionId)
-                ?? activeID
-        } else {
-            canonicalSessionID = activeID
-        }
-
-        var equivalentSessionIDs = candidates
-        if let matchedSession {
-            equivalentSessionIDs.formUnion(
-                ([matchedSession.id] + matchedSession.alternateIds)
-                    .compactMap(Self.normalizedSessionIdentityID)
+        let catalog = (sessions + cronSessions).map { session in
+            ChatScrollSessionCatalogIdentity(
+                profile: session.profile ?? activeProfile,
+                canonicalSessionID: session.id,
+                alternateSessionIDs: Set(session.alternateIds)
             )
         }
-        if continuesPreviousIdentity {
-            equivalentSessionIDs.formUnion(previous.equivalentSessionIDs)
-        }
-
-        let revision = advanceSettledRevision
-            ? current.settledRevision &+ 1
-            : current.settledRevision
-        let updated = ChatScrollSessionIdentity(
-            canonicalSessionID: canonicalSessionID,
-            equivalentSessionIDs: equivalentSessionIDs,
+        let updated = ChatScrollSessionIdentityResolver.resolve(
+            profile: activeProfile,
+            activeSessionID: activeSessionId,
+            catalog: catalog,
+            requestedSessionID: reconciliation?.requestedSessionId,
+            resolvedSessionID: reconciliation?.resolvedSessionId,
+            previousIdentity: current,
             isReconciling: isReconciling ?? current.isReconciling,
-            settledRevision: revision
+            advanceSettledRevision: advanceSettledRevision
         )
-        chatScrollIdentityProfile = activeProfile
         if updated != current {
             activeChatScrollSessionIdentity = updated
         }
-    }
-
-    private static func normalizedSessionIdentityID(_ sessionID: String?) -> String? {
-        guard let value = sessionID?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !value.isEmpty else { return nil }
-        return value
     }
 
     func makeSettingsSnapshot() -> SettingsSnapshot {

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -1,10 +1,187 @@
 import Foundation
 
+struct ChatMessageScrollTarget: Identifiable, Equatable {
+    let message: ChatMessage
+    let semanticID: String
+
+    /// SwiftUI keeps the existing source-row identity for rendering and
+    /// controls. Only scroll targeting uses the source-independent ID.
+    var id: String { message.id }
+}
+
+enum ChatMessageScrollTargets {
+    static func make(for messages: [ChatMessage]) -> [ChatMessageScrollTarget] {
+        var occurrences: [String: Int] = [:]
+        return messages.map { message in
+            let fingerprint = fingerprint(for: message)
+            let occurrence = occurrences[fingerprint, default: 0]
+            occurrences[fingerprint] = occurrence + 1
+            return ChatMessageScrollTarget(
+                message: message,
+                semanticID: "chat-message-\(fingerprint)-\(occurrence)"
+            )
+        }
+    }
+
+    private static func fingerprint(for message: ChatMessage) -> String {
+        var fingerprint = DeterministicChatFingerprint()
+        fingerprint.append("chat-message-v1")
+        fingerprint.append(message.role.rawValue)
+        fingerprint.append(message.content)
+        fingerprint.append(message.code)
+
+        fingerprint.append(message.tool?.name)
+        fingerprint.append(message.tool?.input)
+
+        fingerprint.append(message.clarify?.question)
+        fingerprint.append(message.clarify?.choices.count)
+        message.clarify?.choices.forEach { choice in
+            fingerprint.append(choice.label)
+            fingerprint.append(choice.value)
+        }
+
+        fingerprint.append(message.approval?.command)
+        fingerprint.append(message.approval?.description)
+        fingerprint.append(message.approval?.choices?.count)
+        message.approval?.choices?.forEach { fingerprint.append($0) }
+        fingerprint.append(message.approval?.allowPermanent)
+        fingerprint.append(message.approval?.smartDenied)
+
+        fingerprint.append(message.review?.summary)
+        fingerprint.append(message.review?.details?.count)
+        message.review?.details?.forEach { fingerprint.append($0) }
+
+        fingerprint.append(message.attachments?.count)
+        message.attachments?.forEach { attachment in
+            // Picker/cache IDs and local/gateway URIs change across transcript
+            // projections. These presentation fields remain source-stable.
+            fingerprint.append(attachment.kind.rawValue)
+            fingerprint.append(attachment.name)
+            fingerprint.append(attachment.mimeType)
+        }
+
+        return fingerprint.value
+    }
+}
+
+struct ChatScrollSessionIdentity: Equatable {
+    let canonicalSessionID: String?
+    let equivalentSessionIDs: Set<String>
+    let isReconciling: Bool
+    let settledRevision: UInt64
+
+    static let none = ChatScrollSessionIdentity(
+        canonicalSessionID: nil,
+        equivalentSessionIDs: [],
+        isReconciling: false,
+        settledRevision: 0
+    )
+
+    init(
+        canonicalSessionID: String?,
+        equivalentSessionIDs: Set<String>,
+        isReconciling: Bool,
+        settledRevision: UInt64
+    ) {
+        let canonical = Self.normalized(canonicalSessionID)
+        var equivalents = Set(equivalentSessionIDs.compactMap(Self.normalized))
+        if let canonical { equivalents.insert(canonical) }
+        self.canonicalSessionID = canonical
+        self.equivalentSessionIDs = equivalents
+        self.isReconciling = isReconciling
+        self.settledRevision = settledRevision
+    }
+
+    func contains(_ sessionID: String?) -> Bool {
+        guard let sessionID = Self.normalized(sessionID) else { return false }
+        return equivalentSessionIDs.contains(sessionID)
+    }
+
+    func areEquivalent(_ lhs: String?, _ rhs: String?) -> Bool {
+        guard let lhs = Self.normalized(lhs),
+              let rhs = Self.normalized(rhs) else { return false }
+        if lhs == rhs { return true }
+        return equivalentSessionIDs.contains(lhs) && equivalentSessionIDs.contains(rhs)
+    }
+
+    private static func normalized(_ sessionID: String?) -> String? {
+        guard let value = sessionID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else { return nil }
+        return value
+    }
+}
+
+struct ChatScrollRestorationGate: Equatable {
+    let observedSettledRevision: UInt64
+    let requiresSettledRevisionAdvance: Bool
+
+    init(
+        observing identity: ChatScrollSessionIdentity,
+        reconciliationExpected: Bool = false
+    ) {
+        observedSettledRevision = identity.settledRevision
+        requiresSettledRevisionAdvance = identity.isReconciling || reconciliationExpected
+    }
+
+    func allowsNonLatestRestoration(using identity: ChatScrollSessionIdentity) -> Bool {
+        guard !identity.isReconciling else { return false }
+        return !requiresSettledRevisionAdvance
+            || identity.settledRevision > observedSettledRevision
+    }
+}
+
 struct ChatScrollSnapshot: Equatable {
     let anchorMessageID: String?
     let followsLatest: Bool
 
     static let latest = ChatScrollSnapshot(anchorMessageID: nil, followsLatest: true)
+}
+
+private struct DeterministicChatFingerprint {
+    private var first: UInt64 = 14_695_981_039_346_656_037
+    private var second: UInt64 = 7_809_847_782_465_536_322
+
+    var value: String {
+        paddedHex(first) + paddedHex(second)
+    }
+
+    mutating func append(_ value: String?) {
+        guard let value else {
+            append(byte: 0)
+            return
+        }
+        append(byte: 1)
+        append(length: value.utf8.count)
+        value.utf8.forEach { append(byte: $0) }
+    }
+
+    mutating func append(_ value: Int?) {
+        append(value.map(String.init))
+    }
+
+    mutating func append(_ value: Bool?) {
+        append(value.map { $0 ? "true" : "false" })
+    }
+
+    private mutating func append(length: Int) {
+        var length = UInt64(length)
+        for _ in 0..<MemoryLayout<UInt64>.size {
+            append(byte: UInt8(truncatingIfNeeded: length))
+            length >>= 8
+        }
+    }
+
+    private mutating func append(byte: UInt8) {
+        first ^= UInt64(byte)
+        first &*= 1_099_511_628_211
+        second ^= UInt64(byte)
+        second &*= 14_029_467_366_897_019_727
+    }
+
+    private func paddedHex(_ value: UInt64) -> String {
+        let hex = String(value, radix: 16)
+        return String(repeating: "0", count: 16 - hex.count) + hex
+    }
 }
 
 struct ChatScrollStateStore {

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+struct ChatScrollSnapshot: Equatable {
+    let anchorMessageID: String?
+    let followsLatest: Bool
+
+    static let latest = ChatScrollSnapshot(anchorMessageID: nil, followsLatest: true)
+}
+
+struct ChatScrollStateStore {
+    private var snapshots: [String: ChatScrollSnapshot] = [:]
+
+    mutating func save(_ snapshot: ChatScrollSnapshot, for sessionID: String) {
+        let key = sessionID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !key.isEmpty else { return }
+        snapshots[key] = snapshot
+    }
+
+    func snapshot(for sessionID: String) -> ChatScrollSnapshot? {
+        snapshots[sessionID.trimmingCharacters(in: .whitespacesAndNewlines)]
+    }
+
+    func restoration(
+        for sessionID: String,
+        availableMessageIDs: Set<String>
+    ) -> ChatScrollSnapshot? {
+        guard let snapshot = snapshot(for: sessionID) else { return nil }
+        guard !snapshot.followsLatest else { return .latest }
+        guard let anchor = snapshot.anchorMessageID,
+              availableMessageIDs.contains(anchor) else {
+            return .latest
+        }
+        return snapshot
+    }
+}

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -1,8 +1,14 @@
 import Foundation
 
+struct ChatScrollAnchorMetadata: Equatable {
+    let fingerprint: String
+    let duplicateCount: Int
+}
+
 struct ChatMessageScrollTarget: Identifiable, Equatable {
     let message: ChatMessage
     let semanticID: String
+    let restorationMetadata: ChatScrollAnchorMetadata
 
     /// SwiftUI keeps the existing source-row identity for rendering and
     /// controls. Only scroll targeting uses the source-independent ID.
@@ -15,6 +21,20 @@ enum ChatMessageScrollTargetCacheUpdate: Equatable {
     case semanticsChanged
 }
 
+enum ChatMessageScrollUpdatePolicy {
+    static func shouldReassertLatest(
+        after update: ChatMessageScrollTargetCacheUpdate,
+        followsLatest: Bool,
+        hasPendingNonLatestRestoration: Bool,
+        hasNotificationHandoff: Bool
+    ) -> Bool {
+        update != .unchanged
+            && followsLatest
+            && !hasPendingNonLatestRestoration
+            && !hasNotificationHandoff
+    }
+}
+
 struct ChatMessageScrollTargetCache: Equatable {
     private(set) var targets: [ChatMessageScrollTarget] = []
     private var fingerprints: [String] = []
@@ -25,7 +45,11 @@ struct ChatMessageScrollTargetCache: Equatable {
         if updatedFingerprints == fingerprints, targets.count == messages.count {
             guard targets.map(\.message) != messages else { return .unchanged }
             targets = zip(messages, targets).map { message, target in
-                ChatMessageScrollTarget(message: message, semanticID: target.semanticID)
+                ChatMessageScrollTarget(
+                    message: message,
+                    semanticID: target.semanticID,
+                    restorationMetadata: target.restorationMetadata
+                )
             }
             return .renderingChanged
         }
@@ -52,13 +76,20 @@ enum ChatMessageScrollTargets {
         for messages: [ChatMessage],
         fingerprints: [String]
     ) -> [ChatMessageScrollTarget] {
+        let duplicateCounts = fingerprints.reduce(into: [String: Int]()) { counts, fingerprint in
+            counts[fingerprint, default: 0] += 1
+        }
         var occurrences: [String: Int] = [:]
         return zip(messages, fingerprints).map { message, fingerprint in
             let occurrence = occurrences[fingerprint, default: 0]
             occurrences[fingerprint] = occurrence + 1
             return ChatMessageScrollTarget(
                 message: message,
-                semanticID: "chat-message-\(fingerprint)-\(occurrence)"
+                semanticID: "chat-message-\(fingerprint)-\(occurrence)",
+                restorationMetadata: ChatScrollAnchorMetadata(
+                    fingerprint: fingerprint,
+                    duplicateCount: duplicateCounts[fingerprint, default: 0]
+                )
             )
         }
     }
@@ -343,9 +374,46 @@ struct ChatScrollRestorationGate: Equatable {
     }
 }
 
+struct ChatScrollTargetAvailability: Equatable {
+    private let messageIDs: Set<String>
+    private let metadataByMessageID: [String: ChatScrollAnchorMetadata]
+
+    init(targets: [ChatMessageScrollTarget]) {
+        messageIDs = Set(targets.map(\.semanticID))
+        metadataByMessageID = Dictionary(
+            targets.map { ($0.semanticID, $0.restorationMetadata) },
+            uniquingKeysWith: { existing, _ in existing }
+        )
+    }
+
+    init(messageIDs: Set<String>) {
+        self.messageIDs = messageIDs
+        metadataByMessageID = [:]
+    }
+
+    fileprivate func contains(_ messageID: String) -> Bool {
+        messageIDs.contains(messageID)
+    }
+
+    fileprivate func metadata(for messageID: String) -> ChatScrollAnchorMetadata? {
+        metadataByMessageID[messageID]
+    }
+}
+
 struct ChatScrollSnapshot: Equatable {
     let anchorMessageID: String?
     let followsLatest: Bool
+    let anchorMetadata: ChatScrollAnchorMetadata?
+
+    init(
+        anchorMessageID: String?,
+        followsLatest: Bool,
+        anchorMetadata: ChatScrollAnchorMetadata? = nil
+    ) {
+        self.anchorMessageID = anchorMessageID
+        self.followsLatest = followsLatest
+        self.anchorMetadata = anchorMetadata
+    }
 
     static let latest = ChatScrollSnapshot(anchorMessageID: nil, followsLatest: true)
 }
@@ -371,6 +439,22 @@ enum ChatScrollRestorationResolver {
         store: ChatScrollStateStore,
         availableMessageIDs: Set<String>
     ) -> ChatScrollRestorationDecision {
+        decision(
+            for: pending,
+            identity: identity,
+            activeSessionKey: activeSessionKey,
+            store: store,
+            availableTargets: ChatScrollTargetAvailability(messageIDs: availableMessageIDs)
+        )
+    }
+
+    static func decision(
+        for pending: ChatScrollPendingRestoration,
+        identity: ChatScrollSessionIdentity,
+        activeSessionKey: ChatScrollSessionKey?,
+        store: ChatScrollStateStore,
+        availableTargets: ChatScrollTargetAvailability
+    ) -> ChatScrollRestorationDecision {
         guard identity.areEquivalent(pending.sessionKey, activeSessionKey) else {
             return .cancel
         }
@@ -380,7 +464,7 @@ enum ChatScrollRestorationResolver {
         }
         guard let resolved = store.restoration(
             for: pending.sessionKey,
-            availableMessageIDs: availableMessageIDs
+            availableTargets: availableTargets
         ) else {
             return .cancel
         }
@@ -454,10 +538,24 @@ struct ChatScrollStateStore {
         for key: ChatScrollSessionKey,
         availableMessageIDs: Set<String>
     ) -> ChatScrollSnapshot? {
+        restoration(
+            for: key,
+            availableTargets: ChatScrollTargetAvailability(messageIDs: availableMessageIDs)
+        )
+    }
+
+    func restoration(
+        for key: ChatScrollSessionKey,
+        availableTargets: ChatScrollTargetAvailability
+    ) -> ChatScrollSnapshot? {
         guard let snapshot = snapshot(for: key) else { return nil }
         guard !snapshot.followsLatest else { return .latest }
         guard let anchor = snapshot.anchorMessageID,
-              availableMessageIDs.contains(anchor) else {
+              availableTargets.contains(anchor) else {
+            return .latest
+        }
+        if let expectedMetadata = snapshot.anchorMetadata,
+           availableTargets.metadata(for: anchor) != expectedMetadata {
             return .latest
         }
         return snapshot

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -9,11 +9,51 @@ struct ChatMessageScrollTarget: Identifiable, Equatable {
     var id: String { message.id }
 }
 
+enum ChatMessageScrollTargetCacheUpdate: Equatable {
+    case unchanged
+    case renderingChanged
+    case semanticsChanged
+}
+
+struct ChatMessageScrollTargetCache: Equatable {
+    private(set) var targets: [ChatMessageScrollTarget] = []
+    private var fingerprints: [String] = []
+
+    @discardableResult
+    mutating func update(for messages: [ChatMessage]) -> ChatMessageScrollTargetCacheUpdate {
+        let updatedFingerprints = ChatMessageScrollTargets.fingerprints(for: messages)
+        if updatedFingerprints == fingerprints, targets.count == messages.count {
+            guard targets.map(\.message) != messages else { return .unchanged }
+            targets = zip(messages, targets).map { message, target in
+                ChatMessageScrollTarget(message: message, semanticID: target.semanticID)
+            }
+            return .renderingChanged
+        }
+
+        fingerprints = updatedFingerprints
+        targets = ChatMessageScrollTargets.make(
+            for: messages,
+            fingerprints: updatedFingerprints
+        )
+        return .semanticsChanged
+    }
+}
+
 enum ChatMessageScrollTargets {
     static func make(for messages: [ChatMessage]) -> [ChatMessageScrollTarget] {
+        make(for: messages, fingerprints: fingerprints(for: messages))
+    }
+
+    fileprivate static func fingerprints(for messages: [ChatMessage]) -> [String] {
+        messages.map(fingerprint)
+    }
+
+    fileprivate static func make(
+        for messages: [ChatMessage],
+        fingerprints: [String]
+    ) -> [ChatMessageScrollTarget] {
         var occurrences: [String: Int] = [:]
-        return messages.map { message in
-            let fingerprint = fingerprint(for: message)
+        return zip(messages, fingerprints).map { message, fingerprint in
             let occurrence = occurrences[fingerprint, default: 0]
             occurrences[fingerprint] = occurrence + 1
             return ChatMessageScrollTarget(
@@ -31,7 +71,6 @@ enum ChatMessageScrollTargets {
         fingerprint.append(message.code)
 
         fingerprint.append(message.tool?.name)
-        fingerprint.append(message.tool?.input)
 
         fingerprint.append(message.clarify?.question)
         fingerprint.append(message.clarify?.choices.count)
@@ -64,13 +103,72 @@ enum ChatMessageScrollTargets {
     }
 }
 
+private enum ChatScrollIdentityNormalization {
+    static func profile(_ profile: String?) -> String? {
+        guard let value = profile?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else { return nil }
+        return value.lowercased()
+    }
+
+    static func sessionID(_ sessionID: String?) -> String? {
+        guard let value = sessionID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else { return nil }
+        return value
+    }
+}
+
+struct ChatScrollSessionKey: Hashable {
+    let profile: String
+    let sessionID: String
+
+    init(profile: String, sessionID: String) {
+        self.profile = ChatScrollIdentityNormalization.profile(profile) ?? ""
+        self.sessionID = ChatScrollIdentityNormalization.sessionID(sessionID) ?? ""
+    }
+
+    var isValid: Bool {
+        !profile.isEmpty && !sessionID.isEmpty
+    }
+}
+
+struct ChatScrollSessionCatalogIdentity: Equatable {
+    let profile: String
+    let canonicalSessionID: String
+    let alternateSessionIDs: Set<String>
+
+    init(
+        profile: String,
+        canonicalSessionID: String,
+        alternateSessionIDs: Set<String>
+    ) {
+        self.profile = ChatScrollIdentityNormalization.profile(profile) ?? ""
+        self.canonicalSessionID = ChatScrollIdentityNormalization.sessionID(canonicalSessionID) ?? ""
+        self.alternateSessionIDs = Set(
+            alternateSessionIDs.compactMap(ChatScrollIdentityNormalization.sessionID)
+        )
+    }
+
+    fileprivate var identifiers: Set<String> {
+        guard !canonicalSessionID.isEmpty else { return [] }
+        var result = alternateSessionIDs
+        result.insert(canonicalSessionID)
+        return result
+    }
+
+    fileprivate var isValid: Bool {
+        !canonicalSessionID.isEmpty
+    }
+}
+
 struct ChatScrollSessionIdentity: Equatable {
+    let profile: String?
     let canonicalSessionID: String?
     let equivalentSessionIDs: Set<String>
     let isReconciling: Bool
     let settledRevision: UInt64
 
     static let none = ChatScrollSessionIdentity(
+        profile: nil,
         canonicalSessionID: nil,
         equivalentSessionIDs: [],
         isReconciling: false,
@@ -78,36 +176,151 @@ struct ChatScrollSessionIdentity: Equatable {
     )
 
     init(
+        profile: String?,
         canonicalSessionID: String?,
         equivalentSessionIDs: Set<String>,
         isReconciling: Bool,
         settledRevision: UInt64
     ) {
-        let canonical = Self.normalized(canonicalSessionID)
-        var equivalents = Set(equivalentSessionIDs.compactMap(Self.normalized))
+        let normalizedProfile = ChatScrollIdentityNormalization.profile(profile)
+        let canonical = ChatScrollIdentityNormalization.sessionID(canonicalSessionID)
+        var equivalents = Set(
+            equivalentSessionIDs.compactMap(ChatScrollIdentityNormalization.sessionID)
+        )
         if let canonical { equivalents.insert(canonical) }
+        self.profile = normalizedProfile
         self.canonicalSessionID = canonical
         self.equivalentSessionIDs = equivalents
         self.isReconciling = isReconciling
         self.settledRevision = settledRevision
     }
 
+    var canonicalSessionKey: ChatScrollSessionKey? {
+        key(for: canonicalSessionID)
+    }
+
+    func key(for sessionID: String?) -> ChatScrollSessionKey? {
+        guard let profile,
+              let sessionID = ChatScrollIdentityNormalization.sessionID(sessionID) else {
+            return nil
+        }
+        let key = ChatScrollSessionKey(profile: profile, sessionID: sessionID)
+        return key.isValid ? key : nil
+    }
+
     func contains(_ sessionID: String?) -> Bool {
-        guard let sessionID = Self.normalized(sessionID) else { return false }
+        guard let sessionID = ChatScrollIdentityNormalization.sessionID(sessionID) else {
+            return false
+        }
         return equivalentSessionIDs.contains(sessionID)
     }
 
+    func contains(_ key: ChatScrollSessionKey?) -> Bool {
+        guard let key, key.isValid, key.profile == profile else { return false }
+        return equivalentSessionIDs.contains(key.sessionID)
+    }
+
     func areEquivalent(_ lhs: String?, _ rhs: String?) -> Bool {
-        guard let lhs = Self.normalized(lhs),
-              let rhs = Self.normalized(rhs) else { return false }
+        guard let lhs = ChatScrollIdentityNormalization.sessionID(lhs),
+              let rhs = ChatScrollIdentityNormalization.sessionID(rhs) else {
+            return false
+        }
         if lhs == rhs { return true }
         return equivalentSessionIDs.contains(lhs) && equivalentSessionIDs.contains(rhs)
     }
 
-    private static func normalized(_ sessionID: String?) -> String? {
-        guard let value = sessionID?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !value.isEmpty else { return nil }
-        return value
+    func areEquivalent(_ lhs: ChatScrollSessionKey?, _ rhs: ChatScrollSessionKey?) -> Bool {
+        guard let lhs, let rhs,
+              lhs.isValid, rhs.isValid,
+              lhs.profile == profile,
+              rhs.profile == profile else {
+            return false
+        }
+        if lhs == rhs { return true }
+        return equivalentSessionIDs.contains(lhs.sessionID)
+            && equivalentSessionIDs.contains(rhs.sessionID)
+    }
+}
+
+enum ChatScrollSessionIdentityResolver {
+    static func resolve(
+        profile: String,
+        activeSessionID: String?,
+        catalog: [ChatScrollSessionCatalogIdentity],
+        requestedSessionID: String? = nil,
+        resolvedSessionID: String? = nil,
+        previousIdentity current: ChatScrollSessionIdentity,
+        isReconciling: Bool,
+        advanceSettledRevision: Bool = false
+    ) -> ChatScrollSessionIdentity {
+        let normalizedProfile = ChatScrollIdentityNormalization.profile(profile)
+        let previous = current.profile == normalizedProfile
+            ? current
+            : ChatScrollSessionIdentity(
+                profile: normalizedProfile,
+                canonicalSessionID: nil,
+                equivalentSessionIDs: [],
+                isReconciling: current.isReconciling,
+                settledRevision: current.settledRevision
+            )
+        let profileCatalog = catalog.filter {
+            $0.isValid && ($0.profile.isEmpty || $0.profile == normalizedProfile)
+        }
+        func matchingSession(for ids: Set<String>) -> ChatScrollSessionCatalogIdentity? {
+            guard !ids.isEmpty else { return nil }
+            return profileCatalog.first { !$0.identifiers.isDisjoint(with: ids) }
+        }
+
+        let activeID = ChatScrollIdentityNormalization.sessionID(activeSessionID)
+        let reconciliationIDs = Set(
+            [requestedSessionID, resolvedSessionID]
+                .compactMap(ChatScrollIdentityNormalization.sessionID)
+        )
+        let reconciliationSession = matchingSession(for: reconciliationIDs)
+        let reconciliationCatalogIDs = reconciliationSession?.identifiers ?? []
+        let reconciliationContinuesPrevious = reconciliationIDs.isEmpty
+            || reconciliationIDs.contains(where: previous.contains)
+            || !reconciliationCatalogIDs.isDisjoint(with: previous.equivalentSessionIDs)
+            || activeID.map(reconciliationCatalogIDs.contains) == true
+
+        var candidates = reconciliationIDs
+        if reconciliationIDs.isEmpty || reconciliationContinuesPrevious,
+           let activeID {
+            candidates.insert(activeID)
+        }
+        let matchedSession = reconciliationSession ?? matchingSession(for: candidates)
+        let continuesPreviousIdentity = candidates.contains(where: previous.contains)
+
+        let canonicalSessionID: String?
+        if let matchedSession {
+            canonicalSessionID = matchedSession.canonicalSessionID
+        } else if continuesPreviousIdentity {
+            canonicalSessionID = previous.canonicalSessionID
+        } else if !reconciliationIDs.isEmpty {
+            canonicalSessionID = ChatScrollIdentityNormalization.sessionID(requestedSessionID)
+                ?? ChatScrollIdentityNormalization.sessionID(resolvedSessionID)
+                ?? activeID
+        } else {
+            canonicalSessionID = activeID
+        }
+
+        var equivalentSessionIDs = candidates
+        if let matchedSession {
+            equivalentSessionIDs.formUnion(matchedSession.identifiers)
+        }
+        if continuesPreviousIdentity {
+            equivalentSessionIDs.formUnion(previous.equivalentSessionIDs)
+        }
+
+        return ChatScrollSessionIdentity(
+            profile: normalizedProfile,
+            canonicalSessionID: canonicalSessionID,
+            equivalentSessionIDs: equivalentSessionIDs,
+            isReconciling: isReconciling,
+            settledRevision: advanceSettledRevision
+                ? current.settledRevision &+ 1
+                : current.settledRevision
+        )
     }
 }
 
@@ -135,6 +348,46 @@ struct ChatScrollSnapshot: Equatable {
     let followsLatest: Bool
 
     static let latest = ChatScrollSnapshot(anchorMessageID: nil, followsLatest: true)
+}
+
+struct ChatScrollPendingRestoration: Equatable {
+    let sessionKey: ChatScrollSessionKey
+    let snapshot: ChatScrollSnapshot
+    let gate: ChatScrollRestorationGate
+}
+
+enum ChatScrollRestorationDecision: Equatable {
+    case wait
+    case cancel
+    case latest
+    case anchor(String)
+}
+
+enum ChatScrollRestorationResolver {
+    static func decision(
+        for pending: ChatScrollPendingRestoration,
+        identity: ChatScrollSessionIdentity,
+        activeSessionKey: ChatScrollSessionKey?,
+        store: ChatScrollStateStore,
+        availableMessageIDs: Set<String>
+    ) -> ChatScrollRestorationDecision {
+        guard identity.areEquivalent(pending.sessionKey, activeSessionKey) else {
+            return .cancel
+        }
+        guard !pending.snapshot.followsLatest else { return .latest }
+        guard pending.gate.allowsNonLatestRestoration(using: identity) else {
+            return .wait
+        }
+        guard let resolved = store.restoration(
+            for: pending.sessionKey,
+            availableMessageIDs: availableMessageIDs
+        ) else {
+            return .cancel
+        }
+        if resolved.followsLatest { return .latest }
+        guard let anchor = resolved.anchorMessageID else { return .latest }
+        return .anchor(anchor)
+    }
 }
 
 private struct DeterministicChatFingerprint {
@@ -185,23 +438,23 @@ private struct DeterministicChatFingerprint {
 }
 
 struct ChatScrollStateStore {
-    private var snapshots: [String: ChatScrollSnapshot] = [:]
+    private var snapshots: [ChatScrollSessionKey: ChatScrollSnapshot] = [:]
 
-    mutating func save(_ snapshot: ChatScrollSnapshot, for sessionID: String) {
-        let key = sessionID.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !key.isEmpty else { return }
+    mutating func save(_ snapshot: ChatScrollSnapshot, for key: ChatScrollSessionKey) {
+        guard key.isValid else { return }
         snapshots[key] = snapshot
     }
 
-    func snapshot(for sessionID: String) -> ChatScrollSnapshot? {
-        snapshots[sessionID.trimmingCharacters(in: .whitespacesAndNewlines)]
+    func snapshot(for key: ChatScrollSessionKey) -> ChatScrollSnapshot? {
+        guard key.isValid else { return nil }
+        return snapshots[key]
     }
 
     func restoration(
-        for sessionID: String,
+        for key: ChatScrollSessionKey,
         availableMessageIDs: Set<String>
     ) -> ChatScrollSnapshot? {
-        guard let snapshot = snapshot(for: sessionID) else { return nil }
+        guard let snapshot = snapshot(for: key) else { return nil }
         guard !snapshot.followsLatest else { return .latest }
         guard let anchor = snapshot.anchorMessageID,
               availableMessageIDs.contains(anchor) else {

--- a/Conduit/Services/ChatTextSelectionPolicy.swift
+++ b/Conduit/Services/ChatTextSelectionPolicy.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum ChatTextSelectionPolicy {
+    static func allowsTextSelection(for role: MessageRole) -> Bool {
+        switch role {
+        case .user, .assistant, .reasoning, .system,
+             .partial, .tool, .clarify, .approval:
+            return true
+        }
+    }
+}

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -93,9 +93,9 @@ struct ChatView: View {
                             .padding(.bottom, 126)
                             .id(bottomAnchor)
                     }
+                    .scrollTargetLayout()
                     .padding(.horizontal, 18)
                     .padding(.top, 18)
-                    .scrollTargetLayout()
                     .background {
                         // Measure the lazy stack itself, not its final child.
                         // SwiftUI can unload that child after the user scrolls
@@ -146,20 +146,34 @@ struct ChatView: View {
                         finishChatScrollRestorationIfReady(using: proxy)
                     }
                 }
-                .onChange(of: appState.messages) { oldMessages, newMessages in
-                    chatMessageScrollTargetCache.update(for: newMessages)
+                .onChange(of: appState.messages) { _, newMessages in
+                    let cacheUpdate = chatMessageScrollTargetCache.update(for: newMessages)
+                    let hasNotificationHandoff = appState.isOpeningNotificationSession
+                        || notificationHandoffPending
                     if pendingScrollRestoration != nil,
-                       !appState.isOpeningNotificationSession {
+                       !hasNotificationHandoff {
                         DispatchQueue.main.async {
                             finishChatScrollRestorationIfReady(using: proxy)
                         }
                     }
-                    guard oldMessages.count != newMessages.count else { return }
                     guard !appState.isOpeningNotificationSession else {
                         notificationHandoffPending = true
                         return
                     }
-                    if followsLatest {
+                    guard ChatMessageScrollUpdatePolicy.shouldReassertLatest(
+                        after: cacheUpdate,
+                        followsLatest: followsLatest,
+                        hasPendingNonLatestRestoration: hasPendingNonLatestRestoration,
+                        hasNotificationHandoff: notificationHandoffPending
+                    ) else { return }
+                    DispatchQueue.main.async {
+                        guard ChatMessageScrollUpdatePolicy.shouldReassertLatest(
+                            after: cacheUpdate,
+                            followsLatest: followsLatest,
+                            hasPendingNonLatestRestoration: hasPendingNonLatestRestoration,
+                            hasNotificationHandoff: appState.isOpeningNotificationSession
+                                || notificationHandoffPending
+                        ) else { return }
                         scrollToLatest(using: proxy)
                     }
                 }
@@ -296,14 +310,14 @@ struct ChatView: View {
 
     private func saveChatScrollPosition() {
         guard let sessionKey = activeScrollSessionKey else { return }
-        let messageIDs = Set(chatMessageScrollTargetCache.targets.map(\.semanticID))
-        let anchor = messageIDs.contains(topVisibleChatID ?? "")
-            ? topVisibleChatID
-            : nil
+        let anchorTarget = chatMessageScrollTargetCache.targets.first {
+            $0.semanticID == topVisibleChatID
+        }
         chatScrollState.save(
             ChatScrollSnapshot(
-                anchorMessageID: followsLatest ? nil : anchor,
-                followsLatest: followsLatest
+                anchorMessageID: followsLatest ? nil : anchorTarget?.semanticID,
+                followsLatest: followsLatest,
+                anchorMetadata: followsLatest ? nil : anchorTarget?.restorationMetadata
             ),
             for: sessionKey
         )
@@ -343,7 +357,9 @@ struct ChatView: View {
             identity: identity,
             activeSessionKey: activeScrollSessionKey,
             store: chatScrollState,
-            availableMessageIDs: Set(chatMessageScrollTargetCache.targets.map(\.semanticID))
+            availableTargets: ChatScrollTargetAvailability(
+                targets: chatMessageScrollTargetCache.targets
+            )
         )
 
         switch decision {

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -21,7 +21,12 @@ struct ChatView: View {
     @State private var notificationHandoffSessionID: String?
     @State private var notificationHandoffHasMeasuredLayout = false
 
-    private var bottomAnchor: String { "chat-latest-\(appState.activeSessionId ?? "new")" }
+    private var activeScrollSessionID: String? {
+        appState.activeChatScrollSessionIdentity.canonicalSessionID
+            ?? appState.activeSessionId
+    }
+
+    private var bottomAnchor: String { "chat-latest-\(activeScrollSessionID ?? "new")" }
 
     private var isNearBottom: Bool {
         guard let bottomMarkerMaxY, let scrollViewportMaxY else { return true }
@@ -30,7 +35,10 @@ struct ChatView: View {
 
     private var hasPendingNonLatestRestoration: Bool {
         guard let pendingScrollRestoration,
-              pendingScrollRestoration.sessionID == appState.activeSessionId else {
+              appState.activeChatScrollSessionIdentity.areEquivalent(
+                pendingScrollRestoration.sessionID,
+                activeScrollSessionID
+              ) else {
             return false
         }
         return !pendingScrollRestoration.snapshot.followsLatest
@@ -46,8 +54,8 @@ struct ChatView: View {
                             EmptyChatState().padding(.top, 60)
                         }
 
-                        ForEach(appState.messages) { message in
-                            MessageBubble(message: message).id(message.id)
+                        ForEach(ChatMessageScrollTargets.make(for: appState.messages)) { target in
+                            MessageBubble(message: target.message).id(target.semanticID)
                         }
 
                         if !appState.streamingText.isEmpty {
@@ -135,16 +143,29 @@ struct ChatView: View {
                     followsLatest = true
                     scrollToLatest(using: proxy)
                 }
-                .onChange(of: appState.activeSessionId) { _, _ in
-                    cancelPendingChatScrollRestoration()
+                .onChange(of: appState.activeSessionId) { oldSessionID, newSessionID in
                     guard !appState.isOpeningNotificationSession else {
+                        cancelPendingChatScrollRestoration()
                         notificationHandoffPending = true
-                        notificationHandoffSessionID = appState.activeSessionId
+                        notificationHandoffSessionID = activeScrollSessionID
                         notificationHandoffHasMeasuredLayout = false
                         return
                     }
+                    guard !appState.activeChatScrollSessionIdentity.areEquivalent(
+                        oldSessionID,
+                        newSessionID
+                    ) else { return }
+                    cancelPendingChatScrollRestoration()
                     followsLatest = true
                     scrollToLatest(using: proxy)
+                }
+                .onChange(of: appState.activeChatScrollSessionIdentity) { _, _ in
+                    guard !appState.isOpeningNotificationSession else { return }
+                    // Reconciliation publishes after replacing the transcript.
+                    // Let SwiftUI install the new semantic targets, then retry.
+                    DispatchQueue.main.async {
+                        finishChatScrollRestorationIfReady(using: proxy)
+                    }
                 }
                 .onChange(of: appState.isOpeningNotificationSession) { _, isOpening in
                     if isOpening {
@@ -155,7 +176,7 @@ struct ChatView: View {
                         followsLatest = false
                     } else {
                         if notificationHandoffPending, notificationHandoffSessionID == nil {
-                            notificationHandoffSessionID = appState.activeSessionId
+                            notificationHandoffSessionID = activeScrollSessionID
                             notificationHandoffHasMeasuredLayout = bottomMarkerMaxY != nil && scrollViewportMaxY != nil
                         }
                         finishNotificationHandoffIfReady(using: proxy)
@@ -177,6 +198,9 @@ struct ChatView: View {
                         saveChatScrollPosition()
                     case .active:
                         beginChatScrollRestoration()
+                        DispatchQueue.main.async {
+                            finishChatScrollRestorationIfReady(using: proxy)
+                        }
                     default:
                         break
                     }
@@ -187,6 +211,7 @@ struct ChatView: View {
                             // Only a deliberate user drag opts out of the
                             // stream-following behavior. Content growth alone
                             // must not make a live conversation appear stale.
+                            cancelPendingChatScrollRestoration()
                             followsLatest = false
                         }
                 )
@@ -229,8 +254,10 @@ struct ChatView: View {
     }
 
     private func saveChatScrollPosition() {
-        guard let sessionID = appState.activeSessionId else { return }
-        let messageIDs = Set(appState.messages.map(\.id))
+        guard let sessionID = activeScrollSessionID else { return }
+        let messageIDs = Set(
+            ChatMessageScrollTargets.make(for: appState.messages).map(\.semanticID)
+        )
         let anchor = messageIDs.contains(topVisibleChatID ?? "")
             ? topVisibleChatID
             : nil
@@ -244,7 +271,8 @@ struct ChatView: View {
     }
 
     private func beginChatScrollRestoration() {
-        guard let sessionID = appState.activeSessionId,
+        let identity = appState.activeChatScrollSessionIdentity
+        guard let sessionID = activeScrollSessionID,
               let snapshot = chatScrollState.snapshot(for: sessionID) else {
             pendingScrollRestoration = nil
             return
@@ -252,7 +280,14 @@ struct ChatView: View {
 
         pendingScrollRestoration = PendingChatScrollRestoration(
             sessionID: sessionID,
-            snapshot: snapshot
+            snapshot: snapshot,
+            gate: ChatScrollRestorationGate(
+                observing: identity,
+                // A configured foreground scene always asks AppState to
+                // reconcile. This also closes any SwiftUI callback-order gap
+                // before AppState publishes its synchronous in-progress state.
+                reconciliationExpected: appState.connection != nil
+            )
         )
         followsLatest = snapshot.followsLatest
     }
@@ -263,7 +298,8 @@ struct ChatView: View {
 
     private func finishChatScrollRestorationIfReady(using proxy: ScrollViewProxy) {
         guard let pending = pendingScrollRestoration else { return }
-        guard pending.sessionID == appState.activeSessionId else {
+        let identity = appState.activeChatScrollSessionIdentity
+        guard identity.areEquivalent(pending.sessionID, activeScrollSessionID) else {
             cancelPendingChatScrollRestoration()
             return
         }
@@ -275,7 +311,11 @@ struct ChatView: View {
             return
         }
 
-        let availableIDs = Set(appState.messages.map(\.id))
+        guard pending.gate.allowsNonLatestRestoration(using: identity) else { return }
+
+        let availableIDs = Set(
+            ChatMessageScrollTargets.make(for: appState.messages).map(\.semanticID)
+        )
         guard !availableIDs.isEmpty else { return }
         guard let resolved = chatScrollState.restoration(
             for: pending.sessionID,
@@ -319,7 +359,10 @@ struct ChatView: View {
     /// so a long lazy transcript cannot inherit the old conversation's offset.
     private func recordNotificationHandoffLayout() {
         guard notificationHandoffPending,
-              notificationHandoffSessionID == appState.activeSessionId,
+              appState.activeChatScrollSessionIdentity.areEquivalent(
+                notificationHandoffSessionID,
+                activeScrollSessionID
+              ),
               bottomMarkerMaxY != nil,
               scrollViewportMaxY != nil else { return }
         notificationHandoffHasMeasuredLayout = true
@@ -328,7 +371,10 @@ struct ChatView: View {
     private func finishNotificationHandoffIfReady(using proxy: ScrollViewProxy) {
         guard notificationHandoffPending,
               !appState.isOpeningNotificationSession,
-              notificationHandoffSessionID == appState.activeSessionId,
+              appState.activeChatScrollSessionIdentity.areEquivalent(
+                notificationHandoffSessionID,
+                activeScrollSessionID
+              ),
               notificationHandoffHasMeasuredLayout else { return }
         notificationHandoffPending = false
         notificationHandoffSessionID = nil
@@ -355,6 +401,7 @@ struct ChatView: View {
 private struct PendingChatScrollRestoration: Equatable {
     let sessionID: String
     let snapshot: ChatScrollSnapshot
+    let gate: ChatScrollRestorationGate
 }
 
 private struct ChatBottomMarkerPreferenceKey: PreferenceKey {

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -16,17 +16,31 @@ struct ChatView: View {
     @State private var followsLatest = true
     @State private var topVisibleChatID: String?
     @State private var chatScrollState = ChatScrollStateStore()
-    @State private var pendingScrollRestoration: PendingChatScrollRestoration?
+    @State private var chatMessageScrollTargetCache = ChatMessageScrollTargetCache()
+    @State private var pendingScrollRestoration: ChatScrollPendingRestoration?
     @State private var notificationHandoffPending = false
-    @State private var notificationHandoffSessionID: String?
+    @State private var notificationHandoffSessionKey: ChatScrollSessionKey?
     @State private var notificationHandoffHasMeasuredLayout = false
 
-    private var activeScrollSessionID: String? {
-        appState.activeChatScrollSessionIdentity.canonicalSessionID
-            ?? appState.activeSessionId
+    private var activeScrollSessionKey: ChatScrollSessionKey? {
+        if let canonical = appState.activeChatScrollSessionIdentity.canonicalSessionKey {
+            return canonical
+        }
+        guard let sessionID = appState.activeSessionId else { return nil }
+        let fallback = ChatScrollSessionKey(
+            profile: appState.activeProfile,
+            sessionID: sessionID
+        )
+        return fallback.isValid ? fallback : nil
     }
 
-    private var bottomAnchor: String { "chat-latest-\(activeScrollSessionID ?? "new")" }
+    private var bottomAnchor: String {
+        let scope = activeScrollSessionKey ?? ChatScrollSessionKey(
+            profile: appState.activeProfile,
+            sessionID: "new"
+        )
+        return "chat-latest-\(scope.profile)-\(scope.sessionID)"
+    }
 
     private var isNearBottom: Bool {
         guard let bottomMarkerMaxY, let scrollViewportMaxY else { return true }
@@ -36,8 +50,8 @@ struct ChatView: View {
     private var hasPendingNonLatestRestoration: Bool {
         guard let pendingScrollRestoration,
               appState.activeChatScrollSessionIdentity.areEquivalent(
-                pendingScrollRestoration.sessionID,
-                activeScrollSessionID
+                pendingScrollRestoration.sessionKey,
+                activeScrollSessionKey
               ) else {
             return false
         }
@@ -54,7 +68,7 @@ struct ChatView: View {
                             EmptyChatState().padding(.top, 60)
                         }
 
-                        ForEach(ChatMessageScrollTargets.make(for: appState.messages)) { target in
+                        ForEach(chatMessageScrollTargetCache.targets) { target in
                             MessageBubble(message: target.message).id(target.semanticID)
                         }
 
@@ -113,6 +127,9 @@ struct ChatView: View {
                         )
                     }
                 }
+                .onAppear {
+                    chatMessageScrollTargetCache.update(for: appState.messages)
+                }
                 .onPreferenceChange(ChatBottomMarkerPreferenceKey.self) { value in
                     updateBottomMarker(value)
                     recordNotificationHandoffLayout()
@@ -129,7 +146,15 @@ struct ChatView: View {
                         finishChatScrollRestorationIfReady(using: proxy)
                     }
                 }
-                .onChange(of: appState.messages.count) { _, _ in
+                .onChange(of: appState.messages) { oldMessages, newMessages in
+                    chatMessageScrollTargetCache.update(for: newMessages)
+                    if pendingScrollRestoration != nil,
+                       !appState.isOpeningNotificationSession {
+                        DispatchQueue.main.async {
+                            finishChatScrollRestorationIfReady(using: proxy)
+                        }
+                    }
+                    guard oldMessages.count != newMessages.count else { return }
                     guard !appState.isOpeningNotificationSession else {
                         notificationHandoffPending = true
                         return
@@ -147,15 +172,31 @@ struct ChatView: View {
                     guard !appState.isOpeningNotificationSession else {
                         cancelPendingChatScrollRestoration()
                         notificationHandoffPending = true
-                        notificationHandoffSessionID = activeScrollSessionID
+                        notificationHandoffSessionKey = activeScrollSessionKey
                         notificationHandoffHasMeasuredLayout = false
                         return
                     }
-                    guard !appState.activeChatScrollSessionIdentity.areEquivalent(
-                        oldSessionID,
-                        newSessionID
+                    let identity = appState.activeChatScrollSessionIdentity
+                    guard !identity.areEquivalent(
+                        identity.key(for: oldSessionID),
+                        identity.key(for: newSessionID)
                     ) else { return }
                     cancelPendingChatScrollRestoration()
+                    followsLatest = true
+                    scrollToLatest(using: proxy)
+                }
+                .onChange(of: appState.activeProfile) { _, _ in
+                    cancelPendingChatScrollRestoration()
+                    topVisibleChatID = nil
+                    chatMessageScrollTargetCache = ChatMessageScrollTargetCache()
+                    chatMessageScrollTargetCache.update(for: appState.messages)
+                    guard !appState.isOpeningNotificationSession else {
+                        notificationHandoffPending = true
+                        notificationHandoffSessionKey = activeScrollSessionKey
+                        notificationHandoffHasMeasuredLayout = false
+                        followsLatest = false
+                        return
+                    }
                     followsLatest = true
                     scrollToLatest(using: proxy)
                 }
@@ -171,12 +212,12 @@ struct ChatView: View {
                     if isOpening {
                         cancelPendingChatScrollRestoration()
                         notificationHandoffPending = true
-                        notificationHandoffSessionID = nil
+                        notificationHandoffSessionKey = nil
                         notificationHandoffHasMeasuredLayout = false
                         followsLatest = false
                     } else {
-                        if notificationHandoffPending, notificationHandoffSessionID == nil {
-                            notificationHandoffSessionID = activeScrollSessionID
+                        if notificationHandoffPending, notificationHandoffSessionKey == nil {
+                            notificationHandoffSessionKey = activeScrollSessionKey
                             notificationHandoffHasMeasuredLayout = bottomMarkerMaxY != nil && scrollViewportMaxY != nil
                         }
                         finishNotificationHandoffIfReady(using: proxy)
@@ -254,10 +295,8 @@ struct ChatView: View {
     }
 
     private func saveChatScrollPosition() {
-        guard let sessionID = activeScrollSessionID else { return }
-        let messageIDs = Set(
-            ChatMessageScrollTargets.make(for: appState.messages).map(\.semanticID)
-        )
+        guard let sessionKey = activeScrollSessionKey else { return }
+        let messageIDs = Set(chatMessageScrollTargetCache.targets.map(\.semanticID))
         let anchor = messageIDs.contains(topVisibleChatID ?? "")
             ? topVisibleChatID
             : nil
@@ -266,20 +305,20 @@ struct ChatView: View {
                 anchorMessageID: followsLatest ? nil : anchor,
                 followsLatest: followsLatest
             ),
-            for: sessionID
+            for: sessionKey
         )
     }
 
     private func beginChatScrollRestoration() {
         let identity = appState.activeChatScrollSessionIdentity
-        guard let sessionID = activeScrollSessionID,
-              let snapshot = chatScrollState.snapshot(for: sessionID) else {
+        guard let sessionKey = activeScrollSessionKey,
+              let snapshot = chatScrollState.snapshot(for: sessionKey) else {
             pendingScrollRestoration = nil
             return
         }
 
-        pendingScrollRestoration = PendingChatScrollRestoration(
-            sessionID: sessionID,
+        pendingScrollRestoration = ChatScrollPendingRestoration(
+            sessionKey: sessionKey,
             snapshot: snapshot,
             gate: ChatScrollRestorationGate(
                 observing: identity,
@@ -299,37 +338,25 @@ struct ChatView: View {
     private func finishChatScrollRestorationIfReady(using proxy: ScrollViewProxy) {
         guard let pending = pendingScrollRestoration else { return }
         let identity = appState.activeChatScrollSessionIdentity
-        guard identity.areEquivalent(pending.sessionID, activeScrollSessionID) else {
-            cancelPendingChatScrollRestoration()
-            return
-        }
-
-        if pending.snapshot.followsLatest {
-            pendingScrollRestoration = nil
-            followsLatest = true
-            scrollToLatest(using: proxy)
-            return
-        }
-
-        guard pending.gate.allowsNonLatestRestoration(using: identity) else { return }
-
-        let availableIDs = Set(
-            ChatMessageScrollTargets.make(for: appState.messages).map(\.semanticID)
+        let decision = ChatScrollRestorationResolver.decision(
+            for: pending,
+            identity: identity,
+            activeSessionKey: activeScrollSessionKey,
+            store: chatScrollState,
+            availableMessageIDs: Set(chatMessageScrollTargetCache.targets.map(\.semanticID))
         )
-        guard !availableIDs.isEmpty else { return }
-        guard let resolved = chatScrollState.restoration(
-            for: pending.sessionID,
-            availableMessageIDs: availableIDs
-        ) else {
-            pendingScrollRestoration = nil
-            return
-        }
 
-        pendingScrollRestoration = nil
-        if resolved.followsLatest {
+        switch decision {
+        case .wait:
+            return
+        case .cancel:
+            pendingScrollRestoration = nil
+        case .latest:
+            pendingScrollRestoration = nil
             followsLatest = true
             scrollToLatest(using: proxy)
-        } else if let anchor = resolved.anchorMessageID {
+        case .anchor(let anchor):
+            pendingScrollRestoration = nil
             var transaction = Transaction()
             transaction.animation = nil
             withTransaction(transaction) {
@@ -360,8 +387,8 @@ struct ChatView: View {
     private func recordNotificationHandoffLayout() {
         guard notificationHandoffPending,
               appState.activeChatScrollSessionIdentity.areEquivalent(
-                notificationHandoffSessionID,
-                activeScrollSessionID
+                notificationHandoffSessionKey,
+                activeScrollSessionKey
               ),
               bottomMarkerMaxY != nil,
               scrollViewportMaxY != nil else { return }
@@ -372,12 +399,12 @@ struct ChatView: View {
         guard notificationHandoffPending,
               !appState.isOpeningNotificationSession,
               appState.activeChatScrollSessionIdentity.areEquivalent(
-                notificationHandoffSessionID,
-                activeScrollSessionID
+                notificationHandoffSessionKey,
+                activeScrollSessionKey
               ),
               notificationHandoffHasMeasuredLayout else { return }
         notificationHandoffPending = false
-        notificationHandoffSessionID = nil
+        notificationHandoffSessionKey = nil
         cancelPendingChatScrollRestoration()
         followsLatest = true
         var transaction = Transaction()
@@ -396,12 +423,6 @@ struct ChatView: View {
         scrollViewportMaxY = value
         if isNearBottom && !hasPendingNonLatestRestoration { followsLatest = true }
     }
-}
-
-private struct PendingChatScrollRestoration: Equatable {
-    let sessionID: String
-    let snapshot: ChatScrollSnapshot
-    let gate: ChatScrollRestorationGate
 }
 
 private struct ChatBottomMarkerPreferenceKey: PreferenceKey {

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -131,10 +131,12 @@ struct ChatView: View {
                     }
                 }
                 .onChange(of: appState.chatScrollRequest) { _, _ in
+                    cancelPendingChatScrollRestoration()
                     followsLatest = true
                     scrollToLatest(using: proxy)
                 }
                 .onChange(of: appState.activeSessionId) { _, _ in
+                    cancelPendingChatScrollRestoration()
                     guard !appState.isOpeningNotificationSession else {
                         notificationHandoffPending = true
                         notificationHandoffSessionID = appState.activeSessionId
@@ -146,6 +148,7 @@ struct ChatView: View {
                 }
                 .onChange(of: appState.isOpeningNotificationSession) { _, isOpening in
                     if isOpening {
+                        cancelPendingChatScrollRestoration()
                         notificationHandoffPending = true
                         notificationHandoffSessionID = nil
                         notificationHandoffHasMeasuredLayout = false
@@ -190,6 +193,7 @@ struct ChatView: View {
                 .overlay(alignment: .bottomTrailing) {
                     if !followsLatest && !isNearBottom {
                         Button {
+                            cancelPendingChatScrollRestoration()
                             followsLatest = true
                             scrollToLatest(using: proxy)
                         } label: {
@@ -253,9 +257,16 @@ struct ChatView: View {
         followsLatest = snapshot.followsLatest
     }
 
+    private func cancelPendingChatScrollRestoration() {
+        pendingScrollRestoration = nil
+    }
+
     private func finishChatScrollRestorationIfReady(using proxy: ScrollViewProxy) {
-        guard let pending = pendingScrollRestoration,
-              pending.sessionID == appState.activeSessionId else { return }
+        guard let pending = pendingScrollRestoration else { return }
+        guard pending.sessionID == appState.activeSessionId else {
+            cancelPendingChatScrollRestoration()
+            return
+        }
 
         if pending.snapshot.followsLatest {
             pendingScrollRestoration = nil
@@ -321,6 +332,7 @@ struct ChatView: View {
               notificationHandoffHasMeasuredLayout else { return }
         notificationHandoffPending = false
         notificationHandoffSessionID = nil
+        cancelPendingChatScrollRestoration()
         followsLatest = true
         var transaction = Transaction()
         transaction.animation = nil

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -10,9 +10,13 @@ import UIKit
 
 struct ChatView: View {
     @EnvironmentObject var appState: AppState
+    @Environment(\.scenePhase) private var scenePhase
     @State private var bottomMarkerMaxY: CGFloat?
     @State private var scrollViewportMaxY: CGFloat?
     @State private var followsLatest = true
+    @State private var topVisibleChatID: String?
+    @State private var chatScrollState = ChatScrollStateStore()
+    @State private var pendingScrollRestoration: PendingChatScrollRestoration?
     @State private var notificationHandoffPending = false
     @State private var notificationHandoffSessionID: String?
     @State private var notificationHandoffHasMeasuredLayout = false
@@ -22,6 +26,14 @@ struct ChatView: View {
     private var isNearBottom: Bool {
         guard let bottomMarkerMaxY, let scrollViewportMaxY else { return true }
         return bottomMarkerMaxY <= scrollViewportMaxY + 40
+    }
+
+    private var hasPendingNonLatestRestoration: Bool {
+        guard let pendingScrollRestoration,
+              pendingScrollRestoration.sessionID == appState.activeSessionId else {
+            return false
+        }
+        return !pendingScrollRestoration.snapshot.followsLatest
     }
 
     var body: some View {
@@ -61,6 +73,7 @@ struct ChatView: View {
                     }
                     .padding(.horizontal, 18)
                     .padding(.top, 18)
+                    .scrollTargetLayout()
                     .background {
                         // Measure the lazy stack itself, not its final child.
                         // SwiftUI can unload that child after the user scrolls
@@ -75,6 +88,7 @@ struct ChatView: View {
                     }
                 }
                 .scrollDismissesKeyboard(.interactively)
+                .scrollPosition(id: $topVisibleChatID, anchor: .top)
                 .onTapGesture {
                     UIApplication.shared.sendAction(
                         #selector(UIResponder.resignFirstResponder),
@@ -95,11 +109,17 @@ struct ChatView: View {
                     updateBottomMarker(value)
                     recordNotificationHandoffLayout()
                     finishNotificationHandoffIfReady(using: proxy)
+                    if !appState.isOpeningNotificationSession {
+                        finishChatScrollRestorationIfReady(using: proxy)
+                    }
                 }
                 .onPreferenceChange(ChatViewportBottomPreferenceKey.self) { value in
                     updateViewportBottom(value)
                     recordNotificationHandoffLayout()
                     finishNotificationHandoffIfReady(using: proxy)
+                    if !appState.isOpeningNotificationSession {
+                        finishChatScrollRestorationIfReady(using: proxy)
+                    }
                 }
                 .onChange(of: appState.messages.count) { _, _ in
                     guard !appState.isOpeningNotificationSession else {
@@ -148,6 +168,16 @@ struct ChatView: View {
                         scrollToLatest(using: proxy)
                     }
                 }
+                .onChange(of: scenePhase) { _, phase in
+                    switch phase {
+                    case .inactive, .background:
+                        saveChatScrollPosition()
+                    case .active:
+                        beginChatScrollRestoration()
+                    default:
+                        break
+                    }
+                }
                 .simultaneousGesture(
                     DragGesture(minimumDistance: 3)
                         .onChanged { _ in
@@ -194,6 +224,69 @@ struct ChatView: View {
         .animation(.easeInOut(duration: 0.18), value: appState.isOpeningNotificationSession)
     }
 
+    private func saveChatScrollPosition() {
+        guard let sessionID = appState.activeSessionId else { return }
+        let messageIDs = Set(appState.messages.map(\.id))
+        let anchor = messageIDs.contains(topVisibleChatID ?? "")
+            ? topVisibleChatID
+            : nil
+        chatScrollState.save(
+            ChatScrollSnapshot(
+                anchorMessageID: followsLatest ? nil : anchor,
+                followsLatest: followsLatest
+            ),
+            for: sessionID
+        )
+    }
+
+    private func beginChatScrollRestoration() {
+        guard let sessionID = appState.activeSessionId,
+              let snapshot = chatScrollState.snapshot(for: sessionID) else {
+            pendingScrollRestoration = nil
+            return
+        }
+
+        pendingScrollRestoration = PendingChatScrollRestoration(
+            sessionID: sessionID,
+            snapshot: snapshot
+        )
+        followsLatest = snapshot.followsLatest
+    }
+
+    private func finishChatScrollRestorationIfReady(using proxy: ScrollViewProxy) {
+        guard let pending = pendingScrollRestoration,
+              pending.sessionID == appState.activeSessionId else { return }
+
+        if pending.snapshot.followsLatest {
+            pendingScrollRestoration = nil
+            followsLatest = true
+            scrollToLatest(using: proxy)
+            return
+        }
+
+        let availableIDs = Set(appState.messages.map(\.id))
+        guard !availableIDs.isEmpty else { return }
+        guard let resolved = chatScrollState.restoration(
+            for: pending.sessionID,
+            availableMessageIDs: availableIDs
+        ) else {
+            pendingScrollRestoration = nil
+            return
+        }
+
+        pendingScrollRestoration = nil
+        if resolved.followsLatest {
+            followsLatest = true
+            scrollToLatest(using: proxy)
+        } else if let anchor = resolved.anchorMessageID {
+            var transaction = Transaction()
+            transaction.animation = nil
+            withTransaction(transaction) {
+                proxy.scrollTo(anchor, anchor: .top)
+            }
+        }
+    }
+
     private func scrollToLatest(using proxy: ScrollViewProxy) {
         withAnimation(ConduitMotion.response) {
             proxy.scrollTo(bottomAnchor, anchor: .bottom)
@@ -238,13 +331,18 @@ struct ChatView: View {
 
     private func updateBottomMarker(_ value: CGFloat?) {
         bottomMarkerMaxY = value
-        if isNearBottom { followsLatest = true }
+        if isNearBottom && !hasPendingNonLatestRestoration { followsLatest = true }
     }
 
     private func updateViewportBottom(_ value: CGFloat?) {
         scrollViewportMaxY = value
-        if isNearBottom { followsLatest = true }
+        if isNearBottom && !hasPendingNonLatestRestoration { followsLatest = true }
     }
+}
+
+private struct PendingChatScrollRestoration: Equatable {
+    let sessionID: String
+    let snapshot: ChatScrollSnapshot
 }
 
 private struct ChatBottomMarkerPreferenceKey: PreferenceKey {

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -267,35 +267,55 @@ struct MessageBubble: View {
     @EnvironmentObject var appState: AppState
 
     var body: some View {
-        switch message.role {
-        case .user:
-            UserBubble(message: message)
-        case .assistant:
-            AssistantBubble(message: message)
-        case .reasoning:
-            ThinkingCard(message: message)
-        case .tool:
-            ToolCard(message: message)
-        case .clarify:
-            ClarifyCard(message: message)
-        case .approval:
-            ApprovalCard(message: message)
-        case .system:
-            if let review = message.review ?? MessageNormalizer.reviewActivity(fromText: message.content) {
-                ReviewSummaryCard(activity: review, timestamp: message.timestamp)
-            } else if let modelChange = MessageNormalizer.modelChangeActivity(
-                fromText: message.rawContent ?? message.content
-            ) {
-                ModelChangeSummaryCard(
-                    model: modelChange.model,
-                    provider: modelChange.provider,
-                    timestamp: message.timestamp
-                )
-            } else {
-                SystemBubble(message: message)
+        Group {
+            switch message.role {
+            case .user:
+                UserBubble(message: message)
+            case .assistant:
+                AssistantBubble(message: message)
+            case .reasoning:
+                ThinkingCard(message: message)
+            case .tool:
+                ToolCard(message: message)
+            case .clarify:
+                ClarifyCard(message: message)
+            case .approval:
+                ApprovalCard(message: message)
+            case .system:
+                if let review = message.review ?? MessageNormalizer.reviewActivity(fromText: message.content) {
+                    ReviewSummaryCard(activity: review, timestamp: message.timestamp)
+                } else if let modelChange = MessageNormalizer.modelChangeActivity(
+                    fromText: message.rawContent ?? message.content
+                ) {
+                    ModelChangeSummaryCard(
+                        model: modelChange.model,
+                        provider: modelChange.provider,
+                        timestamp: message.timestamp
+                    )
+                } else {
+                    SystemBubble(message: message)
+                }
+            case .partial:
+                AssistantBubble(message: message)
             }
-        case .partial:
-            AssistantBubble(message: message)
+        }
+        .modifier(
+            ChatTextSelectionModifier(
+                enabled: ChatTextSelectionPolicy.allowsTextSelection(for: message.role)
+            )
+        )
+    }
+}
+
+private struct ChatTextSelectionModifier: ViewModifier {
+    let enabled: Bool
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if enabled {
+            content.textSelection(.enabled)
+        } else {
+            content.textSelection(.disabled)
         }
     }
 }
@@ -1209,10 +1229,10 @@ struct StreamingBubble: View {
                     await appState.gatewayMediaDataURL(for: path, profile: appState.activeProfile)
                 }
             )
-            .textSelection(.disabled)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .textSelection(.enabled)
     }
 }
 

--- a/ConduitTests/ChatScrollStateTests.swift
+++ b/ConduitTests/ChatScrollStateTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import Conduit
+
+final class ChatScrollStateTests: XCTestCase {
+    func testSnapshotsAreIsolatedBySession() {
+        var store = ChatScrollStateStore()
+        store.save(
+            ChatScrollSnapshot(anchorMessageID: "a-3", followsLatest: false),
+            for: "session-a"
+        )
+        store.save(
+            ChatScrollSnapshot(anchorMessageID: "b-1", followsLatest: false),
+            for: "session-b"
+        )
+
+        XCTAssertEqual(store.snapshot(for: "session-a")?.anchorMessageID, "a-3")
+        XCTAssertEqual(store.snapshot(for: "session-b")?.anchorMessageID, "b-1")
+    }
+
+    func testRestorationKeepsAnchorWhenMessageStillExists() {
+        var store = ChatScrollStateStore()
+        let expected = ChatScrollSnapshot(anchorMessageID: "message-4", followsLatest: false)
+        store.save(expected, for: "session")
+
+        XCTAssertEqual(
+            store.restoration(
+                for: "session",
+                availableMessageIDs: ["message-3", "message-4", "message-5"]
+            ),
+            expected
+        )
+    }
+
+    func testRestorationFallsBackToLatestWhenAnchorDisappears() {
+        var store = ChatScrollStateStore()
+        store.save(
+            ChatScrollSnapshot(anchorMessageID: "deleted", followsLatest: false),
+            for: "session"
+        )
+
+        XCTAssertEqual(
+            store.restoration(for: "session", availableMessageIDs: ["message-1"]),
+            .latest
+        )
+    }
+
+    func testLatestSnapshotRemainsLatestRegardlessOfAvailableMessages() {
+        var store = ChatScrollStateStore()
+        store.save(ChatScrollSnapshot.latest, for: "session")
+
+        XCTAssertEqual(
+            store.restoration(for: "session", availableMessageIDs: []),
+            .latest
+        )
+    }
+
+    func testSessionKeysAreTrimmedForSaveAndLookup() {
+        var store = ChatScrollStateStore()
+        let expected = ChatScrollSnapshot(anchorMessageID: "message-1", followsLatest: false)
+        store.save(expected, for: "  session  ")
+
+        XCTAssertEqual(store.snapshot(for: "session"), expected)
+        XCTAssertEqual(store.snapshot(for: "\n session \t"), expected)
+    }
+
+    func testWhitespaceOnlySessionKeysAreIgnored() {
+        var store = ChatScrollStateStore()
+        store.save(ChatScrollSnapshot.latest, for: " \n\t ")
+
+        XCTAssertNil(store.snapshot(for: " \n\t "))
+    }
+}

--- a/ConduitTests/ChatScrollStateTests.swift
+++ b/ConduitTests/ChatScrollStateTests.swift
@@ -2,6 +2,294 @@ import XCTest
 @testable import Conduit
 
 final class ChatScrollStateTests: XCTestCase {
+    func testSemanticAnchorsIgnoreSourceSpecificMessageIdentity() {
+        let localMessages = [
+            ChatMessage(
+                id: "local-user",
+                role: .user,
+                content: "Compare these files",
+                timestamp: "2026-08-08T12:00:00Z",
+                author: "Local user",
+                attachments: [
+                    Attachment(
+                        id: "picker-attachment",
+                        name: "diagram.png",
+                        uri: "file:///tmp/diagram.png",
+                        mimeType: "image/png",
+                        kind: .image
+                    )
+                ]
+            ),
+            ChatMessage(
+                id: "live-assistant",
+                role: .assistant,
+                content: "The files match.",
+                rawContent: "live projection",
+                timestamp: "2026-08-08T12:00:01Z",
+                author: "Hermes",
+                code: "diff --brief a b"
+            )
+        ]
+        let persistedMessages = [
+            ChatMessage(
+                id: "481",
+                role: .user,
+                content: "Compare these files",
+                timestamp: "2026-08-08 12:00:00",
+                author: nil,
+                attachments: [
+                    Attachment(
+                        id: "481-gateway-image-0",
+                        name: "diagram.png",
+                        uri: "/gateway/uploads/diagram.png",
+                        mimeType: "image/png",
+                        kind: .image
+                    )
+                ]
+            ),
+            ChatMessage(
+                id: "482",
+                role: .assistant,
+                content: "The files match.",
+                rawContent: nil,
+                timestamp: "2026-08-08 12:00:01",
+                author: "assistant",
+                code: "diff --brief a b"
+            )
+        ]
+
+        XCTAssertEqual(
+            ChatMessageScrollTargets.make(for: localMessages).map(\.semanticID),
+            ChatMessageScrollTargets.make(for: persistedMessages).map(\.semanticID)
+        )
+    }
+
+    func testDuplicateSemanticRowsReceiveDistinctOccurrenceQualifiedAnchors() {
+        let firstProjection = [
+            ChatMessage(id: "live-1", role: .assistant, content: "Repeated", timestamp: "now"),
+            ChatMessage(id: "live-2", role: .assistant, content: "Repeated", timestamp: "later")
+        ]
+        let secondProjection = [
+            ChatMessage(id: "stored-91", role: .assistant, content: "Repeated", timestamp: "1"),
+            ChatMessage(id: "stored-92", role: .assistant, content: "Repeated", timestamp: "2")
+        ]
+
+        let firstIDs = ChatMessageScrollTargets.make(for: firstProjection).map(\.semanticID)
+        let secondIDs = ChatMessageScrollTargets.make(for: secondProjection).map(\.semanticID)
+
+        XCTAssertNotEqual(firstIDs[0], firstIDs[1])
+        XCTAssertEqual(firstIDs, secondIDs)
+    }
+
+    func testStableActivityAndAttachmentFieldsParticipateInSemanticFingerprint() {
+        func semanticID(for message: ChatMessage) -> String {
+            ChatMessageScrollTargets.make(for: [message])[0].semanticID
+        }
+
+        let toolA = ChatMessage(
+            id: "tool-a",
+            role: .tool,
+            content: "",
+            timestamp: "now",
+            tool: ToolActivity(id: "call-a", name: "read", input: "a.txt", output: nil, status: .running)
+        )
+        let toolB = ChatMessage(
+            id: "tool-b",
+            role: .tool,
+            content: "",
+            timestamp: "now",
+            tool: ToolActivity(id: "call-b", name: "read", input: "b.txt", output: nil, status: .running)
+        )
+        let clarifyA = ChatMessage(
+            id: "clarify-a",
+            role: .clarify,
+            content: "Choose one",
+            timestamp: "now",
+            clarify: ClarifyActivity(
+                requestId: "request-a",
+                question: "Choose one",
+                choices: [ClarifyChoice(label: "Alpha", value: "a")],
+                status: .pending,
+                answer: nil,
+                error: nil
+            )
+        )
+        let clarifyB = ChatMessage(
+            id: "clarify-b",
+            role: .clarify,
+            content: "Choose one",
+            timestamp: "now",
+            clarify: ClarifyActivity(
+                requestId: "request-b",
+                question: "Choose one",
+                choices: [ClarifyChoice(label: "Beta", value: "b")],
+                status: .pending,
+                answer: nil,
+                error: nil
+            )
+        )
+        let approvalA = ChatMessage(
+            id: "approval-a",
+            role: .approval,
+            content: "Approval required",
+            timestamp: "now",
+            approval: ApprovalActivity(
+                sessionId: "runtime-a",
+                command: "git status",
+                description: "Approval required",
+                choices: ["allow", "deny"],
+                allowPermanent: true,
+                smartDenied: false,
+                status: .pending,
+                choice: nil,
+                error: nil
+            )
+        )
+        let approvalB = ChatMessage(
+            id: "approval-b",
+            role: .approval,
+            content: "Approval required",
+            timestamp: "now",
+            approval: ApprovalActivity(
+                sessionId: "runtime-b",
+                command: "git diff",
+                description: "Approval required",
+                choices: ["allow", "deny"],
+                allowPermanent: true,
+                smartDenied: false,
+                status: .pending,
+                choice: nil,
+                error: nil
+            )
+        )
+        let reviewA = ChatMessage(
+            id: "review-a",
+            role: .system,
+            content: "Review complete",
+            timestamp: "now",
+            review: ReviewActivity(summary: "Review complete", details: ["Memory updated"], fullSessionId: "child-a")
+        )
+        let reviewB = ChatMessage(
+            id: "review-b",
+            role: .system,
+            content: "Review complete",
+            timestamp: "now",
+            review: ReviewActivity(summary: "Review complete", details: ["Skill updated"], fullSessionId: "child-b")
+        )
+        let attachmentA = ChatMessage(
+            id: "attachment-a",
+            role: .user,
+            content: "Attached",
+            timestamp: "now",
+            attachments: [Attachment(id: "a", name: "a.pdf", uri: "/tmp/a.pdf", mimeType: "application/pdf", kind: .document)]
+        )
+        let attachmentB = ChatMessage(
+            id: "attachment-b",
+            role: .user,
+            content: "Attached",
+            timestamp: "now",
+            attachments: [Attachment(id: "b", name: "b.pdf", uri: "/tmp/b.pdf", mimeType: "application/pdf", kind: .document)]
+        )
+
+        XCTAssertNotEqual(semanticID(for: toolA), semanticID(for: toolB))
+        XCTAssertNotEqual(semanticID(for: clarifyA), semanticID(for: clarifyB))
+        XCTAssertNotEqual(semanticID(for: approvalA), semanticID(for: approvalB))
+        XCTAssertNotEqual(semanticID(for: reviewA), semanticID(for: reviewB))
+        XCTAssertNotEqual(semanticID(for: attachmentA), semanticID(for: attachmentB))
+    }
+
+    func testVolatileActivityIdentityAndStateDoNotChangeSemanticAnchor() {
+        let pending = ChatMessage(
+            id: "live",
+            role: .approval,
+            content: "Run command?",
+            timestamp: "now",
+            approval: ApprovalActivity(
+                sessionId: "runtime-old",
+                command: "make test",
+                description: "Run command?",
+                choices: ["allow", "deny"],
+                allowPermanent: true,
+                smartDenied: false,
+                status: .pending,
+                choice: nil,
+                error: nil
+            )
+        )
+        let persisted = ChatMessage(
+            id: "stored",
+            role: .approval,
+            content: "Run command?",
+            timestamp: "stored timestamp",
+            approval: ApprovalActivity(
+                sessionId: "runtime-new",
+                command: "make test",
+                description: "Run command?",
+                choices: ["allow", "deny"],
+                allowPermanent: true,
+                smartDenied: false,
+                status: .approved,
+                choice: "allow",
+                error: nil
+            )
+        )
+
+        XCTAssertEqual(
+            ChatMessageScrollTargets.make(for: [pending]).map(\.semanticID),
+            ChatMessageScrollTargets.make(for: [persisted]).map(\.semanticID)
+        )
+    }
+
+    func testEquivalentSessionIDsShareCanonicalIdentity() {
+        let identity = ChatScrollSessionIdentity(
+            canonicalSessionID: "catalog-id",
+            equivalentSessionIDs: ["runtime-old", "runtime-new"],
+            isReconciling: false,
+            settledRevision: 4
+        )
+
+        XCTAssertEqual(identity.canonicalSessionID, "catalog-id")
+        XCTAssertTrue(identity.areEquivalent("catalog-id", "runtime-old"))
+        XCTAssertTrue(identity.areEquivalent("runtime-old", "runtime-new"))
+        XCTAssertFalse(identity.areEquivalent("runtime-old", "different-session"))
+    }
+
+    func testNonLatestRestorationWaitsForReconciliationToSettleAtNewRevision() {
+        let activeIdentity = ChatScrollSessionIdentity(
+            canonicalSessionID: "catalog-id",
+            equivalentSessionIDs: ["runtime-id"],
+            isReconciling: true,
+            settledRevision: 7
+        )
+        let gate = ChatScrollRestorationGate(observing: activeIdentity)
+
+        XCTAssertFalse(gate.allowsNonLatestRestoration(using: activeIdentity))
+        XCTAssertFalse(gate.allowsNonLatestRestoration(using: ChatScrollSessionIdentity(
+            canonicalSessionID: "catalog-id",
+            equivalentSessionIDs: ["runtime-id"],
+            isReconciling: false,
+            settledRevision: 7
+        )))
+        XCTAssertTrue(gate.allowsNonLatestRestoration(using: ChatScrollSessionIdentity(
+            canonicalSessionID: "catalog-id",
+            equivalentSessionIDs: ["runtime-id"],
+            isReconciling: false,
+            settledRevision: 8
+        )))
+    }
+
+    func testNonLatestRestorationCanUseCurrentRevisionWhenNoReconciliationIsExpected() {
+        let settledIdentity = ChatScrollSessionIdentity(
+            canonicalSessionID: "catalog-id",
+            equivalentSessionIDs: [],
+            isReconciling: false,
+            settledRevision: 3
+        )
+        let gate = ChatScrollRestorationGate(observing: settledIdentity)
+
+        XCTAssertTrue(gate.allowsNonLatestRestoration(using: settledIdentity))
+    }
+
     func testSnapshotsAreIsolatedBySession() {
         var store = ChatScrollStateStore()
         store.save(

--- a/ConduitTests/ChatScrollStateTests.swift
+++ b/ConduitTests/ChatScrollStateTests.swift
@@ -98,7 +98,7 @@ final class ChatScrollStateTests: XCTestCase {
             role: .tool,
             content: "",
             timestamp: "now",
-            tool: ToolActivity(id: "call-b", name: "read", input: "b.txt", output: nil, status: .running)
+            tool: ToolActivity(id: "call-b", name: "write", input: "b.txt", output: nil, status: .running)
         )
         let clarifyA = ChatMessage(
             id: "clarify-a",
@@ -240,8 +240,133 @@ final class ChatScrollStateTests: XCTestCase {
         )
     }
 
+    func testToolSemanticAnchorsIgnoreProjectionSpecificInputPreviews() {
+        let fullProjection = [
+            ChatMessage(
+                id: "live-1",
+                role: .tool,
+                content: "",
+                timestamp: "now",
+                tool: ToolActivity(
+                    id: "call-1",
+                    name: "read_file",
+                    input: "A complete request body that only the durable transcript retains",
+                    output: nil,
+                    status: .running
+                )
+            ),
+            ChatMessage(
+                id: "live-2",
+                role: .tool,
+                content: "",
+                timestamp: "later",
+                tool: ToolActivity(
+                    id: "call-2",
+                    name: "read_file",
+                    input: "A second complete request body",
+                    output: nil,
+                    status: .running
+                )
+            )
+        ]
+        let compactProjection = [
+            ChatMessage(
+                id: "stored-91",
+                role: .tool,
+                content: "",
+                timestamp: "stored",
+                tool: ToolActivity(
+                    id: nil,
+                    name: "read_file",
+                    input: nil,
+                    output: "first result",
+                    status: .complete
+                )
+            ),
+            ChatMessage(
+                id: "stored-92",
+                role: .tool,
+                content: "",
+                timestamp: "stored later",
+                tool: ToolActivity(
+                    id: nil,
+                    name: "read_file",
+                    input: "A second complete request…",
+                    output: "second result",
+                    status: .complete
+                )
+            )
+        ]
+
+        let fullIDs = ChatMessageScrollTargets.make(for: fullProjection).map(\.semanticID)
+        let compactIDs = ChatMessageScrollTargets.make(for: compactProjection).map(\.semanticID)
+
+        XCTAssertEqual(fullIDs, compactIDs)
+        XCTAssertNotEqual(fullIDs[0], fullIDs[1])
+    }
+
+    func testTargetCacheDoesNotRegenerateForRepeatedUnchangedMessages() {
+        let messages = [
+            ChatMessage(id: "message-1", role: .assistant, content: "Stable", timestamp: "now")
+        ]
+        var cache = ChatMessageScrollTargetCache()
+
+        XCTAssertEqual(cache.update(for: messages), .semanticsChanged)
+        for _ in 0..<100 {
+            XCTAssertEqual(cache.update(for: messages), .unchanged)
+        }
+    }
+
+    func testTargetCacheRefreshesRenderingIdentityWithoutChangingScrollIdentity() {
+        let live = [
+            ChatMessage(
+                id: "live-message",
+                role: .assistant,
+                content: "Same response",
+                rawContent: "live projection",
+                timestamp: "now",
+                author: "Hermes"
+            )
+        ]
+        let stored = [
+            ChatMessage(
+                id: "stored-message",
+                role: .assistant,
+                content: "Same response",
+                rawContent: nil,
+                timestamp: "stored timestamp",
+                author: "assistant"
+            )
+        ]
+        var cache = ChatMessageScrollTargetCache()
+
+        XCTAssertEqual(cache.update(for: live), .semanticsChanged)
+        let liveScrollID = cache.targets[0].semanticID
+
+        XCTAssertEqual(cache.update(for: stored), .renderingChanged)
+        XCTAssertEqual(cache.targets[0].id, "stored-message")
+        XCTAssertEqual(cache.targets[0].semanticID, liveScrollID)
+    }
+
+    func testTargetCacheRegeneratesWhenMessageSemanticsChange() {
+        var cache = ChatMessageScrollTargetCache()
+        let original = [
+            ChatMessage(id: "message", role: .assistant, content: "Before", timestamp: "now")
+        ]
+        let edited = [
+            ChatMessage(id: "message", role: .assistant, content: "After", timestamp: "now")
+        ]
+
+        XCTAssertEqual(cache.update(for: original), .semanticsChanged)
+        let originalScrollID = cache.targets[0].semanticID
+
+        XCTAssertEqual(cache.update(for: edited), .semanticsChanged)
+        XCTAssertNotEqual(cache.targets[0].semanticID, originalScrollID)
+    }
+
     func testEquivalentSessionIDsShareCanonicalIdentity() {
         let identity = ChatScrollSessionIdentity(
+            profile: "alpha",
             canonicalSessionID: "catalog-id",
             equivalentSessionIDs: ["runtime-old", "runtime-new"],
             isReconciling: false,
@@ -254,8 +379,211 @@ final class ChatScrollStateTests: XCTestCase {
         XCTAssertFalse(identity.areEquivalent("runtime-old", "different-session"))
     }
 
+    func testEquivalentRawSessionIDsRemainSeparatedByProfile() {
+        let identity = ChatScrollSessionIdentity(
+            profile: "alpha",
+            canonicalSessionID: "shared-id",
+            equivalentSessionIDs: ["runtime-id"],
+            isReconciling: false,
+            settledRevision: 2
+        )
+        let alphaRuntime = ChatScrollSessionKey(profile: "alpha", sessionID: "runtime-id")
+        let betaRuntime = ChatScrollSessionKey(profile: "beta", sessionID: "runtime-id")
+
+        XCTAssertTrue(identity.contains(alphaRuntime))
+        XCTAssertFalse(identity.contains(betaRuntime))
+        XCTAssertFalse(identity.areEquivalent(alphaRuntime, betaRuntime))
+    }
+
+    func testResolverUsesCatalogCanonicalIDAndAliases() {
+        let identity = ChatScrollSessionIdentityResolver.resolve(
+            profile: "alpha",
+            activeSessionID: "runtime-id",
+            catalog: [
+                ChatScrollSessionCatalogIdentity(
+                    profile: "alpha",
+                    canonicalSessionID: "catalog-id",
+                    alternateSessionIDs: ["runtime-id", "legacy-id"]
+                )
+            ],
+            previousIdentity: .none,
+            isReconciling: false
+        )
+
+        XCTAssertEqual(identity.canonicalSessionKey, ChatScrollSessionKey(
+            profile: "alpha",
+            sessionID: "catalog-id"
+        ))
+        XCTAssertTrue(identity.contains("runtime-id"))
+        XCTAssertTrue(identity.contains("legacy-id"))
+    }
+
+    func testResolverTreatsUntaggedCatalogRowsAsBelongingToTheActiveProfile() {
+        let identity = ChatScrollSessionIdentityResolver.resolve(
+            profile: "alpha",
+            activeSessionID: "runtime-id",
+            catalog: [
+                ChatScrollSessionCatalogIdentity(
+                    profile: "  ",
+                    canonicalSessionID: "catalog-id",
+                    alternateSessionIDs: ["runtime-id"]
+                )
+            ],
+            previousIdentity: .none,
+            isReconciling: false
+        )
+
+        XCTAssertEqual(identity.canonicalSessionKey, ChatScrollSessionKey(
+            profile: "alpha",
+            sessionID: "catalog-id"
+        ))
+    }
+
+    func testResolverKeepsRuntimeRotationInTheExistingCanonicalIdentity() {
+        let catalog = [
+            ChatScrollSessionCatalogIdentity(
+                profile: "alpha",
+                canonicalSessionID: "catalog-id",
+                alternateSessionIDs: ["runtime-old"]
+            )
+        ]
+        let previous = ChatScrollSessionIdentityResolver.resolve(
+            profile: "alpha",
+            activeSessionID: "runtime-old",
+            catalog: catalog,
+            previousIdentity: .none,
+            isReconciling: false
+        )
+
+        let rotated = ChatScrollSessionIdentityResolver.resolve(
+            profile: "alpha",
+            activeSessionID: "runtime-old",
+            catalog: catalog,
+            requestedSessionID: "catalog-id",
+            resolvedSessionID: "runtime-new",
+            previousIdentity: previous,
+            isReconciling: true
+        )
+
+        XCTAssertEqual(rotated.canonicalSessionID, "catalog-id")
+        XCTAssertTrue(rotated.areEquivalent("runtime-old", "runtime-new"))
+    }
+
+    func testResolverDropsPreviousAliasesForAnUnrelatedSession() {
+        let catalog = [
+            ChatScrollSessionCatalogIdentity(
+                profile: "alpha",
+                canonicalSessionID: "catalog-a",
+                alternateSessionIDs: ["runtime-a"]
+            ),
+            ChatScrollSessionCatalogIdentity(
+                profile: "alpha",
+                canonicalSessionID: "catalog-b",
+                alternateSessionIDs: ["runtime-b"]
+            )
+        ]
+        let previous = ChatScrollSessionIdentityResolver.resolve(
+            profile: "alpha",
+            activeSessionID: "runtime-a",
+            catalog: catalog,
+            previousIdentity: .none,
+            isReconciling: false
+        )
+
+        let unrelated = ChatScrollSessionIdentityResolver.resolve(
+            profile: "alpha",
+            activeSessionID: "runtime-b",
+            catalog: catalog,
+            previousIdentity: previous,
+            isReconciling: false
+        )
+
+        XCTAssertEqual(unrelated.canonicalSessionID, "catalog-b")
+        XCTAssertTrue(unrelated.contains("runtime-b"))
+        XCTAssertFalse(unrelated.contains("runtime-a"))
+    }
+
+    func testResolverDoesNotCarryIdentityAcrossProfilesWithEqualRawIDs() {
+        let previous = ChatScrollSessionIdentityResolver.resolve(
+            profile: "alpha",
+            activeSessionID: "shared-runtime",
+            catalog: [
+                ChatScrollSessionCatalogIdentity(
+                    profile: "alpha",
+                    canonicalSessionID: "alpha-catalog",
+                    alternateSessionIDs: ["shared-runtime"]
+                )
+            ],
+            previousIdentity: .none,
+            isReconciling: false
+        )
+
+        let switched = ChatScrollSessionIdentityResolver.resolve(
+            profile: "beta",
+            activeSessionID: "shared-runtime",
+            catalog: [
+                ChatScrollSessionCatalogIdentity(
+                    profile: "alpha",
+                    canonicalSessionID: "alpha-catalog",
+                    alternateSessionIDs: ["shared-runtime"]
+                ),
+                ChatScrollSessionCatalogIdentity(
+                    profile: "beta",
+                    canonicalSessionID: "beta-catalog",
+                    alternateSessionIDs: ["shared-runtime"]
+                )
+            ],
+            previousIdentity: previous,
+            isReconciling: false
+        )
+
+        XCTAssertEqual(switched.profile, "beta")
+        XCTAssertEqual(switched.canonicalSessionID, "beta-catalog")
+        XCTAssertFalse(switched.contains(ChatScrollSessionKey(
+            profile: "alpha",
+            sessionID: "shared-runtime"
+        )))
+        XCTAssertTrue(switched.contains(ChatScrollSessionKey(
+            profile: "beta",
+            sessionID: "shared-runtime"
+        )))
+    }
+
+    func testResolverOwnsReconciliationStateAndSettledRevisionTransitions() {
+        let settled = ChatScrollSessionIdentityResolver.resolve(
+            profile: "alpha",
+            activeSessionID: "session",
+            catalog: [],
+            previousIdentity: .none,
+            isReconciling: false
+        )
+        let reconciling = ChatScrollSessionIdentityResolver.resolve(
+            profile: "alpha",
+            activeSessionID: "session",
+            catalog: [],
+            previousIdentity: settled,
+            isReconciling: true
+        )
+        let resettled = ChatScrollSessionIdentityResolver.resolve(
+            profile: "alpha",
+            activeSessionID: "session",
+            catalog: [],
+            previousIdentity: reconciling,
+            isReconciling: false,
+            advanceSettledRevision: true
+        )
+
+        XCTAssertFalse(settled.isReconciling)
+        XCTAssertEqual(settled.settledRevision, 0)
+        XCTAssertTrue(reconciling.isReconciling)
+        XCTAssertEqual(reconciling.settledRevision, 0)
+        XCTAssertFalse(resettled.isReconciling)
+        XCTAssertEqual(resettled.settledRevision, 1)
+    }
+
     func testNonLatestRestorationWaitsForReconciliationToSettleAtNewRevision() {
         let activeIdentity = ChatScrollSessionIdentity(
+            profile: "default",
             canonicalSessionID: "catalog-id",
             equivalentSessionIDs: ["runtime-id"],
             isReconciling: true,
@@ -265,12 +593,14 @@ final class ChatScrollStateTests: XCTestCase {
 
         XCTAssertFalse(gate.allowsNonLatestRestoration(using: activeIdentity))
         XCTAssertFalse(gate.allowsNonLatestRestoration(using: ChatScrollSessionIdentity(
+            profile: "default",
             canonicalSessionID: "catalog-id",
             equivalentSessionIDs: ["runtime-id"],
             isReconciling: false,
             settledRevision: 7
         )))
         XCTAssertTrue(gate.allowsNonLatestRestoration(using: ChatScrollSessionIdentity(
+            profile: "default",
             canonicalSessionID: "catalog-id",
             equivalentSessionIDs: ["runtime-id"],
             isReconciling: false,
@@ -280,6 +610,7 @@ final class ChatScrollStateTests: XCTestCase {
 
     func testNonLatestRestorationCanUseCurrentRevisionWhenNoReconciliationIsExpected() {
         let settledIdentity = ChatScrollSessionIdentity(
+            profile: "default",
             canonicalSessionID: "catalog-id",
             equivalentSessionIDs: [],
             isReconciling: false,
@@ -292,27 +623,47 @@ final class ChatScrollStateTests: XCTestCase {
 
     func testSnapshotsAreIsolatedBySession() {
         var store = ChatScrollStateStore()
+        let sessionA = ChatScrollSessionKey(profile: "default", sessionID: "session-a")
+        let sessionB = ChatScrollSessionKey(profile: "default", sessionID: "session-b")
         store.save(
             ChatScrollSnapshot(anchorMessageID: "a-3", followsLatest: false),
-            for: "session-a"
+            for: sessionA
         )
         store.save(
             ChatScrollSnapshot(anchorMessageID: "b-1", followsLatest: false),
-            for: "session-b"
+            for: sessionB
         )
 
-        XCTAssertEqual(store.snapshot(for: "session-a")?.anchorMessageID, "a-3")
-        XCTAssertEqual(store.snapshot(for: "session-b")?.anchorMessageID, "b-1")
+        XCTAssertEqual(store.snapshot(for: sessionA)?.anchorMessageID, "a-3")
+        XCTAssertEqual(store.snapshot(for: sessionB)?.anchorMessageID, "b-1")
+    }
+
+    func testSnapshotsWithEqualRawSessionIDsAreIsolatedByProfile() {
+        var store = ChatScrollStateStore()
+        let alpha = ChatScrollSessionKey(profile: "alpha", sessionID: "shared-session")
+        let beta = ChatScrollSessionKey(profile: "beta", sessionID: "shared-session")
+        store.save(
+            ChatScrollSnapshot(anchorMessageID: "alpha-anchor", followsLatest: false),
+            for: alpha
+        )
+        store.save(
+            ChatScrollSnapshot(anchorMessageID: "beta-anchor", followsLatest: false),
+            for: beta
+        )
+
+        XCTAssertEqual(store.snapshot(for: alpha)?.anchorMessageID, "alpha-anchor")
+        XCTAssertEqual(store.snapshot(for: beta)?.anchorMessageID, "beta-anchor")
     }
 
     func testRestorationKeepsAnchorWhenMessageStillExists() {
         var store = ChatScrollStateStore()
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
         let expected = ChatScrollSnapshot(anchorMessageID: "message-4", followsLatest: false)
-        store.save(expected, for: "session")
+        store.save(expected, for: key)
 
         XCTAssertEqual(
             store.restoration(
-                for: "session",
+                for: key,
                 availableMessageIDs: ["message-3", "message-4", "message-5"]
             ),
             expected
@@ -321,23 +672,100 @@ final class ChatScrollStateTests: XCTestCase {
 
     func testRestorationFallsBackToLatestWhenAnchorDisappears() {
         var store = ChatScrollStateStore()
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
         store.save(
             ChatScrollSnapshot(anchorMessageID: "deleted", followsLatest: false),
-            for: "session"
+            for: key
         )
 
         XCTAssertEqual(
-            store.restoration(for: "session", availableMessageIDs: ["message-1"]),
+            store.restoration(for: key, availableMessageIDs: ["message-1"]),
             .latest
+        )
+    }
+
+    func testSettledPendingRestorationFallsBackToLatestForEmptyTranscript() {
+        var store = ChatScrollStateStore()
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
+        let reconcilingIdentity = ChatScrollSessionIdentity(
+            profile: "default",
+            canonicalSessionID: "session",
+            equivalentSessionIDs: [],
+            isReconciling: true,
+            settledRevision: 3
+        )
+        let settledIdentity = ChatScrollSessionIdentity(
+            profile: "default",
+            canonicalSessionID: "session",
+            equivalentSessionIDs: [],
+            isReconciling: false,
+            settledRevision: 4
+        )
+        let snapshot = ChatScrollSnapshot(anchorMessageID: "deleted", followsLatest: false)
+        store.save(snapshot, for: key)
+        let pending = ChatScrollPendingRestoration(
+            sessionKey: key,
+            snapshot: snapshot,
+            gate: ChatScrollRestorationGate(observing: reconcilingIdentity)
+        )
+
+        XCTAssertEqual(
+            ChatScrollRestorationResolver.decision(
+                for: pending,
+                identity: settledIdentity,
+                activeSessionKey: key,
+                store: store,
+                availableMessageIDs: []
+            ),
+            .latest
+        )
+    }
+
+    func testPendingRestorationCancelsAcrossProfilesWithEqualSessionIDs() {
+        var store = ChatScrollStateStore()
+        let alphaKey = ChatScrollSessionKey(profile: "alpha", sessionID: "shared-session")
+        let betaKey = ChatScrollSessionKey(profile: "beta", sessionID: "shared-session")
+        let alphaIdentity = ChatScrollSessionIdentity(
+            profile: "alpha",
+            canonicalSessionID: "shared-session",
+            equivalentSessionIDs: [],
+            isReconciling: false,
+            settledRevision: 1
+        )
+        let betaIdentity = ChatScrollSessionIdentity(
+            profile: "beta",
+            canonicalSessionID: "shared-session",
+            equivalentSessionIDs: [],
+            isReconciling: false,
+            settledRevision: 1
+        )
+        let snapshot = ChatScrollSnapshot(anchorMessageID: "alpha-anchor", followsLatest: false)
+        store.save(snapshot, for: alphaKey)
+        let pending = ChatScrollPendingRestoration(
+            sessionKey: alphaKey,
+            snapshot: snapshot,
+            gate: ChatScrollRestorationGate(observing: alphaIdentity)
+        )
+
+        XCTAssertEqual(
+            ChatScrollRestorationResolver.decision(
+                for: pending,
+                identity: betaIdentity,
+                activeSessionKey: betaKey,
+                store: store,
+                availableMessageIDs: ["alpha-anchor"]
+            ),
+            .cancel
         )
     }
 
     func testLatestSnapshotRemainsLatestRegardlessOfAvailableMessages() {
         var store = ChatScrollStateStore()
-        store.save(ChatScrollSnapshot.latest, for: "session")
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
+        store.save(ChatScrollSnapshot.latest, for: key)
 
         XCTAssertEqual(
-            store.restoration(for: "session", availableMessageIDs: []),
+            store.restoration(for: key, availableMessageIDs: []),
             .latest
         )
     }
@@ -345,16 +773,26 @@ final class ChatScrollStateTests: XCTestCase {
     func testSessionKeysAreTrimmedForSaveAndLookup() {
         var store = ChatScrollStateStore()
         let expected = ChatScrollSnapshot(anchorMessageID: "message-1", followsLatest: false)
-        store.save(expected, for: "  session  ")
+        store.save(
+            expected,
+            for: ChatScrollSessionKey(profile: "  Alpha  ", sessionID: "  session  ")
+        )
 
-        XCTAssertEqual(store.snapshot(for: "session"), expected)
-        XCTAssertEqual(store.snapshot(for: "\n session \t"), expected)
+        XCTAssertEqual(
+            store.snapshot(for: ChatScrollSessionKey(profile: "alpha", sessionID: "session")),
+            expected
+        )
+        XCTAssertEqual(
+            store.snapshot(for: ChatScrollSessionKey(profile: "ALPHA", sessionID: "\n session \t")),
+            expected
+        )
     }
 
     func testWhitespaceOnlySessionKeysAreIgnored() {
         var store = ChatScrollStateStore()
-        store.save(ChatScrollSnapshot.latest, for: " \n\t ")
+        let key = ChatScrollSessionKey(profile: "default", sessionID: " \n\t ")
+        store.save(ChatScrollSnapshot.latest, for: key)
 
-        XCTAssertNil(store.snapshot(for: " \n\t "))
+        XCTAssertNil(store.snapshot(for: key))
     }
 }

--- a/ConduitTests/ChatScrollStateTests.swift
+++ b/ConduitTests/ChatScrollStateTests.swift
@@ -81,6 +81,82 @@ final class ChatScrollStateTests: XCTestCase {
         XCTAssertEqual(firstIDs, secondIDs)
     }
 
+    func testRestorationFallsBackWhenDuplicateMultiplicityChanges() {
+        let originalTargets = ChatMessageScrollTargets.make(for: [
+            ChatMessage(id: "live-first", role: .assistant, content: "Repeated", timestamp: "now"),
+            ChatMessage(id: "live-second", role: .assistant, content: "Repeated", timestamp: "later")
+        ])
+        let compactedTargets = ChatMessageScrollTargets.make(for: [
+            ChatMessage(id: "stored-second", role: .assistant, content: "Repeated", timestamp: "stored")
+        ])
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
+        let snapshot = ChatScrollSnapshot(
+            anchorMessageID: originalTargets[0].semanticID,
+            followsLatest: false,
+            anchorMetadata: originalTargets[0].restorationMetadata
+        )
+        var store = ChatScrollStateStore()
+        store.save(snapshot, for: key)
+
+        XCTAssertEqual(originalTargets[0].semanticID, compactedTargets[0].semanticID)
+        XCTAssertEqual(
+            store.restoration(
+                for: key,
+                availableTargets: ChatScrollTargetAvailability(targets: compactedTargets)
+            ),
+            .latest
+        )
+    }
+
+    func testRestorationKeepsQualifiedAnchorWhenDuplicateMultiplicityIsUnchanged() {
+        let liveTargets = ChatMessageScrollTargets.make(for: [
+            ChatMessage(id: "live-first", role: .assistant, content: "Repeated", timestamp: "now"),
+            ChatMessage(id: "live-second", role: .assistant, content: "Repeated", timestamp: "later")
+        ])
+        let storedTargets = ChatMessageScrollTargets.make(for: [
+            ChatMessage(id: "stored-first", role: .assistant, content: "Repeated", timestamp: "stored"),
+            ChatMessage(id: "stored-second", role: .assistant, content: "Repeated", timestamp: "stored later")
+        ])
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
+        let snapshot = ChatScrollSnapshot(
+            anchorMessageID: liveTargets[0].semanticID,
+            followsLatest: false,
+            anchorMetadata: liveTargets[0].restorationMetadata
+        )
+        var store = ChatScrollStateStore()
+        store.save(snapshot, for: key)
+
+        XCTAssertEqual(
+            store.restoration(
+                for: key,
+                availableTargets: ChatScrollTargetAvailability(targets: storedTargets)
+            ),
+            snapshot
+        )
+    }
+
+    func testQualifiedRestorationFallsBackForEmptyTranscript() {
+        let target = ChatMessageScrollTargets.make(for: [
+            ChatMessage(id: "live", role: .assistant, content: "Repeated", timestamp: "now")
+        ])[0]
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
+        let snapshot = ChatScrollSnapshot(
+            anchorMessageID: target.semanticID,
+            followsLatest: false,
+            anchorMetadata: target.restorationMetadata
+        )
+        var store = ChatScrollStateStore()
+        store.save(snapshot, for: key)
+
+        XCTAssertEqual(
+            store.restoration(
+                for: key,
+                availableTargets: ChatScrollTargetAvailability(targets: [])
+            ),
+            .latest
+        )
+    }
+
     func testStableActivityAndAttachmentFieldsParticipateInSemanticFingerprint() {
         func semanticID(for message: ChatMessage) -> String {
             ChatMessageScrollTargets.make(for: [message])[0].semanticID
@@ -362,6 +438,43 @@ final class ChatScrollStateTests: XCTestCase {
 
         XCTAssertEqual(cache.update(for: edited), .semanticsChanged)
         XCTAssertNotEqual(cache.targets[0].semanticID, originalScrollID)
+    }
+
+    func testEqualCountProjectionReplacementReassertsLatestAfterCacheUpdate() {
+        var cache = ChatMessageScrollTargetCache()
+        cache.update(for: [
+            ChatMessage(id: "live", role: .assistant, content: "Stable", timestamp: "now")
+        ])
+
+        let update = cache.update(for: [
+            ChatMessage(id: "stored", role: .assistant, content: "Stable", timestamp: "stored")
+        ])
+
+        XCTAssertEqual(update, .renderingChanged)
+        XCTAssertTrue(ChatMessageScrollUpdatePolicy.shouldReassertLatest(
+            after: update,
+            followsLatest: true,
+            hasPendingNonLatestRestoration: false,
+            hasNotificationHandoff: false
+        ))
+    }
+
+    func testLatestReassertionYieldsToPendingNonLatestRestoration() {
+        XCTAssertFalse(ChatMessageScrollUpdatePolicy.shouldReassertLatest(
+            after: .semanticsChanged,
+            followsLatest: true,
+            hasPendingNonLatestRestoration: true,
+            hasNotificationHandoff: false
+        ))
+    }
+
+    func testLatestReassertionYieldsToNotificationHandoff() {
+        XCTAssertFalse(ChatMessageScrollUpdatePolicy.shouldReassertLatest(
+            after: .semanticsChanged,
+            followsLatest: true,
+            hasPendingNonLatestRestoration: false,
+            hasNotificationHandoff: true
+        ))
     }
 
     func testEquivalentSessionIDsShareCanonicalIdentity() {

--- a/ConduitTests/ChatTextSelectionTests.swift
+++ b/ConduitTests/ChatTextSelectionTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import Conduit
+
+final class ChatTextSelectionTests: XCTestCase {
+    func testEveryCurrentMessageRoleAllowsPartialTextSelection() {
+        let roles: [MessageRole] = [
+            .user, .assistant, .reasoning, .system,
+            .partial, .tool, .clarify, .approval
+        ]
+
+        XCTAssertTrue(
+            roles.allSatisfy { ChatTextSelectionPolicy.allowsTextSelection(for: $0) }
+        )
+    }
+}

--- a/docs/superpowers/plans/2026-08-08-chat-selection-scroll-restoration.md
+++ b/docs/superpowers/plans/2026-08-08-chat-selection-scroll-restoration.md
@@ -1,0 +1,529 @@
+# Chat Text Selection and Scroll Restoration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users copy arbitrary text from chat and restore their message-level reading position when the app returns from the background.
+
+**Architecture:** Keep the existing native SwiftUI Markdown and chat-card rendering. Apply one explicit text-selection policy to message and streaming bubbles, and track semantic top-visible message IDs using SwiftUI's iOS 17 `scrollPosition(id:)` binding. Store scene-scoped snapshots in a small Foundation-only value type so restoration rules are unit-testable without UI dependencies.
+
+**Tech Stack:** Swift 5.9, SwiftUI, XCTest, XcodeGen, iOS deployment target 17.0.
+
+## Global Constraints
+
+- Keep the deployment target at iOS 17.0 and use only APIs available from iOS 17.0 onward.
+- Preserve existing whole-response and whole-code copy buttons.
+- Keep buttons, images, diagrams, and non-text controls interactive.
+- Preserve the existing latest-following behavior for users who are already at the bottom.
+- Do not change iPhone portrait-only or iPad orientation behavior.
+- Do not bump the marketing/build version or upload a binary in this feature branch until the user explicitly requests the next submission.
+- Follow red-green-refactor: each new pure behavior gets a failing test before its production implementation.
+- Run `xcodegen generate` before Xcode builds because `Conduit.xcodeproj` is generated and ignored.
+
+---
+
+### Task 1: Establish the chat interaction policy contract
+
+**Files:**
+- Create: `Conduit/Services/ChatTextSelectionPolicy.swift`
+- Test: `ConduitTests/ChatTextSelectionTests.swift`
+
+**Interfaces:**
+- Produces `ChatTextSelectionPolicy.allowsTextSelection(for:) -> Bool` for every `MessageRole`.
+- The policy is Foundation-only and does not depend on SwiftUI view types.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ConduitTests/ChatTextSelectionTests.swift` with an exhaustive list of current roles:
+
+```swift
+import XCTest
+@testable import Conduit
+
+final class ChatTextSelectionTests: XCTestCase {
+    func testEveryCurrentMessageRoleAllowsPartialTextSelection() {
+        let roles: [MessageRole] = [
+            .user, .assistant, .reasoning, .system,
+            .partial, .tool, .clarify, .approval
+        ]
+
+        XCTAssertTrue(
+            roles.allSatisfy { ChatTextSelectionPolicy.allowsTextSelection(for: $0) }
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run the targeted test and verify it fails for the missing production contract**
+
+Run:
+
+```bash
+xcodegen generate
+xcodebuild test \
+  -project Conduit.xcodeproj \
+  -scheme Conduit \
+  -destination 'platform=iOS Simulator,id=E174DE05-4FA3-43F6-8135-38F8835E2313' \
+  -only-testing:ConduitTests/ChatTextSelectionTests \
+  -derivedDataPath /tmp/hermes-conduit-chat-selection-red-derived \
+  CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
+  DEVELOPMENT_TEAM='' PROVISIONING_PROFILE_SPECIFIER=''
+```
+
+Expected result: compilation fails because `ChatTextSelectionPolicy` does not exist yet.
+
+- [ ] **Step 3: Add the minimal exhaustive policy implementation**
+
+Create `Conduit/Services/ChatTextSelectionPolicy.swift`:
+
+```swift
+import Foundation
+
+enum ChatTextSelectionPolicy {
+    static func allowsTextSelection(for role: MessageRole) -> Bool {
+        switch role {
+        case .user, .assistant, .reasoning, .system,
+             .partial, .tool, .clarify, .approval:
+            return true
+        }
+    }
+}
+```
+
+The exhaustive switch makes adding a future message role fail compilation until its selection behavior is consciously chosen.
+
+- [ ] **Step 4: Run the targeted test and verify it passes**
+
+Run the same `xcodebuild test` command from Step 2. Expected result: one test passes with zero failures.
+
+- [ ] **Step 5: Commit the policy contract**
+
+```bash
+git add Conduit/Services/ChatTextSelectionPolicy.swift ConduitTests/ChatTextSelectionTests.swift
+git commit -m "test: define selectable chat message roles"
+```
+
+---
+
+### Task 2: Enable partial selection in message and streaming bubbles
+
+**Files:**
+- Modify: `Conduit/Views/ChatView.swift:250-270` for `MessageBubble`
+- Modify: `Conduit/Views/ChatView.swift:1140-1170` for `StreamingBubble`
+- Test: `ConduitTests/ChatTextSelectionTests.swift` remains the policy regression test; simulator verification covers the SwiftUI gesture behavior.
+
+**Interfaces:**
+- Consumes `ChatTextSelectionPolicy.allowsTextSelection(for:)` from Task 1.
+- Produces system text selection for all current message roles and the active streaming response.
+
+- [ ] **Step 1: Add the smallest view change**
+
+Wrap the existing `MessageBubble` role switch in a `Group` and apply the policy at the shared boundary:
+
+```swift
+var body: some View {
+    Group {
+        switch message.role {
+        // existing role cases unchanged
+        }
+    }
+    .textSelection(
+        ChatTextSelectionPolicy.allowsTextSelection(for: message.role)
+            ? .enabled
+            : .disabled
+    )
+}
+```
+
+In `StreamingBubble`, remove `.textSelection(.disabled)` from `StreamingText` and apply `.textSelection(.enabled)` to the containing streaming `VStack`, so the live response has the same selection behavior as a completed message.
+
+- [ ] **Step 2: Run the policy test and a compile-only simulator build**
+
+Run:
+
+```bash
+xcodegen generate
+xcodebuild test \
+  -project Conduit.xcodeproj \
+  -scheme Conduit \
+  -destination 'platform=iOS Simulator,id=E174DE05-4FA3-43F6-8135-38F8835E2313' \
+  -only-testing:ConduitTests/ChatTextSelectionTests \
+  -derivedDataPath /tmp/hermes-conduit-chat-selection-selection-derived \
+  CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
+  DEVELOPMENT_TEAM='' PROVISIONING_PROFILE_SPECIFIER=''
+```
+
+Expected result: the test passes and the target compiles with no new errors.
+
+- [ ] **Step 3: Commit the selection behavior**
+
+```bash
+git add Conduit/Views/ChatView.swift
+git commit -m "feat: allow partial text selection in chat"
+```
+
+---
+
+### Task 3: Add the testable per-session scroll snapshot store
+
+**Files:**
+- Create: `Conduit/Services/ChatScrollState.swift`
+- Create: `ConduitTests/ChatScrollStateTests.swift`
+
+**Interfaces:**
+- Produces `ChatScrollSnapshot(anchorMessageID:followsLatest:)`.
+- Produces `ChatScrollStateStore.save(_:for:)`, `snapshot(for:)`, and `restoration(for:availableMessageIDs:)`.
+- `restoration` returns the stored snapshot when its non-latest anchor exists, returns a latest-follow snapshot when the stored anchor is missing, and returns `nil` when no snapshot exists.
+
+- [ ] **Step 1: Write failing store tests**
+
+Create `ConduitTests/ChatScrollStateTests.swift`:
+
+```swift
+import XCTest
+@testable import Conduit
+
+final class ChatScrollStateTests: XCTestCase {
+    func testSnapshotsAreIsolatedBySession() {
+        var store = ChatScrollStateStore()
+        store.save(
+            ChatScrollSnapshot(anchorMessageID: "a-3", followsLatest: false),
+            for: "session-a"
+        )
+        store.save(
+            ChatScrollSnapshot(anchorMessageID: "b-1", followsLatest: false),
+            for: "session-b"
+        )
+
+        XCTAssertEqual(store.snapshot(for: "session-a")?.anchorMessageID, "a-3")
+        XCTAssertEqual(store.snapshot(for: "session-b")?.anchorMessageID, "b-1")
+    }
+
+    func testRestorationKeepsAnchorWhenMessageStillExists() {
+        var store = ChatScrollStateStore()
+        let expected = ChatScrollSnapshot(anchorMessageID: "message-4", followsLatest: false)
+        store.save(expected, for: "session")
+
+        XCTAssertEqual(
+            store.restoration(
+                for: "session",
+                availableMessageIDs: ["message-3", "message-4", "message-5"]
+            ),
+            expected
+        )
+    }
+
+    func testRestorationFallsBackToLatestWhenAnchorDisappears() {
+        var store = ChatScrollStateStore()
+        store.save(
+            ChatScrollSnapshot(anchorMessageID: "deleted", followsLatest: false),
+            for: "session"
+        )
+
+        XCTAssertEqual(
+            store.restoration(for: "session", availableMessageIDs: ["message-1"]),
+            .latest
+        )
+    }
+
+    func testLatestSnapshotRemainsLatestRegardlessOfAvailableMessages() {
+        var store = ChatScrollStateStore()
+        store.save(ChatScrollSnapshot.latest, for: "session")
+
+        XCTAssertEqual(
+            store.restoration(for: "session", availableMessageIDs: []),
+            .latest
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run the targeted store tests and verify they fail for missing types**
+
+Run:
+
+```bash
+xcodegen generate
+xcodebuild test \
+  -project Conduit.xcodeproj \
+  -scheme Conduit \
+  -destination 'platform=iOS Simulator,id=E174DE05-4FA3-43F6-8135-38F8835E2313' \
+  -only-testing:ConduitTests/ChatScrollStateTests \
+  -derivedDataPath /tmp/hermes-conduit-chat-scroll-red-derived \
+  CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
+  DEVELOPMENT_TEAM='' PROVISIONING_PROFILE_SPECIFIER=''
+```
+
+Expected result: compilation fails because `ChatScrollStateStore` and `ChatScrollSnapshot` do not exist yet.
+
+- [ ] **Step 3: Implement the minimal Foundation-only store**
+
+Create `Conduit/Services/ChatScrollState.swift`:
+
+```swift
+import Foundation
+
+struct ChatScrollSnapshot: Equatable {
+    let anchorMessageID: String?
+    let followsLatest: Bool
+
+    static let latest = ChatScrollSnapshot(anchorMessageID: nil, followsLatest: true)
+}
+
+struct ChatScrollStateStore {
+    private var snapshots: [String: ChatScrollSnapshot] = [:]
+
+    mutating func save(_ snapshot: ChatScrollSnapshot, for sessionID: String) {
+        let key = sessionID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !key.isEmpty else { return }
+        snapshots[key] = snapshot
+    }
+
+    func snapshot(for sessionID: String) -> ChatScrollSnapshot? {
+        snapshots[sessionID.trimmingCharacters(in: .whitespacesAndNewlines)]
+    }
+
+    func restoration(
+        for sessionID: String,
+        availableMessageIDs: Set<String>
+    ) -> ChatScrollSnapshot? {
+        guard let snapshot = snapshot(for: sessionID) else { return nil }
+        guard !snapshot.followsLatest else { return .latest }
+        guard let anchor = snapshot.anchorMessageID,
+              availableMessageIDs.contains(anchor) else {
+            return .latest
+        }
+        return snapshot
+    }
+}
+```
+
+- [ ] **Step 4: Run the targeted store tests and verify they pass**
+
+Run the same `xcodebuild test` command from Step 2. Expected result: four tests pass with zero failures.
+
+- [ ] **Step 5: Commit the scroll store**
+
+```bash
+git add Conduit/Services/ChatScrollState.swift ConduitTests/ChatScrollStateTests.swift
+git commit -m "test: add per-session chat scroll state"
+```
+
+---
+
+### Task 4: Track and restore the semantic chat position
+
+**Files:**
+- Modify: `Conduit/Views/ChatView.swift` throughout `ChatView`
+
+**Interfaces:**
+- Consumes `ChatScrollStateStore` and `ChatScrollSnapshot` from Task 3.
+- Produces scene-scoped restoration for the active session without changing `AppState` persistence or network reconciliation.
+
+- [ ] **Step 1: Add view state and semantic scroll targets**
+
+Add these properties to `ChatView`:
+
+```swift
+@Environment(\.scenePhase) private var scenePhase
+@State private var topVisibleChatID: String?
+@State private var chatScrollState = ChatScrollStateStore()
+@State private var pendingScrollRestoration: PendingChatScrollRestoration?
+```
+
+Add a private equatable helper near the existing preference keys:
+
+```swift
+private struct PendingChatScrollRestoration: Equatable {
+    let sessionID: String
+    let snapshot: ChatScrollSnapshot
+}
+```
+
+Add `.scrollTargetLayout()` to the existing `LazyVStack` and
+`.scrollPosition(id: $topVisibleChatID, anchor: .top)` to the surrounding
+`ScrollView`. Keep the existing `ScrollViewReader` and proxy-based explicit
+scroll commands so the change does not rewrite the working latest-message
+animation path.
+
+- [ ] **Step 2: Write the scene lifecycle snapshot and restore hooks**
+
+Add these methods to `ChatView`:
+
+```swift
+private func saveChatScrollPosition() {
+    guard let sessionID = appState.activeSessionId else { return }
+    let messageIDs = Set(appState.messages.map(\.id))
+    let anchor = messageIDs.contains(topVisibleChatID ?? "")
+        ? topVisibleChatID
+        : nil
+    chatScrollState.save(
+        ChatScrollSnapshot(
+            anchorMessageID: followsLatest ? nil : anchor,
+            followsLatest: followsLatest
+        ),
+        for: sessionID
+    )
+}
+
+private func beginChatScrollRestoration() {
+    guard let sessionID = appState.activeSessionId,
+          let snapshot = chatScrollState.snapshot(for: sessionID) else {
+        pendingScrollRestoration = nil
+        return
+    }
+
+    pendingScrollRestoration = PendingChatScrollRestoration(
+        sessionID: sessionID,
+        snapshot: snapshot
+    )
+    followsLatest = snapshot.followsLatest
+}
+```
+
+Add an `onChange(of: scenePhase)` handler inside the `ScrollViewReader` content:
+
+```swift
+.onChange(of: scenePhase) { _, phase in
+    switch phase {
+    case .inactive, .background:
+        saveChatScrollPosition()
+    case .active:
+        beginChatScrollRestoration()
+    default:
+        break
+    }
+}
+```
+
+- [ ] **Step 3: Restore only after the transcript has a usable layout**
+
+Add `finishChatScrollRestorationIfReady(using:)` and call it from the existing
+bottom-marker and viewport preference callbacks, alongside the notification
+handoff checks:
+
+```swift
+private func finishChatScrollRestorationIfReady(using proxy: ScrollViewProxy) {
+    guard let pending = pendingScrollRestoration,
+          pending.sessionID == appState.activeSessionId else { return }
+
+    if pending.snapshot.followsLatest {
+        pendingScrollRestoration = nil
+        followsLatest = true
+        scrollToLatest(using: proxy)
+        return
+    }
+
+    let availableIDs = Set(appState.messages.map(\.id))
+    guard !availableIDs.isEmpty else { return }
+    guard let resolved = chatScrollState.restoration(
+        for: pending.sessionID,
+        availableMessageIDs: availableIDs
+    ) else {
+        pendingScrollRestoration = nil
+        return
+    }
+
+    pendingScrollRestoration = nil
+    if resolved.followsLatest {
+        followsLatest = true
+        scrollToLatest(using: proxy)
+    } else if let anchor = resolved.anchorMessageID {
+        var transaction = Transaction()
+        transaction.animation = nil
+        withTransaction(transaction) {
+            proxy.scrollTo(anchor, anchor: .top)
+        }
+    }
+}
+```
+
+Do not let `updateBottomMarker` or `updateViewportBottom` set
+`followsLatest = true` while a non-latest restoration is pending. This avoids
+stale pre-refresh geometry re-enabling the latest-message scroll path before
+the saved anchor is applied. Keep the existing notification handoff logic
+separate and give it priority when `isOpeningNotificationSession` is true.
+
+- [ ] **Step 4: Re-run the targeted state tests and build the chat UI**
+
+Run both targeted test classes together:
+
+```bash
+xcodegen generate
+xcodebuild test \
+  -project Conduit.xcodeproj \
+  -scheme Conduit \
+  -destination 'platform=iOS Simulator,id=E174DE05-4FA3-43F6-8135-38F8835E2313' \
+  -only-testing:ConduitTests/ChatScrollStateTests \
+  -only-testing:ConduitTests/ChatTextSelectionTests \
+  -derivedDataPath /tmp/hermes-conduit-chat-interactions-targeted-derived \
+  CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
+  DEVELOPMENT_TEAM='' PROVISIONING_PROFILE_SPECIFIER=''
+```
+
+Expected result: all targeted tests pass and the updated `ChatView` compiles.
+
+- [ ] **Step 5: Commit semantic restoration**
+
+```bash
+git add Conduit/Views/ChatView.swift
+git commit -m "fix: restore chat position after backgrounding"
+```
+
+---
+
+### Task 5: Run the full verification suite and perform simulator acceptance testing
+
+**Files:**
+- Modify: none unless verification exposes a defect.
+- Verify: all source and test files from Tasks 1–4.
+
+- [ ] **Step 1: Regenerate the project and run the complete simulator suite**
+
+```bash
+xcodegen generate
+xcodebuild test \
+  -project Conduit.xcodeproj \
+  -scheme Conduit \
+  -destination 'platform=iOS Simulator,id=E174DE05-4FA3-43F6-8135-38F8835E2313' \
+  -derivedDataPath /tmp/hermes-conduit-chat-interactions-final-derived \
+  -resultBundlePath /tmp/hermes-conduit-chat-interactions-final-tests.xcresult \
+  CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
+  DEVELOPMENT_TEAM='' PROVISIONING_PROFILE_SPECIFIER=''
+```
+
+Expected result: the complete suite passes with zero failures. Record the exact test count.
+
+- [ ] **Step 2: Build and install the simulator app**
+
+```bash
+xcrun simctl install \
+  E174DE05-4FA3-43F6-8135-38F8835E2313 \
+  /tmp/hermes-conduit-chat-interactions-final-derived/Build/Products/Debug-iphonesimulator/Conduit.app
+xcrun simctl launch E174DE05-4FA3-43F6-8135-38F8835E2313 com.milim.relay
+plutil -p \
+  /tmp/hermes-conduit-chat-interactions-final-derived/Build/Products/Debug-iphonesimulator/Conduit.app/Info.plist \
+  | rg 'CFBundleShortVersionString|CFBundleVersion'
+```
+
+Expected result: the simulator launches the follow-up branch and reports version/build `0.1.2 (120)` inherited from the release branch.
+
+- [ ] **Step 3: Verify partial text selection manually**
+
+On the simulator, connect to the test Hermes gateway and long-press/select a substring in each of these surfaces: a user message, an assistant Markdown paragraph, a code block, and tool/approval text. Tap Copy and paste into a text field outside Conduit. Confirm the selection is partial, action buttons still work, and images/diagrams do not become selectable.
+
+- [ ] **Step 4: Verify scroll restoration manually**
+
+1. Open a long conversation and scroll into earlier history. Switch to another app, return after the foreground refresh completes, and confirm the same message remains at the reading position.
+2. Repeat while the assistant is streaming and confirm the saved anchor survives the refreshed transcript.
+3. Scroll to the bottom, background the app, and confirm new content appears at the latest edge on return.
+4. Exercise a session whose saved anchor is no longer present and confirm the view deterministically falls back to the latest message.
+
+- [ ] **Step 5: Review the final diff and verify the working tree**
+
+```bash
+git diff --check
+git status --short --branch
+git log -4 --oneline
+```
+
+Expected result: the working tree contains only the intentional source and test changes; the generated Xcode project remains ignored. Do not add a version bump, archive, TestFlight upload, or merge action to this branch until the user requests the next submission after reviewing the simulator behavior.

--- a/docs/superpowers/plans/2026-08-08-chat-selection-scroll-restoration.md
+++ b/docs/superpowers/plans/2026-08-08-chat-selection-scroll-restoration.md
@@ -603,3 +603,26 @@ Run the two new/updated focused test classes, then the complete simulator suite.
 - [ ] **Step 2: Implement the pure fixes and resolver/cache seams**
 - [ ] **Step 3: Integrate profile-scoped identity and cached targets into AppState/ChatView**
 - [ ] **Step 4: Run focused tests and full simulator verification**
+
+---
+
+### Task 8: Fix scroll-target registration and duplicate/latest edge cases
+
+**Reason:** Final review found that `.scrollTargetLayout()` is attached after the padded `LazyVStack`, equal-count transcript replacement does not reassert latest-following, and occurrence-only duplicate anchors can be reused by a different row after compaction.
+
+**Files:**
+- Modify: `Conduit/Views/ChatView.swift`
+- Modify: `Conduit/Services/ChatScrollState.swift`
+- Modify: `ConduitTests/ChatScrollStateTests.swift`
+
+**Requirements:**
+
+- Attach `.scrollTargetLayout()` directly to the `LazyVStack` before its padding/background modifiers so semantic child IDs are registered as scroll targets. Preserve the existing layout/padding and `ScrollViewReader` behavior.
+- When `AppState.messages` changes but the count stays equal, reassert `scrollToLatest` when `followsLatest` is true after the new target cache is installed. Never override a pending non-latest restore or notification handoff.
+- Make duplicate-anchor restoration conservative: save enough fingerprint/duplicate-count metadata to detect when duplicate multiplicity changes, and fall back to `.latest` rather than treating a shifted occurrence ordinal as the same message. Preserve backward-compatible snapshot initialization for existing tests/callers.
+- Add pure tests for empty/changed duplicate multiplicity and latest-following replacement logic where practical. If a full SwiftUI hosting test is not practical in this target, document the exact limitation; the production modifier placement must still match the iOS 17 API contract.
+- Preserve all previous constraints and do not add version, orientation, gateway, persistence, archive, upload, or merge changes.
+
+- [ ] **Step 1: Add failing pure tests**
+- [ ] **Step 2: Implement modifier/order and lifecycle fixes**
+- [ ] **Step 3: Run focused and full simulator verification**

--- a/docs/superpowers/plans/2026-08-08-chat-selection-scroll-restoration.md
+++ b/docs/superpowers/plans/2026-08-08-chat-selection-scroll-restoration.md
@@ -527,3 +527,53 @@ git log -4 --oneline
 ```
 
 Expected result: the working tree contains only the intentional source and test changes; the generated Xcode project remains ignored. Do not add a version bump, archive, TestFlight upload, or merge action to this branch until the user requests the next submission after reviewing the simulator behavior.
+
+---
+
+### Task 6: Harden restoration across reconciliation and transcript identity changes
+
+**Reason:** Final review found that geometry readiness alone can race foreground reconciliation, `session.resume` can rotate a runtime ID for the same logical conversation, and `ChatMessage.id` is not stable across local/live/persisted transcript projections. Fix these without changing gateway/network semantics or the existing user-facing latest/notification behavior.
+
+**Files:**
+- Modify: `Conduit/Services/ChatScrollState.swift`
+- Modify: `ConduitTests/ChatScrollStateTests.swift`
+- Modify: `Conduit/Services/AppState.swift`
+- Modify: `Conduit/Views/ChatView.swift`
+
+**Interfaces and invariants:**
+
+- Add a Foundation-only deterministic semantic anchor helper for `ChatMessage` rows. Its generated IDs must exclude `ChatMessage.id`, timestamp, author, and other source-specific volatile identifiers; include role/content and the stable activity fields needed to distinguish tool, clarify, approval, review, and attachment rows; and add an occurrence ordinal for duplicate fingerprints. The helper must produce equal anchors for the same logical message represented with different source IDs.
+- Add a Foundation-only `ChatScrollSessionIdentity` value type containing a canonical session ID, equivalent runtime/catalog IDs, reconciliation state, and a settled revision. It must answer whether two IDs are equivalent without depending on SwiftUI.
+- Expose the active identity from `AppState` as read-only published state. Populate equivalent IDs from the existing session catalog plus reconciliation requested/resolved IDs. Preserve the canonical ID while `session.resume` rotates a runtime ID for the same logical session. Increment the settled revision when existing reconciliation work settles; do not alter RPC payloads, network reconciliation decisions, or persistence formats.
+- In `ChatView`, use semantic anchor IDs as scroll targets and use the canonical session ID for scroll-state keys and the latest-message anchor. Keep `ForEach` rendering identity and existing controls intact.
+- Do not finish a non-latest restoration until the active identity is no longer reconciling and its settled revision has advanced past the revision observed when foreground restoration was requested. Re-check from identity/revision changes as well as geometry callbacks. If the scene becomes active without a reconciliation, the current revision may be used immediately.
+- Treat a raw `activeSessionId` change as a user session switch only when the old and new IDs are not equivalent under the published identity. Runtime-ID rotation must not cancel a pending restoration or force latest. Deliberate user drag, explicit scroll-to-latest, notification handoff, and a genuinely different session must still cancel/override restoration.
+- Keep iOS 17 APIs, iPhone/iPad orientation behavior, version/build metadata, whole-response/code copy buttons, latest-following behavior, and interactive non-text controls unchanged.
+
+- [ ] **Step 1: Add failing pure tests**
+
+Extend `ChatScrollStateTests` with coverage for:
+
+- semantically identical user/assistant rows with different raw IDs producing equal anchors;
+- duplicate semantic rows receiving distinct occurrence-qualified anchors;
+- stable activity/attachment fields participating in the fingerprint;
+- equivalent session IDs sharing one canonical identity while unrelated IDs do not;
+- a pending restoration remaining blocked while reconciliation is active and becoming eligible only after the settled revision advances (using a pure helper if needed).
+
+Run the focused test command before adding production implementations and record the expected compile/test failure.
+
+- [ ] **Step 2: Implement the pure identity and anchor helpers**
+
+Keep the helpers deterministic, bounded, and independent of SwiftUI. Preserve the existing `ChatScrollSnapshot` and `ChatScrollStateStore` behavior, changing only the anchor/session-key types needed to make restoration source-stable.
+
+- [ ] **Step 3: Expose AppState reconciliation/session identity**
+
+Connect the new value type to the already-existing `reconciliation`, `reconciliationToken`, active session catalog, and `session.resume` result flow. Ensure successful, failed, invalidated, and user-selected session paths cannot leave the published state claiming that reconciliation is active forever.
+
+- [ ] **Step 4: Integrate the hardening into ChatView**
+
+Replace raw message IDs in semantic scroll targets and snapshot availability checks; gate restoration on the published reconciliation identity; preserve notification/manual-latest/session-switch priority; and cancel pending restoration on deliberate user drag.
+
+- [ ] **Step 5: Run targeted and full verification**
+
+Run the two new/updated focused test classes, then the complete simulator suite. Record any unavailable XcodeGen/manual-authenticated UI limitation truthfully. Do not bump the version, archive, upload, or merge.

--- a/docs/superpowers/plans/2026-08-08-chat-selection-scroll-restoration.md
+++ b/docs/superpowers/plans/2026-08-08-chat-selection-scroll-restoration.md
@@ -577,3 +577,29 @@ Replace raw message IDs in semantic scroll targets and snapshot availability che
 - [ ] **Step 5: Run targeted and full verification**
 
 Run the two new/updated focused test classes, then the complete simulator suite. Record any unavailable XcodeGen/manual-authenticated UI limitation truthfully. Do not bump the version, archive, upload, or merge.
+
+---
+
+### Task 7: Close restoration correctness and streaming-cost gaps from final review
+
+**Reason:** Final review identified an empty-authoritative-transcript deadlock, profile collisions in the in-memory scroll store, projection-dependent tool anchors, repeated full-transcript fingerprinting during streaming, and insufficient direct coverage of the identity resolver.
+
+**Files:**
+- Modify: `Conduit/Services/ChatScrollState.swift`
+- Modify: `ConduitTests/ChatScrollStateTests.swift`
+- Modify: `Conduit/Views/ChatView.swift`
+- Modify: `Conduit/Services/AppState.swift`
+
+**Requirements:**
+
+- Once reconciliation has settled, allow a non-latest snapshot to resolve against an empty authoritative transcript. The existing store fallback must produce `.latest`, clear the pending restore, and let streaming/typing follow latest normally. Add a pure regression test.
+- Make scroll-state keys and session identity profile-qualified. Equal IDs in different Hermes profiles must not be equivalent, overwrite snapshots, or preserve pending restoration/following state across `activeProfile` changes. Explicitly cancel/reset pending restoration on profile changes and add a pure test.
+- Make tool-row semantic anchors independent of full/absent/truncated projection previews. Use only source-stable tool identity fields and occurrence ordering; add a test where the same tool has full input in one projection and missing or truncated input in another.
+- Cache `ChatMessageScrollTargets` in `ChatView`/a small pure cache and refresh it only when message semantics change, not on every `streamingText` render. Keep rendering identity and scroll identity behavior unchanged. The cache must be initialized when the view appears and refreshed when `AppState.messages` changes; a bounded pure cache/update test is preferred.
+- Route AppState’s catalog/requested/resolved canonical-ID calculation through a pure Foundation-only resolver, or add an equally direct pure seam, and test catalog aliases, runtime-ID rotation, unrelated sessions, profile separation, and reconciliation state/revision transitions. Do not alter RPC payloads or network semantics.
+- Preserve all earlier constraints: iOS 17 APIs, latest-following, manual latest, notification priority, controls/copy actions, iPhone/iPad orientations, version/build `0.1.2 (120)`, and no archive/upload/merge.
+
+- [ ] **Step 1: Add failing pure tests for all five findings**
+- [ ] **Step 2: Implement the pure fixes and resolver/cache seams**
+- [ ] **Step 3: Integrate profile-scoped identity and cached targets into AppState/ChatView**
+- [ ] **Step 4: Run focused tests and full simulator verification**

--- a/docs/superpowers/specs/2026-08-08-chat-selection-scroll-restoration-design.md
+++ b/docs/superpowers/specs/2026-08-08-chat-selection-scroll-restoration-design.md
@@ -1,0 +1,134 @@
+# Chat Text Selection and Scroll Restoration Design
+
+## Goal
+
+Improve the chat reading experience for the next submission by allowing users
+to select and copy portions of any textual chat content, and by preserving the
+current conversation position when the app is backgrounded and foregrounded.
+
+## User-facing behavior
+
+- Long-press selection is available for user messages, assistant responses,
+  streamed text, reasoning, tool output, review/clarification/approval text,
+  system messages, and code.
+- The existing whole-response and whole-code copy buttons remain available.
+- Buttons, controls, images, diagrams, and other non-text content remain
+  interactive rather than becoming part of a selectable surface.
+- When the app leaves the foreground, Conduit records the active conversation's
+  semantic scroll position.
+- If the user was reading above the latest message, returning to Conduit
+  restores the top visible message instead of jumping to the newest message,
+  even if new messages arrived while the app was away.
+- If the user was already following the latest message, returning to Conduit
+  continues to show the latest content and new responses.
+- If the saved message no longer exists after the gateway refreshes or compacts
+  history, Conduit falls back to its existing latest-message behavior rather
+  than leaving the transcript at an undefined position.
+- Scroll state is retained in memory for the current scene lifetime and is
+  scoped by session ID. A process relaunch continues to use the existing
+  startup restoration behavior; this feature does not add durable scroll
+  preferences.
+
+## Chosen approach
+
+### Native selection at the message boundary
+
+Apply SwiftUI's `.textSelection(.enabled)` to the `MessageBubble` container so
+all nested native `Text` views inherit the same selection policy. Remove the
+streaming bubble's explicit selection opt-out and enable selection on the
+streaming bubble itself. Keep the current block-aware Markdown renderer,
+syntax-highlighted code presentation, images, diagrams, and action buttons
+unchanged. This provides partial selection without replacing the existing rich
+rendering system.
+
+The message boundary is the narrowest shared surface that covers all current
+message roles. Selection is a view capability, not a new copy service; the
+system text interaction supplies the contextual Copy action for selected text,
+while existing explicit copy buttons continue to copy complete responses or
+code blocks.
+
+### Semantic scroll anchors
+
+Use the iOS 17 `ScrollPosition` API with the existing stable message IDs and a
+scroll target layout. `ScrollPosition` reports the top-most visible target and
+can be restored by target ID, which is appropriate for a transcript whose
+content may be reconstructed during foreground recovery.
+
+Add a small, pure `ChatScrollStateStore` value type that keeps snapshots keyed
+by session ID:
+
+```swift
+struct ChatScrollSnapshot: Equatable {
+    let anchorMessageID: String?
+    let followsLatest: Bool
+}
+```
+
+The store exposes a restoration lookup that accepts the current set of message
+IDs. A saved non-latest snapshot whose anchor is absent returns a latest-follow
+snapshot, making the missing-history fallback explicit and testable.
+
+`ChatView` owns the store for the scene lifetime. On `.inactive` or
+`.background`, it saves the active session's current top visible message ID
+and whether the view was following the bottom. On `.active`, a non-latest
+snapshot becomes a pending restoration. Existing geometry callbacks wait until
+the refreshed transcript has emitted layout, then restore the saved message
+without animation. During that handoff, existing automatic latest-message
+scroll triggers are suppressed. A latest-following snapshot uses the current
+follow-latest behavior instead.
+
+The implementation will preserve the message-level position. It will not try
+to persist a pixel offset inside a long message, because message IDs remain
+stable across transcript refreshes while pixel offsets can become invalid when
+streaming content, images, or tool cards change height.
+
+## Alternatives considered
+
+1. **Unified attributed text for each response.** Rejected: it would make
+   cross-block selection easier but would discard or complicate the current
+   Markdown blocks, code formatting, tables, diagrams, media, and controls.
+2. **HTML or `UITextView` chat rendering.** Rejected: it would introduce a
+   large UIKit/WebKit integration and new layout, accessibility, and streaming
+   risks for a problem the native SwiftUI text hierarchy can address.
+3. **Persist raw scroll offsets in `UserDefaults`.** Rejected: offsets are
+   fragile when transcript content changes; semantic message IDs are stable
+   and are sufficient for the requested app-switch behavior.
+
+## Files and boundaries
+
+- `Conduit/Services/ChatTextSelectionPolicy.swift`: define the exhaustive,
+  pure message-role selection contract used by the chat views.
+- `Conduit/Views/ChatView.swift`: apply the shared text-selection policy to
+  message and streaming bubbles, attach semantic scroll targets, save/restore
+  scene-scoped scroll snapshots, and coordinate restoration with existing
+  layout and follow-latest logic.
+- `Conduit/Services/ChatScrollState.swift`: define the testable snapshot and
+  per-session store without UIKit or SwiftUI dependencies.
+- `ConduitTests/ChatScrollStateTests.swift`: cover session isolation,
+  latest-following state, non-latest anchor restoration, and missing-anchor
+  fallback behavior.
+- `ConduitTests/ChatTextSelectionTests.swift`: cover the explicit selection
+  policy for every current `MessageRole`, preventing future message roles from
+  silently opting out. The UI behavior itself will also receive simulator
+  verification because SwiftUI text-selection gestures are not unit-testable.
+
+## Testing and acceptance criteria
+
+- Add the pure state tests before changing production code and observe them
+  fail for the new behavior.
+- Run the targeted chat-state tests after implementation, then the complete
+  iOS simulator suite.
+- Build and launch the simulator app from the follow-up branch.
+- Manually verify that partial text can be selected and copied from at least a
+  user message, assistant Markdown paragraph, code block, and tool/approval
+  text. Verify action buttons still respond and images are not selectable.
+- Manually verify the following scroll cases:
+  - scroll into earlier history, background, return after the transcript
+    refreshes, and confirm the same message remains at the reading position;
+  - background while a response is active and confirm the saved anchor is
+    restored after the response completes;
+  - remain at the bottom, background, and confirm new content still appears at
+    the latest edge on return;
+  - remove or invalidate the saved message and confirm the latest-message
+    fallback is deterministic.
+- Keep iPhone portrait-only and iPad orientation behavior unchanged.


### PR DESCRIPTION
## What changed

- Enable native partial text selection across textual chat content, including streaming responses, while preserving existing copy controls and interactive content.
- Restore the user's chat position when returning to the app or switching sessions.
- Follow new messages only when the user was already near the latest message.
- Use semantic, profile-qualified scroll anchors that remain stable across reconciliation, runtime session ID changes, duplicate messages, and streaming updates.
- Add focused regression coverage for selection and scroll restoration edge cases.

## Validation

- `xcodebuild test`: 243/243 tests passed.
- Simulator install and launch succeeded.
- `git diff --check` passed.
- Build metadata remains 0.1.2 (120).

Manual authenticated Hermes UI acceptance remains to be performed.

Closes #2