### PR TITLE
Fix haptics toggle persistence

### DIFF
--- a/Conduit/Services/Haptics.swift
+++ b/Conduit/Services/Haptics.swift
@@ -8,58 +8,83 @@
 
 import SwiftUI
 
+@MainActor
 enum Haptics {
+    static let preferenceKey = "conduit.haptics"
+
+    enum Event: Equatable {
+        case light
+        case medium
+        case rigid
+        case success
+        case error
+        case warning
+        case selection
+    }
+
     private static let lightGenerator = UIImpactFeedbackGenerator(style: .light)
     private static let mediumGenerator = UIImpactFeedbackGenerator(style: .medium)
     private static let rigidGenerator = UIImpactFeedbackGenerator(style: .rigid)
     private static let notificationGenerator = UINotificationFeedbackGenerator()
     private static let selectionGenerator = UISelectionFeedbackGenerator()
 
+#if DEBUG
+    static var testEmissionHandler: ((Event) -> Void)?
+    static var testSuppressesHardware = false
+#endif
+
     static var enabled: Bool {
-        get { UserDefaults.standard.object(forKey: "conduit.haptics") as? Bool ?? true }
-        set { UserDefaults.standard.set(newValue, forKey: "conduit.haptics") }
+        get { UserDefaults.standard.object(forKey: preferenceKey) as? Bool ?? true }
+        set { UserDefaults.standard.set(newValue, forKey: preferenceKey) }
     }
 
     static func light() {
-        guard enabled else { return }
-        lightGenerator.impactOccurred()
-        lightGenerator.prepare()
+        emit(.light) {
+            lightGenerator.impactOccurred()
+            lightGenerator.prepare()
+        }
     }
 
     static func medium() {
-        guard enabled else { return }
-        mediumGenerator.impactOccurred()
-        mediumGenerator.prepare()
+        emit(.medium) {
+            mediumGenerator.impactOccurred()
+            mediumGenerator.prepare()
+        }
     }
 
     static func rigid() {
-        guard enabled else { return }
-        rigidGenerator.impactOccurred()
-        rigidGenerator.prepare()
+        emit(.rigid) {
+            rigidGenerator.impactOccurred()
+            rigidGenerator.prepare()
+        }
     }
 
     static func success() {
-        guard enabled else { return }
-        notificationGenerator.notificationOccurred(.success)
-        notificationGenerator.prepare()
+        emit(.success) {
+            notificationGenerator.notificationOccurred(.success)
+            notificationGenerator.prepare()
+        }
     }
 
     static func error() {
-        guard enabled else { return }
-        notificationGenerator.notificationOccurred(.error)
-        notificationGenerator.prepare()
+        emit(.error) {
+            notificationGenerator.notificationOccurred(.error)
+            notificationGenerator.prepare()
+        }
     }
 
     static func warning() {
-        guard enabled else { return }
-        notificationGenerator.notificationOccurred(.warning)
-        notificationGenerator.prepare()
+        emit(.warning) {
+            notificationGenerator.notificationOccurred(.warning)
+            notificationGenerator.prepare()
+        }
     }
 
     static func selection() {
-        guard enabled else { return }
-        selectionGenerator.selectionChanged()
-        selectionGenerator.prepare()
+        emit(.selection) {
+            selectionGenerator.selectionChanged()
+            selectionGenerator.prepare()
+        }
     }
 
     static func prepare() {
@@ -68,5 +93,14 @@ enum Haptics {
         rigidGenerator.prepare()
         notificationGenerator.prepare()
         selectionGenerator.prepare()
+    }
+
+    private static func emit(_ event: Event, action: () -> Void) {
+        guard enabled else { return }
+#if DEBUG
+        testEmissionHandler?(event)
+        guard !testSuppressesHardware else { return }
+#endif
+        action()
     }
 }

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -711,7 +711,8 @@ private struct ChatSettingsDetail: View {
             save: save,
             showsNavigationTitle: false,
             optionOverrides: ["display.personality": ["", "helpful", "concise", "technical", "creative", "teacher", "kawaii", "catgirl", "pirate", "shakespeare", "surfer", "noir", "uwu", "philosopher", "hype"] + options.personalities],
-            leadingSection: AnyView(ResponseBehaviorSettings(initialMode: busyInputMode, save: persistBusyInputMode))
+            leadingSection: AnyView(ResponseBehaviorSettings(initialMode: busyInputMode, save: persistBusyInputMode)),
+            trailingSection: AnyView(DeviceHapticsSettings())
         )
         .navigationTitle("Chat")
         .task { options = await loadOptions() }
@@ -723,10 +724,28 @@ private struct ChatSettingsDetail: View {
         .init(key: "display.show_reasoning", label: "Show thinking", help: "Show collapsible thinking blocks when provided.", control: .toggle(defaultValue: true)),
         .init(key: "display.tool_progress", label: "Tool cards", help: "Show tool calls and expandable details in conversations.", control: .textToggle(onValue: "all", offValue: "off", defaultValue: true)),
         .init(key: "display.expand_tools", label: "Keep tool cards expanded", help: "Keep completed tool details open by default.", control: .toggle(defaultValue: false)),
-        .init(key: "conduit.haptics", label: "Haptic feedback", help: "Vibration feedback on button taps and key actions.", control: .toggle(defaultValue: true)),
         .init(key: "display.memory_notifications", label: "Self-improvement updates", help: "Choose whether Conduit follows Hermes, always shows, or never shows maintenance updates.", control: .labeledOptions([(value: "default", label: "Use Hermes default"), (value: "on", label: "Always show"), (value: "off", label: "Never show")], defaultValue: "default")),
         .init(key: "agent.image_input_mode", label: "Image attachments", help: "How Hermes supplies images to a model.", control: .options(["auto", "native", "text"], defaultValue: "auto")),
     ]
+}
+
+private struct DeviceHapticsSettings: View {
+    @AppStorage(Haptics.preferenceKey) private var enabled = true
+
+    var body: some View {
+        ConduitSettingsSection(
+            title: "Haptic feedback",
+            symbol: "waveform",
+            tint: .conduitAura
+        ) {
+            Text("Conduit-generated vibration feedback for app actions. iOS system controls can still provide their own feedback.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            Toggle("Haptic feedback", isOn: $enabled)
+                .labelsHidden()
+                .tint(.conduitAccent)
+        }
+    }
 }
 
 private struct ResponseBehaviorSettings: View {

--- a/ConduitTests/HapticsTests.swift
+++ b/ConduitTests/HapticsTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class HapticsTests: XCTestCase {
+    func testEnabledUsesDevicePreference() {
+        let defaults = UserDefaults.standard
+        let previousValue = defaults.object(forKey: Haptics.preferenceKey)
+        defer {
+            if let previousValue {
+                defaults.set(previousValue, forKey: Haptics.preferenceKey)
+            } else {
+                defaults.removeObject(forKey: Haptics.preferenceKey)
+            }
+        }
+
+        defaults.removeObject(forKey: Haptics.preferenceKey)
+        XCTAssertTrue(Haptics.enabled)
+
+        Haptics.enabled = false
+        XCTAssertFalse(Haptics.enabled)
+        XCTAssertEqual(
+            defaults.object(forKey: Haptics.preferenceKey) as? Bool,
+            false
+        )
+
+        Haptics.enabled = true
+        XCTAssertTrue(Haptics.enabled)
+        XCTAssertEqual(
+            defaults.object(forKey: Haptics.preferenceKey) as? Bool,
+            true
+        )
+    }
+
+    func testDisabledPreferenceSuppressesEveryBaseEmitter() {
+        let defaults = UserDefaults.standard
+        let previousValue = defaults.object(forKey: Haptics.preferenceKey)
+        let previousHandler = Haptics.testEmissionHandler
+        let previousSuppressesHardware = Haptics.testSuppressesHardware
+        var events: [Haptics.Event] = []
+        defer {
+            if let previousValue {
+                defaults.set(previousValue, forKey: Haptics.preferenceKey)
+            } else {
+                defaults.removeObject(forKey: Haptics.preferenceKey)
+            }
+            Haptics.testEmissionHandler = previousHandler
+            Haptics.testSuppressesHardware = previousSuppressesHardware
+        }
+
+        Haptics.testEmissionHandler = { events.append($0) }
+        Haptics.testSuppressesHardware = true
+        Haptics.enabled = false
+
+        Haptics.light()
+        Haptics.medium()
+        Haptics.rigid()
+        Haptics.success()
+        Haptics.error()
+        Haptics.warning()
+        Haptics.selection()
+
+        XCTAssertTrue(events.isEmpty)
+    }
+
+    func testEnabledPreferenceRecordsEveryBaseEmitterInOrder() {
+        let defaults = UserDefaults.standard
+        let previousValue = defaults.object(forKey: Haptics.preferenceKey)
+        let previousHandler = Haptics.testEmissionHandler
+        let previousSuppressesHardware = Haptics.testSuppressesHardware
+        var events: [Haptics.Event] = []
+        defer {
+            if let previousValue {
+                defaults.set(previousValue, forKey: Haptics.preferenceKey)
+            } else {
+                defaults.removeObject(forKey: Haptics.preferenceKey)
+            }
+            Haptics.testEmissionHandler = previousHandler
+            Haptics.testSuppressesHardware = previousSuppressesHardware
+        }
+
+        Haptics.testEmissionHandler = { events.append($0) }
+        Haptics.testSuppressesHardware = true
+        Haptics.enabled = true
+
+        Haptics.light()
+        Haptics.medium()
+        Haptics.rigid()
+        Haptics.success()
+        Haptics.error()
+        Haptics.warning()
+        Haptics.selection()
+
+        XCTAssertEqual(events, [.light, .medium, .rigid, .success, .error, .warning, .selection])
+    }
+}


### PR DESCRIPTION
## Summary
- Store the Haptic Feedback setting in the same device-local preference read by Conduit's haptic emitters.
- Remove the unrelated Hermes profile configuration read and write from the Chat settings control.
- Add regression coverage that exercises every explicit haptic emitter with the preference enabled and disabled.

## Behavior
Turning Haptic Feedback off now suppresses Conduit-generated feedback immediately and after relaunch. Turning it back on restores feedback. Native iOS controls can still provide their own system feedback.

Fixes #22

## Validation
Simulator:
- `ConduitTests/HapticsTests` passed on commit `bc2aaf0`.
- The complete Xcode simulator suite passed: 221 tests, 0 failures.

Physical iPhone:
- Not yet performed on reviewed commit `bc2aaf0`.
- A pre-rebase build was signed, installed, and opened on iPhone Air (`iPhone18,4`), but tactile validation was paused before the enabled, disabled, disabled-after-relaunch, and re-enabled observations. No tactile outcome is claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a device-level setting to enable or disable haptic feedback.
  * Haptic preferences now persist independently of chat profile settings.
  * Haptic events are consistently handled according to the selected preference.

* **Bug Fixes**
  * Disabled haptic feedback no longer triggers device vibrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->