### PR TITLE
fix: show error when 'On this Phone' STT provider selection fails silently

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -4107,7 +4107,17 @@ final class AppState: ObservableObject {
     @discardableResult
     func setVoiceTranscriptionMode(_ mode: VoiceTranscriptionMode) async -> Bool {
         appleSpeechAvailability = AppleOnDeviceSpeechTranscriber.currentAvailability()
-        if mode == .appleOnDevice, !appleSpeechAvailability.canAttemptRecognition { return false }
+        if mode == .appleOnDevice, !appleSpeechAvailability.canAttemptRecognition {
+            switch appleSpeechAvailability {
+            case .permissionDenied:
+                errorMessage = "Speech Recognition permission was denied. Please enable it in Settings > Conduit > Speech Recognition."
+            case .unsupported:
+                errorMessage = "On-device speech recognition is not available for \(Locale.current.localizedString(forIdentifier: Locale.current.identifier) ?? "your locale")."
+            default:
+                errorMessage = "On-device speech recognition is unavailable."
+            }
+            return false
+        }
         if mode == .appleOnDevice {
             let permissionResult = await voiceConversationController.requestOnDeviceTranscriptionPermissions()
             appleSpeechAvailability = AppleOnDeviceSpeechTranscriber.currentAvailability()

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -4111,8 +4111,9 @@ final class AppState: ObservableObject {
             switch appleSpeechAvailability {
             case .permissionDenied:
                 errorMessage = "Speech Recognition permission was denied. Please enable it in Settings > Conduit > Speech Recognition."
-            case .unsupported:
-                errorMessage = "On-device speech recognition is not available for \(Locale.current.localizedString(forIdentifier: Locale.current.identifier) ?? "your locale")."
+            case .unsupported(let localeIdentifier):
+                let localeName = Locale.current.localizedString(forIdentifier: localeIdentifier) ?? localeIdentifier
+                errorMessage = "On-device speech recognition is not available for \(localeName)."
             default:
                 errorMessage = "On-device speech recognition is unavailable."
             }

--- a/Conduit/Views/VoiceSettingsView.swift
+++ b/Conduit/Views/VoiceSettingsView.swift
@@ -440,8 +440,13 @@ struct VoiceSettingsView: View {
                 appleSpeechAvailability = AppleOnDeviceSpeechTranscriber.currentAvailability()
                 if selected {
                     transcriptionMode = .appleOnDevice
+                    testStatus = nil
                 } else if case .permissionRequired = appleSpeechAvailability {
                     testStatus = "iOS will prompt for Speech Recognition permission when you start a voice conversation or tap \"Record ASR\"."
+                } else if case .permissionDenied = appleSpeechAvailability {
+                    testStatus = "Speech Recognition permission was denied. Please enable it in Settings > Conduit > Speech Recognition."
+                } else if case .unsupported = appleSpeechAvailability {
+                    testStatus = "On-device speech recognition is not available for your current language locale."
                 }
             } else {
                 let providerSaved: Bool

--- a/Conduit/Views/VoiceSettingsView.swift
+++ b/Conduit/Views/VoiceSettingsView.swift
@@ -225,7 +225,7 @@ struct VoiceSettingsView: View {
             case .ready:
                 EmptyView()
             case .permissionRequired:
-                Text("Tap \"Record ASR\" below to grant Speech Recognition permission, or enable it in Settings > Conduit > Speech Recognition.")
+                Text("Enable Speech Recognition in Settings > Conduit > Speech Recognition, then retry selecting \"On this iPhone\".")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             case .permissionDenied:
@@ -442,7 +442,7 @@ struct VoiceSettingsView: View {
                     transcriptionMode = .appleOnDevice
                     testStatus = nil
                 } else if case .permissionRequired = appleSpeechAvailability {
-                    testStatus = "iOS will prompt for Speech Recognition permission when you start a voice conversation or tap \"Record ASR\"."
+                    testStatus = "Enable Speech Recognition in Settings > Conduit > Speech Recognition, then retry selecting \"On this iPhone\"."
                 } else if case .permissionDenied = appleSpeechAvailability {
                     testStatus = "Speech Recognition permission was denied. Please enable it in Settings > Conduit > Speech Recognition."
                 } else if case .unsupported = appleSpeechAvailability {

--- a/Conduit/Views/VoiceSettingsView.swift
+++ b/Conduit/Views/VoiceSettingsView.swift
@@ -221,8 +221,19 @@ struct VoiceSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
-            if case .permissionRequired = appleSpeechAvailability {
-                Text("iOS will ask for Speech Recognition permission when you run the test or start listening.")
+            switch appleSpeechAvailability {
+            case .ready:
+                EmptyView()
+            case .permissionRequired:
+                Text("Tap \"Record ASR\" below to grant Speech Recognition permission, or enable it in Settings > Conduit > Speech Recognition.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            case .permissionDenied:
+                Text("Speech Recognition permission was denied. Please enable it in Settings > Conduit > Speech Recognition.")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            case .unsupported:
+                Text("On-device speech recognition is not available for your current language locale.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -427,7 +438,11 @@ struct VoiceSettingsView: View {
             if kind == .stt, provider == Self.appleProviderID {
                 let selected = await setTranscriptionMode(.appleOnDevice)
                 appleSpeechAvailability = AppleOnDeviceSpeechTranscriber.currentAvailability()
-                if selected { transcriptionMode = .appleOnDevice }
+                if selected {
+                    transcriptionMode = .appleOnDevice
+                } else if case .permissionRequired = appleSpeechAvailability {
+                    testStatus = "iOS will prompt for Speech Recognition permission when you start a voice conversation or tap \"Record ASR\"."
+                }
             } else {
                 let providerSaved: Bool
                 if provider == selectedProvider(kind) {

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -117,6 +117,52 @@ final class VoiceConversationControllerTests: XCTestCase {
         XCTAssertEqual(result.message, "Speech Recognition permission is required for on-device transcription.")
     }
 
+    func testOnDevicePermissionPreparationReportsMicrophoneDenial() async {
+        let controller = VoiceConversationController(
+            capture: MockCapture(permissionGranted: false),
+            playback: MockPlayback(),
+            deviceTranscriber: MockDeviceTranscriber(transcript: "", permissionGranted: true),
+            gateway: MockGateway(),
+            submit: { _ in true },
+            interrupt: {}
+        )
+
+        let result = await controller.requestOnDeviceTranscriptionPermissions()
+
+        XCTAssertFalse(result.passed)
+        XCTAssertEqual(result.message, "Microphone access is required for voice conversations.")
+    }
+
+    func testOnDevicePermissionPreparationSucceedsWhenBothGranted() async {
+        let controller = VoiceConversationController(
+            capture: MockCapture(permissionGranted: true),
+            playback: MockPlayback(),
+            deviceTranscriber: MockDeviceTranscriber(transcript: "", permissionGranted: true),
+            gateway: MockGateway(),
+            submit: { _ in true },
+            interrupt: {}
+        )
+
+        let result = await controller.requestOnDeviceTranscriptionPermissions()
+
+        XCTAssertTrue(result.passed)
+        XCTAssertEqual(result.message, "On-device speech recognition is ready.")
+    }
+
+    func testAppleSpeechAvailabilityCanAttemptRecognition() {
+        let ready = AppleSpeechRecognitionAvailability.ready(localeIdentifier: "en_US")
+        XCTAssertTrue(ready.canAttemptRecognition)
+
+        let permissionRequired = AppleSpeechRecognitionAvailability.permissionRequired(localeIdentifier: "en_US")
+        XCTAssertTrue(permissionRequired.canAttemptRecognition)
+
+        let permissionDenied = AppleSpeechRecognitionAvailability.permissionDenied
+        XCTAssertFalse(permissionDenied.canAttemptRecognition)
+
+        let unsupported = AppleSpeechRecognitionAvailability.unsupported(localeIdentifier: "en_US")
+        XCTAssertFalse(unsupported.canAttemptRecognition)
+    }
+
     func testTrailingSilenceTranscribesThenSubmitsThroughAuthoritativeSeam() async {
         let capture = MockCapture(permissionGranted: true)
         let gateway = MockGateway(transcript: "Hello Hermes")

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -118,10 +118,11 @@ final class VoiceConversationControllerTests: XCTestCase {
     }
 
     func testOnDevicePermissionPreparationReportsMicrophoneDenial() async {
+        let deviceTranscriber = MockDeviceTranscriber(transcript: "", permissionGranted: true)
         let controller = VoiceConversationController(
             capture: MockCapture(permissionGranted: false),
             playback: MockPlayback(),
-            deviceTranscriber: MockDeviceTranscriber(transcript: "", permissionGranted: true),
+            deviceTranscriber: deviceTranscriber,
             gateway: MockGateway(),
             submit: { _ in true },
             interrupt: {}
@@ -131,13 +132,15 @@ final class VoiceConversationControllerTests: XCTestCase {
 
         XCTAssertFalse(result.passed)
         XCTAssertEqual(result.message, "Microphone access is required for voice conversations.")
+        XCTAssertEqual(deviceTranscriber.permissionRequestCount, 0, "Speech permission should not be requested after microphone denial")
     }
 
     func testOnDevicePermissionPreparationSucceedsWhenBothGranted() async {
+        let deviceTranscriber = MockDeviceTranscriber(transcript: "", permissionGranted: true)
         let controller = VoiceConversationController(
             capture: MockCapture(permissionGranted: true),
             playback: MockPlayback(),
-            deviceTranscriber: MockDeviceTranscriber(transcript: "", permissionGranted: true),
+            deviceTranscriber: deviceTranscriber,
             gateway: MockGateway(),
             submit: { _ in true },
             interrupt: {}
@@ -147,6 +150,7 @@ final class VoiceConversationControllerTests: XCTestCase {
 
         XCTAssertTrue(result.passed)
         XCTAssertEqual(result.message, "On-device speech recognition is ready.")
+        XCTAssertEqual(deviceTranscriber.permissionRequestCount, 1, "Speech permission should be requested exactly once")
     }
 
     func testAppleSpeechAvailabilityCanAttemptRecognition() {
@@ -626,11 +630,12 @@ private final class MockDeviceTranscriber: DeviceSpeechTranscriptionService {
     let transcript: String
     let permissionGranted: Bool
     private(set) var transcriptionCount = 0
+    private(set) var permissionRequestCount = 0
     init(transcript: String, permissionGranted: Bool = true) {
         self.transcript = transcript
         self.permissionGranted = permissionGranted
     }
-    func requestPermission() async -> Bool { permissionGranted }
+    func requestPermission() async -> Bool { permissionRequestCount += 1; return permissionGranted }
     func transcribe(_ audio: VoiceCapturedAudio) async throws -> String {
         transcriptionCount += 1
         return transcript


### PR DESCRIPTION
Fix silent failure when selecting the 'On this Phone' speech-to-text provider.

When selecting 'On this Phone', setVoiceTranscriptionMode(.appleOnDevice) checks canAttemptRecognition first. If the status is .permissionDenied or .unsupported, it returned false immediately without setting any error message — the UI silently reverted to the previous provider.

Changes:
- AppState.swift: replaced silent return false with a switch that sets errorMessage based on availability status
- VoiceSettingsView.swift: updated appleOnDeviceDetail to show contextual messages per availability state; updated selectProvider to show an informational message when permission is required

Closes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice transcription availability messaging with distinct guidance for ready, permission-required, denied, unsupported-language, and unavailable-device states.
  * Added more accurate status feedback when selecting on-device Apple transcription.
  * Preserved the selected transcription mode after successful setup.
  * Clarified when microphone and speech-recognition permissions are required before transcription can be used.
  * Improved handling of microphone and speech-recognition permission errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->