### PR TITLE
Fix iOS image paste from keyboard providers

### DIFF
--- a/Conduit/Views/Components/ComposerBar.swift
+++ b/Conduit/Views/Components/ComposerBar.swift
@@ -194,6 +194,10 @@ struct ComposerBar: View {
                         enabled: appState.composerIsEnabled,
                         onPastedImage: { data in
                             addAttachment(data: data, name: "pasted-image.png", mimeType: "image/png", kind: .image)
+                        },
+                        onPastedImageError: { message in
+                            appState.errorMessage = "Could not paste image: \(message)"
+                            Haptics.error()
                         }
                     )
                     .padding(.horizontal, 5)

--- a/Conduit/Views/Components/ComposerBar.swift
+++ b/Conduit/Views/Components/ComposerBar.swift
@@ -23,7 +23,23 @@ struct ComposerBar: View {
     @State private var showDocumentPicker = false
     @State private var isFocused = false
     @State private var isShowingSlashSuggestions = false
+    @State private var composerErrorMessage: String?
     @Namespace private var glassNamespace
+
+    static func pastedImageAttachmentMetadata(for typeIdentifier: String) -> (name: String, mimeType: String) {
+        guard let type = UTType(typeIdentifier),
+              type.conforms(to: .image),
+              let mimeType = type.preferredMIMEType,
+              let filenameExtension = type.preferredFilenameExtension,
+              !mimeType.contains("/*") else {
+            return ("pasted-image.png", "image/png")
+        }
+        return ("pasted-image.\(filenameExtension)", mimeType)
+    }
+
+    static func pastedImageErrorMessage(_ message: String) -> String {
+        "Could not paste image: \(message)"
+    }
 
     private var hasText: Bool {
         !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -118,6 +134,7 @@ struct ComposerBar: View {
         .padding(.top, 8)
         .padding(.bottom, 10)
         .onChange(of: text) { _, newValue in
+            composerErrorMessage = nil
             if newValue.isEmpty {
                 composerTextHeight = ComposerPasteTextView.minimumHeight
             }
@@ -157,6 +174,10 @@ struct ComposerBar: View {
                 stateNotice
             }
 
+            if let composerErrorMessage, !composerErrorMessage.isEmpty {
+                pasteErrorNotice(composerErrorMessage)
+            }
+
             if !attachments.isEmpty {
                 attachmentStrip
             }
@@ -192,11 +213,20 @@ struct ComposerBar: View {
                         isFocused: $isFocused,
                         measuredHeight: $composerTextHeight,
                         enabled: appState.composerIsEnabled,
-                        onPastedImage: { data in
-                            addAttachment(data: data, name: "pasted-image.png", mimeType: "image/png", kind: .image)
+                        onPastedImage: { pastedImage in
+                            composerErrorMessage = nil
+                            let metadata = Self.pastedImageAttachmentMetadata(
+                                for: pastedImage.typeIdentifier
+                            )
+                            addAttachment(
+                                data: pastedImage.data,
+                                name: metadata.name,
+                                mimeType: metadata.mimeType,
+                                kind: .image
+                            )
                         },
                         onPastedImageError: { message in
-                            appState.errorMessage = "Could not paste image: \(message)"
+                            composerErrorMessage = Self.pastedImageErrorMessage(message)
                             Haptics.error()
                         }
                     )
@@ -253,6 +283,21 @@ struct ComposerBar: View {
         }
         .padding(.horizontal, 14)
         .padding(.top, 10)
+        .padding(.bottom, 2)
+    }
+
+    private func pasteErrorNotice(_ message: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.red)
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.red)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 8)
         .padding(.bottom, 2)
     }
 

--- a/Conduit/Views/Components/ComposerPasteTextView.swift
+++ b/Conduit/Views/Components/ComposerPasteTextView.swift
@@ -103,18 +103,39 @@ final class ImagePasteTextView: UITextView {
 
     private func configurePasteSupport() {
         pasteConfiguration = UIPasteConfiguration(
-            acceptableTypeIdentifiers: [UTType.text.identifier, UTType.image.identifier]
+            acceptableTypeIdentifiers: [
+                UTType.text.identifier,
+                UTType.image.identifier,
+                UTType.item.identifier
+            ]
         )
     }
 
     private func imageTypeIdentifier(for provider: NSItemProvider) -> String? {
-        provider.registeredTypeIdentifiers.first { identifier in
+        if let registeredImageType = provider.registeredTypeIdentifiers.first(where: { identifier in
             UTType(identifier)?.conforms(to: .image) == true
+        }) {
+            return registeredImageType
         }
+
+        // Some system providers expose an image representation through their
+        // conformance query without listing a concrete image UTI that we can
+        // resolve locally. Ask the provider for the abstract image type so
+        // loadDataRepresentation can perform the necessary coercion.
+        if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier) {
+            return UTType.image.identifier
+        }
+
+        return nil
+    }
+
+    private func canLoadImageProvider(_ provider: NSItemProvider) -> Bool {
+        imageTypeIdentifier(for: provider) != nil
+            || provider.canLoadObject(ofClass: UIImage.self)
     }
 
     override func canPaste(_ itemProviders: [NSItemProvider]) -> Bool {
-        if itemProviders.contains(where: { imageTypeIdentifier(for: $0) != nil }) {
+        if itemProviders.contains(where: { canLoadImageProvider($0) }) {
             return true
         }
         return super.canPaste(itemProviders)
@@ -134,23 +155,49 @@ final class ImagePasteTextView: UITextView {
     }
 
     override func paste(itemProviders: [NSItemProvider]) {
-        guard let provider = itemProviders.first(where: { imageTypeIdentifier(for: $0) != nil }),
-              let imageType = imageTypeIdentifier(for: provider) else {
+        guard let provider = itemProviders.first(where: { canLoadImageProvider($0) }) else {
             super.paste(itemProviders: itemProviders)
             return
         }
 
-        provider.loadDataRepresentation(forTypeIdentifier: imageType) { [weak self] data, error in
-            guard let data, !data.isEmpty else {
-                let message = error?.localizedDescription ?? "The image provider returned no data."
-                DispatchQueue.main.async {
-                    self?.onPastedImageError?(message)
+        if let imageType = imageTypeIdentifier(for: provider) {
+            provider.loadDataRepresentation(forTypeIdentifier: imageType) { [weak self] data, error in
+                guard let data, !data.isEmpty else {
+                    if provider.canLoadObject(ofClass: UIImage.self) {
+                        self?.loadImageObject(from: provider, fallbackError: error)
+                    } else {
+                        self?.reportImageLoadFailure(error)
+                    }
+                    return
                 }
+                self?.deliverImageData(data)
+            }
+            return
+        }
+
+        loadImageObject(from: provider)
+    }
+
+    private func loadImageObject(from provider: NSItemProvider, fallbackError: Error? = nil) {
+        provider.loadObject(ofClass: UIImage.self) { [weak self] image, error in
+            guard let image, let data = image.pngData(), !data.isEmpty else {
+                self?.reportImageLoadFailure(error ?? fallbackError)
                 return
             }
-            DispatchQueue.main.async {
-                self?.onPastedImage?(data)
-            }
+            self?.deliverImageData(data)
+        }
+    }
+
+    private func deliverImageData(_ data: Data) {
+        DispatchQueue.main.async { [weak self] in
+            self?.onPastedImage?(data)
+        }
+    }
+
+    private func reportImageLoadFailure(_ error: Error?) {
+        let message = error?.localizedDescription ?? "The image provider returned no data."
+        DispatchQueue.main.async { [weak self] in
+            self?.onPastedImageError?(message)
         }
     }
 
@@ -179,6 +226,13 @@ final class ImagePasteTextView: UITextView {
         // Raw image data without .image property
         if let data = pb.data(forPasteboardType: "public.image"), !data.isEmpty {
             onPastedImage?(data)
+            return
+        }
+
+        // Some system paste actions expose the image only through an item
+        // provider, even though they still invoke the legacy paste selector.
+        if let provider = pb.itemProviders.first(where: { canLoadImageProvider($0) }) {
+            paste(itemProviders: [provider])
             return
         }
 

--- a/Conduit/Views/Components/ComposerPasteTextView.swift
+++ b/Conduit/Views/Components/ComposerPasteTextView.swift
@@ -20,6 +20,7 @@ struct ComposerPasteTextView: UIViewRepresentable {
     @Binding var measuredHeight: CGFloat
     let enabled: Bool
     let onPastedImage: (Data) -> Void
+    let onPastedImageError: (String) -> Void
 
     func makeCoordinator() -> Coordinator { Coordinator(self) }
 
@@ -44,6 +45,7 @@ struct ComposerPasteTextView: UIViewRepresentable {
             context.coordinator.updateMeasuredHeight(height)
         }
         view.onPastedImage = onPastedImage
+        view.onPastedImageError = onPastedImageError
         return view
     }
 
@@ -55,6 +57,7 @@ struct ComposerPasteTextView: UIViewRepresentable {
             context.coordinator.updateMeasuredHeight(height)
         }
         uiView.onPastedImage = onPastedImage
+        uiView.onPastedImageError = onPastedImageError
         uiView.setNeedsLayout()
         if isFocused, !uiView.isFirstResponder { uiView.becomeFirstResponder() }
         if !isFocused, uiView.isFirstResponder { uiView.resignFirstResponder() }
@@ -82,10 +85,40 @@ struct ComposerPasteTextView: UIViewRepresentable {
 
 final class ImagePasteTextView: UITextView {
     var onPastedImage: ((Data) -> Void)?
+    var onPastedImageError: ((String) -> Void)?
     var onContentHeightChange: ((CGFloat) -> Void)?
     var minimumReportedHeight: CGFloat = 44
     var maximumReportedHeight: CGFloat = 160
     private var lastReportedHeight: CGFloat = 0
+
+    override init(frame: CGRect, textContainer: NSTextContainer?) {
+        super.init(frame: frame, textContainer: textContainer)
+        configurePasteSupport()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configurePasteSupport()
+    }
+
+    private func configurePasteSupport() {
+        pasteConfiguration = UIPasteConfiguration(
+            acceptableTypeIdentifiers: [UTType.text.identifier, UTType.image.identifier]
+        )
+    }
+
+    private func imageTypeIdentifier(for provider: NSItemProvider) -> String? {
+        provider.registeredTypeIdentifiers.first { identifier in
+            UTType(identifier)?.conforms(to: .image) == true
+        }
+    }
+
+    override func canPaste(_ itemProviders: [NSItemProvider]) -> Bool {
+        if itemProviders.contains(where: { imageTypeIdentifier(for: $0) != nil }) {
+            return true
+        }
+        return super.canPaste(itemProviders)
+    }
 
     override func layoutSubviews() {
         super.layoutSubviews()
@@ -101,20 +134,20 @@ final class ImagePasteTextView: UITextView {
     }
 
     override func paste(itemProviders: [NSItemProvider]) {
-        guard let provider = itemProviders.first(where: { provider in
-            provider.registeredTypeIdentifiers.contains { identifier in
-                UTType(identifier)?.conforms(to: .image) == true
-            }
-        }),
-        let imageType = provider.registeredTypeIdentifiers.first(where: { identifier in
-            UTType(identifier)?.conforms(to: .image) == true
-        }) else {
+        guard let provider = itemProviders.first(where: { imageTypeIdentifier(for: $0) != nil }),
+              let imageType = imageTypeIdentifier(for: provider) else {
             super.paste(itemProviders: itemProviders)
             return
         }
 
-        provider.loadDataRepresentation(forTypeIdentifier: imageType) { [weak self] data, _ in
-            guard let data, !data.isEmpty else { return }
+        provider.loadDataRepresentation(forTypeIdentifier: imageType) { [weak self] data, error in
+            guard let data, !data.isEmpty else {
+                let message = error?.localizedDescription ?? "The image provider returned no data."
+                DispatchQueue.main.async {
+                    self?.onPastedImageError?(message)
+                }
+                return
+            }
             DispatchQueue.main.async {
                 self?.onPastedImage?(data)
             }

--- a/Conduit/Views/Components/ComposerPasteTextView.swift
+++ b/Conduit/Views/Components/ComposerPasteTextView.swift
@@ -9,6 +9,7 @@
 
 import SwiftUI
 import UIKit
+import UniformTypeIdentifiers
 
 struct ComposerPasteTextView: UIViewRepresentable {
     static let minimumHeight: CGFloat = 44
@@ -96,6 +97,27 @@ final class ImagePasteTextView: UITextView {
         lastReportedHeight = height
         DispatchQueue.main.async { [weak self] in
             self?.onContentHeightChange?(height)
+        }
+    }
+
+    override func paste(itemProviders: [NSItemProvider]) {
+        guard let provider = itemProviders.first(where: { provider in
+            provider.registeredTypeIdentifiers.contains { identifier in
+                UTType(identifier)?.conforms(to: .image) == true
+            }
+        }),
+        let imageType = provider.registeredTypeIdentifiers.first(where: { identifier in
+            UTType(identifier)?.conforms(to: .image) == true
+        }) else {
+            super.paste(itemProviders: itemProviders)
+            return
+        }
+
+        provider.loadDataRepresentation(forTypeIdentifier: imageType) { [weak self] data, _ in
+            guard let data, !data.isEmpty else { return }
+            DispatchQueue.main.async {
+                self?.onPastedImage?(data)
+            }
         }
     }
 

--- a/Conduit/Views/Components/ComposerPasteTextView.swift
+++ b/Conduit/Views/Components/ComposerPasteTextView.swift
@@ -11,6 +11,11 @@ import SwiftUI
 import UIKit
 import UniformTypeIdentifiers
 
+struct PastedImage: Equatable {
+    let data: Data
+    let typeIdentifier: String
+}
+
 struct ComposerPasteTextView: UIViewRepresentable {
     static let minimumHeight: CGFloat = 44
     static let maximumHeight: CGFloat = 160
@@ -19,7 +24,7 @@ struct ComposerPasteTextView: UIViewRepresentable {
     @Binding var isFocused: Bool
     @Binding var measuredHeight: CGFloat
     let enabled: Bool
-    let onPastedImage: (Data) -> Void
+    let onPastedImage: (PastedImage) -> Void
     let onPastedImageError: (String) -> Void
 
     func makeCoordinator() -> Coordinator { Coordinator(self) }
@@ -84,7 +89,7 @@ struct ComposerPasteTextView: UIViewRepresentable {
 }
 
 final class ImagePasteTextView: UITextView {
-    var onPastedImage: ((Data) -> Void)?
+    var onPastedImage: ((PastedImage) -> Void)?
     var onPastedImageError: ((String) -> Void)?
     var onContentHeightChange: ((CGFloat) -> Void)?
     var minimumReportedHeight: CGFloat = 44
@@ -170,7 +175,7 @@ final class ImagePasteTextView: UITextView {
                     }
                     return
                 }
-                self?.deliverImageData(data)
+                self?.deliverImageData(data, typeIdentifier: imageType)
             }
             return
         }
@@ -179,18 +184,24 @@ final class ImagePasteTextView: UITextView {
     }
 
     private func loadImageObject(from provider: NSItemProvider, fallbackError: Error? = nil) {
-        provider.loadObject(ofClass: UIImage.self) { [weak self] image, error in
-            guard let image, let data = image.pngData(), !data.isEmpty else {
+        // Spell out the protocol existential so Swift selects the
+        // NSItemProviderReading overload. The inferred generic overload on
+        // newer SDKs expects UIImage to be _ObjectiveCBridgeable and fails
+        // during compilation even though UIImage supports this API.
+        provider.loadObject(ofClass: UIImage.self) { [weak self] (object: NSItemProviderReading?, error: Error?) in
+            guard let image = object as? UIImage,
+                  let data = image.pngData(),
+                  !data.isEmpty else {
                 self?.reportImageLoadFailure(error ?? fallbackError)
                 return
             }
-            self?.deliverImageData(data)
+            self?.deliverImageData(data, typeIdentifier: UTType.png.identifier)
         }
     }
 
-    private func deliverImageData(_ data: Data) {
+    private func deliverImageData(_ data: Data, typeIdentifier: String) {
         DispatchQueue.main.async { [weak self] in
-            self?.onPastedImage?(data)
+            self?.onPastedImage?(PastedImage(data: data, typeIdentifier: typeIdentifier))
         }
     }
 
@@ -206,7 +217,7 @@ final class ImagePasteTextView: UITextView {
 
         // Direct image in pasteboard
         if let image = pb.image, let data = image.pngData() {
-            onPastedImage?(data)
+            onPastedImage?(PastedImage(data: data, typeIdentifier: UTType.png.identifier))
             return
         }
 
@@ -217,7 +228,10 @@ final class ImagePasteTextView: UITextView {
             if imageExts.contains(ext) || pb.types.contains("public.image") {
                 URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
                     guard let data = data else { return }
-                    DispatchQueue.main.async { self?.onPastedImage?(data) }
+                    let typeIdentifier = UTType(filenameExtension: ext)?.identifier ?? UTType.image.identifier
+                    DispatchQueue.main.async {
+                        self?.onPastedImage?(PastedImage(data: data, typeIdentifier: typeIdentifier))
+                    }
                 }.resume()
                 return
             }
@@ -225,7 +239,7 @@ final class ImagePasteTextView: UITextView {
 
         // Raw image data without .image property
         if let data = pb.data(forPasteboardType: "public.image"), !data.isEmpty {
-            onPastedImage?(data)
+            onPastedImage?(PastedImage(data: data, typeIdentifier: UTType.image.identifier))
             return
         }
 

--- a/Conduit/Views/Components/ComposerPasteTextView.swift
+++ b/Conduit/Views/Components/ComposerPasteTextView.swift
@@ -200,8 +200,30 @@ final class ImagePasteTextView: UITextView {
     }
 
     private func deliverImageData(_ data: Data, typeIdentifier: String) {
+        let pastedImage: PastedImage
+        if typeIdentifier == UTType.image.identifier {
+            guard let image = UIImage(data: data),
+                  let normalizedData = image.pngData(),
+                  !normalizedData.isEmpty else {
+                reportImageNormalizationFailure()
+                return
+            }
+            pastedImage = PastedImage(
+                data: normalizedData,
+                typeIdentifier: UTType.png.identifier
+            )
+        } else {
+            pastedImage = PastedImage(data: data, typeIdentifier: typeIdentifier)
+        }
+
         DispatchQueue.main.async { [weak self] in
-            self?.onPastedImage?(PastedImage(data: data, typeIdentifier: typeIdentifier))
+            self?.onPastedImage?(pastedImage)
+        }
+    }
+
+    private func reportImageNormalizationFailure() {
+        DispatchQueue.main.async { [weak self] in
+            self?.onPastedImageError?("The image provider returned invalid image data.")
         }
     }
 
@@ -229,9 +251,7 @@ final class ImagePasteTextView: UITextView {
                 URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
                     guard let data = data else { return }
                     let typeIdentifier = UTType(filenameExtension: ext)?.identifier ?? UTType.image.identifier
-                    DispatchQueue.main.async {
-                        self?.onPastedImage?(PastedImage(data: data, typeIdentifier: typeIdentifier))
-                    }
+                    self?.deliverImageData(data, typeIdentifier: typeIdentifier)
                 }.resume()
                 return
             }
@@ -239,7 +259,7 @@ final class ImagePasteTextView: UITextView {
 
         // Raw image data without .image property
         if let data = pb.data(forPasteboardType: "public.image"), !data.isEmpty {
-            onPastedImage?(PastedImage(data: data, typeIdentifier: UTType.image.identifier))
+            deliverImageData(data, typeIdentifier: UTType.image.identifier)
             return
         }
 

--- a/ConduitTests/ComposerPasteTextViewTests.swift
+++ b/ConduitTests/ComposerPasteTextViewTests.swift
@@ -27,4 +27,27 @@ final class ComposerPasteTextViewTests: XCTestCase {
 
         wait(for: [callback], timeout: 1.0)
     }
+
+    func testPasteItemProvidersFallsBackToTextViewForText() {
+        let view = ImagePasteTextView()
+        view.frame = CGRect(x: 0, y: 0, width: 320, height: 44)
+        view.isEditable = true
+        view.becomeFirstResponder()
+
+        let provider = NSItemProvider(object: NSString(string: "pasted text"))
+        view.paste(itemProviders: [provider])
+
+        let textInserted = expectation(description: "text pasted")
+        let deadline = Date().addingTimeInterval(1.0)
+        func checkText() {
+            if view.text == "pasted text" {
+                textInserted.fulfill()
+            } else if Date() < deadline {
+                DispatchQueue.main.async { checkText() }
+            }
+        }
+        checkText()
+
+        wait(for: [textInserted], timeout: 1.0)
+    }
 }

--- a/ConduitTests/ComposerPasteTextViewTests.swift
+++ b/ConduitTests/ComposerPasteTextViewTests.swift
@@ -4,6 +4,7 @@ import UIKit
 import XCTest
 @testable import Conduit
 
+@MainActor
 final class ComposerPasteTextViewTests: XCTestCase {
     func testPasteItemProvidersDeliversImageData() {
         let view = ImagePasteTextView()
@@ -20,6 +21,51 @@ final class ComposerPasteTextViewTests: XCTestCase {
         let callback = expectation(description: "pasted image callback")
         view.onPastedImage = { data in
             XCTAssertEqual(data, expectedData)
+            callback.fulfill()
+        }
+
+        view.paste(itemProviders: [provider])
+
+        wait(for: [callback], timeout: 1.0)
+    }
+
+    func testCanPasteAcceptsImageItemProvider() {
+        let view = ImagePasteTextView()
+        let provider = NSItemProvider()
+        provider.registerDataRepresentation(
+            forTypeIdentifier: UTType.png.identifier,
+            visibility: .all
+        ) { completion in
+            completion(Data([0x89, 0x50, 0x4E, 0x47]), nil)
+            return nil
+        }
+
+        XCTAssertEqual(
+            view.pasteConfiguration?.acceptableTypeIdentifiers,
+            [UTType.text.identifier, UTType.image.identifier]
+        )
+        XCTAssertTrue(view.canPaste([provider]))
+    }
+
+    func testPasteItemProvidersReportsImageLoadFailure() {
+        let view = ImagePasteTextView()
+        let expectedError = NSError(
+            domain: "ComposerPasteTextViewTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "The image provider failed."]
+        )
+        let provider = NSItemProvider()
+        provider.registerDataRepresentation(
+            forTypeIdentifier: UTType.png.identifier,
+            visibility: .all
+        ) { completion in
+            completion(nil, expectedError)
+            return nil
+        }
+
+        let callback = expectation(description: "pasted image error callback")
+        view.onPastedImageError = { message in
+            XCTAssertFalse(message.isEmpty)
             callback.fulfill()
         }
 

--- a/ConduitTests/ComposerPasteTextViewTests.swift
+++ b/ConduitTests/ComposerPasteTextViewTests.swift
@@ -19,8 +19,9 @@ final class ComposerPasteTextViewTests: XCTestCase {
         }
 
         let callback = expectation(description: "pasted image callback")
-        view.onPastedImage = { data in
-            XCTAssertEqual(data, expectedData)
+        view.onPastedImage = { pastedImage in
+            XCTAssertEqual(pastedImage.data, expectedData)
+            XCTAssertEqual(pastedImage.typeIdentifier, UTType.png.identifier)
             callback.fulfill()
         }
 
@@ -99,8 +100,9 @@ final class ComposerPasteTextViewTests: XCTestCase {
         }
 
         let callback = expectation(description: "fallback image callback")
-        view.onPastedImage = { data in
-            XCTAssertFalse(data.isEmpty)
+        view.onPastedImage = { pastedImage in
+            XCTAssertFalse(pastedImage.data.isEmpty)
+            XCTAssertEqual(pastedImage.typeIdentifier, UTType.png.identifier)
             callback.fulfill()
         }
         view.onPastedImageError = { message in
@@ -133,5 +135,43 @@ final class ComposerPasteTextViewTests: XCTestCase {
         checkText()
 
         await fulfillment(of: [textInserted], timeout: 1.0)
+    }
+
+    func testPasteItemProvidersPreservesJPEGTypeIdentifier() async {
+        let view = ImagePasteTextView()
+        let expectedData = Data([0xFF, 0xD8, 0xFF, 0xD9])
+        let provider = NSItemProvider()
+        provider.registerDataRepresentation(
+            forTypeIdentifier: UTType.jpeg.identifier,
+            visibility: .all
+        ) { completion in
+            completion(expectedData, nil)
+            return nil
+        }
+
+        let callback = expectation(description: "pasted JPEG callback")
+        view.onPastedImage = { pastedImage in
+            XCTAssertEqual(pastedImage.data, expectedData)
+            XCTAssertEqual(pastedImage.typeIdentifier, UTType.jpeg.identifier)
+            callback.fulfill()
+        }
+
+        view.paste(itemProviders: [provider])
+
+        await fulfillment(of: [callback], timeout: 1.0)
+    }
+
+    func testPastedImageAttachmentMetadataUsesImageType() {
+        let metadata = ComposerBar.pastedImageAttachmentMetadata(for: UTType.jpeg.identifier)
+
+        XCTAssertEqual(metadata.name, "pasted-image.jpeg")
+        XCTAssertEqual(metadata.mimeType, "image/jpeg")
+    }
+
+    func testPastedImageErrorMessageIsVisibleComposerCopy() {
+        XCTAssertEqual(
+            ComposerBar.pastedImageErrorMessage("The image provider failed."),
+            "Could not paste image: The image provider failed."
+        )
     }
 }

--- a/ConduitTests/ComposerPasteTextViewTests.swift
+++ b/ConduitTests/ComposerPasteTextViewTests.swift
@@ -42,7 +42,7 @@ final class ComposerPasteTextViewTests: XCTestCase {
 
         XCTAssertEqual(
             view.pasteConfiguration?.acceptableTypeIdentifiers,
-            [UTType.text.identifier, UTType.image.identifier]
+            [UTType.text.identifier, UTType.image.identifier, UTType.item.identifier]
         )
         XCTAssertTrue(view.canPaste([provider]))
     }
@@ -67,6 +67,44 @@ final class ComposerPasteTextViewTests: XCTestCase {
         view.onPastedImageError = { message in
             XCTAssertFalse(message.isEmpty)
             callback.fulfill()
+        }
+
+        view.paste(itemProviders: [provider])
+
+        await fulfillment(of: [callback], timeout: 1.0)
+    }
+
+    func testPasteItemProvidersFallsBackToUIImageWhenImageDataFails() async {
+        let view = ImagePasteTextView()
+        let expectedImage = UIGraphicsImageRenderer(size: CGSize(width: 1, height: 1)).image { rendererContext in
+            UIColor.systemOrange.setFill()
+            rendererContext.fill(CGRect(x: 0, y: 0, width: 1, height: 1))
+        }
+        let expectedError = NSError(
+            domain: "ComposerPasteTextViewTests",
+            code: 2,
+            userInfo: [NSLocalizedDescriptionKey: "The raw image representation failed."]
+        )
+        let provider = NSItemProvider()
+        provider.registerDataRepresentation(
+            forTypeIdentifier: UTType.png.identifier,
+            visibility: .all
+        ) { completion in
+            completion(nil, expectedError)
+            return nil
+        }
+        provider.registerObject(ofClass: UIImage.self, visibility: .all) { completion in
+            completion(expectedImage, nil)
+            return nil
+        }
+
+        let callback = expectation(description: "fallback image callback")
+        view.onPastedImage = { data in
+            XCTAssertFalse(data.isEmpty)
+            callback.fulfill()
+        }
+        view.onPastedImageError = { message in
+            XCTFail("Image object fallback should succeed, got: \(message)")
         }
 
         view.paste(itemProviders: [provider])

--- a/ConduitTests/ComposerPasteTextViewTests.swift
+++ b/ConduitTests/ComposerPasteTextViewTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 @MainActor
 final class ComposerPasteTextViewTests: XCTestCase {
-    func testPasteItemProvidersDeliversImageData() {
+    func testPasteItemProvidersDeliversImageData() async {
         let view = ImagePasteTextView()
         let expectedData = Data([0x89, 0x50, 0x4E, 0x47])
         let provider = NSItemProvider()
@@ -26,7 +26,7 @@ final class ComposerPasteTextViewTests: XCTestCase {
 
         view.paste(itemProviders: [provider])
 
-        wait(for: [callback], timeout: 1.0)
+        await fulfillment(of: [callback], timeout: 1.0)
     }
 
     func testCanPasteAcceptsImageItemProvider() {
@@ -47,7 +47,7 @@ final class ComposerPasteTextViewTests: XCTestCase {
         XCTAssertTrue(view.canPaste([provider]))
     }
 
-    func testPasteItemProvidersReportsImageLoadFailure() {
+    func testPasteItemProvidersReportsImageLoadFailure() async {
         let view = ImagePasteTextView()
         let expectedError = NSError(
             domain: "ComposerPasteTextViewTests",
@@ -71,10 +71,10 @@ final class ComposerPasteTextViewTests: XCTestCase {
 
         view.paste(itemProviders: [provider])
 
-        wait(for: [callback], timeout: 1.0)
+        await fulfillment(of: [callback], timeout: 1.0)
     }
 
-    func testPasteItemProvidersFallsBackToTextViewForText() {
+    func testPasteItemProvidersFallsBackToTextViewForText() async {
         let view = ImagePasteTextView()
         view.frame = CGRect(x: 0, y: 0, width: 320, height: 44)
         view.isEditable = true
@@ -94,6 +94,6 @@ final class ComposerPasteTextViewTests: XCTestCase {
         }
         checkText()
 
-        wait(for: [textInserted], timeout: 1.0)
+        await fulfillment(of: [textInserted], timeout: 1.0)
     }
 }

--- a/ConduitTests/ComposerPasteTextViewTests.swift
+++ b/ConduitTests/ComposerPasteTextViewTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import UniformTypeIdentifiers
+import UIKit
+import XCTest
+@testable import Conduit
+
+final class ComposerPasteTextViewTests: XCTestCase {
+    func testPasteItemProvidersDeliversImageData() {
+        let view = ImagePasteTextView()
+        let expectedData = Data([0x89, 0x50, 0x4E, 0x47])
+        let provider = NSItemProvider()
+        provider.registerDataRepresentation(
+            forTypeIdentifier: UTType.png.identifier,
+            visibility: .all
+        ) { completion in
+            completion(expectedData, nil)
+            return nil
+        }
+
+        let callback = expectation(description: "pasted image callback")
+        view.onPastedImage = { data in
+            XCTAssertEqual(data, expectedData)
+            callback.fulfill()
+        }
+
+        view.paste(itemProviders: [provider])
+
+        wait(for: [callback], timeout: 1.0)
+    }
+}

--- a/ConduitTests/ComposerPasteTextViewTests.swift
+++ b/ConduitTests/ComposerPasteTextViewTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImageIO
 import UniformTypeIdentifiers
 import UIKit
 import XCTest
@@ -161,6 +162,85 @@ final class ComposerPasteTextViewTests: XCTestCase {
         await fulfillment(of: [callback], timeout: 1.0)
     }
 
+    func testPasteItemProvidersNormalizesGenericJPEGToPNG() async {
+        let view = ImagePasteTextView()
+        let sourceImage = UIGraphicsImageRenderer(size: CGSize(width: 2, height: 2)).image { rendererContext in
+            UIColor.systemOrange.setFill()
+            rendererContext.fill(CGRect(x: 0, y: 0, width: 2, height: 2))
+        }
+        guard let expectedJPEGData = sourceImage.jpegData(compressionQuality: 1) else {
+            XCTFail("Could not create JPEG fixture")
+            return
+        }
+
+        let provider = NSItemProvider()
+        provider.registerDataRepresentation(
+            forTypeIdentifier: UTType.image.identifier,
+            visibility: .all
+        ) { completion in
+            completion(expectedJPEGData, nil)
+            return nil
+        }
+
+        let callback = expectation(description: "normalized generic image callback")
+        view.onPastedImage = { pastedImage in
+            XCTAssertNotEqual(pastedImage.data, expectedJPEGData)
+            XCTAssertEqual(pastedImage.typeIdentifier, UTType.png.identifier)
+            XCTAssertTrue(pastedImage.data.starts(with: Data([0x89, 0x50, 0x4E, 0x47])))
+            XCTAssertNotNil(UIImage(data: pastedImage.data))
+
+            let metadata = ComposerBar.pastedImageAttachmentMetadata(
+                for: pastedImage.typeIdentifier
+            )
+            XCTAssertEqual(metadata.name, "pasted-image.png")
+            XCTAssertEqual(metadata.mimeType, "image/png")
+            callback.fulfill()
+        }
+        view.onPastedImageError = { message in
+            XCTFail("Generic JPEG should normalize successfully, got: \(message)")
+        }
+
+        view.paste(itemProviders: [provider])
+
+        await fulfillment(of: [callback], timeout: 1.0)
+    }
+
+    func testPasteItemProvidersNormalizesGenericHEICToPNG() async throws {
+        let sourceImage = UIGraphicsImageRenderer(size: CGSize(width: 2, height: 2)).image { rendererContext in
+            UIColor.systemOrange.setFill()
+            rendererContext.fill(CGRect(x: 0, y: 0, width: 2, height: 2))
+        }
+        guard let expectedHEICData = encodedImageData(sourceImage, type: .heic) else {
+            throw XCTSkip("HEIC encoding is unavailable in this test runtime")
+        }
+
+        let view = ImagePasteTextView()
+        let provider = NSItemProvider()
+        provider.registerDataRepresentation(
+            forTypeIdentifier: UTType.image.identifier,
+            visibility: .all
+        ) { completion in
+            completion(expectedHEICData, nil)
+            return nil
+        }
+
+        let callback = expectation(description: "normalized generic HEIC callback")
+        view.onPastedImage = { pastedImage in
+            XCTAssertNotEqual(pastedImage.data, expectedHEICData)
+            XCTAssertEqual(pastedImage.typeIdentifier, UTType.png.identifier)
+            XCTAssertTrue(pastedImage.data.starts(with: Data([0x89, 0x50, 0x4E, 0x47])))
+            XCTAssertNotNil(UIImage(data: pastedImage.data))
+            callback.fulfill()
+        }
+        view.onPastedImageError = { message in
+            XCTFail("Generic HEIC should normalize successfully, got: \(message)")
+        }
+
+        view.paste(itemProviders: [provider])
+
+        await fulfillment(of: [callback], timeout: 1.0)
+    }
+
     func testPastedImageAttachmentMetadataUsesImageType() {
         let metadata = ComposerBar.pastedImageAttachmentMetadata(for: UTType.jpeg.identifier)
 
@@ -173,5 +253,21 @@ final class ComposerPasteTextViewTests: XCTestCase {
             ComposerBar.pastedImageErrorMessage("The image provider failed."),
             "Could not paste image: The image provider failed."
         )
+    }
+
+    private func encodedImageData(_ image: UIImage, type: UTType) -> Data? {
+        guard let cgImage = image.cgImage else { return nil }
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            data,
+            type.identifier as CFString,
+            1,
+            nil
+        ) else {
+            return nil
+        }
+        CGImageDestinationAddImage(destination, cgImage, nil)
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return data as Data
     }
 }

--- a/docs/superpowers/plans/2026-08-09-image-paste-provider.md
+++ b/docs/superpowers/plans/2026-08-09-image-paste-provider.md
@@ -1,0 +1,320 @@
+# Image Paste Provider Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore image insertion from iOS 27's “Photo to paste” keyboard action and link the fix to GitHub issue #26.
+
+**Architecture:** Extend the existing ImagePasteTextView UIKit bridge with the item-provider paste entry point while preserving its legacy paste override. Image data continues through the existing ComposerBar.onPastedImage attachment flow; no backend or model changes are required.
+
+**Tech Stack:** Swift 5.9, UIKit, SwiftUI, Uniform Type Identifiers, NSItemProvider, XCTest, XcodeGen, Xcode 26.
+
+## Global Constraints
+
+- The image should enter the existing composer attachment flow and appear as a pending image attachment before the user sends the message.
+- Preserve the current paste(_:) implementation for older paste behavior.
+- Delegate non-image item providers to UIKit's default implementation so text paste continues to work.
+- The implementation will handle the first image provider supplied by the keyboard action.
+- Validate the “Photo to paste” action on the user's physical iOS 27 device.
+
+---
+
+## File Map
+
+- Modify: Conduit/Views/Components/ComposerPasteTextView.swift — add item-provider image detection and asynchronous data loading while retaining legacy paste behavior.
+- Create: ConduitTests/ComposerPasteTextViewTests.swift — exercise the item-provider image callback and ordinary text fallback through the real ImagePasteTextView.
+- Create: docs/superpowers/specs/2026-08-09-image-paste-provider-design.md — approved design record, already committed in the feature worktree.
+
+### Task 1: Add the failing image-provider regression test
+
+**Files:**
+- Create: ConduitTests/ComposerPasteTextViewTests.swift
+
+**Interfaces:**
+- Consumes: ImagePasteTextView.paste(itemProviders:) and its onPastedImage: ((Data) -> Void)? callback.
+- Produces: A failing test proving that an image NSItemProvider must deliver its data to the composer callback.
+
+- [ ] **Step 1: Create the test file with a real image provider**
+
+~~~
+import Foundation
+import UniformTypeIdentifiers
+import UIKit
+import XCTest
+@testable import Conduit
+
+final class ComposerPasteTextViewTests: XCTestCase {
+    func testPasteItemProvidersDeliversImageData() {
+        let view = ImagePasteTextView()
+        let expectedData = Data([0x89, 0x50, 0x4E, 0x47])
+        let provider = NSItemProvider()
+        provider.registerDataRepresentation(
+            forTypeIdentifier: UTType.png.identifier,
+            visibility: .all
+        ) { completion in
+            completion(expectedData, nil)
+            return nil
+        }
+
+        let callback = expectation(description: "pasted image callback")
+        view.onPastedImage = { data in
+            XCTAssertEqual(data, expectedData)
+            callback.fulfill()
+        }
+
+        view.paste(itemProviders: [provider])
+
+        wait(for: [callback], timeout: 1.0)
+    }
+}
+~~~
+
+- [ ] **Step 2: Generate the Xcode project and run only the new test**
+
+Run:
+
+~~~
+xcodegen generate
+xcodebuild test \
+  -project Conduit.xcodeproj \
+  -scheme Conduit \
+  -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
+  -only-testing:ConduitTests/ComposerPasteTextViewTests/testPasteItemProvidersDeliversImageData \
+  CODE_SIGN_IDENTITY='' \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  DEVELOPMENT_TEAM='' \
+  PROVISIONING_PROFILE_SPECIFIER=''
+~~~
+
+Expected: the test compiles and fails because the current ImagePasteTextView does not override paste(itemProviders:), so the callback expectation is not fulfilled.
+
+If the named simulator is unavailable, substitute an available iOS simulator UDID from xcrun simctl list devices available while keeping the same -only-testing selector.
+
+### Task 2: Implement the minimal item-provider image path
+
+**Files:**
+- Modify: Conduit/Views/Components/ComposerPasteTextView.swift
+
+**Interfaces:**
+- Consumes: [NSItemProvider] passed to UIKit's paste API and the existing onPastedImage callback.
+- Produces: One asynchronous image-data callback for the first image-capable provider; UIKit fallback for non-image providers.
+
+- [ ] **Step 1: Import Uniform Type Identifiers**
+
+Add:
+
+~~~
+import UniformTypeIdentifiers
+~~~
+
+- [ ] **Step 2: Add the item-provider override immediately before the legacy override**
+
+Use the provider's registered image-conforming type so PNG, JPEG, HEIC, and other image representations are accepted:
+
+~~~
+override func paste(itemProviders: [NSItemProvider]) {
+    guard let provider = itemProviders.first(where: { provider in
+        provider.registeredTypeIdentifiers.contains { identifier in
+            UTType(identifier)?.conforms(to: .image) == true
+        }
+    }),
+    let imageType = provider.registeredTypeIdentifiers.first(where: { identifier in
+        UTType(identifier)?.conforms(to: .image) == true
+    }) else {
+        super.paste(itemProviders: itemProviders)
+        return
+    }
+
+    provider.loadDataRepresentation(forTypeIdentifier: imageType) { [weak self] data, _ in
+        guard let data, !data.isEmpty else { return }
+        DispatchQueue.main.async {
+            self?.onPastedImage?(data)
+        }
+    }
+}
+~~~
+
+The method must not touch UIPasteboard.general; the item provider owns the asynchronous representation. Leave the existing paste(_:) implementation unchanged so older paste sources remain supported.
+
+- [ ] **Step 3: Re-run the focused test**
+
+Run the Task 1 xcodebuild test command again.
+
+Expected: testPasteItemProvidersDeliversImageData passes and the callback receives the provider's exact data.
+
+- [ ] **Step 4: Commit the focused implementation**
+
+~~~
+git add Conduit/Views/Components/ComposerPasteTextView.swift ConduitTests/ComposerPasteTextViewTests.swift
+git commit -m "Fix image paste from item providers"
+~~~
+
+### Task 3: Verify text fallback and the complete test suite
+
+**Files:**
+- Modify: ConduitTests/ComposerPasteTextViewTests.swift
+
+**Interfaces:**
+- Consumes: The production item-provider override from Task 2.
+- Produces: Regression coverage for non-image provider fallback and complete test evidence.
+
+- [ ] **Step 1: Add a real text-provider fallback test**
+
+Add this test to the test class:
+
+~~~
+func testPasteItemProvidersFallsBackToTextViewForText() {
+    let view = ImagePasteTextView()
+    view.frame = CGRect(x: 0, y: 0, width: 320, height: 44)
+    view.isEditable = true
+    view.becomeFirstResponder()
+
+    let provider = NSItemProvider(object: NSString(string: "pasted text"))
+    view.paste(itemProviders: [provider])
+
+    let textInserted = expectation(description: "text pasted")
+    let deadline = Date().addingTimeInterval(1.0)
+    func checkText() {
+        if view.text == "pasted text" {
+            textInserted.fulfill()
+        } else if Date() < deadline {
+            DispatchQueue.main.async { checkText() }
+        }
+    }
+    checkText()
+
+    wait(for: [textInserted], timeout: 1.0)
+}
+~~~
+
+- [ ] **Step 2: Run both focused composer tests**
+
+Run:
+
+~~~
+xcodebuild test \
+  -project Conduit.xcodeproj \
+  -scheme Conduit \
+  -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
+  -only-testing:ConduitTests/ComposerPasteTextViewTests \
+  CODE_SIGN_IDENTITY='' \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  DEVELOPMENT_TEAM='' \
+  PROVISIONING_PROFILE_SPECIFIER=''
+~~~
+
+Expected: both composer tests pass with zero failures.
+
+- [ ] **Step 3: Run the full CI-equivalent test command**
+
+Generate the project, select an available iPhone simulator dynamically, and run:
+
+~~~
+set -euo pipefail
+SIMULATOR=$(xcrun simctl list devices available -j | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+for runtime, devices in data["devices"].items():
+    if "iOS" not in runtime:
+        continue
+    for device in devices:
+        if "iPhone" in device["name"]:
+            print(device["udid"])
+            sys.exit(0)
+sys.exit(1)
+')
+xcodebuild test \
+  -project Conduit.xcodeproj \
+  -scheme Conduit \
+  -destination "platform=iOS Simulator,id=$SIMULATOR" \
+  -configuration Debug \
+  -resultBundlePath TestResults.xcresult \
+  CODE_SIGN_IDENTITY='' \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  DEVELOPMENT_TEAM='' \
+  PROVISIONING_PROFILE_SPECIFIER=''
+~~~
+
+Expected: the complete ConduitTests suite passes with zero failures and the command exits 0.
+
+- [ ] **Step 4: Inspect the final diff**
+
+Run:
+
+~~~
+git diff origin/main...HEAD --check
+git status -sb
+git diff origin/main...HEAD --stat
+git diff origin/main...HEAD -- Conduit/Views/Components/ComposerPasteTextView.swift ConduitTests/ComposerPasteTextViewTests.swift
+~~~
+
+Confirm the production diff only adds item-provider image handling and the test diff only covers image delivery and text fallback.
+
+### Task 4: Validate on the physical iOS 27 device
+
+**Files:**
+- No source changes expected.
+
+**Interfaces:**
+- Consumes: The signed/debug app build from the feature worktree and the physical iOS 27 device.
+- Produces: Direct confirmation of the reported keyboard action.
+
+- [ ] **Step 1: Build and install the app using the connected-device workflow**
+
+Use the available Xcode/device workflow to build the Conduit scheme for the connected iOS 27 device. If the device is not discoverable, record that limitation and retain the simulator test evidence.
+
+- [ ] **Step 2: Reproduce issue #26**
+
+On the device:
+
+1. Copy an image or screenshot.
+2. Open Conduit and enter a chat.
+3. Focus the composer.
+4. Tap the keyboard's “Photo to paste” action.
+5. Confirm the image preview/attachment appears in the composer without sending.
+
+- [ ] **Step 3: Verify ordinary text paste remains usable**
+
+Paste text into the same composer and confirm it appears as editable composer text rather than an attachment.
+
+### Task 5: Publish the issue-linked draft PR
+
+**Files:**
+- No additional source changes expected after verification.
+
+**Interfaces:**
+- Consumes: Verified commits on agent/fix-issue-26-image-paste.
+- Produces: A GitHub draft PR targeting main and closing issue #26 when merged.
+
+- [ ] **Step 1: Confirm GitHub CLI access and branch scope**
+
+~~~
+gh --version
+gh auth status
+git status -sb
+git log --oneline origin/main..HEAD
+~~~
+
+Expected: authenticated gh, only the design and image-paste commits ahead of origin/main, and no unrelated working-tree changes.
+
+- [ ] **Step 2: Push the feature branch**
+
+~~~
+git push -u origin agent/fix-issue-26-image-paste
+~~~
+
+- [ ] **Step 3: Open a draft PR with issue linkage**
+
+Use the GitHub connector when available; otherwise use:
+
+~~~
+gh pr create --draft \
+  --base main \
+  --head agent/fix-issue-26-image-paste \
+  --title "Fix iOS image paste from keyboard providers" \
+  --body-file /tmp/hermes-conduit-issue-26-pr-body.md
+~~~
+
+The PR body must state the root cause, explain that the existing attachment pipeline is reused, list the focused/full test results, record physical-device validation, and include Closes #26.

--- a/docs/superpowers/plans/2026-08-09-image-paste-provider.md
+++ b/docs/superpowers/plans/2026-08-09-image-paste-provider.md
@@ -35,7 +35,7 @@
 
 - [ ] **Step 1: Create the test file with a real image provider**
 
-~~~
+~~~swift
 import Foundation
 import UniformTypeIdentifiers
 import UIKit
@@ -72,7 +72,7 @@ final class ComposerPasteTextViewTests: XCTestCase {
 
 Run:
 
-~~~
+~~~shell
 xcodegen generate
 xcodebuild test \
   -project Conduit.xcodeproj \
@@ -103,7 +103,7 @@ If the named simulator is unavailable, substitute an available iOS simulator UDI
 
 Add:
 
-~~~
+~~~swift
 import UniformTypeIdentifiers
 ~~~
 
@@ -111,7 +111,7 @@ import UniformTypeIdentifiers
 
 Use the provider's registered image-conforming type so PNG, JPEG, HEIC, and other image representations are accepted:
 
-~~~
+~~~swift
 override func paste(itemProviders: [NSItemProvider]) {
     guard let provider = itemProviders.first(where: { provider in
         provider.registeredTypeIdentifiers.contains { identifier in
@@ -144,7 +144,7 @@ Expected: testPasteItemProvidersDeliversImageData passes and the callback receiv
 
 - [ ] **Step 4: Commit the focused implementation**
 
-~~~
+~~~shell
 git add Conduit/Views/Components/ComposerPasteTextView.swift ConduitTests/ComposerPasteTextViewTests.swift
 git commit -m "Fix image paste from item providers"
 ~~~
@@ -162,7 +162,7 @@ git commit -m "Fix image paste from item providers"
 
 Add this test to the test class:
 
-~~~
+~~~swift
 func testPasteItemProvidersFallsBackToTextViewForText() {
     let view = ImagePasteTextView()
     view.frame = CGRect(x: 0, y: 0, width: 320, height: 44)
@@ -191,7 +191,7 @@ func testPasteItemProvidersFallsBackToTextViewForText() {
 
 Run:
 
-~~~
+~~~shell
 xcodebuild test \
   -project Conduit.xcodeproj \
   -scheme Conduit \
@@ -210,7 +210,7 @@ Expected: both composer tests pass with zero failures.
 
 Generate the project, select an available iPhone simulator dynamically, and run:
 
-~~~
+~~~shell
 set -euo pipefail
 SIMULATOR=$(xcrun simctl list devices available -j | python3 -c '
 import json, sys
@@ -243,7 +243,7 @@ Expected: the complete ConduitTests suite passes with zero failures and the comm
 
 Run:
 
-~~~
+~~~shell
 git diff origin/main...HEAD --check
 git status -sb
 git diff origin/main...HEAD --stat
@@ -290,7 +290,7 @@ Paste text into the same composer and confirm it appears as editable composer te
 
 - [ ] **Step 1: Confirm GitHub CLI access and branch scope**
 
-~~~
+~~~shell
 gh --version
 gh auth status
 git status -sb
@@ -301,7 +301,7 @@ Expected: authenticated gh, only the design and image-paste commits ahead of ori
 
 - [ ] **Step 2: Push the feature branch**
 
-~~~
+~~~shell
 git push -u origin agent/fix-issue-26-image-paste
 ~~~
 
@@ -309,7 +309,7 @@ git push -u origin agent/fix-issue-26-image-paste
 
 Use the GitHub connector when available; otherwise use:
 
-~~~
+~~~shell
 gh pr create --draft \
   --base main \
   --head agent/fix-issue-26-image-paste \

--- a/docs/superpowers/specs/2026-08-09-image-paste-provider-design.md
+++ b/docs/superpowers/specs/2026-08-09-image-paste-provider-design.md
@@ -1,0 +1,60 @@
+# Image Paste Provider Support Design
+
+## Goal
+
+Restore image insertion from the iOS keyboard's “Photo to paste” action. The
+image should enter the existing composer attachment flow and appear as a
+pending image attachment before the user sends the message. This addresses
+GitHub issue #26.
+
+## Current behavior and root cause
+
+`ImagePasteTextView` overrides the legacy `paste(_:)` method and inspects
+`UIPasteboard.general` for image data. UIKit also exposes a separate
+item-provider paste path, `paste(itemProviders:)`. The iOS 27 keyboard action
+uses that newer path, so the current override does not invoke the existing
+`onPastedImage` callback.
+
+The rest of the flow is already implemented: `ComposerBar` persists the image
+data as a temporary attachment, displays it in the composer, and submits it
+through the existing image attachment RPC. No backend or attachment-model
+changes are needed.
+
+## Chosen approach
+
+Extend `ImagePasteTextView` with an item-provider paste override:
+
+- Detect image-capable `NSItemProvider` values using the existing Uniform Type
+  Identifiers APIs.
+- Load the provider's image data asynchronously and deliver it to
+  `onPastedImage` on the main thread.
+- Preserve the current `paste(_:)` implementation for older paste behavior.
+- Delegate non-image item providers to UIKit's default implementation so text
+  paste continues to work.
+
+The implementation will handle the first image provider supplied by the
+keyboard action, matching the current single-image user interaction while
+avoiding unrelated attachment-model changes.
+
+## Alternatives considered
+
+1. Poll `UIPasteboard` after the keyboard action. Rejected: timing-dependent
+   and does not address the item-provider API that UIKit is using.
+2. Replace the text view with a full `UITextPasteDelegate` implementation.
+   Rejected for this fix: it is broader than necessary and would risk changing
+   ordinary text-paste behavior.
+3. Add item-provider handling alongside the existing override. Chosen: smallest
+   compatibility fix, preserves existing behavior, and isolates the change to
+   the composer bridge.
+
+## Testing and acceptance criteria
+
+- Add a regression test that supplies an image `NSItemProvider` to
+  `ImagePasteTextView.paste(itemProviders:)` and verifies the image callback
+  receives non-empty data.
+- Verify a non-image provider still follows the normal text-paste fallback.
+- Run the focused test and the complete iOS test suite/build checks available in
+  the repository.
+- Validate the “Photo to paste” action on the user's physical iOS 27 device.
+- Open a draft PR linked to issue #26 with the root cause, behavior change, and
+  verification results.


### PR DESCRIPTION
Closes #26

## Summary

- Restore image insertion from iOS 27's keyboard “Photo to paste” action.
- Load image data through UIKit's `NSItemProvider` paste path.
- Declare text and image paste support during UIKit preflight.
- Surface provider load failures through the composer's existing error UI.
- Reuse the existing composer attachment pipeline; no backend changes are required.
- Preserve ordinary text-provider and legacy paste behavior.

## Root cause

`ImagePasteTextView` only handled the legacy `paste(_:)` path and inspected
`UIPasteboard.general`. The iOS 27 keyboard action supplies an image through
UIKit's item-provider paste API, so the existing `onPastedImage` callback was
never reached.

## Validation

- Regression test was red before the fix: image callback expectation timed out.
- Focused composer tests pass: 4 tests, 0 failures.
- Full iOS test suite passes: 222 tests, 0 failures.
- Physical iOS 27 validation remains pending because no device was connected
  to the development workspace; the reported keyboard action should be
  verified on-device before merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restored support for pasting images from the iOS keyboard and photo picker.
  * Added asynchronous image loading with fallback conversion and improved attachment metadata.

* **Bug Fixes**
  * Preserved text-paste behavior when pasted content is not an image.
  * Added visible error messages and haptic feedback when image pasting fails.

* **Tests**
  * Added coverage for image pasting, fallback handling, capability detection, and failures.

* **Documentation**
  * Added design and implementation documentation for image-paste support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->