### PR TITLE
Add response lifecycle haptics

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -461,6 +461,12 @@ final class AppState: ObservableObject {
     private var hasScheduledStreamingPublish = false
     private var lastStreamingPublishBurst = 0
     private var lastStreamingPublishDate: Date?
+    private var responseHapticConclusionTask: Task<Void, Never>?
+    private var responseHapticConclusionToken: UUID?
+    private var responseHapticIsActive = false
+    private var responseHapticStartPlayed = false
+    private var lastToolHapticDate: Date?
+    private var hapticsForegroundActive = true
     private var scenePhaseTask: Task<Void, Never>?
     private var scenePhaseAttemptID: UUID?
     private var explicitSessionOpenTask: Task<Bool, Never>?
@@ -805,6 +811,7 @@ final class AppState: ObservableObject {
     private func setActiveSessionState(id: String?, title: String? = nil) {
         if activeSessionId != id {
             clearPendingDecisionRestorationGuard()
+            resetResponseHapticTurn()
         }
         activeSessionId = id
         if let persistedID = ChatSessionPersistenceIdentity.canonicalID(
@@ -2965,6 +2972,10 @@ final class AppState: ObservableObject {
 
     @discardableResult
     func handleScenePhase(_ phase: ScenePhase) -> Task<Void, Never>? {
+        hapticsForegroundActive = phase == .active
+        if !hapticsForegroundActive {
+            Haptics.cancelLifecyclePattern()
+        }
         switch phase {
         case .active:
             voiceConversationController.setForegroundActive(true)
@@ -3745,6 +3756,7 @@ final class AppState: ObservableObject {
     func sendMessage(_ text: String, attachments: [Attachment] = []) async -> Bool {
         guard let client, let sessionId = activeSessionId else { return false }
         cancelChatResumeRestoration()
+        resetResponseHapticTurn()
 
         let userMessage = ChatMessage(
             id: "local-\(Date().timeIntervalSince1970)",
@@ -5710,6 +5722,7 @@ final class AppState: ObservableObject {
 
         switch event {
         case .messageStart:
+            registerResponseActivity(playsStart: false)
             finalizePendingStreamingCompletion()
             activeReasoningMessageId = nil
             receivedReasoningForCurrentTurn = false
@@ -5717,6 +5730,7 @@ final class AppState: ObservableObject {
             notifyVoiceAssistant(.started(sessionID: streamSessionId))
 
         case .messageDelta(_, let text):
+            registerResponseActivity(playsStart: true)
             finalizePendingStreamingCompletion()
             streamingBuffer += text
             scheduleStreamingPublish()
@@ -5724,6 +5738,7 @@ final class AppState: ObservableObject {
             notifyVoiceAssistant(.delta(sessionID: streamSessionId, text: text))
 
         case .reasoningDelta(_, let text):
+            registerResponseActivity(playsStart: false)
             finalizePendingStreamingCompletion()
             receivedReasoningForCurrentTurn = true
             appendReasoning(text)
@@ -5739,6 +5754,7 @@ final class AppState: ObservableObject {
             notifyVoiceAssistant(.completed(sessionID: streamSessionId, content: content))
 
         case .messageError(_, let message):
+            failResponseHapticTurn()
             clearStreamingText()
             activeReasoningMessageId = nil
             errorMessage = message
@@ -5746,6 +5762,7 @@ final class AppState: ObservableObject {
             notifyVoiceAssistant(.failed(sessionID: streamSessionId, message: message))
 
         case .messageInterrupted:
+            resetResponseHapticTurn()
             clearStreamingText()
             activeReasoningMessageId = nil
             setRunning(false)
@@ -5753,6 +5770,11 @@ final class AppState: ObservableObject {
 
         case .sessionBusy(_, let busy):
             setRunning(busy)
+            if !busy,
+               responseHapticConclusionTask == nil,
+               !responseAwaitsUserInput {
+                scheduleResponseHapticConclusion(after: 180)
+            }
 
         case .sessionInfo(_, let snapshot):
             applyRuntime(snapshot)
@@ -5767,6 +5789,7 @@ final class AppState: ObservableObject {
 
         case .toolStart(_, let name, let input):
             if name.lowercased() == "clarify" { break }
+            registerToolHaptic()
             activeReasoningMessageId = nil
             flushStreamingPartial()
             messages.append(ChatMessage(
@@ -5824,6 +5847,7 @@ final class AppState: ObservableObject {
             ))
 
         case .clarify(_, let requestId, let question, let choices):
+            registerResponseActivity(playsStart: false)
             let activity = ClarifyActivity(
                 requestId: requestId,
                 question: question,
@@ -5845,6 +5869,7 @@ final class AppState: ObservableObject {
             setRunning(true)
 
         case .approval(_, let activity):
+            registerResponseActivity(playsStart: false)
             if let index = messages.lastIndex(where: {
                 $0.approval?.sessionId == activity.sessionId
                     && ($0.approval?.status == .pending || $0.approval?.status == .submitting)
@@ -5878,6 +5903,9 @@ final class AppState: ObservableObject {
             activeAgents = count
 
         case .delegateAgent(_, let activity):
+            if activity.stream.contains(where: { $0.kind == .tool }) {
+                registerToolHaptic()
+            }
             if let index = delegateAgents.firstIndex(where: { $0.id == activity.id }) {
                 var updated = activity
                 let existing = delegateAgents[index]
@@ -6132,6 +6160,81 @@ final class AppState: ObservableObject {
             clearPendingDecisionRestorationGuard()
         }
         turnState = running ? .running : .idle
+    }
+
+    private func registerResponseActivity(playsStart: Bool) {
+        cancelPendingResponseHapticConclusion()
+        responseHapticIsActive = true
+        guard playsStart, !responseHapticStartPlayed else { return }
+        responseHapticStartPlayed = true
+        if hapticsForegroundActive {
+            Haptics.responseStarted()
+        }
+    }
+
+    private func registerToolHaptic() {
+        registerResponseActivity(playsStart: false)
+        guard hapticsForegroundActive else { return }
+        let now = Date()
+        guard lastToolHapticDate.map({ now.timeIntervalSince($0) >= 0.25 }) ?? true else { return }
+        lastToolHapticDate = now
+        Haptics.toolStarted()
+    }
+
+    private var responseAwaitsUserInput: Bool {
+        messages.contains { message in
+            message.clarify.map { $0.status == .pending || $0.status == .submitting } == true
+                || message.approval.map { $0.status == .pending || $0.status == .submitting } == true
+        }
+    }
+
+    private func scheduleResponseHapticConclusion(after delayMilliseconds: Int) {
+        guard responseHapticIsActive else { return }
+        cancelPendingResponseHapticConclusion()
+        let token = UUID()
+        let sessionId = activeSessionId
+        responseHapticConclusionToken = token
+        responseHapticConclusionTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(for: .milliseconds(delayMilliseconds))
+            } catch {
+                return
+            }
+            guard !Task.isCancelled,
+                  let self,
+                  self.responseHapticConclusionToken == token,
+                  self.activeSessionId == sessionId else { return }
+            self.responseHapticConclusionTask = nil
+            self.responseHapticConclusionToken = nil
+            self.responseHapticIsActive = false
+            self.responseHapticStartPlayed = false
+            self.lastToolHapticDate = nil
+            if self.hapticsForegroundActive {
+                Haptics.responseConcluded()
+            }
+        }
+    }
+
+    private func failResponseHapticTurn() {
+        let shouldNotify = responseHapticIsActive && hapticsForegroundActive
+        resetResponseHapticTurn()
+        if shouldNotify {
+            Haptics.error()
+        }
+    }
+
+    private func resetResponseHapticTurn() {
+        cancelPendingResponseHapticConclusion()
+        responseHapticIsActive = false
+        responseHapticStartPlayed = false
+        lastToolHapticDate = nil
+        Haptics.cancelLifecyclePattern()
+    }
+
+    private func cancelPendingResponseHapticConclusion() {
+        responseHapticConclusionTask?.cancel()
+        responseHapticConclusionTask = nil
+        responseHapticConclusionToken = nil
     }
 
     /// Voice uses the same submission and active-turn interruption policy as
@@ -6465,6 +6568,7 @@ final class AppState: ObservableObject {
             1_200,
             max(180, Int((Double(charactersToDrain) / 540.0) * 1_000) + 180)
         )
+        scheduleResponseHapticConclusion(after: drainMilliseconds)
 
         streamingCompletionTask = Task { @MainActor [weak self] in
             do {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2972,7 +2972,9 @@ final class AppState: ObservableObject {
             responseHapticConclusionTask?.cancel()
             responseHapticConclusionTask = nil
         }
-        if let effect = responseHaptics.setForegroundActive(phase == .active) {
+        if let effect = responseHaptics.setForegroundActive(
+            ResponseHapticPolicy.treatsAsForegroundActive(phase)
+        ) {
             performResponseHapticEffects([effect])
         }
         switch phase {
@@ -6588,12 +6590,17 @@ final class AppState: ObservableObject {
             guard !Task.isCancelled,
                   let self,
                   self.activeSessionId == sessionId else { return }
-            self.finalizePendingStreamingCompletion()
+            self.finalizePendingStreamingCompletion(cancelResponseHapticConclusion: false)
         }
     }
 
-    private func finalizePendingStreamingCompletion() {
+    private func finalizePendingStreamingCompletion(
+        cancelResponseHapticConclusion: Bool = true
+    ) {
         guard let pendingStreamingCompletion else { return }
+        if cancelResponseHapticConclusion {
+            cancelPendingResponseHapticConclusion()
+        }
         streamingCompletionTask?.cancel()
         streamingCompletionTask = nil
         self.pendingStreamingCompletion = nil

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -462,11 +462,7 @@ final class AppState: ObservableObject {
     private var lastStreamingPublishBurst = 0
     private var lastStreamingPublishDate: Date?
     private var responseHapticConclusionTask: Task<Void, Never>?
-    private var responseHapticConclusionToken: UUID?
-    private var responseHapticIsActive = false
-    private var responseHapticStartPlayed = false
-    private var lastToolHapticDate: Date?
-    private var hapticsForegroundActive = true
+    private var responseHaptics = ResponseHapticState()
     private var scenePhaseTask: Task<Void, Never>?
     private var scenePhaseAttemptID: UUID?
     private var explicitSessionOpenTask: Task<Bool, Never>?
@@ -2972,9 +2968,12 @@ final class AppState: ObservableObject {
 
     @discardableResult
     func handleScenePhase(_ phase: ScenePhase) -> Task<Void, Never>? {
-        hapticsForegroundActive = phase == .active
-        if !hapticsForegroundActive {
-            Haptics.cancelLifecyclePattern()
+        if phase != .active {
+            responseHapticConclusionTask?.cancel()
+            responseHapticConclusionTask = nil
+        }
+        if let effect = responseHaptics.setForegroundActive(phase == .active) {
+            performResponseHapticEffects([effect])
         }
         switch phase {
         case .active:
@@ -5719,10 +5718,12 @@ final class AppState: ObservableObject {
         let streamSessionId = sessionID(for: event)
         guard eventBelongsToActiveSession(streamSessionId) else { return }
         defer { schedulePresentationCacheFlush(for: streamSessionId) }
+        if let signal = ResponseHapticPolicy.signal(for: event) {
+            applyResponseHapticSignal(signal)
+        }
 
         switch event {
         case .messageStart:
-            registerResponseActivity(playsStart: false)
             finalizePendingStreamingCompletion()
             activeReasoningMessageId = nil
             receivedReasoningForCurrentTurn = false
@@ -5730,7 +5731,6 @@ final class AppState: ObservableObject {
             notifyVoiceAssistant(.started(sessionID: streamSessionId))
 
         case .messageDelta(_, let text):
-            registerResponseActivity(playsStart: true)
             finalizePendingStreamingCompletion()
             streamingBuffer += text
             scheduleStreamingPublish()
@@ -5738,7 +5738,6 @@ final class AppState: ObservableObject {
             notifyVoiceAssistant(.delta(sessionID: streamSessionId, text: text))
 
         case .reasoningDelta(_, let text):
-            registerResponseActivity(playsStart: false)
             finalizePendingStreamingCompletion()
             receivedReasoningForCurrentTurn = true
             appendReasoning(text)
@@ -5754,7 +5753,6 @@ final class AppState: ObservableObject {
             notifyVoiceAssistant(.completed(sessionID: streamSessionId, content: content))
 
         case .messageError(_, let message):
-            failResponseHapticTurn()
             clearStreamingText()
             activeReasoningMessageId = nil
             errorMessage = message
@@ -5762,7 +5760,6 @@ final class AppState: ObservableObject {
             notifyVoiceAssistant(.failed(sessionID: streamSessionId, message: message))
 
         case .messageInterrupted:
-            resetResponseHapticTurn()
             clearStreamingText()
             activeReasoningMessageId = nil
             setRunning(false)
@@ -5770,9 +5767,11 @@ final class AppState: ObservableObject {
 
         case .sessionBusy(_, let busy):
             setRunning(busy)
-            if !busy,
-               responseHapticConclusionTask == nil,
-               !responseAwaitsUserInput {
+            if ResponseHapticPolicy.shouldScheduleIdleConclusion(
+                isBusy: busy,
+                hasPendingConclusion: responseHaptics.pendingConclusion != nil,
+                awaitsUserInput: responseAwaitsUserInput
+            ) {
                 scheduleResponseHapticConclusion(after: 180)
             }
 
@@ -5789,7 +5788,6 @@ final class AppState: ObservableObject {
 
         case .toolStart(_, let name, let input):
             if name.lowercased() == "clarify" { break }
-            registerToolHaptic()
             activeReasoningMessageId = nil
             flushStreamingPartial()
             messages.append(ChatMessage(
@@ -5847,7 +5845,6 @@ final class AppState: ObservableObject {
             ))
 
         case .clarify(_, let requestId, let question, let choices):
-            registerResponseActivity(playsStart: false)
             let activity = ClarifyActivity(
                 requestId: requestId,
                 question: question,
@@ -5869,7 +5866,6 @@ final class AppState: ObservableObject {
             setRunning(true)
 
         case .approval(_, let activity):
-            registerResponseActivity(playsStart: false)
             if let index = messages.lastIndex(where: {
                 $0.approval?.sessionId == activity.sessionId
                     && ($0.approval?.status == .pending || $0.approval?.status == .submitting)
@@ -5903,9 +5899,6 @@ final class AppState: ObservableObject {
             activeAgents = count
 
         case .delegateAgent(_, let activity):
-            if activity.stream.contains(where: { $0.kind == .tool }) {
-                registerToolHaptic()
-            }
             if let index = delegateAgents.firstIndex(where: { $0.id == activity.id }) {
                 var updated = activity
                 let existing = delegateAgents[index]
@@ -6162,23 +6155,29 @@ final class AppState: ObservableObject {
         turnState = running ? .running : .idle
     }
 
-    private func registerResponseActivity(playsStart: Bool) {
-        cancelPendingResponseHapticConclusion()
-        responseHapticIsActive = true
-        guard playsStart, !responseHapticStartPlayed else { return }
-        responseHapticStartPlayed = true
-        if hapticsForegroundActive {
-            Haptics.responseStarted()
+    private func applyResponseHapticSignal(_ signal: ResponseHapticPolicy.Signal) {
+        switch signal {
+        case .activity(let playsStart):
+            registerResponseActivity(playsStart: playsStart)
+        case .tool:
+            registerToolHaptic()
+        case .failure:
+            failResponseHapticTurn()
+        case .reset:
+            resetResponseHapticTurn()
         }
     }
 
+    private func registerResponseActivity(playsStart: Bool) {
+        cancelPendingResponseHapticConclusion()
+        performResponseHapticEffects(
+            responseHaptics.registerActivity(playsStart: playsStart)
+        )
+    }
+
     private func registerToolHaptic() {
-        registerResponseActivity(playsStart: false)
-        guard hapticsForegroundActive else { return }
-        let now = Date()
-        guard lastToolHapticDate.map({ now.timeIntervalSince($0) >= 0.25 }) ?? true else { return }
-        lastToolHapticDate = now
-        Haptics.toolStarted()
+        cancelPendingResponseHapticConclusion()
+        performResponseHapticEffects(responseHaptics.registerTool(at: Date()))
     }
 
     private var responseAwaitsUserInput: Bool {
@@ -6189,11 +6188,10 @@ final class AppState: ObservableObject {
     }
 
     private func scheduleResponseHapticConclusion(after delayMilliseconds: Int) {
-        guard responseHapticIsActive else { return }
         cancelPendingResponseHapticConclusion()
-        let token = UUID()
-        let sessionId = activeSessionId
-        responseHapticConclusionToken = token
+        guard let conclusion = responseHaptics.scheduleConclusion(
+            sessionID: activeSessionId
+        ) else { return }
         responseHapticConclusionTask = Task { @MainActor [weak self] in
             do {
                 try await Task.sleep(for: .milliseconds(delayMilliseconds))
@@ -6202,39 +6200,50 @@ final class AppState: ObservableObject {
             }
             guard !Task.isCancelled,
                   let self,
-                  self.responseHapticConclusionToken == token,
-                  self.activeSessionId == sessionId else { return }
-            self.responseHapticConclusionTask = nil
-            self.responseHapticConclusionToken = nil
-            self.responseHapticIsActive = false
-            self.responseHapticStartPlayed = false
-            self.lastToolHapticDate = nil
-            if self.hapticsForegroundActive {
-                Haptics.responseConcluded()
+                  self.activeSessionId == conclusion.sessionID,
+                  let effect = self.responseHaptics.finishConclusion(conclusion) else {
+                return
             }
+            self.responseHapticConclusionTask = nil
+            self.performResponseHapticEffects([effect])
         }
     }
 
     private func failResponseHapticTurn() {
-        let shouldNotify = responseHapticIsActive && hapticsForegroundActive
-        resetResponseHapticTurn()
-        if shouldNotify {
-            Haptics.error()
-        }
+        responseHapticConclusionTask?.cancel()
+        responseHapticConclusionTask = nil
+        performResponseHapticEffects(responseHaptics.fail())
     }
 
     private func resetResponseHapticTurn() {
-        cancelPendingResponseHapticConclusion()
-        responseHapticIsActive = false
-        responseHapticStartPlayed = false
-        lastToolHapticDate = nil
-        Haptics.cancelLifecyclePattern()
+        responseHapticConclusionTask?.cancel()
+        responseHapticConclusionTask = nil
+        performResponseHapticEffects(responseHaptics.reset())
     }
 
     private func cancelPendingResponseHapticConclusion() {
         responseHapticConclusionTask?.cancel()
         responseHapticConclusionTask = nil
-        responseHapticConclusionToken = nil
+        responseHaptics.invalidateConclusion()
+    }
+
+    private func performResponseHapticEffects(
+        _ effects: [ResponseHapticState.Effect]
+    ) {
+        for effect in effects {
+            switch effect {
+            case .responseStarted:
+                Haptics.responseStarted()
+            case .toolStarted:
+                Haptics.toolStarted()
+            case .responseConcluded:
+                Haptics.responseConcluded()
+            case .error:
+                Haptics.error()
+            case .cancelPattern:
+                Haptics.cancelLifecyclePattern()
+            }
+        }
     }
 
     /// Voice uses the same submission and active-turn interruption policy as

--- a/Conduit/Services/Haptics.swift
+++ b/Conduit/Services/Haptics.swift
@@ -2,11 +2,13 @@
 //  Haptics.swift
 //  Conduit
 //
-//  Centralized haptic feedback with a user-toggleable preference.
-//  Usage: Haptics.light() / Haptics.medium() / Haptics.success() / Haptics.selection()
+//  Centralized haptic feedback with a user-toggleable preference, including
+//  calibrated response lifecycle patterns and subordinate tool activity.
 //
 
+import CoreHaptics
 import SwiftUI
+import UIKit
 
 @MainActor
 enum Haptics {
@@ -22,11 +24,17 @@ enum Haptics {
         case selection
     }
 
+    private static let softGenerator = UIImpactFeedbackGenerator(style: .soft)
     private static let lightGenerator = UIImpactFeedbackGenerator(style: .light)
     private static let mediumGenerator = UIImpactFeedbackGenerator(style: .medium)
     private static let rigidGenerator = UIImpactFeedbackGenerator(style: .rigid)
     private static let notificationGenerator = UINotificationFeedbackGenerator()
     private static let selectionGenerator = UISelectionFeedbackGenerator()
+    private static var coreHapticsEngine: CHHapticEngine?
+    private static var lifecyclePatternPlayer: CHHapticPatternPlayer?
+    private static var lifecyclePatternTask: Task<Void, Never>?
+    private static var lifecyclePatternToken: UUID?
+    private static var lifecyclePatternEndsAt = Date.distantPast
 
 #if DEBUG
     static var testEmissionHandler: ((Event) -> Void)?
@@ -36,6 +44,12 @@ enum Haptics {
     static var enabled: Bool {
         get { UserDefaults.standard.object(forKey: preferenceKey) as? Bool ?? true }
         set { UserDefaults.standard.set(newValue, forKey: preferenceKey) }
+    }
+
+    static func soft() {
+        guard enabled else { return }
+        softGenerator.impactOccurred()
+        softGenerator.prepare()
     }
 
     static func light() {
@@ -86,8 +100,83 @@ enum Haptics {
             selectionGenerator.prepare()
         }
     }
+    static func toolStarted() {
+        guard enabled, Date() >= lifecyclePatternEndsAt else { return }
+        softGenerator.impactOccurred(intensity: 0.65)
+        softGenerator.prepare()
+    }
+
+    static func responseStarted() {
+        guard enabled else { return }
+        let token = beginLifecyclePattern(duration: 0.18)
+        do {
+            let engine: CHHapticEngine
+            if let coreHapticsEngine {
+                engine = coreHapticsEngine
+            } else {
+                engine = try CHHapticEngine()
+                engine.isAutoShutdownEnabled = true
+                coreHapticsEngine = engine
+            }
+            try engine.start()
+            let events = [
+                CHHapticEvent(
+                    eventType: .hapticTransient,
+                    parameters: Self.transientParameters(intensity: 1),
+                    relativeTime: 0
+                ),
+                CHHapticEvent(
+                    eventType: .hapticTransient,
+                    parameters: Self.transientParameters(intensity: 0.59),
+                    relativeTime: 0.060
+                ),
+                CHHapticEvent(
+                    eventType: .hapticTransient,
+                    parameters: Self.transientParameters(intensity: 0.52),
+                    relativeTime: 0.150
+                )
+            ]
+            let player = try engine.makePlayer(with: CHHapticPattern(events: events, parameters: []))
+            lifecyclePatternPlayer = player
+            try player.start(atTime: CHHapticTimeImmediate)
+            lifecyclePatternTask = Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(180))
+                finishLifecyclePattern(token)
+            }
+        } catch {
+            playResponseStartFallback(token: token)
+        }
+    }
+
+    static func responseConcluded() {
+        guard enabled else { return }
+        let token = beginLifecyclePattern(duration: 0.20)
+        lightGenerator.impactOccurred(intensity: 0.79)
+        lightGenerator.prepare()
+        lifecyclePatternTask = Task { @MainActor in
+            do {
+                try await Task.sleep(for: .milliseconds(173))
+                guard lifecyclePatternToken == token, enabled else { return }
+                mediumGenerator.impactOccurred(intensity: 1)
+                mediumGenerator.prepare()
+                finishLifecyclePattern(token)
+            } catch {
+                return
+            }
+        }
+    }
+
+    static func cancelLifecyclePattern() {
+        lifecyclePatternTask?.cancel()
+        try? lifecyclePatternPlayer?.stop(atTime: CHHapticTimeImmediate)
+        lifecyclePatternTask = nil
+        lifecyclePatternPlayer = nil
+        lifecyclePatternToken = nil
+        lifecyclePatternEndsAt = .distantPast
+    }
 
     static func prepare() {
+        softGenerator.prepare()
         lightGenerator.prepare()
         mediumGenerator.prepare()
         rigidGenerator.prepare()
@@ -102,5 +191,47 @@ enum Haptics {
         guard !testSuppressesHardware else { return }
 #endif
         action()
+    }
+
+    private static func transientParameters(intensity: Float) -> [CHHapticEventParameter] {
+        [
+            CHHapticEventParameter(parameterID: .hapticIntensity, value: intensity),
+            CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.7)
+        ]
+    }
+
+    private static func playResponseStartFallback(token: UUID) {
+        mediumGenerator.impactOccurred(intensity: 1)
+        mediumGenerator.prepare()
+        lifecyclePatternTask = Task { @MainActor in
+            do {
+                try await Task.sleep(for: .milliseconds(60))
+                guard lifecyclePatternToken == token, enabled else { return }
+                lightGenerator.impactOccurred(intensity: 0.8)
+                try await Task.sleep(for: .milliseconds(90))
+                guard lifecyclePatternToken == token, enabled else { return }
+                lightGenerator.impactOccurred(intensity: 0.7)
+                lightGenerator.prepare()
+                finishLifecyclePattern(token)
+            } catch {
+                return
+            }
+        }
+    }
+
+    private static func beginLifecyclePattern(duration: TimeInterval) -> UUID {
+        cancelLifecyclePattern()
+        let token = UUID()
+        lifecyclePatternToken = token
+        lifecyclePatternEndsAt = Date().addingTimeInterval(duration)
+        return token
+    }
+
+    private static func finishLifecyclePattern(_ token: UUID) {
+        guard lifecyclePatternToken == token else { return }
+        lifecyclePatternPlayer = nil
+        lifecyclePatternTask = nil
+        lifecyclePatternToken = nil
+        lifecyclePatternEndsAt = .distantPast
     }
 }

--- a/Conduit/Services/Haptics.swift
+++ b/Conduit/Services/Haptics.swift
@@ -10,11 +10,137 @@ import CoreHaptics
 import SwiftUI
 import UIKit
 
+struct ResponseHapticState {
+    enum Effect: Equatable {
+        case responseStarted
+        case toolStarted
+        case responseConcluded
+        case error
+        case cancelPattern
+    }
+
+    struct Conclusion: Equatable {
+        let token: UUID
+        let sessionID: String?
+    }
+
+    private(set) var pendingConclusion: Conclusion?
+    private(set) var isActive = false
+    private(set) var startPlayed = false
+    private(set) var foregroundActive = true
+    private var lastToolDate: Date?
+    private var suppressesFeedbackUntilReset = false
+
+    mutating func setForegroundActive(_ active: Bool) -> Effect? {
+        foregroundActive = active
+        guard active else {
+            pendingConclusion = nil
+            isActive = false
+            startPlayed = false
+            lastToolDate = nil
+            suppressesFeedbackUntilReset = true
+            return .cancelPattern
+        }
+        return nil
+    }
+
+    mutating func registerActivity(playsStart: Bool) -> [Effect] {
+        guard foregroundActive, !suppressesFeedbackUntilReset else { return [] }
+        pendingConclusion = nil
+        isActive = true
+        guard playsStart, !startPlayed else { return [] }
+        startPlayed = true
+        return [.responseStarted]
+    }
+
+    mutating func registerTool(at date: Date) -> [Effect] {
+        var effects = registerActivity(playsStart: false)
+        guard foregroundActive,
+              lastToolDate.map({ date.timeIntervalSince($0) >= 0.25 }) ?? true else {
+            return effects
+        }
+        lastToolDate = date
+        effects.append(.toolStarted)
+        return effects
+    }
+
+    mutating func scheduleConclusion(sessionID: String?) -> Conclusion? {
+        guard isActive else { return nil }
+        let conclusion = Conclusion(token: UUID(), sessionID: sessionID)
+        pendingConclusion = conclusion
+        return conclusion
+    }
+
+    mutating func finishConclusion(_ conclusion: Conclusion) -> Effect? {
+        guard pendingConclusion == conclusion else { return nil }
+        pendingConclusion = nil
+        isActive = false
+        startPlayed = false
+        lastToolDate = nil
+        return foregroundActive ? .responseConcluded : nil
+    }
+
+    mutating func fail() -> [Effect] {
+        let shouldNotify = isActive && foregroundActive
+        var effects = reset()
+        if shouldNotify { effects.append(.error) }
+        return effects
+    }
+
+    mutating func reset() -> [Effect] {
+        pendingConclusion = nil
+        isActive = false
+        startPlayed = false
+        lastToolDate = nil
+        suppressesFeedbackUntilReset = false
+        return [.cancelPattern]
+    }
+
+    mutating func invalidateConclusion() {
+        pendingConclusion = nil
+    }
+}
+
+enum ResponseHapticPolicy {
+    enum Signal: Equatable {
+        case activity(playsStart: Bool)
+        case tool
+        case failure
+        case reset
+    }
+
+    static func signal(for event: StreamEvent) -> Signal? {
+        switch event {
+        case .messageStart, .reasoningDelta, .clarify, .approval:
+            return .activity(playsStart: false)
+        case .messageDelta:
+            return .activity(playsStart: true)
+        case .toolStart(_, let name, _):
+            return name.lowercased() == "clarify" ? nil : .tool
+        case .delegateAgent(_, let activity):
+            return activity.stream.contains { $0.kind == .tool } ? .tool : nil
+        case .messageError:
+            return .failure
+        case .messageInterrupted:
+            return .reset
+        default:
+            return nil
+        }
+    }
+
+    static func shouldScheduleIdleConclusion(
+        isBusy: Bool,
+        hasPendingConclusion: Bool,
+        awaitsUserInput: Bool
+    ) -> Bool {
+        !isBusy && !hasPendingConclusion && !awaitsUserInput
+    }
+}
+
 @MainActor
 enum Haptics {
-    static let preferenceKey = "conduit.haptics"
-
     enum Event: Equatable {
+        case soft
         case light
         case medium
         case rigid
@@ -22,7 +148,18 @@ enum Haptics {
         case error
         case warning
         case selection
+        case toolStarted
+        case responseStarted
+        case responseConcluded
     }
+
+#if DEBUG
+    static var testEmissionHandler: ((Event) -> Void)?
+    static var testSuppressesHardware = false
+#endif
+
+    static let preferenceKey = "conduit.haptics"
+
 
     private static let softGenerator = UIImpactFeedbackGenerator(style: .soft)
     private static let lightGenerator = UIImpactFeedbackGenerator(style: .light)
@@ -36,78 +173,73 @@ enum Haptics {
     private static var lifecyclePatternToken: UUID?
     private static var lifecyclePatternEndsAt = Date.distantPast
 
-#if DEBUG
-    static var testEmissionHandler: ((Event) -> Void)?
-    static var testSuppressesHardware = false
-#endif
 
     static var enabled: Bool {
         get { UserDefaults.standard.object(forKey: preferenceKey) as? Bool ?? true }
-        set { UserDefaults.standard.set(newValue, forKey: preferenceKey) }
+        set {
+            UserDefaults.standard.set(newValue, forKey: preferenceKey)
+            if !newValue {
+                cancelLifecyclePattern()
+            }
+        }
     }
 
     static func soft() {
-        guard enabled else { return }
+        guard emit(.soft) else { return }
         softGenerator.impactOccurred()
         softGenerator.prepare()
     }
 
     static func light() {
-        emit(.light) {
-            lightGenerator.impactOccurred()
-            lightGenerator.prepare()
-        }
+        guard emit(.light) else { return }
+        lightGenerator.impactOccurred()
+        lightGenerator.prepare()
     }
 
     static func medium() {
-        emit(.medium) {
-            mediumGenerator.impactOccurred()
-            mediumGenerator.prepare()
-        }
+        guard emit(.medium) else { return }
+        mediumGenerator.impactOccurred()
+        mediumGenerator.prepare()
     }
 
     static func rigid() {
-        emit(.rigid) {
-            rigidGenerator.impactOccurred()
-            rigidGenerator.prepare()
-        }
+        guard emit(.rigid) else { return }
+        rigidGenerator.impactOccurred()
+        rigidGenerator.prepare()
     }
 
     static func success() {
-        emit(.success) {
-            notificationGenerator.notificationOccurred(.success)
-            notificationGenerator.prepare()
-        }
+        guard emit(.success) else { return }
+        notificationGenerator.notificationOccurred(.success)
+        notificationGenerator.prepare()
     }
 
     static func error() {
-        emit(.error) {
-            notificationGenerator.notificationOccurred(.error)
-            notificationGenerator.prepare()
-        }
+        guard emit(.error) else { return }
+        notificationGenerator.notificationOccurred(.error)
+        notificationGenerator.prepare()
     }
 
     static func warning() {
-        emit(.warning) {
-            notificationGenerator.notificationOccurred(.warning)
-            notificationGenerator.prepare()
-        }
+        guard emit(.warning) else { return }
+        notificationGenerator.notificationOccurred(.warning)
+        notificationGenerator.prepare()
     }
 
     static func selection() {
-        emit(.selection) {
-            selectionGenerator.selectionChanged()
-            selectionGenerator.prepare()
-        }
+        guard emit(.selection) else { return }
+        selectionGenerator.selectionChanged()
+        selectionGenerator.prepare()
     }
+
     static func toolStarted() {
-        guard enabled, Date() >= lifecyclePatternEndsAt else { return }
+        guard Date() >= lifecyclePatternEndsAt, emit(.toolStarted) else { return }
         softGenerator.impactOccurred(intensity: 0.65)
         softGenerator.prepare()
     }
 
     static func responseStarted() {
-        guard enabled else { return }
+        guard emit(.responseStarted) else { return }
         let token = beginLifecyclePattern(duration: 0.18)
         do {
             let engine: CHHapticEngine
@@ -149,7 +281,7 @@ enum Haptics {
     }
 
     static func responseConcluded() {
-        guard enabled else { return }
+        guard emit(.responseConcluded) else { return }
         let token = beginLifecyclePattern(duration: 0.20)
         lightGenerator.impactOccurred(intensity: 0.79)
         lightGenerator.prepare()
@@ -184,13 +316,13 @@ enum Haptics {
         selectionGenerator.prepare()
     }
 
-    private static func emit(_ event: Event, action: () -> Void) {
-        guard enabled else { return }
+    private static func emit(_ event: Event) -> Bool {
+        guard enabled else { return false }
 #if DEBUG
         testEmissionHandler?(event)
-        guard !testSuppressesHardware else { return }
+        guard !testSuppressesHardware else { return false }
 #endif
-        action()
+        return true
     }
 
     private static func transientParameters(intensity: Float) -> [CHHapticEventParameter] {

--- a/Conduit/Services/Haptics.swift
+++ b/Conduit/Services/Haptics.swift
@@ -127,6 +127,10 @@ enum ResponseHapticPolicy {
             return nil
         }
     }
+    static func treatsAsForegroundActive(_ phase: ScenePhase) -> Bool {
+        phase != .background
+    }
+
 
     static func shouldScheduleIdleConclusion(
         isBusy: Bool,
@@ -246,8 +250,7 @@ enum Haptics {
             if let coreHapticsEngine {
                 engine = coreHapticsEngine
             } else {
-                engine = try CHHapticEngine()
-                engine.isAutoShutdownEnabled = true
+                engine = try makeCoreHapticsEngine()
                 coreHapticsEngine = engine
             }
             try engine.start()
@@ -331,6 +334,33 @@ enum Haptics {
             CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.7)
         ]
     }
+    private static func makeCoreHapticsEngine() throws -> CHHapticEngine {
+        let engine = try CHHapticEngine()
+        engine.isAutoShutdownEnabled = true
+        engine.resetHandler = { [weak engine] in
+            Task { @MainActor in
+                guard let engine, coreHapticsEngine === engine else { return }
+                clearLifecyclePatternState()
+                coreHapticsEngine = nil
+            }
+        }
+        engine.stoppedHandler = { [weak engine] _ in
+            Task { @MainActor in
+                guard let engine, coreHapticsEngine === engine else { return }
+                clearLifecyclePatternState()
+            }
+        }
+        return engine
+    }
+
+    private static func clearLifecyclePatternState() {
+        lifecyclePatternTask?.cancel()
+        lifecyclePatternTask = nil
+        lifecyclePatternPlayer = nil
+        lifecyclePatternToken = nil
+        lifecyclePatternEndsAt = .distantPast
+    }
+
 
     private static func playResponseStartFallback(token: UUID) {
         mediumGenerator.impactOccurred(intensity: 1)

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -759,9 +759,7 @@ private struct DeviceHapticsSettings: View {
                 .labelsHidden()
                 .tint(.conduitAccent)
                 .onChange(of: enabled) { _, enabled in
-                    if !enabled {
-                        Haptics.cancelLifecyclePattern()
-                    }
+                    Haptics.enabled = enabled
                 }
         }
     }

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -752,12 +752,17 @@ private struct DeviceHapticsSettings: View {
             symbol: "waveform",
             tint: .conduitAura
         ) {
-            Text("Conduit-generated vibration feedback for app actions. iOS system controls can still provide their own feedback.")
+            Text("Conduit-generated vibration feedback for actions and response progress. iOS system controls can still provide their own feedback.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
             Toggle("Haptic feedback", isOn: $enabled)
                 .labelsHidden()
                 .tint(.conduitAccent)
+                .onChange(of: enabled) { _, enabled in
+                    if !enabled {
+                        Haptics.cancelLifecyclePattern()
+                    }
+                }
         }
     }
 }

--- a/ConduitTests/HapticsTests.swift
+++ b/ConduitTests/HapticsTests.swift
@@ -52,6 +52,7 @@ final class HapticsTests: XCTestCase {
         Haptics.testSuppressesHardware = true
         Haptics.enabled = false
 
+        Haptics.soft()
         Haptics.light()
         Haptics.medium()
         Haptics.rigid()
@@ -83,6 +84,7 @@ final class HapticsTests: XCTestCase {
         Haptics.testSuppressesHardware = true
         Haptics.enabled = true
 
+        Haptics.soft()
         Haptics.light()
         Haptics.medium()
         Haptics.rigid()
@@ -91,6 +93,6 @@ final class HapticsTests: XCTestCase {
         Haptics.warning()
         Haptics.selection()
 
-        XCTAssertEqual(events, [.light, .medium, .rigid, .success, .error, .warning, .selection])
+        XCTAssertEqual(events, [.soft, .light, .medium, .rigid, .success, .error, .warning, .selection])
     }
 }

--- a/ConduitTests/ResponseHapticStateTests.swift
+++ b/ConduitTests/ResponseHapticStateTests.swift
@@ -1,0 +1,203 @@
+import XCTest
+@testable import Conduit
+
+final class ResponseHapticStateTests: XCTestCase {
+    func testVisibleAnswerStartsOncePerTurn() {
+        var state = ResponseHapticState()
+
+        XCTAssertEqual(state.registerActivity(playsStart: false), [])
+        XCTAssertEqual(state.registerActivity(playsStart: true), [.responseStarted])
+        XCTAssertEqual(state.registerActivity(playsStart: true), [])
+        XCTAssertTrue(state.isActive)
+        XCTAssertTrue(state.startPlayed)
+    }
+
+    func testToolFeedbackIsDebouncedAndSubordinateToResponseStart() {
+        var state = ResponseHapticState()
+        let first = Date(timeIntervalSince1970: 1_000)
+
+        XCTAssertEqual(state.registerTool(at: first), [.toolStarted])
+        XCTAssertEqual(state.registerTool(at: first.addingTimeInterval(0.249)), [])
+        XCTAssertEqual(
+            state.registerTool(at: first.addingTimeInterval(0.25)),
+            [.toolStarted]
+        )
+        XCTAssertEqual(state.registerActivity(playsStart: true), [.responseStarted])
+    }
+
+    func testLatestConclusionTokenOwnsCompletion() throws {
+        var state = ResponseHapticState()
+        _ = state.registerActivity(playsStart: true)
+        let stale = try XCTUnwrap(state.scheduleConclusion(sessionID: "session"))
+        let current = try XCTUnwrap(state.scheduleConclusion(sessionID: "session"))
+
+        XCTAssertNil(state.finishConclusion(stale))
+        XCTAssertEqual(state.pendingConclusion, current)
+        XCTAssertEqual(state.finishConclusion(current), .responseConcluded)
+        XCTAssertFalse(state.isActive)
+        XCTAssertFalse(state.startPlayed)
+    }
+
+    func testNewActivityInvalidatesPendingConclusion() throws {
+        var state = ResponseHapticState()
+        _ = state.registerActivity(playsStart: true)
+        let pending = try XCTUnwrap(state.scheduleConclusion(sessionID: "session"))
+
+        XCTAssertEqual(state.registerActivity(playsStart: false), [])
+
+        XCTAssertNil(state.pendingConclusion)
+        XCTAssertNil(state.finishConclusion(pending))
+        XCTAssertTrue(state.isActive)
+    }
+
+    func testBackgroundSuppressesFeedbackAndClearsTurn() throws {
+        var state = ResponseHapticState()
+        _ = state.registerActivity(playsStart: true)
+        let stale = try XCTUnwrap(state.scheduleConclusion(sessionID: "session"))
+
+        XCTAssertEqual(state.setForegroundActive(false), .cancelPattern)
+        XCTAssertFalse(state.isActive)
+        XCTAssertFalse(state.startPlayed)
+        XCTAssertNil(state.pendingConclusion)
+        XCTAssertNil(state.finishConclusion(stale))
+        XCTAssertEqual(state.registerActivity(playsStart: true), [])
+        XCTAssertEqual(state.setForegroundActive(true), nil)
+        XCTAssertEqual(state.registerActivity(playsStart: true), [])
+        XCTAssertEqual(state.reset(), [.cancelPattern])
+        XCTAssertEqual(state.registerActivity(playsStart: true), [.responseStarted])
+    }
+
+    func testFailureCancelsPatternAndReportsErrorOnlyForActiveTurn() {
+        var state = ResponseHapticState()
+
+        XCTAssertEqual(state.fail(), [.cancelPattern])
+        _ = state.registerActivity(playsStart: false)
+        XCTAssertEqual(state.fail(), [.cancelPattern, .error])
+        XCTAssertFalse(state.isActive)
+        XCTAssertFalse(state.startPlayed)
+        XCTAssertNil(state.pendingConclusion)
+    }
+
+    func testResetInvalidatesTurnAndAllowsNextStart() throws {
+        var state = ResponseHapticState()
+        _ = state.registerActivity(playsStart: true)
+        let stale = try XCTUnwrap(state.scheduleConclusion(sessionID: "old"))
+
+        XCTAssertEqual(state.reset(), [.cancelPattern])
+        XCTAssertNil(state.finishConclusion(stale))
+        XCTAssertEqual(state.registerActivity(playsStart: true), [.responseStarted])
+    }
+}
+
+final class ResponseHapticPolicyTests: XCTestCase {
+    func testMapsEveryLifecycleEventCategory() {
+        let sessionID = "session"
+        let approval = ApprovalActivity(
+            sessionId: sessionID,
+            command: "echo hi",
+            description: "Run command",
+            choices: nil,
+            allowPermanent: false,
+            smartDenied: false,
+            status: .pending,
+            choice: nil,
+            error: nil
+        )
+        let delegateTool = DelegateAgentActivity(
+            id: "agent",
+            goal: "goal",
+            model: nil,
+            status: .running,
+            taskCount: 1,
+            taskIndex: 0,
+            currentTool: "shell",
+            summary: nil,
+            stream: [DelegateAgentActivity.StreamLine(kind: .tool, text: "tool", isError: false)]
+        )
+
+        XCTAssertEqual(ResponseHapticPolicy.signal(for: .messageStart(sessionId: sessionID)), .activity(playsStart: false))
+        XCTAssertEqual(ResponseHapticPolicy.signal(for: .reasoningDelta(sessionId: sessionID, text: "thinking")), .activity(playsStart: false))
+        XCTAssertEqual(ResponseHapticPolicy.signal(for: .messageDelta(sessionId: sessionID, text: "answer")), .activity(playsStart: true))
+        XCTAssertEqual(ResponseHapticPolicy.signal(for: .clarify(sessionId: sessionID, requestId: "request", question: "Choose", choices: [])), .activity(playsStart: false))
+        XCTAssertEqual(ResponseHapticPolicy.signal(for: .approval(sessionId: sessionID, activity: approval)), .activity(playsStart: false))
+        XCTAssertEqual(ResponseHapticPolicy.signal(for: .toolStart(sessionId: sessionID, toolName: "shell", toolInput: nil)), .tool)
+        XCTAssertEqual(ResponseHapticPolicy.signal(for: .delegateAgent(sessionId: sessionID, activity: delegateTool)), .tool)
+        XCTAssertEqual(ResponseHapticPolicy.signal(for: .messageError(sessionId: sessionID, message: "failed")), .failure)
+        XCTAssertEqual(ResponseHapticPolicy.signal(for: .messageInterrupted(sessionId: sessionID)), .reset)
+        XCTAssertNil(ResponseHapticPolicy.signal(for: .toolStart(sessionId: sessionID, toolName: "clarify", toolInput: nil)))
+        XCTAssertNil(ResponseHapticPolicy.signal(for: .messageComplete(sessionId: sessionID, messageId: nil, content: nil, reasoning: nil)))
+        XCTAssertNil(ResponseHapticPolicy.signal(for: .toolComplete(sessionId: sessionID, toolName: "shell", toolOutput: nil)))
+        XCTAssertNil(ResponseHapticPolicy.signal(for: .sessionBusy(sessionId: sessionID, busy: false)))
+    }
+
+    func testIdleConclusionRequiresAnIdleNonInteractiveTurn() {
+        XCTAssertFalse(ResponseHapticPolicy.shouldScheduleIdleConclusion(isBusy: true, hasPendingConclusion: false, awaitsUserInput: false))
+        XCTAssertFalse(ResponseHapticPolicy.shouldScheduleIdleConclusion(isBusy: false, hasPendingConclusion: true, awaitsUserInput: false))
+        XCTAssertFalse(ResponseHapticPolicy.shouldScheduleIdleConclusion(isBusy: false, hasPendingConclusion: false, awaitsUserInput: true))
+        XCTAssertTrue(ResponseHapticPolicy.shouldScheduleIdleConclusion(isBusy: false, hasPendingConclusion: false, awaitsUserInput: false))
+    }
+}
+
+@MainActor
+final class HapticsEmissionTests: XCTestCase {
+    func testDevicePreferenceSuppressesEveryConduitEmission() {
+        let defaults = UserDefaults.standard
+        let previousValue = defaults.object(forKey: Haptics.preferenceKey)
+        var emissions: [Haptics.Event] = []
+        Haptics.testSuppressesHardware = true
+        Haptics.testEmissionHandler = { emissions.append($0) }
+        defer {
+            Haptics.testEmissionHandler = nil
+            Haptics.testSuppressesHardware = false
+            if let previousValue {
+                defaults.set(previousValue, forKey: Haptics.preferenceKey)
+            } else {
+                defaults.removeObject(forKey: Haptics.preferenceKey)
+            }
+        }
+
+        Haptics.enabled = false
+        emitEveryHaptic()
+
+        XCTAssertFalse(Haptics.enabled)
+        XCTAssertEqual(
+            UserDefaults.standard.object(forKey: Haptics.preferenceKey) as? Bool,
+            false
+        )
+        XCTAssertEqual(emissions, [])
+
+        Haptics.enabled = true
+        emitEveryHaptic()
+
+        XCTAssertEqual(
+            emissions,
+            [
+                .soft,
+                .light,
+                .medium,
+                .rigid,
+                .success,
+                .error,
+                .warning,
+                .selection,
+                .toolStarted,
+                .responseStarted,
+                .responseConcluded
+            ]
+        )
+    }
+
+    private func emitEveryHaptic() {
+        Haptics.soft()
+        Haptics.light()
+        Haptics.medium()
+        Haptics.rigid()
+        Haptics.success()
+        Haptics.error()
+        Haptics.warning()
+        Haptics.selection()
+        Haptics.toolStarted()
+        Haptics.responseStarted()
+        Haptics.responseConcluded()
+    }
+}

--- a/ConduitTests/ResponseHapticStateTests.swift
+++ b/ConduitTests/ResponseHapticStateTests.swift
@@ -114,6 +114,10 @@ final class ResponseHapticPolicyTests: XCTestCase {
             summary: nil,
             stream: [DelegateAgentActivity.StreamLine(kind: .tool, text: "tool", isError: false)]
         )
+        var delegateProgress = delegateTool
+        delegateProgress.stream = [
+            DelegateAgentActivity.StreamLine(kind: .progress, text: "working", isError: false)
+        ]
 
         XCTAssertEqual(ResponseHapticPolicy.signal(for: .messageStart(sessionId: sessionID)), .activity(playsStart: false))
         XCTAssertEqual(ResponseHapticPolicy.signal(for: .reasoningDelta(sessionId: sessionID, text: "thinking")), .activity(playsStart: false))
@@ -122,12 +126,19 @@ final class ResponseHapticPolicyTests: XCTestCase {
         XCTAssertEqual(ResponseHapticPolicy.signal(for: .approval(sessionId: sessionID, activity: approval)), .activity(playsStart: false))
         XCTAssertEqual(ResponseHapticPolicy.signal(for: .toolStart(sessionId: sessionID, toolName: "shell", toolInput: nil)), .tool)
         XCTAssertEqual(ResponseHapticPolicy.signal(for: .delegateAgent(sessionId: sessionID, activity: delegateTool)), .tool)
+        XCTAssertNil(ResponseHapticPolicy.signal(for: .delegateAgent(sessionId: sessionID, activity: delegateProgress)))
         XCTAssertEqual(ResponseHapticPolicy.signal(for: .messageError(sessionId: sessionID, message: "failed")), .failure)
         XCTAssertEqual(ResponseHapticPolicy.signal(for: .messageInterrupted(sessionId: sessionID)), .reset)
         XCTAssertNil(ResponseHapticPolicy.signal(for: .toolStart(sessionId: sessionID, toolName: "clarify", toolInput: nil)))
         XCTAssertNil(ResponseHapticPolicy.signal(for: .messageComplete(sessionId: sessionID, messageId: nil, content: nil, reasoning: nil)))
         XCTAssertNil(ResponseHapticPolicy.signal(for: .toolComplete(sessionId: sessionID, toolName: "shell", toolOutput: nil)))
         XCTAssertNil(ResponseHapticPolicy.signal(for: .sessionBusy(sessionId: sessionID, busy: false)))
+    }
+
+    func testScenePhasePolicySuppressesOnlyBackgroundFeedback() {
+        XCTAssertTrue(ResponseHapticPolicy.treatsAsForegroundActive(.active))
+        XCTAssertTrue(ResponseHapticPolicy.treatsAsForegroundActive(.inactive))
+        XCTAssertFalse(ResponseHapticPolicy.treatsAsForegroundActive(.background))
     }
 
     func testIdleConclusionRequiresAnIdleNonInteractiveTurn() {
@@ -143,12 +154,14 @@ final class HapticsEmissionTests: XCTestCase {
     func testDevicePreferenceSuppressesEveryConduitEmission() {
         let defaults = UserDefaults.standard
         let previousValue = defaults.object(forKey: Haptics.preferenceKey)
+        let previousHandler = Haptics.testEmissionHandler
+        let previousSuppressesHardware = Haptics.testSuppressesHardware
         var emissions: [Haptics.Event] = []
         Haptics.testSuppressesHardware = true
         Haptics.testEmissionHandler = { emissions.append($0) }
         defer {
-            Haptics.testEmissionHandler = nil
-            Haptics.testSuppressesHardware = false
+            Haptics.testEmissionHandler = previousHandler
+            Haptics.testSuppressesHardware = previousSuppressesHardware
             if let previousValue {
                 defaults.set(previousValue, forKey: Haptics.preferenceKey)
             } else {


### PR DESCRIPTION
> Draft dependency: this branch is temporarily based on `fix/haptics-toggle` so lifecycle feedback uses the repaired device-local preference. It will be rebased onto upstream `main` after the toggle fix merges. The PR will remain draft until the dependency commit is removed and final validation is rerun.

## Summary
- Add calibrated response-start, subordinate tool, and response-conclusion feedback.
- Drive feedback from active-session lifecycle events rather than view timing.
- Cancel stale patterns across interruption, failure, session changes, foreground changes, and superseded completion tasks.
- Keep every lifecycle emitter behind the device-local Haptic Feedback preference.

## Behavior
The first visible answer text begins one response pattern. Tool activity uses a softer, debounced cue. A completed response emits one conclusion cue after the existing streaming drain. Errors emit error feedback; interruption, session changes, and backgrounding cancel stale lifecycle state. Clarify and approval waits remain active until user input resolves them.

## Validation
Simulator:
- Focused lifecycle, policy, emission, and preference tests passed on commit `db74d0c`: 14 tests, 0 failures.
- The complete Xcode simulator suite passed on commit `db74d0c`: 232 tests, 0 failures.

Physical iPhone:
- Not yet performed on the reviewed commit `db74d0c`.
- On the pre-restack branch, a normal tool-using response produced one start pattern, softer tool feedback, and one conclusion; interruption produced no delayed conclusion; the corrected foreground path produced no restart or conclusion; and disabling/re-enabling the preference suppressed/restored lifecycle feedback.
- Response-error and clarify/approval-wait scenarios were unavailable. These pre-restack observations are not claimed as validation of the current commit.

Lifecycle commits:
- `b5c5fd1` Add response lifecycle haptics
- `312a797` Harden response lifecycle haptics
- `db74d0c` Address response haptics review findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tactile feedback throughout response activity, including tool execution, failures, cancellation, completion, and user-input requests.
  * Added device-level haptic controls in Chat Settings.
  * Haptic patterns now adapt to app backgrounding, session changes, and response completion timing.

* **Bug Fixes**
  * Disabling haptics immediately stops active feedback and suppresses future notifications.

* **Tests**
  * Added coverage for haptic preferences, lifecycle transitions, scheduling, cancellation, and event behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->