### PR TITLE
Fix Cloudflare Access token injection origin leakage

### DIFF
--- a/Conduit/Services/CloudflareAccess.swift
+++ b/Conduit/Services/CloudflareAccess.swift
@@ -46,6 +46,14 @@ struct CloudflareAccessCredentials: Equatable, CustomStringConvertible {
         return request
     }
 
+    private func javaScriptStringLiteral(_ value: String) -> String? {
+        guard let data = try? JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed]),
+              let literal = String(data: data, encoding: .utf8),
+              literal.first == "\"",
+              literal.last == "\"" else { return nil }
+        return literal
+    }
+
     /// JavaScript injected at document start so that every `fetch()` and
     /// `XMLHttpRequest` originating inside the WKWebView includes the
     /// Cloudflare Access service-token headers. Without this, only the
@@ -54,12 +62,12 @@ struct CloudflareAccessCredentials: Equatable, CustomStringConvertible {
     /// evaluated scripts would be rejected by Cloudflare Service Auth.
     var fetchInjectionUserScript: String {
         guard isConfigured else { return "" }
-        let idEscaped = clientID.replacingOccurrences(of: "'", with: "\\'")
-        let secretEscaped = clientSecret.replacingOccurrences(of: "'", with: "\\'")
+        guard let idLiteral = javaScriptStringLiteral(clientID),
+              let secretLiteral = javaScriptStringLiteral(clientSecret) else { return "" }
         return """
         (function() {
-            var cfId = '\(idEscaped)';
-            var cfSecret = '\(secretEscaped)';
+            var cfId = \(idLiteral);
+            var cfSecret = \(secretLiteral);
             var origFetch = window.fetch;
             if (origFetch) {
                 window.fetch = function(input, init) {

--- a/Conduit/Services/CloudflareAccess.swift
+++ b/Conduit/Services/CloudflareAccess.swift
@@ -54,31 +54,52 @@ struct CloudflareAccessCredentials: Equatable, CustomStringConvertible {
         return literal
     }
 
-    /// JavaScript injected at document start so that every `fetch()` and
-    /// `XMLHttpRequest` originating inside the WKWebView includes the
-    /// Cloudflare Access service-token headers. Without this, only the
-    /// initial navigation request carries the headers; subsequent API/ticket
-    /// fetches issued by the dashboard page or by DashboardTicketBridge's
-    /// evaluated scripts would be rejected by Cloudflare Service Auth.
-    var fetchInjectionUserScript: String {
-        guard isConfigured else { return "" }
-        guard let idLiteral = javaScriptStringLiteral(clientID),
+    /// JavaScript injected at document start so that same-origin dashboard
+    /// `fetch()` and `XMLHttpRequest` calls inside the WKWebView include the
+    /// Cloudflare Access service-token headers. The script is intentionally
+    /// scoped to the configured dashboard origin; native requests still apply
+    /// the headers directly to the initial dashboard request.
+    func fetchInjectionUserScript(expectedBaseURL: String) -> String {
+        guard isConfigured,
+              let normalizedBaseURL = try? ConnectionURLPolicy.normalizedBaseURL(expectedBaseURL),
+              let baseURLLiteral = javaScriptStringLiteral(normalizedBaseURL),
+              let idLiteral = javaScriptStringLiteral(clientID),
               let secretLiteral = javaScriptStringLiteral(clientSecret) else { return "" }
         return """
         (function() {
             var cfId = \(idLiteral);
             var cfSecret = \(secretLiteral);
+            var cfOrigin = new URL(\(baseURLLiteral)).origin;
+            function resolvedURL(input) {
+                try {
+                    var value = input;
+                    if (value && typeof value === 'object' && typeof value.url === 'string') {
+                        value = value.url;
+                    }
+                    return new URL(value, window.location.href);
+                } catch (_) {
+                    return null;
+                }
+            }
+            function shouldAttach(input) {
+                var resolved = resolvedURL(input);
+                return window.location.origin === cfOrigin
+                    && resolved !== null
+                    && resolved.origin === cfOrigin;
+            }
             var origFetch = window.fetch;
             if (origFetch) {
                 window.fetch = function(input, init) {
-                    init = init || {};
-                    if (init.headers instanceof Headers) {
-                        init.headers.set('CF-Access-Client-Id', cfId);
-                        init.headers.set('CF-Access-Client-Secret', cfSecret);
-                    } else {
-                        init.headers = Object.assign({}, init.headers || {});
-                        init.headers['CF-Access-Client-Id'] = cfId;
-                        init.headers['CF-Access-Client-Secret'] = cfSecret;
+                    if (shouldAttach(input)) {
+                        init = init || {};
+                        if (init.headers instanceof Headers) {
+                            init.headers.set('CF-Access-Client-Id', cfId);
+                            init.headers.set('CF-Access-Client-Secret', cfSecret);
+                        } else {
+                            init.headers = Object.assign({}, init.headers || {});
+                            init.headers['CF-Access-Client-Id'] = cfId;
+                            init.headers['CF-Access-Client-Secret'] = cfSecret;
+                        }
                     }
                     return origFetch.call(this, input, init);
                 };
@@ -86,14 +107,13 @@ struct CloudflareAccessCredentials: Equatable, CustomStringConvertible {
             var origOpen = XMLHttpRequest.prototype.open;
             var origSend = XMLHttpRequest.prototype.send;
             XMLHttpRequest.prototype.open = function(method, url) {
-                this._cfHeadersApplied = false;
+                this._cfHeadersEligible = shouldAttach(url);
                 return origOpen.apply(this, arguments);
             };
             XMLHttpRequest.prototype.send = function(body) {
-                if (!this._cfHeadersApplied) {
+                if (this._cfHeadersEligible) {
                     this.setRequestHeader('CF-Access-Client-Id', cfId);
                     this.setRequestHeader('CF-Access-Client-Secret', cfSecret);
-                    this._cfHeadersApplied = true;
                 }
                 return origSend.apply(this, arguments);
             };

--- a/Conduit/Services/CloudflareAccess.swift
+++ b/Conduit/Services/CloudflareAccess.swift
@@ -92,26 +92,32 @@ struct CloudflareAccessCredentials: Equatable, CustomStringConvertible {
                 window.fetch = function(input, init) {
                     if (shouldAttach(input)) {
                         init = init || {};
-                        if (init.headers instanceof Headers) {
-                            init.headers.set('CF-Access-Client-Id', cfId);
-                            init.headers.set('CF-Access-Client-Secret', cfSecret);
-                        } else {
-                            init.headers = Object.assign({}, init.headers || {});
-                            init.headers['CF-Access-Client-Id'] = cfId;
-                            init.headers['CF-Access-Client-Secret'] = cfSecret;
+                        var sourceHeaders = init.headers;
+                        if (sourceHeaders === undefined
+                            && input
+                            && typeof input === 'object'
+                            && input.headers) {
+                            sourceHeaders = input.headers;
                         }
+                        var headers = new Headers(sourceHeaders || undefined);
+                        headers.set('CF-Access-Client-Id', cfId);
+                        headers.set('CF-Access-Client-Secret', cfSecret);
+                        init.headers = headers;
                     }
                     return origFetch.call(this, input, init);
                 };
             }
             var origOpen = XMLHttpRequest.prototype.open;
             var origSend = XMLHttpRequest.prototype.send;
+            var eligibleXhrs = new WeakMap();
+            var setXhrEligibility = eligibleXhrs.set.bind(eligibleXhrs);
+            var getXhrEligibility = eligibleXhrs.get.bind(eligibleXhrs);
             XMLHttpRequest.prototype.open = function(method, url) {
-                this._cfHeadersEligible = shouldAttach(url);
+                setXhrEligibility(this, shouldAttach(url));
                 return origOpen.apply(this, arguments);
             };
             XMLHttpRequest.prototype.send = function(body) {
-                if (this._cfHeadersEligible) {
+                if (getXhrEligibility(this) === true) {
                     this.setRequestHeader('CF-Access-Client-Id', cfId);
                     this.setRequestHeader('CF-Access-Client-Secret', cfSecret);
                 }

--- a/Conduit/Services/DashboardTicketBridge.swift
+++ b/Conduit/Services/DashboardTicketBridge.swift
@@ -115,13 +115,14 @@ final class DashboardTicketBridge: NSObject {
     private var pendingRequests: [Int: CheckedContinuation<[String: Any], Error>] = [:]
 
     init(baseURL: String, cloudflareAccess: CloudflareAccessCredentials? = nil) {
-        self.baseURL = (try? ConnectionURLPolicy.normalizedBaseURL(baseURL)) ?? ""
+        let normalizedBaseURL = (try? ConnectionURLPolicy.normalizedBaseURL(baseURL)) ?? ""
+        self.baseURL = normalizedBaseURL
         self.cloudflareAccess = cloudflareAccess
         let configuration = WKWebViewConfiguration()
         configuration.websiteDataStore = .default()
-        if let script = cloudflareAccess?.fetchInjectionUserScript, !script.isEmpty {
+        if let script = cloudflareAccess?.fetchInjectionUserScript(expectedBaseURL: normalizedBaseURL), !script.isEmpty {
             configuration.userContentController.addUserScript(
-                WKUserScript(source: script, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+                WKUserScript(source: script, injectionTime: .atDocumentStart, forMainFrameOnly: true)
             )
         }
         self.webView = WKWebView(frame: .zero, configuration: configuration)

--- a/Conduit/Views/LoginView.swift
+++ b/Conduit/Views/LoginView.swift
@@ -272,18 +272,20 @@ struct AuthWebView: UIViewRepresentable {
     let onError: (String) -> Void
 
     func makeUIView(context: Context) -> WKWebView {
+        let normalized = try? ConnectionURLPolicy.normalizedBaseURL(url)
         let config = WKWebViewConfiguration()
         config.websiteDataStore = .default()
         config.userContentController.add(context.coordinator, name: "ticket")
-        if let script = cloudflareAccess?.fetchInjectionUserScript, !script.isEmpty {
+        if let normalized,
+           let script = cloudflareAccess?.fetchInjectionUserScript(expectedBaseURL: normalized),
+           !script.isEmpty {
             config.userContentController.addUserScript(
-                WKUserScript(source: script, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+                WKUserScript(source: script, injectionTime: .atDocumentStart, forMainFrameOnly: true)
             )
         }
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
-        guard let normalized = try? ConnectionURLPolicy.normalizedBaseURL(url),
-              let dashboardURL = URL(string: normalized) else {
+        guard let normalized, let dashboardURL = URL(string: normalized) else {
             onError(ConnectionURLPolicyError.invalidURL.localizedDescription)
             return webView
         }

--- a/ConduitTests/CloudflareAccessTests.swift
+++ b/ConduitTests/CloudflareAccessTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import JavaScriptCore
 import XCTest
 @testable import Conduit
 
@@ -99,9 +100,177 @@ final class CloudflareAccessTests: XCTestCase {
         XCTAssertTrue(script.contains("resolved.origin === cfOrigin"))
     }
 
+    func testFetchInjectionPreservesRequestHeadersWhenInitHeadersAreAbsent() throws {
+        let credentials = CloudflareAccessCredentials(clientID: "test-id", clientSecret: "test-secret")
+        let context = try makeJavaScriptContext(documentOrigin: "https://dashboard.example")
+        _ = try evaluateJavaScript(
+            credentials.fetchInjectionUserScript(expectedBaseURL: "https://dashboard.example/hermes"),
+            in: context
+        )
+
+        let result = try evaluateJavaScript(
+            """
+            var request = new Request('https://dashboard.example/api', {
+                headers: { 'X-Application-Header': 'present' }
+            });
+            window.fetch(request);
+            var passedHeaders = new Headers(__lastFetch.init.headers);
+            passedHeaders.get('X-Application-Header') === 'present'
+                && passedHeaders.get('CF-Access-Client-Id') === 'test-id'
+                && passedHeaders.get('CF-Access-Client-Secret') === 'test-secret';
+            """,
+            in: context
+        )
+
+        XCTAssertTrue(result.toBool())
+    }
+
+    func testFetchInjectionPreservesExplicitInitHeaders() throws {
+        let credentials = CloudflareAccessCredentials(clientID: "test-id", clientSecret: "test-secret")
+        let context = try makeJavaScriptContext(documentOrigin: "https://dashboard.example")
+        _ = try evaluateJavaScript(
+            credentials.fetchInjectionUserScript(expectedBaseURL: "https://dashboard.example/hermes"),
+            in: context
+        )
+
+        let result = try evaluateJavaScript(
+            """
+            var request = new Request('https://dashboard.example/api', {
+                headers: { 'X-Application-Header': 'from-request' }
+            });
+            window.fetch(request, {
+                headers: { 'X-Application-Header': 'from-init' }
+            });
+            var passedHeaders = new Headers(__lastFetch.init.headers);
+            passedHeaders.get('X-Application-Header') === 'from-init'
+                && passedHeaders.get('CF-Access-Client-Id') === 'test-id'
+                && passedHeaders.get('CF-Access-Client-Secret') === 'test-secret';
+            """,
+            in: context
+        )
+
+        XCTAssertTrue(result.toBool())
+    }
+
+    func testFetchInjectionCannotForgeXHREligibilityFromPageJavaScript() throws {
+        let credentials = CloudflareAccessCredentials(clientID: "test-id", clientSecret: "test-secret")
+        let context = try makeJavaScriptContext(documentOrigin: "https://oauth.example")
+        _ = try evaluateJavaScript(
+            credentials.fetchInjectionUserScript(expectedBaseURL: "https://dashboard.example/hermes"),
+            in: context
+        )
+
+        let result = try evaluateJavaScript(
+            """
+            var xhr = new XMLHttpRequest();
+            xhr.open('GET', 'https://dashboard.example/api');
+            xhr._cfHeadersEligible = true;
+            xhr.send();
+            typeof __lastXHRHeaders['CF-Access-Client-Secret'] === 'undefined';
+            """,
+            in: context
+        )
+
+        XCTAssertTrue(result.toBool())
+    }
+
     func testFetchInjectionFailsClosedForInvalidDashboardURL() {
         let credentials = CloudflareAccessCredentials(clientID: "test-id", clientSecret: "test-secret")
         XCTAssertTrue(credentials.fetchInjectionUserScript(expectedBaseURL: "not a URL").isEmpty)
+    }
+
+    private func makeJavaScriptContext(documentOrigin: String) throws -> JSContext {
+        let context = try XCTUnwrap(JSContext())
+        context.setObject(documentOrigin, forKeyedSubscript: "__documentOrigin" as NSString)
+        _ = context.evaluateScript(
+            #"""
+            var window = {
+                location: {
+                    origin: __documentOrigin,
+                    href: __documentOrigin + '/login'
+                }
+            };
+
+            function originOf(value) {
+                var match = String(value).match(/^[a-z][a-z0-9+.-]*:\/\/[^\/]+/i);
+                if (!match) { throw new TypeError('Unsupported URL'); }
+                return match[0];
+            }
+
+            function URL(value, base) {
+                var text = String(value);
+                if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(text)) {
+                    text = text.charAt(0) === '/'
+                        ? originOf(base) + text
+                        : String(base).replace(/\/[^\/]*$/, '/') + text;
+                }
+                this.href = text;
+                this.origin = originOf(text);
+            }
+
+            function Headers(init) {
+                this.values = {};
+                if (init instanceof Headers) {
+                    for (var key in init.values) { this.values[key] = init.values[key]; }
+                } else if (init && init.values) {
+                    for (var valueKey in init.values) { this.values[valueKey] = init.values[valueKey]; }
+                } else if (init) {
+                    for (var name in init) {
+                        this.values[String(name).toLowerCase()] = String(init[name]);
+                    }
+                }
+            }
+            Headers.prototype.set = function(name, value) {
+                this.values[String(name).toLowerCase()] = String(value);
+            };
+            Headers.prototype.get = function(name) {
+                return this.values[String(name).toLowerCase()] || null;
+            };
+
+            function Request(url, init) {
+                this.url = new URL(url, window.location.href).href;
+                this.headers = new Headers(init && init.headers);
+            }
+
+            var __lastFetch = null;
+            window.fetch = function(input, init) {
+                __lastFetch = { input: input, init: init };
+                return null;
+            };
+
+            function XMLHttpRequest() {
+                this.headers = {};
+            }
+            XMLHttpRequest.prototype.open = function(method, url) {
+                this.method = method;
+                this.url = url;
+            };
+            XMLHttpRequest.prototype.setRequestHeader = function(name, value) {
+                this.headers[name] = value;
+            };
+            XMLHttpRequest.prototype.send = function(body) {
+                __lastXHRHeaders = this.headers;
+            };
+            window.XMLHttpRequest = XMLHttpRequest;
+            var __lastXHRHeaders = {};
+            """#
+        )
+        return context
+    }
+
+    private func evaluateJavaScript(_ source: String, in context: JSContext) throws -> JSValue {
+        var exception: JSValue?
+        context.exceptionHandler = { _, value in exception = value }
+        let result = context.evaluateScript(source)
+        context.exceptionHandler = nil
+        if let exception {
+            throw NSError(
+                domain: "CloudflareAccessTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: exception.toString() ?? "JavaScript evaluation failed"]
+            )
+        }
+        return try XCTUnwrap(result)
     }
 
     // MARK: - Origin Binding

--- a/ConduitTests/CloudflareAccessTests.swift
+++ b/ConduitTests/CloudflareAccessTests.swift
@@ -152,6 +152,68 @@ final class CloudflareAccessTests: XCTestCase {
         XCTAssertTrue(result.toBool())
     }
 
+    func testFetchInjectionAddsHeadersOnlyForSameOriginRequests() throws {
+        let credentials = CloudflareAccessCredentials(clientID: "test-id", clientSecret: "test-secret")
+        let context = try makeJavaScriptContext(documentOrigin: "https://dashboard.example")
+        _ = try evaluateJavaScript(
+            credentials.fetchInjectionUserScript(expectedBaseURL: "https://dashboard.example/hermes"),
+            in: context
+        )
+
+        let result = try evaluateJavaScript(
+            """
+            function hasAccessHeaders() {
+                var passedHeaders = new Headers(__lastFetch.init && __lastFetch.init.headers);
+                return passedHeaders.get('CF-Access-Client-Id') === 'test-id'
+                    && passedHeaders.get('CF-Access-Client-Secret') === 'test-secret';
+            }
+            window.fetch('/api');
+            var sameOrigin = hasAccessHeaders();
+            window.fetch('//attacker.example/api');
+            var networkPathCrossOrigin = !hasAccessHeaders();
+            window.fetch('https://attacker.example/api');
+            var absoluteCrossOrigin = !hasAccessHeaders();
+            sameOrigin && networkPathCrossOrigin && absoluteCrossOrigin;
+            """,
+            in: context
+        )
+
+        XCTAssertTrue(result.toBool())
+    }
+
+    func testXHRInjectionAddsHeadersOnlyForSameOriginRequests() throws {
+        let credentials = CloudflareAccessCredentials(clientID: "test-id", clientSecret: "test-secret")
+        let context = try makeJavaScriptContext(documentOrigin: "https://dashboard.example")
+        _ = try evaluateJavaScript(
+            credentials.fetchInjectionUserScript(expectedBaseURL: "https://dashboard.example/hermes"),
+            in: context
+        )
+
+        let result = try evaluateJavaScript(
+            """
+            var sameOriginXHR = new XMLHttpRequest();
+            sameOriginXHR.open('GET', '/api');
+            sameOriginXHR.send();
+            var sameOrigin = __lastXHRHeaders['CF-Access-Client-Secret'] === 'test-secret';
+
+            var networkPathCrossOriginXHR = new XMLHttpRequest();
+            networkPathCrossOriginXHR.open('GET', '//attacker.example/api');
+            networkPathCrossOriginXHR.send();
+            var networkPathCrossOrigin = typeof __lastXHRHeaders['CF-Access-Client-Secret'] === 'undefined';
+
+            var absoluteCrossOriginXHR = new XMLHttpRequest();
+            absoluteCrossOriginXHR.open('GET', 'https://attacker.example/api');
+            absoluteCrossOriginXHR.send();
+            var absoluteCrossOrigin = typeof __lastXHRHeaders['CF-Access-Client-Secret'] === 'undefined';
+
+            sameOrigin && networkPathCrossOrigin && absoluteCrossOrigin;
+            """,
+            in: context
+        )
+
+        XCTAssertTrue(result.toBool())
+    }
+
     func testFetchInjectionCannotForgeXHREligibilityFromPageJavaScript() throws {
         let credentials = CloudflareAccessCredentials(clientID: "test-id", clientSecret: "test-secret")
         let context = try makeJavaScriptContext(documentOrigin: "https://oauth.example")
@@ -200,9 +262,15 @@ final class CloudflareAccessTests: XCTestCase {
             function URL(value, base) {
                 var text = String(value);
                 if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(text)) {
-                    text = text.charAt(0) === '/'
-                        ? originOf(base) + text
-                        : String(base).replace(/\/[^\/]*$/, '/') + text;
+                    if (text.indexOf('//') === 0) {
+                        var schemeMatch = String(base).match(/^[a-z][a-z0-9+.-]*:/i);
+                        if (!schemeMatch) { throw new TypeError('Unsupported URL'); }
+                        text = schemeMatch[0] + text;
+                    } else {
+                        text = text.charAt(0) === '/'
+                            ? originOf(base) + text
+                            : String(base).replace(/\/[^\/]*$/, '/') + text;
+                    }
                 }
                 this.href = text;
                 this.origin = originOf(text);

--- a/ConduitTests/CloudflareAccessTests.swift
+++ b/ConduitTests/CloudflareAccessTests.swift
@@ -74,9 +74,20 @@ final class CloudflareAccessTests: XCTestCase {
     func testFetchInjectionEscapesSingleQuotes() throws {
         let credentials = CloudflareAccessCredentials(clientID: "id'with'quotes", clientSecret: "secret'val")
         let script = credentials.fetchInjectionUserScript
-        // Escaped quotes should be present, raw unescaped values should not
-        XCTAssertTrue(script.contains(#"id\'with\'quotes"#))
-        XCTAssertTrue(script.contains(#"secret\'val"#))
+        XCTAssertTrue(script.contains("var cfId = \"id'with'quotes\";"))
+        XCTAssertTrue(script.contains("var cfSecret = \"secret'val\";"))
+    }
+
+    func testFetchInjectionEscapesBackslashesAndControlCharacters() {
+        let credentials = CloudflareAccessCredentials(
+            clientID: "id\\with\"quote\n\t",
+            clientSecret: "secret\\value\"quote\r\n"
+        )
+
+        let script = credentials.fetchInjectionUserScript
+
+        XCTAssertTrue(script.contains(#"id\\with\"quote\n\t"#))
+        XCTAssertTrue(script.contains(#"secret\\value\"quote\r\n"#))
     }
 
     // MARK: - Origin Binding

--- a/ConduitTests/CloudflareAccessTests.swift
+++ b/ConduitTests/CloudflareAccessTests.swift
@@ -59,7 +59,7 @@ final class CloudflareAccessTests: XCTestCase {
 
     func testFetchInjectionContainsBothHeaders() throws {
         let credentials = CloudflareAccessCredentials(clientID: "test-id", clientSecret: "test-secret")
-        let script = credentials.fetchInjectionUserScript
+        let script = credentials.fetchInjectionUserScript(expectedBaseURL: "https://dashboard.example/hermes")
         XCTAssertTrue(script.contains("CF-Access-Client-Id"))
         XCTAssertTrue(script.contains("CF-Access-Client-Secret"))
         XCTAssertTrue(script.contains("test-id"))
@@ -68,12 +68,12 @@ final class CloudflareAccessTests: XCTestCase {
 
     func testFetchInjectionIsEmptyWhenUnconfigured() {
         let credentials = CloudflareAccessCredentials(clientID: "", clientSecret: "")
-        XCTAssertTrue(credentials.fetchInjectionUserScript.isEmpty)
+        XCTAssertTrue(credentials.fetchInjectionUserScript(expectedBaseURL: "https://dashboard.example/hermes").isEmpty)
     }
 
     func testFetchInjectionEscapesSingleQuotes() throws {
         let credentials = CloudflareAccessCredentials(clientID: "id'with'quotes", clientSecret: "secret'val")
-        let script = credentials.fetchInjectionUserScript
+        let script = credentials.fetchInjectionUserScript(expectedBaseURL: "https://dashboard.example/hermes")
         XCTAssertTrue(script.contains("var cfId = \"id'with'quotes\";"))
         XCTAssertTrue(script.contains("var cfSecret = \"secret'val\";"))
     }
@@ -84,10 +84,24 @@ final class CloudflareAccessTests: XCTestCase {
             clientSecret: "secret\\value\"quote\r\n"
         )
 
-        let script = credentials.fetchInjectionUserScript
+        let script = credentials.fetchInjectionUserScript(expectedBaseURL: "https://dashboard.example/hermes")
 
         XCTAssertTrue(script.contains(#"id\\with\"quote\n\t"#))
         XCTAssertTrue(script.contains(#"secret\\value\"quote\r\n"#))
+    }
+
+    func testFetchInjectionContainsOriginGuards() {
+        let credentials = CloudflareAccessCredentials(clientID: "test-id", clientSecret: "test-secret")
+        let script = credentials.fetchInjectionUserScript(expectedBaseURL: "https://dashboard.example/hermes")
+
+        XCTAssertTrue(script.contains(#"var cfOrigin = new URL("https:\/\/dashboard.example\/hermes").origin;"#))
+        XCTAssertTrue(script.contains("window.location.origin === cfOrigin"))
+        XCTAssertTrue(script.contains("resolved.origin === cfOrigin"))
+    }
+
+    func testFetchInjectionFailsClosedForInvalidDashboardURL() {
+        let credentials = CloudflareAccessCredentials(clientID: "test-id", clientSecret: "test-secret")
+        XCTAssertTrue(credentials.fetchInjectionUserScript(expectedBaseURL: "not a URL").isEmpty)
     }
 
     // MARK: - Origin Binding

--- a/docs/superpowers/plans/2026-08-09-cloudflare-token-origin-guard.md
+++ b/docs/superpowers/plans/2026-08-09-cloudflare-token-origin-guard.md
@@ -1,0 +1,257 @@
+# Cloudflare Access Token Origin Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restrict Cloudflare Access service-token headers to same-origin main-frame dashboard requests in both WebViews, with safe JavaScript serialization and regression coverage.
+
+**Architecture:** `CloudflareAccessCredentials` will generate an origin-scoped script from JSON string literals. `AuthWebView` and `DashboardTicketBridge` will pass the normalized dashboard URL and install the script for the main frame only. The script will independently check the current document origin and each resolved fetch/XHR destination before mutating request headers.
+
+**Tech Stack:** Swift, Foundation `JSONSerialization`, SwiftUI `UIViewRepresentable`, WebKit `WKUserScript`, XCTest, XcodeGen, `xcodebuild` on iOS Simulator.
+
+## Global Constraints
+
+- Keep service-token headers off subframes and every cross-origin request.
+- Preserve initial native dashboard requests and same-origin dashboard `fetch`/XHR behavior.
+- Fail closed by omitting the injection script when a credential or expected origin cannot be serialized.
+- Do not modify remote Markdown loading, dashboard logout, presentation-cache lifetime, or push-relay credential binding.
+- Preserve existing local workspace changes by working only in the isolated worktree.
+
+---
+
+## File map
+
+- Modify `Conduit/Services/CloudflareAccess.swift`: add JSON-safe literal generation and origin-aware fetch/XHR guards.
+- Modify `Conduit/Views/LoginView.swift`: pass the normalized dashboard URL and set `forMainFrameOnly: true`.
+- Modify `Conduit/Services/DashboardTicketBridge.swift`: use the same origin-aware script and main-frame restriction.
+- Modify `ConduitTests/CloudflareAccessTests.swift`: prove escaping, origin scoping, and fail-closed generation.
+- Regenerate `Conduit.xcodeproj` with XcodeGen; do not hand-edit generated project files.
+
+### Task 1: Prove safe credential serialization
+
+**Files:**
+
+- Modify: `ConduitTests/CloudflareAccessTests.swift`
+- Modify: `Conduit/Services/CloudflareAccess.swift`
+
+**Interfaces:**
+
+- Existing `CloudflareAccessCredentials.fetchInjectionUserScript` behavior remains covered while the serializer is extracted.
+- The implementation will use one internal JSON-string-literal helper for credentials and URLs.
+
+- [ ] **Step 1: Write the failing regression test**
+
+Add `testFetchInjectionEscapesBackslashesAndControlCharacters` using a client ID
+and secret containing a backslash, quote, newline, and tab. Assert that the
+generated source contains JSON-escaped literals and does not contain raw
+control characters inside the assigned values.
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+~~~bash
+xcodebuild -project Conduit.xcodeproj -scheme Conduit \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:ConduitTests/CloudflareAccessTests \
+  test
+~~~
+
+Expected: the new assertion fails because the current implementation only
+escapes single quotes.
+
+- [ ] **Step 3: Implement minimal JSON literal serialization**
+
+Replace manual quote replacement with a helper equivalent to:
+
+~~~swift
+private func javaScriptStringLiteral(_ value: String) -> String? {
+    guard let data = try? JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed]),
+          let literal = String(data: data, encoding: .utf8),
+          literal.first == "\"",
+          literal.last == "\"" else { return nil }
+    return literal
+}
+~~~
+
+Use the helper for both credential values and return an empty script if either
+literal cannot be produced.
+
+- [ ] **Step 4: Run the focused test to verify it passes**
+
+Run the same focused `xcodebuild` command and confirm the new test passes with
+the existing Cloudflare tests.
+
+- [ ] **Step 5: Commit the serializer change**
+
+~~~bash
+git add Conduit/Services/CloudflareAccess.swift ConduitTests/CloudflareAccessTests.swift
+git commit -m "fix: serialize Cloudflare injection credentials safely"
+~~~
+
+### Task 2: Add origin and frame guards
+
+**Files:**
+
+- Modify: `ConduitTests/CloudflareAccessTests.swift`
+- Modify: `Conduit/Services/CloudflareAccess.swift`
+
+**Interfaces:**
+
+- Replace the app-facing script property with `fetchInjectionUserScript(expectedBaseURL: String) -> String`.
+- The script will define `cfOrigin` from the serialized expected base URL and attach headers only when `window.location.origin === cfOrigin` and the resolved request origin equals `cfOrigin`.
+
+- [ ] **Step 1: Write the failing origin-scope tests**
+
+Add tests that generate the script for `https://dashboard.example/hermes` and
+assert it contains the exact current-document and resolved-request origin
+guards, plus a test that an unconfigured credential returns an empty script.
+Keep the existing header and quote tests pointed at the new method.
+
+- [ ] **Step 2: Run the focused tests to verify they fail**
+
+Run:
+
+~~~bash
+xcodebuild -project Conduit.xcodeproj -scheme Conduit \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:ConduitTests/CloudflareAccessTests \
+  test
+~~~
+
+Expected: the origin-guard assertions fail because the current script has no
+configured dashboard origin or cross-origin eligibility check.
+
+- [ ] **Step 3: Implement the guarded fetch/XHR script**
+
+Generate `cfOrigin` with `new URL(<serialized expected base URL>).origin`.
+Resolve string, URL, and Request-like fetch inputs against
+`window.location.href`; for XHR, evaluate the URL during `open`. Only mutate
+headers when both the document origin and resolved request origin equal
+`cfOrigin`. Keep the existing `Headers` and plain-object handling for
+eligible requests.
+
+- [ ] **Step 4: Run the focused tests to verify they pass**
+
+Run the focused Cloudflare test command again and confirm all origin, escaping,
+and existing credential tests pass.
+
+- [ ] **Step 5: Commit the origin guard**
+
+~~~bash
+git add Conduit/Services/CloudflareAccess.swift ConduitTests/CloudflareAccessTests.swift
+git commit -m "fix: scope Cloudflare headers to dashboard origin"
+~~~
+
+### Task 3: Apply the boundary to both WebViews
+
+**Files:**
+
+- Modify: `Conduit/Views/LoginView.swift`
+- Modify: `Conduit/Services/DashboardTicketBridge.swift`
+
+**Interfaces:**
+
+- Both callers pass the normalized dashboard URL to
+  `fetchInjectionUserScript(expectedBaseURL:)`.
+- Both callers install `WKUserScript(..., forMainFrameOnly: true)`.
+
+- [ ] **Step 1: Update `AuthWebView.makeUIView`**
+
+Normalize the dashboard URL before configuring the user script, pass that
+normalized value into the script generator, and change the user-script option
+to `forMainFrameOnly: true`. Leave the initial `URLRequest` and its native
+Cloudflare headers unchanged.
+
+- [ ] **Step 2: Update `DashboardTicketBridge.init`**
+
+Use the already normalized `baseURL` when generating the script and install it
+for the main frame only. Keep the existing cookie restoration and dashboard
+navigation policy unchanged.
+
+- [ ] **Step 3: Search for remaining unsafe call sites**
+
+Run:
+
+~~~bash
+rg -n "fetchInjectionUserScript|forMainFrameOnly" Conduit
+~~~
+
+Expected: both Cloudflare injection call sites pass an expected base URL and
+use `forMainFrameOnly: true`; unrelated WebKit scripts may retain their own
+frame policy.
+
+- [ ] **Step 4: Commit the WebView boundary changes**
+
+~~~bash
+git add Conduit/Views/LoginView.swift Conduit/Services/DashboardTicketBridge.swift
+git commit -m "fix: restrict Cloudflare injection to dashboard main frames"
+~~~
+
+### Task 4: Verify, publish, and open the PR
+
+**Files:**
+
+- Modify: regenerated `Conduit.xcodeproj` only if XcodeGen changes it.
+
+- [ ] **Step 1: Regenerate the Xcode project and inspect the diff**
+
+~~~bash
+/opt/homebrew/bin/xcodegen generate
+git diff --check
+git status --short
+~~~
+
+Expected: no unrelated source changes and no whitespace errors.
+
+- [ ] **Step 2: Run the focused regression suite**
+
+~~~bash
+xcodebuild -project Conduit.xcodeproj -scheme Conduit \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:ConduitTests/CloudflareAccessTests \
+  test
+~~~
+
+Expected: all Cloudflare tests pass.
+
+- [ ] **Step 3: Run the full simulator suite**
+
+~~~bash
+set -o pipefail
+xcodebuild -project Conduit.xcodeproj -scheme Conduit \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  test -resultBundlePath /tmp/conduit-cloudflare-token-guard.xcresult \
+  | tee /tmp/conduit-cloudflare-token-guard.log | tail -160
+~~~
+
+Expected: `** TEST SUCCEEDED **` and zero test failures.
+
+- [ ] **Step 4: Inspect the final diff and branch status**
+
+~~~bash
+git diff origin/agent/release-118-docs...HEAD --stat
+git diff --check
+git status -sb
+~~~
+
+Expected: only the approved design/plan docs, Cloudflare generator, two WebView
+call sites, and focused tests are present.
+
+- [ ] **Step 5: Push the branch**
+
+~~~bash
+git push -u origin agent/cloudflare-token-origin-guard
+~~~
+
+- [ ] **Step 6: Open a draft PR against `agent/release-118-docs`**
+
+Use the GitHub app after the push with this title:
+
+~~~text
+Fix Cloudflare Access token injection origin leakage
+~~~
+
+The body should state that the old script injected credentials into subframes
+and cross-origin requests, that the fix uses JSON literals plus main-frame and
+same-origin guards, and that focused and full simulator tests passed. Link
+issue #20 and identify the remaining findings as out of scope.

--- a/docs/superpowers/specs/2026-08-09-cloudflare-token-origin-guard-design.md
+++ b/docs/superpowers/specs/2026-08-09-cloudflare-token-origin-guard-design.md
@@ -1,0 +1,65 @@
+# Cloudflare Access Token Origin Guard
+
+## Goal
+
+Prevent Cloudflare Access service-token headers from reaching subframes or
+cross-origin requests made by the authentication and dashboard WebViews,
+while preserving same-origin dashboard authentication.
+
+## Current boundary
+
+`CloudflareAccessCredentials.fetchInjectionUserScript` embeds the client ID
+and secret into JavaScript. `AuthWebView` and `DashboardTicketBridge` install
+that script with `forMainFrameOnly: false`, and the script adds the headers to
+every intercepted `fetch` and `XMLHttpRequest`. Credential strings currently
+escape only single quotes, so backslashes and other JavaScript-sensitive input
+can change the generated source.
+
+## Design
+
+1. Serialize the client ID, client secret, and expected dashboard origin as
+   JSON string literals rather than interpolating manually escaped strings.
+2. Pass the normalized dashboard origin into the generated script.
+3. Install the script with `forMainFrameOnly: true` in both WebViews.
+4. Require both the current document origin and the fully resolved request
+   origin to equal the configured dashboard origin before adding either
+   Cloudflare header. Relative URLs resolve against the current document.
+5. Leave initial native requests and same-origin dashboard `fetch`/XHR traffic
+   unchanged. Cross-origin OAuth pages, third-party frames, redirects, and
+   external API requests receive no service-token headers.
+
+## Components
+
+- `CloudflareAccess.swift`: generate origin-scoped, safely serialized
+  injection JavaScript.
+- `LoginView.swift`: install the script only in the main frame and provide the
+  configured dashboard origin.
+- `DashboardTicketBridge.swift`: apply the same main-frame and origin-scoped
+  policy to the background ticket WebView.
+- `CloudflareAccessTests.swift`: cover quotes, backslashes, control characters,
+  same-origin requests, and cross-origin rejection.
+
+## Error and compatibility behavior
+
+If a value cannot be serialized or the expected origin is unavailable, the
+injection script will be omitted rather than emitting unsafe JavaScript. The
+existing native request path remains responsible for the initial dashboard
+request. Service-token mode therefore fails closed for the affected WebView
+request without changing non-Cloudflare connections.
+
+## Verification
+
+- Run focused Cloudflare tests through the real `CloudflareAccessCredentials`
+  script-generation boundary.
+- Confirm the regression tests fail before the implementation and pass after
+  it.
+- Run the complete iOS simulator test suite and inspect the final diff for
+  unrelated changes.
+- Manually verify that a same-origin dashboard request remains eligible and a
+  cross-origin request or subframe cannot receive the headers.
+
+## Scope boundary
+
+This change does not address remote Markdown image loading, dashboard cookie
+logout, presentation-cache lifetime, or push-relay credential binding. Those
+remain separate maintenance work.


### PR DESCRIPTION
## Summary

- serialize Cloudflare Access client ID, secret, and expected dashboard URL as JSON string literals;
- only attach service-token headers to requests whose document and resolved request origins match the configured dashboard origin;
- restrict Cloudflare user scripts to WebKit main frames in both authentication WebViews.

## Security impact

Previously, the injected fetch/XHR hooks could expose service-token headers to subframes and cross-origin requests, and manual escaping could produce unsafe JavaScript for values containing backslashes or control characters. This PR fails closed for invalid dashboard URLs and preserves native initial requests and same-origin dashboard API/ticket requests.

This addresses the Cloudflare token-injection finding in #20. The other findings in that issue are intentionally out of scope for this PR.

## Verification

- Focused Cloudflare suite: 16/16 passed
- Full simulator suite: 353/353 passed
- `git diff --check`: passed

Related to #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Cloudflare Access credentials are sent only with valid, same-origin dashboard requests.
  * Credential injection is restricted to the dashboard’s main frame.
  * Invalid URLs, configuration, or request inputs fail safely without attaching credentials.
  * Supports fetch requests, request objects, and XMLHttpRequests while preventing forged cross-origin eligibility.
  * Credentials and URLs are safely serialized, including special characters.

* **Documentation**
  * Added design and implementation documentation covering credential origin protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->