### PR TITLE
Normalize interaction haptics

### DIFF
--- a/Conduit/Services/Haptics.swift
+++ b/Conduit/Services/Haptics.swift
@@ -86,6 +86,14 @@ enum Haptics {
             selectionGenerator.prepare()
         }
     }
+    static func selectionChanged(_ changed: Bool) {
+        guard changed else { return }
+        selection()
+    }
+
+    static func mutationCompleted(_ succeeded: Bool) {
+        succeeded ? success() : error()
+    }
 
     static func prepare() {
         lightGenerator.prepare()

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -798,7 +798,6 @@ private struct ChatReturnBehaviorSettings: View {
         persist(next)
     }
 }
-
 private struct ResponseBehaviorSettings: View {
     let initialMode: BusyInputMode
     let save: (BusyInputMode) async -> Bool

--- a/Conduit/Views/ModelPickerView.swift
+++ b/Conduit/Views/ModelPickerView.swift
@@ -144,6 +144,7 @@ struct ModelPickerView: View {
 
     private func modelRow(_ model: ModelInfo, providerName: String) -> some View {
         Button {
+            Haptics.selectionChanged(selectedModel != model.id || selectedProvider != providerName)
             selectedModel = model.id
             selectedProvider = providerName
         } label: {

--- a/Conduit/Views/SidebarView.swift
+++ b/Conduit/Views/SidebarView.swift
@@ -477,15 +477,16 @@ struct SessionList: View {
             .disabled(appState.isSessionMutationInFlight(session))
 
             Button {
-                Haptics.selection()
+                Haptics.light()
                 appState.toggleSessionPinned(session)
             } label: {
                 Label(appState.isSessionPinned(session) ? "Unpin" : "Pin", systemImage: appState.isSessionPinned(session) ? "pin.slash" : "pin")
             }
 
             Button {
-                Haptics.selection()
-                Task { await appState.archiveSession(session) }
+                Task {
+                    Haptics.mutationCompleted(await appState.archiveSession(session))
+                }
             } label: {
                 Label("Archive", systemImage: "archivebox")
             }
@@ -501,7 +502,7 @@ struct SessionList: View {
         }
         .swipeActions(edge: .leading, allowsFullSwipe: false) {
             Button {
-                Haptics.selection()
+                Haptics.light()
                 appState.toggleSessionPinned(session)
             } label: {
                 Label(appState.isSessionPinned(session) ? "Unpin" : "Pin", systemImage: appState.isSessionPinned(session) ? "pin.slash" : "pin")
@@ -510,8 +511,9 @@ struct SessionList: View {
         }
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             Button {
-                Haptics.selection()
-                Task { await appState.archiveSession(session) }
+                Task {
+                    Haptics.mutationCompleted(await appState.archiveSession(session))
+                }
             } label: {
                 Label("Archive", systemImage: "archivebox")
             }
@@ -596,8 +598,9 @@ private struct ArchivedSessionsSheet: View {
 
                                 VStack(spacing: 6) {
                                     Button {
-                                        Haptics.selection()
-                                        Task { await appState.restoreArchivedSession(session) }
+                                        Task {
+                                            Haptics.mutationCompleted(await appState.restoreArchivedSession(session))
+                                        }
                                     } label: {
                                         Image(systemName: "arrow.uturn.backward")
                                             .font(.caption.weight(.bold))

--- a/ConduitTests/InteractionHapticsTests.swift
+++ b/ConduitTests/InteractionHapticsTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class InteractionHapticsTests: XCTestCase {
+    func testUnchangedSelectionIsSilent() {
+        XCTAssertTrue(capture(enabled: true) {
+            Haptics.selectionChanged(false)
+        }.isEmpty)
+    }
+
+    func testChangedSelectionEmitsSelectionFeedback() {
+        XCTAssertEqual(capture(enabled: true) {
+            Haptics.selectionChanged(true)
+        }, [.selection])
+    }
+
+    func testSuccessfulMutationEmitsSuccessFeedback() {
+        XCTAssertEqual(capture(enabled: true) {
+            Haptics.mutationCompleted(true)
+        }, [.success])
+    }
+
+    func testFailedMutationEmitsErrorFeedback() {
+        XCTAssertEqual(capture(enabled: true) {
+            Haptics.mutationCompleted(false)
+        }, [.error])
+    }
+
+    func testDisabledPreferenceSuppressesEveryInteractionOutcome() {
+        XCTAssertTrue(capture(enabled: false) {
+            Haptics.selectionChanged(true)
+            Haptics.mutationCompleted(true)
+            Haptics.mutationCompleted(false)
+        }.isEmpty)
+    }
+
+    private func capture(enabled: Bool, _ action: () -> Void) -> [Haptics.Event] {
+        let defaults = UserDefaults.standard
+        let previousValue = defaults.object(forKey: Haptics.preferenceKey)
+        let previousHandler = Haptics.testEmissionHandler
+        let previousSuppressesHardware = Haptics.testSuppressesHardware
+        var events: [Haptics.Event] = []
+        defer {
+            if let previousValue {
+                defaults.set(previousValue, forKey: Haptics.preferenceKey)
+            } else {
+                defaults.removeObject(forKey: Haptics.preferenceKey)
+            }
+            Haptics.testEmissionHandler = previousHandler
+            Haptics.testSuppressesHardware = previousSuppressesHardware
+        }
+
+        Haptics.testEmissionHandler = { events.append($0) }
+        Haptics.testSuppressesHardware = true
+        Haptics.enabled = enabled
+        action()
+        return events
+    }
+}


### PR DESCRIPTION
## Summary

- Play selection feedback only when the chosen model actually changes.
- Use a light impact for pin and unpin actions in both context menus and swipe actions.
- Play success or error notification feedback only after archive and restore operations return their actual result.

## Behavior

Selecting the already-active model remains silent. Selecting another model produces selection feedback.

Pin and unpin are immediate local mutations, so they produce a light impact at interaction time.

Archive and restore wait for `AppState` to complete the server-backed mutation. A successful mutation produces success feedback; a rejected or disconnected mutation produces error feedback and preserves the prior session state through the existing `AppState` failure behavior.

## Validation

Simulator:

- Regenerated the Xcode project from `project.yml` after switching branches.
- The complete Xcode 26.3.1 simulator test suite passed on an iPhone 17 Pro simulator.

Physical iPhone:

- Built, signed, installed, and opened the branch on an iPhone Air.
- Selecting a different model produced selection feedback; selecting the already-active model was silent.
- Pin and unpin each produced a light impact.
- Connected archive and restore operations each produced success feedback and moved the session to the expected catalog.
- Disconnected archive and restore attempts each produced error feedback and preserved the prior session state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tactile feedback when changing model or provider selections.
  * Added success or error feedback for completed archive and restore actions.
  * Added immediate feedback when starting session pin, archive, and restore actions.

* **Bug Fixes**
  * Prevented unnecessary selection feedback when no change occurs.
  * Respected disabled haptic settings across all supported interactions.

* **Tests**
  * Added coverage for selection, mutation results, disabled haptics, and unchanged selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->