### PR TITLE
Restore chat scroll position + session switch stability (#19 + #24 restored)

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -183,6 +183,7 @@ final class AppState: ObservableObject {
     @Published var messages: [ChatMessage] = [] {
         didSet {
             chatTranscriptRevision &+= 1
+            advanceChatViewportExpectedTranscriptRevisionIfNeeded()
         }
     }
     @Published private(set) var activeSessionTitle = "New conversation"
@@ -384,6 +385,7 @@ final class AppState: ObservableObject {
     private var lastStreamingPublishBurst = 0
     private var lastStreamingPublishDate: Date?
     private var scenePhaseTask: Task<Void, Never>?
+    private var scenePhaseAttemptID: UUID?
     private var activeAutomaticChatResumeWork: ChatResumeAutomaticWorkToken?
     private var chatViewportSnapshotProvider: (
         id: UUID,
@@ -723,13 +725,7 @@ final class AppState: ObservableObject {
     }
 
     @discardableResult
-    func beginExplicitChatViewportTransition(
-        reusing generation: UInt64? = nil
-    ) -> UInt64 {
-        if let transition = chatViewportTransition,
-           generation == transition.generation {
-            return transition.generation
-        }
+    func beginExplicitChatViewportTransition() -> UInt64 {
         if let transition = chatViewportTransition {
             finishChatViewportTransition(generation: transition.generation)
         }
@@ -746,6 +742,14 @@ final class AppState: ObservableObject {
         return chatViewportTransitionGeneration
     }
 
+    private func chatViewportTransitionIsCurrent(generation: UInt64) -> Bool {
+        chatViewportTransition?.generation == generation
+    }
+
+    private func chatViewportTransitionIsCurrent(_ generation: UInt64?) -> Bool {
+        generation.map { chatViewportTransitionIsCurrent(generation: $0) } ?? true
+    }
+
     private func markChatViewportReplacement() {
         guard var transition = chatViewportTransition else { return }
         transition.hasReplacement = true
@@ -756,6 +760,19 @@ final class AppState: ObservableObject {
         guard var transition = chatViewportTransition,
               transition.hasReplacement else { return }
         transition.expectedSessionKey = currentChatScrollSessionKey
+        transition.expectedTranscriptRevision = chatTranscriptRevision
+        chatViewportTransition = transition
+    }
+
+    private func advanceChatViewportExpectedTranscriptRevisionIfNeeded() {
+        guard var transition = chatViewportTransition,
+              transition.hasReplacement,
+              transition.expectedTranscriptRevision != nil,
+              transition.expectedSessionKey.map({ expected in
+                  currentChatScrollSessionKey.map {
+                      activeChatScrollSessionIdentity.areEquivalent(expected, $0)
+                  } == true
+              }) == true else { return }
         transition.expectedTranscriptRevision = chatTranscriptRevision
         chatViewportTransition = transition
     }
@@ -786,13 +803,14 @@ final class AppState: ObservableObject {
         sessionKey: ChatScrollSessionKey,
         transitionGeneration: UInt64,
         transcriptRevision: UInt64,
-        renderRevision: UInt64
+        renderRevision: UInt64,
+        receivedScopedPreference: Bool
     ) {
         guard let transition = chatViewportTransition,
               transitionGeneration == transition.generation,
               transition.hasReplacement,
               transition.expectedTranscriptRevision == transcriptRevision,
-              renderRevision > 0,
+              receivedScopedPreference,
               transition.expectedSessionKey.map({ expected in
                   activeChatScrollSessionIdentity.areEquivalent(expected, sessionKey)
               }) == true,
@@ -853,9 +871,21 @@ final class AppState: ObservableObject {
     }
 
     private func automaticChatResumeWorkIsCurrent(
-        _ token: ChatResumeAutomaticWorkToken?
+        _ token: ChatResumeAutomaticWorkToken?,
+        syncOperationID: UUID? = nil,
+        reconnectOperationID: UUID? = nil
     ) -> Bool {
-        token.map(chatResumeCoordinator.isCurrent) ?? true
+        guard !Task.isCancelled,
+              token.map(chatResumeCoordinator.isCurrent) ?? true else { return false }
+        if let syncOperationID,
+           activeAutomaticSyncOperation?.id != syncOperationID {
+            return false
+        }
+        if let reconnectOperationID,
+           activeAutomaticReconnectOperation?.id != reconnectOperationID {
+            return false
+        }
+        return true
     }
 
     func cancelChatResumeRestoration() {
@@ -882,8 +912,13 @@ final class AppState: ObservableObject {
         return operation.id
     }
 
-    private func finishAutomaticSyncOperation(id: UUID?) {
+    private func finishAutomaticSyncOperation(id: UUID?, restoringBaseline: Bool = false) {
         guard let id, activeAutomaticSyncOperation?.id == id else { return }
+        if restoringBaseline,
+           let operation = activeAutomaticSyncOperation,
+           turnState == .synchronizing {
+            turnState = operation.previousTurnState
+        }
         activeAutomaticSyncOperation = nil
     }
 
@@ -902,8 +937,16 @@ final class AppState: ObservableObject {
         return operation.id
     }
 
-    private func finishAutomaticReconnectOperation(id: UUID?) {
+    private func finishAutomaticReconnectOperation(id: UUID?, restoringBaseline: Bool = false) {
         guard let id, activeAutomaticReconnectOperation?.id == id else { return }
+        if restoringBaseline, let operation = activeAutomaticReconnectOperation {
+            if isConnecting {
+                isConnecting = operation.previousIsConnecting
+            }
+            if turnState == .reconnecting {
+                turnState = operation.previousTurnState
+            }
+        }
         activeAutomaticReconnectOperation = nil
     }
 
@@ -1157,7 +1200,8 @@ final class AppState: ObservableObject {
         profile: String,
         syncPurpose: ChatResumeSyncPurpose,
         cancelsResumeRestoration: Bool,
-        automaticWorkToken existingAutomaticWorkToken: ChatResumeAutomaticWorkToken? = nil
+        automaticWorkToken existingAutomaticWorkToken: ChatResumeAutomaticWorkToken? = nil,
+        automaticReconnectOperationID: UUID? = nil
     ) async {
         if cancelsResumeRestoration {
             cancelChatResumeRestoration()
@@ -1173,7 +1217,10 @@ final class AppState: ObservableObject {
         let automaticWorkToken = syncPurpose == .automaticReturn
             ? (existingAutomaticWorkToken ?? beginAutomaticChatResumeWork())
             : nil
-        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
+        guard automaticChatResumeWorkIsCurrent(
+            automaticWorkToken,
+            reconnectOperationID: automaticReconnectOperationID
+        ) else { return }
         rememberDashboardURL(conn.baseUrl)
         cancelScheduledReconnect()
         isConnecting = true
@@ -1199,7 +1246,10 @@ final class AppState: ObservableObject {
 
         do {
             try await client.connect()
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+            guard automaticChatResumeWorkIsCurrent(
+                    automaticWorkToken,
+                    reconnectOperationID: automaticReconnectOperationID
+                  ),
                   let activeClient = self.client, activeClient === client else { return }
             isConnected = true
             isConnecting = false
@@ -1208,22 +1258,37 @@ final class AppState: ObservableObject {
             KeychainHelper.saveConnection(conn)
 
             await loadProfiles()
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
+            guard automaticChatResumeWorkIsCurrent(
+                automaticWorkToken,
+                reconnectOperationID: automaticReconnectOperationID
+            ) else { return }
             await syncSession(
                 purpose: syncPurpose,
                 using: nil,
                 automaticWorkToken: automaticWorkToken
             )
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+            guard automaticChatResumeWorkIsCurrent(
+                    automaticWorkToken,
+                    reconnectOperationID: automaticReconnectOperationID
+                  ),
                   let activeClient = self.client, activeClient === client else { return }
             await loadBusyInputMode(using: client)
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+            guard automaticChatResumeWorkIsCurrent(
+                    automaticWorkToken,
+                    reconnectOperationID: automaticReconnectOperationID
+                  ),
                   let activeClient = self.client, activeClient === client else { return }
             await loadProfileDisplayPreferences()
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
+            guard automaticChatResumeWorkIsCurrent(
+                automaticWorkToken,
+                reconnectOperationID: automaticReconnectOperationID
+            ) else { return }
             Task { await loadSlashCommands() }
         } catch {
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+            guard automaticChatResumeWorkIsCurrent(
+                    automaticWorkToken,
+                    reconnectOperationID: automaticReconnectOperationID
+                  ),
                   let activeClient = self.client, activeClient === client else { return }
             isConnecting = false
             isConnected = false
@@ -1245,7 +1310,7 @@ final class AppState: ObservableObject {
         recoverySequence.cancel()
         chatResumeRestorationRequest = nil
         invalidateReconciliation()
-        scenePhaseTask?.cancel()
+        cancelScenePhaseAttempt()
         client?.disconnect()
         isConnected = false
         isConnecting = false
@@ -1371,15 +1436,27 @@ final class AppState: ObservableObject {
     func syncSession(
         purpose: ChatResumeSyncPurpose,
         using existingReconciliationToken: UUID?,
-        automaticWorkToken existingAutomaticWorkToken: ChatResumeAutomaticWorkToken?
+        automaticWorkToken existingAutomaticWorkToken: ChatResumeAutomaticWorkToken?,
+        requiredViewportTransitionGeneration: UInt64? = nil
     ) async {
+        guard chatViewportTransitionIsCurrent(
+            requiredViewportTransitionGeneration
+        ) else { return }
         let purpose = beginChatResumeRecovery(purpose: purpose)
         let automaticWorkToken = purpose == .automaticReturn
             ? (existingAutomaticWorkToken ?? beginAutomaticChatResumeWork())
             : nil
         guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
         let automaticOperationID = beginAutomaticSyncOperation(for: automaticWorkToken)
-        defer { finishAutomaticSyncOperation(id: automaticOperationID) }
+        defer {
+            finishAutomaticSyncOperation(
+                id: automaticOperationID,
+                restoringBaseline: !automaticChatResumeWorkIsCurrent(
+                    automaticWorkToken,
+                    syncOperationID: automaticOperationID
+                )
+            )
+        }
         guard let client else {
             if let existingReconciliationToken {
                 settleReconciliation(existingReconciliationToken)
@@ -1410,7 +1487,11 @@ final class AppState: ObservableObject {
             let allSessions = uniqueSessions(
                 [retainedActiveTurn].compactMap { $0 } + loadedSessions
             )
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+            guard automaticChatResumeWorkIsCurrent(
+                    automaticWorkToken,
+                    syncOperationID: automaticOperationID
+                  ),
+                  chatViewportTransitionIsCurrent(requiredViewportTransitionGeneration),
                   token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
@@ -1423,14 +1504,20 @@ final class AppState: ObservableObject {
                 settleReconciliation(token)
                 return
             }
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else {
+            guard automaticChatResumeWorkIsCurrent(
+                automaticWorkToken,
+                syncOperationID: automaticOperationID
+            ), chatViewportTransitionIsCurrent(requiredViewportTransitionGeneration) else {
                 settleReconciliation(token)
                 return
             }
             sessions = allSessions.filter { $0.source != .cron }
             cronSessions = allSessions.filter { $0.source == .cron }
 
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else {
+            guard automaticChatResumeWorkIsCurrent(
+                automaticWorkToken,
+                syncOperationID: automaticOperationID
+            ), chatViewportTransitionIsCurrent(requiredViewportTransitionGeneration) else {
                 settleReconciliation(token)
                 return
             }
@@ -1439,7 +1526,8 @@ final class AppState: ObservableObject {
                 profile: profile,
                 purpose: purpose,
                 currentSessionID: activeSessionId,
-                automaticWorkToken: automaticWorkToken
+                automaticWorkToken: automaticWorkToken,
+                automaticSyncOperationID: automaticOperationID
             )
             if let target {
                 let succeeded = await reconcile(
@@ -1447,11 +1535,16 @@ final class AppState: ObservableObject {
                     using: client,
                     token: token,
                     acceptedSessionIDs: Set([target.id] + target.alternateIds),
-                    automaticWorkToken: automaticWorkToken
+                    automaticWorkToken: automaticWorkToken,
+                    automaticSyncOperationID: automaticOperationID,
+                    requiredViewportTransitionGeneration: requiredViewportTransitionGeneration
                 )
                 if !succeeded,
                    purpose == .automaticReturn,
-                   automaticChatResumeWorkIsCurrent(automaticWorkToken),
+                   automaticChatResumeWorkIsCurrent(
+                    automaticWorkToken,
+                    syncOperationID: automaticOperationID
+                   ),
                    token == reconciliationToken,
                    profile == activeProfile {
                     scheduleReconnect(purpose: purpose)
@@ -1462,11 +1555,17 @@ final class AppState: ObservableObject {
                     profile: profile,
                     token: token,
                     resumePurpose: purpose,
-                    automaticWorkToken: automaticWorkToken
+                    automaticWorkToken: automaticWorkToken,
+                    automaticSyncOperationID: automaticOperationID,
+                    requiredViewportTransitionGeneration: requiredViewportTransitionGeneration
                 )
             }
         } catch {
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+            guard automaticChatResumeWorkIsCurrent(
+                    automaticWorkToken,
+                    syncOperationID: automaticOperationID
+                  ),
+                  chatViewportTransitionIsCurrent(requiredViewportTransitionGeneration),
                   token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
@@ -1524,9 +1623,13 @@ final class AppState: ObservableObject {
         profile: String,
         purpose: ChatResumeSyncPurpose,
         currentSessionID: String?,
-        automaticWorkToken: ChatResumeAutomaticWorkToken? = nil
+        automaticWorkToken: ChatResumeAutomaticWorkToken? = nil,
+        automaticSyncOperationID: UUID? = nil
     ) -> SessionSummary? {
-        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return nil }
+        guard automaticChatResumeWorkIsCurrent(
+            automaticWorkToken,
+            syncOperationID: automaticSyncOperationID
+        ) else { return nil }
         if purpose == .automaticReturn {
             chatResumeRestorationRequest = nil
         }
@@ -1556,9 +1659,13 @@ final class AppState: ObservableObject {
     }
 
     private func publishChatResumeRestorationIfReady(
-        automaticWorkToken: ChatResumeAutomaticWorkToken? = nil
+        automaticWorkToken: ChatResumeAutomaticWorkToken? = nil,
+        automaticSyncOperationID: UUID? = nil
     ) {
-        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
+        guard automaticChatResumeWorkIsCurrent(
+            automaticWorkToken,
+            syncOperationID: automaticSyncOperationID
+        ) else { return }
         guard let sessionKey = activeChatScrollSessionIdentity.canonicalSessionKey,
               let request = chatResumeCoordinator.reconciliationSettled(sessionKey: sessionKey) else {
             return
@@ -1569,15 +1676,25 @@ final class AppState: ObservableObject {
     @discardableResult
     func settleReconciliationAndPublish(
         _ token: UUID,
-        automaticWorkToken: ChatResumeAutomaticWorkToken? = nil
+        automaticWorkToken: ChatResumeAutomaticWorkToken? = nil,
+        automaticSyncOperationID: UUID? = nil
     ) -> Bool {
-        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else {
+        guard automaticChatResumeWorkIsCurrent(
+            automaticWorkToken,
+            syncOperationID: automaticSyncOperationID
+        ) else {
             settleReconciliation(token)
             return false
         }
         guard settleReconciliation(token) else { return false }
-        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return false }
-        publishChatResumeRestorationIfReady(automaticWorkToken: automaticWorkToken)
+        guard automaticChatResumeWorkIsCurrent(
+            automaticWorkToken,
+            syncOperationID: automaticSyncOperationID
+        ) else { return false }
+        publishChatResumeRestorationIfReady(
+            automaticWorkToken: automaticWorkToken,
+            automaticSyncOperationID: automaticSyncOperationID
+        )
         cancelScheduledReconnect()
         recoverySequence.complete()
         if automaticWorkToken != nil {
@@ -1592,9 +1709,16 @@ final class AppState: ObservableObject {
         using client: HermesClient,
         token: UUID,
         acceptedSessionIDs: Set<String> = [],
-        automaticWorkToken: ChatResumeAutomaticWorkToken? = nil
+        automaticWorkToken: ChatResumeAutomaticWorkToken? = nil,
+        automaticSyncOperationID: UUID? = nil,
+        requiredViewportTransitionGeneration: UInt64? = nil
     ) async -> Bool {
-        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return false }
+        guard automaticChatResumeWorkIsCurrent(
+            automaticWorkToken,
+            syncOperationID: automaticSyncOperationID
+        ), chatViewportTransitionIsCurrent(requiredViewportTransitionGeneration) else {
+            return false
+        }
         let bufferedEvents = reconciliation?.token == token
             ? reconciliation?.bufferedEvents ?? []
             : []
@@ -1626,7 +1750,11 @@ final class AppState: ObservableObject {
 
             let result = try await resumedSession
             let transcript = await persistedTranscript
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+            guard automaticChatResumeWorkIsCurrent(
+                    automaticWorkToken,
+                    syncOperationID: automaticSyncOperationID
+                  ),
+                  chatViewportTransitionIsCurrent(requiredViewportTransitionGeneration),
                   token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
@@ -1678,14 +1806,19 @@ final class AppState: ObservableObject {
 
             guard applyChatResume(
                 presentationResult,
-                automaticWorkToken: automaticWorkToken
+                automaticWorkToken: automaticWorkToken,
+                automaticSyncOperationID: automaticSyncOperationID
             ) else {
                 settleReconciliation(token)
                 return false
             }
             await refreshChatResumeContext(sessionId: result.sessionId, using: client)
 
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+            guard automaticChatResumeWorkIsCurrent(
+                    automaticWorkToken,
+                    syncOperationID: automaticSyncOperationID
+                  ),
+                  chatViewportTransitionIsCurrent(requiredViewportTransitionGeneration),
                   token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
@@ -1702,11 +1835,16 @@ final class AppState: ObservableObject {
             bufferedEvents.forEach(applyStreamEvent)
             return settleReconciliationAndPublish(
                 token,
-                automaticWorkToken: automaticWorkToken
+                automaticWorkToken: automaticWorkToken,
+                automaticSyncOperationID: automaticSyncOperationID
             )
 
         } catch {
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+            guard automaticChatResumeWorkIsCurrent(
+                    automaticWorkToken,
+                    syncOperationID: automaticSyncOperationID
+                  ),
+                  chatViewportTransitionIsCurrent(requiredViewportTransitionGeneration),
                   token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
@@ -1748,16 +1886,25 @@ final class AppState: ObservableObject {
         token: UUID,
         resumePurpose: ChatResumeSyncPurpose = .preserveCurrent,
         automaticWorkToken: ChatResumeAutomaticWorkToken? = nil,
+        automaticSyncOperationID: UUID? = nil,
+        requiredViewportTransitionGeneration: UInt64? = nil,
         cwd: String? = nil
     ) async {
-        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
+        guard automaticChatResumeWorkIsCurrent(
+            automaticWorkToken,
+            syncOperationID: automaticSyncOperationID
+        ), chatViewportTransitionIsCurrent(requiredViewportTransitionGeneration) else { return }
         do {
             let created = try await client.createSession(
                 model: runtime.model.isEmpty ? nil : runtime.model,
                 provider: runtime.provider.isEmpty ? nil : runtime.provider,
                 cwd: cwd
             )
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+            guard automaticChatResumeWorkIsCurrent(
+                    automaticWorkToken,
+                    syncOperationID: automaticSyncOperationID
+                  ),
+                  chatViewportTransitionIsCurrent(requiredViewportTransitionGeneration),
                   token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
@@ -1822,7 +1969,8 @@ final class AppState: ObservableObject {
                     profile: profile,
                     purpose: resumePurpose,
                     currentSessionID: runtimeSessionID,
-                    automaticWorkToken: automaticWorkToken
+                    automaticWorkToken: automaticWorkToken,
+                    automaticSyncOperationID: automaticSyncOperationID
                 )
             }
             Task { [weak self] in
@@ -1834,10 +1982,15 @@ final class AppState: ObservableObject {
             }
             settleReconciliationAndPublish(
                 token,
-                automaticWorkToken: automaticWorkToken
+                automaticWorkToken: automaticWorkToken,
+                automaticSyncOperationID: automaticSyncOperationID
             )
         } catch {
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+            guard automaticChatResumeWorkIsCurrent(
+                    automaticWorkToken,
+                    syncOperationID: automaticSyncOperationID
+                  ),
+                  chatViewportTransitionIsCurrent(requiredViewportTransitionGeneration),
                   token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
@@ -1857,9 +2010,13 @@ final class AppState: ObservableObject {
     @discardableResult
     func applyChatResume(
         _ result: SessionResumeResult,
-        automaticWorkToken: ChatResumeAutomaticWorkToken? = nil
+        automaticWorkToken: ChatResumeAutomaticWorkToken? = nil,
+        automaticSyncOperationID: UUID? = nil
     ) -> Bool {
-        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return false }
+        guard automaticChatResumeWorkIsCurrent(
+            automaticWorkToken,
+            syncOperationID: automaticSyncOperationID
+        ) else { return false }
         markChatViewportReplacement()
         setActiveSessionState(id: result.sessionId, title: "New conversation")
         updateActiveSessionTitle(
@@ -2052,7 +2209,15 @@ final class AppState: ObservableObject {
             : nil
         guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
         let automaticOperationID = beginAutomaticReconnectOperation(for: automaticWorkToken)
-        defer { finishAutomaticReconnectOperation(id: automaticOperationID) }
+        defer {
+            finishAutomaticReconnectOperation(
+                id: automaticOperationID,
+                restoringBaseline: !automaticChatResumeWorkIsCurrent(
+                    automaticWorkToken,
+                    reconnectOperationID: automaticOperationID
+                )
+            )
+        }
         if purpose == .automaticReturn, reconnectTask != nil {
             cancelScheduledReconnect()
         }
@@ -2062,12 +2227,18 @@ final class AppState: ObservableObject {
         let connection: HermesConnection
         do {
             let ticket = try await mintChatResumeTicket(for: savedConnection)
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
+            guard automaticChatResumeWorkIsCurrent(
+                automaticWorkToken,
+                reconnectOperationID: automaticOperationID
+            ) else { return }
             connection = HermesConnection(baseUrl: savedConnection.baseUrl, ticket: ticket)
             self.connection = connection
             KeychainHelper.saveConnection(connection)
         } catch {
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
+            guard automaticChatResumeWorkIsCurrent(
+                automaticWorkToken,
+                reconnectOperationID: automaticOperationID
+            ) else { return }
             if let bridgeError = error as? DashboardTicketBridgeError, case .signInRequired = bridgeError {
                 if let credentials = KeychainHelper.loadCredentials(),
                    credentials.baseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/")) == savedConnection.baseUrl.trimmingCharacters(in: CharacterSet(charactersIn: "/")) {
@@ -2076,7 +2247,10 @@ final class AppState: ObservableObject {
                             username: credentials.username,
                             password: credentials.password
                         )
-                        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
+                        guard automaticChatResumeWorkIsCurrent(
+                            automaticWorkToken,
+                            reconnectOperationID: automaticOperationID
+                        ) else { return }
                         // URLSession and WebKit have separate cookie stores.
                         // Reload the bridge so it receives the fresh session.
                         dashboardTicketBridge?.reload()
@@ -2085,17 +2259,29 @@ final class AppState: ObservableObject {
                             profile: activeProfile,
                             syncPurpose: purpose,
                             cancelsResumeRestoration: false,
-                            automaticWorkToken: automaticWorkToken
+                            automaticWorkToken: automaticWorkToken,
+                            automaticReconnectOperationID: automaticOperationID
                         )
                         return
                     } catch {
-                        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
+                        guard automaticChatResumeWorkIsCurrent(
+                            automaticWorkToken,
+                            reconnectOperationID: automaticOperationID
+                        ) else { return }
                         // This only determines whether recovery can be silent.
                         // Preserve the saved credentials for the login screen.
                     }
                 }
+                guard automaticChatResumeWorkIsCurrent(
+                    automaticWorkToken,
+                    reconnectOperationID: automaticOperationID
+                ) else { return }
                 requireSignIn(message: error.localizedDescription)
             } else {
+                guard automaticChatResumeWorkIsCurrent(
+                    automaticWorkToken,
+                    reconnectOperationID: automaticOperationID
+                ) else { return }
                 isConnected = false
                 isConnecting = false
                 turnState = .reconnecting
@@ -2106,14 +2292,20 @@ final class AppState: ObservableObject {
         }
 
         let previousClient = client
-        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
+        guard automaticChatResumeWorkIsCurrent(
+            automaticWorkToken,
+            reconnectOperationID: automaticOperationID
+        ) else { return }
         let client = makeClient(connection: connection, profile: activeProfile)
         self.client = client
         previousClient?.disconnect()
 
         do {
             try await client.connect()
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+            guard automaticChatResumeWorkIsCurrent(
+                    automaticWorkToken,
+                    reconnectOperationID: automaticOperationID
+                  ),
                   let activeClient = self.client, activeClient === client else { return }
             isConnected = true
             isConnecting = false
@@ -2124,19 +2316,34 @@ final class AppState: ObservableObject {
                 using: nil,
                 automaticWorkToken: automaticWorkToken
             )
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+            guard automaticChatResumeWorkIsCurrent(
+                    automaticWorkToken,
+                    reconnectOperationID: automaticOperationID
+                  ),
                   let activeClient = self.client, activeClient === client else { return }
             await loadBusyInputMode(using: client)
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+            guard automaticChatResumeWorkIsCurrent(
+                    automaticWorkToken,
+                    reconnectOperationID: automaticOperationID
+                  ),
                   let activeClient = self.client, activeClient === client else { return }
             await loadProfiles()
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+            guard automaticChatResumeWorkIsCurrent(
+                    automaticWorkToken,
+                    reconnectOperationID: automaticOperationID
+                  ),
                   let activeClient = self.client, activeClient === client else { return }
             await loadProfileDisplayPreferences()
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
+            guard automaticChatResumeWorkIsCurrent(
+                automaticWorkToken,
+                reconnectOperationID: automaticOperationID
+            ) else { return }
             Task { await loadSlashCommands() }
         } catch {
-            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+            guard automaticChatResumeWorkIsCurrent(
+                    automaticWorkToken,
+                    reconnectOperationID: automaticOperationID
+                  ),
                   let activeClient = self.client, activeClient === client else { return }
             isConnected = false
             isConnecting = false
@@ -2154,23 +2361,29 @@ final class AppState: ObservableObject {
         return try await dashboardTicketBridge.mintTicket()
     }
 
-    func handleScenePhase(_ phase: ScenePhase) {
+    @discardableResult
+    func handleScenePhase(_ phase: ScenePhase) -> Task<Void, Never>? {
         switch phase {
         case .active:
             voiceConversationController.setForegroundActive(true)
-            guard connection != nil else { return }
-            scenePhaseTask?.cancel()
+            guard connection != nil else { return nil }
+            cancelScenePhaseAttempt()
             // Publish the foreground reconciliation boundary synchronously.
             // ChatView may receive the same scene transition before the health
             // check task runs, so geometry alone must not restore stale rows.
             let token = beginReconciliation()
             let automaticWorkToken = beginAutomaticChatResumeWork()
-            scenePhaseTask = Task { @MainActor [weak self] in
+            let sceneAttemptID = UUID()
+            self.scenePhaseAttemptID = sceneAttemptID
+            let task = Task { @MainActor [weak self] in
                 guard let self else { return }
+                defer { self.finishScenePhaseAttempt(id: sceneAttemptID) }
+                guard self.scenePhaseAttemptIsCurrent(sceneAttemptID) else { return }
                 if let client = self.client, client.isConnected {
                     do {
                         try await client.healthCheck()
-                        guard self.automaticChatResumeWorkIsCurrent(automaticWorkToken) else {
+                        guard self.scenePhaseAttemptIsCurrent(sceneAttemptID),
+                              self.automaticChatResumeWorkIsCurrent(automaticWorkToken) else {
                             self.settleReconciliation(token)
                             return
                         }
@@ -2180,7 +2393,8 @@ final class AppState: ObservableObject {
                             automaticWorkToken: automaticWorkToken
                         )
                     } catch {
-                        guard self.automaticChatResumeWorkIsCurrent(automaticWorkToken) else {
+                        guard self.scenePhaseAttemptIsCurrent(sceneAttemptID),
+                              self.automaticChatResumeWorkIsCurrent(automaticWorkToken) else {
                             self.settleReconciliation(token)
                             return
                         }
@@ -2188,7 +2402,8 @@ final class AppState: ObservableObject {
                         self.settleReconciliation(token)
                     }
                 } else {
-                    guard self.automaticChatResumeWorkIsCurrent(automaticWorkToken) else {
+                    guard self.scenePhaseAttemptIsCurrent(sceneAttemptID),
+                          self.automaticChatResumeWorkIsCurrent(automaticWorkToken) else {
                         self.settleReconciliation(token)
                         return
                     }
@@ -2196,6 +2411,8 @@ final class AppState: ObservableObject {
                     self.settleReconciliation(token)
                 }
             }
+            scenePhaseTask = task
+            return task
 
         case .background:
             voiceConversationController.setForegroundActive(false)
@@ -2206,23 +2423,56 @@ final class AppState: ObservableObject {
             // A suspended socket may still look open. Invalidate incomplete
             // snapshots so foreground always obtains a fresh authoritative one.
             invalidateReconciliation()
-            scenePhaseTask?.cancel()
+            cancelScenePhaseAttempt()
+            return nil
 
         case .inactive:
             chatResumeCoordinator.freezeViewport()
             voiceConversationController.setForegroundActive(false)
-            break
+            return nil
 
         @unknown default:
-            break
+            return nil
         }
+    }
+
+    private func scenePhaseAttemptIsCurrent(_ id: UUID) -> Bool {
+        !Task.isCancelled && scenePhaseAttemptID == id
+    }
+
+    private func cancelScenePhaseAttempt() {
+        scenePhaseAttemptID = nil
+        scenePhaseTask?.cancel()
+        scenePhaseTask = nil
+        cancelOwnedAutomaticOperations()
+    }
+
+    private func finishScenePhaseAttempt(id: UUID) {
+        guard scenePhaseAttemptID == id else { return }
+        scenePhaseAttemptID = nil
+        scenePhaseTask = nil
     }
 
     // MARK: - Session management
 
     func loadSessions(forceRefresh: Bool = false) async {
+        _ = await loadSessions(
+            forceRefresh: forceRefresh,
+            requiredViewportTransitionGeneration: nil
+        )
+    }
+
+    @discardableResult
+    private func loadSessions(
+        forceRefresh: Bool,
+        requiredViewportTransitionGeneration: UInt64?
+    ) async -> Bool {
+        if let requiredViewportTransitionGeneration,
+           !chatViewportTransitionIsCurrent(generation: requiredViewportTransitionGeneration) {
+            return false
+        }
         let activeClient = client
-        guard activeClient != nil || sessionCatalogLoaderOverride != nil else { return }
+        guard activeClient != nil || sessionCatalogLoaderOverride != nil else { return false }
         let profile = activeProfile
         let retainedActiveTurn = activeTurnCatalogSession()
         do {
@@ -2235,12 +2485,15 @@ final class AppState: ObservableObject {
                     forceRefresh: forceRefresh
                 )
             } else {
-                return
+                return false
             }
-            guard profile == activeProfile else { return }
+            guard profile == activeProfile else { return false }
             if sessionCatalogLoaderOverride == nil {
-                guard let activeClient, self.client === activeClient else { return }
+                guard let activeClient, self.client === activeClient else { return false }
             }
+            requiredViewportTransitionGeneration.map {
+                chatViewportTransitionIsCurrent(generation: $0)
+            } ?? true else { return false }
             let allSessions = uniqueSessions(
                 [retainedActiveTurn].compactMap { $0 } + loadedSessions
             )
@@ -2252,12 +2505,17 @@ final class AppState: ObservableObject {
                     await self?.loadProjects(using: activeClient, profile: profile)
                 }
             }
+            return true
         } catch {
-            guard profile == activeProfile else { return }
+            guard profile == activeProfile else { return false }
             if sessionCatalogLoaderOverride == nil {
-                guard let activeClient, self.client === activeClient else { return }
+                guard let activeClient, self.client === activeClient else { return false }
             }
+            requiredViewportTransitionGeneration.map {
+                chatViewportTransitionIsCurrent(generation: $0)
+            } ?? true else { return false }
             errorMessage = "Failed to load sessions: \(error.localizedDescription)"
+            return false
         }
     }
 
@@ -2522,9 +2780,18 @@ final class AppState: ObservableObject {
             errorMessage = "That conversation belongs to another workspace. Switch profiles to open it."
             return false
         }
-        let transitionGeneration = beginExplicitChatViewportTransition(
-            reusing: viewportTransitionGeneration
-        )
+        let transitionGeneration: UInt64
+        if let viewportTransitionGeneration {
+            guard chatViewportTransitionIsCurrent(
+                generation: viewportTransitionGeneration
+            ) else { return false }
+            transitionGeneration = viewportTransitionGeneration
+        } else {
+            transitionGeneration = beginExplicitChatViewportTransition()
+        }
+        guard chatViewportTransitionIsCurrent(generation: transitionGeneration) else {
+            return false
+        }
         markChatViewportReplacement()
         // Atomically switch session identity BEFORE clearing the transcript.
         // This prevents stale stream events from the old session falling
@@ -2543,8 +2810,12 @@ final class AppState: ObservableObject {
             sessionId: sessionId,
             using: client,
             token: token,
-            acceptedSessionIDs: acceptedSessionIDs
+            acceptedSessionIDs: acceptedSessionIDs,
+            requiredViewportTransitionGeneration: transitionGeneration
         )
+        guard chatViewportTransitionIsCurrent(generation: transitionGeneration) else {
+            return false
+        }
         if !reconciled {
             finishChatViewportTransition(generation: transitionGeneration)
         }
@@ -2563,10 +2834,13 @@ final class AppState: ObservableObject {
         defer { isOpeningNotificationSession = false }
         let targetProfile = notificationProfileID(target.profile)
         if let targetProfile, targetProfile != activeProfile {
-            await switchProfile(
+            guard await switchProfile(
                 to: targetProfile,
                 reusing: transitionGeneration
-            )
+            ) else { return false }
+        }
+        guard chatViewportTransitionIsCurrent(generation: transitionGeneration) else {
+            return false
         }
         if let targetProfile, activeProfile != targetProfile { return false }
         guard client != nil else { return false }
@@ -2580,7 +2854,13 @@ final class AppState: ObservableObject {
         // Do not share the sidebar refresh guard here. The notification route
         // needs one authoritative read even if a visual refresh is already in
         // progress, otherwise it can resolve against the stale catalog.
-        await loadSessions(forceRefresh: true)
+        guard await loadSessions(
+            forceRefresh: true,
+            requiredViewportTransitionGeneration: transitionGeneration
+        ) else { return false }
+        guard chatViewportTransitionIsCurrent(generation: transitionGeneration) else {
+            return false
+        }
         let requestedID = target.sessionId
         let matchingSession = (sessions + cronSessions).first { session in
             session.id == requestedID || session.alternateIds.contains(requestedID)
@@ -2637,7 +2917,8 @@ final class AppState: ObservableObject {
             sessionId: sessionId,
             using: client,
             token: token,
-            acceptedSessionIDs: knownSessionIDs(for: sessionId)
+            acceptedSessionIDs: knownSessionIDs(for: sessionId),
+            requiredViewportTransitionGeneration: transitionGeneration
         )
         if !succeeded || messages == previousMessages {
             finishChatViewportTransition(generation: transitionGeneration)
@@ -2737,7 +3018,8 @@ final class AppState: ObservableObject {
                 sessionId: branched.sessionId,
                 using: client,
                 token: token,
-                acceptedSessionIDs: knownSessionIDs(for: branched.sessionId)
+                acceptedSessionIDs: knownSessionIDs(for: branched.sessionId),
+                requiredViewportTransitionGeneration: transitionGeneration
             )
             if !reconciled {
                 finishChatViewportTransition(generation: transitionGeneration)
@@ -3583,19 +3865,28 @@ final class AppState: ObservableObject {
     }
 
     func switchProfile(to profile: String) async {
-        await switchProfile(to: profile, reusing: nil)
+        _ = await switchProfile(to: profile, reusing: nil)
     }
 
+    @discardableResult
     private func switchProfile(
         to profile: String,
         reusing viewportTransitionGeneration: UInt64?
-    ) async {
+    ) async -> Bool {
         let target = profile.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !target.isEmpty, target != activeProfile, let savedConnection = connection else { return }
-        guard !isProfileSwitching else { return }
-        let transitionGeneration = beginExplicitChatViewportTransition(
-            reusing: viewportTransitionGeneration
-        )
+        guard !target.isEmpty, target != activeProfile, let savedConnection = connection else {
+            return false
+        }
+        guard !isProfileSwitching else { return false }
+        let transitionGeneration: UInt64
+        if let viewportTransitionGeneration {
+            guard chatViewportTransitionIsCurrent(
+                generation: viewportTransitionGeneration
+            ) else { return false }
+            transitionGeneration = viewportTransitionGeneration
+        } else {
+            transitionGeneration = beginExplicitChatViewportTransition()
+        }
         cacheMessagePresentation()
         cancelSecondaryProfileTitleRecovery()
 
@@ -3619,6 +3910,9 @@ final class AppState: ObservableObject {
             prepareDashboardBridge(for: savedConnection.baseUrl)
             guard let dashboardTicketBridge else { throw DashboardTicketBridgeError.notReady }
             let ticket = try await dashboardTicketBridge.mintTicket()
+            guard chatViewportTransitionIsCurrent(generation: transitionGeneration) else {
+                return false
+            }
             let freshConnection = HermesConnection(baseUrl: savedConnection.baseUrl, ticket: ticket)
             let previousClient = client
             let nextClient = makeClient(connection: freshConnection, profile: target)
@@ -3637,7 +3931,8 @@ final class AppState: ObservableObject {
             restoreActiveSessionState(for: target)
             restorePinnedSessions(for: target)
             try await nextClient.connect()
-            guard self.client === nextClient else { return }
+            guard chatViewportTransitionIsCurrent(generation: transitionGeneration),
+                  self.client === nextClient else { return false }
             // Keep the previous socket alive until the new profile has
             // actually connected, so a failed switch has a recovery path.
             previousClient?.disconnect()
@@ -3646,14 +3941,32 @@ final class AppState: ObservableObject {
             KeychainHelper.saveConnection(freshConnection)
             defaults.set(target, forKey: activeProfileKey)
 
-            await syncSession()
+            await syncSession(
+                purpose: .preserveCurrent,
+                using: nil,
+                automaticWorkToken: nil,
+                requiredViewportTransitionGeneration: transitionGeneration
+            )
+            guard chatViewportTransitionIsCurrent(generation: transitionGeneration) else {
+                return false
+            }
             finishChatViewportTransitionIfNoTranscriptReplacement(
                 generation: transitionGeneration
             )
             await loadBusyInputMode(using: nextClient)
+            guard chatViewportTransitionIsCurrent(generation: transitionGeneration) else {
+                return false
+            }
             await loadProfileDisplayPreferences()
+            guard chatViewportTransitionIsCurrent(generation: transitionGeneration) else {
+                return false
+            }
             Task { await loadSlashCommands() }
+            return true
         } catch {
+            guard chatViewportTransitionIsCurrent(generation: transitionGeneration) else {
+                return false
+            }
             errorMessage = "Could not switch workspace: \(error.localizedDescription)"
             activeProfile = previousProfile
             sessions = previousSessions
@@ -3671,6 +3984,7 @@ final class AppState: ObservableObject {
             turnState = .reconnecting
             finishChatViewportTransition(generation: transitionGeneration)
             await reconnect()
+            return false
         }
     }
 

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2872,9 +2872,7 @@ final class AppState: ObservableObject {
             if sessionCatalogLoaderOverride == nil {
                 guard let activeClient, self.client === activeClient else { return false }
             }
-            guard requiredViewportTransitionGeneration.map {
-                chatViewportTransitionIsCurrent(generation: $0)
-            } ?? true else { return false }
+            guard requiredViewportTransitionGeneration.map({ chatViewportTransitionIsCurrent(generation: $0) }) ?? true else { return false }
             let allSessions = uniqueSessions(
                 [retainedActiveTurn].compactMap { $0 } + loadedSessions
             )
@@ -2892,9 +2890,7 @@ final class AppState: ObservableObject {
             if sessionCatalogLoaderOverride == nil {
                 guard let activeClient, self.client === activeClient else { return false }
             }
-            guard requiredViewportTransitionGeneration.map {
-                chatViewportTransitionIsCurrent(generation: $0)
-            } ?? true else { return false }
+            guard requiredViewportTransitionGeneration.map({ chatViewportTransitionIsCurrent(generation: $0) }) ?? true else { return false }
             errorMessage = "Failed to load sessions: \(error.localizedDescription)"
             return false
         }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -471,8 +471,12 @@ final class AppState: ObservableObject {
 
     private func setActiveSessionState(id: String?, title: String? = nil) {
         activeSessionId = id
-        if let id, !id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            activeSessionIDsByProfile[activeProfile] = id
+        if let persistedID = ChatSessionPersistenceIdentity.canonicalID(
+            for: id,
+            identity: activeChatScrollSessionIdentity,
+            catalog: sessions + cronSessions
+        ) {
+            activeSessionIDsByProfile[activeProfile] = persistedID
         } else {
             activeSessionIDsByProfile.removeValue(forKey: activeProfile)
         }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -58,6 +58,8 @@ final class AppState: ObservableObject {
     @Published var messages: [ChatMessage] = []
     @Published private(set) var activeSessionTitle = "New conversation"
     @Published private(set) var isChatRefreshing = false
+    @Published private(set) var chatResumeBehavior: ChatResumeBehavior = .continueWhereLeftOff
+    @Published private(set) var chatResumeRestorationRequest: ChatResumeRestorationRequest?
     /// Keeps the current transcript visible while a notification destination is
     /// being prepared, so the chat never appears to jump to an empty canvas.
     @Published private(set) var isOpeningNotificationSession = false
@@ -340,9 +342,6 @@ final class AppState: ObservableObject {
     // MARK: - Persistence
 
     private let defaults = UserDefaults.standard
-    private let activeSessionKey = "conduit.activeSessionId"
-    private let activeSessionTitleKey = "conduit.activeSessionTitle"
-    private let activeSessionIDsByProfileKey = "conduit.activeSessionIdsByProfile.v1"
     private let activeSessionTitlesByProfileKey = "conduit.activeSessionTitlesByProfile.v1"
     private let pinnedSessionIDsByProfileKey = "conduit.pinnedSessionIdsByProfile.v1"
     private let activeProfileKey = "conduit.activeProfile"
@@ -353,9 +352,9 @@ final class AppState: ObservableObject {
     private let sessionFilterOrderKey = "conduit.sessionFilterOrder.v1"
     private let reviewSummaryCacheKey = "conduit.reviewSummaryCache.v1"
     private let knownProfilesKey = "conduit.knownProfiles.v1"
-    private var activeSessionIDsByProfile: [String: String] = [:]
     private var activeSessionTitlesByProfile: [String: String] = [:]
     private var pinnedSessionIDsByProfile: [String: [String]] = [:]
+    private let chatResumeCoordinator = ChatResumeCoordinator(store: ChatResumeStore())
 
     private func mergeCachedReviews(into history: [ChatMessage], sessionId: String) -> [ChatMessage] {
         let records = cachedReviews().filter { $0.profile == activeProfile && $0.sessionId == sessionId }
@@ -402,6 +401,7 @@ final class AppState: ObservableObject {
     ) {
         sessionRenameOperationsOverride = sessionRenameOperations
         sessionCatalogLoaderOverride = sessionCatalogLoader
+        chatResumeBehavior = chatResumeCoordinator.behavior
         defaultProfileName = ProfileAppearanceStore.loadDefaultName()
         profileAvatarURLs = ProfileAppearanceStore.loadAvatarURLs()
         appIconChoice = UIApplication.shared.alternateIconName == AppIconChoice.light.alternateIconName ? .light : .dark
@@ -418,32 +418,18 @@ final class AppState: ObservableObject {
         activeProfile = defaults.string(forKey: activeProfileKey)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? "default"
         if activeProfile.isEmpty { activeProfile = "default" }
-        activeSessionIDsByProfile = defaults.dictionary(forKey: activeSessionIDsByProfileKey) as? [String: String] ?? [:]
         activeSessionTitlesByProfile = defaults.dictionary(forKey: activeSessionTitlesByProfileKey) as? [String: String] ?? [:]
         if let data = defaults.data(forKey: pinnedSessionIDsByProfileKey),
            let stored = try? JSONDecoder().decode([String: [String]].self, from: data) {
             pinnedSessionIDsByProfile = stored
         }
-        migrateLegacyActiveSessionStateIfNeeded()
         restoreActiveSessionState(for: activeProfile)
         restorePinnedSessions(for: activeProfile)
         if restoreSavedConnection { loadSavedConnection() }
     }
 
-    /// Session IDs are only meaningful within their Hermes profile. The first
-    /// release stored one global "last session", which could make a profile
-    /// switch try to restore a conversation owned by another profile.
-    private func migrateLegacyActiveSessionStateIfNeeded() {
-        guard activeSessionIDsByProfile[activeProfile] == nil,
-              let legacySessionID = defaults.string(forKey: activeSessionKey),
-              !legacySessionID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-        activeSessionIDsByProfile[activeProfile] = legacySessionID
-        activeSessionTitlesByProfile[activeProfile] = defaults.string(forKey: activeSessionTitleKey) ?? "New conversation"
-        persistActiveSessionState()
-    }
-
     private func restoreActiveSessionState(for profile: String) {
-        activeSessionId = activeSessionIDsByProfile[profile]
+        activeSessionId = chatResumeCoordinator.lastSessionID(for: profile)
         activeSessionTitle = activeSessionTitlesByProfile[profile] ?? "New conversation"
     }
 
@@ -496,26 +482,52 @@ final class AppState: ObservableObject {
             identity: activeChatScrollSessionIdentity,
             catalog: sessions + cronSessions
         ) {
-            activeSessionIDsByProfile[activeProfile] = persistedID
+            chatResumeCoordinator.rememberSessionID(persistedID, for: activeProfile)
         } else {
-            activeSessionIDsByProfile.removeValue(forKey: activeProfile)
+            chatResumeCoordinator.rememberSessionID(nil, for: activeProfile)
         }
         if let title {
             activeSessionTitle = title
             activeSessionTitlesByProfile[activeProfile] = title
         }
-        persistActiveSessionState()
+        persistActiveSessionTitles()
     }
 
     private func setActiveSessionTitle(_ title: String) {
         activeSessionTitle = title
         activeSessionTitlesByProfile[activeProfile] = title
-        persistActiveSessionState()
+        persistActiveSessionTitles()
     }
 
-    private func persistActiveSessionState() {
-        defaults.set(activeSessionIDsByProfile, forKey: activeSessionIDsByProfileKey)
+    private func persistActiveSessionTitles() {
         defaults.set(activeSessionTitlesByProfile, forKey: activeSessionTitlesByProfileKey)
+    }
+
+    func setChatResumeBehavior(_ behavior: ChatResumeBehavior) {
+        chatResumeCoordinator.setBehavior(behavior)
+        chatResumeBehavior = chatResumeCoordinator.behavior
+        chatResumeRestorationRequest = nil
+    }
+
+    func recordChatViewport(_ snapshot: ChatScrollSnapshot, for key: ChatScrollSessionKey) {
+        chatResumeCoordinator.recordViewport(snapshot, for: key)
+    }
+
+    func flushChatResumeViewport() {
+        chatResumeCoordinator.flush()
+    }
+
+    func completeChatResumeRestoration(generation: UInt64) {
+        chatResumeCoordinator.completeRestoration(generation: generation)
+        if chatResumeRestorationRequest?.generation == generation,
+           !chatResumeCoordinator.isCurrent(generation: generation) {
+            chatResumeRestorationRequest = nil
+        }
+    }
+
+    func cancelChatResumeRestoration() {
+        chatResumeCoordinator.cancelRestoration()
+        chatResumeRestorationRequest = nil
     }
 
     private func refreshActiveChatScrollSessionIdentity(
@@ -676,6 +688,23 @@ final class AppState: ObservableObject {
     }
 
     func connect(with conn: HermesConnection, profile: String = "default") async {
+        await connect(
+            with: conn,
+            profile: profile,
+            syncPurpose: .automaticReturn,
+            cancelsResumeRestoration: true
+        )
+    }
+
+    private func connect(
+        with conn: HermesConnection,
+        profile: String,
+        syncPurpose: ChatResumeSyncPurpose,
+        cancelsResumeRestoration: Bool
+    ) async {
+        if cancelsResumeRestoration {
+            cancelChatResumeRestoration()
+        }
         guard (try? ConnectionURLPolicy.normalizedBaseURL(conn.baseUrl)) != nil else {
             isConnecting = false
             isConnected = false
@@ -717,7 +746,7 @@ final class AppState: ObservableObject {
             KeychainHelper.saveConnection(conn)
 
             await loadProfiles()
-            await syncSession()
+            await syncSession(purpose: syncPurpose, using: nil)
             await loadBusyInputMode(using: client)
             await loadProfileDisplayPreferences()
             Task { await loadSlashCommands() }
@@ -731,11 +760,13 @@ final class AppState: ObservableObject {
             // sign-in screen. A transient gateway or WebKit startup failure
             // must retain the saved dashboard session and retry.
             showLogin = false
-            scheduleReconnect()
+            scheduleReconnect(purpose: syncPurpose)
         }
     }
 
     func disconnect() {
+        chatResumeCoordinator.clearResumeState()
+        chatResumeRestorationRequest = nil
         invalidateReconciliation()
         reconnectTask?.cancel()
         reconnectTask = nil
@@ -764,12 +795,8 @@ final class AppState: ObservableObject {
         setActiveSessionState(id: nil, title: "New conversation")
         clearStreamingText()
         turnState = .idle
-        defaults.removeObject(forKey: activeSessionKey)
-        defaults.removeObject(forKey: activeSessionTitleKey)
-        defaults.removeObject(forKey: activeSessionIDsByProfileKey)
         defaults.removeObject(forKey: activeSessionTitlesByProfileKey)
         defaults.removeObject(forKey: pinnedSessionIDsByProfileKey)
-        activeSessionIDsByProfile = [:]
         activeSessionTitlesByProfile = [:]
         pinnedSessionIDsByProfile = [:]
         defaults.removeObject(forKey: activeProfileKey)
@@ -838,6 +865,7 @@ final class AppState: ObservableObject {
     }
 
     private func requireSignIn(message: String) {
+        cancelChatResumeRestoration()
         invalidateReconciliation()
         cancelSecondaryProfileTitleRecovery()
         reconnectTask?.cancel()
@@ -863,10 +891,13 @@ final class AppState: ObservableObject {
     /// The only entry point for cold start, foreground refresh, reconnect, and
     /// manual refresh. It never derives liveness from transcript shape.
     func syncSession() async {
-        await syncSession(using: nil)
+        await syncSession(purpose: .preserveCurrent, using: nil)
     }
 
-    private func syncSession(using existingReconciliationToken: UUID?) async {
+    private func syncSession(
+        purpose: ChatResumeSyncPurpose,
+        using existingReconciliationToken: UUID?
+    ) async {
         guard let client else {
             if let existingReconciliationToken {
                 settleReconciliation(existingReconciliationToken)
@@ -877,6 +908,7 @@ final class AppState: ObservableObject {
         // the previously active/newest session. Check both before and after
         // the catalog fetch because a notification tap can arrive mid-launch.
         guard PushNotificationService.shared.pendingTarget == nil else {
+            cancelChatResumeRestoration()
             if let existingReconciliationToken {
                 settleReconciliation(existingReconciliationToken)
             }
@@ -904,20 +936,20 @@ final class AppState: ObservableObject {
                 return
             }
             guard PushNotificationService.shared.pendingTarget == nil else {
+                cancelChatResumeRestoration()
                 settleReconciliation(token)
                 return
             }
             sessions = allSessions.filter { $0.source != .cron }
             cronSessions = allSessions.filter { $0.source == .cron }
 
-            // Keep scheduled-job runs eligible for restoration. They are
-            // intentionally excluded from the ordinary Sessions tab, but a
-            // notification may have just opened one and it must not be
-            // replaced by the newest normal conversation on the next recovery.
-            let savedSession = activeSessionId.flatMap { savedId in
-                allSessions.first { $0.id == savedId || $0.alternateIds.contains(savedId) }
-            }
-            if let target = savedSession ?? sessions.first(where: { $0.source == .chat }) ?? sessions.first {
+            let target = chatResumeCoordinator.selectTarget(
+                in: allSessions,
+                profile: profile,
+                purpose: purpose,
+                currentSessionID: activeSessionId
+            )
+            if let target {
                 await reconcile(
                     sessionId: target.id,
                     using: client,
@@ -925,7 +957,12 @@ final class AppState: ObservableObject {
                     acceptedSessionIDs: Set([target.id] + target.alternateIds)
                 )
             } else {
-                await createAndReconcileSession(using: client, profile: profile, token: token)
+                await createAndReconcileSession(
+                    using: client,
+                    profile: profile,
+                    token: token,
+                    resumePurpose: purpose
+                )
             }
         } catch {
             guard token == reconciliationToken,
@@ -973,6 +1010,14 @@ final class AppState: ObservableObject {
             isReconciling: false,
             advanceSettledRevision: wasReconciling
         )
+    }
+
+    private func publishChatResumeRestorationIfReady() {
+        guard let sessionKey = activeChatScrollSessionIdentity.canonicalSessionKey,
+              let request = chatResumeCoordinator.reconciliationSettled(sessionKey: sessionKey) else {
+            return
+        }
+        chatResumeRestorationRequest = request
     }
 
     @discardableResult
@@ -1069,6 +1114,7 @@ final class AppState: ObservableObject {
                 : []
             bufferedEvents.forEach(applyStreamEvent)
             settleReconciliation(token)
+            publishChatResumeRestorationIfReady()
             return true
 
         } catch {
@@ -1090,6 +1136,7 @@ final class AppState: ObservableObject {
         using client: HermesClient,
         profile: String,
         token: UUID,
+        resumePurpose: ChatResumeSyncPurpose = .preserveCurrent,
         cwd: String? = nil
     ) async {
         do {
@@ -1154,6 +1201,14 @@ final class AppState: ObservableObject {
                 updated.isActive = false
                 return updated
             }
+            if resumePurpose == .automaticReturn {
+                _ = chatResumeCoordinator.selectTarget(
+                    in: [summary],
+                    profile: profile,
+                    purpose: resumePurpose,
+                    currentSessionID: runtimeSessionID
+                )
+            }
             Task { [weak self] in
                 guard let self,
                       self.activeProfile == profile,
@@ -1162,6 +1217,7 @@ final class AppState: ObservableObject {
                 await self.loadSessions()
             }
             settleReconciliation(token)
+            publishChatResumeRestorationIfReady()
         } catch {
             guard token == reconciliationToken,
                   profile == activeProfile,
@@ -1312,7 +1368,10 @@ final class AppState: ObservableObject {
         scheduleReconnect(immediately: wasRunning)
     }
 
-    private func scheduleReconnect(immediately: Bool = false) {
+    private func scheduleReconnect(
+        immediately: Bool = false,
+        purpose: ChatResumeSyncPurpose = .preserveCurrent
+    ) {
         guard reconnectTask == nil, connection != nil else { return }
         let delay = immediately ? 0.1 : min(5.0, pow(2.0, Double(reconnectAttempts)))
         if !immediately { reconnectAttempts += 1 }
@@ -1321,11 +1380,13 @@ final class AppState: ObservableObject {
             try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
             guard !Task.isCancelled, let self else { return }
             self.reconnectTask = nil
-            await self.reconnect()
+            await self.reconnect(purpose: purpose)
         }
     }
 
-    func reconnect() async {
+    func reconnect(
+        purpose: ChatResumeSyncPurpose = .preserveCurrent
+    ) async {
         guard let savedConnection = connection else { return }
         isConnecting = true
         turnState = .reconnecting
@@ -1352,7 +1413,9 @@ final class AppState: ObservableObject {
                         dashboardTicketBridge?.reload()
                         await connect(
                             with: HermesConnection(baseUrl: credentials.baseURL, ticket: ticket),
-                            profile: activeProfile
+                            profile: activeProfile,
+                            syncPurpose: purpose,
+                            cancelsResumeRestoration: false
                         )
                         return
                     } catch {
@@ -1366,7 +1429,7 @@ final class AppState: ObservableObject {
                 isConnecting = false
                 turnState = .reconnecting
                 errorMessage = "Failed to refresh the dashboard session: \(error.localizedDescription)"
-                scheduleReconnect()
+                scheduleReconnect(purpose: purpose)
             }
             return
         }
@@ -1383,7 +1446,7 @@ final class AppState: ObservableObject {
             isConnecting = false
             reconnectAttempts = 0
             connectedAt = Date()
-            await syncSession()
+            await syncSession(purpose: purpose, using: nil)
             await loadBusyInputMode(using: client)
             await loadProfiles()
             await loadProfileDisplayPreferences()
@@ -1393,7 +1456,7 @@ final class AppState: ObservableObject {
             isConnected = false
             isConnecting = false
             turnState = .reconnecting
-            scheduleReconnect()
+            scheduleReconnect(purpose: purpose)
         }
     }
 
@@ -1412,13 +1475,13 @@ final class AppState: ObservableObject {
                 if let client = self.client, client.isConnected {
                     do {
                         try await client.healthCheck()
-                        await self.syncSession(using: token)
+                        await self.syncSession(purpose: .automaticReturn, using: token)
                     } catch {
-                        await self.reconnect()
+                        await self.reconnect(purpose: .automaticReturn)
                         self.settleReconciliation(token)
                     }
                 } else {
-                    await self.reconnect()
+                    await self.reconnect(purpose: .automaticReturn)
                     self.settleReconciliation(token)
                 }
             }
@@ -1435,6 +1498,7 @@ final class AppState: ObservableObject {
             scenePhaseTask?.cancel()
 
         case .inactive:
+            chatResumeCoordinator.freezeViewport()
             voiceConversationController.setForegroundActive(false)
             break
 
@@ -1727,6 +1791,7 @@ final class AppState: ObservableObject {
 
     @discardableResult
     func openSession(_ sessionId: String) async -> Bool {
+        cancelChatResumeRestoration()
         guard let client else { return false }
         if let session = (sessions + cronSessions).first(where: {
             $0.id == sessionId || $0.alternateIds.contains(sessionId)
@@ -1758,6 +1823,7 @@ final class AppState: ObservableObject {
     /// Routes a notification to its originating profile/session without
     /// allowing the ordinary cold-start session restoration to win first.
     func openNotificationTarget(_ target: ConduitNotificationTarget) async -> Bool {
+        cancelChatResumeRestoration()
         guard connection != nil else { return false }
         isOpeningNotificationSession = true
         defer { isOpeningNotificationSession = false }
@@ -1797,6 +1863,7 @@ final class AppState: ObservableObject {
     }
 
     func createNewSession(cwd: String? = nil) async {
+        cancelChatResumeRestoration()
         guard !isProfileSwitching, isConnected, !isConnecting, let client else {
             if isProfileSwitching || isConnecting {
                 errorMessage = "Wait for the workspace switch to finish before starting a conversation."
@@ -2745,6 +2812,7 @@ final class AppState: ObservableObject {
         let target = profile.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !target.isEmpty, target != activeProfile, let savedConnection = connection else { return }
         guard !isProfileSwitching else { return }
+        cancelChatResumeRestoration()
         cacheMessagePresentation()
         cancelSecondaryProfileTitleRecovery()
 

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -143,6 +143,7 @@ final class AppState: ObservableObject {
     @Published private(set) var isChatRefreshing = false
     @Published private(set) var chatResumeBehavior: ChatResumeBehavior = .continueWhereLeftOff
     @Published private(set) var chatResumeRestorationRequest: ChatResumeRestorationRequest?
+    @Published private(set) var chatViewportTransitionGeneration: UInt64 = 0
     /// Keeps the current transcript visible while a notification destination is
     /// being prepared, so the chat never appears to jump to an empty canvas.
     @Published private(set) var isOpeningNotificationSession = false
@@ -337,6 +338,13 @@ final class AppState: ObservableObject {
     private var lastStreamingPublishBurst = 0
     private var lastStreamingPublishDate: Date?
     private var scenePhaseTask: Task<Void, Never>?
+    private var activeAutomaticChatResumeWork: ChatResumeAutomaticWorkToken?
+    private var chatViewportSnapshotProvider: (
+        id: UUID,
+        snapshot: @MainActor () -> ChatScrollSnapshot?
+    )?
+    private var chatViewportTransitionIsFrozen = false
+    private var chatViewportTransitionHasReplacement = false
     private var reconnectTask: ChatResumeReconnectCancellation?
     private let reconnectScheduler: ChatResumeReconnectScheduler
     private let reconnectExecutor: ChatResumeReconnectExecutor?
@@ -623,6 +631,7 @@ final class AppState: ObservableObject {
     func setChatResumeBehavior(_ behavior: ChatResumeBehavior) {
         cancelScheduledReconnect()
         chatResumeCoordinator.setBehavior(behavior)
+        activeAutomaticChatResumeWork = nil
         recoverySequence.cancel()
         chatResumeBehavior = chatResumeCoordinator.behavior
         chatResumeRestorationRequest = nil
@@ -630,6 +639,81 @@ final class AppState: ObservableObject {
 
     func recordChatViewport(_ snapshot: ChatScrollSnapshot, for key: ChatScrollSessionKey) {
         chatResumeCoordinator.recordViewport(snapshot, for: key)
+    }
+
+    func installChatViewportSnapshotProvider(
+        id: UUID,
+        snapshot: @escaping @MainActor () -> ChatScrollSnapshot?
+    ) {
+        chatViewportSnapshotProvider = (id, snapshot)
+    }
+
+    func removeChatViewportSnapshotProvider(id: UUID) {
+        guard chatViewportSnapshotProvider?.id == id else { return }
+        chatViewportSnapshotProvider = nil
+    }
+
+    @discardableResult
+    func beginExplicitChatViewportTransition() -> UInt64 {
+        guard !chatViewportTransitionIsFrozen else {
+            return chatViewportTransitionGeneration
+        }
+        let snapshot = chatViewportSnapshotProvider?.snapshot()
+        chatResumeCoordinator.captureViewportAndFreeze(
+            snapshot,
+            for: currentChatScrollSessionKey
+        )
+        chatViewportTransitionIsFrozen = true
+        chatViewportTransitionHasReplacement = false
+        chatViewportTransitionGeneration &+= 1
+        cancelChatResumeRestoration()
+        return chatViewportTransitionGeneration
+    }
+
+    private func markChatViewportReplacement() {
+        guard chatViewportTransitionIsFrozen else { return }
+        chatViewportTransitionHasReplacement = true
+    }
+
+    private func cancelChatViewportTransitionIfNoReplacement(generation: UInt64) {
+        guard chatViewportTransitionIsFrozen,
+              generation == chatViewportTransitionGeneration,
+              !chatViewportTransitionHasReplacement else { return }
+        chatViewportTransitionIsFrozen = false
+        chatViewportTransitionHasReplacement = false
+        chatResumeCoordinator.unfreezeViewport()
+    }
+
+    private func finishChatViewportTransition(generation: UInt64) {
+        guard chatViewportTransitionIsFrozen,
+              generation == chatViewportTransitionGeneration else { return }
+        chatViewportTransitionIsFrozen = false
+        chatViewportTransitionHasReplacement = false
+        chatResumeCoordinator.unfreezeViewport()
+    }
+
+    func chatViewportLayoutDidSettle(
+        sessionKey: ChatScrollSessionKey,
+        transitionGeneration: UInt64
+    ) {
+        guard chatViewportTransitionIsFrozen,
+              transitionGeneration == chatViewportTransitionGeneration,
+              activeChatScrollSessionIdentity.areEquivalent(
+                sessionKey,
+                currentChatScrollSessionKey
+              ) else { return }
+        chatViewportTransitionIsFrozen = false
+        chatViewportTransitionHasReplacement = false
+        chatResumeCoordinator.unfreezeViewport()
+    }
+
+    private var currentChatScrollSessionKey: ChatScrollSessionKey? {
+        if let canonical = activeChatScrollSessionIdentity.canonicalSessionKey {
+            return canonical
+        }
+        guard let activeSessionId else { return nil }
+        let fallback = ChatScrollSessionKey(profile: activeProfile, sessionID: activeSessionId)
+        return fallback.isValid ? fallback : nil
     }
 
     func flushChatResumeViewport() {
@@ -644,17 +728,45 @@ final class AppState: ObservableObject {
         }
     }
 
+    func abandonChatResumeRestoration(generation: UInt64) {
+        chatResumeCoordinator.abandonRestoration(generation: generation)
+        if chatResumeRestorationRequest?.generation == generation,
+           !chatResumeCoordinator.isCurrent(generation: generation) {
+            chatResumeRestorationRequest = nil
+        }
+    }
+
+    func beginAutomaticChatResumeWork() -> ChatResumeAutomaticWorkToken {
+        if let activeAutomaticChatResumeWork,
+           chatResumeCoordinator.isCurrent(activeAutomaticChatResumeWork) {
+            return activeAutomaticChatResumeWork
+        }
+        let token = chatResumeCoordinator.beginAutomaticWork()
+        activeAutomaticChatResumeWork = token
+        return token
+    }
+
+    private func automaticChatResumeWorkIsCurrent(
+        _ token: ChatResumeAutomaticWorkToken?
+    ) -> Bool {
+        token.map(chatResumeCoordinator.isCurrent) ?? true
+    }
+
     func cancelChatResumeRestoration() {
         cancelScheduledReconnect()
-        chatResumeCoordinator.cancelRestoration()
+        chatResumeCoordinator.cancelRestoration(
+            keepViewportFrozen: chatViewportTransitionIsFrozen
+        )
+        activeAutomaticChatResumeWork = nil
         recoverySequence.cancel()
         chatResumeRestorationRequest = nil
     }
 
+    @discardableResult
     func acceptChatResumeConversationReplacement(
         _ replacement: ChatResumeConversationReplacement
-    ) {
-        cancelChatResumeRestoration()
+    ) -> UInt64 {
+        beginExplicitChatViewportTransition()
     }
 
     @discardableResult
@@ -667,6 +779,7 @@ final class AppState: ObservableObject {
         guard let previousIdentity, previousIdentity != identity else { return false }
 
         chatResumeCoordinator.clearResumeState()
+        activeAutomaticChatResumeWork = nil
         cancelScheduledReconnect()
         recoverySequence.cancel()
         chatResumeRestorationRequest = nil
@@ -879,7 +992,8 @@ final class AppState: ObservableObject {
         with conn: HermesConnection,
         profile: String,
         syncPurpose: ChatResumeSyncPurpose,
-        cancelsResumeRestoration: Bool
+        cancelsResumeRestoration: Bool,
+        automaticWorkToken existingAutomaticWorkToken: ChatResumeAutomaticWorkToken? = nil
     ) async {
         if cancelsResumeRestoration {
             cancelChatResumeRestoration()
@@ -892,6 +1006,10 @@ final class AppState: ObservableObject {
             return
         }
         prepareChatResumeForConnection(to: normalizedBaseURL)
+        let automaticWorkToken = syncPurpose == .automaticReturn
+            ? (existingAutomaticWorkToken ?? beginAutomaticChatResumeWork())
+            : nil
+        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
         rememberDashboardURL(conn.baseUrl)
         cancelScheduledReconnect()
         isConnecting = true
@@ -917,7 +1035,8 @@ final class AppState: ObservableObject {
 
         do {
             try await client.connect()
-            guard let activeClient = self.client, activeClient === client else { return }
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+                  let activeClient = self.client, activeClient === client else { return }
             isConnected = true
             isConnecting = false
             reconnectAttempts = 0
@@ -925,12 +1044,18 @@ final class AppState: ObservableObject {
             KeychainHelper.saveConnection(conn)
 
             await loadProfiles()
-            await syncSession(purpose: syncPurpose, using: nil)
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
+            await syncSession(
+                purpose: syncPurpose,
+                using: nil,
+                automaticWorkToken: automaticWorkToken
+            )
             await loadBusyInputMode(using: client)
             await loadProfileDisplayPreferences()
             Task { await loadSlashCommands() }
         } catch {
-            guard let activeClient = self.client, activeClient === client else { return }
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+                  let activeClient = self.client, activeClient === client else { return }
             isConnecting = false
             isConnected = false
             turnState = .reconnecting
@@ -945,6 +1070,7 @@ final class AppState: ObservableObject {
 
     func disconnect() {
         chatResumeCoordinator.clearResumeState()
+        activeAutomaticChatResumeWork = nil
         cancelScheduledReconnect()
         recoverySequence.cancel()
         chatResumeRestorationRequest = nil
@@ -1069,14 +1195,19 @@ final class AppState: ObservableObject {
     /// manual refresh. It never derives liveness from transcript shape.
     func syncSession() async {
         cancelChatResumeRestoration()
-        await syncSession(purpose: .preserveCurrent, using: nil)
+        await syncSession(purpose: .preserveCurrent, using: nil, automaticWorkToken: nil)
     }
 
     private func syncSession(
         purpose: ChatResumeSyncPurpose,
-        using existingReconciliationToken: UUID?
+        using existingReconciliationToken: UUID?,
+        automaticWorkToken existingAutomaticWorkToken: ChatResumeAutomaticWorkToken?
     ) async {
         let purpose = beginChatResumeRecovery(purpose: purpose)
+        let automaticWorkToken = purpose == .automaticReturn
+            ? (existingAutomaticWorkToken ?? beginAutomaticChatResumeWork())
+            : nil
+        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
         guard let client else {
             if let existingReconciliationToken {
                 settleReconciliation(existingReconciliationToken)
@@ -1107,7 +1238,8 @@ final class AppState: ObservableObject {
             let allSessions = uniqueSessions(
                 [retainedActiveTurn].compactMap { $0 } + loadedSessions
             )
-            guard token == reconciliationToken,
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+                  token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
                   activeClient === client else {
@@ -1119,24 +1251,35 @@ final class AppState: ObservableObject {
                 settleReconciliation(token)
                 return
             }
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else {
+                settleReconciliation(token)
+                return
+            }
             sessions = allSessions.filter { $0.source != .cron }
             cronSessions = allSessions.filter { $0.source == .cron }
 
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else {
+                settleReconciliation(token)
+                return
+            }
             let target = selectChatResumeTarget(
                 in: allSessions,
                 profile: profile,
                 purpose: purpose,
-                currentSessionID: activeSessionId
+                currentSessionID: activeSessionId,
+                automaticWorkToken: automaticWorkToken
             )
             if let target {
                 let succeeded = await reconcile(
                     sessionId: target.id,
                     using: client,
                     token: token,
-                    acceptedSessionIDs: Set([target.id] + target.alternateIds)
+                    acceptedSessionIDs: Set([target.id] + target.alternateIds),
+                    automaticWorkToken: automaticWorkToken
                 )
                 if !succeeded,
                    purpose == .automaticReturn,
+                   automaticChatResumeWorkIsCurrent(automaticWorkToken),
                    token == reconciliationToken,
                    profile == activeProfile {
                     scheduleReconnect(purpose: purpose)
@@ -1146,11 +1289,13 @@ final class AppState: ObservableObject {
                     using: client,
                     profile: profile,
                     token: token,
-                    resumePurpose: purpose
+                    resumePurpose: purpose,
+                    automaticWorkToken: automaticWorkToken
                 )
             }
         } catch {
-            guard token == reconciliationToken,
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+                  token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
                   activeClient === client else {
@@ -1206,8 +1351,10 @@ final class AppState: ObservableObject {
         in catalog: [SessionSummary],
         profile: String,
         purpose: ChatResumeSyncPurpose,
-        currentSessionID: String?
+        currentSessionID: String?,
+        automaticWorkToken: ChatResumeAutomaticWorkToken? = nil
     ) -> SessionSummary? {
+        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return nil }
         if purpose == .automaticReturn {
             chatResumeRestorationRequest = nil
         }
@@ -1236,7 +1383,10 @@ final class AppState: ObservableObject {
         recoverySequence.planReconnect(requestedPurpose: purpose)
     }
 
-    private func publishChatResumeRestorationIfReady() {
+    private func publishChatResumeRestorationIfReady(
+        automaticWorkToken: ChatResumeAutomaticWorkToken? = nil
+    ) {
+        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
         guard let sessionKey = activeChatScrollSessionIdentity.canonicalSessionKey,
               let request = chatResumeCoordinator.reconciliationSettled(sessionKey: sessionKey) else {
             return
@@ -1245,11 +1395,22 @@ final class AppState: ObservableObject {
     }
 
     @discardableResult
-    func settleReconciliationAndPublish(_ token: UUID) -> Bool {
+    func settleReconciliationAndPublish(
+        _ token: UUID,
+        automaticWorkToken: ChatResumeAutomaticWorkToken? = nil
+    ) -> Bool {
+        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else {
+            settleReconciliation(token)
+            return false
+        }
         guard settleReconciliation(token) else { return false }
-        publishChatResumeRestorationIfReady()
+        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return false }
+        publishChatResumeRestorationIfReady(automaticWorkToken: automaticWorkToken)
         cancelScheduledReconnect()
         recoverySequence.complete()
+        if automaticWorkToken != nil {
+            activeAutomaticChatResumeWork = nil
+        }
         return true
     }
 
@@ -1258,8 +1419,10 @@ final class AppState: ObservableObject {
         sessionId: String,
         using client: HermesClient,
         token: UUID,
-        acceptedSessionIDs: Set<String> = []
+        acceptedSessionIDs: Set<String> = [],
+        automaticWorkToken: ChatResumeAutomaticWorkToken? = nil
     ) async -> Bool {
+        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return false }
         let bufferedEvents = reconciliation?.token == token
             ? reconciliation?.bufferedEvents ?? []
             : []
@@ -1288,7 +1451,8 @@ final class AppState: ObservableObject {
 
             let result = try await resumedSession
             let transcript = await persistedTranscript
-            guard token == reconciliationToken,
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+                  token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
                   activeClient === client else {
@@ -1337,10 +1501,17 @@ final class AppState: ObservableObject {
                 presentationResult = result
             }
 
-            applyResume(presentationResult)
+            guard applyChatResume(
+                presentationResult,
+                automaticWorkToken: automaticWorkToken
+            ) else {
+                settleReconciliation(token)
+                return false
+            }
             await refreshContextUsage(sessionId: result.sessionId, using: client)
 
-            guard token == reconciliationToken,
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+                  token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
                   activeClient === client else {
@@ -1354,10 +1525,14 @@ final class AppState: ObservableObject {
                 }
                 : []
             bufferedEvents.forEach(applyStreamEvent)
-            return settleReconciliationAndPublish(token)
+            return settleReconciliationAndPublish(
+                token,
+                automaticWorkToken: automaticWorkToken
+            )
 
         } catch {
-            guard token == reconciliationToken,
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+                  token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
                   activeClient === client else {
@@ -1376,15 +1551,18 @@ final class AppState: ObservableObject {
         profile: String,
         token: UUID,
         resumePurpose: ChatResumeSyncPurpose = .preserveCurrent,
+        automaticWorkToken: ChatResumeAutomaticWorkToken? = nil,
         cwd: String? = nil
     ) async {
+        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
         do {
             let created = try await client.createSession(
                 model: runtime.model.isEmpty ? nil : runtime.model,
                 provider: runtime.provider.isEmpty ? nil : runtime.provider,
                 cwd: cwd
             )
-            guard token == reconciliationToken,
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+                  token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
                   activeClient === client else {
@@ -1411,6 +1589,7 @@ final class AppState: ObservableObject {
             // Some Hermes versions do not make its history-resume record
             // available immediately, so resuming here races the persistence
             // layer and leaves the composer stuck synchronizing.
+            markChatViewportReplacement()
             setActiveSessionState(id: runtimeSessionID, title: "New conversation")
             messages = []
             clearStreamingText()
@@ -1445,7 +1624,8 @@ final class AppState: ObservableObject {
                     in: [summary],
                     profile: profile,
                     purpose: resumePurpose,
-                    currentSessionID: runtimeSessionID
+                    currentSessionID: runtimeSessionID,
+                    automaticWorkToken: automaticWorkToken
                 )
             }
             Task { [weak self] in
@@ -1455,9 +1635,13 @@ final class AppState: ObservableObject {
                 await self.loadSlashCommands()
                 await self.loadSessions()
             }
-            settleReconciliationAndPublish(token)
+            settleReconciliationAndPublish(
+                token,
+                automaticWorkToken: automaticWorkToken
+            )
         } catch {
-            guard token == reconciliationToken,
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+                  token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
                   activeClient === client else {
@@ -1473,7 +1657,13 @@ final class AppState: ObservableObject {
         }
     }
 
-    private func applyResume(_ result: SessionResumeResult) {
+    @discardableResult
+    func applyChatResume(
+        _ result: SessionResumeResult,
+        automaticWorkToken: ChatResumeAutomaticWorkToken? = nil
+    ) -> Bool {
+        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return false }
+        markChatViewportReplacement()
         setActiveSessionState(id: result.sessionId, title: "New conversation")
         updateActiveSessionTitle(
             for: result.sessionId,
@@ -1509,10 +1699,11 @@ final class AppState: ObservableObject {
         if TurnState.fromGatewayRunning(result.snapshot.running) == .unsupportedGateway {
             turnState = .unsupportedGateway
             errorMessage = "This Hermes gateway must support session turn state. Update Hermes to enable message, stop, and steer controls."
-            return
+            return true
         }
 
         turnState = TurnState.fromGatewayRunning(result.snapshot.running)
+        return true
     }
 
     /// `session.resume.inflight` is a cumulative projection on some gateways.
@@ -1658,6 +1849,9 @@ final class AppState: ObservableObject {
     private func reconnectForRetry(purpose requestedPurpose: ChatResumeSyncPurpose) async {
         guard let savedConnection = connection else { return }
         let purpose = beginChatResumeRecovery(purpose: requestedPurpose)
+        let automaticWorkToken = purpose == .automaticReturn
+            ? beginAutomaticChatResumeWork()
+            : nil
         if purpose == .automaticReturn, reconnectTask != nil {
             cancelScheduledReconnect()
         }
@@ -1669,6 +1863,7 @@ final class AppState: ObservableObject {
             prepareDashboardBridge(for: savedConnection.baseUrl)
             guard let dashboardTicketBridge else { throw DashboardTicketBridgeError.notReady }
             let ticket = try await dashboardTicketBridge.mintTicket()
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
             connection = HermesConnection(baseUrl: savedConnection.baseUrl, ticket: ticket)
             self.connection = connection
             KeychainHelper.saveConnection(connection)
@@ -1688,7 +1883,8 @@ final class AppState: ObservableObject {
                             with: HermesConnection(baseUrl: credentials.baseURL, ticket: ticket),
                             profile: activeProfile,
                             syncPurpose: purpose,
-                            cancelsResumeRestoration: false
+                            cancelsResumeRestoration: false,
+                            automaticWorkToken: automaticWorkToken
                         )
                         return
                     } catch {
@@ -1698,6 +1894,7 @@ final class AppState: ObservableObject {
                 }
                 requireSignIn(message: error.localizedDescription)
             } else {
+                guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
                 isConnected = false
                 isConnecting = false
                 turnState = .reconnecting
@@ -1714,18 +1911,24 @@ final class AppState: ObservableObject {
 
         do {
             try await client.connect()
-            guard let activeClient = self.client, activeClient === client else { return }
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+                  let activeClient = self.client, activeClient === client else { return }
             isConnected = true
             isConnecting = false
             reconnectAttempts = 0
             connectedAt = Date()
-            await syncSession(purpose: purpose, using: nil)
+            await syncSession(
+                purpose: purpose,
+                using: nil,
+                automaticWorkToken: automaticWorkToken
+            )
             await loadBusyInputMode(using: client)
             await loadProfiles()
             await loadProfileDisplayPreferences()
             Task { await loadSlashCommands() }
         } catch {
-            guard let activeClient = self.client, activeClient === client else { return }
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+                  let activeClient = self.client, activeClient === client else { return }
             isConnected = false
             isConnecting = false
             turnState = .reconnecting
@@ -1743,17 +1946,34 @@ final class AppState: ObservableObject {
             // ChatView may receive the same scene transition before the health
             // check task runs, so geometry alone must not restore stale rows.
             let token = beginReconciliation()
+            let automaticWorkToken = beginAutomaticChatResumeWork()
             scenePhaseTask = Task { @MainActor [weak self] in
                 guard let self else { return }
                 if let client = self.client, client.isConnected {
                     do {
                         try await client.healthCheck()
-                        await self.syncSession(purpose: .automaticReturn, using: token)
+                        guard self.automaticChatResumeWorkIsCurrent(automaticWorkToken) else {
+                            self.settleReconciliation(token)
+                            return
+                        }
+                        await self.syncSession(
+                            purpose: .automaticReturn,
+                            using: token,
+                            automaticWorkToken: automaticWorkToken
+                        )
                     } catch {
+                        guard self.automaticChatResumeWorkIsCurrent(automaticWorkToken) else {
+                            self.settleReconciliation(token)
+                            return
+                        }
                         await self.reconnectForRetry(purpose: .automaticReturn)
                         self.settleReconciliation(token)
                     }
                 } else {
+                    guard self.automaticChatResumeWorkIsCurrent(automaticWorkToken) else {
+                        self.settleReconciliation(token)
+                        return
+                    }
                     await self.reconnectForRetry(purpose: .automaticReturn)
                     self.settleReconciliation(token)
                 }
@@ -2047,7 +2267,8 @@ final class AppState: ObservableObject {
         replacement: ChatResumeConversationReplacement
     ) {
         guard sessionMatchesActiveSession(session) else { return }
-        acceptChatResumeConversationReplacement(replacement)
+        let transitionGeneration = acceptChatResumeConversationReplacement(replacement)
+        markChatViewportReplacement()
         setActiveSessionState(id: nil, title: "New conversation")
         messages = []
         clearStreamingText()
@@ -2055,6 +2276,7 @@ final class AppState: ObservableObject {
         activeReasoningMessageId = nil
         receivedReasoningForCurrentTurn = false
         turnState = .idle
+        finishChatViewportTransition(generation: transitionGeneration)
     }
 
     /// The Cron tab presents two independent server-backed surfaces: the job
@@ -2068,7 +2290,6 @@ final class AppState: ObservableObject {
 
     @discardableResult
     func openSession(_ sessionId: String) async -> Bool {
-        cancelChatResumeRestoration()
         guard let client else { return false }
         if let session = (sessions + cronSessions).first(where: {
             $0.id == sessionId || $0.alternateIds.contains(sessionId)
@@ -2076,6 +2297,8 @@ final class AppState: ObservableObject {
             errorMessage = "That conversation belongs to another workspace. Switch profiles to open it."
             return false
         }
+        beginExplicitChatViewportTransition()
+        markChatViewportReplacement()
         // Atomically switch session identity BEFORE clearing the transcript.
         // This prevents stale stream events from the old session falling
         // through `eventBelongsToActiveSession` and repopulating the
@@ -2100,8 +2323,11 @@ final class AppState: ObservableObject {
     /// Routes a notification to its originating profile/session without
     /// allowing the ordinary cold-start session restoration to win first.
     func openNotificationTarget(_ target: ConduitNotificationTarget) async -> Bool {
-        cancelChatResumeRestoration()
         guard connection != nil else { return false }
+        let transitionGeneration = beginExplicitChatViewportTransition()
+        defer {
+            cancelChatViewportTransitionIfNoReplacement(generation: transitionGeneration)
+        }
         isOpeningNotificationSession = true
         defer { isOpeningNotificationSession = false }
         let targetProfile = notificationProfileID(target.profile)
@@ -2140,12 +2366,15 @@ final class AppState: ObservableObject {
     }
 
     func createNewSession(cwd: String? = nil) async {
-        cancelChatResumeRestoration()
         guard !isProfileSwitching, isConnected, !isConnecting, let client else {
             if isProfileSwitching || isConnecting {
                 errorMessage = "Wait for the workspace switch to finish before starting a conversation."
             }
             return
+        }
+        let transitionGeneration = beginExplicitChatViewportTransition()
+        defer {
+            cancelChatViewportTransitionIfNoReplacement(generation: transitionGeneration)
         }
         let profile = activeProfile
         cacheMessagePresentation()
@@ -2160,17 +2389,21 @@ final class AppState: ObservableObject {
     /// during a turn cannot leave the composer with stale busy state.
     func refreshActiveSession() async {
         guard let client, let sessionId = activeSessionId, !isChatRefreshing else { return }
-        cancelChatResumeRestoration()
+        beginExplicitChatViewportTransition()
+        markChatViewportReplacement()
         isChatRefreshing = true
         defer { isChatRefreshing = false }
 
         let token = beginReconciliation()
-        await reconcile(
+        let succeeded = await reconcile(
             sessionId: sessionId,
             using: client,
             token: token,
             acceptedSessionIDs: knownSessionIDs(for: sessionId)
         )
+        if !succeeded {
+            finishChatViewportTransition(generation: chatViewportTransitionGeneration)
+        }
         await loadSessions()
     }
 
@@ -3091,7 +3324,7 @@ final class AppState: ObservableObject {
         let target = profile.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !target.isEmpty, target != activeProfile, let savedConnection = connection else { return }
         guard !isProfileSwitching else { return }
-        cancelChatResumeRestoration()
+        let transitionGeneration = beginExplicitChatViewportTransition()
         cacheMessagePresentation()
         cancelSecondaryProfileTitleRecovery()
 
@@ -3119,6 +3352,7 @@ final class AppState: ObservableObject {
             let previousClient = client
             let nextClient = makeClient(connection: freshConnection, profile: target)
 
+            markChatViewportReplacement()
             connection = freshConnection
             client = nextClient
             activeProfile = target
@@ -3161,6 +3395,7 @@ final class AppState: ObservableObject {
             client = nil
             isConnected = false
             turnState = .reconnecting
+            finishChatViewportTransition(generation: transitionGeneration)
             await reconnect()
         }
     }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -54,6 +54,10 @@ struct ChatResumeLifecycleOperations {
         String
     ) async throws -> AnyCodable)?
     var setBusyInputMode: (@MainActor (HermesClient, BusyInputMode) async throws -> Void)?
+    var loadProfiles: (@MainActor () async -> Void)?
+    var loadBusyInputMode: (@MainActor (HermesClient) async -> Void)?
+    var loadProfileDisplayPreferences: (@MainActor () async -> Void)?
+    var loadSlashCommands: (@MainActor () async -> Void)?
 
     init(
         connectClient: (@MainActor (HermesClient) async throws -> Void)? = nil,
@@ -84,7 +88,11 @@ struct ChatResumeLifecycleOperations {
             String,
             String
         ) async throws -> AnyCodable)? = nil,
-        setBusyInputMode: (@MainActor (HermesClient, BusyInputMode) async throws -> Void)? = nil
+        setBusyInputMode: (@MainActor (HermesClient, BusyInputMode) async throws -> Void)? = nil,
+        loadProfiles: (@MainActor () async -> Void)? = nil,
+        loadBusyInputMode: (@MainActor (HermesClient) async -> Void)? = nil,
+        loadProfileDisplayPreferences: (@MainActor () async -> Void)? = nil,
+        loadSlashCommands: (@MainActor () async -> Void)? = nil
     ) {
         self.connectClient = connectClient
         self.loadCatalog = loadCatalog
@@ -100,6 +108,10 @@ struct ChatResumeLifecycleOperations {
         self.executeSlash = executeSlash
         self.dispatchCommand = dispatchCommand
         self.setBusyInputMode = setBusyInputMode
+        self.loadProfiles = loadProfiles
+        self.loadBusyInputMode = loadBusyInputMode
+        self.loadProfileDisplayPreferences = loadProfileDisplayPreferences
+        self.loadSlashCommands = loadSlashCommands
     }
 
     static let live = ChatResumeLifecycleOperations()
@@ -133,6 +145,18 @@ enum ChatResumeConversationReplacement {
     case archive
     case delete
 }
+
+private enum ChatResumeSyncExecutionOutcome: Equatable {
+    case completed
+    case automaticIntentInvalidated
+    case superseded
+}
+
+private typealias ChatResumeTransportContinuation = (
+    purpose: ChatResumeSyncPurpose,
+    automaticWorkToken: ChatResumeAutomaticWorkToken?,
+    handedOffAutomaticIntent: Bool
+)
 
 final class ChatResumeRecoverySequence {
     private(set) var currentPurpose: ChatResumeSyncPurpose = .preserveCurrent
@@ -944,11 +968,7 @@ final class AppState: ObservableObject {
         purpose: ChatResumeSyncPurpose,
         automaticWorkToken: ChatResumeAutomaticWorkToken?,
         automaticReconnectOperationID: UUID?
-    ) -> (
-        purpose: ChatResumeSyncPurpose,
-        automaticWorkToken: ChatResumeAutomaticWorkToken?,
-        handedOffAutomaticIntent: Bool
-    )? {
+    ) -> ChatResumeTransportContinuation? {
         guard !Task.isCancelled else { return nil }
         if let automaticReconnectOperationID,
            activeAutomaticReconnectOperation?.id != automaticReconnectOperationID {
@@ -962,6 +982,63 @@ final class AppState: ObservableObject {
         }
         guard purpose == .automaticReturn else { return nil }
         return (.preserveCurrent, nil, true)
+    }
+
+    private func synchronizeTransportContinuation(
+        purpose: ChatResumeSyncPurpose,
+        automaticWorkToken: ChatResumeAutomaticWorkToken?,
+        automaticReconnectOperationID: UUID?,
+        client: HermesClient,
+        profile: String
+    ) async -> ChatResumeTransportContinuation? {
+        guard transportContinuation(
+                purpose: purpose,
+                automaticWorkToken: automaticWorkToken,
+                automaticReconnectOperationID: automaticReconnectOperationID
+              ) != nil,
+              let activeClient = self.client,
+              activeClient === client,
+              activeProfile == profile else { return nil }
+        let viewportTransitionGeneration = chatViewportTransitionGeneration
+        let outcome = await performSyncSession(
+            purpose: purpose,
+            using: nil,
+            automaticWorkToken: automaticWorkToken
+        )
+        guard let continuation = transportContinuation(
+                purpose: purpose,
+                automaticWorkToken: automaticWorkToken,
+                automaticReconnectOperationID: automaticReconnectOperationID
+              ),
+              let activeClient = self.client,
+              activeClient === client,
+              activeProfile == profile else { return nil }
+        guard outcome == .automaticIntentInvalidated,
+              continuation.handedOffAutomaticIntent,
+              purpose == .automaticReturn,
+              chatViewportTransition == nil,
+              chatViewportTransitionGeneration == viewportTransitionGeneration else {
+            return continuation
+        }
+
+        _ = await performSyncSession(
+            purpose: .preserveCurrent,
+            using: nil,
+            automaticWorkToken: nil
+        )
+        guard let preservedContinuation = transportContinuation(
+                purpose: .preserveCurrent,
+                automaticWorkToken: nil,
+                automaticReconnectOperationID: automaticReconnectOperationID
+              ),
+              let activeClient = self.client,
+              activeClient === client,
+              activeProfile == profile else { return nil }
+        return (
+            preservedContinuation.purpose,
+            preservedContinuation.automaticWorkToken,
+            true
+        )
     }
 
     func cancelChatResumeRestoration() {
@@ -1421,7 +1498,7 @@ final class AppState: ObservableObject {
             connectedAt = Date()
             KeychainHelper.saveConnection(conn)
 
-            await loadProfiles()
+            await loadChatResumeProfiles()
             guard let continuation = transportContinuation(
                 purpose: continuationPurpose,
                 automaticWorkToken: continuationAutomaticWorkToken,
@@ -1431,11 +1508,18 @@ final class AppState: ObservableObject {
             continuationAutomaticWorkToken = continuation.automaticWorkToken
             handedOffAutomaticIntent = handedOffAutomaticIntent
                 || continuation.handedOffAutomaticIntent
-            await syncSession(
+            guard let continuation = await synchronizeTransportContinuation(
                 purpose: continuationPurpose,
-                using: nil,
-                automaticWorkToken: continuationAutomaticWorkToken
-            )
+                automaticWorkToken: continuationAutomaticWorkToken,
+                automaticReconnectOperationID: transportOperationID,
+                client: client,
+                profile: profile
+            ) else { return }
+            continuationPurpose = continuation.purpose
+            continuationAutomaticWorkToken = continuation.automaticWorkToken
+            handedOffAutomaticIntent = handedOffAutomaticIntent
+                || continuation.handedOffAutomaticIntent
+            await loadChatResumeBusyInputMode(using: client)
             guard let continuation = transportContinuation(
                     purpose: continuationPurpose,
                     automaticWorkToken: continuationAutomaticWorkToken,
@@ -1446,18 +1530,7 @@ final class AppState: ObservableObject {
             continuationAutomaticWorkToken = continuation.automaticWorkToken
             handedOffAutomaticIntent = handedOffAutomaticIntent
                 || continuation.handedOffAutomaticIntent
-            await loadBusyInputMode(using: client)
-            guard let continuation = transportContinuation(
-                    purpose: continuationPurpose,
-                    automaticWorkToken: continuationAutomaticWorkToken,
-                    automaticReconnectOperationID: transportOperationID
-                  ),
-                  let activeClient = self.client, activeClient === client else { return }
-            continuationPurpose = continuation.purpose
-            continuationAutomaticWorkToken = continuation.automaticWorkToken
-            handedOffAutomaticIntent = handedOffAutomaticIntent
-                || continuation.handedOffAutomaticIntent
-            await loadProfileDisplayPreferences()
+            await loadChatResumeProfileDisplayPreferences()
             guard let continuation = transportContinuation(
                 purpose: continuationPurpose,
                 automaticWorkToken: continuationAutomaticWorkToken,
@@ -1465,7 +1538,7 @@ final class AppState: ObservableObject {
             ) else { return }
             handedOffAutomaticIntent = handedOffAutomaticIntent
                 || continuation.handedOffAutomaticIntent
-            Task { await loadSlashCommands() }
+            Task { await loadChatResumeSlashCommands() }
         } catch {
             guard let continuation = transportContinuation(
                     purpose: syncPurpose,
@@ -1623,14 +1696,30 @@ final class AppState: ObservableObject {
         automaticWorkToken existingAutomaticWorkToken: ChatResumeAutomaticWorkToken?,
         requiredViewportTransitionGeneration: UInt64? = nil
     ) async {
+        _ = await performSyncSession(
+            purpose: purpose,
+            using: existingReconciliationToken,
+            automaticWorkToken: existingAutomaticWorkToken,
+            requiredViewportTransitionGeneration: requiredViewportTransitionGeneration
+        )
+    }
+
+    private func performSyncSession(
+        purpose: ChatResumeSyncPurpose,
+        using existingReconciliationToken: UUID?,
+        automaticWorkToken existingAutomaticWorkToken: ChatResumeAutomaticWorkToken?,
+        requiredViewportTransitionGeneration: UInt64? = nil
+    ) async -> ChatResumeSyncExecutionOutcome {
         guard chatViewportTransitionIsCurrent(
             requiredViewportTransitionGeneration
-        ) else { return }
+        ) else { return .superseded }
         let purpose = beginChatResumeRecovery(purpose: purpose)
         let automaticWorkToken = purpose == .automaticReturn
             ? (existingAutomaticWorkToken ?? beginAutomaticChatResumeWork())
             : nil
-        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
+        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else {
+            return chatResumeSyncInterruptionOutcome(for: automaticWorkToken)
+        }
         let automaticOperationID = beginAutomaticSyncOperation(for: automaticWorkToken)
         defer {
             finishAutomaticSyncOperation(
@@ -1646,7 +1735,7 @@ final class AppState: ObservableObject {
             existingReconciliationToken,
             automaticSyncOperationID: automaticOperationID
            ) {
-            return
+            return .superseded
         }
         guard let client else {
             if let existingReconciliationToken {
@@ -1655,7 +1744,7 @@ final class AppState: ObservableObject {
                     automaticSyncOperationID: automaticOperationID
                 )
             }
-            return
+            return .completed
         }
         // A notification destination always wins over automatic restoration of
         // the previously active/newest session. Check both before and after
@@ -1668,13 +1757,13 @@ final class AppState: ObservableObject {
                     automaticSyncOperationID: automaticOperationID
                 )
             }
-            return
+            return .superseded
         }
         let token = existingReconciliationToken ?? beginReconciliation()
         guard claimReconciliation(
             token,
             automaticSyncOperationID: automaticOperationID
-        ) else { return }
+        ) else { return .superseded }
         let profile = activeProfile
         let retainedActiveTurn = activeTurnCatalogSession()
         turnState = .synchronizing
@@ -1701,7 +1790,7 @@ final class AppState: ObservableObject {
                     token,
                     automaticSyncOperationID: automaticOperationID
                 )
-                return
+                return chatResumeSyncInterruptionOutcome(for: automaticWorkToken)
             }
             guard PushNotificationService.shared.pendingTarget == nil else {
                 cancelChatResumeRestoration()
@@ -1709,7 +1798,7 @@ final class AppState: ObservableObject {
                     token,
                     automaticSyncOperationID: automaticOperationID
                 )
-                return
+                return .superseded
             }
             guard automaticChatResumeWorkIsCurrent(
                 automaticWorkToken,
@@ -1719,7 +1808,7 @@ final class AppState: ObservableObject {
                     token,
                     automaticSyncOperationID: automaticOperationID
                 )
-                return
+                return chatResumeSyncInterruptionOutcome(for: automaticWorkToken)
             }
             sessions = allSessions.filter { $0.source != .cron }
             cronSessions = allSessions.filter { $0.source == .cron }
@@ -1732,7 +1821,7 @@ final class AppState: ObservableObject {
                     token,
                     automaticSyncOperationID: automaticOperationID
                 )
-                return
+                return chatResumeSyncInterruptionOutcome(for: automaticWorkToken)
             }
             let target = selectChatResumeTarget(
                 in: allSessions,
@@ -1762,6 +1851,9 @@ final class AppState: ObservableObject {
                    profile == activeProfile {
                     scheduleReconnect(purpose: purpose)
                 }
+                return succeeded
+                    ? .completed
+                    : chatResumeSyncInterruptionOutcome(for: automaticWorkToken)
             } else {
                 await createAndReconcileSession(
                     using: client,
@@ -1772,6 +1864,12 @@ final class AppState: ObservableObject {
                     automaticSyncOperationID: automaticOperationID,
                     requiredViewportTransitionGeneration: requiredViewportTransitionGeneration
                 )
+                return automaticChatResumeWorkIsCurrent(
+                    automaticWorkToken,
+                    syncOperationID: automaticOperationID
+                )
+                    ? .completed
+                    : chatResumeSyncInterruptionOutcome(for: automaticWorkToken)
             }
         } catch {
             guard automaticChatResumeWorkIsCurrent(
@@ -1787,7 +1885,7 @@ final class AppState: ObservableObject {
                     token,
                     automaticSyncOperationID: automaticOperationID
                 )
-                return
+                return chatResumeSyncInterruptionOutcome(for: automaticWorkToken)
             }
             turnState = .reconnecting
             errorMessage = "Failed to load gateway sessions: \(error.localizedDescription)"
@@ -1798,7 +1896,18 @@ final class AppState: ObservableObject {
             if purpose == .automaticReturn {
                 scheduleReconnect(purpose: purpose)
             }
+            return .completed
         }
+    }
+
+    private func chatResumeSyncInterruptionOutcome(
+        for automaticWorkToken: ChatResumeAutomaticWorkToken?
+    ) -> ChatResumeSyncExecutionOutcome {
+        guard let automaticWorkToken,
+              !chatResumeCoordinator.isCurrent(automaticWorkToken) else {
+            return .superseded
+        }
+        return .automaticIntentInvalidated
     }
 
     func beginReconciliation() -> UUID {
@@ -2537,7 +2646,8 @@ final class AppState: ObservableObject {
 
         let previousClient = client
         guard refreshTransportContinuation() else { return }
-        let client = makeClient(connection: connection, profile: activeProfile)
+        let profile = activeProfile
+        let client = makeClient(connection: connection, profile: profile)
         self.client = client
         previousClient?.disconnect()
 
@@ -2549,22 +2659,26 @@ final class AppState: ObservableObject {
             isConnecting = false
             reconnectAttempts = 0
             connectedAt = Date()
-            await syncSession(
+            guard let continuation = await synchronizeTransportContinuation(
                 purpose: continuationPurpose,
-                using: nil,
-                automaticWorkToken: continuationAutomaticWorkToken
-            )
+                automaticWorkToken: continuationAutomaticWorkToken,
+                automaticReconnectOperationID: automaticOperationID,
+                client: client,
+                profile: profile
+            ) else { return }
+            continuationPurpose = continuation.purpose
+            continuationAutomaticWorkToken = continuation.automaticWorkToken
+            handedOffAutomaticIntent = handedOffAutomaticIntent
+                || continuation.handedOffAutomaticIntent
+            await loadChatResumeBusyInputMode(using: client)
             guard refreshTransportContinuation(),
                   let activeClient = self.client, activeClient === client else { return }
-            await loadBusyInputMode(using: client)
+            await loadChatResumeProfiles()
             guard refreshTransportContinuation(),
                   let activeClient = self.client, activeClient === client else { return }
-            await loadProfiles()
-            guard refreshTransportContinuation(),
-                  let activeClient = self.client, activeClient === client else { return }
-            await loadProfileDisplayPreferences()
+            await loadChatResumeProfileDisplayPreferences()
             guard refreshTransportContinuation() else { return }
-            Task { await loadSlashCommands() }
+            Task { await loadChatResumeSlashCommands() }
         } catch {
             guard refreshTransportContinuation(),
                   let activeClient = self.client, activeClient === client else { return }
@@ -2589,6 +2703,38 @@ final class AppState: ObservableObject {
             try await connectClient(client)
         } else {
             try await client.connect()
+        }
+    }
+
+    private func loadChatResumeProfiles() async {
+        if let loadProfiles = chatResumeLifecycleOperations.loadProfiles {
+            await loadProfiles()
+        } else {
+            await loadProfiles()
+        }
+    }
+
+    private func loadChatResumeBusyInputMode(using client: HermesClient) async {
+        if let loadBusyInputMode = chatResumeLifecycleOperations.loadBusyInputMode {
+            await loadBusyInputMode(client)
+        } else {
+            await loadBusyInputMode(using: client)
+        }
+    }
+
+    private func loadChatResumeProfileDisplayPreferences() async {
+        if let loadProfileDisplayPreferences = chatResumeLifecycleOperations.loadProfileDisplayPreferences {
+            await loadProfileDisplayPreferences()
+        } else {
+            await loadProfileDisplayPreferences()
+        }
+    }
+
+    private func loadChatResumeSlashCommands() async {
+        if let loadSlashCommands = chatResumeLifecycleOperations.loadSlashCommands {
+            await loadSlashCommands()
+        } else {
+            await loadSlashCommands()
         }
     }
 
@@ -4229,6 +4375,7 @@ final class AppState: ObservableObject {
         } else {
             transitionGeneration = beginExplicitChatViewportTransition()
         }
+        cancelChatResumeTransportRecovery()
         cacheMessagePresentation()
         cancelSecondaryProfileTitleRecovery()
 
@@ -4249,9 +4396,7 @@ final class AppState: ObservableObject {
         turnState = .synchronizing
 
         do {
-            prepareDashboardBridge(for: savedConnection.baseUrl)
-            guard let dashboardTicketBridge else { throw DashboardTicketBridgeError.notReady }
-            let ticket = try await dashboardTicketBridge.mintTicket()
+            let ticket = try await mintChatResumeTicket(for: savedConnection)
             guard chatViewportTransitionIsCurrent(generation: transitionGeneration) else {
                 return false
             }
@@ -4272,7 +4417,7 @@ final class AppState: ObservableObject {
             slashCommands = Self.builtInSlashCommands
             restoreActiveSessionState(for: target)
             restorePinnedSessions(for: target)
-            try await nextClient.connect()
+            try await connectChatResumeClient(nextClient)
             guard chatViewportTransitionIsCurrent(generation: transitionGeneration),
                   self.client === nextClient else { return false }
             // Keep the previous socket alive until the new profile has
@@ -4295,15 +4440,15 @@ final class AppState: ObservableObject {
             finishChatViewportTransitionIfNoTranscriptReplacement(
                 generation: transitionGeneration
             )
-            await loadBusyInputMode(using: nextClient)
+            await loadChatResumeBusyInputMode(using: nextClient)
             guard chatViewportTransitionIsCurrent(generation: transitionGeneration) else {
                 return false
             }
-            await loadProfileDisplayPreferences()
+            await loadChatResumeProfileDisplayPreferences()
             guard chatViewportTransitionIsCurrent(generation: transitionGeneration) else {
                 return false
             }
-            Task { await loadSlashCommands() }
+            Task { await loadChatResumeSlashCommands() }
             return true
         } catch {
             guard chatViewportTransitionIsCurrent(generation: transitionGeneration) else {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -22,6 +22,47 @@ typealias ChatResumeReconnectScheduler = @MainActor (
     _ operation: @escaping @MainActor () async -> Void
 ) -> ChatResumeReconnectCancellation
 
+struct ChatResumeLifecycleOperations {
+    typealias BranchResult = (sessionId: String, storedSessionId: String?, profile: String?)
+
+    var loadCatalog: (@MainActor (HermesClient, Bool) async throws -> [SessionSummary])?
+    var mintTicket: (@MainActor (String) async throws -> String)?
+    var openSession: (@MainActor (HermesClient, String) async throws -> SessionResumeResult)?
+    var branchSession: (@MainActor (
+        HermesClient,
+        String,
+        [SessionBranchMessage],
+        String,
+        String?
+    ) async throws -> BranchResult)?
+    var setSessionTitle: (@MainActor (HermesClient, String, String) async throws -> Void)?
+    var refreshContext: (@MainActor (HermesClient, String) async -> Void)?
+
+    init(
+        loadCatalog: (@MainActor (HermesClient, Bool) async throws -> [SessionSummary])? = nil,
+        mintTicket: (@MainActor (String) async throws -> String)? = nil,
+        openSession: (@MainActor (HermesClient, String) async throws -> SessionResumeResult)? = nil,
+        branchSession: (@MainActor (
+            HermesClient,
+            String,
+            [SessionBranchMessage],
+            String,
+            String?
+        ) async throws -> BranchResult)? = nil,
+        setSessionTitle: (@MainActor (HermesClient, String, String) async throws -> Void)? = nil,
+        refreshContext: (@MainActor (HermesClient, String) async -> Void)? = nil
+    ) {
+        self.loadCatalog = loadCatalog
+        self.mintTicket = mintTicket
+        self.openSession = openSession
+        self.branchSession = branchSession
+        self.setSessionTitle = setSessionTitle
+        self.refreshContext = refreshContext
+    }
+
+    static let live = ChatResumeLifecycleOperations()
+}
+
 @MainActor
 private func scheduleChatResumeReconnectTask(
     after delay: TimeInterval,
@@ -138,7 +179,12 @@ final class AppState: ObservableObject {
         didSet { refreshActiveChatScrollSessionIdentity() }
     }
     @Published private(set) var activeChatScrollSessionIdentity = ChatScrollSessionIdentity.none
-    @Published var messages: [ChatMessage] = []
+    @Published private(set) var chatTranscriptRevision: UInt64 = 0
+    @Published var messages: [ChatMessage] = [] {
+        didSet {
+            chatTranscriptRevision &+= 1
+        }
+    }
     @Published private(set) var activeSessionTitle = "New conversation"
     @Published private(set) var isChatRefreshing = false
     @Published private(set) var chatResumeBehavior: ChatResumeBehavior = .continueWhereLeftOff
@@ -343,11 +389,31 @@ final class AppState: ObservableObject {
         id: UUID,
         snapshot: @MainActor () -> ChatScrollSnapshot?
     )?
-    private var chatViewportTransitionIsFrozen = false
-    private var chatViewportTransitionHasReplacement = false
+    private struct ChatViewportTransition {
+        let generation: UInt64
+        var hasReplacement = false
+        var expectedSessionKey: ChatScrollSessionKey?
+        var expectedTranscriptRevision: UInt64?
+    }
+
+    private struct AutomaticSyncOperation {
+        let id: UUID
+        let previousTurnState: TurnState
+    }
+
+    private struct AutomaticReconnectOperation {
+        let id: UUID
+        let previousIsConnecting: Bool
+        let previousTurnState: TurnState
+    }
+
+    private var chatViewportTransition: ChatViewportTransition?
+    private var activeAutomaticSyncOperation: AutomaticSyncOperation?
+    private var activeAutomaticReconnectOperation: AutomaticReconnectOperation?
     private var reconnectTask: ChatResumeReconnectCancellation?
     private let reconnectScheduler: ChatResumeReconnectScheduler
     private let reconnectExecutor: ChatResumeReconnectExecutor?
+    private let chatResumeLifecycleOperations: ChatResumeLifecycleOperations
     /// Coalesces presentation-cache flushes during streaming so we
     /// don't serialize and write UserDefaults on every WebSocket frame.
     private var presentationCacheFlushTask: Task<Void, Never>?
@@ -502,7 +568,8 @@ final class AppState: ObservableObject {
         sessionRenameOperations: SessionRenameOperation.Operations? = nil,
         sessionCatalogLoader: ((Bool) async throws -> [SessionSummary])? = nil,
         reconnectScheduler: ChatResumeReconnectScheduler? = nil,
-        reconnectExecutor: ChatResumeReconnectExecutor? = nil
+        reconnectExecutor: ChatResumeReconnectExecutor? = nil,
+        chatResumeLifecycleOperations: ChatResumeLifecycleOperations = .live
     ) {
         self.defaults = defaults
         self.chatResumeCoordinator = chatResumeCoordinator
@@ -513,6 +580,7 @@ final class AppState: ObservableObject {
         sessionCatalogLoaderOverride = sessionCatalogLoader
         self.reconnectScheduler = reconnectScheduler ?? scheduleChatResumeReconnectTask
         self.reconnectExecutor = reconnectExecutor
+        self.chatResumeLifecycleOperations = chatResumeLifecycleOperations
         self.initialChatResumeServerIdentity = defaults
             .string(forKey: "conduit.chatResumeServerIdentity.v1")
             .flatMap(Self.normalizedChatResumeServerIdentity)
@@ -631,6 +699,7 @@ final class AppState: ObservableObject {
     func setChatResumeBehavior(_ behavior: ChatResumeBehavior) {
         cancelScheduledReconnect()
         chatResumeCoordinator.setBehavior(behavior)
+        cancelOwnedAutomaticOperations()
         activeAutomaticChatResumeWork = nil
         recoverySequence.cancel()
         chatResumeBehavior = chatResumeCoordinator.behavior
@@ -654,57 +723,84 @@ final class AppState: ObservableObject {
     }
 
     @discardableResult
-    func beginExplicitChatViewportTransition() -> UInt64 {
-        guard !chatViewportTransitionIsFrozen else {
-            return chatViewportTransitionGeneration
+    func beginExplicitChatViewportTransition(
+        reusing generation: UInt64? = nil
+    ) -> UInt64 {
+        if let transition = chatViewportTransition,
+           generation == transition.generation {
+            return transition.generation
+        }
+        if let transition = chatViewportTransition {
+            finishChatViewportTransition(generation: transition.generation)
         }
         let snapshot = chatViewportSnapshotProvider?.snapshot()
         chatResumeCoordinator.captureViewportAndFreeze(
             snapshot,
             for: currentChatScrollSessionKey
         )
-        chatViewportTransitionIsFrozen = true
-        chatViewportTransitionHasReplacement = false
         chatViewportTransitionGeneration &+= 1
+        chatViewportTransition = ChatViewportTransition(
+            generation: chatViewportTransitionGeneration
+        )
         cancelChatResumeRestoration()
         return chatViewportTransitionGeneration
     }
 
     private func markChatViewportReplacement() {
-        guard chatViewportTransitionIsFrozen else { return }
-        chatViewportTransitionHasReplacement = true
+        guard var transition = chatViewportTransition else { return }
+        transition.hasReplacement = true
+        chatViewportTransition = transition
+    }
+
+    private func noteChatViewportTranscriptReplacement() {
+        guard var transition = chatViewportTransition,
+              transition.hasReplacement else { return }
+        transition.expectedSessionKey = currentChatScrollSessionKey
+        transition.expectedTranscriptRevision = chatTranscriptRevision
+        chatViewportTransition = transition
     }
 
     private func cancelChatViewportTransitionIfNoReplacement(generation: UInt64) {
-        guard chatViewportTransitionIsFrozen,
-              generation == chatViewportTransitionGeneration,
-              !chatViewportTransitionHasReplacement else { return }
-        chatViewportTransitionIsFrozen = false
-        chatViewportTransitionHasReplacement = false
-        chatResumeCoordinator.unfreezeViewport()
+        guard let transition = chatViewportTransition,
+              generation == transition.generation,
+              !transition.hasReplacement else { return }
+        finishChatViewportTransition(generation: generation)
     }
 
     private func finishChatViewportTransition(generation: UInt64) {
-        guard chatViewportTransitionIsFrozen,
-              generation == chatViewportTransitionGeneration else { return }
-        chatViewportTransitionIsFrozen = false
-        chatViewportTransitionHasReplacement = false
+        guard chatViewportTransition?.generation == generation else { return }
+        chatViewportTransition = nil
         chatResumeCoordinator.unfreezeViewport()
+    }
+
+    private func finishChatViewportTransitionIfNoTranscriptReplacement(
+        generation: UInt64
+    ) {
+        guard let transition = chatViewportTransition,
+              transition.generation == generation,
+              transition.expectedTranscriptRevision == nil else { return }
+        finishChatViewportTransition(generation: generation)
     }
 
     func chatViewportLayoutDidSettle(
         sessionKey: ChatScrollSessionKey,
-        transitionGeneration: UInt64
+        transitionGeneration: UInt64,
+        transcriptRevision: UInt64,
+        renderRevision: UInt64
     ) {
-        guard chatViewportTransitionIsFrozen,
-              transitionGeneration == chatViewportTransitionGeneration,
+        guard let transition = chatViewportTransition,
+              transitionGeneration == transition.generation,
+              transition.hasReplacement,
+              transition.expectedTranscriptRevision == transcriptRevision,
+              renderRevision > 0,
+              transition.expectedSessionKey.map({ expected in
+                  activeChatScrollSessionIdentity.areEquivalent(expected, sessionKey)
+              }) == true,
               activeChatScrollSessionIdentity.areEquivalent(
                 sessionKey,
                 currentChatScrollSessionKey
               ) else { return }
-        chatViewportTransitionIsFrozen = false
-        chatViewportTransitionHasReplacement = false
-        chatResumeCoordinator.unfreezeViewport()
+        finishChatViewportTransition(generation: transitionGeneration)
     }
 
     private var currentChatScrollSessionKey: ChatScrollSessionKey? {
@@ -729,10 +825,20 @@ final class AppState: ObservableObject {
     }
 
     func abandonChatResumeRestoration(generation: UInt64) {
+        let abandonedSessionKey = chatResumeRestorationRequest?.generation == generation
+            ? chatResumeRestorationRequest?.sessionKey
+            : nil
         chatResumeCoordinator.abandonRestoration(generation: generation)
         if chatResumeRestorationRequest?.generation == generation,
            !chatResumeCoordinator.isCurrent(generation: generation) {
             chatResumeRestorationRequest = nil
+        }
+        if let transition = chatViewportTransition,
+           let abandonedSessionKey,
+           transition.expectedSessionKey.map({ expected in
+               activeChatScrollSessionIdentity.areEquivalent(expected, abandonedSessionKey)
+           }) == true {
+            finishChatViewportTransition(generation: transition.generation)
         }
     }
 
@@ -755,11 +861,68 @@ final class AppState: ObservableObject {
     func cancelChatResumeRestoration() {
         cancelScheduledReconnect()
         chatResumeCoordinator.cancelRestoration(
-            keepViewportFrozen: chatViewportTransitionIsFrozen
+            keepViewportFrozen: chatViewportTransition != nil
         )
+        cancelOwnedAutomaticOperations()
         activeAutomaticChatResumeWork = nil
         recoverySequence.cancel()
         chatResumeRestorationRequest = nil
+    }
+
+    private func beginAutomaticSyncOperation(
+        for token: ChatResumeAutomaticWorkToken?
+    ) -> UUID? {
+        guard token != nil else { return nil }
+        let operation = AutomaticSyncOperation(
+            id: UUID(),
+            previousTurnState: activeAutomaticSyncOperation?.previousTurnState
+                ?? turnState
+        )
+        activeAutomaticSyncOperation = operation
+        return operation.id
+    }
+
+    private func finishAutomaticSyncOperation(id: UUID?) {
+        guard let id, activeAutomaticSyncOperation?.id == id else { return }
+        activeAutomaticSyncOperation = nil
+    }
+
+    private func beginAutomaticReconnectOperation(
+        for token: ChatResumeAutomaticWorkToken?
+    ) -> UUID? {
+        guard token != nil else { return nil }
+        let operation = AutomaticReconnectOperation(
+            id: UUID(),
+            previousIsConnecting: activeAutomaticReconnectOperation?.previousIsConnecting
+                ?? isConnecting,
+            previousTurnState: activeAutomaticReconnectOperation?.previousTurnState
+                ?? turnState
+        )
+        activeAutomaticReconnectOperation = operation
+        return operation.id
+    }
+
+    private func finishAutomaticReconnectOperation(id: UUID?) {
+        guard let id, activeAutomaticReconnectOperation?.id == id else { return }
+        activeAutomaticReconnectOperation = nil
+    }
+
+    private func cancelOwnedAutomaticOperations() {
+        if let operation = activeAutomaticSyncOperation {
+            if turnState == .synchronizing {
+                turnState = operation.previousTurnState
+            }
+            activeAutomaticSyncOperation = nil
+        }
+        if let operation = activeAutomaticReconnectOperation {
+            if isConnecting {
+                isConnecting = operation.previousIsConnecting
+            }
+            if turnState == .reconnecting {
+                turnState = operation.previousTurnState
+            }
+            activeAutomaticReconnectOperation = nil
+        }
     }
 
     @discardableResult
@@ -779,6 +942,7 @@ final class AppState: ObservableObject {
         guard let previousIdentity, previousIdentity != identity else { return false }
 
         chatResumeCoordinator.clearResumeState()
+        cancelOwnedAutomaticOperations()
         activeAutomaticChatResumeWork = nil
         cancelScheduledReconnect()
         recoverySequence.cancel()
@@ -1050,8 +1214,13 @@ final class AppState: ObservableObject {
                 using: nil,
                 automaticWorkToken: automaticWorkToken
             )
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+                  let activeClient = self.client, activeClient === client else { return }
             await loadBusyInputMode(using: client)
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+                  let activeClient = self.client, activeClient === client else { return }
             await loadProfileDisplayPreferences()
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
             Task { await loadSlashCommands() }
         } catch {
             guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
@@ -1070,6 +1239,7 @@ final class AppState: ObservableObject {
 
     func disconnect() {
         chatResumeCoordinator.clearResumeState()
+        cancelOwnedAutomaticOperations()
         activeAutomaticChatResumeWork = nil
         cancelScheduledReconnect()
         recoverySequence.cancel()
@@ -1198,7 +1368,7 @@ final class AppState: ObservableObject {
         await syncSession(purpose: .preserveCurrent, using: nil, automaticWorkToken: nil)
     }
 
-    private func syncSession(
+    func syncSession(
         purpose: ChatResumeSyncPurpose,
         using existingReconciliationToken: UUID?,
         automaticWorkToken existingAutomaticWorkToken: ChatResumeAutomaticWorkToken?
@@ -1208,6 +1378,8 @@ final class AppState: ObservableObject {
             ? (existingAutomaticWorkToken ?? beginAutomaticChatResumeWork())
             : nil
         guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
+        let automaticOperationID = beginAutomaticSyncOperation(for: automaticWorkToken)
+        defer { finishAutomaticSyncOperation(id: automaticOperationID) }
         guard let client else {
             if let existingReconciliationToken {
                 settleReconciliation(existingReconciliationToken)
@@ -1442,7 +1614,10 @@ final class AppState: ObservableObject {
             // compact projection which omits persisted timestamps, while the
             // HTTP endpoint reads the timestamped rows from state.db.
             let bridge = dashboardTicketBridge
-            async let resumedSession = client.openSession(sessionId)
+            async let resumedSession = openChatResumeSession(
+                sessionId,
+                using: client
+            )
             async let persistedTranscript = dashboardSessionTranscript(
                 sessionId: sessionId,
                 profile: profile,
@@ -1508,7 +1683,7 @@ final class AppState: ObservableObject {
                 settleReconciliation(token)
                 return false
             }
-            await refreshContextUsage(sessionId: result.sessionId, using: client)
+            await refreshChatResumeContext(sessionId: result.sessionId, using: client)
 
             guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
                   token == reconciliationToken,
@@ -1543,6 +1718,27 @@ final class AppState: ObservableObject {
             errorMessage = "Failed to restore this conversation: \(error.localizedDescription)"
             settleReconciliation(token)
             return false
+        }
+    }
+
+    private func openChatResumeSession(
+        _ sessionID: String,
+        using client: HermesClient
+    ) async throws -> SessionResumeResult {
+        if let openSession = chatResumeLifecycleOperations.openSession {
+            return try await openSession(client, sessionID)
+        }
+        return try await client.openSession(sessionID)
+    }
+
+    private func refreshChatResumeContext(
+        sessionId: String,
+        using client: HermesClient
+    ) async {
+        if let refreshContext = chatResumeLifecycleOperations.refreshContext {
+            await refreshContext(client, sessionId)
+        } else {
+            await refreshContextUsage(sessionId: sessionId, using: client)
         }
     }
 
@@ -1592,6 +1788,7 @@ final class AppState: ObservableObject {
             markChatViewportReplacement()
             setActiveSessionState(id: runtimeSessionID, title: "New conversation")
             messages = []
+            noteChatViewportTranscriptReplacement()
             clearStreamingText()
             activeAssistantMessageId = nil
             activeReasoningMessageId = nil
@@ -1677,6 +1874,7 @@ final class AppState: ObservableObject {
             includePendingApprovals: result.snapshot.running == true
         )
         messages = mergeCachedReviews(into: restored, sessionId: result.sessionId)
+        noteChatViewportTranscriptReplacement()
         cacheMessagePresentation(for: [result.sessionId])
         scheduleSecondaryProfileTitleRecovery(
             sessionId: result.sessionId,
@@ -1846,12 +2044,15 @@ final class AppState: ObservableObject {
         }
     }
 
-    private func reconnectForRetry(purpose requestedPurpose: ChatResumeSyncPurpose) async {
+    func reconnectForRetry(purpose requestedPurpose: ChatResumeSyncPurpose) async {
         guard let savedConnection = connection else { return }
         let purpose = beginChatResumeRecovery(purpose: requestedPurpose)
         let automaticWorkToken = purpose == .automaticReturn
             ? beginAutomaticChatResumeWork()
             : nil
+        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
+        let automaticOperationID = beginAutomaticReconnectOperation(for: automaticWorkToken)
+        defer { finishAutomaticReconnectOperation(id: automaticOperationID) }
         if purpose == .automaticReturn, reconnectTask != nil {
             cancelScheduledReconnect()
         }
@@ -1860,14 +2061,13 @@ final class AppState: ObservableObject {
 
         let connection: HermesConnection
         do {
-            prepareDashboardBridge(for: savedConnection.baseUrl)
-            guard let dashboardTicketBridge else { throw DashboardTicketBridgeError.notReady }
-            let ticket = try await dashboardTicketBridge.mintTicket()
+            let ticket = try await mintChatResumeTicket(for: savedConnection)
             guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
             connection = HermesConnection(baseUrl: savedConnection.baseUrl, ticket: ticket)
             self.connection = connection
             KeychainHelper.saveConnection(connection)
         } catch {
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
             if let bridgeError = error as? DashboardTicketBridgeError, case .signInRequired = bridgeError {
                 if let credentials = KeychainHelper.loadCredentials(),
                    credentials.baseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/")) == savedConnection.baseUrl.trimmingCharacters(in: CharacterSet(charactersIn: "/")) {
@@ -1876,6 +2076,7 @@ final class AppState: ObservableObject {
                             username: credentials.username,
                             password: credentials.password
                         )
+                        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
                         // URLSession and WebKit have separate cookie stores.
                         // Reload the bridge so it receives the fresh session.
                         dashboardTicketBridge?.reload()
@@ -1888,13 +2089,13 @@ final class AppState: ObservableObject {
                         )
                         return
                     } catch {
+                        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
                         // This only determines whether recovery can be silent.
                         // Preserve the saved credentials for the login screen.
                     }
                 }
                 requireSignIn(message: error.localizedDescription)
             } else {
-                guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
                 isConnected = false
                 isConnecting = false
                 turnState = .reconnecting
@@ -1905,6 +2106,7 @@ final class AppState: ObservableObject {
         }
 
         let previousClient = client
+        guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
         let client = makeClient(connection: connection, profile: activeProfile)
         self.client = client
         previousClient?.disconnect()
@@ -1922,9 +2124,16 @@ final class AppState: ObservableObject {
                 using: nil,
                 automaticWorkToken: automaticWorkToken
             )
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+                  let activeClient = self.client, activeClient === client else { return }
             await loadBusyInputMode(using: client)
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+                  let activeClient = self.client, activeClient === client else { return }
             await loadProfiles()
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
+                  let activeClient = self.client, activeClient === client else { return }
             await loadProfileDisplayPreferences()
+            guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
             Task { await loadSlashCommands() }
         } catch {
             guard automaticChatResumeWorkIsCurrent(automaticWorkToken),
@@ -1934,6 +2143,15 @@ final class AppState: ObservableObject {
             turnState = .reconnecting
             scheduleReconnect(purpose: purpose)
         }
+    }
+
+    private func mintChatResumeTicket(for connection: HermesConnection) async throws -> String {
+        if let mintTicket = chatResumeLifecycleOperations.mintTicket {
+            return try await mintTicket(connection.baseUrl)
+        }
+        prepareDashboardBridge(for: connection.baseUrl)
+        guard let dashboardTicketBridge else { throw DashboardTicketBridgeError.notReady }
+        return try await dashboardTicketBridge.mintTicket()
     }
 
     func handleScenePhase(_ phase: ScenePhase) {
@@ -2290,6 +2508,13 @@ final class AppState: ObservableObject {
 
     @discardableResult
     func openSession(_ sessionId: String) async -> Bool {
+        await openSession(sessionId, reusing: nil)
+    }
+
+    private func openSession(
+        _ sessionId: String,
+        reusing viewportTransitionGeneration: UInt64?
+    ) async -> Bool {
         guard let client else { return false }
         if let session = (sessions + cronSessions).first(where: {
             $0.id == sessionId || $0.alternateIds.contains(sessionId)
@@ -2297,7 +2522,9 @@ final class AppState: ObservableObject {
             errorMessage = "That conversation belongs to another workspace. Switch profiles to open it."
             return false
         }
-        beginExplicitChatViewportTransition()
+        let transitionGeneration = beginExplicitChatViewportTransition(
+            reusing: viewportTransitionGeneration
+        )
         markChatViewportReplacement()
         // Atomically switch session identity BEFORE clearing the transcript.
         // This prevents stale stream events from the old session falling
@@ -2312,12 +2539,16 @@ final class AppState: ObservableObject {
         activeAssistantMessageId = nil
         activeReasoningMessageId = nil
         updateActiveSessionTitle(for: sessionId)
-        return await reconcile(
+        let reconciled = await reconcile(
             sessionId: sessionId,
             using: client,
             token: token,
             acceptedSessionIDs: acceptedSessionIDs
         )
+        if !reconciled {
+            finishChatViewportTransition(generation: transitionGeneration)
+        }
+        return reconciled
     }
 
     /// Routes a notification to its originating profile/session without
@@ -2332,7 +2563,10 @@ final class AppState: ObservableObject {
         defer { isOpeningNotificationSession = false }
         let targetProfile = notificationProfileID(target.profile)
         if let targetProfile, targetProfile != activeProfile {
-            await switchProfile(to: targetProfile)
+            await switchProfile(
+                to: targetProfile,
+                reusing: transitionGeneration
+            )
         }
         if let targetProfile, activeProfile != targetProfile { return false }
         guard client != nil else { return false }
@@ -2351,7 +2585,10 @@ final class AppState: ObservableObject {
         let matchingSession = (sessions + cronSessions).first { session in
             session.id == requestedID || session.alternateIds.contains(requestedID)
         }
-        return await openSession(matchingSession?.id ?? requestedID)
+        return await openSession(
+            matchingSession?.id ?? requestedID,
+            reusing: transitionGeneration
+        )
     }
 
     private func notificationProfileID(_ notifiedProfile: String?) -> String? {
@@ -2389,10 +2626,11 @@ final class AppState: ObservableObject {
     /// during a turn cannot leave the composer with stale busy state.
     func refreshActiveSession() async {
         guard let client, let sessionId = activeSessionId, !isChatRefreshing else { return }
-        beginExplicitChatViewportTransition()
+        let transitionGeneration = beginExplicitChatViewportTransition()
         markChatViewportReplacement()
         isChatRefreshing = true
         defer { isChatRefreshing = false }
+        let previousMessages = messages
 
         let token = beginReconciliation()
         let succeeded = await reconcile(
@@ -2401,8 +2639,8 @@ final class AppState: ObservableObject {
             token: token,
             acceptedSessionIDs: knownSessionIDs(for: sessionId)
         )
-        if !succeeded {
-            finishChatViewportTransition(generation: chatViewportTransitionGeneration)
+        if !succeeded || messages == previousMessages {
+            finishChatViewportTransition(generation: transitionGeneration)
         }
         await loadSessions()
     }
@@ -2437,12 +2675,23 @@ final class AppState: ObservableObject {
         let title = "Branch of \(activeSessionTitle)"
 
         do {
-            let branched = try await client.branchSession(
-                parentSessionId: parentSessionId,
-                messages: prefix,
-                title: title,
-                cwd: runtime.cwd
-            )
+            let branched: ChatResumeLifecycleOperations.BranchResult
+            if let branchSession = chatResumeLifecycleOperations.branchSession {
+                branched = try await branchSession(
+                    client,
+                    parentSessionId,
+                    Array(prefix),
+                    title,
+                    runtime.cwd
+                )
+            } else {
+                branched = try await client.branchSession(
+                    parentSessionId: parentSessionId,
+                    messages: Array(prefix),
+                    title: title,
+                    cwd: runtime.cwd
+                )
+            }
             guard profile == activeProfile, self.client === client else { return }
             if let returnedProfile = branched.profile,
                !profilesMatch(returnedProfile, profile) {
@@ -2451,9 +2700,16 @@ final class AppState: ObservableObject {
                 await loadSessions(forceRefresh: true)
                 return
             }
-            acceptChatResumeConversationReplacement(.branch)
-            try? await client.setSessionTitle(branched.sessionId, title: title)
-            guard profile == activeProfile, self.client === client else { return }
+            let transitionGeneration = acceptChatResumeConversationReplacement(.branch)
+            if let setSessionTitle = chatResumeLifecycleOperations.setSessionTitle {
+                try? await setSessionTitle(client, branched.sessionId, title)
+            } else {
+                try? await client.setSessionTitle(branched.sessionId, title: title)
+            }
+            guard profile == activeProfile, self.client === client else {
+                finishChatViewportTransition(generation: transitionGeneration)
+                return
+            }
 
             let summary = SessionSummary(
                 id: branched.storedSessionId ?? branched.sessionId,
@@ -2477,12 +2733,15 @@ final class AppState: ObservableObject {
 
             activeSessionTitle = title
             let token = beginReconciliation()
-            await reconcile(
+            let reconciled = await reconcile(
                 sessionId: branched.sessionId,
                 using: client,
                 token: token,
                 acceptedSessionIDs: knownSessionIDs(for: branched.sessionId)
             )
+            if !reconciled {
+                finishChatViewportTransition(generation: transitionGeneration)
+            }
             await loadSessions()
         } catch {
             guard profile == activeProfile, self.client === client else { return }
@@ -3070,6 +3329,9 @@ final class AppState: ObservableObject {
     /// legacy fallback because it is backed by the gateway's current runtime
     /// database and can otherwise leak or omit profile history.
     private func profileSessions(using client: HermesClient, forceRefresh: Bool = false) async throws -> [SessionSummary] {
+        if let loadCatalog = chatResumeLifecycleOperations.loadCatalog {
+            return try await loadCatalog(client, forceRefresh)
+        }
         let profile = activeProfile
         if let dashboardTicketBridge {
             do {
@@ -3321,10 +3583,19 @@ final class AppState: ObservableObject {
     }
 
     func switchProfile(to profile: String) async {
+        await switchProfile(to: profile, reusing: nil)
+    }
+
+    private func switchProfile(
+        to profile: String,
+        reusing viewportTransitionGeneration: UInt64?
+    ) async {
         let target = profile.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !target.isEmpty, target != activeProfile, let savedConnection = connection else { return }
         guard !isProfileSwitching else { return }
-        let transitionGeneration = beginExplicitChatViewportTransition()
+        let transitionGeneration = beginExplicitChatViewportTransition(
+            reusing: viewportTransitionGeneration
+        )
         cacheMessagePresentation()
         cancelSecondaryProfileTitleRecovery()
 
@@ -3376,6 +3647,9 @@ final class AppState: ObservableObject {
             defaults.set(target, forKey: activeProfileKey)
 
             await syncSession()
+            finishChatViewportTransitionIfNoTranscriptReplacement(
+                generation: transitionGeneration
+            )
             await loadBusyInputMode(using: nextClient)
             await loadProfileDisplayPreferences()
             Task { await loadSlashCommands() }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2018,12 +2018,15 @@ final class AppState: ObservableObject {
             automaticWorkToken,
             syncOperationID: automaticSyncOperationID
         ) else { return }
-        guard let sessionKey = activeChatScrollSessionIdentity.canonicalSessionKey,
-              let request = chatResumeCoordinator.reconciliationSettled(sessionKey: sessionKey) else {
-            // Reconciliation settled but no request was published (key mismatch
-            // or already-pending restoration). Clear the freeze so viewport
-            // recording resumes — otherwise recordViewport stays a no-op.
-            chatResumeCoordinator.abandonPendingAutomaticSync()
+        guard let sessionKey = activeChatScrollSessionIdentity.canonicalSessionKey else {
+            return
+        }
+        guard let request = chatResumeCoordinator.reconciliationSettled(sessionKey: sessionKey) else {
+            // reconciliationSettled returned nil. If there was a pending
+            // session key (mismatch path), clear the freeze so viewport
+            // recording resumes. If there was no pending key, there's
+            // nothing to clean up.
+            chatResumeCoordinator.abandonPendingAutomaticSyncIfPending()
             return
         }
         chatResumeRestorationRequest = request

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -36,8 +36,12 @@ final class AppState: ObservableObject {
 
     // MARK: - Session
 
-    @Published var sessions: [SessionSummary] = []
-    @Published var cronSessions: [SessionSummary] = []
+    @Published var sessions: [SessionSummary] = [] {
+        didSet { refreshActiveChatScrollSessionIdentity() }
+    }
+    @Published var cronSessions: [SessionSummary] = [] {
+        didSet { refreshActiveChatScrollSessionIdentity() }
+    }
     @Published private(set) var projects: [ProjectSummary] = []
     @Published private(set) var supportsProjects = false
     @Published private(set) var projectsLoading = false
@@ -45,7 +49,10 @@ final class AppState: ObservableObject {
     @Published private(set) var pinnedSessionIDs: [String] = []
     @Published private(set) var sessionMutationID: String?
     @Published private(set) var isRefreshingSessionCatalog = false
-    @Published var activeSessionId: String?
+    @Published var activeSessionId: String? {
+        didSet { refreshActiveChatScrollSessionIdentity() }
+    }
+    @Published private(set) var activeChatScrollSessionIdentity = ChatScrollSessionIdentity.none
     @Published var messages: [ChatMessage] = []
     @Published private(set) var activeSessionTitle = "New conversation"
     @Published private(set) var isChatRefreshing = false
@@ -204,6 +211,7 @@ final class AppState: ObservableObject {
 
     private var reconciliationToken = UUID()
     private var reconciliation: Reconciliation?
+    private var chatScrollIdentityProfile = "default"
     private var activeClientEpoch = UUID()
     private var activeAssistantMessageId: String?
     private var activeReasoningMessageId: String?
@@ -483,6 +491,93 @@ final class AppState: ObservableObject {
     private func persistActiveSessionState() {
         defaults.set(activeSessionIDsByProfile, forKey: activeSessionIDsByProfileKey)
         defaults.set(activeSessionTitlesByProfile, forKey: activeSessionTitlesByProfileKey)
+    }
+
+    private func refreshActiveChatScrollSessionIdentity(
+        isReconciling: Bool? = nil,
+        advanceSettledRevision: Bool = false
+    ) {
+        let current = activeChatScrollSessionIdentity
+        let previous = chatScrollIdentityProfile == activeProfile
+            ? current
+            : ChatScrollSessionIdentity(
+                canonicalSessionID: nil,
+                equivalentSessionIDs: [],
+                isReconciling: current.isReconciling,
+                settledRevision: current.settledRevision
+            )
+        let catalog = sessions + cronSessions
+        func identifiers(for session: SessionSummary) -> Set<String> {
+            Set(([session.id] + session.alternateIds).compactMap(Self.normalizedSessionIdentityID))
+        }
+        func matchingSession(for ids: Set<String>) -> SessionSummary? {
+            guard !ids.isEmpty else { return nil }
+            return catalog.first { !identifiers(for: $0).isDisjoint(with: ids) }
+        }
+
+        let activeID = Self.normalizedSessionIdentityID(activeSessionId)
+        let reconciliationIDs = Set([
+            reconciliation?.requestedSessionId,
+            reconciliation?.resolvedSessionId
+        ].compactMap(Self.normalizedSessionIdentityID))
+        let reconciliationSession = matchingSession(for: reconciliationIDs)
+        let reconciliationCatalogIDs = reconciliationSession.map(identifiers) ?? []
+        let reconciliationContinuesPrevious = reconciliationIDs.isEmpty
+            || reconciliationIDs.contains(where: previous.contains)
+            || !reconciliationCatalogIDs.isDisjoint(with: previous.equivalentSessionIDs)
+            || activeID.map(reconciliationCatalogIDs.contains) == true
+
+        var candidates = reconciliationIDs
+        if reconciliationIDs.isEmpty || reconciliationContinuesPrevious,
+           let activeID {
+            candidates.insert(activeID)
+        }
+        let matchedSession = reconciliationSession ?? matchingSession(for: candidates)
+        let continuesPreviousIdentity = candidates.contains(where: previous.contains)
+
+        let canonicalSessionID: String?
+        if let matchedSession {
+            canonicalSessionID = matchedSession.id
+        } else if continuesPreviousIdentity {
+            canonicalSessionID = previous.canonicalSessionID
+        } else if !reconciliationIDs.isEmpty {
+            canonicalSessionID = Self.normalizedSessionIdentityID(reconciliation?.requestedSessionId)
+                ?? Self.normalizedSessionIdentityID(reconciliation?.resolvedSessionId)
+                ?? activeID
+        } else {
+            canonicalSessionID = activeID
+        }
+
+        var equivalentSessionIDs = candidates
+        if let matchedSession {
+            equivalentSessionIDs.formUnion(
+                ([matchedSession.id] + matchedSession.alternateIds)
+                    .compactMap(Self.normalizedSessionIdentityID)
+            )
+        }
+        if continuesPreviousIdentity {
+            equivalentSessionIDs.formUnion(previous.equivalentSessionIDs)
+        }
+
+        let revision = advanceSettledRevision
+            ? current.settledRevision &+ 1
+            : current.settledRevision
+        let updated = ChatScrollSessionIdentity(
+            canonicalSessionID: canonicalSessionID,
+            equivalentSessionIDs: equivalentSessionIDs,
+            isReconciling: isReconciling ?? current.isReconciling,
+            settledRevision: revision
+        )
+        chatScrollIdentityProfile = activeProfile
+        if updated != current {
+            activeChatScrollSessionIdentity = updated
+        }
+    }
+
+    private static func normalizedSessionIdentityID(_ sessionID: String?) -> String? {
+        guard let value = sessionID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else { return nil }
+        return value
     }
 
     func makeSettingsSnapshot() -> SettingsSnapshot {
@@ -803,12 +898,26 @@ final class AppState: ObservableObject {
     /// The only entry point for cold start, foreground refresh, reconnect, and
     /// manual refresh. It never derives liveness from transcript shape.
     func syncSession() async {
-        guard let client else { return }
+        await syncSession(using: nil)
+    }
+
+    private func syncSession(using existingReconciliationToken: UUID?) async {
+        guard let client else {
+            if let existingReconciliationToken {
+                settleReconciliation(existingReconciliationToken)
+            }
+            return
+        }
         // A notification destination always wins over automatic restoration of
         // the previously active/newest session. Check both before and after
         // the catalog fetch because a notification tap can arrive mid-launch.
-        guard PushNotificationService.shared.pendingTarget == nil else { return }
-        let token = beginReconciliation()
+        guard PushNotificationService.shared.pendingTarget == nil else {
+            if let existingReconciliationToken {
+                settleReconciliation(existingReconciliationToken)
+            }
+            return
+        }
+        let token = existingReconciliationToken ?? beginReconciliation()
         let profile = activeProfile
         let retainedActiveTurn = activeTurnCatalogSession()
         turnState = .synchronizing
@@ -825,8 +934,14 @@ final class AppState: ObservableObject {
             guard token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
-                  activeClient === client else { return }
-            guard PushNotificationService.shared.pendingTarget == nil else { return }
+                  activeClient === client else {
+                settleReconciliation(token)
+                return
+            }
+            guard PushNotificationService.shared.pendingTarget == nil else {
+                settleReconciliation(token)
+                return
+            }
             sessions = allSessions.filter { $0.source != .cron }
             cronSessions = allSessions.filter { $0.source == .cron }
 
@@ -846,9 +961,13 @@ final class AppState: ObservableObject {
             guard token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
-                  activeClient === client else { return }
+                  activeClient === client else {
+                settleReconciliation(token)
+                return
+            }
             turnState = .reconnecting
             errorMessage = "Failed to load gateway sessions: \(error.localizedDescription)"
+            settleReconciliation(token)
         }
     }
 
@@ -856,17 +975,34 @@ final class AppState: ObservableObject {
         let token = UUID()
         reconciliationToken = token
         reconciliation = nil
+        refreshActiveChatScrollSessionIdentity(isReconciling: true)
         return token
     }
 
     private func invalidateReconciliation() {
+        let wasReconciling = activeChatScrollSessionIdentity.isReconciling
         reconciliationToken = UUID()
         reconciliation = nil
+        refreshActiveChatScrollSessionIdentity(
+            isReconciling: false,
+            advanceSettledRevision: wasReconciling
+        )
+    }
+
+    private func settleReconciliation(_ token: UUID) {
+        guard token == reconciliationToken else { return }
+        let wasReconciling = activeChatScrollSessionIdentity.isReconciling
+        reconciliation = nil
+        refreshActiveChatScrollSessionIdentity(
+            isReconciling: false,
+            advanceSettledRevision: wasReconciling
+        )
     }
 
     @discardableResult
     private func reconcile(sessionId: String, using client: HermesClient, token: UUID) async -> Bool {
         reconciliation = Reconciliation(token: token, requestedSessionId: sessionId)
+        refreshActiveChatScrollSessionIdentity(isReconciling: true)
         turnState = .synchronizing
         let profile = activeProfile
 
@@ -888,11 +1024,15 @@ final class AppState: ObservableObject {
             guard token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
-                  activeClient === client else { return false }
+                  activeClient === client else {
+                settleReconciliation(token)
+                return false
+            }
 
             var context = reconciliation
             context?.resolvedSessionId = result.sessionId
             reconciliation = context
+            refreshActiveChatScrollSessionIdentity(isReconciling: true)
 
             // Do not replace a live/in-flight projection with a database read
             // that may be a few events behind. Once the turn is settled, the
@@ -933,18 +1073,21 @@ final class AppState: ObservableObject {
             await refreshContextUsage(sessionId: result.sessionId, using: client)
 
             let bufferedEvents = reconciliation?.token == token ? reconciliation?.bufferedEvents ?? [] : []
-            reconciliation = nil
             bufferedEvents.forEach(applyStreamEvent)
+            settleReconciliation(token)
             return true
 
         } catch {
             guard token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
-                  activeClient === client else { return false }
-            reconciliation = nil
+                  activeClient === client else {
+                settleReconciliation(token)
+                return false
+            }
             turnState = .reconnecting
             errorMessage = "Failed to restore this conversation: \(error.localizedDescription)"
+            settleReconciliation(token)
             return false
         }
     }
@@ -964,11 +1107,15 @@ final class AppState: ObservableObject {
             guard token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
-                  activeClient === client else { return }
+                  activeClient === client else {
+                settleReconciliation(token)
+                return
+            }
             if let returnedProfile = created.profile,
                !profilesMatch(returnedProfile, profile) {
                 turnState = .idle
                 errorMessage = "Hermes created this conversation in \(profileDisplayName(returnedProfile)), not \(profileDisplayName(profile)). It was not opened."
+                settleReconciliation(token)
                 await loadSessions(forceRefresh: true)
                 return
             }
@@ -976,6 +1123,7 @@ final class AppState: ObservableObject {
             guard !runtimeSessionID.isEmpty else {
                 turnState = .idle
                 errorMessage = "Hermes created a conversation without a session ID."
+                settleReconciliation(token)
                 return
             }
 
@@ -1019,13 +1167,18 @@ final class AppState: ObservableObject {
                 await self.loadSlashCommands()
                 await self.loadSessions()
             }
+            settleReconciliation(token)
         } catch {
             guard token == reconciliationToken,
                   profile == activeProfile,
                   let activeClient = self.client,
-                  activeClient === client else { return }
+                  activeClient === client else {
+                settleReconciliation(token)
+                return
+            }
             turnState = .idle
             errorMessage = "Failed to create session: \(error.localizedDescription)"
+            settleReconciliation(token)
         }
     }
 
@@ -1256,17 +1409,23 @@ final class AppState: ObservableObject {
             voiceConversationController.setForegroundActive(true)
             guard connection != nil else { return }
             scenePhaseTask?.cancel()
+            // Publish the foreground reconciliation boundary synchronously.
+            // ChatView may receive the same scene transition before the health
+            // check task runs, so geometry alone must not restore stale rows.
+            let token = beginReconciliation()
             scenePhaseTask = Task { @MainActor [weak self] in
                 guard let self else { return }
                 if let client = self.client, client.isConnected {
                     do {
                         try await client.healthCheck()
-                        await self.syncSession()
+                        await self.syncSession(using: token)
                     } catch {
                         await self.reconnect()
+                        self.settleReconciliation(token)
                     }
                 } else {
                     await self.reconnect()
+                    self.settleReconciliation(token)
                 }
             }
 
@@ -1577,13 +1736,13 @@ final class AppState: ObservableObject {
         // through `eventBelongsToActiveSession` and repopulating the
         // cleared message array while reconciliation is in flight.
         flushPendingPresentationCache()
+        let token = beginReconciliation()
         setActiveSessionState(id: sessionId)
         messages = []
         clearStreamingText()
         activeAssistantMessageId = nil
         activeReasoningMessageId = nil
         updateActiveSessionTitle(for: sessionId)
-        let token = beginReconciliation()
         return await reconcile(sessionId: sessionId, using: client, token: token)
     }
 

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2020,6 +2020,10 @@ final class AppState: ObservableObject {
         ) else { return }
         guard let sessionKey = activeChatScrollSessionIdentity.canonicalSessionKey,
               let request = chatResumeCoordinator.reconciliationSettled(sessionKey: sessionKey) else {
+            // Reconciliation settled but no request was published (key mismatch
+            // or already-pending restoration). Clear the freeze so viewport
+            // recording resumes — otherwise recordViewport stays a no-op.
+            chatResumeCoordinator.abandonPendingAutomaticSync()
             return
         }
         chatResumeRestorationRequest = request

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -197,10 +197,30 @@ final class AppState: ObservableObject {
         let token: UUID
         let requestedSessionId: String
         var resolvedSessionId: String?
+        var acceptedSessionIDs: Set<String>
+        let acceptsAnySession: Bool
         var bufferedEvents: [StreamEvent] = []
 
+        init(
+            token: UUID,
+            requestedSessionId: String,
+            acceptedSessionIDs: Set<String> = [],
+            acceptsAnySession: Bool = false,
+            bufferedEvents: [StreamEvent] = []
+        ) {
+            self.token = token
+            self.requestedSessionId = requestedSessionId
+            self.acceptedSessionIDs = acceptedSessionIDs
+            self.acceptsAnySession = acceptsAnySession
+            self.bufferedEvents = bufferedEvents
+        }
+
         func accepts(_ sessionId: String) -> Bool {
-            !sessionId.isEmpty && (sessionId == requestedSessionId || sessionId == resolvedSessionId)
+            guard !sessionId.isEmpty else { return false }
+            if acceptsAnySession { return true }
+            return acceptedSessionIDs.contains(sessionId)
+                || sessionId == requestedSessionId
+                || sessionId == resolvedSessionId
         }
     }
 
@@ -898,7 +918,12 @@ final class AppState: ObservableObject {
                 allSessions.first { $0.id == savedId || $0.alternateIds.contains(savedId) }
             }
             if let target = savedSession ?? sessions.first(where: { $0.source == .chat }) ?? sessions.first {
-                await reconcile(sessionId: target.id, using: client, token: token)
+                await reconcile(
+                    sessionId: target.id,
+                    using: client,
+                    token: token,
+                    acceptedSessionIDs: Set([target.id] + target.alternateIds)
+                )
             } else {
                 await createAndReconcileSession(using: client, profile: profile, token: token)
             }
@@ -918,8 +943,14 @@ final class AppState: ObservableObject {
 
     private func beginReconciliation() -> UUID {
         let token = UUID()
+        let bufferedEvents = reconciliation?.bufferedEvents ?? []
         reconciliationToken = token
-        reconciliation = nil
+        reconciliation = Reconciliation(
+            token: token,
+            requestedSessionId: activeSessionId ?? "",
+            acceptsAnySession: true,
+            bufferedEvents: bufferedEvents
+        )
         refreshActiveChatScrollSessionIdentity(isReconciling: true)
         return token
     }
@@ -945,8 +976,21 @@ final class AppState: ObservableObject {
     }
 
     @discardableResult
-    private func reconcile(sessionId: String, using client: HermesClient, token: UUID) async -> Bool {
-        reconciliation = Reconciliation(token: token, requestedSessionId: sessionId)
+    private func reconcile(
+        sessionId: String,
+        using client: HermesClient,
+        token: UUID,
+        acceptedSessionIDs: Set<String> = []
+    ) async -> Bool {
+        let bufferedEvents = reconciliation?.token == token
+            ? reconciliation?.bufferedEvents ?? []
+            : []
+        reconciliation = Reconciliation(
+            token: token,
+            requestedSessionId: sessionId,
+            acceptedSessionIDs: acceptedSessionIDs.union([sessionId]),
+            bufferedEvents: bufferedEvents
+        )
         refreshActiveChatScrollSessionIdentity(isReconciling: true)
         turnState = .synchronizing
         let profile = activeProfile
@@ -976,6 +1020,7 @@ final class AppState: ObservableObject {
 
             var context = reconciliation
             context?.resolvedSessionId = result.sessionId
+            context?.acceptedSessionIDs.insert(result.sessionId)
             reconciliation = context
             refreshActiveChatScrollSessionIdentity(isReconciling: true)
 
@@ -1017,7 +1062,11 @@ final class AppState: ObservableObject {
             applyResume(presentationResult)
             await refreshContextUsage(sessionId: result.sessionId, using: client)
 
-            let bufferedEvents = reconciliation?.token == token ? reconciliation?.bufferedEvents ?? [] : []
+            let bufferedEvents = reconciliation?.token == token
+                ? (reconciliation?.bufferedEvents ?? []).filter {
+                    reconciliation?.accepts(sessionID(for: $0)) == true
+                }
+                : []
             bufferedEvents.forEach(applyStreamEvent)
             settleReconciliation(token)
             return true
@@ -1637,6 +1686,15 @@ final class AppState: ObservableObject {
         return !left.isDisjoint(with: right)
     }
 
+    private func knownSessionIDs(for sessionID: String) -> Set<String> {
+        guard let session = (sessions + cronSessions).first(where: {
+            $0.id == sessionID || $0.alternateIds.contains(sessionID)
+        }) else {
+            return [sessionID]
+        }
+        return Set([session.id] + session.alternateIds)
+    }
+
     private func sessionMatchesActiveSession(_ session: SessionSummary) -> Bool {
         guard let activeSessionId else { return false }
         return Set([session.id] + session.alternateIds).contains(activeSessionId)
@@ -1682,13 +1740,19 @@ final class AppState: ObservableObject {
         // cleared message array while reconciliation is in flight.
         flushPendingPresentationCache()
         let token = beginReconciliation()
+        let acceptedSessionIDs = knownSessionIDs(for: sessionId)
         setActiveSessionState(id: sessionId)
         messages = []
         clearStreamingText()
         activeAssistantMessageId = nil
         activeReasoningMessageId = nil
         updateActiveSessionTitle(for: sessionId)
-        return await reconcile(sessionId: sessionId, using: client, token: token)
+        return await reconcile(
+            sessionId: sessionId,
+            using: client,
+            token: token,
+            acceptedSessionIDs: acceptedSessionIDs
+        )
     }
 
     /// Routes a notification to its originating profile/session without
@@ -1756,7 +1820,12 @@ final class AppState: ObservableObject {
         defer { isChatRefreshing = false }
 
         let token = beginReconciliation()
-        await reconcile(sessionId: sessionId, using: client, token: token)
+        await reconcile(
+            sessionId: sessionId,
+            using: client,
+            token: token,
+            acceptedSessionIDs: knownSessionIDs(for: sessionId)
+        )
         await loadSessions()
     }
 
@@ -1829,7 +1898,12 @@ final class AppState: ObservableObject {
 
             activeSessionTitle = title
             let token = beginReconciliation()
-            await reconcile(sessionId: branched.sessionId, using: client, token: token)
+            await reconcile(
+                sessionId: branched.sessionId,
+                using: client,
+                token: token,
+                acceptedSessionIDs: knownSessionIDs(for: branched.sessionId)
+            )
             await loadSessions()
         } catch {
             guard profile == activeProfile, self.client === client else { return }
@@ -3697,7 +3771,25 @@ final class AppState: ObservableObject {
 
     private func eventBelongsToActiveSession(_ sessionId: String) -> Bool {
         guard let activeSessionId, !sessionId.isEmpty else { return false }
-        return sessionId == activeSessionId
+        if sessionId == activeSessionId { return true }
+
+        if let activeSession = (sessions + cronSessions).first(where: {
+            $0.id == activeSessionId || $0.alternateIds.contains(activeSessionId)
+        }) {
+            let activeIDs = Set([activeSession.id] + activeSession.alternateIds)
+            if activeIDs.contains(sessionId) { return true }
+        }
+
+        // During resume, the gateway may switch between the requested and
+        // runtime IDs before the catalog has caught up. Only accept those
+        // aliases when the active ID is part of the same reconciliation set;
+        // this prevents a prior session's buffered events from leaking into a
+        // newly selected transcript.
+        guard let reconciliation,
+              reconciliation.acceptedSessionIDs.contains(activeSessionId) else {
+            return false
+        }
+        return reconciliation.acceptedSessionIDs.contains(sessionId)
     }
 
     private func applyStreamEvent(_ event: StreamEvent) {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2118,6 +2118,7 @@ final class AppState: ObservableObject {
                   let activeClient = self.client,
                   activeClient === client else {
                 settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
+                chatResumeCoordinator.abandonPendingAutomaticSync()
                 return false
             }
 
@@ -2213,6 +2214,7 @@ final class AppState: ObservableObject {
             turnState = .reconnecting
             errorMessage = "Failed to restore this conversation: \(error.localizedDescription)"
             settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
+            chatResumeCoordinator.abandonPendingAutomaticSync()
             return false
         }
     }
@@ -2359,6 +2361,7 @@ final class AppState: ObservableObject {
             turnState = .idle
             errorMessage = "Failed to create session: \(error.localizedDescription)"
             settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
+            chatResumeCoordinator.abandonPendingAutomaticSync()
             if resumePurpose == .automaticReturn {
                 scheduleReconnect(purpose: resumePurpose)
             }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -15,6 +15,29 @@ import UIKit
 private let sessionCatalogLog = Logger(subsystem: "com.milim.conduit", category: "SessionCatalog")
 private let titleGenerationLog = Logger(subsystem: "com.milim.conduit", category: "TitleGeneration")
 
+typealias ChatResumeReconnectCancellation = @MainActor () -> Void
+typealias ChatResumeReconnectScheduler = @MainActor (
+    _ delay: TimeInterval,
+    _ operation: @escaping @MainActor () async -> Void
+) -> ChatResumeReconnectCancellation
+
+@MainActor
+private func scheduleChatResumeReconnectTask(
+    after delay: TimeInterval,
+    operation: @escaping @MainActor () async -> Void
+) -> ChatResumeReconnectCancellation {
+    let task = Task { @MainActor in
+        do {
+            try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+        } catch {
+            return
+        }
+        guard !Task.isCancelled else { return }
+        await operation()
+    }
+    return { task.cancel() }
+}
+
 enum ChatResumeReconnectSchedulingDecision: Equatable {
     case schedule(ChatResumeSyncPurpose)
     case replace(ChatResumeSyncPurpose)
@@ -65,6 +88,7 @@ final class ChatResumeRecoverySequence {
 
     func complete() {
         currentPurpose = .preserveCurrent
+        queuedReconnectPurpose = nil
     }
 
     func cancel() {
@@ -312,7 +336,9 @@ final class AppState: ObservableObject {
     private var lastStreamingPublishBurst = 0
     private var lastStreamingPublishDate: Date?
     private var scenePhaseTask: Task<Void, Never>?
-    private var reconnectTask: Task<Void, Never>?
+    private var reconnectTask: ChatResumeReconnectCancellation?
+    private let reconnectScheduler: ChatResumeReconnectScheduler
+    private let scheduledReconnectExecutor: (@MainActor (ChatResumeSyncPurpose) async -> Void)?
     /// Coalesces presentation-cache flushes during streaming so we
     /// don't serialize and write UserDefaults on every WebSocket frame.
     private var presentationCacheFlushTask: Task<Void, Never>?
@@ -416,6 +442,7 @@ final class AppState: ObservableObject {
     private let chatResumeCoordinator: ChatResumeCoordinator
     private let recoverySequence: ChatResumeRecoverySequence
     private let clearSessionPresentationCache: () -> Void
+    private let initialChatResumeServerIdentity: String?
 
     private func mergeCachedReviews(into history: [ChatMessage], sessionId: String) -> [ChatMessage] {
         let records = cachedReviews().filter { $0.profile == activeProfile && $0.sessionId == sessionId }
@@ -464,7 +491,9 @@ final class AppState: ObservableObject {
             SessionPresentationCache.shared.clear()
         },
         sessionRenameOperations: SessionRenameOperation.Operations? = nil,
-        sessionCatalogLoader: ((Bool) async throws -> [SessionSummary])? = nil
+        sessionCatalogLoader: ((Bool) async throws -> [SessionSummary])? = nil,
+        reconnectScheduler: ChatResumeReconnectScheduler? = nil,
+        scheduledReconnectExecutor: (@MainActor (ChatResumeSyncPurpose) async -> Void)? = nil
     ) {
         self.defaults = defaults
         self.chatResumeCoordinator = chatResumeCoordinator
@@ -473,6 +502,13 @@ final class AppState: ObservableObject {
         self.clearSessionPresentationCache = clearSessionPresentationCache
         sessionRenameOperationsOverride = sessionRenameOperations
         sessionCatalogLoaderOverride = sessionCatalogLoader
+        self.reconnectScheduler = reconnectScheduler ?? scheduleChatResumeReconnectTask
+        self.scheduledReconnectExecutor = scheduledReconnectExecutor
+        self.initialChatResumeServerIdentity = defaults
+            .string(forKey: "conduit.chatResumeServerIdentity.v1")
+            .flatMap(Self.normalizedChatResumeServerIdentity)
+            ?? defaults.string(forKey: "conduit.dashboardURL")
+                .flatMap(Self.normalizedChatResumeServerIdentity)
         chatResumeBehavior = self.chatResumeCoordinator.behavior
         defaultProfileName = ProfileAppearanceStore.loadDefaultName()
         profileAvatarURLs = ProfileAppearanceStore.loadAvatarURLs()
@@ -577,7 +613,14 @@ final class AppState: ObservableObject {
         defaults.set(activeSessionTitlesByProfile, forKey: activeSessionTitlesByProfileKey)
     }
 
+    private func cancelScheduledReconnect() {
+        reconnectTask?()
+        reconnectTask = nil
+        recoverySequence.clearQueuedReconnect()
+    }
+
     func setChatResumeBehavior(_ behavior: ChatResumeBehavior) {
+        cancelScheduledReconnect()
         chatResumeCoordinator.setBehavior(behavior)
         recoverySequence.cancel()
         chatResumeBehavior = chatResumeCoordinator.behavior
@@ -601,6 +644,7 @@ final class AppState: ObservableObject {
     }
 
     func cancelChatResumeRestoration() {
+        cancelScheduledReconnect()
         chatResumeCoordinator.cancelRestoration()
         recoverySequence.cancel()
         chatResumeRestorationRequest = nil
@@ -614,13 +658,15 @@ final class AppState: ObservableObject {
 
     @discardableResult
     func prepareChatResumeForConnection(to baseURL: String) -> Bool {
-        guard let identity = normalizedChatResumeServerIdentity(baseURL) else { return false }
+        guard let identity = Self.normalizedChatResumeServerIdentity(baseURL) else { return false }
         let previousIdentity = defaults.string(forKey: chatResumeServerIdentityKey)
-            ?? defaults.string(forKey: dashboardURLKey).flatMap(normalizedChatResumeServerIdentity)
+            .flatMap(Self.normalizedChatResumeServerIdentity)
+            ?? initialChatResumeServerIdentity
         defaults.set(identity, forKey: chatResumeServerIdentityKey)
         guard let previousIdentity, previousIdentity != identity else { return false }
 
         chatResumeCoordinator.clearResumeState()
+        cancelScheduledReconnect()
         recoverySequence.cancel()
         chatResumeRestorationRequest = nil
         invalidateReconciliation()
@@ -642,11 +688,13 @@ final class AppState: ObservableObject {
         pinnedSessionIDs = []
         defaults.removeObject(forKey: activeSessionTitlesByProfileKey)
         defaults.removeObject(forKey: pinnedSessionIDsByProfileKey)
+        defaults.removeObject(forKey: reviewSummaryCacheKey)
+        defaults.removeObject(forKey: knownProfilesKey)
         clearSessionPresentationCache()
         return true
     }
 
-    private func normalizedChatResumeServerIdentity(_ baseURL: String) -> String? {
+    private static func normalizedChatResumeServerIdentity(_ baseURL: String) -> String? {
         guard let normalized = try? ConnectionURLPolicy.normalizedBaseURL(baseURL),
               var components = URLComponents(string: normalized),
               let scheme = components.scheme?.lowercased(),
@@ -844,8 +892,7 @@ final class AppState: ObservableObject {
         }
         prepareChatResumeForConnection(to: normalizedBaseURL)
         rememberDashboardURL(conn.baseUrl)
-        reconnectTask?.cancel()
-        reconnectTask = nil
+        cancelScheduledReconnect()
         isConnecting = true
         showLogin = false
         connection = conn
@@ -897,11 +944,10 @@ final class AppState: ObservableObject {
 
     func disconnect() {
         chatResumeCoordinator.clearResumeState()
+        cancelScheduledReconnect()
         recoverySequence.cancel()
         chatResumeRestorationRequest = nil
         invalidateReconciliation()
-        reconnectTask?.cancel()
-        reconnectTask = nil
         scenePhaseTask?.cancel()
         client?.disconnect()
         isConnected = false
@@ -1000,8 +1046,6 @@ final class AppState: ObservableObject {
         cancelChatResumeRestoration()
         invalidateReconciliation()
         cancelSecondaryProfileTitleRecovery()
-        reconnectTask?.cancel()
-        reconnectTask = nil
         client?.disconnect()
         client = nil
         isConnected = false
@@ -1203,6 +1247,7 @@ final class AppState: ObservableObject {
     func settleReconciliationAndPublish(_ token: UUID) -> Bool {
         guard settleReconciliation(token) else { return false }
         publishChatResumeRestorationIfReady()
+        cancelScheduledReconnect()
         recoverySequence.complete()
         return true
     }
@@ -1566,7 +1611,7 @@ final class AppState: ObservableObject {
         )
     }
 
-    private func scheduleReconnect(
+    func scheduleReconnect(
         immediately: Bool = false,
         purpose: ChatResumeSyncPurpose = .preserveCurrent
     ) {
@@ -1579,7 +1624,7 @@ final class AppState: ObservableObject {
         case .keepExisting:
             return
         case .replace:
-            reconnectTask?.cancel()
+            reconnectTask?()
             reconnectTask = nil
         case .schedule:
             break
@@ -1587,25 +1632,29 @@ final class AppState: ObservableObject {
         let delay = immediately ? 0.1 : min(5.0, pow(2.0, Double(reconnectAttempts)))
         if !immediately { reconnectAttempts += 1 }
 
-        reconnectTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
-            guard !Task.isCancelled, let self else { return }
+        reconnectTask = reconnectScheduler(delay) { [weak self] in
+            guard let self else { return }
             self.reconnectTask = nil
             let purpose = self.recoverySequence.takeQueuedReconnectPurpose()
                 ?? .preserveCurrent
-            await self.reconnect(purpose: purpose)
+            if let scheduledReconnectExecutor = self.scheduledReconnectExecutor {
+                await scheduledReconnectExecutor(purpose)
+            } else {
+                await self.reconnectForRetry(purpose: purpose)
+            }
         }
     }
 
-    func reconnect(
-        purpose: ChatResumeSyncPurpose = .preserveCurrent
-    ) async {
+    func reconnect() async {
+        cancelChatResumeRestoration()
+        await reconnectForRetry(purpose: .preserveCurrent)
+    }
+
+    private func reconnectForRetry(purpose requestedPurpose: ChatResumeSyncPurpose) async {
         guard let savedConnection = connection else { return }
-        let purpose = beginChatResumeRecovery(purpose: purpose)
+        let purpose = beginChatResumeRecovery(purpose: requestedPurpose)
         if purpose == .automaticReturn, reconnectTask != nil {
-            reconnectTask?.cancel()
-            reconnectTask = nil
-            recoverySequence.clearQueuedReconnect()
+            cancelScheduledReconnect()
         }
         isConnecting = true
         turnState = .reconnecting
@@ -1696,11 +1745,11 @@ final class AppState: ObservableObject {
                         try await client.healthCheck()
                         await self.syncSession(purpose: .automaticReturn, using: token)
                     } catch {
-                        await self.reconnect(purpose: .automaticReturn)
+                        await self.reconnectForRetry(purpose: .automaticReturn)
                         self.settleReconciliation(token)
                     }
                 } else {
-                    await self.reconnect(purpose: .automaticReturn)
+                    await self.reconnectForRetry(purpose: .automaticReturn)
                     self.settleReconciliation(token)
                 }
             }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2872,7 +2872,7 @@ final class AppState: ObservableObject {
             if sessionCatalogLoaderOverride == nil {
                 guard let activeClient, self.client === activeClient else { return false }
             }
-            requiredViewportTransitionGeneration.map {
+            guard requiredViewportTransitionGeneration.map {
                 chatViewportTransitionIsCurrent(generation: $0)
             } ?? true else { return false }
             let allSessions = uniqueSessions(
@@ -2892,7 +2892,7 @@ final class AppState: ObservableObject {
             if sessionCatalogLoaderOverride == nil {
                 guard let activeClient, self.client === activeClient else { return false }
             }
-            requiredViewportTransitionGeneration.map {
+            guard requiredViewportTransitionGeneration.map {
                 chatViewportTransitionIsCurrent(generation: $0)
             } ?? true else { return false }
             errorMessage = "Failed to load sessions: \(error.localizedDescription)"

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -329,6 +329,7 @@ final class AppState: ObservableObject {
     private struct Reconciliation {
         let token: UUID
         let requestedSessionId: String
+        var automaticSyncOperationID: UUID?
         var resolvedSessionId: String?
         var acceptedSessionIDs: Set<String>
         let acceptsAnySession: Bool
@@ -337,12 +338,14 @@ final class AppState: ObservableObject {
         init(
             token: UUID,
             requestedSessionId: String,
+            automaticSyncOperationID: UUID? = nil,
             acceptedSessionIDs: Set<String> = [],
             acceptsAnySession: Bool = false,
             bufferedEvents: [StreamEvent] = []
         ) {
             self.token = token
             self.requestedSessionId = requestedSessionId
+            self.automaticSyncOperationID = automaticSyncOperationID
             self.acceptedSessionIDs = acceptedSessionIDs
             self.acceptsAnySession = acceptsAnySession
             self.bufferedEvents = bufferedEvents
@@ -410,6 +413,7 @@ final class AppState: ObservableObject {
     }
 
     private var chatViewportTransition: ChatViewportTransition?
+    private var activeNotificationOpenAttemptID: UUID?
     private var activeAutomaticSyncOperation: AutomaticSyncOperation?
     private var activeAutomaticReconnectOperation: AutomaticReconnectOperation?
     private var reconnectTask: ChatResumeReconnectCancellation?
@@ -1457,9 +1461,19 @@ final class AppState: ObservableObject {
                 )
             )
         }
+        if let existingReconciliationToken,
+           !claimReconciliation(
+            existingReconciliationToken,
+            automaticSyncOperationID: automaticOperationID
+           ) {
+            return
+        }
         guard let client else {
             if let existingReconciliationToken {
-                settleReconciliation(existingReconciliationToken)
+                settleReconciliation(
+                    existingReconciliationToken,
+                    automaticSyncOperationID: automaticOperationID
+                )
             }
             return
         }
@@ -1469,11 +1483,18 @@ final class AppState: ObservableObject {
         guard PushNotificationService.shared.pendingTarget == nil else {
             cancelChatResumeRestoration()
             if let existingReconciliationToken {
-                settleReconciliation(existingReconciliationToken)
+                settleReconciliation(
+                    existingReconciliationToken,
+                    automaticSyncOperationID: automaticOperationID
+                )
             }
             return
         }
         let token = existingReconciliationToken ?? beginReconciliation()
+        guard claimReconciliation(
+            token,
+            automaticSyncOperationID: automaticOperationID
+        ) else { return }
         let profile = activeProfile
         let retainedActiveTurn = activeTurnCatalogSession()
         turnState = .synchronizing
@@ -1496,19 +1517,28 @@ final class AppState: ObservableObject {
                   profile == activeProfile,
                   let activeClient = self.client,
                   activeClient === client else {
-                settleReconciliation(token)
+                settleReconciliation(
+                    token,
+                    automaticSyncOperationID: automaticOperationID
+                )
                 return
             }
             guard PushNotificationService.shared.pendingTarget == nil else {
                 cancelChatResumeRestoration()
-                settleReconciliation(token)
+                settleReconciliation(
+                    token,
+                    automaticSyncOperationID: automaticOperationID
+                )
                 return
             }
             guard automaticChatResumeWorkIsCurrent(
                 automaticWorkToken,
                 syncOperationID: automaticOperationID
             ), chatViewportTransitionIsCurrent(requiredViewportTransitionGeneration) else {
-                settleReconciliation(token)
+                settleReconciliation(
+                    token,
+                    automaticSyncOperationID: automaticOperationID
+                )
                 return
             }
             sessions = allSessions.filter { $0.source != .cron }
@@ -1518,7 +1548,10 @@ final class AppState: ObservableObject {
                 automaticWorkToken,
                 syncOperationID: automaticOperationID
             ), chatViewportTransitionIsCurrent(requiredViewportTransitionGeneration) else {
-                settleReconciliation(token)
+                settleReconciliation(
+                    token,
+                    automaticSyncOperationID: automaticOperationID
+                )
                 return
             }
             let target = selectChatResumeTarget(
@@ -1570,12 +1603,18 @@ final class AppState: ObservableObject {
                   profile == activeProfile,
                   let activeClient = self.client,
                   activeClient === client else {
-                settleReconciliation(token)
+                settleReconciliation(
+                    token,
+                    automaticSyncOperationID: automaticOperationID
+                )
                 return
             }
             turnState = .reconnecting
             errorMessage = "Failed to load gateway sessions: \(error.localizedDescription)"
-            settleReconciliation(token)
+            settleReconciliation(
+                token,
+                automaticSyncOperationID: automaticOperationID
+            )
             if purpose == .automaticReturn {
                 scheduleReconnect(purpose: purpose)
             }
@@ -1607,8 +1646,27 @@ final class AppState: ObservableObject {
     }
 
     @discardableResult
-    private func settleReconciliation(_ token: UUID) -> Bool {
-        guard token == reconciliationToken else { return false }
+    private func claimReconciliation(
+        _ token: UUID,
+        automaticSyncOperationID: UUID?
+    ) -> Bool {
+        guard token == reconciliationToken,
+              var reconciliation else { return false }
+        reconciliation.automaticSyncOperationID = automaticSyncOperationID
+        self.reconciliation = reconciliation
+        return true
+    }
+
+    @discardableResult
+    private func settleReconciliation(
+        _ token: UUID,
+        automaticSyncOperationID: UUID? = nil
+    ) -> Bool {
+        guard token == reconciliationToken,
+              let activeReconciliation = reconciliation,
+              activeReconciliation.automaticSyncOperationID == automaticSyncOperationID else {
+            return false
+        }
         let wasReconciling = activeChatScrollSessionIdentity.isReconciling
         reconciliation = nil
         refreshActiveChatScrollSessionIdentity(
@@ -1683,10 +1741,16 @@ final class AppState: ObservableObject {
             automaticWorkToken,
             syncOperationID: automaticSyncOperationID
         ) else {
-            settleReconciliation(token)
+            settleReconciliation(
+                token,
+                automaticSyncOperationID: automaticSyncOperationID
+            )
             return false
         }
-        guard settleReconciliation(token) else { return false }
+        guard settleReconciliation(
+            token,
+            automaticSyncOperationID: automaticSyncOperationID
+        ) else { return false }
         guard automaticChatResumeWorkIsCurrent(
             automaticWorkToken,
             syncOperationID: automaticSyncOperationID
@@ -1725,6 +1789,7 @@ final class AppState: ObservableObject {
         reconciliation = Reconciliation(
             token: token,
             requestedSessionId: sessionId,
+            automaticSyncOperationID: automaticSyncOperationID,
             acceptedSessionIDs: acceptedSessionIDs.union([sessionId]),
             bufferedEvents: bufferedEvents
         )
@@ -1759,7 +1824,7 @@ final class AppState: ObservableObject {
                   profile == activeProfile,
                   let activeClient = self.client,
                   activeClient === client else {
-                settleReconciliation(token)
+                settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
                 return false
             }
 
@@ -1809,7 +1874,7 @@ final class AppState: ObservableObject {
                 automaticWorkToken: automaticWorkToken,
                 automaticSyncOperationID: automaticSyncOperationID
             ) else {
-                settleReconciliation(token)
+                settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
                 return false
             }
             await refreshChatResumeContext(sessionId: result.sessionId, using: client)
@@ -1823,7 +1888,7 @@ final class AppState: ObservableObject {
                   profile == activeProfile,
                   let activeClient = self.client,
                   activeClient === client else {
-                settleReconciliation(token)
+                settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
                 return false
             }
 
@@ -1849,12 +1914,12 @@ final class AppState: ObservableObject {
                   profile == activeProfile,
                   let activeClient = self.client,
                   activeClient === client else {
-                settleReconciliation(token)
+                settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
                 return false
             }
             turnState = .reconnecting
             errorMessage = "Failed to restore this conversation: \(error.localizedDescription)"
-            settleReconciliation(token)
+            settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
             return false
         }
     }
@@ -1909,14 +1974,14 @@ final class AppState: ObservableObject {
                   profile == activeProfile,
                   let activeClient = self.client,
                   activeClient === client else {
-                settleReconciliation(token)
+                settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
                 return
             }
             if let returnedProfile = created.profile,
                !profilesMatch(returnedProfile, profile) {
                 turnState = .idle
                 errorMessage = "Hermes created this conversation in \(profileDisplayName(returnedProfile)), not \(profileDisplayName(profile)). It was not opened."
-                settleReconciliation(token)
+                settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
                 await loadSessions(forceRefresh: true)
                 return
             }
@@ -1924,7 +1989,7 @@ final class AppState: ObservableObject {
             guard !runtimeSessionID.isEmpty else {
                 turnState = .idle
                 errorMessage = "Hermes created a conversation without a session ID."
-                settleReconciliation(token)
+                settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
                 return
             }
 
@@ -1995,12 +2060,12 @@ final class AppState: ObservableObject {
                   profile == activeProfile,
                   let activeClient = self.client,
                   activeClient === client else {
-                settleReconciliation(token)
+                settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
                 return
             }
             turnState = .idle
             errorMessage = "Failed to create session: \(error.localizedDescription)"
-            settleReconciliation(token)
+            settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
             if resumePurpose == .automaticReturn {
                 scheduleReconnect(purpose: resumePurpose)
             }
@@ -2826,12 +2891,18 @@ final class AppState: ObservableObject {
     /// allowing the ordinary cold-start session restoration to win first.
     func openNotificationTarget(_ target: ConduitNotificationTarget) async -> Bool {
         guard connection != nil else { return false }
+        let notificationAttemptID = UUID()
+        activeNotificationOpenAttemptID = notificationAttemptID
+        isOpeningNotificationSession = true
         let transitionGeneration = beginExplicitChatViewportTransition()
         defer {
             cancelChatViewportTransitionIfNoReplacement(generation: transitionGeneration)
+            finishNotificationOpenAttempt(id: notificationAttemptID)
         }
-        isOpeningNotificationSession = true
-        defer { isOpeningNotificationSession = false }
+        guard notificationOpenAttemptIsCurrent(
+            id: notificationAttemptID,
+            transitionGeneration: transitionGeneration
+        ) else { return false }
         let targetProfile = notificationProfileID(target.profile)
         if let targetProfile, targetProfile != activeProfile {
             guard await switchProfile(
@@ -2839,7 +2910,10 @@ final class AppState: ObservableObject {
                 reusing: transitionGeneration
             ) else { return false }
         }
-        guard chatViewportTransitionIsCurrent(generation: transitionGeneration) else {
+        guard notificationOpenAttemptIsCurrent(
+            id: notificationAttemptID,
+            transitionGeneration: transitionGeneration
+        ) else {
             return false
         }
         if let targetProfile, activeProfile != targetProfile { return false }
@@ -2858,17 +2932,39 @@ final class AppState: ObservableObject {
             forceRefresh: true,
             requiredViewportTransitionGeneration: transitionGeneration
         ) else { return false }
-        guard chatViewportTransitionIsCurrent(generation: transitionGeneration) else {
+        guard notificationOpenAttemptIsCurrent(
+            id: notificationAttemptID,
+            transitionGeneration: transitionGeneration
+        ) else {
             return false
         }
         let requestedID = target.sessionId
         let matchingSession = (sessions + cronSessions).first { session in
             session.id == requestedID || session.alternateIds.contains(requestedID)
         }
-        return await openSession(
+        let opened = await openSession(
             matchingSession?.id ?? requestedID,
             reusing: transitionGeneration
         )
+        guard notificationOpenAttemptIsCurrent(
+            id: notificationAttemptID,
+            transitionGeneration: transitionGeneration
+        ) else { return false }
+        return opened
+    }
+
+    private func notificationOpenAttemptIsCurrent(
+        id: UUID,
+        transitionGeneration: UInt64
+    ) -> Bool {
+        activeNotificationOpenAttemptID == id
+            && chatViewportTransitionIsCurrent(generation: transitionGeneration)
+    }
+
+    private func finishNotificationOpenAttempt(id: UUID) {
+        guard activeNotificationOpenAttemptID == id else { return }
+        activeNotificationOpenAttemptID = nil
+        isOpeningNotificationSession = false
     }
 
     private func notificationProfileID(_ notifiedProfile: String?) -> String? {
@@ -2954,6 +3050,10 @@ final class AppState: ObservableObject {
         let profile = activeProfile
         turnState = .synchronizing
         let title = "Branch of \(activeSessionTitle)"
+        let transitionGeneration = acceptChatResumeConversationReplacement(.branch)
+        defer {
+            cancelChatViewportTransitionIfNoReplacement(generation: transitionGeneration)
+        }
 
         do {
             let branched: ChatResumeLifecycleOperations.BranchResult
@@ -2973,24 +3073,29 @@ final class AppState: ObservableObject {
                     cwd: runtime.cwd
                 )
             }
-            guard profile == activeProfile, self.client === client else { return }
+            guard chatViewportTransitionIsCurrent(generation: transitionGeneration),
+                  profile == activeProfile,
+                  self.client === client else { return }
             if let returnedProfile = branched.profile,
                !profilesMatch(returnedProfile, profile) {
                 turnState = previousTurnState
                 errorMessage = "Hermes created this branch in \(profileDisplayName(returnedProfile)), not \(profileDisplayName(profile)). It was not opened."
-                await loadSessions(forceRefresh: true)
+                guard await loadSessions(
+                    forceRefresh: true,
+                    requiredViewportTransitionGeneration: transitionGeneration
+                ), chatViewportTransitionIsCurrent(
+                    generation: transitionGeneration
+                ) else { return }
                 return
             }
-            let transitionGeneration = acceptChatResumeConversationReplacement(.branch)
             if let setSessionTitle = chatResumeLifecycleOperations.setSessionTitle {
                 try? await setSessionTitle(client, branched.sessionId, title)
             } else {
                 try? await client.setSessionTitle(branched.sessionId, title: title)
             }
-            guard profile == activeProfile, self.client === client else {
-                finishChatViewportTransition(generation: transitionGeneration)
-                return
-            }
+            guard chatViewportTransitionIsCurrent(generation: transitionGeneration),
+                  profile == activeProfile,
+                  self.client === client else { return }
 
             let summary = SessionSummary(
                 id: branched.storedSessionId ?? branched.sessionId,
@@ -3021,12 +3126,25 @@ final class AppState: ObservableObject {
                 acceptedSessionIDs: knownSessionIDs(for: branched.sessionId),
                 requiredViewportTransitionGeneration: transitionGeneration
             )
+            guard chatViewportTransitionIsCurrent(generation: transitionGeneration),
+                  profile == activeProfile,
+                  self.client === client else { return }
+            let loadedFinalCatalog = await loadSessions(
+                forceRefresh: false,
+                requiredViewportTransitionGeneration: transitionGeneration
+            )
+            guard chatViewportTransitionIsCurrent(generation: transitionGeneration),
+                  profile == activeProfile,
+                  self.client === client else { return }
             if !reconciled {
                 finishChatViewportTransition(generation: transitionGeneration)
+                return
             }
-            await loadSessions()
+            guard loadedFinalCatalog else { return }
         } catch {
-            guard profile == activeProfile, self.client === client else { return }
+            guard chatViewportTransitionIsCurrent(generation: transitionGeneration),
+                  profile == activeProfile,
+                  self.client === client else { return }
             turnState = previousTurnState
             errorMessage = "Could not branch conversation: \(error.localizedDescription)"
         }
@@ -4898,7 +5016,7 @@ final class AppState: ObservableObject {
 
     // MARK: - Stream event handling
 
-    private func handleStreamEvent(_ event: StreamEvent) {
+    func handleStreamEvent(_ event: StreamEvent) {
         if case .sessionTitle(let runtimeSessionId, let storedSessionId, let title) = event {
             let taskKey = "\(activeProfile)|\(runtimeSessionId)"
             sessionTitleRecoveryTracker.cancel(taskKey)

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -16,6 +16,7 @@ private let sessionCatalogLog = Logger(subsystem: "com.milim.conduit", category:
 private let titleGenerationLog = Logger(subsystem: "com.milim.conduit", category: "TitleGeneration")
 
 typealias ChatResumeReconnectCancellation = @MainActor () -> Void
+typealias ChatResumeReconnectExecutor = @MainActor (ChatResumeSyncPurpose) async -> Void
 typealias ChatResumeReconnectScheduler = @MainActor (
     _ delay: TimeInterval,
     _ operation: @escaping @MainActor () async -> Void
@@ -338,7 +339,7 @@ final class AppState: ObservableObject {
     private var scenePhaseTask: Task<Void, Never>?
     private var reconnectTask: ChatResumeReconnectCancellation?
     private let reconnectScheduler: ChatResumeReconnectScheduler
-    private let scheduledReconnectExecutor: (@MainActor (ChatResumeSyncPurpose) async -> Void)?
+    private let reconnectExecutor: ChatResumeReconnectExecutor?
     /// Coalesces presentation-cache flushes during streaming so we
     /// don't serialize and write UserDefaults on every WebSocket frame.
     private var presentationCacheFlushTask: Task<Void, Never>?
@@ -493,7 +494,7 @@ final class AppState: ObservableObject {
         sessionRenameOperations: SessionRenameOperation.Operations? = nil,
         sessionCatalogLoader: ((Bool) async throws -> [SessionSummary])? = nil,
         reconnectScheduler: ChatResumeReconnectScheduler? = nil,
-        scheduledReconnectExecutor: (@MainActor (ChatResumeSyncPurpose) async -> Void)? = nil
+        reconnectExecutor: ChatResumeReconnectExecutor? = nil
     ) {
         self.defaults = defaults
         self.chatResumeCoordinator = chatResumeCoordinator
@@ -503,7 +504,7 @@ final class AppState: ObservableObject {
         sessionRenameOperationsOverride = sessionRenameOperations
         sessionCatalogLoaderOverride = sessionCatalogLoader
         self.reconnectScheduler = reconnectScheduler ?? scheduleChatResumeReconnectTask
-        self.scheduledReconnectExecutor = scheduledReconnectExecutor
+        self.reconnectExecutor = reconnectExecutor
         self.initialChatResumeServerIdentity = defaults
             .string(forKey: "conduit.chatResumeServerIdentity.v1")
             .flatMap(Self.normalizedChatResumeServerIdentity)
@@ -1637,17 +1638,21 @@ final class AppState: ObservableObject {
             self.reconnectTask = nil
             let purpose = self.recoverySequence.takeQueuedReconnectPurpose()
                 ?? .preserveCurrent
-            if let scheduledReconnectExecutor = self.scheduledReconnectExecutor {
-                await scheduledReconnectExecutor(purpose)
-            } else {
-                await self.reconnectForRetry(purpose: purpose)
-            }
+            await self.executeReconnect(purpose: purpose)
         }
     }
 
     func reconnect() async {
         cancelChatResumeRestoration()
-        await reconnectForRetry(purpose: .preserveCurrent)
+        await executeReconnect(purpose: .preserveCurrent)
+    }
+
+    private func executeReconnect(purpose: ChatResumeSyncPurpose) async {
+        if let reconnectExecutor {
+            await reconnectExecutor(purpose)
+        } else {
+            await reconnectForRetry(purpose: purpose)
+        }
     }
 
     private func reconnectForRetry(purpose requestedPurpose: ChatResumeSyncPurpose) async {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -25,6 +25,7 @@ typealias ChatResumeReconnectScheduler = @MainActor (
 struct ChatResumeLifecycleOperations {
     typealias BranchResult = (sessionId: String, storedSessionId: String?, profile: String?)
 
+    var connectClient: (@MainActor (HermesClient) async throws -> Void)?
     var loadCatalog: (@MainActor (HermesClient, Bool) async throws -> [SessionSummary])?
     var mintTicket: (@MainActor (String) async throws -> String)?
     var openSession: (@MainActor (HermesClient, String) async throws -> SessionResumeResult)?
@@ -37,8 +38,25 @@ struct ChatResumeLifecycleOperations {
     ) async throws -> BranchResult)?
     var setSessionTitle: (@MainActor (HermesClient, String, String) async throws -> Void)?
     var refreshContext: (@MainActor (HermesClient, String) async -> Void)?
+    var sendPrompt: (@MainActor (HermesClient, String, String) async throws -> Void)?
+    var steer: (@MainActor (HermesClient, String, String) async throws -> Void)?
+    var redirect: (@MainActor (
+        HermesClient,
+        String,
+        String
+    ) async throws -> SessionRedirectOutcome)?
+    var interrupt: (@MainActor (HermesClient, String) async throws -> Void)?
+    var executeSlash: (@MainActor (HermesClient, String, String) async throws -> AnyCodable)?
+    var dispatchCommand: (@MainActor (
+        HermesClient,
+        String,
+        String,
+        String
+    ) async throws -> AnyCodable)?
+    var setBusyInputMode: (@MainActor (HermesClient, BusyInputMode) async throws -> Void)?
 
     init(
+        connectClient: (@MainActor (HermesClient) async throws -> Void)? = nil,
         loadCatalog: (@MainActor (HermesClient, Bool) async throws -> [SessionSummary])? = nil,
         mintTicket: (@MainActor (String) async throws -> String)? = nil,
         openSession: (@MainActor (HermesClient, String) async throws -> SessionResumeResult)? = nil,
@@ -50,14 +68,38 @@ struct ChatResumeLifecycleOperations {
             String?
         ) async throws -> BranchResult)? = nil,
         setSessionTitle: (@MainActor (HermesClient, String, String) async throws -> Void)? = nil,
-        refreshContext: (@MainActor (HermesClient, String) async -> Void)? = nil
+        refreshContext: (@MainActor (HermesClient, String) async -> Void)? = nil,
+        sendPrompt: (@MainActor (HermesClient, String, String) async throws -> Void)? = nil,
+        steer: (@MainActor (HermesClient, String, String) async throws -> Void)? = nil,
+        redirect: (@MainActor (
+            HermesClient,
+            String,
+            String
+        ) async throws -> SessionRedirectOutcome)? = nil,
+        interrupt: (@MainActor (HermesClient, String) async throws -> Void)? = nil,
+        executeSlash: (@MainActor (HermesClient, String, String) async throws -> AnyCodable)? = nil,
+        dispatchCommand: (@MainActor (
+            HermesClient,
+            String,
+            String,
+            String
+        ) async throws -> AnyCodable)? = nil,
+        setBusyInputMode: (@MainActor (HermesClient, BusyInputMode) async throws -> Void)? = nil
     ) {
+        self.connectClient = connectClient
         self.loadCatalog = loadCatalog
         self.mintTicket = mintTicket
         self.openSession = openSession
         self.branchSession = branchSession
         self.setSessionTitle = setSessionTitle
         self.refreshContext = refreshContext
+        self.sendPrompt = sendPrompt
+        self.steer = steer
+        self.redirect = redirect
+        self.interrupt = interrupt
+        self.executeSlash = executeSlash
+        self.dispatchCommand = dispatchCommand
+        self.setBusyInputMode = setBusyInputMode
     }
 
     static let live = ChatResumeLifecycleOperations()
@@ -126,6 +168,13 @@ final class ChatResumeRecoverySequence {
 
     func clearQueuedReconnect() {
         queuedReconnectPurpose = nil
+    }
+
+    func preserveTransportAfterAutomaticIntentCancellation() {
+        currentPurpose = .preserveCurrent
+        if queuedReconnectPurpose != nil {
+            queuedReconnectPurpose = .preserveCurrent
+        }
     }
 
     func complete() {
@@ -392,7 +441,7 @@ final class AppState: ObservableObject {
     private var activeAutomaticChatResumeWork: ChatResumeAutomaticWorkToken?
     private var chatViewportSnapshotProvider: (
         id: UUID,
-        snapshot: @MainActor () -> ChatScrollSnapshot?
+        capture: @MainActor () -> ChatRenderedViewportSnapshot?
     )?
     private struct ChatViewportTransition {
         let generation: UInt64
@@ -703,11 +752,10 @@ final class AppState: ObservableObject {
     }
 
     func setChatResumeBehavior(_ behavior: ChatResumeBehavior) {
-        cancelScheduledReconnect()
         chatResumeCoordinator.setBehavior(behavior)
-        cancelOwnedAutomaticOperations()
+        cancelOwnedAutomaticSyncOperation()
         activeAutomaticChatResumeWork = nil
-        recoverySequence.cancel()
+        recoverySequence.preserveTransportAfterAutomaticIntentCancellation()
         chatResumeBehavior = chatResumeCoordinator.behavior
         chatResumeRestorationRequest = nil
     }
@@ -718,9 +766,9 @@ final class AppState: ObservableObject {
 
     func installChatViewportSnapshotProvider(
         id: UUID,
-        snapshot: @escaping @MainActor () -> ChatScrollSnapshot?
+        capture: @escaping @MainActor () -> ChatRenderedViewportSnapshot?
     ) {
-        chatViewportSnapshotProvider = (id, snapshot)
+        chatViewportSnapshotProvider = (id, capture)
     }
 
     func removeChatViewportSnapshotProvider(id: UUID) {
@@ -733,10 +781,10 @@ final class AppState: ObservableObject {
         if let transition = chatViewportTransition {
             finishChatViewportTransition(generation: transition.generation)
         }
-        let snapshot = chatViewportSnapshotProvider?.snapshot()
+        let renderedViewport = chatViewportSnapshotProvider?.capture()
         chatResumeCoordinator.captureViewportAndFreeze(
-            snapshot,
-            for: currentChatScrollSessionKey
+            renderedViewport?.snapshot,
+            for: renderedViewport?.sessionKey
         )
         chatViewportTransitionGeneration &+= 1
         chatViewportTransition = ChatViewportTransition(
@@ -892,9 +940,43 @@ final class AppState: ObservableObject {
         return true
     }
 
+    private func transportContinuation(
+        purpose: ChatResumeSyncPurpose,
+        automaticWorkToken: ChatResumeAutomaticWorkToken?,
+        automaticReconnectOperationID: UUID?
+    ) -> (
+        purpose: ChatResumeSyncPurpose,
+        automaticWorkToken: ChatResumeAutomaticWorkToken?,
+        handedOffAutomaticIntent: Bool
+    )? {
+        guard !Task.isCancelled else { return nil }
+        if let automaticReconnectOperationID,
+           activeAutomaticReconnectOperation?.id != automaticReconnectOperationID {
+            return nil
+        }
+        guard let automaticWorkToken else {
+            return (purpose, nil, false)
+        }
+        if chatResumeCoordinator.isCurrent(automaticWorkToken) {
+            return (purpose, automaticWorkToken, false)
+        }
+        guard purpose == .automaticReturn else { return nil }
+        return (.preserveCurrent, nil, true)
+    }
+
     func cancelChatResumeRestoration() {
+        chatResumeCoordinator.cancelViewportRestoration(
+            keepViewportFrozen: chatViewportTransition != nil
+        )
+        cancelOwnedAutomaticSyncOperation()
+        activeAutomaticChatResumeWork = nil
+        recoverySequence.preserveTransportAfterAutomaticIntentCancellation()
+        chatResumeRestorationRequest = nil
+    }
+
+    private func cancelChatResumeTransportRecovery() {
         cancelScheduledReconnect()
-        chatResumeCoordinator.cancelRestoration(
+        chatResumeCoordinator.cancelViewportRestoration(
             keepViewportFrozen: chatViewportTransition != nil
         )
         cancelOwnedAutomaticOperations()
@@ -955,12 +1037,20 @@ final class AppState: ObservableObject {
     }
 
     private func cancelOwnedAutomaticOperations() {
+        cancelOwnedAutomaticSyncOperation()
+        cancelOwnedAutomaticReconnectOperation()
+    }
+
+    private func cancelOwnedAutomaticSyncOperation() {
         if let operation = activeAutomaticSyncOperation {
             if turnState == .synchronizing {
                 turnState = operation.previousTurnState
             }
             activeAutomaticSyncOperation = nil
         }
+    }
+
+    private func cancelOwnedAutomaticReconnectOperation() {
         if let operation = activeAutomaticReconnectOperation {
             if isConnecting {
                 isConnecting = operation.previousIsConnecting
@@ -1038,7 +1128,8 @@ final class AppState: ObservableObject {
         advanceSettledRevision: Bool = false
     ) {
         let current = activeChatScrollSessionIdentity
-        let catalog = (sessions + cronSessions).map { session in
+        let sessionCatalog = sessions + cronSessions
+        let identityCatalog = sessionCatalog.map { session in
             ChatScrollSessionCatalogIdentity(
                 profile: session.profile ?? activeProfile,
                 canonicalSessionID: session.id,
@@ -1048,7 +1139,7 @@ final class AppState: ObservableObject {
         let updated = ChatScrollSessionIdentityResolver.resolve(
             profile: activeProfile,
             activeSessionID: activeSessionId,
-            catalog: catalog,
+            catalog: identityCatalog,
             requestedSessionID: reconciliation?.requestedSessionId,
             resolvedSessionID: reconciliation?.resolvedSessionId,
             previousIdentity: current,
@@ -1056,8 +1147,54 @@ final class AppState: ObservableObject {
             advanceSettledRevision: advanceSettledRevision
         )
         if updated != current {
+            migrateChatResumePersistenceIfNeeded(
+                from: current,
+                to: updated,
+                catalog: sessionCatalog
+            )
             activeChatScrollSessionIdentity = updated
         }
+    }
+
+    private func migrateChatResumePersistenceIfNeeded(
+        from current: ChatScrollSessionIdentity,
+        to updated: ChatScrollSessionIdentity,
+        catalog: [SessionSummary]
+    ) {
+        guard let canonicalKey = updated.canonicalSessionKey,
+              let canonicalSession = catalog.first(where: { session in
+                  let profile = session.profile ?? canonicalKey.profile
+                  return ChatScrollSessionKey(
+                      profile: profile,
+                      sessionID: session.id
+                  ) == canonicalKey
+              }) else { return }
+
+        let equivalentSessionIDs = Set(
+            ([canonicalSession.id] + canonicalSession.alternateIds).compactMap { sessionID in
+                let key = ChatScrollSessionKey(
+                    profile: canonicalKey.profile,
+                    sessionID: sessionID
+                )
+                return key.isValid ? key.sessionID : nil
+            }
+        )
+
+        let persistedKey = chatResumeCoordinator
+            .lastSessionID(for: canonicalKey.profile)
+            .map { ChatScrollSessionKey(profile: canonicalKey.profile, sessionID: $0) }
+        let activeKey = activeSessionId.map {
+            ChatScrollSessionKey(profile: canonicalKey.profile, sessionID: $0)
+        }
+        let candidates = [persistedKey, current.canonicalSessionKey, activeKey]
+            .compactMap { $0 }
+        guard let runtimeKey = candidates.first(where: {
+            $0 != canonicalKey
+                && $0.profile == canonicalKey.profile
+                && equivalentSessionIDs.contains($0.sessionID)
+        }) else { return }
+
+        chatResumeCoordinator.migrateSessionIdentity(from: runtimeKey, to: canonicalKey)
     }
 
     func makeSettingsSnapshot() -> SettingsSnapshot {
@@ -1209,7 +1346,7 @@ final class AppState: ObservableObject {
         automaticReconnectOperationID: UUID? = nil
     ) async {
         if cancelsResumeRestoration {
-            cancelChatResumeRestoration()
+            cancelChatResumeTransportRecovery()
         }
         guard let normalizedBaseURL = try? ConnectionURLPolicy.normalizedBaseURL(conn.baseUrl) else {
             isConnecting = false
@@ -1222,9 +1359,27 @@ final class AppState: ObservableObject {
         let automaticWorkToken = syncPurpose == .automaticReturn
             ? (existingAutomaticWorkToken ?? beginAutomaticChatResumeWork())
             : nil
+        let ownedAutomaticReconnectOperationID = automaticReconnectOperationID == nil
+            ? beginAutomaticReconnectOperation(for: automaticWorkToken)
+            : nil
+        let transportOperationID = automaticReconnectOperationID
+            ?? ownedAutomaticReconnectOperationID
+        var handedOffAutomaticIntent = false
+        defer {
+            if ownedAutomaticReconnectOperationID != nil {
+                finishAutomaticReconnectOperation(
+                    id: ownedAutomaticReconnectOperationID,
+                    restoringBaseline: !handedOffAutomaticIntent
+                        && !automaticChatResumeWorkIsCurrent(
+                            automaticWorkToken,
+                            reconnectOperationID: transportOperationID
+                        )
+                )
+            }
+        }
         guard automaticChatResumeWorkIsCurrent(
             automaticWorkToken,
-            reconnectOperationID: automaticReconnectOperationID
+            reconnectOperationID: transportOperationID
         ) else { return }
         rememberDashboardURL(conn.baseUrl)
         cancelScheduledReconnect()
@@ -1250,12 +1405,16 @@ final class AppState: ObservableObject {
         previousClient?.disconnect()
 
         do {
-            try await client.connect()
-            guard automaticChatResumeWorkIsCurrent(
-                    automaticWorkToken,
-                    reconnectOperationID: automaticReconnectOperationID
+            try await connectChatResumeClient(client)
+            guard let continuation = transportContinuation(
+                    purpose: syncPurpose,
+                    automaticWorkToken: automaticWorkToken,
+                    automaticReconnectOperationID: transportOperationID
                   ),
                   let activeClient = self.client, activeClient === client else { return }
+            var continuationPurpose = continuation.purpose
+            var continuationAutomaticWorkToken = continuation.automaticWorkToken
+            handedOffAutomaticIntent = continuation.handedOffAutomaticIntent
             isConnected = true
             isConnecting = false
             reconnectAttempts = 0
@@ -1263,38 +1422,58 @@ final class AppState: ObservableObject {
             KeychainHelper.saveConnection(conn)
 
             await loadProfiles()
-            guard automaticChatResumeWorkIsCurrent(
-                automaticWorkToken,
-                reconnectOperationID: automaticReconnectOperationID
+            guard let continuation = transportContinuation(
+                purpose: continuationPurpose,
+                automaticWorkToken: continuationAutomaticWorkToken,
+                automaticReconnectOperationID: transportOperationID
             ) else { return }
+            continuationPurpose = continuation.purpose
+            continuationAutomaticWorkToken = continuation.automaticWorkToken
+            handedOffAutomaticIntent = handedOffAutomaticIntent
+                || continuation.handedOffAutomaticIntent
             await syncSession(
-                purpose: syncPurpose,
+                purpose: continuationPurpose,
                 using: nil,
-                automaticWorkToken: automaticWorkToken
+                automaticWorkToken: continuationAutomaticWorkToken
             )
-            guard automaticChatResumeWorkIsCurrent(
-                    automaticWorkToken,
-                    reconnectOperationID: automaticReconnectOperationID
+            guard let continuation = transportContinuation(
+                    purpose: continuationPurpose,
+                    automaticWorkToken: continuationAutomaticWorkToken,
+                    automaticReconnectOperationID: transportOperationID
                   ),
                   let activeClient = self.client, activeClient === client else { return }
+            continuationPurpose = continuation.purpose
+            continuationAutomaticWorkToken = continuation.automaticWorkToken
+            handedOffAutomaticIntent = handedOffAutomaticIntent
+                || continuation.handedOffAutomaticIntent
             await loadBusyInputMode(using: client)
-            guard automaticChatResumeWorkIsCurrent(
-                    automaticWorkToken,
-                    reconnectOperationID: automaticReconnectOperationID
+            guard let continuation = transportContinuation(
+                    purpose: continuationPurpose,
+                    automaticWorkToken: continuationAutomaticWorkToken,
+                    automaticReconnectOperationID: transportOperationID
                   ),
                   let activeClient = self.client, activeClient === client else { return }
+            continuationPurpose = continuation.purpose
+            continuationAutomaticWorkToken = continuation.automaticWorkToken
+            handedOffAutomaticIntent = handedOffAutomaticIntent
+                || continuation.handedOffAutomaticIntent
             await loadProfileDisplayPreferences()
-            guard automaticChatResumeWorkIsCurrent(
-                automaticWorkToken,
-                reconnectOperationID: automaticReconnectOperationID
+            guard let continuation = transportContinuation(
+                purpose: continuationPurpose,
+                automaticWorkToken: continuationAutomaticWorkToken,
+                automaticReconnectOperationID: transportOperationID
             ) else { return }
+            handedOffAutomaticIntent = handedOffAutomaticIntent
+                || continuation.handedOffAutomaticIntent
             Task { await loadSlashCommands() }
         } catch {
-            guard automaticChatResumeWorkIsCurrent(
-                    automaticWorkToken,
-                    reconnectOperationID: automaticReconnectOperationID
+            guard let continuation = transportContinuation(
+                    purpose: syncPurpose,
+                    automaticWorkToken: automaticWorkToken,
+                    automaticReconnectOperationID: transportOperationID
                   ),
                   let activeClient = self.client, activeClient === client else { return }
+            handedOffAutomaticIntent = continuation.handedOffAutomaticIntent
             isConnecting = false
             isConnected = false
             turnState = .reconnecting
@@ -1303,7 +1482,7 @@ final class AppState: ObservableObject {
             // sign-in screen. A transient gateway or WebKit startup failure
             // must retain the saved dashboard session and retry.
             showLogin = false
-            scheduleReconnect(purpose: syncPurpose)
+            scheduleReconnect(purpose: continuation.purpose)
         }
     }
 
@@ -1410,7 +1589,7 @@ final class AppState: ObservableObject {
     }
 
     private func requireSignIn(message: String) {
-        cancelChatResumeRestoration()
+        cancelChatResumeTransportRecovery()
         invalidateReconciliation()
         cancelSecondaryProfileTitleRecovery()
         client?.disconnect()
@@ -2255,7 +2434,7 @@ final class AppState: ObservableObject {
     }
 
     func reconnect() async {
-        cancelChatResumeRestoration()
+        cancelChatResumeTransportRecovery()
         await executeReconnect(purpose: .preserveCurrent)
     }
 
@@ -2275,13 +2454,29 @@ final class AppState: ObservableObject {
             : nil
         guard automaticChatResumeWorkIsCurrent(automaticWorkToken) else { return }
         let automaticOperationID = beginAutomaticReconnectOperation(for: automaticWorkToken)
+        var continuationPurpose = purpose
+        var continuationAutomaticWorkToken = automaticWorkToken
+        var handedOffAutomaticIntent = false
+        func refreshTransportContinuation() -> Bool {
+            guard let continuation = transportContinuation(
+                purpose: continuationPurpose,
+                automaticWorkToken: continuationAutomaticWorkToken,
+                automaticReconnectOperationID: automaticOperationID
+            ) else { return false }
+            continuationPurpose = continuation.purpose
+            continuationAutomaticWorkToken = continuation.automaticWorkToken
+            handedOffAutomaticIntent = handedOffAutomaticIntent
+                || continuation.handedOffAutomaticIntent
+            return true
+        }
         defer {
             finishAutomaticReconnectOperation(
                 id: automaticOperationID,
-                restoringBaseline: !automaticChatResumeWorkIsCurrent(
-                    automaticWorkToken,
-                    reconnectOperationID: automaticOperationID
-                )
+                restoringBaseline: !handedOffAutomaticIntent
+                    && !automaticChatResumeWorkIsCurrent(
+                        automaticWorkToken,
+                        reconnectOperationID: automaticOperationID
+                    )
             )
         }
         if purpose == .automaticReturn, reconnectTask != nil {
@@ -2293,18 +2488,12 @@ final class AppState: ObservableObject {
         let connection: HermesConnection
         do {
             let ticket = try await mintChatResumeTicket(for: savedConnection)
-            guard automaticChatResumeWorkIsCurrent(
-                automaticWorkToken,
-                reconnectOperationID: automaticOperationID
-            ) else { return }
+            guard refreshTransportContinuation() else { return }
             connection = HermesConnection(baseUrl: savedConnection.baseUrl, ticket: ticket)
             self.connection = connection
             KeychainHelper.saveConnection(connection)
         } catch {
-            guard automaticChatResumeWorkIsCurrent(
-                automaticWorkToken,
-                reconnectOperationID: automaticOperationID
-            ) else { return }
+            guard refreshTransportContinuation() else { return }
             if let bridgeError = error as? DashboardTicketBridgeError, case .signInRequired = bridgeError {
                 if let credentials = KeychainHelper.loadCredentials(),
                    credentials.baseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/")) == savedConnection.baseUrl.trimmingCharacters(in: CharacterSet(charactersIn: "/")) {
@@ -2313,108 +2502,76 @@ final class AppState: ObservableObject {
                             username: credentials.username,
                             password: credentials.password
                         )
-                        guard automaticChatResumeWorkIsCurrent(
-                            automaticWorkToken,
-                            reconnectOperationID: automaticOperationID
-                        ) else { return }
+                        guard refreshTransportContinuation() else { return }
                         // URLSession and WebKit have separate cookie stores.
                         // Reload the bridge so it receives the fresh session.
                         dashboardTicketBridge?.reload()
                         await connect(
                             with: HermesConnection(baseUrl: credentials.baseURL, ticket: ticket),
                             profile: activeProfile,
-                            syncPurpose: purpose,
+                            syncPurpose: continuationPurpose,
                             cancelsResumeRestoration: false,
-                            automaticWorkToken: automaticWorkToken,
+                            automaticWorkToken: continuationAutomaticWorkToken,
                             automaticReconnectOperationID: automaticOperationID
                         )
+                        guard refreshTransportContinuation() else { return }
                         return
                     } catch {
-                        guard automaticChatResumeWorkIsCurrent(
-                            automaticWorkToken,
-                            reconnectOperationID: automaticOperationID
-                        ) else { return }
+                        guard refreshTransportContinuation() else { return }
                         // This only determines whether recovery can be silent.
                         // Preserve the saved credentials for the login screen.
                     }
                 }
-                guard automaticChatResumeWorkIsCurrent(
-                    automaticWorkToken,
-                    reconnectOperationID: automaticOperationID
-                ) else { return }
+                guard refreshTransportContinuation() else { return }
                 requireSignIn(message: error.localizedDescription)
             } else {
-                guard automaticChatResumeWorkIsCurrent(
-                    automaticWorkToken,
-                    reconnectOperationID: automaticOperationID
-                ) else { return }
+                guard refreshTransportContinuation() else { return }
                 isConnected = false
                 isConnecting = false
                 turnState = .reconnecting
                 errorMessage = "Failed to refresh the dashboard session: \(error.localizedDescription)"
-                scheduleReconnect(purpose: purpose)
+                scheduleReconnect(purpose: continuationPurpose)
             }
             return
         }
 
         let previousClient = client
-        guard automaticChatResumeWorkIsCurrent(
-            automaticWorkToken,
-            reconnectOperationID: automaticOperationID
-        ) else { return }
+        guard refreshTransportContinuation() else { return }
         let client = makeClient(connection: connection, profile: activeProfile)
         self.client = client
         previousClient?.disconnect()
 
         do {
-            try await client.connect()
-            guard automaticChatResumeWorkIsCurrent(
-                    automaticWorkToken,
-                    reconnectOperationID: automaticOperationID
-                  ),
+            try await connectChatResumeClient(client)
+            guard refreshTransportContinuation(),
                   let activeClient = self.client, activeClient === client else { return }
             isConnected = true
             isConnecting = false
             reconnectAttempts = 0
             connectedAt = Date()
             await syncSession(
-                purpose: purpose,
+                purpose: continuationPurpose,
                 using: nil,
-                automaticWorkToken: automaticWorkToken
+                automaticWorkToken: continuationAutomaticWorkToken
             )
-            guard automaticChatResumeWorkIsCurrent(
-                    automaticWorkToken,
-                    reconnectOperationID: automaticOperationID
-                  ),
+            guard refreshTransportContinuation(),
                   let activeClient = self.client, activeClient === client else { return }
             await loadBusyInputMode(using: client)
-            guard automaticChatResumeWorkIsCurrent(
-                    automaticWorkToken,
-                    reconnectOperationID: automaticOperationID
-                  ),
+            guard refreshTransportContinuation(),
                   let activeClient = self.client, activeClient === client else { return }
             await loadProfiles()
-            guard automaticChatResumeWorkIsCurrent(
-                    automaticWorkToken,
-                    reconnectOperationID: automaticOperationID
-                  ),
+            guard refreshTransportContinuation(),
                   let activeClient = self.client, activeClient === client else { return }
             await loadProfileDisplayPreferences()
-            guard automaticChatResumeWorkIsCurrent(
-                automaticWorkToken,
-                reconnectOperationID: automaticOperationID
-            ) else { return }
+            guard refreshTransportContinuation() else { return }
             Task { await loadSlashCommands() }
         } catch {
-            guard automaticChatResumeWorkIsCurrent(
-                    automaticWorkToken,
-                    reconnectOperationID: automaticOperationID
-                  ),
+            guard refreshTransportContinuation(),
                   let activeClient = self.client, activeClient === client else { return }
             isConnected = false
             isConnecting = false
             turnState = .reconnecting
-            scheduleReconnect(purpose: purpose)
+            scheduleReconnect(purpose: continuationPurpose)
         }
     }
 
@@ -2425,6 +2582,14 @@ final class AppState: ObservableObject {
         prepareDashboardBridge(for: connection.baseUrl)
         guard let dashboardTicketBridge else { throw DashboardTicketBridgeError.notReady }
         return try await dashboardTicketBridge.mintTicket()
+    }
+
+    private func connectChatResumeClient(_ client: HermesClient) async throws {
+        if let connectClient = chatResumeLifecycleOperations.connectClient {
+            try await connectClient(client)
+        } else {
+            try await client.connect()
+        }
     }
 
     @discardableResult
@@ -3185,6 +3350,7 @@ final class AppState: ObservableObject {
 
     func sendMessage(_ text: String, attachments: [Attachment] = []) async -> Bool {
         guard let client, let sessionId = activeSessionId else { return false }
+        cancelChatResumeRestoration()
 
         let userMessage = ChatMessage(
             id: "local-\(Date().timeIntervalSince1970)",
@@ -3224,7 +3390,11 @@ final class AppState: ObservableObject {
         }
 
         do {
-            try await client.sendPrompt(sessionId, text: text)
+            if let sendPrompt = chatResumeLifecycleOperations.sendPrompt {
+                try await sendPrompt(client, sessionId, text)
+            } else {
+                try await client.sendPrompt(sessionId, text: text)
+            }
             return true
         } catch {
             errorMessage = "Failed to send: \(error.localizedDescription)"
@@ -3446,6 +3616,13 @@ final class AppState: ObservableObject {
         // Client-side special cases
         switch command.name {
         case "new", "reset":
+            guard !isProfileSwitching, isConnected, !isConnecting else {
+                if isProfileSwitching || isConnecting {
+                    errorMessage = "Wait for the workspace switch to finish before starting a conversation."
+                }
+                return
+            }
+            cancelChatResumeRestoration()
             await createNewSession()
             return
         case "branch", "fork":
@@ -3453,23 +3630,40 @@ final class AppState: ObservableObject {
                 errorMessage = "Stop the active response before branching this conversation."
                 return
             }
+            guard !isBranchingChat, !isProfileSwitching else { return }
             guard let assistantMessage = messages.last(where: { $0.role == .assistant }) else {
                 errorMessage = "There is no assistant response to branch from yet."
                 return
             }
+            guard let messageIndex = messages.firstIndex(where: { $0.id == assistantMessage.id }),
+                  messages[...messageIndex].contains(where: { message in
+                      guard message.role == .user || message.role == .assistant else {
+                          return false
+                      }
+                      let content = (message.role == .user ? message.rawContent : nil)
+                          ?? message.content
+                      return !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                  }) else {
+                errorMessage = "There is no message history to branch from."
+                return
+            }
+            cancelChatResumeRestoration()
             await branchFromAssistantMessage(assistantMessage.id)
             return
         case "model":
             if command.argument.isEmpty {
+                cancelChatResumeRestoration()
                 showModelPicker = true
                 return
             }
         case "yolo":
             if command.argument.isEmpty {
+                cancelChatResumeRestoration()
                 await toggleYolo()
                 return
             }
         case "help":
+            cancelChatResumeRestoration()
             appendSlashOutput(Self.formatSlashHelp())
             return
         default:
@@ -3477,6 +3671,7 @@ final class AppState: ObservableObject {
         }
 
         // Server-side execution
+        cancelChatResumeRestoration()
         do {
             let result = try await executeGatewaySlash(client: client, sessionID: sessionId, command: command.cleaned)
             await handleSlashResult(result, depth: 0, aliasArgument: command.argument)
@@ -3491,9 +3686,20 @@ final class AppState: ObservableObject {
         command: String
     ) async throws -> AnyCodable {
         do {
+            if let executeSlash = chatResumeLifecycleOperations.executeSlash {
+                return try await executeSlash(client, sessionID, command)
+            }
             return try await client.executeSlash(sessionId: sessionID, command: command)
         } catch {
             guard let parsed = Self.parseSlashCommand(command) else { throw error }
+            if let dispatchCommand = chatResumeLifecycleOperations.dispatchCommand {
+                return try await dispatchCommand(
+                    client,
+                    sessionID,
+                    parsed.name,
+                    parsed.argument
+                )
+            }
             return try await client.dispatchCommand(sessionId: sessionID, name: parsed.name, arg: parsed.argument)
         }
     }
@@ -3570,8 +3776,13 @@ final class AppState: ObservableObject {
 
     private func steer(_ text: String) async -> Bool {
         guard let client, let sessionId = activeSessionId else { return false }
+        cancelChatResumeRestoration()
         do {
-            try await client.steer(sessionId, text: text)
+            if let steer = chatResumeLifecycleOperations.steer {
+                try await steer(client, sessionId, text)
+            } else {
+                try await client.steer(sessionId, text: text)
+            }
             return true
         } catch {
             errorMessage = error.localizedDescription
@@ -3586,9 +3797,16 @@ final class AppState: ObservableObject {
     /// retain the established `session.interrupt` then `prompt.submit` flow.
     private func redirectOrInterruptAndSend(_ text: String, retriedAfterResume: Bool = false) async -> Bool {
         guard let client, let sessionId = activeSessionId else { return false }
+        cancelChatResumeRestoration()
 
         do {
-            switch try await client.redirect(sessionId, text: text) {
+            let outcome: SessionRedirectOutcome
+            if let redirect = chatResumeLifecycleOperations.redirect {
+                outcome = try await redirect(client, sessionId, text)
+            } else {
+                outcome = try await client.redirect(sessionId, text: text)
+            }
+            switch outcome {
             case .redirected, .queued:
                 appendLocalUserMessage(text)
                 return true
@@ -3672,9 +3890,14 @@ final class AppState: ObservableObject {
 
     private func interruptForReplacement() async -> Bool {
         guard let client, let sessionId = activeSessionId else { return false }
+        cancelChatResumeRestoration()
         turnState = .synchronizing
         do {
-            try await client.cancel(sessionId)
+            if let interrupt = chatResumeLifecycleOperations.interrupt {
+                try await interrupt(client, sessionId)
+            } else {
+                try await client.cancel(sessionId)
+            }
             return true
         } catch {
             errorMessage = "Could not interrupt the active response: \(error.localizedDescription)"
@@ -4816,7 +5039,11 @@ final class AppState: ObservableObject {
         let previous = busyInputMode
         busyInputMode = mode
         do {
-            try await client.setBusyInputMode(mode)
+            if let setBusyInputMode = chatResumeLifecycleOperations.setBusyInputMode {
+                try await setBusyInputMode(client, mode)
+            } else {
+                try await client.setBusyInputMode(mode)
+            }
             return true
         } catch {
             busyInputMode = previous

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -462,6 +462,8 @@ final class AppState: ObservableObject {
     private var lastStreamingPublishDate: Date?
     private var scenePhaseTask: Task<Void, Never>?
     private var scenePhaseAttemptID: UUID?
+    private var explicitSessionOpenTask: Task<Bool, Never>?
+    private var explicitSessionOpenRequestID: UUID?
     private var activeAutomaticChatResumeWork: ChatResumeAutomaticWorkToken?
     private var chatViewportSnapshotProvider: (
         id: UUID,
@@ -1052,6 +1054,7 @@ final class AppState: ObservableObject {
     }
 
     private func cancelChatResumeTransportRecovery() {
+        cancelExplicitSessionOpen()
         cancelScheduledReconnect()
         chatResumeCoordinator.cancelViewportRestoration(
             keepViewportFrozen: chatViewportTransition != nil
@@ -1560,6 +1563,7 @@ final class AppState: ObservableObject {
     }
 
     func disconnect() {
+        cancelExplicitSessionOpen()
         chatResumeCoordinator.clearResumeState()
         cancelOwnedAutomaticOperations()
         activeAutomaticChatResumeWork = nil
@@ -3146,11 +3150,35 @@ final class AppState: ObservableObject {
         await openSession(sessionId, reusing: nil)
     }
 
+    @discardableResult
+    func requestOpenSession(_ sessionId: String) -> Task<Bool, Never> {
+        cancelExplicitSessionOpen()
+        let requestID = UUID()
+        explicitSessionOpenRequestID = requestID
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return false }
+            let opened = await self.openSession(sessionId)
+            guard self.explicitSessionOpenRequestID == requestID else { return opened }
+            self.explicitSessionOpenRequestID = nil
+            self.explicitSessionOpenTask = nil
+            return opened
+        }
+        explicitSessionOpenTask = task
+        return task
+    }
+
+    private func cancelExplicitSessionOpen() {
+        explicitSessionOpenRequestID = nil
+        explicitSessionOpenTask?.cancel()
+        explicitSessionOpenTask = nil
+    }
+
     private func openSession(
         _ sessionId: String,
         reusing viewportTransitionGeneration: UInt64?
     ) async -> Bool {
         guard let client else { return false }
+        let previousTurnState = turnState
         if let session = (sessions + cronSessions).first(where: {
             $0.id == sessionId || $0.alternateIds.contains(sessionId)
         }), !sessionBelongsToProfile(session, profile: activeProfile) {
@@ -3195,6 +3223,9 @@ final class AppState: ObservableObject {
         }
         if !reconciled {
             finishChatViewportTransition(generation: transitionGeneration)
+            if Task.isCancelled, turnState == .synchronizing {
+                turnState = previousTurnState
+            }
         }
         return reconciled
     }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -26,7 +26,9 @@ final class AppState: ObservableObject {
     @Published var isConnecting = false
     @Published var profiles: [String] = []
     @Published private(set) var sessionFilterOrder: [SessionSource] = [.chat, .discord, .telegram, .api, .webhook, .other]
-    @Published private(set) var activeProfile: String = "default"
+    @Published private(set) var activeProfile: String = "default" {
+        didSet { refreshActiveChatScrollSessionIdentity() }
+    }
     @Published private(set) var defaultProfileName: String
     @Published private(set) var profileAvatarURLs: [String: URL]
     @Published private(set) var isProfileSwitching = false
@@ -211,7 +213,6 @@ final class AppState: ObservableObject {
 
     private var reconciliationToken = UUID()
     private var reconciliation: Reconciliation?
-    private var chatScrollIdentityProfile = "default"
     private var activeClientEpoch = UUID()
     private var activeAssistantMessageId: String?
     private var activeReasoningMessageId: String?
@@ -498,86 +499,26 @@ final class AppState: ObservableObject {
         advanceSettledRevision: Bool = false
     ) {
         let current = activeChatScrollSessionIdentity
-        let previous = chatScrollIdentityProfile == activeProfile
-            ? current
-            : ChatScrollSessionIdentity(
-                canonicalSessionID: nil,
-                equivalentSessionIDs: [],
-                isReconciling: current.isReconciling,
-                settledRevision: current.settledRevision
-            )
-        let catalog = sessions + cronSessions
-        func identifiers(for session: SessionSummary) -> Set<String> {
-            Set(([session.id] + session.alternateIds).compactMap(Self.normalizedSessionIdentityID))
-        }
-        func matchingSession(for ids: Set<String>) -> SessionSummary? {
-            guard !ids.isEmpty else { return nil }
-            return catalog.first { !identifiers(for: $0).isDisjoint(with: ids) }
-        }
-
-        let activeID = Self.normalizedSessionIdentityID(activeSessionId)
-        let reconciliationIDs = Set([
-            reconciliation?.requestedSessionId,
-            reconciliation?.resolvedSessionId
-        ].compactMap(Self.normalizedSessionIdentityID))
-        let reconciliationSession = matchingSession(for: reconciliationIDs)
-        let reconciliationCatalogIDs = reconciliationSession.map(identifiers) ?? []
-        let reconciliationContinuesPrevious = reconciliationIDs.isEmpty
-            || reconciliationIDs.contains(where: previous.contains)
-            || !reconciliationCatalogIDs.isDisjoint(with: previous.equivalentSessionIDs)
-            || activeID.map(reconciliationCatalogIDs.contains) == true
-
-        var candidates = reconciliationIDs
-        if reconciliationIDs.isEmpty || reconciliationContinuesPrevious,
-           let activeID {
-            candidates.insert(activeID)
-        }
-        let matchedSession = reconciliationSession ?? matchingSession(for: candidates)
-        let continuesPreviousIdentity = candidates.contains(where: previous.contains)
-
-        let canonicalSessionID: String?
-        if let matchedSession {
-            canonicalSessionID = matchedSession.id
-        } else if continuesPreviousIdentity {
-            canonicalSessionID = previous.canonicalSessionID
-        } else if !reconciliationIDs.isEmpty {
-            canonicalSessionID = Self.normalizedSessionIdentityID(reconciliation?.requestedSessionId)
-                ?? Self.normalizedSessionIdentityID(reconciliation?.resolvedSessionId)
-                ?? activeID
-        } else {
-            canonicalSessionID = activeID
-        }
-
-        var equivalentSessionIDs = candidates
-        if let matchedSession {
-            equivalentSessionIDs.formUnion(
-                ([matchedSession.id] + matchedSession.alternateIds)
-                    .compactMap(Self.normalizedSessionIdentityID)
+        let catalog = (sessions + cronSessions).map { session in
+            ChatScrollSessionCatalogIdentity(
+                profile: session.profile ?? activeProfile,
+                canonicalSessionID: session.id,
+                alternateSessionIDs: Set(session.alternateIds)
             )
         }
-        if continuesPreviousIdentity {
-            equivalentSessionIDs.formUnion(previous.equivalentSessionIDs)
-        }
-
-        let revision = advanceSettledRevision
-            ? current.settledRevision &+ 1
-            : current.settledRevision
-        let updated = ChatScrollSessionIdentity(
-            canonicalSessionID: canonicalSessionID,
-            equivalentSessionIDs: equivalentSessionIDs,
+        let updated = ChatScrollSessionIdentityResolver.resolve(
+            profile: activeProfile,
+            activeSessionID: activeSessionId,
+            catalog: catalog,
+            requestedSessionID: reconciliation?.requestedSessionId,
+            resolvedSessionID: reconciliation?.resolvedSessionId,
+            previousIdentity: current,
             isReconciling: isReconciling ?? current.isReconciling,
-            settledRevision: revision
+            advanceSettledRevision: advanceSettledRevision
         )
-        chatScrollIdentityProfile = activeProfile
         if updated != current {
             activeChatScrollSessionIdentity = updated
         }
-    }
-
-    private static func normalizedSessionIdentityID(_ sessionID: String?) -> String? {
-        guard let value = sessionID?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !value.isEmpty else { return nil }
-        return value
     }
 
     func makeSettingsSnapshot() -> SettingsSnapshot {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -1068,6 +1068,7 @@ final class AppState: ObservableObject {
             defaultProfileName: defaultProfileName,
             theme: themePreference,
             busyInputMode: busyInputMode,
+            chatResumeBehavior: chatResumeBehavior,
             displayPreferences: displayPreferences,
             cloudflareAccess: KeychainHelper.loadCloudflareAccess(for: connection?.baseUrl)
         )

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -748,7 +748,8 @@ final class AppState: ObservableObject {
         if let persistedID = ChatSessionPersistenceIdentity.canonicalID(
             for: id,
             identity: activeChatScrollSessionIdentity,
-            catalog: sessions + cronSessions
+            catalog: sessions + cronSessions,
+            activeProfile: activeProfile
         ) {
             chatResumeCoordinator.rememberSessionID(persistedID, for: activeProfile)
         } else {
@@ -2270,6 +2271,7 @@ final class AppState: ObservableObject {
                   let activeClient = self.client,
                   activeClient === client else {
                 settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
+                chatResumeCoordinator.abandonPendingAutomaticSync()
                 return
             }
             if let returnedProfile = created.profile,
@@ -2277,6 +2279,7 @@ final class AppState: ObservableObject {
                 turnState = .idle
                 errorMessage = "Hermes created this conversation in \(profileDisplayName(returnedProfile)), not \(profileDisplayName(profile)). It was not opened."
                 settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
+                chatResumeCoordinator.abandonPendingAutomaticSync()
                 await loadSessions(forceRefresh: true)
                 return
             }
@@ -2285,6 +2288,7 @@ final class AppState: ObservableObject {
                 turnState = .idle
                 errorMessage = "Hermes created a conversation without a session ID."
                 settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
+                chatResumeCoordinator.abandonPendingAutomaticSync()
                 return
             }
 

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -15,6 +15,64 @@ import UIKit
 private let sessionCatalogLog = Logger(subsystem: "com.milim.conduit", category: "SessionCatalog")
 private let titleGenerationLog = Logger(subsystem: "com.milim.conduit", category: "TitleGeneration")
 
+enum ChatResumeReconnectSchedulingDecision: Equatable {
+    case schedule(ChatResumeSyncPurpose)
+    case replace(ChatResumeSyncPurpose)
+    case keepExisting
+}
+
+enum ChatResumeConversationReplacement {
+    case branch
+    case archive
+    case delete
+}
+
+final class ChatResumeRecoverySequence {
+    private(set) var currentPurpose: ChatResumeSyncPurpose = .preserveCurrent
+    private(set) var queuedReconnectPurpose: ChatResumeSyncPurpose?
+
+    @discardableResult
+    func register(_ purpose: ChatResumeSyncPurpose) -> ChatResumeSyncPurpose {
+        if purpose == .automaticReturn {
+            currentPurpose = .automaticReturn
+        }
+        return currentPurpose
+    }
+
+    func planReconnect(
+        requestedPurpose: ChatResumeSyncPurpose
+    ) -> ChatResumeReconnectSchedulingDecision {
+        let purpose = register(requestedPurpose)
+        guard let queuedReconnectPurpose else {
+            self.queuedReconnectPurpose = purpose
+            return .schedule(purpose)
+        }
+        if queuedReconnectPurpose == .preserveCurrent, purpose == .automaticReturn {
+            self.queuedReconnectPurpose = .automaticReturn
+            return .replace(.automaticReturn)
+        }
+        return .keepExisting
+    }
+
+    func takeQueuedReconnectPurpose() -> ChatResumeSyncPurpose? {
+        defer { queuedReconnectPurpose = nil }
+        return queuedReconnectPurpose
+    }
+
+    func clearQueuedReconnect() {
+        queuedReconnectPurpose = nil
+    }
+
+    func complete() {
+        currentPurpose = .preserveCurrent
+    }
+
+    func cancel() {
+        currentPurpose = .preserveCurrent
+        queuedReconnectPurpose = nil
+    }
+}
+
 @MainActor
 final class AppState: ObservableObject {
 
@@ -341,7 +399,7 @@ final class AppState: ObservableObject {
 
     // MARK: - Persistence
 
-    private let defaults = UserDefaults.standard
+    private let defaults: UserDefaults
     private let activeSessionTitlesByProfileKey = "conduit.activeSessionTitlesByProfile.v1"
     private let pinnedSessionIDsByProfileKey = "conduit.pinnedSessionIdsByProfile.v1"
     private let activeProfileKey = "conduit.activeProfile"
@@ -352,9 +410,12 @@ final class AppState: ObservableObject {
     private let sessionFilterOrderKey = "conduit.sessionFilterOrder.v1"
     private let reviewSummaryCacheKey = "conduit.reviewSummaryCache.v1"
     private let knownProfilesKey = "conduit.knownProfiles.v1"
+    private let chatResumeServerIdentityKey = "conduit.chatResumeServerIdentity.v1"
     private var activeSessionTitlesByProfile: [String: String] = [:]
     private var pinnedSessionIDsByProfile: [String: [String]] = [:]
-    private let chatResumeCoordinator = ChatResumeCoordinator(store: ChatResumeStore())
+    private let chatResumeCoordinator: ChatResumeCoordinator
+    private let recoverySequence: ChatResumeRecoverySequence
+    private let clearSessionPresentationCache: () -> Void
 
     private func mergeCachedReviews(into history: [ChatMessage], sessionId: String) -> [ChatMessage] {
         let records = cachedReviews().filter { $0.profile == activeProfile && $0.sessionId == sessionId }
@@ -395,13 +456,24 @@ final class AppState: ObservableObject {
     }
 
     init(
+        defaults: UserDefaults = .standard,
+        chatResumeCoordinator: ChatResumeCoordinator? = nil,
+        recoverySequence: ChatResumeRecoverySequence = ChatResumeRecoverySequence(),
+        loadSavedConnection shouldLoadSavedConnection: Bool = true,
+        clearSessionPresentationCache: @escaping () -> Void = {
+            SessionPresentationCache.shared.clear()
+        },
         sessionRenameOperations: SessionRenameOperation.Operations? = nil,
-        sessionCatalogLoader: ((Bool) async throws -> [SessionSummary])? = nil,
-        restoreSavedConnection: Bool = true
+        sessionCatalogLoader: ((Bool) async throws -> [SessionSummary])? = nil
     ) {
+        self.defaults = defaults
+        self.chatResumeCoordinator = chatResumeCoordinator
+            ?? ChatResumeCoordinator(store: ChatResumeStore(defaults: defaults))
+        self.recoverySequence = recoverySequence
+        self.clearSessionPresentationCache = clearSessionPresentationCache
         sessionRenameOperationsOverride = sessionRenameOperations
         sessionCatalogLoaderOverride = sessionCatalogLoader
-        chatResumeBehavior = chatResumeCoordinator.behavior
+        chatResumeBehavior = self.chatResumeCoordinator.behavior
         defaultProfileName = ProfileAppearanceStore.loadDefaultName()
         profileAvatarURLs = ProfileAppearanceStore.loadAvatarURLs()
         appIconChoice = UIApplication.shared.alternateIconName == AppIconChoice.light.alternateIconName ? .light : .dark
@@ -425,10 +497,12 @@ final class AppState: ObservableObject {
         }
         restoreActiveSessionState(for: activeProfile)
         restorePinnedSessions(for: activeProfile)
-        if restoreSavedConnection { loadSavedConnection() }
+        if shouldLoadSavedConnection {
+            loadSavedConnection()
+        }
     }
 
-    private func restoreActiveSessionState(for profile: String) {
+    func restoreActiveSessionState(for profile: String) {
         activeSessionId = chatResumeCoordinator.lastSessionID(for: profile)
         activeSessionTitle = activeSessionTitlesByProfile[profile] ?? "New conversation"
     }
@@ -505,6 +579,7 @@ final class AppState: ObservableObject {
 
     func setChatResumeBehavior(_ behavior: ChatResumeBehavior) {
         chatResumeCoordinator.setBehavior(behavior)
+        recoverySequence.cancel()
         chatResumeBehavior = chatResumeCoordinator.behavior
         chatResumeRestorationRequest = nil
     }
@@ -527,7 +602,62 @@ final class AppState: ObservableObject {
 
     func cancelChatResumeRestoration() {
         chatResumeCoordinator.cancelRestoration()
+        recoverySequence.cancel()
         chatResumeRestorationRequest = nil
+    }
+
+    func acceptChatResumeConversationReplacement(
+        _ replacement: ChatResumeConversationReplacement
+    ) {
+        cancelChatResumeRestoration()
+    }
+
+    @discardableResult
+    func prepareChatResumeForConnection(to baseURL: String) -> Bool {
+        guard let identity = normalizedChatResumeServerIdentity(baseURL) else { return false }
+        let previousIdentity = defaults.string(forKey: chatResumeServerIdentityKey)
+            ?? defaults.string(forKey: dashboardURLKey).flatMap(normalizedChatResumeServerIdentity)
+        defaults.set(identity, forKey: chatResumeServerIdentityKey)
+        guard let previousIdentity, previousIdentity != identity else { return false }
+
+        chatResumeCoordinator.clearResumeState()
+        recoverySequence.cancel()
+        chatResumeRestorationRequest = nil
+        invalidateReconciliation()
+        profileSessionCache.removeAll()
+        loadedFullSessionHistory.removeAll()
+        sessions = []
+        cronSessions = []
+        archivedSessions = []
+        projects = []
+        supportsProjects = false
+        projectsLoading = false
+        profiles = []
+        activeSessionId = nil
+        activeSessionTitle = "New conversation"
+        messages = []
+        clearStreamingText()
+        activeSessionTitlesByProfile = [:]
+        pinnedSessionIDsByProfile = [:]
+        pinnedSessionIDs = []
+        defaults.removeObject(forKey: activeSessionTitlesByProfileKey)
+        defaults.removeObject(forKey: pinnedSessionIDsByProfileKey)
+        clearSessionPresentationCache()
+        return true
+    }
+
+    private func normalizedChatResumeServerIdentity(_ baseURL: String) -> String? {
+        guard let normalized = try? ConnectionURLPolicy.normalizedBaseURL(baseURL),
+              var components = URLComponents(string: normalized),
+              let scheme = components.scheme?.lowercased(),
+              let host = components.host?.lowercased() else { return nil }
+        components.scheme = scheme
+        components.host = host
+        if (scheme == "https" && components.port == 443)
+            || (scheme == "http" && components.port == 80) {
+            components.port = nil
+        }
+        return components.string
     }
 
     private func refreshActiveChatScrollSessionIdentity(
@@ -705,13 +835,14 @@ final class AppState: ObservableObject {
         if cancelsResumeRestoration {
             cancelChatResumeRestoration()
         }
-        guard (try? ConnectionURLPolicy.normalizedBaseURL(conn.baseUrl)) != nil else {
+        guard let normalizedBaseURL = try? ConnectionURLPolicy.normalizedBaseURL(conn.baseUrl) else {
             isConnecting = false
             isConnected = false
             showLogin = true
             errorMessage = ConnectionURLPolicyError.insecureTransport.localizedDescription
             return
         }
+        prepareChatResumeForConnection(to: normalizedBaseURL)
         rememberDashboardURL(conn.baseUrl)
         reconnectTask?.cancel()
         reconnectTask = nil
@@ -766,6 +897,7 @@ final class AppState: ObservableObject {
 
     func disconnect() {
         chatResumeCoordinator.clearResumeState()
+        recoverySequence.cancel()
         chatResumeRestorationRequest = nil
         invalidateReconciliation()
         reconnectTask?.cancel()
@@ -891,6 +1023,7 @@ final class AppState: ObservableObject {
     /// The only entry point for cold start, foreground refresh, reconnect, and
     /// manual refresh. It never derives liveness from transcript shape.
     func syncSession() async {
+        cancelChatResumeRestoration()
         await syncSession(purpose: .preserveCurrent, using: nil)
     }
 
@@ -898,6 +1031,7 @@ final class AppState: ObservableObject {
         purpose: ChatResumeSyncPurpose,
         using existingReconciliationToken: UUID?
     ) async {
+        let purpose = beginChatResumeRecovery(purpose: purpose)
         guard let client else {
             if let existingReconciliationToken {
                 settleReconciliation(existingReconciliationToken)
@@ -943,19 +1077,25 @@ final class AppState: ObservableObject {
             sessions = allSessions.filter { $0.source != .cron }
             cronSessions = allSessions.filter { $0.source == .cron }
 
-            let target = chatResumeCoordinator.selectTarget(
+            let target = selectChatResumeTarget(
                 in: allSessions,
                 profile: profile,
                 purpose: purpose,
                 currentSessionID: activeSessionId
             )
             if let target {
-                await reconcile(
+                let succeeded = await reconcile(
                     sessionId: target.id,
                     using: client,
                     token: token,
                     acceptedSessionIDs: Set([target.id] + target.alternateIds)
                 )
+                if !succeeded,
+                   purpose == .automaticReturn,
+                   token == reconciliationToken,
+                   profile == activeProfile {
+                    scheduleReconnect(purpose: purpose)
+                }
             } else {
                 await createAndReconcileSession(
                     using: client,
@@ -975,10 +1115,13 @@ final class AppState: ObservableObject {
             turnState = .reconnecting
             errorMessage = "Failed to load gateway sessions: \(error.localizedDescription)"
             settleReconciliation(token)
+            if purpose == .automaticReturn {
+                scheduleReconnect(purpose: purpose)
+            }
         }
     }
 
-    private func beginReconciliation() -> UUID {
+    func beginReconciliation() -> UUID {
         let token = UUID()
         let bufferedEvents = reconciliation?.bufferedEvents ?? []
         reconciliationToken = token
@@ -1002,14 +1145,50 @@ final class AppState: ObservableObject {
         )
     }
 
-    private func settleReconciliation(_ token: UUID) {
-        guard token == reconciliationToken else { return }
+    @discardableResult
+    private func settleReconciliation(_ token: UUID) -> Bool {
+        guard token == reconciliationToken else { return false }
         let wasReconciling = activeChatScrollSessionIdentity.isReconciling
         reconciliation = nil
         refreshActiveChatScrollSessionIdentity(
             isReconciling: false,
             advanceSettledRevision: wasReconciling
         )
+        return true
+    }
+
+    func selectChatResumeTarget(
+        in catalog: [SessionSummary],
+        profile: String,
+        purpose: ChatResumeSyncPurpose,
+        currentSessionID: String?
+    ) -> SessionSummary? {
+        if purpose == .automaticReturn {
+            chatResumeRestorationRequest = nil
+        }
+        return chatResumeCoordinator.selectTarget(
+            in: catalog,
+            profile: profile,
+            purpose: purpose,
+            currentSessionID: currentSessionID
+        )
+    }
+
+    @discardableResult
+    func beginChatResumeRecovery(
+        purpose: ChatResumeSyncPurpose
+    ) -> ChatResumeSyncPurpose {
+        recoverySequence.register(purpose)
+    }
+
+    func chatResumePurposeForDisconnect() -> ChatResumeSyncPurpose {
+        recoverySequence.currentPurpose
+    }
+
+    func planChatResumeReconnect(
+        purpose: ChatResumeSyncPurpose
+    ) -> ChatResumeReconnectSchedulingDecision {
+        recoverySequence.planReconnect(requestedPurpose: purpose)
     }
 
     private func publishChatResumeRestorationIfReady() {
@@ -1018,6 +1197,14 @@ final class AppState: ObservableObject {
             return
         }
         chatResumeRestorationRequest = request
+    }
+
+    @discardableResult
+    func settleReconciliationAndPublish(_ token: UUID) -> Bool {
+        guard settleReconciliation(token) else { return false }
+        publishChatResumeRestorationIfReady()
+        recoverySequence.complete()
+        return true
     }
 
     @discardableResult
@@ -1107,15 +1294,21 @@ final class AppState: ObservableObject {
             applyResume(presentationResult)
             await refreshContextUsage(sessionId: result.sessionId, using: client)
 
+            guard token == reconciliationToken,
+                  profile == activeProfile,
+                  let activeClient = self.client,
+                  activeClient === client else {
+                settleReconciliation(token)
+                return false
+            }
+
             let bufferedEvents = reconciliation?.token == token
                 ? (reconciliation?.bufferedEvents ?? []).filter {
                     reconciliation?.accepts(sessionID(for: $0)) == true
                 }
                 : []
             bufferedEvents.forEach(applyStreamEvent)
-            settleReconciliation(token)
-            publishChatResumeRestorationIfReady()
-            return true
+            return settleReconciliationAndPublish(token)
 
         } catch {
             guard token == reconciliationToken,
@@ -1202,7 +1395,7 @@ final class AppState: ObservableObject {
                 return updated
             }
             if resumePurpose == .automaticReturn {
-                _ = chatResumeCoordinator.selectTarget(
+                _ = selectChatResumeTarget(
                     in: [summary],
                     profile: profile,
                     purpose: resumePurpose,
@@ -1216,8 +1409,7 @@ final class AppState: ObservableObject {
                 await self.loadSlashCommands()
                 await self.loadSessions()
             }
-            settleReconciliation(token)
-            publishChatResumeRestorationIfReady()
+            settleReconciliationAndPublish(token)
         } catch {
             guard token == reconciliationToken,
                   profile == activeProfile,
@@ -1229,6 +1421,9 @@ final class AppState: ObservableObject {
             turnState = .idle
             errorMessage = "Failed to create session: \(error.localizedDescription)"
             settleReconciliation(token)
+            if resumePurpose == .automaticReturn {
+                scheduleReconnect(purpose: resumePurpose)
+            }
         }
     }
 
@@ -1365,14 +1560,30 @@ final class AppState: ObservableObject {
         if let connectedAt, Date().timeIntervalSince(connectedAt) > 10 {
             reconnectAttempts = 0
         }
-        scheduleReconnect(immediately: wasRunning)
+        scheduleReconnect(
+            immediately: wasRunning,
+            purpose: chatResumePurposeForDisconnect()
+        )
     }
 
     private func scheduleReconnect(
         immediately: Bool = false,
         purpose: ChatResumeSyncPurpose = .preserveCurrent
     ) {
-        guard reconnectTask == nil, connection != nil else { return }
+        guard connection != nil else { return }
+        if reconnectTask == nil {
+            recoverySequence.clearQueuedReconnect()
+        }
+        let decision = planChatResumeReconnect(purpose: purpose)
+        switch decision {
+        case .keepExisting:
+            return
+        case .replace:
+            reconnectTask?.cancel()
+            reconnectTask = nil
+        case .schedule:
+            break
+        }
         let delay = immediately ? 0.1 : min(5.0, pow(2.0, Double(reconnectAttempts)))
         if !immediately { reconnectAttempts += 1 }
 
@@ -1380,6 +1591,8 @@ final class AppState: ObservableObject {
             try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
             guard !Task.isCancelled, let self else { return }
             self.reconnectTask = nil
+            let purpose = self.recoverySequence.takeQueuedReconnectPurpose()
+                ?? .preserveCurrent
             await self.reconnect(purpose: purpose)
         }
     }
@@ -1388,6 +1601,12 @@ final class AppState: ObservableObject {
         purpose: ChatResumeSyncPurpose = .preserveCurrent
     ) async {
         guard let savedConnection = connection else { return }
+        let purpose = beginChatResumeRecovery(purpose: purpose)
+        if purpose == .automaticReturn, reconnectTask != nil {
+            reconnectTask?.cancel()
+            reconnectTask = nil
+            recoverySequence.clearQueuedReconnect()
+        }
         isConnecting = true
         turnState = .reconnecting
 
@@ -1615,7 +1834,7 @@ final class AppState: ObservableObject {
                 removeSessionFromLiveCatalog(updated)
                 archivedSessions = [updated] + archivedSessions.filter { !sessionMatches($0, updated) }
                 removePinnedState(for: updated)
-                clearActiveSessionIfNeeded(updated)
+                clearActiveSessionIfNeeded(updated, replacement: .archive)
             } else {
                 archivedSessions.removeAll { sessionMatches($0, updated) }
                 sessions = [updated] + sessions.filter { !sessionMatches($0, updated) }
@@ -1727,7 +1946,7 @@ final class AppState: ObservableObject {
             removeSessionFromLiveCatalog(session)
             archivedSessions.removeAll { sessionMatches($0, session) }
             removePinnedState(for: session)
-            clearActiveSessionIfNeeded(session)
+            clearActiveSessionIfNeeded(session, replacement: .delete)
             return true
         } catch {
             guard profile == activeProfile else { return false }
@@ -1769,8 +1988,12 @@ final class AppState: ObservableObject {
         cronSessions.removeAll { sessionMatches($0, session) }
     }
 
-    private func clearActiveSessionIfNeeded(_ session: SessionSummary) {
+    func clearActiveSessionIfNeeded(
+        _ session: SessionSummary,
+        replacement: ChatResumeConversationReplacement
+    ) {
         guard sessionMatchesActiveSession(session) else { return }
+        acceptChatResumeConversationReplacement(replacement)
         setActiveSessionState(id: nil, title: "New conversation")
         messages = []
         clearStreamingText()
@@ -1883,6 +2106,7 @@ final class AppState: ObservableObject {
     /// during a turn cannot leave the composer with stale busy state.
     func refreshActiveSession() async {
         guard let client, let sessionId = activeSessionId, !isChatRefreshing else { return }
+        cancelChatResumeRestoration()
         isChatRefreshing = true
         defer { isChatRefreshing = false }
 
@@ -1940,6 +2164,7 @@ final class AppState: ObservableObject {
                 await loadSessions(forceRefresh: true)
                 return
             }
+            acceptChatResumeConversationReplacement(.branch)
             try? await client.setSessionTitle(branched.sessionId, title: title)
             guard profile == activeProfile, self.client === client else { return }
 

--- a/Conduit/Services/ChatResumeCoordinator.swift
+++ b/Conduit/Services/ChatResumeCoordinator.swift
@@ -145,8 +145,27 @@ final class ChatResumeCoordinator {
         viewportIsFrozen = false
     }
 
+    /// Called when an automatic sync attempt ends without publishing a
+    /// restoration request (reconcile failure, stale guard, exception).
+    /// Clears pending state and unfreezes the viewport so scroll recording
+    /// resumes. Does NOT cancel the automatic-work epoch so the reconnect
+    /// retry can still proceed.
+    func abandonPendingAutomaticSync() {
+        pendingSessionKey = nil
+        pendingFallbackSelection = false
+        viewportIsFrozen = false
+    }
+
     func reconciliationSettled(sessionKey: ChatScrollSessionKey) -> ChatResumeRestorationRequest? {
-        guard pendingSessionKey == sessionKey, pendingRestoration == nil else { return nil }
+        guard pendingSessionKey == sessionKey, pendingRestoration == nil else {
+            // Mismatch: the settled session doesn't match what we were waiting
+            // for. Clear pending state and unfreeze so the viewport can resume
+            // recording. Otherwise the freeze persists forever.
+            pendingSessionKey = nil
+            pendingFallbackSelection = false
+            viewportIsFrozen = false
+            return nil
+        }
 
         pendingSessionKey = nil
         let isFallbackSelection = pendingFallbackSelection
@@ -178,6 +197,7 @@ final class ChatResumeCoordinator {
     ) {
         if invalidateAutomaticWork {
             automaticCancellationEpoch &+= 1
+            if automaticCancellationEpoch == 0 { automaticCancellationEpoch = 1 }
         }
         pendingFallbackSelection = false
         pendingSessionKey = nil

--- a/Conduit/Services/ChatResumeCoordinator.swift
+++ b/Conduit/Services/ChatResumeCoordinator.swift
@@ -169,13 +169,11 @@ final class ChatResumeCoordinator {
 
     func reconciliationSettled(sessionKey: ChatScrollSessionKey) -> ChatResumeRestorationRequest? {
         guard pendingSessionKey == sessionKey, pendingRestoration == nil else {
-            // Mismatch: clear the stale pending key but leave the freeze
-            // intact. The freeze will be cleared by abandonPendingAutomaticSync()
-            // on actual failure paths, or by completeRestoration/abandonRestoration
-            // when a published request resolves. Unfreezing here would let
-            // `.latest` snapshots overwrite old readings during normal ID
-            // remapping flows (runtime → stored key canonicalization).
-            pendingSessionKey = nil
+            // Mismatch: leave pendingSessionKey intact so the caller
+            // (publishChatResumeRestorationIfReady) can detect it via
+            // abandonPendingAutomaticSyncIfPending() and unfreeze.
+            // If we clear it here, the caller can't distinguish "mismatch
+            // that needs cleanup" from "no pending work at all".
             pendingFallbackSelection = false
             return nil
         }

--- a/Conduit/Services/ChatResumeCoordinator.swift
+++ b/Conduit/Services/ChatResumeCoordinator.swift
@@ -70,7 +70,8 @@ final class ChatResumeCoordinator {
             behavior: store.behavior,
             purpose: purpose,
             savedSessionID: savedSessionID,
-            currentSessionID: currentSessionID
+            currentSessionID: currentSessionID,
+            activeProfile: profile
         )
 
         guard purpose == .automaticReturn else { return selected }
@@ -86,7 +87,10 @@ final class ChatResumeCoordinator {
             ChatScrollSessionKey(profile: profile, sessionID: $0.id)
         }.flatMap { $0.isValid ? $0 : nil }
         pendingFallbackSelection = pendingFallbackSelection && pendingSessionKey != nil
-        viewportIsFrozen = true
+        // Only freeze when we have a valid pending session to restore into.
+        // If the target is nil, no restoration request will ever be published,
+        // so freezing would permanently disable scroll persistence.
+        viewportIsFrozen = pendingSessionKey != nil
         return selected
     }
 
@@ -154,6 +158,7 @@ final class ChatResumeCoordinator {
         }
 
         nextGeneration &+= 1
+        if nextGeneration == 0 { nextGeneration = 1 }
         let request = ChatResumeRestorationRequest(
             generation: nextGeneration,
             sessionKey: sessionKey,

--- a/Conduit/Services/ChatResumeCoordinator.swift
+++ b/Conduit/Services/ChatResumeCoordinator.swift
@@ -16,6 +16,7 @@ struct ChatResumeRestorationRequest: Identifiable, Equatable {
 @MainActor
 final class ChatResumeCoordinator {
     private let store: ChatResumeStore
+    private var pendingFallbackSelection = false
     private var pendingSessionKey: ChatScrollSessionKey?
     private var pendingFlushTask: Task<Void, Never>?
     private var viewportIsFrozen = false
@@ -50,20 +51,28 @@ final class ChatResumeCoordinator {
         purpose: ChatResumeSyncPurpose,
         currentSessionID: String?
     ) -> SessionSummary? {
+        let savedSessionID = store.lastSessionID(for: profile)
         let selected = ChatResumeSessionResolver.target(
             in: catalog,
             behavior: store.behavior,
             purpose: purpose,
-            savedSessionID: store.lastSessionID(for: profile),
+            savedSessionID: savedSessionID,
             currentSessionID: currentSessionID
         )
 
         guard purpose == .automaticReturn else { return selected }
 
         pendingRestoration = nil
+        let savedSessionIsMissing = savedSessionID.map { savedSessionID in
+            !catalog.contains { session in
+                session.id == savedSessionID || session.alternateIds.contains(savedSessionID)
+            }
+        } ?? false
+        pendingFallbackSelection = store.behavior == .continueWhereLeftOff && savedSessionIsMissing
         pendingSessionKey = selected.map {
             ChatScrollSessionKey(profile: profile, sessionID: $0.id)
         }.flatMap { $0.isValid ? $0 : nil }
+        pendingFallbackSelection = pendingFallbackSelection && pendingSessionKey != nil
         viewportIsFrozen = pendingSessionKey != nil
         return selected
     }
@@ -71,7 +80,7 @@ final class ChatResumeCoordinator {
     func recordViewport(_ snapshot: ChatScrollSnapshot, for key: ChatScrollSessionKey) {
         guard !viewportIsFrozen, key.isValid else { return }
 
-        store.save(snapshot, for: key, at: Date())
+        store.stageSnapshot(snapshot, for: key, at: Date())
         pendingFlushTask?.cancel()
         pendingFlushTask = Task { [weak self] in
             do {
@@ -99,8 +108,10 @@ final class ChatResumeCoordinator {
         guard pendingSessionKey == sessionKey, pendingRestoration == nil else { return nil }
 
         pendingSessionKey = nil
+        let isFallbackSelection = pendingFallbackSelection
+        pendingFallbackSelection = false
         let destination: ChatResumeRestorationDestination
-        if store.behavior == .latestActivity {
+        if isFallbackSelection || store.behavior == .latestActivity {
             destination = .latest
         } else if let snapshot = store.snapshot(for: sessionKey), !snapshot.followsLatest {
             destination = .snapshot(snapshot)
@@ -120,6 +131,7 @@ final class ChatResumeCoordinator {
     }
 
     func cancelRestoration() {
+        pendingFallbackSelection = false
         pendingSessionKey = nil
         pendingRestoration = nil
         viewportIsFrozen = false

--- a/Conduit/Services/ChatResumeCoordinator.swift
+++ b/Conduit/Services/ChatResumeCoordinator.swift
@@ -156,6 +156,17 @@ final class ChatResumeCoordinator {
         viewportIsFrozen = false
     }
 
+    /// Like abandonPendingAutomaticSync but only acts if there was actually
+    /// a pending session key. Used on success paths where reconciliationSettled
+    /// returned nil — if there was no pending key, there's nothing to clean up
+    /// and we must not unfreeze an existing freeze from a different source.
+    func abandonPendingAutomaticSyncIfPending() {
+        guard pendingSessionKey != nil else { return }
+        pendingSessionKey = nil
+        pendingFallbackSelection = false
+        viewportIsFrozen = false
+    }
+
     func reconciliationSettled(sessionKey: ChatScrollSessionKey) -> ChatResumeRestorationRequest? {
         guard pendingSessionKey == sessionKey, pendingRestoration == nil else {
             // Mismatch: clear the stale pending key but leave the freeze

--- a/Conduit/Services/ChatResumeCoordinator.swift
+++ b/Conduit/Services/ChatResumeCoordinator.swift
@@ -158,12 +158,14 @@ final class ChatResumeCoordinator {
 
     func reconciliationSettled(sessionKey: ChatScrollSessionKey) -> ChatResumeRestorationRequest? {
         guard pendingSessionKey == sessionKey, pendingRestoration == nil else {
-            // Mismatch: the settled session doesn't match what we were waiting
-            // for. Clear pending state and unfreeze so the viewport can resume
-            // recording. Otherwise the freeze persists forever.
+            // Mismatch: clear the stale pending key but leave the freeze
+            // intact. The freeze will be cleared by abandonPendingAutomaticSync()
+            // on actual failure paths, or by completeRestoration/abandonRestoration
+            // when a published request resolves. Unfreezing here would let
+            // `.latest` snapshots overwrite old readings during normal ID
+            // remapping flows (runtime → stored key canonicalization).
             pendingSessionKey = nil
             pendingFallbackSelection = false
-            viewportIsFrozen = false
             return nil
         }
 

--- a/Conduit/Services/ChatResumeCoordinator.swift
+++ b/Conduit/Services/ChatResumeCoordinator.swift
@@ -87,10 +87,13 @@ final class ChatResumeCoordinator {
             ChatScrollSessionKey(profile: profile, sessionID: $0.id)
         }.flatMap { $0.isValid ? $0 : nil }
         pendingFallbackSelection = pendingFallbackSelection && pendingSessionKey != nil
-        // Only freeze when we have a valid pending session to restore into.
-        // If the target is nil, no restoration request will ever be published,
-        // so freezing would permanently disable scroll persistence.
-        viewportIsFrozen = pendingSessionKey != nil
+        // Freeze the viewport whenever we have a valid pending session.
+        // If target is nil, preserve any existing freeze (e.g. set by
+        // freezeViewport before the catalog loaded) rather than unfreezing,
+        // which would let stale snapshots overwrite the pre-freeze state.
+        if pendingSessionKey != nil {
+            viewportIsFrozen = true
+        }
         return selected
     }
 

--- a/Conduit/Services/ChatResumeCoordinator.swift
+++ b/Conduit/Services/ChatResumeCoordinator.swift
@@ -73,7 +73,7 @@ final class ChatResumeCoordinator {
             ChatScrollSessionKey(profile: profile, sessionID: $0.id)
         }.flatMap { $0.isValid ? $0 : nil }
         pendingFallbackSelection = pendingFallbackSelection && pendingSessionKey != nil
-        viewportIsFrozen = pendingSessionKey != nil
+        viewportIsFrozen = true
         return selected
     }
 

--- a/Conduit/Services/ChatResumeCoordinator.swift
+++ b/Conduit/Services/ChatResumeCoordinator.swift
@@ -46,7 +46,7 @@ final class ChatResumeCoordinator {
     }
 
     func setBehavior(_ behavior: ChatResumeBehavior) {
-        cancelRestoration()
+        cancelViewportRestoration()
         store.setBehavior(behavior)
     }
 
@@ -110,6 +110,10 @@ final class ChatResumeCoordinator {
         store.migrateSnapshot(from: oldKey, to: newKey)
     }
 
+    func migrateSessionIdentity(from oldKey: ChatScrollSessionKey, to newKey: ChatScrollSessionKey) {
+        store.migrateSessionIdentity(from: oldKey, to: newKey)
+    }
+
     func freezeViewport() {
         viewportIsFrozen = true
         pendingFlushTask?.cancel()
@@ -160,7 +164,7 @@ final class ChatResumeCoordinator {
         return request
     }
 
-    func cancelRestoration(
+    func cancelViewportRestoration(
         invalidateAutomaticWork: Bool = true,
         keepViewportFrozen: Bool = false
     ) {
@@ -190,7 +194,7 @@ final class ChatResumeCoordinator {
     }
 
     func clearResumeState() {
-        cancelRestoration()
+        cancelViewportRestoration()
         store.clearResumeState()
     }
 

--- a/Conduit/Services/ChatResumeCoordinator.swift
+++ b/Conduit/Services/ChatResumeCoordinator.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+enum ChatResumeRestorationDestination: Equatable {
+    case latest
+    case snapshot(ChatScrollSnapshot)
+}
+
+struct ChatResumeRestorationRequest: Identifiable, Equatable {
+    let generation: UInt64
+    let sessionKey: ChatScrollSessionKey
+    let destination: ChatResumeRestorationDestination
+
+    var id: UInt64 { generation }
+}
+
+@MainActor
+final class ChatResumeCoordinator {
+    private let store: ChatResumeStore
+    private var pendingSessionKey: ChatScrollSessionKey?
+    private var pendingFlushTask: Task<Void, Never>?
+    private var viewportIsFrozen = false
+    private var nextGeneration: UInt64 = 0
+
+    private(set) var pendingRestoration: ChatResumeRestorationRequest?
+
+    var behavior: ChatResumeBehavior {
+        store.behavior
+    }
+
+    init(store: ChatResumeStore) {
+        self.store = store
+    }
+
+    func setBehavior(_ behavior: ChatResumeBehavior) {
+        cancelRestoration()
+        store.setBehavior(behavior)
+    }
+
+    func lastSessionID(for profile: String) -> String? {
+        store.lastSessionID(for: profile)
+    }
+
+    func rememberSessionID(_ sessionID: String?, for profile: String) {
+        store.setLastSessionID(sessionID, for: profile)
+    }
+
+    func selectTarget(
+        in catalog: [SessionSummary],
+        profile: String,
+        purpose: ChatResumeSyncPurpose,
+        currentSessionID: String?
+    ) -> SessionSummary? {
+        let selected = ChatResumeSessionResolver.target(
+            in: catalog,
+            behavior: store.behavior,
+            purpose: purpose,
+            savedSessionID: store.lastSessionID(for: profile),
+            currentSessionID: currentSessionID
+        )
+
+        guard purpose == .automaticReturn else { return selected }
+
+        pendingRestoration = nil
+        pendingSessionKey = selected.map {
+            ChatScrollSessionKey(profile: profile, sessionID: $0.id)
+        }.flatMap { $0.isValid ? $0 : nil }
+        viewportIsFrozen = pendingSessionKey != nil
+        return selected
+    }
+
+    func recordViewport(_ snapshot: ChatScrollSnapshot, for key: ChatScrollSessionKey) {
+        guard !viewportIsFrozen, key.isValid else { return }
+
+        store.save(snapshot, for: key, at: Date())
+        pendingFlushTask?.cancel()
+        pendingFlushTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: .milliseconds(300))
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            self?.store.flush()
+        }
+    }
+
+    func migrateSnapshot(from oldKey: ChatScrollSessionKey, to newKey: ChatScrollSessionKey) {
+        store.migrateSnapshot(from: oldKey, to: newKey)
+    }
+
+    func freezeViewport() {
+        viewportIsFrozen = true
+        pendingFlushTask?.cancel()
+        pendingFlushTask = nil
+        store.flush()
+    }
+
+    func reconciliationSettled(sessionKey: ChatScrollSessionKey) -> ChatResumeRestorationRequest? {
+        guard pendingSessionKey == sessionKey, pendingRestoration == nil else { return nil }
+
+        pendingSessionKey = nil
+        let destination: ChatResumeRestorationDestination
+        if store.behavior == .latestActivity {
+            destination = .latest
+        } else if let snapshot = store.snapshot(for: sessionKey), !snapshot.followsLatest {
+            destination = .snapshot(snapshot)
+        } else {
+            destination = .latest
+        }
+
+        nextGeneration &+= 1
+        let request = ChatResumeRestorationRequest(
+            generation: nextGeneration,
+            sessionKey: sessionKey,
+            destination: destination
+        )
+        pendingRestoration = request
+        viewportIsFrozen = true
+        return request
+    }
+
+    func cancelRestoration() {
+        pendingSessionKey = nil
+        pendingRestoration = nil
+        viewportIsFrozen = false
+    }
+
+    func completeRestoration(generation: UInt64) {
+        guard pendingRestoration?.generation == generation else { return }
+        pendingRestoration = nil
+        viewportIsFrozen = false
+    }
+
+    func isCurrent(generation: UInt64) -> Bool {
+        pendingRestoration?.generation == generation
+    }
+
+    func clearResumeState() {
+        cancelRestoration()
+        store.clearResumeState()
+    }
+
+    func flush() {
+        pendingFlushTask?.cancel()
+        pendingFlushTask = nil
+        store.flush()
+    }
+}

--- a/Conduit/Services/ChatResumeCoordinator.swift
+++ b/Conduit/Services/ChatResumeCoordinator.swift
@@ -13,6 +13,10 @@ struct ChatResumeRestorationRequest: Identifiable, Equatable {
     var id: UInt64 { generation }
 }
 
+struct ChatResumeAutomaticWorkToken: Equatable {
+    fileprivate let cancellationEpoch: UInt64
+}
+
 @MainActor
 final class ChatResumeCoordinator {
     private let store: ChatResumeStore
@@ -21,6 +25,7 @@ final class ChatResumeCoordinator {
     private var pendingFlushTask: Task<Void, Never>?
     private var viewportIsFrozen = false
     private var nextGeneration: UInt64 = 0
+    private var automaticCancellationEpoch: UInt64 = 0
 
     private(set) var pendingRestoration: ChatResumeRestorationRequest?
 
@@ -30,6 +35,14 @@ final class ChatResumeCoordinator {
 
     init(store: ChatResumeStore) {
         self.store = store
+    }
+
+    func beginAutomaticWork() -> ChatResumeAutomaticWorkToken {
+        ChatResumeAutomaticWorkToken(cancellationEpoch: automaticCancellationEpoch)
+    }
+
+    func isCurrent(_ token: ChatResumeAutomaticWorkToken) -> Bool {
+        token.cancellationEpoch == automaticCancellationEpoch
     }
 
     func setBehavior(_ behavior: ChatResumeBehavior) {
@@ -104,6 +117,23 @@ final class ChatResumeCoordinator {
         store.flush()
     }
 
+    func captureViewportAndFreeze(
+        _ snapshot: ChatScrollSnapshot?,
+        for key: ChatScrollSessionKey?
+    ) {
+        pendingFlushTask?.cancel()
+        pendingFlushTask = nil
+        if let snapshot, let key, key.isValid {
+            store.stageSnapshot(snapshot, for: key, at: Date())
+        }
+        viewportIsFrozen = true
+        store.flush()
+    }
+
+    func unfreezeViewport() {
+        viewportIsFrozen = false
+    }
+
     func reconciliationSettled(sessionKey: ChatScrollSessionKey) -> ChatResumeRestorationRequest? {
         guard pendingSessionKey == sessionKey, pendingRestoration == nil else { return nil }
 
@@ -130,14 +160,26 @@ final class ChatResumeCoordinator {
         return request
     }
 
-    func cancelRestoration() {
+    func cancelRestoration(
+        invalidateAutomaticWork: Bool = true,
+        keepViewportFrozen: Bool = false
+    ) {
+        if invalidateAutomaticWork {
+            automaticCancellationEpoch &+= 1
+        }
         pendingFallbackSelection = false
         pendingSessionKey = nil
+        pendingRestoration = nil
+        viewportIsFrozen = keepViewportFrozen
+    }
+
+    func completeRestoration(generation: UInt64) {
+        guard pendingRestoration?.generation == generation else { return }
         pendingRestoration = nil
         viewportIsFrozen = false
     }
 
-    func completeRestoration(generation: UInt64) {
+    func abandonRestoration(generation: UInt64) {
         guard pendingRestoration?.generation == generation else { return }
         pendingRestoration = nil
         viewportIsFrozen = false

--- a/Conduit/Services/ChatResumePolicy.swift
+++ b/Conduit/Services/ChatResumePolicy.swift
@@ -32,8 +32,13 @@ enum ChatResumeSessionResolver {
     ) -> SessionSummary? {
         // Filter to the active profile when available so sessions from
         // other profiles don't interfere with ID matching or fallback.
+        // Use case-insensitive comparison to match AppState.profilesMatch.
         let scoped = activeProfile.map { profile in
-            catalog.filter { $0.profile == nil || $0.profile == profile }
+            catalog.filter { entry in
+                guard let entryProfile = entry.profile else { return true }
+                return entryProfile.trimmingCharacters(in: .whitespacesAndNewlines)
+                    .caseInsensitiveCompare(profile.trimmingCharacters(in: .whitespacesAndNewlines)) == .orderedSame
+            }
         } ?? catalog
 
         let requestedID = purpose == .preserveCurrent ? currentSessionID : savedSessionID

--- a/Conduit/Services/ChatResumePolicy.swift
+++ b/Conduit/Services/ChatResumePolicy.swift
@@ -27,17 +27,24 @@ enum ChatResumeSessionResolver {
         behavior: ChatResumeBehavior,
         purpose: ChatResumeSyncPurpose,
         savedSessionID: String?,
-        currentSessionID: String?
+        currentSessionID: String?,
+        activeProfile: String? = nil
     ) -> SessionSummary? {
+        // Filter to the active profile when available so sessions from
+        // other profiles don't interfere with ID matching or fallback.
+        let scoped = activeProfile.map { profile in
+            catalog.filter { $0.profile == nil || $0.profile == profile }
+        } ?? catalog
+
         let requestedID = purpose == .preserveCurrent ? currentSessionID : savedSessionID
         if purpose == .preserveCurrent || behavior == .continueWhereLeftOff,
            let requestedID,
-           let matched = catalog.first(where: {
-               $0.id == requestedID || $0.alternateIds.contains(requestedID)
+           let matched = scoped.first(where: {
+                $0.id == requestedID || $0.alternateIds.contains(requestedID)
            }) {
             return matched
         }
-        return catalog.first(where: { $0.source == .chat })
+        return scoped.first(where: { $0.source == .chat })
     }
 }
 

--- a/Conduit/Services/ChatResumePolicy.swift
+++ b/Conduit/Services/ChatResumePolicy.swift
@@ -5,6 +5,17 @@ enum ChatResumeBehavior: String, Codable, CaseIterable {
     case latestActivity
 }
 
+extension ChatResumeBehavior {
+    var title: String {
+        switch self {
+        case .continueWhereLeftOff:
+            "Continue where I left off"
+        case .latestActivity:
+            "Jump to latest activity"
+        }
+    }
+}
+
 enum ChatResumeSyncPurpose: Equatable {
     case automaticReturn
     case preserveCurrent

--- a/Conduit/Services/ChatResumePolicy.swift
+++ b/Conduit/Services/ChatResumePolicy.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+enum ChatResumeBehavior: String, Codable, CaseIterable {
+    case continueWhereLeftOff
+    case latestActivity
+}
+
+enum ChatResumeSyncPurpose: Equatable {
+    case automaticReturn
+    case preserveCurrent
+}
+
+enum ChatResumeSessionResolver {
+    static func target(
+        in catalog: [SessionSummary],
+        behavior: ChatResumeBehavior,
+        purpose: ChatResumeSyncPurpose,
+        savedSessionID: String?,
+        currentSessionID: String?
+    ) -> SessionSummary? {
+        let requestedID = purpose == .preserveCurrent ? currentSessionID : savedSessionID
+        if purpose == .preserveCurrent || behavior == .continueWhereLeftOff,
+           let requestedID,
+           let matched = catalog.first(where: {
+               $0.id == requestedID || $0.alternateIds.contains(requestedID)
+           }) {
+            return matched
+        }
+        return catalog.first(where: { $0.source == .chat })
+    }
+}

--- a/Conduit/Services/ChatResumePolicy.swift
+++ b/Conduit/Services/ChatResumePolicy.swift
@@ -29,3 +29,32 @@ enum ChatResumeSessionResolver {
         return catalog.first(where: { $0.source == .chat })
     }
 }
+
+enum ChatResumeViewportDestination: Equatable {
+    case latest
+    case anchor(String)
+}
+
+enum ChatResumeViewportResolver {
+    static func destination(
+        for snapshot: ChatScrollSnapshot,
+        availableTargets: ChatScrollTargetAvailability
+    ) -> ChatResumeViewportDestination {
+        guard !snapshot.followsLatest else { return .latest }
+        if let anchor = snapshot.anchorMessageID,
+           availableTargets.contains(anchor),
+           snapshot.anchorMetadata == nil
+            || availableTargets.metadata(for: anchor) == snapshot.anchorMetadata {
+            return .anchor(anchor)
+        }
+
+        guard let sourceMessageID = snapshot.anchorSourceMessageID,
+              let refreshedAnchor = availableTargets.semanticID(
+                forSourceMessageID: sourceMessageID
+              ),
+              availableTargets.metadata(for: refreshedAnchor) != nil else {
+            return .latest
+        }
+        return .anchor(refreshedAnchor)
+    }
+}

--- a/Conduit/Services/ChatResumeStore.swift
+++ b/Conduit/Services/ChatResumeStore.swift
@@ -134,7 +134,6 @@ final class ChatResumeStore {
 
     func flush() {
         persist()
-        defaults.synchronize()
     }
 
     private static var emptyPayload: Payload {

--- a/Conduit/Services/ChatResumeStore.swift
+++ b/Conduit/Services/ChatResumeStore.swift
@@ -104,7 +104,12 @@ final class ChatResumeStore {
               let source = payload.snapshots.first(where: { $0.key == oldKey }) else {
             return
         }
-        save(source.snapshot, for: newKey, at: source.updatedAt)
+        payload.snapshots.removeAll { $0.key == oldKey }
+        payload.snapshots.append(
+            StoredSnapshot(key: newKey, snapshot: source.snapshot, updatedAt: source.updatedAt)
+        )
+        payload.snapshots = Self.pruned(payload.snapshots)
+        persist()
     }
 
     func clearResumeState() {
@@ -137,10 +142,17 @@ final class ChatResumeStore {
     }
 
     private static func normalizedLastSessionIDs(_ values: [String: String]) -> [String: String] {
-        values.reduce(into: [:]) { result, entry in
+        let normalized = values.compactMap { entry -> ChatScrollSessionKey? in
             let key = ChatScrollSessionKey(profile: entry.key, sessionID: entry.value)
-            guard key.isValid else { return }
-            result[key.profile] = key.sessionID
+            return key.isValid ? key : nil
+        }.sorted { lhs, rhs in
+            if lhs.profile != rhs.profile { return lhs.profile < rhs.profile }
+            return lhs.sessionID < rhs.sessionID
+        }
+        return normalized.reduce(into: [:]) { result, key in
+            if result[key.profile] == nil {
+                result[key.profile] = key.sessionID
+            }
         }
     }
 
@@ -162,10 +174,51 @@ final class ChatResumeStore {
                 )
             }
             .filter { $0.key.isValid }
-            .sorted { $0.updatedAt > $1.updatedAt }
+            .sorted(by: isOrderedBefore)
 
         var seenKeys = Set<ChatScrollSessionKey>()
         return ordered.filter { seenKeys.insert($0.key).inserted }.prefix(maximumSnapshots).map { $0 }
+    }
+
+    private static func isOrderedBefore(_ lhs: StoredSnapshot, _ rhs: StoredSnapshot) -> Bool {
+        if lhs.updatedAt != rhs.updatedAt { return lhs.updatedAt > rhs.updatedAt }
+        if lhs.key.profile != rhs.key.profile { return lhs.key.profile < rhs.key.profile }
+        if lhs.key.sessionID != rhs.key.sessionID { return lhs.key.sessionID < rhs.key.sessionID }
+        return isOrderedBefore(lhs.snapshot, rhs.snapshot)
+    }
+
+    private static func isOrderedBefore(_ lhs: ChatScrollSnapshot, _ rhs: ChatScrollSnapshot) -> Bool {
+        if let result = optionalIsOrderedBefore(lhs.anchorMessageID, rhs.anchorMessageID) {
+            return result
+        }
+        if lhs.followsLatest != rhs.followsLatest { return !lhs.followsLatest }
+        if let result = optionalIsOrderedBefore(
+            lhs.anchorMetadata?.fingerprint,
+            rhs.anchorMetadata?.fingerprint
+        ) {
+            return result
+        }
+        if let result = optionalIsOrderedBefore(
+            lhs.anchorMetadata?.duplicateCount,
+            rhs.anchorMetadata?.duplicateCount
+        ) {
+            return result
+        }
+        return optionalIsOrderedBefore(lhs.anchorSourceMessageID, rhs.anchorSourceMessageID) ?? false
+    }
+
+    private static func optionalIsOrderedBefore<T: Comparable>(_ lhs: T?, _ rhs: T?) -> Bool? {
+        switch (lhs, rhs) {
+        case (nil, nil):
+            return nil
+        case (nil, .some):
+            return true
+        case (.some, nil):
+            return false
+        case let (.some(lhs), .some(rhs)):
+            guard lhs != rhs else { return nil }
+            return lhs < rhs
+        }
     }
 
     private func persist() {

--- a/Conduit/Services/ChatResumeStore.swift
+++ b/Conduit/Services/ChatResumeStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@MainActor
 final class ChatResumeStore {
     static let defaultStorageKey = "conduit.chatResume.v1"
     static let schemaVersion = 1

--- a/Conduit/Services/ChatResumeStore.swift
+++ b/Conduit/Services/ChatResumeStore.swift
@@ -102,18 +102,28 @@ final class ChatResumeStore {
     }
 
     func migrateSnapshot(from oldKey: ChatScrollSessionKey, to newKey: ChatScrollSessionKey) {
+        guard migrateSnapshotInPayload(from: oldKey, to: newKey) else { return }
+        persist()
+    }
+
+    func migrateSessionIdentity(from oldKey: ChatScrollSessionKey, to newKey: ChatScrollSessionKey) {
         guard oldKey.isValid,
               newKey.isValid,
-              oldKey != newKey,
-              let source = payload.snapshots.first(where: { $0.key == oldKey }) else {
-            return
+              oldKey.profile == newKey.profile,
+              oldKey != newKey else { return }
+
+        let migratedSnapshot = migrateSnapshotInPayload(from: oldKey, to: newKey)
+        let migratedLastSession: Bool
+        if payload.lastSessionIDsByProfile[oldKey.profile] == oldKey.sessionID {
+            payload.lastSessionIDsByProfile[oldKey.profile] = newKey.sessionID
+            migratedLastSession = true
+        } else {
+            migratedLastSession = false
         }
-        payload.snapshots.removeAll { $0.key == oldKey }
-        payload.snapshots.append(
-            StoredSnapshot(key: newKey, snapshot: source.snapshot, updatedAt: source.updatedAt)
-        )
-        payload.snapshots = Self.pruned(payload.snapshots)
-        persist()
+
+        if migratedSnapshot || migratedLastSession {
+            persist()
+        }
     }
 
     func clearResumeState() {
@@ -134,6 +144,25 @@ final class ChatResumeStore {
             lastSessionIDsByProfile: [:],
             snapshots: []
         )
+    }
+
+    @discardableResult
+    private func migrateSnapshotInPayload(
+        from oldKey: ChatScrollSessionKey,
+        to newKey: ChatScrollSessionKey
+    ) -> Bool {
+        guard oldKey.isValid,
+              newKey.isValid,
+              oldKey != newKey,
+              let source = payload.snapshots.first(where: { $0.key == oldKey }) else {
+            return false
+        }
+        payload.snapshots.removeAll { $0.key == oldKey }
+        payload.snapshots.append(
+            StoredSnapshot(key: newKey, snapshot: source.snapshot, updatedAt: source.updatedAt)
+        )
+        payload.snapshots = Self.pruned(payload.snapshots)
+        return true
     }
 
     private static func normalized(_ payload: Payload) -> Payload {

--- a/Conduit/Services/ChatResumeStore.swift
+++ b/Conduit/Services/ChatResumeStore.swift
@@ -90,11 +90,15 @@ final class ChatResumeStore {
     }
 
     func save(_ snapshot: ChatScrollSnapshot, for key: ChatScrollSessionKey, at updatedAt: Date) {
+        stageSnapshot(snapshot, for: key, at: updatedAt)
+        persist()
+    }
+
+    func stageSnapshot(_ snapshot: ChatScrollSnapshot, for key: ChatScrollSessionKey, at updatedAt: Date) {
         guard key.isValid else { return }
         payload.snapshots.removeAll { $0.key == key }
         payload.snapshots.append(StoredSnapshot(key: key, snapshot: snapshot, updatedAt: updatedAt))
         payload.snapshots = Self.pruned(payload.snapshots)
-        persist()
     }
 
     func migrateSnapshot(from oldKey: ChatScrollSessionKey, to newKey: ChatScrollSessionKey) {

--- a/Conduit/Services/ChatResumeStore.swift
+++ b/Conduit/Services/ChatResumeStore.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+final class ChatResumeStore {
+    static let defaultStorageKey = "conduit.chatResume.v1"
+    static let schemaVersion = 1
+    static let maximumSnapshots = 100
+
+    private struct StoredSnapshot: Codable, Equatable {
+        let key: ChatScrollSessionKey
+        let snapshot: ChatScrollSnapshot
+        let updatedAt: Date
+    }
+
+    private struct Payload: Codable, Equatable {
+        let version: Int
+        var behavior: ChatResumeBehavior
+        var lastSessionIDsByProfile: [String: String]
+        var snapshots: [StoredSnapshot]
+    }
+
+    private let defaults: UserDefaults
+    private let storageKey: String
+    private var payload: Payload
+
+    init(
+        defaults: UserDefaults = .standard,
+        storageKey: String = ChatResumeStore.defaultStorageKey,
+        legacyActiveSessionsKey: String = "conduit.activeSessionIdsByProfile.v1"
+    ) {
+        self.defaults = defaults
+        self.storageKey = storageKey
+
+        guard defaults.object(forKey: storageKey) != nil else {
+            payload = Payload(
+                version: Self.schemaVersion,
+                behavior: .continueWhereLeftOff,
+                lastSessionIDsByProfile: Self.normalizedLastSessionIDs(
+                    defaults.dictionary(forKey: legacyActiveSessionsKey) as? [String: String] ?? [:]
+                ),
+                snapshots: []
+            )
+            persist()
+            return
+        }
+
+        guard let data = defaults.data(forKey: storageKey),
+              let storedPayload = try? JSONDecoder().decode(Payload.self, from: data),
+              storedPayload.version == Self.schemaVersion else {
+            payload = Self.emptyPayload
+            persist()
+            return
+        }
+
+        payload = Self.normalized(storedPayload)
+        if payload != storedPayload {
+            persist()
+        }
+    }
+
+    var behavior: ChatResumeBehavior {
+        payload.behavior
+    }
+
+    func setBehavior(_ behavior: ChatResumeBehavior) {
+        payload.behavior = behavior
+        persist()
+    }
+
+    func lastSessionID(for profile: String) -> String? {
+        guard let normalizedProfile = Self.normalizedProfile(profile) else { return nil }
+        return payload.lastSessionIDsByProfile[normalizedProfile]
+    }
+
+    func setLastSessionID(_ sessionID: String?, for profile: String) {
+        guard let normalizedProfile = Self.normalizedProfile(profile) else { return }
+        guard let sessionID else {
+            payload.lastSessionIDsByProfile.removeValue(forKey: normalizedProfile)
+            persist()
+            return
+        }
+        let key = ChatScrollSessionKey(profile: normalizedProfile, sessionID: sessionID)
+        guard key.isValid else { return }
+        payload.lastSessionIDsByProfile[key.profile] = key.sessionID
+        persist()
+    }
+
+    func snapshot(for key: ChatScrollSessionKey) -> ChatScrollSnapshot? {
+        guard key.isValid else { return nil }
+        return payload.snapshots.first(where: { $0.key == key })?.snapshot
+    }
+
+    func save(_ snapshot: ChatScrollSnapshot, for key: ChatScrollSessionKey, at updatedAt: Date) {
+        guard key.isValid else { return }
+        payload.snapshots.removeAll { $0.key == key }
+        payload.snapshots.append(StoredSnapshot(key: key, snapshot: snapshot, updatedAt: updatedAt))
+        payload.snapshots = Self.pruned(payload.snapshots)
+        persist()
+    }
+
+    func migrateSnapshot(from oldKey: ChatScrollSessionKey, to newKey: ChatScrollSessionKey) {
+        guard oldKey.isValid,
+              newKey.isValid,
+              oldKey != newKey,
+              let source = payload.snapshots.first(where: { $0.key == oldKey }) else {
+            return
+        }
+        save(source.snapshot, for: newKey, at: source.updatedAt)
+    }
+
+    func clearResumeState() {
+        payload.lastSessionIDsByProfile = [:]
+        payload.snapshots = []
+        persist()
+    }
+
+    func flush() {
+        persist()
+        defaults.synchronize()
+    }
+
+    private static var emptyPayload: Payload {
+        Payload(
+            version: schemaVersion,
+            behavior: .continueWhereLeftOff,
+            lastSessionIDsByProfile: [:],
+            snapshots: []
+        )
+    }
+
+    private static func normalized(_ payload: Payload) -> Payload {
+        Payload(
+            version: schemaVersion,
+            behavior: payload.behavior,
+            lastSessionIDsByProfile: normalizedLastSessionIDs(payload.lastSessionIDsByProfile),
+            snapshots: pruned(payload.snapshots)
+        )
+    }
+
+    private static func normalizedLastSessionIDs(_ values: [String: String]) -> [String: String] {
+        values.reduce(into: [:]) { result, entry in
+            let key = ChatScrollSessionKey(profile: entry.key, sessionID: entry.value)
+            guard key.isValid else { return }
+            result[key.profile] = key.sessionID
+        }
+    }
+
+    private static func normalizedProfile(_ profile: String) -> String? {
+        let key = ChatScrollSessionKey(profile: profile, sessionID: "profile-normalization")
+        return key.isValid ? key.profile : nil
+    }
+
+    private static func pruned(_ snapshots: [StoredSnapshot]) -> [StoredSnapshot] {
+        let ordered = snapshots
+            .map { snapshot in
+                StoredSnapshot(
+                    key: ChatScrollSessionKey(
+                        profile: snapshot.key.profile,
+                        sessionID: snapshot.key.sessionID
+                    ),
+                    snapshot: snapshot.snapshot,
+                    updatedAt: snapshot.updatedAt
+                )
+            }
+            .filter { $0.key.isValid }
+            .sorted { $0.updatedAt > $1.updatedAt }
+
+        var seenKeys = Set<ChatScrollSessionKey>()
+        return ordered.filter { seenKeys.insert($0.key).inserted }.prefix(maximumSnapshots).map { $0 }
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(payload) else { return }
+        defaults.set(data, forKey: storageKey)
+    }
+}

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -103,12 +103,18 @@ struct ChatRenderedScrollTargets: Equatable {
         value: inout ChatRenderedScrollTargets,
         nextValue: ChatRenderedScrollTargets
     ) {
+        // Merge new rows and bottoms into the accumulator.
         for (scope, rows) in nextValue.rowsByScope {
             value.rowsByScope[scope, default: []].formUnion(rows)
         }
         for (scope, bottoms) in nextValue.bottomsByScope {
             value.bottomsByScope[scope, default: []].formUnion(bottoms)
         }
+        // Prune: keep only scopes from the latest preference value plus
+        // a small overlap window. Each message update creates a new scope
+        // (different revision numbers), so without pruning the dictionaries
+        // grow one entry per update for the view's lifetime.
+        value.retainLatestScopes(from: nextValue)
     }
 
     func contains(row semanticID: String, in scope: ChatRenderedScrollScope) -> Bool {
@@ -117,6 +123,17 @@ struct ChatRenderedScrollTargets: Equatable {
 
     func contains(bottom anchorID: String, in scope: ChatRenderedScrollScope) -> Bool {
         bottomsByScope[scope]?.contains(anchorID) == true
+    }
+
+    /// Remove scopes that are no longer in the latest preference value.
+    /// This prevents unbounded accumulation across message updates without
+    /// relying on ordering — we simply keep only scopes present in the
+    /// current frame.
+    mutating func retainLatestScopes(from latest: ChatRenderedScrollTargets) {
+        let activeScopes = Set(latest.rowsByScope.keys).union(latest.bottomsByScope.keys)
+        guard !activeScopes.isEmpty else { return }
+        rowsByScope = rowsByScope.filter { activeScopes.contains($0.key) }
+        bottomsByScope = bottomsByScope.filter { activeScopes.contains($0.key) }
     }
 }
 

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -38,7 +38,6 @@ enum ChatMessageScrollUpdatePolicy {
 struct ChatMessageScrollTargetCache: Equatable {
     private(set) var targets: [ChatMessageScrollTarget] = []
     private(set) var renderingRevision: UInt64 = 0
-    private(set) var semanticTargetIDs: Set<String> = []
     private var fingerprints: [String] = []
 
     @discardableResult
@@ -62,34 +61,62 @@ struct ChatMessageScrollTargetCache: Equatable {
             for: messages,
             fingerprints: updatedFingerprints
         )
-        semanticTargetIDs = Set(targets.map(\.semanticID))
         renderingRevision &+= 1
         return .semanticsChanged
     }
 }
 
-struct ChatRenderedScrollContent: Equatable {
+struct ChatRenderedScrollScope: Hashable {
     let sessionKey: ChatScrollSessionKey
     let cacheRevision: UInt64
-    let semanticTargetIDs: Set<String>
-    let bottomAnchorID: String
     let restorationGeneration: UInt64?
+    let transcriptRevision: UInt64
     let viewportTransitionGeneration: UInt64
+}
 
-    init(
-        sessionKey: ChatScrollSessionKey,
-        cacheRevision: UInt64,
-        semanticTargetIDs: Set<String>,
-        bottomAnchorID: String,
-        restorationGeneration: UInt64? = nil,
-        viewportTransitionGeneration: UInt64 = 0
+struct ChatRenderedScrollContent: Equatable {
+    let scope: ChatRenderedScrollScope
+}
+
+/// A preference payload emitted only by targets SwiftUI has instantiated.
+/// The cache deliberately cannot populate this value: lazy offscreen rows
+/// become ready only when their own geometry participates in the layout pass.
+struct ChatRenderedScrollTargets: Equatable {
+    private(set) var rowsByScope: [ChatRenderedScrollScope: Set<String>] = [:]
+    private(set) var bottomsByScope: [ChatRenderedScrollScope: Set<String>] = [:]
+
+    static func row(
+        semanticID: String,
+        scope: ChatRenderedScrollScope
+    ) -> ChatRenderedScrollTargets {
+        ChatRenderedScrollTargets(rowsByScope: [scope: [semanticID]])
+    }
+
+    static func bottom(
+        anchorID: String,
+        scope: ChatRenderedScrollScope
+    ) -> ChatRenderedScrollTargets {
+        ChatRenderedScrollTargets(bottomsByScope: [scope: [anchorID]])
+    }
+
+    static func reduce(
+        value: inout ChatRenderedScrollTargets,
+        nextValue: ChatRenderedScrollTargets
     ) {
-        self.sessionKey = sessionKey
-        self.cacheRevision = cacheRevision
-        self.semanticTargetIDs = semanticTargetIDs
-        self.bottomAnchorID = bottomAnchorID
-        self.restorationGeneration = restorationGeneration
-        self.viewportTransitionGeneration = viewportTransitionGeneration
+        for (scope, rows) in nextValue.rowsByScope {
+            value.rowsByScope[scope, default: []].formUnion(rows)
+        }
+        for (scope, bottoms) in nextValue.bottomsByScope {
+            value.bottomsByScope[scope, default: []].formUnion(bottoms)
+        }
+    }
+
+    func contains(row semanticID: String, in scope: ChatRenderedScrollScope) -> Bool {
+        rowsByScope[scope]?.contains(semanticID) == true
+    }
+
+    func contains(bottom anchorID: String, in scope: ChatRenderedScrollScope) -> Bool {
+        bottomsByScope[scope]?.contains(anchorID) == true
     }
 }
 
@@ -140,7 +167,9 @@ struct ChatResumeRenderRestorationState {
 
     mutating func nextAction(
         renderedContent: ChatRenderedScrollContent?,
+        installedTargets: ChatRenderedScrollTargets,
         cacheRevision: UInt64,
+        transcriptRevision: UInt64,
         topVisibleID: String?,
         isNearBottom: Bool
     ) -> ChatResumeRenderRestorationAction {
@@ -148,35 +177,49 @@ struct ChatResumeRenderRestorationState {
         checkCount += 1
 
         guard let renderedContent,
-              renderedContent.restorationGeneration == generation,
-              renderedContent.sessionKey == sessionKey,
-              renderedContent.cacheRevision == cacheRevision,
-              targetIsInstalled(in: renderedContent) else {
+              renderedContent.scope.restorationGeneration == generation,
+              renderedContent.scope.sessionKey == sessionKey,
+              renderedContent.scope.cacheRevision == cacheRevision,
+              renderedContent.scope.transcriptRevision == transcriptRevision else {
             return checkCount > maximumChecks ? .abandon : .wait
         }
 
-        if lastScrollCheck != nil, destinationIsConfirmed(
+        if lastScrollCheck != nil,
+           targetIsInstalled(in: installedTargets, scope: renderedContent.scope),
+           destinationIsConfirmed(
             topVisibleID: topVisibleID,
             isNearBottom: isNearBottom
         ) {
             return .complete
         }
 
+        guard checkCount <= maximumChecks else { return .abandon }
+
         if lastScrollCheck.map({ checkCount - $0 >= retryInterval }) ?? true {
             lastScrollCheck = checkCount
             return .scroll(destination)
         }
 
-        return checkCount > maximumChecks ? .abandon : .wait
+        return .wait
     }
 
-    private func targetIsInstalled(in content: ChatRenderedScrollContent) -> Bool {
+    private func targetIsInstalled(
+        in installedTargets: ChatRenderedScrollTargets,
+        scope: ChatRenderedScrollScope
+    ) -> Bool {
         switch destination {
         case .latest:
-            return !content.bottomAnchorID.isEmpty
+            return installedTargets.contains(
+                bottom: bottomAnchorID(for: scope.sessionKey),
+                in: scope
+            )
         case .anchor(let anchor):
-            return content.semanticTargetIDs.contains(anchor)
+            return installedTargets.contains(row: anchor, in: scope)
         }
+    }
+
+    private func bottomAnchorID(for sessionKey: ChatScrollSessionKey) -> String {
+        "chat-latest-\(sessionKey.profile)-\(sessionKey.sessionID)"
     }
 
     private func destinationIsConfirmed(

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -37,6 +37,8 @@ enum ChatMessageScrollUpdatePolicy {
 
 struct ChatMessageScrollTargetCache: Equatable {
     private(set) var targets: [ChatMessageScrollTarget] = []
+    private(set) var renderingRevision: UInt64 = 0
+    private(set) var semanticTargetIDs: Set<String> = []
     private var fingerprints: [String] = []
 
     @discardableResult
@@ -51,6 +53,7 @@ struct ChatMessageScrollTargetCache: Equatable {
                     restorationMetadata: target.restorationMetadata
                 )
             }
+            renderingRevision &+= 1
             return .renderingChanged
         }
 
@@ -59,7 +62,133 @@ struct ChatMessageScrollTargetCache: Equatable {
             for: messages,
             fingerprints: updatedFingerprints
         )
+        semanticTargetIDs = Set(targets.map(\.semanticID))
+        renderingRevision &+= 1
         return .semanticsChanged
+    }
+}
+
+struct ChatRenderedScrollContent: Equatable {
+    let sessionKey: ChatScrollSessionKey
+    let cacheRevision: UInt64
+    let semanticTargetIDs: Set<String>
+    let bottomAnchorID: String
+    let restorationGeneration: UInt64?
+    let viewportTransitionGeneration: UInt64
+
+    init(
+        sessionKey: ChatScrollSessionKey,
+        cacheRevision: UInt64,
+        semanticTargetIDs: Set<String>,
+        bottomAnchorID: String,
+        restorationGeneration: UInt64? = nil,
+        viewportTransitionGeneration: UInt64 = 0
+    ) {
+        self.sessionKey = sessionKey
+        self.cacheRevision = cacheRevision
+        self.semanticTargetIDs = semanticTargetIDs
+        self.bottomAnchorID = bottomAnchorID
+        self.restorationGeneration = restorationGeneration
+        self.viewportTransitionGeneration = viewportTransitionGeneration
+    }
+}
+
+enum ChatResumeRenderRestorationAction: Equatable {
+    case wait
+    case scroll(ChatResumeViewportDestination)
+    case complete
+    case abandon
+    case cancelled
+}
+
+/// A deterministic policy for the view-owned part of restoration. SwiftUI
+/// supplies actual layout observations; the policy never treats a derived
+/// message cache as proof that ScrollViewReader has installed its targets.
+struct ChatResumeRenderRestorationState {
+    let generation: UInt64
+    let sessionKey: ChatScrollSessionKey
+    private(set) var destination: ChatResumeViewportDestination
+    private let maximumChecks: Int
+    private let retryInterval: Int
+    private var checkCount = 0
+    private var lastScrollCheck: Int?
+    private var isCancelled = false
+
+    init(
+        generation: UInt64,
+        sessionKey: ChatScrollSessionKey,
+        destination: ChatResumeViewportDestination,
+        maximumChecks: Int = 80,
+        retryInterval: Int = 4
+    ) {
+        self.generation = generation
+        self.sessionKey = sessionKey
+        self.destination = destination
+        self.maximumChecks = max(maximumChecks, 1)
+        self.retryInterval = max(retryInterval, 1)
+    }
+
+    mutating func updateDestination(_ destination: ChatResumeViewportDestination) {
+        guard self.destination != destination else { return }
+        self.destination = destination
+        lastScrollCheck = nil
+    }
+
+    mutating func cancel() {
+        isCancelled = true
+    }
+
+    mutating func nextAction(
+        renderedContent: ChatRenderedScrollContent?,
+        cacheRevision: UInt64,
+        topVisibleID: String?,
+        isNearBottom: Bool
+    ) -> ChatResumeRenderRestorationAction {
+        guard !isCancelled else { return .cancelled }
+        checkCount += 1
+
+        guard let renderedContent,
+              renderedContent.restorationGeneration == generation,
+              renderedContent.sessionKey == sessionKey,
+              renderedContent.cacheRevision == cacheRevision,
+              targetIsInstalled(in: renderedContent) else {
+            return checkCount > maximumChecks ? .abandon : .wait
+        }
+
+        if lastScrollCheck != nil, destinationIsConfirmed(
+            topVisibleID: topVisibleID,
+            isNearBottom: isNearBottom
+        ) {
+            return .complete
+        }
+
+        if lastScrollCheck.map({ checkCount - $0 >= retryInterval }) ?? true {
+            lastScrollCheck = checkCount
+            return .scroll(destination)
+        }
+
+        return checkCount > maximumChecks ? .abandon : .wait
+    }
+
+    private func targetIsInstalled(in content: ChatRenderedScrollContent) -> Bool {
+        switch destination {
+        case .latest:
+            return !content.bottomAnchorID.isEmpty
+        case .anchor(let anchor):
+            return content.semanticTargetIDs.contains(anchor)
+        }
+    }
+
+    private func destinationIsConfirmed(
+        topVisibleID: String?,
+        isNearBottom: Bool
+    ) -> Bool {
+        switch destination {
+        case .latest:
+            return isNearBottom
+        case .anchor(let anchor):
+            return topVisibleID == anchor
+        }
     }
 }
 

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -1,10 +1,187 @@
 import Foundation
 
+struct ChatMessageScrollTarget: Identifiable, Equatable {
+    let message: ChatMessage
+    let semanticID: String
+
+    /// SwiftUI keeps the existing source-row identity for rendering and
+    /// controls. Only scroll targeting uses the source-independent ID.
+    var id: String { message.id }
+}
+
+enum ChatMessageScrollTargets {
+    static func make(for messages: [ChatMessage]) -> [ChatMessageScrollTarget] {
+        var occurrences: [String: Int] = [:]
+        return messages.map { message in
+            let fingerprint = fingerprint(for: message)
+            let occurrence = occurrences[fingerprint, default: 0]
+            occurrences[fingerprint] = occurrence + 1
+            return ChatMessageScrollTarget(
+                message: message,
+                semanticID: "chat-message-\(fingerprint)-\(occurrence)"
+            )
+        }
+    }
+
+    private static func fingerprint(for message: ChatMessage) -> String {
+        var fingerprint = DeterministicChatFingerprint()
+        fingerprint.append("chat-message-v1")
+        fingerprint.append(message.role.rawValue)
+        fingerprint.append(message.content)
+        fingerprint.append(message.code)
+
+        fingerprint.append(message.tool?.name)
+        fingerprint.append(message.tool?.input)
+
+        fingerprint.append(message.clarify?.question)
+        fingerprint.append(message.clarify?.choices.count)
+        message.clarify?.choices.forEach { choice in
+            fingerprint.append(choice.label)
+            fingerprint.append(choice.value)
+        }
+
+        fingerprint.append(message.approval?.command)
+        fingerprint.append(message.approval?.description)
+        fingerprint.append(message.approval?.choices?.count)
+        message.approval?.choices?.forEach { fingerprint.append($0) }
+        fingerprint.append(message.approval?.allowPermanent)
+        fingerprint.append(message.approval?.smartDenied)
+
+        fingerprint.append(message.review?.summary)
+        fingerprint.append(message.review?.details?.count)
+        message.review?.details?.forEach { fingerprint.append($0) }
+
+        fingerprint.append(message.attachments?.count)
+        message.attachments?.forEach { attachment in
+            // Picker/cache IDs and local/gateway URIs change across transcript
+            // projections. These presentation fields remain source-stable.
+            fingerprint.append(attachment.kind.rawValue)
+            fingerprint.append(attachment.name)
+            fingerprint.append(attachment.mimeType)
+        }
+
+        return fingerprint.value
+    }
+}
+
+struct ChatScrollSessionIdentity: Equatable {
+    let canonicalSessionID: String?
+    let equivalentSessionIDs: Set<String>
+    let isReconciling: Bool
+    let settledRevision: UInt64
+
+    static let none = ChatScrollSessionIdentity(
+        canonicalSessionID: nil,
+        equivalentSessionIDs: [],
+        isReconciling: false,
+        settledRevision: 0
+    )
+
+    init(
+        canonicalSessionID: String?,
+        equivalentSessionIDs: Set<String>,
+        isReconciling: Bool,
+        settledRevision: UInt64
+    ) {
+        let canonical = Self.normalized(canonicalSessionID)
+        var equivalents = Set(equivalentSessionIDs.compactMap(Self.normalized))
+        if let canonical { equivalents.insert(canonical) }
+        self.canonicalSessionID = canonical
+        self.equivalentSessionIDs = equivalents
+        self.isReconciling = isReconciling
+        self.settledRevision = settledRevision
+    }
+
+    func contains(_ sessionID: String?) -> Bool {
+        guard let sessionID = Self.normalized(sessionID) else { return false }
+        return equivalentSessionIDs.contains(sessionID)
+    }
+
+    func areEquivalent(_ lhs: String?, _ rhs: String?) -> Bool {
+        guard let lhs = Self.normalized(lhs),
+              let rhs = Self.normalized(rhs) else { return false }
+        if lhs == rhs { return true }
+        return equivalentSessionIDs.contains(lhs) && equivalentSessionIDs.contains(rhs)
+    }
+
+    private static func normalized(_ sessionID: String?) -> String? {
+        guard let value = sessionID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else { return nil }
+        return value
+    }
+}
+
+struct ChatScrollRestorationGate: Equatable {
+    let observedSettledRevision: UInt64
+    let requiresSettledRevisionAdvance: Bool
+
+    init(
+        observing identity: ChatScrollSessionIdentity,
+        reconciliationExpected: Bool = false
+    ) {
+        observedSettledRevision = identity.settledRevision
+        requiresSettledRevisionAdvance = identity.isReconciling || reconciliationExpected
+    }
+
+    func allowsNonLatestRestoration(using identity: ChatScrollSessionIdentity) -> Bool {
+        guard !identity.isReconciling else { return false }
+        return !requiresSettledRevisionAdvance
+            || identity.settledRevision > observedSettledRevision
+    }
+}
+
 struct ChatScrollSnapshot: Equatable {
     let anchorMessageID: String?
     let followsLatest: Bool
 
     static let latest = ChatScrollSnapshot(anchorMessageID: nil, followsLatest: true)
+}
+
+private struct DeterministicChatFingerprint {
+    private var first: UInt64 = 14_695_981_039_346_656_037
+    private var second: UInt64 = 7_809_847_782_465_536_322
+
+    var value: String {
+        paddedHex(first) + paddedHex(second)
+    }
+
+    mutating func append(_ value: String?) {
+        guard let value else {
+            append(byte: 0)
+            return
+        }
+        append(byte: 1)
+        append(length: value.utf8.count)
+        value.utf8.forEach { append(byte: $0) }
+    }
+
+    mutating func append(_ value: Int?) {
+        append(value.map(String.init))
+    }
+
+    mutating func append(_ value: Bool?) {
+        append(value.map { $0 ? "true" : "false" })
+    }
+
+    private mutating func append(length: Int) {
+        var length = UInt64(length)
+        for _ in 0..<MemoryLayout<UInt64>.size {
+            append(byte: UInt8(truncatingIfNeeded: length))
+            length >>= 8
+        }
+    }
+
+    private mutating func append(byte: UInt8) {
+        first ^= UInt64(byte)
+        first &*= 1_099_511_628_211
+        second ^= UInt64(byte)
+        second &*= 14_029_467_366_897_019_727
+    }
+
+    private func paddedHex(_ value: UInt64) -> String {
+        let hex = String(value, radix: 16)
+        return String(repeating: "0", count: 16 - hex.count) + hex
+    }
 }
 
 struct ChatScrollStateStore {

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+struct ChatScrollSnapshot: Equatable {
+    let anchorMessageID: String?
+    let followsLatest: Bool
+
+    static let latest = ChatScrollSnapshot(anchorMessageID: nil, followsLatest: true)
+}
+
+struct ChatScrollStateStore {
+    private var snapshots: [String: ChatScrollSnapshot] = [:]
+
+    mutating func save(_ snapshot: ChatScrollSnapshot, for sessionID: String) {
+        let key = sessionID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !key.isEmpty else { return }
+        snapshots[key] = snapshot
+    }
+
+    func snapshot(for sessionID: String) -> ChatScrollSnapshot? {
+        snapshots[sessionID.trimmingCharacters(in: .whitespacesAndNewlines)]
+    }
+
+    func restoration(
+        for sessionID: String,
+        availableMessageIDs: Set<String>
+    ) -> ChatScrollSnapshot? {
+        guard let snapshot = snapshot(for: sessionID) else { return nil }
+        guard !snapshot.followsLatest else { return .latest }
+        guard let anchor = snapshot.anchorMessageID,
+              availableMessageIDs.contains(anchor) else {
+            return .latest
+        }
+        return snapshot
+    }
+}

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct ChatScrollAnchorMetadata: Equatable {
+struct ChatScrollAnchorMetadata: Codable, Equatable {
     let fingerprint: String
     let duplicateCount: Int
 }
@@ -148,7 +148,7 @@ private enum ChatScrollIdentityNormalization {
     }
 }
 
-struct ChatScrollSessionKey: Hashable {
+struct ChatScrollSessionKey: Codable, Hashable {
     let profile: String
     let sessionID: String
 
@@ -434,7 +434,7 @@ struct ChatScrollTargetAvailability: Equatable {
     }
 }
 
-struct ChatScrollSnapshot: Equatable {
+struct ChatScrollSnapshot: Codable, Equatable {
     let anchorMessageID: String?
     let followsLatest: Bool
     let anchorMetadata: ChatScrollAnchorMetadata?

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -589,6 +589,17 @@ struct ChatScrollStateStore {
         return snapshots[key]
     }
 
+    mutating func migrateSnapshot(
+        from oldKey: ChatScrollSessionKey,
+        to newKey: ChatScrollSessionKey
+    ) {
+        guard oldKey.isValid,
+              newKey.isValid,
+              oldKey != newKey,
+              let snapshot = snapshots[oldKey] else { return }
+        snapshots[newKey] = snapshot
+    }
+
     func restoration(
         for key: ChatScrollSessionKey,
         availableMessageIDs: Set<String>

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -25,12 +25,12 @@ enum ChatMessageScrollUpdatePolicy {
     static func shouldReassertLatest(
         after update: ChatMessageScrollTargetCacheUpdate,
         followsLatest: Bool,
-        hasPendingNonLatestRestoration: Bool,
+        hasPendingRestoration: Bool,
         hasNotificationHandoff: Bool
     ) -> Bool {
         update != .unchanged
             && followsLatest
-            && !hasPendingNonLatestRestoration
+            && !hasPendingRestoration
             && !hasNotificationHandoff
     }
 }
@@ -379,25 +379,6 @@ enum ChatScrollSessionIdentityResolver {
     }
 }
 
-struct ChatScrollRestorationGate: Equatable {
-    let observedSettledRevision: UInt64
-    let requiresSettledRevisionAdvance: Bool
-
-    init(
-        observing identity: ChatScrollSessionIdentity,
-        reconciliationExpected: Bool = false
-    ) {
-        observedSettledRevision = identity.settledRevision
-        requiresSettledRevisionAdvance = identity.isReconciling || reconciliationExpected
-    }
-
-    func allowsNonLatestRestoration(using identity: ChatScrollSessionIdentity) -> Bool {
-        guard !identity.isReconciling else { return false }
-        return !requiresSettledRevisionAdvance
-            || identity.settledRevision > observedSettledRevision
-    }
-}
-
 struct ChatScrollTargetAvailability: Equatable {
     private let messageIDs: Set<String>
     private let metadataByMessageID: [String: ChatScrollAnchorMetadata]
@@ -415,21 +396,15 @@ struct ChatScrollTargetAvailability: Equatable {
         )
     }
 
-    init(messageIDs: Set<String>) {
-        self.messageIDs = messageIDs
-        metadataByMessageID = [:]
-        semanticIDBySourceMessageID = [:]
-    }
-
-    fileprivate func contains(_ messageID: String) -> Bool {
+    func contains(_ messageID: String) -> Bool {
         messageIDs.contains(messageID)
     }
 
-    fileprivate func metadata(for messageID: String) -> ChatScrollAnchorMetadata? {
+    func metadata(for messageID: String) -> ChatScrollAnchorMetadata? {
         metadataByMessageID[messageID]
     }
 
-    fileprivate func semanticID(forSourceMessageID sourceMessageID: String) -> String? {
+    func semanticID(forSourceMessageID sourceMessageID: String) -> String? {
         semanticIDBySourceMessageID[sourceMessageID]
     }
 }
@@ -453,80 +428,6 @@ struct ChatScrollSnapshot: Codable, Equatable {
     }
 
     static let latest = ChatScrollSnapshot(anchorMessageID: nil, followsLatest: true)
-}
-
-struct ChatScrollPendingRestoration: Equatable {
-    let sessionKey: ChatScrollSessionKey
-    let snapshot: ChatScrollSnapshot
-    let gate: ChatScrollRestorationGate
-}
-
-enum ChatScrollRestorationDecision: Equatable {
-    case wait
-    case cancel
-    case latest
-    case anchor(String)
-}
-
-enum ChatScrollSessionTransitionAction: Equatable {
-    case ignore
-    case latest
-    case restore
-}
-
-enum ChatScrollSessionTransitionPolicy {
-    static func action(
-        from oldSessionKey: ChatScrollSessionKey?,
-        to newSessionKey: ChatScrollSessionKey?,
-        snapshot: ChatScrollSnapshot?
-    ) -> ChatScrollSessionTransitionAction {
-        guard oldSessionKey != newSessionKey else { return .ignore }
-        guard let snapshot, !snapshot.followsLatest else { return .latest }
-        return .restore
-    }
-}
-
-enum ChatScrollRestorationResolver {
-    static func decision(
-        for pending: ChatScrollPendingRestoration,
-        identity: ChatScrollSessionIdentity,
-        activeSessionKey: ChatScrollSessionKey?,
-        store: ChatScrollStateStore,
-        availableMessageIDs: Set<String>
-    ) -> ChatScrollRestorationDecision {
-        decision(
-            for: pending,
-            identity: identity,
-            activeSessionKey: activeSessionKey,
-            store: store,
-            availableTargets: ChatScrollTargetAvailability(messageIDs: availableMessageIDs)
-        )
-    }
-
-    static func decision(
-        for pending: ChatScrollPendingRestoration,
-        identity: ChatScrollSessionIdentity,
-        activeSessionKey: ChatScrollSessionKey?,
-        store: ChatScrollStateStore,
-        availableTargets: ChatScrollTargetAvailability
-    ) -> ChatScrollRestorationDecision {
-        guard identity.areEquivalent(pending.sessionKey, activeSessionKey) else {
-            return .cancel
-        }
-        guard !pending.snapshot.followsLatest else { return .latest }
-        guard pending.gate.allowsNonLatestRestoration(using: identity) else {
-            return .wait
-        }
-        guard let resolved = store.restoration(
-            for: pending.sessionKey,
-            availableTargets: availableTargets
-        ) else {
-            return .cancel
-        }
-        if resolved.followsLatest { return .latest }
-        guard let anchor = resolved.anchorMessageID else { return .latest }
-        return .anchor(anchor)
-    }
 }
 
 private struct DeterministicChatFingerprint {
@@ -573,68 +474,5 @@ private struct DeterministicChatFingerprint {
     private func paddedHex(_ value: UInt64) -> String {
         let hex = String(value, radix: 16)
         return String(repeating: "0", count: 16 - hex.count) + hex
-    }
-}
-
-struct ChatScrollStateStore {
-    private var snapshots: [ChatScrollSessionKey: ChatScrollSnapshot] = [:]
-
-    mutating func save(_ snapshot: ChatScrollSnapshot, for key: ChatScrollSessionKey) {
-        guard key.isValid else { return }
-        snapshots[key] = snapshot
-    }
-
-    func snapshot(for key: ChatScrollSessionKey) -> ChatScrollSnapshot? {
-        guard key.isValid else { return nil }
-        return snapshots[key]
-    }
-
-    mutating func migrateSnapshot(
-        from oldKey: ChatScrollSessionKey,
-        to newKey: ChatScrollSessionKey
-    ) {
-        guard oldKey.isValid,
-              newKey.isValid,
-              oldKey != newKey,
-              let snapshot = snapshots[oldKey] else { return }
-        snapshots[newKey] = snapshot
-    }
-
-    func restoration(
-        for key: ChatScrollSessionKey,
-        availableMessageIDs: Set<String>
-    ) -> ChatScrollSnapshot? {
-        restoration(
-            for: key,
-            availableTargets: ChatScrollTargetAvailability(messageIDs: availableMessageIDs)
-        )
-    }
-
-    func restoration(
-        for key: ChatScrollSessionKey,
-        availableTargets: ChatScrollTargetAvailability
-    ) -> ChatScrollSnapshot? {
-        guard let snapshot = snapshot(for: key) else { return nil }
-        guard !snapshot.followsLatest else { return .latest }
-        if let anchor = snapshot.anchorMessageID,
-           availableTargets.contains(anchor),
-           (snapshot.anchorMetadata == nil || availableTargets.metadata(for: anchor) == snapshot.anchorMetadata) {
-            return snapshot
-        }
-
-        // A streaming projection can keep the same source message while its
-        // content (and therefore semantic fingerprint) changes. Re-anchor by
-        // source identity before giving up and jumping to the newest message.
-        guard let sourceMessageID = snapshot.anchorSourceMessageID,
-              let refreshedAnchor = availableTargets.semanticID(forSourceMessageID: sourceMessageID),
-              let refreshedMetadata = availableTargets.metadata(for: refreshedAnchor) else {
-            return .latest
-        }
-        return ChatScrollSnapshot(
-            anchorMessageID: refreshedAnchor,
-            followsLatest: false,
-            anchorMetadata: refreshedMetadata,
-            anchorSourceMessageID: sourceMessageID
-        )
     }
 }

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -355,14 +355,25 @@ enum ChatSessionPersistenceIdentity {
     static func canonicalID(
         for sessionID: String?,
         identity: ChatScrollSessionIdentity,
-        catalog: [SessionSummary]
+        catalog: [SessionSummary],
+        activeProfile: String? = nil
     ) -> String? {
         guard let sessionID,
               !sessionID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return nil
         }
 
-        if let catalogSession = catalog.first(where: {
+        // Scope the catalog lookup to the active profile when available,
+        // matching ChatResumeSessionResolver.target's profile filter.
+        let scoped = activeProfile.map { profile in
+            catalog.filter { entry in
+                guard let entryProfile = entry.profile else { return true }
+                return entryProfile.trimmingCharacters(in: .whitespacesAndNewlines)
+                    .caseInsensitiveCompare(profile.trimmingCharacters(in: .whitespacesAndNewlines)) == .orderedSame
+            }
+        } ?? catalog
+
+        if let catalogSession = scoped.first(where: {
             $0.id == sessionID || $0.alternateIds.contains(sessionID)
         }) {
             return catalogSession.id

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -1,8 +1,14 @@
 import Foundation
 
+struct ChatScrollAnchorMetadata: Equatable {
+    let fingerprint: String
+    let duplicateCount: Int
+}
+
 struct ChatMessageScrollTarget: Identifiable, Equatable {
     let message: ChatMessage
     let semanticID: String
+    let restorationMetadata: ChatScrollAnchorMetadata
 
     /// SwiftUI keeps the existing source-row identity for rendering and
     /// controls. Only scroll targeting uses the source-independent ID.
@@ -15,6 +21,20 @@ enum ChatMessageScrollTargetCacheUpdate: Equatable {
     case semanticsChanged
 }
 
+enum ChatMessageScrollUpdatePolicy {
+    static func shouldReassertLatest(
+        after update: ChatMessageScrollTargetCacheUpdate,
+        followsLatest: Bool,
+        hasPendingNonLatestRestoration: Bool,
+        hasNotificationHandoff: Bool
+    ) -> Bool {
+        update != .unchanged
+            && followsLatest
+            && !hasPendingNonLatestRestoration
+            && !hasNotificationHandoff
+    }
+}
+
 struct ChatMessageScrollTargetCache: Equatable {
     private(set) var targets: [ChatMessageScrollTarget] = []
     private var fingerprints: [String] = []
@@ -25,7 +45,11 @@ struct ChatMessageScrollTargetCache: Equatable {
         if updatedFingerprints == fingerprints, targets.count == messages.count {
             guard targets.map(\.message) != messages else { return .unchanged }
             targets = zip(messages, targets).map { message, target in
-                ChatMessageScrollTarget(message: message, semanticID: target.semanticID)
+                ChatMessageScrollTarget(
+                    message: message,
+                    semanticID: target.semanticID,
+                    restorationMetadata: target.restorationMetadata
+                )
             }
             return .renderingChanged
         }
@@ -52,13 +76,20 @@ enum ChatMessageScrollTargets {
         for messages: [ChatMessage],
         fingerprints: [String]
     ) -> [ChatMessageScrollTarget] {
+        let duplicateCounts = fingerprints.reduce(into: [String: Int]()) { counts, fingerprint in
+            counts[fingerprint, default: 0] += 1
+        }
         var occurrences: [String: Int] = [:]
         return zip(messages, fingerprints).map { message, fingerprint in
             let occurrence = occurrences[fingerprint, default: 0]
             occurrences[fingerprint] = occurrence + 1
             return ChatMessageScrollTarget(
                 message: message,
-                semanticID: "chat-message-\(fingerprint)-\(occurrence)"
+                semanticID: "chat-message-\(fingerprint)-\(occurrence)",
+                restorationMetadata: ChatScrollAnchorMetadata(
+                    fingerprint: fingerprint,
+                    duplicateCount: duplicateCounts[fingerprint, default: 0]
+                )
             )
         }
     }
@@ -343,9 +374,46 @@ struct ChatScrollRestorationGate: Equatable {
     }
 }
 
+struct ChatScrollTargetAvailability: Equatable {
+    private let messageIDs: Set<String>
+    private let metadataByMessageID: [String: ChatScrollAnchorMetadata]
+
+    init(targets: [ChatMessageScrollTarget]) {
+        messageIDs = Set(targets.map(\.semanticID))
+        metadataByMessageID = Dictionary(
+            targets.map { ($0.semanticID, $0.restorationMetadata) },
+            uniquingKeysWith: { existing, _ in existing }
+        )
+    }
+
+    init(messageIDs: Set<String>) {
+        self.messageIDs = messageIDs
+        metadataByMessageID = [:]
+    }
+
+    fileprivate func contains(_ messageID: String) -> Bool {
+        messageIDs.contains(messageID)
+    }
+
+    fileprivate func metadata(for messageID: String) -> ChatScrollAnchorMetadata? {
+        metadataByMessageID[messageID]
+    }
+}
+
 struct ChatScrollSnapshot: Equatable {
     let anchorMessageID: String?
     let followsLatest: Bool
+    let anchorMetadata: ChatScrollAnchorMetadata?
+
+    init(
+        anchorMessageID: String?,
+        followsLatest: Bool,
+        anchorMetadata: ChatScrollAnchorMetadata? = nil
+    ) {
+        self.anchorMessageID = anchorMessageID
+        self.followsLatest = followsLatest
+        self.anchorMetadata = anchorMetadata
+    }
 
     static let latest = ChatScrollSnapshot(anchorMessageID: nil, followsLatest: true)
 }
@@ -371,6 +439,22 @@ enum ChatScrollRestorationResolver {
         store: ChatScrollStateStore,
         availableMessageIDs: Set<String>
     ) -> ChatScrollRestorationDecision {
+        decision(
+            for: pending,
+            identity: identity,
+            activeSessionKey: activeSessionKey,
+            store: store,
+            availableTargets: ChatScrollTargetAvailability(messageIDs: availableMessageIDs)
+        )
+    }
+
+    static func decision(
+        for pending: ChatScrollPendingRestoration,
+        identity: ChatScrollSessionIdentity,
+        activeSessionKey: ChatScrollSessionKey?,
+        store: ChatScrollStateStore,
+        availableTargets: ChatScrollTargetAvailability
+    ) -> ChatScrollRestorationDecision {
         guard identity.areEquivalent(pending.sessionKey, activeSessionKey) else {
             return .cancel
         }
@@ -380,7 +464,7 @@ enum ChatScrollRestorationResolver {
         }
         guard let resolved = store.restoration(
             for: pending.sessionKey,
-            availableMessageIDs: availableMessageIDs
+            availableTargets: availableTargets
         ) else {
             return .cancel
         }
@@ -454,10 +538,24 @@ struct ChatScrollStateStore {
         for key: ChatScrollSessionKey,
         availableMessageIDs: Set<String>
     ) -> ChatScrollSnapshot? {
+        restoration(
+            for: key,
+            availableTargets: ChatScrollTargetAvailability(messageIDs: availableMessageIDs)
+        )
+    }
+
+    func restoration(
+        for key: ChatScrollSessionKey,
+        availableTargets: ChatScrollTargetAvailability
+    ) -> ChatScrollSnapshot? {
         guard let snapshot = snapshot(for: key) else { return nil }
         guard !snapshot.followsLatest else { return .latest }
         guard let anchor = snapshot.anchorMessageID,
-              availableMessageIDs.contains(anchor) else {
+              availableTargets.contains(anchor) else {
+            return .latest
+        }
+        if let expectedMetadata = snapshot.anchorMetadata,
+           availableTargets.metadata(for: anchor) != expectedMetadata {
             return .latest
         }
         return snapshot

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -602,6 +602,17 @@ struct ChatScrollSnapshot: Codable, Equatable {
     static let latest = ChatScrollSnapshot(anchorMessageID: nil, followsLatest: true)
 }
 
+struct ChatRenderedViewportSnapshot: Equatable {
+    let sessionKey: ChatScrollSessionKey
+    let snapshot: ChatScrollSnapshot
+
+    init?(sessionKey: ChatScrollSessionKey, snapshot: ChatScrollSnapshot) {
+        guard sessionKey.isValid else { return nil }
+        self.sessionKey = sessionKey
+        self.snapshot = snapshot
+    }
+}
+
 private struct DeterministicChatFingerprint {
     private var first: UInt64 = 14_695_981_039_346_656_037
     private var second: UInt64 = 7_809_847_782_465_536_322

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -162,6 +162,30 @@ struct ChatScrollSessionKey: Hashable {
     }
 }
 
+enum ChatSessionPersistenceIdentity {
+    static func canonicalID(
+        for sessionID: String?,
+        identity: ChatScrollSessionIdentity,
+        catalog: [SessionSummary]
+    ) -> String? {
+        guard let sessionID,
+              !sessionID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+
+        if let catalogSession = catalog.first(where: {
+            $0.id == sessionID || $0.alternateIds.contains(sessionID)
+        }) {
+            return catalogSession.id
+        }
+
+        if identity.contains(sessionID) {
+            return identity.canonicalSessionID ?? sessionID
+        }
+        return sessionID
+    }
+}
+
 struct ChatScrollSessionCatalogIdentity: Equatable {
     let profile: String
     let canonicalSessionID: String
@@ -377,6 +401,7 @@ struct ChatScrollRestorationGate: Equatable {
 struct ChatScrollTargetAvailability: Equatable {
     private let messageIDs: Set<String>
     private let metadataByMessageID: [String: ChatScrollAnchorMetadata]
+    private let semanticIDBySourceMessageID: [String: String]
 
     init(targets: [ChatMessageScrollTarget]) {
         messageIDs = Set(targets.map(\.semanticID))
@@ -384,11 +409,16 @@ struct ChatScrollTargetAvailability: Equatable {
             targets.map { ($0.semanticID, $0.restorationMetadata) },
             uniquingKeysWith: { existing, _ in existing }
         )
+        semanticIDBySourceMessageID = Dictionary(
+            targets.map { ($0.id, $0.semanticID) },
+            uniquingKeysWith: { existing, _ in existing }
+        )
     }
 
     init(messageIDs: Set<String>) {
         self.messageIDs = messageIDs
         metadataByMessageID = [:]
+        semanticIDBySourceMessageID = [:]
     }
 
     fileprivate func contains(_ messageID: String) -> Bool {
@@ -398,21 +428,28 @@ struct ChatScrollTargetAvailability: Equatable {
     fileprivate func metadata(for messageID: String) -> ChatScrollAnchorMetadata? {
         metadataByMessageID[messageID]
     }
+
+    fileprivate func semanticID(forSourceMessageID sourceMessageID: String) -> String? {
+        semanticIDBySourceMessageID[sourceMessageID]
+    }
 }
 
 struct ChatScrollSnapshot: Equatable {
     let anchorMessageID: String?
     let followsLatest: Bool
     let anchorMetadata: ChatScrollAnchorMetadata?
+    let anchorSourceMessageID: String?
 
     init(
         anchorMessageID: String?,
         followsLatest: Bool,
-        anchorMetadata: ChatScrollAnchorMetadata? = nil
+        anchorMetadata: ChatScrollAnchorMetadata? = nil,
+        anchorSourceMessageID: String? = nil
     ) {
         self.anchorMessageID = anchorMessageID
         self.followsLatest = followsLatest
         self.anchorMetadata = anchorMetadata
+        self.anchorSourceMessageID = anchorSourceMessageID
     }
 
     static let latest = ChatScrollSnapshot(anchorMessageID: nil, followsLatest: true)
@@ -429,6 +466,24 @@ enum ChatScrollRestorationDecision: Equatable {
     case cancel
     case latest
     case anchor(String)
+}
+
+enum ChatScrollSessionTransitionAction: Equatable {
+    case ignore
+    case latest
+    case restore
+}
+
+enum ChatScrollSessionTransitionPolicy {
+    static func action(
+        from oldSessionKey: ChatScrollSessionKey?,
+        to newSessionKey: ChatScrollSessionKey?,
+        snapshot: ChatScrollSnapshot?
+    ) -> ChatScrollSessionTransitionAction {
+        guard oldSessionKey != newSessionKey else { return .ignore }
+        guard let snapshot, !snapshot.followsLatest else { return .latest }
+        return .restore
+    }
 }
 
 enum ChatScrollRestorationResolver {
@@ -550,14 +605,25 @@ struct ChatScrollStateStore {
     ) -> ChatScrollSnapshot? {
         guard let snapshot = snapshot(for: key) else { return nil }
         guard !snapshot.followsLatest else { return .latest }
-        guard let anchor = snapshot.anchorMessageID,
-              availableTargets.contains(anchor) else {
+        if let anchor = snapshot.anchorMessageID,
+           availableTargets.contains(anchor),
+           (snapshot.anchorMetadata == nil || availableTargets.metadata(for: anchor) == snapshot.anchorMetadata) {
+            return snapshot
+        }
+
+        // A streaming projection can keep the same source message while its
+        // content (and therefore semantic fingerprint) changes. Re-anchor by
+        // source identity before giving up and jumping to the newest message.
+        guard let sourceMessageID = snapshot.anchorSourceMessageID,
+              let refreshedAnchor = availableTargets.semanticID(forSourceMessageID: sourceMessageID),
+              let refreshedMetadata = availableTargets.metadata(for: refreshedAnchor) else {
             return .latest
         }
-        if let expectedMetadata = snapshot.anchorMetadata,
-           availableTargets.metadata(for: anchor) != expectedMetadata {
-            return .latest
-        }
-        return snapshot
+        return ChatScrollSnapshot(
+            anchorMessageID: refreshedAnchor,
+            followsLatest: false,
+            anchorMetadata: refreshedMetadata,
+            anchorSourceMessageID: sourceMessageID
+        )
     }
 }

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -9,11 +9,51 @@ struct ChatMessageScrollTarget: Identifiable, Equatable {
     var id: String { message.id }
 }
 
+enum ChatMessageScrollTargetCacheUpdate: Equatable {
+    case unchanged
+    case renderingChanged
+    case semanticsChanged
+}
+
+struct ChatMessageScrollTargetCache: Equatable {
+    private(set) var targets: [ChatMessageScrollTarget] = []
+    private var fingerprints: [String] = []
+
+    @discardableResult
+    mutating func update(for messages: [ChatMessage]) -> ChatMessageScrollTargetCacheUpdate {
+        let updatedFingerprints = ChatMessageScrollTargets.fingerprints(for: messages)
+        if updatedFingerprints == fingerprints, targets.count == messages.count {
+            guard targets.map(\.message) != messages else { return .unchanged }
+            targets = zip(messages, targets).map { message, target in
+                ChatMessageScrollTarget(message: message, semanticID: target.semanticID)
+            }
+            return .renderingChanged
+        }
+
+        fingerprints = updatedFingerprints
+        targets = ChatMessageScrollTargets.make(
+            for: messages,
+            fingerprints: updatedFingerprints
+        )
+        return .semanticsChanged
+    }
+}
+
 enum ChatMessageScrollTargets {
     static func make(for messages: [ChatMessage]) -> [ChatMessageScrollTarget] {
+        make(for: messages, fingerprints: fingerprints(for: messages))
+    }
+
+    fileprivate static func fingerprints(for messages: [ChatMessage]) -> [String] {
+        messages.map(fingerprint)
+    }
+
+    fileprivate static func make(
+        for messages: [ChatMessage],
+        fingerprints: [String]
+    ) -> [ChatMessageScrollTarget] {
         var occurrences: [String: Int] = [:]
-        return messages.map { message in
-            let fingerprint = fingerprint(for: message)
+        return zip(messages, fingerprints).map { message, fingerprint in
             let occurrence = occurrences[fingerprint, default: 0]
             occurrences[fingerprint] = occurrence + 1
             return ChatMessageScrollTarget(
@@ -31,7 +71,6 @@ enum ChatMessageScrollTargets {
         fingerprint.append(message.code)
 
         fingerprint.append(message.tool?.name)
-        fingerprint.append(message.tool?.input)
 
         fingerprint.append(message.clarify?.question)
         fingerprint.append(message.clarify?.choices.count)
@@ -64,13 +103,72 @@ enum ChatMessageScrollTargets {
     }
 }
 
+private enum ChatScrollIdentityNormalization {
+    static func profile(_ profile: String?) -> String? {
+        guard let value = profile?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else { return nil }
+        return value.lowercased()
+    }
+
+    static func sessionID(_ sessionID: String?) -> String? {
+        guard let value = sessionID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else { return nil }
+        return value
+    }
+}
+
+struct ChatScrollSessionKey: Hashable {
+    let profile: String
+    let sessionID: String
+
+    init(profile: String, sessionID: String) {
+        self.profile = ChatScrollIdentityNormalization.profile(profile) ?? ""
+        self.sessionID = ChatScrollIdentityNormalization.sessionID(sessionID) ?? ""
+    }
+
+    var isValid: Bool {
+        !profile.isEmpty && !sessionID.isEmpty
+    }
+}
+
+struct ChatScrollSessionCatalogIdentity: Equatable {
+    let profile: String
+    let canonicalSessionID: String
+    let alternateSessionIDs: Set<String>
+
+    init(
+        profile: String,
+        canonicalSessionID: String,
+        alternateSessionIDs: Set<String>
+    ) {
+        self.profile = ChatScrollIdentityNormalization.profile(profile) ?? ""
+        self.canonicalSessionID = ChatScrollIdentityNormalization.sessionID(canonicalSessionID) ?? ""
+        self.alternateSessionIDs = Set(
+            alternateSessionIDs.compactMap(ChatScrollIdentityNormalization.sessionID)
+        )
+    }
+
+    fileprivate var identifiers: Set<String> {
+        guard !canonicalSessionID.isEmpty else { return [] }
+        var result = alternateSessionIDs
+        result.insert(canonicalSessionID)
+        return result
+    }
+
+    fileprivate var isValid: Bool {
+        !canonicalSessionID.isEmpty
+    }
+}
+
 struct ChatScrollSessionIdentity: Equatable {
+    let profile: String?
     let canonicalSessionID: String?
     let equivalentSessionIDs: Set<String>
     let isReconciling: Bool
     let settledRevision: UInt64
 
     static let none = ChatScrollSessionIdentity(
+        profile: nil,
         canonicalSessionID: nil,
         equivalentSessionIDs: [],
         isReconciling: false,
@@ -78,36 +176,151 @@ struct ChatScrollSessionIdentity: Equatable {
     )
 
     init(
+        profile: String?,
         canonicalSessionID: String?,
         equivalentSessionIDs: Set<String>,
         isReconciling: Bool,
         settledRevision: UInt64
     ) {
-        let canonical = Self.normalized(canonicalSessionID)
-        var equivalents = Set(equivalentSessionIDs.compactMap(Self.normalized))
+        let normalizedProfile = ChatScrollIdentityNormalization.profile(profile)
+        let canonical = ChatScrollIdentityNormalization.sessionID(canonicalSessionID)
+        var equivalents = Set(
+            equivalentSessionIDs.compactMap(ChatScrollIdentityNormalization.sessionID)
+        )
         if let canonical { equivalents.insert(canonical) }
+        self.profile = normalizedProfile
         self.canonicalSessionID = canonical
         self.equivalentSessionIDs = equivalents
         self.isReconciling = isReconciling
         self.settledRevision = settledRevision
     }
 
+    var canonicalSessionKey: ChatScrollSessionKey? {
+        key(for: canonicalSessionID)
+    }
+
+    func key(for sessionID: String?) -> ChatScrollSessionKey? {
+        guard let profile,
+              let sessionID = ChatScrollIdentityNormalization.sessionID(sessionID) else {
+            return nil
+        }
+        let key = ChatScrollSessionKey(profile: profile, sessionID: sessionID)
+        return key.isValid ? key : nil
+    }
+
     func contains(_ sessionID: String?) -> Bool {
-        guard let sessionID = Self.normalized(sessionID) else { return false }
+        guard let sessionID = ChatScrollIdentityNormalization.sessionID(sessionID) else {
+            return false
+        }
         return equivalentSessionIDs.contains(sessionID)
     }
 
+    func contains(_ key: ChatScrollSessionKey?) -> Bool {
+        guard let key, key.isValid, key.profile == profile else { return false }
+        return equivalentSessionIDs.contains(key.sessionID)
+    }
+
     func areEquivalent(_ lhs: String?, _ rhs: String?) -> Bool {
-        guard let lhs = Self.normalized(lhs),
-              let rhs = Self.normalized(rhs) else { return false }
+        guard let lhs = ChatScrollIdentityNormalization.sessionID(lhs),
+              let rhs = ChatScrollIdentityNormalization.sessionID(rhs) else {
+            return false
+        }
         if lhs == rhs { return true }
         return equivalentSessionIDs.contains(lhs) && equivalentSessionIDs.contains(rhs)
     }
 
-    private static func normalized(_ sessionID: String?) -> String? {
-        guard let value = sessionID?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !value.isEmpty else { return nil }
-        return value
+    func areEquivalent(_ lhs: ChatScrollSessionKey?, _ rhs: ChatScrollSessionKey?) -> Bool {
+        guard let lhs, let rhs,
+              lhs.isValid, rhs.isValid,
+              lhs.profile == profile,
+              rhs.profile == profile else {
+            return false
+        }
+        if lhs == rhs { return true }
+        return equivalentSessionIDs.contains(lhs.sessionID)
+            && equivalentSessionIDs.contains(rhs.sessionID)
+    }
+}
+
+enum ChatScrollSessionIdentityResolver {
+    static func resolve(
+        profile: String,
+        activeSessionID: String?,
+        catalog: [ChatScrollSessionCatalogIdentity],
+        requestedSessionID: String? = nil,
+        resolvedSessionID: String? = nil,
+        previousIdentity current: ChatScrollSessionIdentity,
+        isReconciling: Bool,
+        advanceSettledRevision: Bool = false
+    ) -> ChatScrollSessionIdentity {
+        let normalizedProfile = ChatScrollIdentityNormalization.profile(profile)
+        let previous = current.profile == normalizedProfile
+            ? current
+            : ChatScrollSessionIdentity(
+                profile: normalizedProfile,
+                canonicalSessionID: nil,
+                equivalentSessionIDs: [],
+                isReconciling: current.isReconciling,
+                settledRevision: current.settledRevision
+            )
+        let profileCatalog = catalog.filter {
+            $0.isValid && ($0.profile.isEmpty || $0.profile == normalizedProfile)
+        }
+        func matchingSession(for ids: Set<String>) -> ChatScrollSessionCatalogIdentity? {
+            guard !ids.isEmpty else { return nil }
+            return profileCatalog.first { !$0.identifiers.isDisjoint(with: ids) }
+        }
+
+        let activeID = ChatScrollIdentityNormalization.sessionID(activeSessionID)
+        let reconciliationIDs = Set(
+            [requestedSessionID, resolvedSessionID]
+                .compactMap(ChatScrollIdentityNormalization.sessionID)
+        )
+        let reconciliationSession = matchingSession(for: reconciliationIDs)
+        let reconciliationCatalogIDs = reconciliationSession?.identifiers ?? []
+        let reconciliationContinuesPrevious = reconciliationIDs.isEmpty
+            || reconciliationIDs.contains(where: previous.contains)
+            || !reconciliationCatalogIDs.isDisjoint(with: previous.equivalentSessionIDs)
+            || activeID.map(reconciliationCatalogIDs.contains) == true
+
+        var candidates = reconciliationIDs
+        if reconciliationIDs.isEmpty || reconciliationContinuesPrevious,
+           let activeID {
+            candidates.insert(activeID)
+        }
+        let matchedSession = reconciliationSession ?? matchingSession(for: candidates)
+        let continuesPreviousIdentity = candidates.contains(where: previous.contains)
+
+        let canonicalSessionID: String?
+        if let matchedSession {
+            canonicalSessionID = matchedSession.canonicalSessionID
+        } else if continuesPreviousIdentity {
+            canonicalSessionID = previous.canonicalSessionID
+        } else if !reconciliationIDs.isEmpty {
+            canonicalSessionID = ChatScrollIdentityNormalization.sessionID(requestedSessionID)
+                ?? ChatScrollIdentityNormalization.sessionID(resolvedSessionID)
+                ?? activeID
+        } else {
+            canonicalSessionID = activeID
+        }
+
+        var equivalentSessionIDs = candidates
+        if let matchedSession {
+            equivalentSessionIDs.formUnion(matchedSession.identifiers)
+        }
+        if continuesPreviousIdentity {
+            equivalentSessionIDs.formUnion(previous.equivalentSessionIDs)
+        }
+
+        return ChatScrollSessionIdentity(
+            profile: normalizedProfile,
+            canonicalSessionID: canonicalSessionID,
+            equivalentSessionIDs: equivalentSessionIDs,
+            isReconciling: isReconciling,
+            settledRevision: advanceSettledRevision
+                ? current.settledRevision &+ 1
+                : current.settledRevision
+        )
     }
 }
 
@@ -135,6 +348,46 @@ struct ChatScrollSnapshot: Equatable {
     let followsLatest: Bool
 
     static let latest = ChatScrollSnapshot(anchorMessageID: nil, followsLatest: true)
+}
+
+struct ChatScrollPendingRestoration: Equatable {
+    let sessionKey: ChatScrollSessionKey
+    let snapshot: ChatScrollSnapshot
+    let gate: ChatScrollRestorationGate
+}
+
+enum ChatScrollRestorationDecision: Equatable {
+    case wait
+    case cancel
+    case latest
+    case anchor(String)
+}
+
+enum ChatScrollRestorationResolver {
+    static func decision(
+        for pending: ChatScrollPendingRestoration,
+        identity: ChatScrollSessionIdentity,
+        activeSessionKey: ChatScrollSessionKey?,
+        store: ChatScrollStateStore,
+        availableMessageIDs: Set<String>
+    ) -> ChatScrollRestorationDecision {
+        guard identity.areEquivalent(pending.sessionKey, activeSessionKey) else {
+            return .cancel
+        }
+        guard !pending.snapshot.followsLatest else { return .latest }
+        guard pending.gate.allowsNonLatestRestoration(using: identity) else {
+            return .wait
+        }
+        guard let resolved = store.restoration(
+            for: pending.sessionKey,
+            availableMessageIDs: availableMessageIDs
+        ) else {
+            return .cancel
+        }
+        if resolved.followsLatest { return .latest }
+        guard let anchor = resolved.anchorMessageID else { return .latest }
+        return .anchor(anchor)
+    }
 }
 
 private struct DeterministicChatFingerprint {
@@ -185,23 +438,23 @@ private struct DeterministicChatFingerprint {
 }
 
 struct ChatScrollStateStore {
-    private var snapshots: [String: ChatScrollSnapshot] = [:]
+    private var snapshots: [ChatScrollSessionKey: ChatScrollSnapshot] = [:]
 
-    mutating func save(_ snapshot: ChatScrollSnapshot, for sessionID: String) {
-        let key = sessionID.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !key.isEmpty else { return }
+    mutating func save(_ snapshot: ChatScrollSnapshot, for key: ChatScrollSessionKey) {
+        guard key.isValid else { return }
         snapshots[key] = snapshot
     }
 
-    func snapshot(for sessionID: String) -> ChatScrollSnapshot? {
-        snapshots[sessionID.trimmingCharacters(in: .whitespacesAndNewlines)]
+    func snapshot(for key: ChatScrollSessionKey) -> ChatScrollSnapshot? {
+        guard key.isValid else { return nil }
+        return snapshots[key]
     }
 
     func restoration(
-        for sessionID: String,
+        for key: ChatScrollSessionKey,
         availableMessageIDs: Set<String>
     ) -> ChatScrollSnapshot? {
-        guard let snapshot = snapshot(for: sessionID) else { return nil }
+        guard let snapshot = snapshot(for: key) else { return nil }
         guard !snapshot.followsLatest else { return .latest }
         guard let anchor = snapshot.anchorMessageID,
               availableMessageIDs.contains(anchor) else {

--- a/Conduit/Services/DashboardTicketBridge.swift
+++ b/Conduit/Services/DashboardTicketBridge.swift
@@ -208,71 +208,87 @@ final class DashboardTicketBridge: NSObject {
         let timeout = max(1_000, timeoutMilliseconds)
         let responseLimit = max(1_024, maxResponseBytes)
 
-        return try await withCheckedThrowingContinuation { continuation in
-            pendingRequests[id] = continuation
-            let script = """
-            (async function() {
-                try {
-                    const requestBody = \(bodyLiteral);
-                    const controller = new AbortController();
-                    const timeout = setTimeout(() => controller.abort(), \(timeout));
-                    const response = await fetch(\(pathLiteral), {
-                        method: \(methodLiteral),
-                        credentials: 'include',
-                        headers: requestBody === null
-                            ? { Accept: 'application/json' }
-                            : { Accept: 'application/json', 'Content-Type': 'application/json' },
-                        body: requestBody === null ? undefined : JSON.stringify(requestBody),
-                        signal: controller.signal
-                    });
-                    const declaredLength = Number(response.headers.get('content-length') || 0);
-                    if (declaredLength > \(responseLimit)) throw new Error('response_too_large');
-                    const text = await (async function() {
-                        if (!response.body || typeof response.body.getReader !== 'function') {
-                            if (!Number.isFinite(declaredLength) || declaredLength <= 0) throw new Error('bounded_response_unavailable');
-                            return response.text();
-                        }
-                        const reader = response.body.getReader();
-                        const decoder = new TextDecoder();
-                        let totalBytes = 0;
-                        let result = '';
-                        while (true) {
-                            const chunk = await reader.read();
-                            if (chunk.done) {
-                                result += decoder.decode();
-                                return result;
-                            }
-                            totalBytes += chunk.value.byteLength;
-                            if (totalBytes > \(responseLimit)) {
-                                await reader.cancel();
-                                throw new Error('response_too_large');
-                            }
-                            result += decoder.decode(chunk.value, { stream: true });
-                        }
-                    })();
-                    clearTimeout(timeout);
-                    let body = null;
-                    try { body = text ? JSON.parse(text) : null; } catch (_) { body = text; }
-                    const normalizedBody = Array.isArray(body) ? { _array: body } : (body && typeof body === 'object' ? body : { value: body });
-                    window.webkit.messageHandlers['dashboard-response'].postMessage(JSON.stringify({
-                        type: 'dashboard-response', id: \(id), ok: response.ok,
-                        status: response.status, body: normalizedBody,
-                        error: !response.ok && body && typeof body === 'object'
-                            ? (body.error || body.message || body.detail) : null
-                    }));
-                } catch (error) {
-                    window.webkit.messageHandlers['dashboard-response'].postMessage(JSON.stringify({
-                        type: 'dashboard-response', id: \(id), ok: false, status: 0, error: String(error)
-                    }));
+        return try await withTaskCancellationHandler(operation: {
+            try await withCheckedThrowingContinuation { continuation in
+                guard !Task.isCancelled else {
+                    continuation.resume(throwing: CancellationError())
+                    return
                 }
-            })();
-            true;
-            """
-            webView.evaluateJavaScript(script) { _, error in
-                guard let error, let pending = self.pendingRequests.removeValue(forKey: id) else { return }
-                pending.resume(throwing: error)
+
+                pendingRequests[id] = continuation
+                let script = """
+                (async function() {
+                    try {
+                        const requestBody = \(bodyLiteral);
+                        const controller = new AbortController();
+                        const timeout = setTimeout(() => controller.abort(), \(timeout));
+                        const response = await fetch(\(pathLiteral), {
+                            method: \(methodLiteral),
+                            credentials: 'include',
+                            headers: requestBody === null
+                                ? { Accept: 'application/json' }
+                                : { Accept: 'application/json', 'Content-Type': 'application/json' },
+                            body: requestBody === null ? undefined : JSON.stringify(requestBody),
+                            signal: controller.signal
+                        });
+                        const declaredLength = Number(response.headers.get('content-length') || 0);
+                        if (declaredLength > \(responseLimit)) throw new Error('response_too_large');
+                        const text = await (async function() {
+                            if (!response.body || typeof response.body.getReader !== 'function') {
+                                if (!Number.isFinite(declaredLength) || declaredLength <= 0) throw new Error('bounded_response_unavailable');
+                                return response.text();
+                            }
+                            const reader = response.body.getReader();
+                            const decoder = new TextDecoder();
+                            let totalBytes = 0;
+                            let result = '';
+                            while (true) {
+                                const chunk = await reader.read();
+                                if (chunk.done) {
+                                    result += decoder.decode();
+                                    return result;
+                                }
+                                totalBytes += chunk.value.byteLength;
+                                if (totalBytes > \(responseLimit)) {
+                                    await reader.cancel();
+                                    throw new Error('response_too_large');
+                                }
+                                result += decoder.decode(chunk.value, { stream: true });
+                            }
+                        })();
+                        clearTimeout(timeout);
+                        let body = null;
+                        try { body = text ? JSON.parse(text) : null; } catch (_) { body = text; }
+                        const normalizedBody = Array.isArray(body) ? { _array: body } : (body && typeof body === 'object' ? body : { value: body });
+                        window.webkit.messageHandlers['dashboard-response'].postMessage(JSON.stringify({
+                            type: 'dashboard-response', id: \(id), ok: response.ok,
+                            status: response.status, body: normalizedBody,
+                            error: !response.ok && body && typeof body === 'object'
+                                ? (body.error || body.message || body.detail) : null
+                        }));
+                    } catch (error) {
+                        window.webkit.messageHandlers['dashboard-response'].postMessage(JSON.stringify({
+                            type: 'dashboard-response', id: \(id), ok: false, status: 0, error: String(error)
+                        }));
+                    }
+                })();
+                true;
+                """
+                webView.evaluateJavaScript(script) { _, error in
+                    guard let error, let pending = self.pendingRequests.removeValue(forKey: id) else { return }
+                    pending.resume(throwing: error)
+                }
             }
-        }
+        }, onCancel: {
+            Task { @MainActor [weak self] in
+                self?.cancelPendingRequest(id: id)
+            }
+        })
+    }
+
+    private func cancelPendingRequest(id: Int) {
+        guard let continuation = pendingRequests.removeValue(forKey: id) else { return }
+        continuation.resume(throwing: CancellationError())
     }
 
     private func javaScriptLiteral(_ value: Any) throws -> String {

--- a/Conduit/Services/HermesClient.swift
+++ b/Conduit/Services/HermesClient.swift
@@ -532,9 +532,9 @@ final class HermesClient: ObservableObject {
         let body = try JSONEncoder().encode(request)
         logger.notice("Sending RPC id \(id) method \(method, privacy: .public)")
 
-        return try await withTaskCancellationHandler {
+        return try await withTaskCancellationHandler(operation: {
             try await withCheckedThrowingContinuation { continuation in
-                if Task.isCancelled {
+                guard !Task.isCancelled else {
                     continuation.resume(throwing: CancellationError())
                     return
                 }
@@ -553,8 +553,6 @@ final class HermesClient: ObservableObject {
                 // Hermes' established React Native client uses WebSocket text
                 // frames (`socket.send(JSON.stringify(...))`). The gateway accepts
                 // the connection but does not dispatch binary JSON-RPC frames.
-                // JSONEncoder output is valid UTF-8; keep this transport conversion nonfailable.
-                // swiftlint:disable:next optional_data_string_conversion
                 let text = String(decoding: body, as: UTF8.self)
                 socket.send(.string(text)) { [weak self] error in
                     if let error {
@@ -568,13 +566,17 @@ final class HermesClient: ObservableObject {
                     }
                 }
             }
-        } onCancel: { [weak self] in
+        }, onCancel: {
             Task { @MainActor [weak self] in
-                guard let pending = self?.pending.removeValue(forKey: id) else { return }
-                pending.timer?.invalidate()
-                pending.continuation.resume(throwing: CancellationError())
+                self?.cancelPendingRequest(id: id)
             }
-        }
+        })
+    }
+
+    private func cancelPendingRequest(id: Int) {
+        guard let pending = pending.removeValue(forKey: id) else { return }
+        pending.timer?.invalidate()
+        pending.continuation.resume(throwing: CancellationError())
     }
 
     private func incrementRequestId() -> Int {

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -110,6 +110,7 @@ struct SettingsSnapshot: Identifiable {
     let defaultProfileName: String
     let theme: ThemePreference
     let busyInputMode: BusyInputMode
+    let chatResumeBehavior: ChatResumeBehavior
     let displayPreferences: ProfileDisplayPreferences
     let cloudflareAccess: CloudflareAccessCredentials?
 }
@@ -454,6 +455,7 @@ struct SettingsView: View {
     let snapshot: SettingsSnapshot
     let saveTheme: (ThemePreference) -> Void
     let persistBusyInputMode: (BusyInputMode) async -> Bool
+    let persistChatResumeBehavior: (ChatResumeBehavior) -> Void
     let loadProfileSettings: ([String]) async -> [String: ProfileSettingValue]
     let persistProfileSetting: (String, ProfileSettingValue) async -> Bool
     let loadProfileConfigOptions: () async -> ProfileConfigOptions
@@ -495,6 +497,8 @@ struct SettingsView: View {
             ChatSettingsDetail(
                 busyInputMode: snapshot.busyInputMode,
                 persistBusyInputMode: persistBusyInputMode,
+                chatResumeBehavior: snapshot.chatResumeBehavior,
+                persistChatResumeBehavior: persistChatResumeBehavior,
                 load: loadProfileSettings,
                 save: persistProfileSetting,
                 loadOptions: loadProfileConfigOptions
@@ -697,6 +701,8 @@ private struct ProfileSettingsDetail: View {
 private struct ChatSettingsDetail: View {
     let busyInputMode: BusyInputMode
     let persistBusyInputMode: (BusyInputMode) async -> Bool
+    let chatResumeBehavior: ChatResumeBehavior
+    let persistChatResumeBehavior: (ChatResumeBehavior) -> Void
     let load: ([String]) async -> [String: ProfileSettingValue]
     let save: (String, ProfileSettingValue) async -> Bool
     let loadOptions: () async -> ProfileConfigOptions
@@ -711,7 +717,15 @@ private struct ChatSettingsDetail: View {
             save: save,
             showsNavigationTitle: false,
             optionOverrides: ["display.personality": ["", "helpful", "concise", "technical", "creative", "teacher", "kawaii", "catgirl", "pirate", "shakespeare", "surfer", "noir", "uwu", "philosopher", "hype"] + options.personalities],
-            leadingSection: AnyView(ResponseBehaviorSettings(initialMode: busyInputMode, save: persistBusyInputMode)),
+            leadingSection: AnyView(
+                VStack(spacing: 14) {
+                    ChatReturnBehaviorSettings(
+                        initialBehavior: chatResumeBehavior,
+                        persist: persistChatResumeBehavior
+                    )
+                    ResponseBehaviorSettings(initialMode: busyInputMode, save: persistBusyInputMode)
+                }
+            ),
             trailingSection: AnyView(DeviceHapticsSettings())
         )
         .navigationTitle("Chat")
@@ -745,6 +759,42 @@ private struct DeviceHapticsSettings: View {
                 .labelsHidden()
                 .tint(.conduitAccent)
         }
+}
+
+private struct ChatReturnBehaviorSettings: View {
+    let persist: (ChatResumeBehavior) -> Void
+    @State private var behavior: ChatResumeBehavior
+
+    init(
+        initialBehavior: ChatResumeBehavior,
+        persist: @escaping (ChatResumeBehavior) -> Void
+    ) {
+        self.persist = persist
+        _behavior = State(initialValue: initialBehavior)
+    }
+
+    var body: some View {
+        ConduitSettingsSection(
+            title: "When returning to Conduit",
+            symbol: "arrow.uturn.backward.circle",
+            tint: .conduitAccent
+        ) {
+            Text("Stored only on this device, not in your Hermes profile. Choose whether Conduit preserves your exact reading position or follows the newest conversation.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            Picker("When returning to Conduit", selection: Binding(get: { behavior }, set: choose)) {
+                Text("Continue").tag(ChatResumeBehavior.continueWhereLeftOff)
+                Text("Latest").tag(ChatResumeBehavior.latestActivity)
+            }
+            .pickerStyle(.segmented)
+            .accessibilityHint("Stored only on this device, not in your Hermes profile.")
+        }
+    }
+
+    private func choose(_ next: ChatResumeBehavior) {
+        guard next != behavior else { return }
+        behavior = next
+        persist(next)
     }
 }
 

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -759,6 +759,7 @@ private struct DeviceHapticsSettings: View {
                 .labelsHidden()
                 .tint(.conduitAccent)
         }
+    }
 }
 
 private struct ChatReturnBehaviorSettings: View {

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -93,9 +93,9 @@ struct ChatView: View {
                             .padding(.bottom, 126)
                             .id(bottomAnchor)
                     }
+                    .scrollTargetLayout()
                     .padding(.horizontal, 18)
                     .padding(.top, 18)
-                    .scrollTargetLayout()
                     .background {
                         // Measure the lazy stack itself, not its final child.
                         // SwiftUI can unload that child after the user scrolls
@@ -146,20 +146,34 @@ struct ChatView: View {
                         finishChatScrollRestorationIfReady(using: proxy)
                     }
                 }
-                .onChange(of: appState.messages) { oldMessages, newMessages in
-                    chatMessageScrollTargetCache.update(for: newMessages)
+                .onChange(of: appState.messages) { _, newMessages in
+                    let cacheUpdate = chatMessageScrollTargetCache.update(for: newMessages)
+                    let hasNotificationHandoff = appState.isOpeningNotificationSession
+                        || notificationHandoffPending
                     if pendingScrollRestoration != nil,
-                       !appState.isOpeningNotificationSession {
+                       !hasNotificationHandoff {
                         DispatchQueue.main.async {
                             finishChatScrollRestorationIfReady(using: proxy)
                         }
                     }
-                    guard oldMessages.count != newMessages.count else { return }
                     guard !appState.isOpeningNotificationSession else {
                         notificationHandoffPending = true
                         return
                     }
-                    if followsLatest {
+                    guard ChatMessageScrollUpdatePolicy.shouldReassertLatest(
+                        after: cacheUpdate,
+                        followsLatest: followsLatest,
+                        hasPendingNonLatestRestoration: hasPendingNonLatestRestoration,
+                        hasNotificationHandoff: notificationHandoffPending
+                    ) else { return }
+                    DispatchQueue.main.async {
+                        guard ChatMessageScrollUpdatePolicy.shouldReassertLatest(
+                            after: cacheUpdate,
+                            followsLatest: followsLatest,
+                            hasPendingNonLatestRestoration: hasPendingNonLatestRestoration,
+                            hasNotificationHandoff: appState.isOpeningNotificationSession
+                                || notificationHandoffPending
+                        ) else { return }
                         scrollToLatest(using: proxy)
                     }
                 }
@@ -296,14 +310,14 @@ struct ChatView: View {
 
     private func saveChatScrollPosition() {
         guard let sessionKey = activeScrollSessionKey else { return }
-        let messageIDs = Set(chatMessageScrollTargetCache.targets.map(\.semanticID))
-        let anchor = messageIDs.contains(topVisibleChatID ?? "")
-            ? topVisibleChatID
-            : nil
+        let anchorTarget = chatMessageScrollTargetCache.targets.first {
+            $0.semanticID == topVisibleChatID
+        }
         chatScrollState.save(
             ChatScrollSnapshot(
-                anchorMessageID: followsLatest ? nil : anchor,
-                followsLatest: followsLatest
+                anchorMessageID: followsLatest ? nil : anchorTarget?.semanticID,
+                followsLatest: followsLatest,
+                anchorMetadata: followsLatest ? nil : anchorTarget?.restorationMetadata
             ),
             for: sessionKey
         )
@@ -343,7 +357,9 @@ struct ChatView: View {
             identity: identity,
             activeSessionKey: activeScrollSessionKey,
             store: chatScrollState,
-            availableMessageIDs: Set(chatMessageScrollTargetCache.targets.map(\.semanticID))
+            availableTargets: ChatScrollTargetAvailability(
+                targets: chatMessageScrollTargetCache.targets
+            )
         )
 
         switch decision {

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -16,6 +16,9 @@ struct ChatView: View {
     @State private var topVisibleChatID: String?
     @State private var chatMessageScrollTargetCache = ChatMessageScrollTargetCache()
     @State private var renderedScrollSessionKey: ChatScrollSessionKey?
+    @State private var renderedScrollContent: ChatRenderedScrollContent?
+    @State private var renderedViewportTransitionGeneration: UInt64 = 0
+    @State private var viewportSnapshotProviderID = UUID()
     @State private var isDraggingChat = false
     @State private var notificationHandoffPending = false
     @State private var notificationHandoffSessionKey: ChatScrollSessionKey?
@@ -94,10 +97,24 @@ struct ChatView: View {
                         // away, leaving the old "at bottom" value stuck and
                         // suppressing the scroll-to-latest button.
                         GeometryReader { geometry in
-                            Color.clear.preference(
-                                key: ChatBottomMarkerPreferenceKey.self,
-                                value: geometry.frame(in: .global).maxY
-                            )
+                            Color.clear
+                                .preference(
+                                    key: ChatBottomMarkerPreferenceKey.self,
+                                    value: geometry.frame(in: .global).maxY
+                                )
+                                .preference(
+                                    key: ChatRenderedScrollContentPreferenceKey.self,
+                                    value: renderedScrollSessionKey.map {
+                                        ChatRenderedScrollContent(
+                                            sessionKey: $0,
+                                            cacheRevision: chatMessageScrollTargetCache.renderingRevision,
+                                            semanticTargetIDs: chatMessageScrollTargetCache.semanticTargetIDs,
+                                            bottomAnchorID: bottomAnchor,
+                                            restorationGeneration: appState.chatResumeRestorationRequest?.generation,
+                                            viewportTransitionGeneration: renderedViewportTransitionGeneration
+                                        )
+                                    }
+                                )
                         }
                     }
                 }
@@ -122,6 +139,29 @@ struct ChatView: View {
                 .onAppear {
                     renderedScrollSessionKey = activeScrollSessionKey
                     chatMessageScrollTargetCache.update(for: appState.messages)
+                    renderedViewportTransitionGeneration = appState.chatViewportTransitionGeneration
+                    let followsLatestState = $followsLatest
+                    let topVisibleChatIDState = $topVisibleChatID
+                    let targetCacheState = $chatMessageScrollTargetCache
+                    appState.installChatViewportSnapshotProvider(
+                        id: viewportSnapshotProviderID,
+                        snapshot: {
+                            let followsLatest = followsLatestState.wrappedValue
+                            let target = targetCacheState.wrappedValue.targets.first {
+                                $0.semanticID == topVisibleChatIDState.wrappedValue
+                            }
+                            guard followsLatest || target != nil else { return nil }
+                            return ChatScrollSnapshot(
+                                anchorMessageID: followsLatest ? nil : target?.semanticID,
+                                followsLatest: followsLatest,
+                                anchorMetadata: followsLatest ? nil : target?.restorationMetadata,
+                                anchorSourceMessageID: followsLatest ? nil : target?.id
+                            )
+                        }
+                    )
+                }
+                .onDisappear {
+                    appState.removeChatViewportSnapshotProvider(id: viewportSnapshotProviderID)
                 }
                 .task(id: appState.chatResumeRestorationRequest?.generation) {
                     guard let request = appState.chatResumeRestorationRequest else { return }
@@ -137,8 +177,17 @@ struct ChatView: View {
                     recordNotificationHandoffLayout()
                     finishNotificationHandoffIfReady(using: proxy)
                 }
+                .onPreferenceChange(ChatRenderedScrollContentPreferenceKey.self) { value in
+                    renderedScrollContent = value
+                    guard let value else { return }
+                    appState.chatViewportLayoutDidSettle(
+                        sessionKey: value.sessionKey,
+                        transitionGeneration: value.viewportTransitionGeneration
+                    )
+                }
                 .onChange(of: appState.messages) { _, newMessages in
                     let cacheUpdate = chatMessageScrollTargetCache.update(for: newMessages)
+                    renderedViewportTransitionGeneration = appState.chatViewportTransitionGeneration
                     guard !appState.isOpeningNotificationSession else {
                         notificationHandoffPending = true
                         return
@@ -181,6 +230,10 @@ struct ChatView: View {
                         notificationHandoffPending = true
                         notificationHandoffSessionKey = activeScrollSessionKey
                         notificationHandoffHasMeasuredLayout = false
+                        renderedScrollSessionKey = activeScrollSessionKey
+                        if followsLatest {
+                            renderedViewportTransitionGeneration = appState.chatViewportTransitionGeneration
+                        }
                         return
                     }
                     let identity = appState.activeChatScrollSessionIdentity
@@ -190,9 +243,11 @@ struct ChatView: View {
                        !identity.areEquivalent(request.sessionKey, newKey) {
                         cancelAutomaticRestoration()
                     }
-                    saveChatScrollPosition(for: oldKey)
                     let keysAreEquivalent = identity.areEquivalent(oldKey, newKey)
                     renderedScrollSessionKey = newKey
+                    if followsLatest {
+                        renderedViewportTransitionGeneration = appState.chatViewportTransitionGeneration
+                    }
                     guard !keysAreEquivalent else { return }
                     topVisibleChatID = nil
                     followsLatest = true
@@ -205,11 +260,13 @@ struct ChatView: View {
                        request.sessionKey != newKey {
                         cancelAutomaticRestoration()
                     }
-                    saveChatScrollPosition(for: oldKey)
                     topVisibleChatID = nil
                     chatMessageScrollTargetCache = ChatMessageScrollTargetCache()
                     chatMessageScrollTargetCache.update(for: appState.messages)
                     renderedScrollSessionKey = newKey
+                    if followsLatest {
+                        renderedViewportTransitionGeneration = appState.chatViewportTransitionGeneration
+                    }
                     guard !appState.isOpeningNotificationSession else {
                         notificationHandoffPending = true
                         notificationHandoffSessionKey = newKey
@@ -227,7 +284,7 @@ struct ChatView: View {
                        appState.activeChatScrollSessionIdentity.areEquivalent(
                            renderedScrollSessionKey,
                            activeScrollSessionKey
-                       ) {
+                    ) {
                         renderedScrollSessionKey = activeScrollSessionKey
                     }
                 }
@@ -313,18 +370,20 @@ struct ChatView: View {
 
     private func saveChatScrollPosition(for preferredKey: ChatScrollSessionKey? = nil) {
         guard let sessionKey = preferredKey ?? renderedScrollSessionKey ?? activeScrollSessionKey else { return }
+        guard let snapshot = currentChatViewportSnapshot() else { return }
+        appState.recordChatViewport(snapshot, for: sessionKey)
+    }
+
+    private func currentChatViewportSnapshot() -> ChatScrollSnapshot? {
         let anchorTarget = chatMessageScrollTargetCache.targets.first {
             $0.semanticID == topVisibleChatID
         }
-        guard followsLatest || anchorTarget != nil else { return }
-        appState.recordChatViewport(
-            ChatScrollSnapshot(
-                anchorMessageID: followsLatest ? nil : anchorTarget?.semanticID,
-                followsLatest: followsLatest,
-                anchorMetadata: followsLatest ? nil : anchorTarget?.restorationMetadata,
-                anchorSourceMessageID: followsLatest ? nil : anchorTarget?.id
-            ),
-            for: sessionKey
+        guard followsLatest || anchorTarget != nil else { return nil }
+        return ChatScrollSnapshot(
+            anchorMessageID: followsLatest ? nil : anchorTarget?.semanticID,
+            followsLatest: followsLatest,
+            anchorMetadata: followsLatest ? nil : anchorTarget?.restorationMetadata,
+            anchorSourceMessageID: followsLatest ? nil : anchorTarget?.id
         )
     }
 
@@ -338,66 +397,92 @@ struct ChatView: View {
         using proxy: ScrollViewProxy
     ) async {
         guard restorationRequestIsCurrent(request) else { return }
-
-        let destination: ChatResumeViewportDestination
-        switch request.destination {
-        case .latest:
-            followsLatest = true
-            await Task.yield()
-            guard restorationRequestIsCurrent(request) else { return }
-            destination = .latest
-
-        case .snapshot(let snapshot):
-            followsLatest = snapshot.followsLatest
-            guard await waitForRestorationTargets(for: request) else { return }
-            destination = ChatResumeViewportResolver.destination(
-                for: snapshot,
-                availableTargets: ChatScrollTargetAvailability(
-                    targets: chatMessageScrollTargetCache.targets
-                )
-            )
+        if chatMessageScrollTargetCache.targets.map(\.message) != appState.messages {
+            chatMessageScrollTargetCache.update(for: appState.messages)
         }
 
-        guard restorationRequestIsCurrent(request) else { return }
-        var transaction = Transaction()
-        transaction.animation = nil
-        withTransaction(transaction) {
-            switch destination {
-            case .latest:
-                followsLatest = true
-                proxy.scrollTo(bottomAnchor, anchor: .bottom)
-            case .anchor(let anchor):
-                followsLatest = false
-                proxy.scrollTo(anchor, anchor: .top)
-            }
-        }
+        var destination = restorationDestination(
+            for: request,
+            targets: chatMessageScrollTargetCache.targets
+        )
+        followsLatest = destination == .latest
+        var restoration = ChatResumeRenderRestorationState(
+            generation: request.generation,
+            sessionKey: request.sessionKey,
+            destination: destination
+        )
 
-        guard restorationRequestIsCurrent(request) else { return }
-        appState.completeChatResumeRestoration(generation: request.generation)
-        if destination == .latest {
-            saveChatScrollPosition(for: request.sessionKey)
-        }
-    }
-
-    @MainActor
-    private func waitForRestorationTargets(
-        for request: ChatResumeRestorationRequest
-    ) async -> Bool {
         while restorationRequestIsCurrent(request) {
             if chatMessageScrollTargetCache.targets.map(\.message) != appState.messages {
                 chatMessageScrollTargetCache.update(for: appState.messages)
-                await Task.yield()
-                continue
+            }
+            destination = restorationDestination(
+                for: request,
+                targets: chatMessageScrollTargetCache.targets
+            )
+            restoration.updateDestination(destination)
+
+            switch restoration.nextAction(
+                renderedContent: renderedScrollContent,
+                cacheRevision: chatMessageScrollTargetCache.renderingRevision,
+                topVisibleID: topVisibleChatID,
+                isNearBottom: bottomMarkerMaxY != nil
+                    && scrollViewportMaxY != nil
+                    && isNearBottom
+            ) {
+            case .wait:
+                break
+            case .scroll(let destination):
+                guard restorationRequestIsCurrent(request) else { return }
+                var transaction = Transaction()
+                transaction.animation = nil
+                withTransaction(transaction) {
+                    switch destination {
+                    case .latest:
+                        followsLatest = true
+                        proxy.scrollTo(bottomAnchor, anchor: .bottom)
+                    case .anchor(let anchor):
+                        followsLatest = false
+                        proxy.scrollTo(anchor, anchor: .top)
+                    }
+                }
+            case .complete:
+                guard restorationRequestIsCurrent(request) else { return }
+                appState.completeChatResumeRestoration(generation: request.generation)
+                if destination == .latest {
+                    saveChatScrollPosition(for: request.sessionKey)
+                }
+                return
+            case .abandon:
+                guard restorationRequestIsCurrent(request) else { return }
+                appState.abandonChatResumeRestoration(generation: request.generation)
+                return
+            case .cancelled:
+                return
             }
 
-            // Give SwiftUI one update cycle to install the semantic rows that
-            // correspond to the now-current target cache.
-            await Task.yield()
-            if chatMessageScrollTargetCache.targets.map(\.message) == appState.messages {
-                return restorationRequestIsCurrent(request)
+            do {
+                try await Task.sleep(for: .milliseconds(25))
+            } catch {
+                restoration.cancel()
+                return
             }
         }
-        return false
+    }
+
+    private func restorationDestination(
+        for request: ChatResumeRestorationRequest,
+        targets: [ChatMessageScrollTarget]
+    ) -> ChatResumeViewportDestination {
+        switch request.destination {
+        case .latest:
+            return .latest
+        case .snapshot(let snapshot):
+            return ChatResumeViewportResolver.destination(
+                for: snapshot,
+                availableTargets: ChatScrollTargetAvailability(targets: targets)
+            )
+        }
     }
 
     private func restorationRequestIsCurrent(
@@ -472,6 +557,16 @@ private struct ChatBottomMarkerPreferenceKey: PreferenceKey {
 private struct ChatViewportBottomPreferenceKey: PreferenceKey {
     static var defaultValue: CGFloat? = nil
     static func reduce(value: inout CGFloat?, nextValue: () -> CGFloat?) {
+        value = nextValue() ?? value
+    }
+}
+
+private struct ChatRenderedScrollContentPreferenceKey: PreferenceKey {
+    static var defaultValue: ChatRenderedScrollContent? = nil
+    static func reduce(
+        value: inout ChatRenderedScrollContent?,
+        nextValue: () -> ChatRenderedScrollContent?
+    ) {
         value = nextValue() ?? value
     }
 }

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -79,7 +79,7 @@ struct ChatView: View {
 
                         ForEach(chatMessageScrollTargetCache.targets) { target in
                             MessageBubble(message: target.message)
-                                .id(target.semanticID)
+                                .id(target.id)
                                 .background {
                                     GeometryReader { _ in
                                         Color.clear.preference(
@@ -452,7 +452,14 @@ struct ChatView: View {
         _ request: ChatResumeRestorationRequest,
         using proxy: ScrollViewProxy
     ) async {
-        guard restorationRequestIsCurrent(request) else { return }
+        guard restorationRequestIsCurrent(request) else {
+            // If the generation is still current but identity drifted,
+            // abandon so pendingRestoration doesn't get stuck forever.
+            if appState.chatResumeRestorationRequest?.generation == request.generation {
+                appState.abandonChatResumeRestoration(generation: request.generation)
+            }
+            return
+        }
         if chatMessageScrollTargetCache.targets.map(\.message) != appState.messages {
             chatMessageScrollTargetCache.update(for: appState.messages)
             renderedTranscriptRevision = appState.chatTranscriptRevision
@@ -503,7 +510,12 @@ struct ChatView: View {
                         proxy.scrollTo(bottomAnchor, anchor: .bottom)
                     case .anchor(let anchor):
                         followsLatest = false
-                        proxy.scrollTo(anchor, anchor: .top)
+                        // Resolve semantic anchor ID to the stable source
+                        // message ID used for row identity (.id(target.id)).
+                        let scrollAnchor = chatMessageScrollTargetCache.targets.first {
+                            $0.semanticID == anchor
+                        }?.id ?? anchor
+                        proxy.scrollTo(scrollAnchor, anchor: .top)
                     }
                 }
             case .complete:
@@ -560,6 +572,17 @@ struct ChatView: View {
         guard !hasPendingRestoration else { return }
         withAnimation(ConduitMotion.response) {
             proxy.scrollTo(bottomAnchor, anchor: .bottom)
+        }
+        // Retry after a short delay: proxy.scrollTo is a silent no-op if the
+        // bottom anchor row isn't materialized yet (LazyVStack on a long
+        // transcript). A single delayed retry covers the common case where
+        // messages arrive on the same main-actor turn.
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled, !hasPendingRestoration else { return }
+            withAnimation(ConduitMotion.response) {
+                proxy.scrollTo(bottomAnchor, anchor: .bottom)
+            }
         }
     }
 

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -535,6 +535,13 @@ struct ChatView: View {
                 return
             }
         }
+
+        // Loop exited because restorationRequestIsCurrent returned false.
+        // If the generation is still current but identity drifted mid-loop,
+        // abandon so pendingRestoration doesn't get stuck forever.
+        if appState.chatResumeRestorationRequest?.generation == request.generation {
+            appState.abandonChatResumeRestoration(generation: request.generation)
+        }
     }
 
     private func restorationDestination(

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -86,7 +86,7 @@ struct ChatView: View {
                                             key: ChatRenderedScrollTargetsPreferenceKey.self,
                                             value: renderedScrollScope.map {
                                                 ChatRenderedScrollTargets.row(
-                                                    semanticID: target.semanticID,
+                                                    semanticID: target.id,
                                                     scope: $0
                                                 )
                                             } ?? ChatRenderedScrollTargets()
@@ -185,7 +185,7 @@ struct ChatView: View {
                             }
                             let followsLatest = followsLatestState.wrappedValue
                             let target = targetCacheState.wrappedValue.targets.first {
-                                $0.semanticID == topVisibleChatIDState.wrappedValue
+                                $0.id == topVisibleChatIDState.wrappedValue
                             }
                             guard followsLatest || target != nil else { return nil }
                             let snapshot = ChatScrollSnapshot(
@@ -432,7 +432,7 @@ struct ChatView: View {
 
     private func currentChatViewportSnapshot() -> ChatScrollSnapshot? {
         let anchorTarget = chatMessageScrollTargetCache.targets.first {
-            $0.semanticID == topVisibleChatID
+            $0.id == topVisibleChatID
         }
         guard followsLatest || anchorTarget != nil else { return nil }
         return ChatScrollSnapshot(
@@ -510,12 +510,7 @@ struct ChatView: View {
                         proxy.scrollTo(bottomAnchor, anchor: .bottom)
                     case .anchor(let anchor):
                         followsLatest = false
-                        // Resolve semantic anchor ID to the stable source
-                        // message ID used for row identity (.id(target.id)).
-                        let scrollAnchor = chatMessageScrollTargetCache.targets.first {
-                            $0.semanticID == anchor
-                        }?.id ?? anchor
-                        proxy.scrollTo(scrollAnchor, anchor: .top)
+                        proxy.scrollTo(anchor, anchor: .top)
                     }
                 }
             case .complete:
@@ -550,10 +545,21 @@ struct ChatView: View {
         case .latest:
             return .latest
         case .snapshot(let snapshot):
-            return ChatResumeViewportResolver.destination(
+            // The resolver returns semantic anchor IDs, but rows are now
+            // keyed by message.id (.id(target.id)). Resolve the semantic
+            // anchor to its source message.id so the entire restoration
+            // state machine operates in one identity space.
+            let resolved = ChatResumeViewportResolver.destination(
                 for: snapshot,
                 availableTargets: ChatScrollTargetAvailability(targets: targets)
             )
+            switch resolved {
+            case .latest:
+                return .latest
+            case .anchor(let semanticAnchor):
+                let sourceAnchor = targets.first { $0.semanticID == semanticAnchor }?.id ?? semanticAnchor
+                return .anchor(sourceAnchor)
+            }
         }
     }
 

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -18,6 +18,7 @@ struct ChatView: View {
     @State private var chatScrollState = ChatScrollStateStore()
     @State private var chatMessageScrollTargetCache = ChatMessageScrollTargetCache()
     @State private var pendingScrollRestoration: ChatScrollPendingRestoration?
+    @State private var renderedScrollSessionKey: ChatScrollSessionKey?
     @State private var notificationHandoffPending = false
     @State private var notificationHandoffSessionKey: ChatScrollSessionKey?
     @State private var notificationHandoffHasMeasuredLayout = false
@@ -128,6 +129,7 @@ struct ChatView: View {
                     }
                 }
                 .onAppear {
+                    renderedScrollSessionKey = activeScrollSessionKey
                     chatMessageScrollTargetCache.update(for: appState.messages)
                 }
                 .onPreferenceChange(ChatBottomMarkerPreferenceKey.self) { value in
@@ -177,6 +179,13 @@ struct ChatView: View {
                         scrollToLatest(using: proxy)
                     }
                 }
+                .onChange(of: topVisibleChatID) { _, _ in
+                    // Persist the browsing position while the old transcript
+                    // is still rendered. A session switch clears messages in
+                    // the same main-actor turn, so waiting until the switch
+                    // callback would leave us with no anchor to save.
+                    saveChatScrollPosition(for: renderedScrollSessionKey)
+                }
                 .onChange(of: appState.chatScrollRequest) { _, _ in
                     cancelPendingChatScrollRestoration()
                     followsLatest = true
@@ -191,31 +200,72 @@ struct ChatView: View {
                         return
                     }
                     let identity = appState.activeChatScrollSessionIdentity
-                    guard !identity.areEquivalent(
-                        identity.key(for: oldSessionID),
-                        identity.key(for: newSessionID)
-                    ) else { return }
-                    cancelPendingChatScrollRestoration()
-                    followsLatest = true
-                    scrollToLatest(using: proxy)
+                    let oldKey = renderedScrollSessionKey ?? identity.key(for: oldSessionID)
+                    let newKey = activeScrollSessionKey
+                    renderedScrollSessionKey = newKey
+                    guard !identity.areEquivalent(oldKey, newKey) else { return }
+
+                    let action = ChatScrollSessionTransitionPolicy.action(
+                        from: oldKey,
+                        to: newKey,
+                        snapshot: newKey.flatMap { chatScrollState.snapshot(for: $0) }
+                    )
+                    switch action {
+                    case .ignore:
+                        break
+                    case .latest:
+                        cancelPendingChatScrollRestoration()
+                        followsLatest = true
+                        scrollToLatest(using: proxy)
+                    case .restore:
+                        beginChatScrollRestoration()
+                        DispatchQueue.main.async {
+                            finishChatScrollRestorationIfReady(using: proxy)
+                        }
+                    }
                 }
                 .onChange(of: appState.activeProfile) { _, _ in
-                    cancelPendingChatScrollRestoration()
                     topVisibleChatID = nil
                     chatMessageScrollTargetCache = ChatMessageScrollTargetCache()
                     chatMessageScrollTargetCache.update(for: appState.messages)
+                    let oldKey = renderedScrollSessionKey
+                    let newKey = activeScrollSessionKey
+                    renderedScrollSessionKey = newKey
                     guard !appState.isOpeningNotificationSession else {
                         notificationHandoffPending = true
-                        notificationHandoffSessionKey = activeScrollSessionKey
+                        notificationHandoffSessionKey = newKey
                         notificationHandoffHasMeasuredLayout = false
                         followsLatest = false
                         return
                     }
-                    followsLatest = true
-                    scrollToLatest(using: proxy)
+                    let action = ChatScrollSessionTransitionPolicy.action(
+                        from: oldKey,
+                        to: newKey,
+                        snapshot: newKey.flatMap { chatScrollState.snapshot(for: $0) }
+                    )
+                    switch action {
+                    case .ignore:
+                        break
+                    case .latest:
+                        cancelPendingChatScrollRestoration()
+                        followsLatest = true
+                        scrollToLatest(using: proxy)
+                    case .restore:
+                        beginChatScrollRestoration()
+                        DispatchQueue.main.async {
+                            finishChatScrollRestorationIfReady(using: proxy)
+                        }
+                    }
                 }
                 .onChange(of: appState.activeChatScrollSessionIdentity) { _, _ in
                     guard !appState.isOpeningNotificationSession else { return }
+                    if let activeScrollSessionKey,
+                       appState.activeChatScrollSessionIdentity.areEquivalent(
+                           renderedScrollSessionKey,
+                           activeScrollSessionKey
+                       ) {
+                        renderedScrollSessionKey = activeScrollSessionKey
+                    }
                     // Reconciliation publishes after replacing the transcript.
                     // Let SwiftUI install the new semantic targets, then retry.
                     DispatchQueue.main.async {
@@ -308,16 +358,18 @@ struct ChatView: View {
         .animation(.easeInOut(duration: 0.18), value: appState.isOpeningNotificationSession)
     }
 
-    private func saveChatScrollPosition() {
-        guard let sessionKey = activeScrollSessionKey else { return }
+    private func saveChatScrollPosition(for preferredKey: ChatScrollSessionKey? = nil) {
+        guard let sessionKey = preferredKey ?? renderedScrollSessionKey ?? activeScrollSessionKey else { return }
         let anchorTarget = chatMessageScrollTargetCache.targets.first {
             $0.semanticID == topVisibleChatID
         }
+        guard followsLatest || anchorTarget != nil else { return }
         chatScrollState.save(
             ChatScrollSnapshot(
                 anchorMessageID: followsLatest ? nil : anchorTarget?.semanticID,
                 followsLatest: followsLatest,
-                anchorMetadata: followsLatest ? nil : anchorTarget?.restorationMetadata
+                anchorMetadata: followsLatest ? nil : anchorTarget?.restorationMetadata,
+                anchorSourceMessageID: followsLatest ? nil : anchorTarget?.id
             ),
             for: sessionKey
         )

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -1023,7 +1023,7 @@ private struct ReviewSummaryCard: View {
 
             if let fullSessionId = activity.fullSessionId, !fullSessionId.isEmpty {
                 Button {
-                    Task { await appState.openSession(fullSessionId) }
+                    appState.requestOpenSession(fullSessionId)
                 } label: {
                     Label("Open full review", systemImage: "arrow.up.forward.square")
                         .font(.subheadline.weight(.semibold))

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -19,6 +19,7 @@ struct ChatView: View {
     @State private var chatMessageScrollTargetCache = ChatMessageScrollTargetCache()
     @State private var pendingScrollRestoration: ChatScrollPendingRestoration?
     @State private var renderedScrollSessionKey: ChatScrollSessionKey?
+    @State private var scheduledLatestScrollGeneration = 0
     @State private var notificationHandoffPending = false
     @State private var notificationHandoffSessionKey: ChatScrollSessionKey?
     @State private var notificationHandoffHasMeasuredLayout = false
@@ -184,6 +185,7 @@ struct ChatView: View {
                     // is still rendered. A session switch clears messages in
                     // the same main-actor turn, so waiting until the switch
                     // callback would leave us with no anchor to save.
+                    guard pendingScrollRestoration == nil else { return }
                     saveChatScrollPosition(for: renderedScrollSessionKey)
                 }
                 .onChange(of: appState.chatScrollRequest) { _, _ in
@@ -202,8 +204,15 @@ struct ChatView: View {
                     let identity = appState.activeChatScrollSessionIdentity
                     let oldKey = renderedScrollSessionKey ?? identity.key(for: oldSessionID)
                     let newKey = activeScrollSessionKey
+                    saveChatScrollPosition(for: oldKey)
+                    let keysAreEquivalent = identity.areEquivalent(oldKey, newKey)
+                    if keysAreEquivalent,
+                       let oldKey,
+                       let newKey {
+                        chatScrollState.migrateSnapshot(from: oldKey, to: newKey)
+                    }
                     renderedScrollSessionKey = newKey
-                    guard !identity.areEquivalent(oldKey, newKey) else { return }
+                    guard !keysAreEquivalent else { return }
 
                     let action = ChatScrollSessionTransitionPolicy.action(
                         from: oldKey,
@@ -225,6 +234,7 @@ struct ChatView: View {
                     }
                 }
                 .onChange(of: appState.activeProfile) { _, _ in
+                    saveChatScrollPosition(for: renderedScrollSessionKey)
                     topVisibleChatID = nil
                     chatMessageScrollTargetCache = ChatMessageScrollTargetCache()
                     chatMessageScrollTargetCache.update(for: appState.messages)
@@ -264,6 +274,12 @@ struct ChatView: View {
                            renderedScrollSessionKey,
                            activeScrollSessionKey
                        ) {
+                        if let renderedScrollSessionKey {
+                            chatScrollState.migrateSnapshot(
+                                from: renderedScrollSessionKey,
+                                to: activeScrollSessionKey
+                            )
+                        }
                         renderedScrollSessionKey = activeScrollSessionKey
                     }
                     // Reconciliation publishes after replacing the transcript.
@@ -376,6 +392,7 @@ struct ChatView: View {
     }
 
     private func beginChatScrollRestoration() {
+        scheduledLatestScrollGeneration &+= 1
         let identity = appState.activeChatScrollSessionIdentity
         guard let sessionKey = activeScrollSessionKey,
               let snapshot = chatScrollState.snapshot(for: sessionKey) else {
@@ -399,6 +416,7 @@ struct ChatView: View {
 
     private func cancelPendingChatScrollRestoration() {
         pendingScrollRestoration = nil
+        scheduledLatestScrollGeneration &+= 1
     }
 
     private func finishChatScrollRestorationIfReady(using proxy: ScrollViewProxy) {
@@ -434,15 +452,22 @@ struct ChatView: View {
     }
 
     private func scrollToLatest(using proxy: ScrollViewProxy) {
+        guard pendingScrollRestoration == nil else { return }
+        scheduledLatestScrollGeneration &+= 1
+        let generation = scheduledLatestScrollGeneration
         withAnimation(ConduitMotion.response) {
             proxy.scrollTo(bottomAnchor, anchor: .bottom)
         }
         DispatchQueue.main.async {
+            guard self.scheduledLatestScrollGeneration == generation,
+                  self.pendingScrollRestoration == nil else { return }
             withAnimation(ConduitMotion.response) {
                 proxy.scrollTo(bottomAnchor, anchor: .bottom)
             }
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) {
+            guard self.scheduledLatestScrollGeneration == generation,
+                  self.pendingScrollRestoration == nil else { return }
             withAnimation(ConduitMotion.response) {
                 proxy.scrollTo(bottomAnchor, anchor: .bottom)
             }

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -21,7 +21,12 @@ struct ChatView: View {
     @State private var notificationHandoffSessionID: String?
     @State private var notificationHandoffHasMeasuredLayout = false
 
-    private var bottomAnchor: String { "chat-latest-\(appState.activeSessionId ?? "new")" }
+    private var activeScrollSessionID: String? {
+        appState.activeChatScrollSessionIdentity.canonicalSessionID
+            ?? appState.activeSessionId
+    }
+
+    private var bottomAnchor: String { "chat-latest-\(activeScrollSessionID ?? "new")" }
 
     private var isNearBottom: Bool {
         guard let bottomMarkerMaxY, let scrollViewportMaxY else { return true }
@@ -30,7 +35,10 @@ struct ChatView: View {
 
     private var hasPendingNonLatestRestoration: Bool {
         guard let pendingScrollRestoration,
-              pendingScrollRestoration.sessionID == appState.activeSessionId else {
+              appState.activeChatScrollSessionIdentity.areEquivalent(
+                pendingScrollRestoration.sessionID,
+                activeScrollSessionID
+              ) else {
             return false
         }
         return !pendingScrollRestoration.snapshot.followsLatest
@@ -46,8 +54,8 @@ struct ChatView: View {
                             EmptyChatState().padding(.top, 60)
                         }
 
-                        ForEach(appState.messages) { message in
-                            MessageBubble(message: message).id(message.id)
+                        ForEach(ChatMessageScrollTargets.make(for: appState.messages)) { target in
+                            MessageBubble(message: target.message).id(target.semanticID)
                         }
 
                         if !appState.streamingText.isEmpty {
@@ -135,16 +143,29 @@ struct ChatView: View {
                     followsLatest = true
                     scrollToLatest(using: proxy)
                 }
-                .onChange(of: appState.activeSessionId) { _, _ in
-                    cancelPendingChatScrollRestoration()
+                .onChange(of: appState.activeSessionId) { oldSessionID, newSessionID in
                     guard !appState.isOpeningNotificationSession else {
+                        cancelPendingChatScrollRestoration()
                         notificationHandoffPending = true
-                        notificationHandoffSessionID = appState.activeSessionId
+                        notificationHandoffSessionID = activeScrollSessionID
                         notificationHandoffHasMeasuredLayout = false
                         return
                     }
+                    guard !appState.activeChatScrollSessionIdentity.areEquivalent(
+                        oldSessionID,
+                        newSessionID
+                    ) else { return }
+                    cancelPendingChatScrollRestoration()
                     followsLatest = true
                     scrollToLatest(using: proxy)
+                }
+                .onChange(of: appState.activeChatScrollSessionIdentity) { _, _ in
+                    guard !appState.isOpeningNotificationSession else { return }
+                    // Reconciliation publishes after replacing the transcript.
+                    // Let SwiftUI install the new semantic targets, then retry.
+                    DispatchQueue.main.async {
+                        finishChatScrollRestorationIfReady(using: proxy)
+                    }
                 }
                 .onChange(of: appState.isOpeningNotificationSession) { _, isOpening in
                     if isOpening {
@@ -155,7 +176,7 @@ struct ChatView: View {
                         followsLatest = false
                     } else {
                         if notificationHandoffPending, notificationHandoffSessionID == nil {
-                            notificationHandoffSessionID = appState.activeSessionId
+                            notificationHandoffSessionID = activeScrollSessionID
                             notificationHandoffHasMeasuredLayout = bottomMarkerMaxY != nil && scrollViewportMaxY != nil
                         }
                         finishNotificationHandoffIfReady(using: proxy)
@@ -177,6 +198,9 @@ struct ChatView: View {
                         saveChatScrollPosition()
                     case .active:
                         beginChatScrollRestoration()
+                        DispatchQueue.main.async {
+                            finishChatScrollRestorationIfReady(using: proxy)
+                        }
                     default:
                         break
                     }
@@ -187,6 +211,7 @@ struct ChatView: View {
                             // Only a deliberate user drag opts out of the
                             // stream-following behavior. Content growth alone
                             // must not make a live conversation appear stale.
+                            cancelPendingChatScrollRestoration()
                             followsLatest = false
                         }
                 )
@@ -229,8 +254,10 @@ struct ChatView: View {
     }
 
     private func saveChatScrollPosition() {
-        guard let sessionID = appState.activeSessionId else { return }
-        let messageIDs = Set(appState.messages.map(\.id))
+        guard let sessionID = activeScrollSessionID else { return }
+        let messageIDs = Set(
+            ChatMessageScrollTargets.make(for: appState.messages).map(\.semanticID)
+        )
         let anchor = messageIDs.contains(topVisibleChatID ?? "")
             ? topVisibleChatID
             : nil
@@ -244,7 +271,8 @@ struct ChatView: View {
     }
 
     private func beginChatScrollRestoration() {
-        guard let sessionID = appState.activeSessionId,
+        let identity = appState.activeChatScrollSessionIdentity
+        guard let sessionID = activeScrollSessionID,
               let snapshot = chatScrollState.snapshot(for: sessionID) else {
             pendingScrollRestoration = nil
             return
@@ -252,7 +280,14 @@ struct ChatView: View {
 
         pendingScrollRestoration = PendingChatScrollRestoration(
             sessionID: sessionID,
-            snapshot: snapshot
+            snapshot: snapshot,
+            gate: ChatScrollRestorationGate(
+                observing: identity,
+                // A configured foreground scene always asks AppState to
+                // reconcile. This also closes any SwiftUI callback-order gap
+                // before AppState publishes its synchronous in-progress state.
+                reconciliationExpected: appState.connection != nil
+            )
         )
         followsLatest = snapshot.followsLatest
     }
@@ -263,7 +298,8 @@ struct ChatView: View {
 
     private func finishChatScrollRestorationIfReady(using proxy: ScrollViewProxy) {
         guard let pending = pendingScrollRestoration else { return }
-        guard pending.sessionID == appState.activeSessionId else {
+        let identity = appState.activeChatScrollSessionIdentity
+        guard identity.areEquivalent(pending.sessionID, activeScrollSessionID) else {
             cancelPendingChatScrollRestoration()
             return
         }
@@ -275,7 +311,11 @@ struct ChatView: View {
             return
         }
 
-        let availableIDs = Set(appState.messages.map(\.id))
+        guard pending.gate.allowsNonLatestRestoration(using: identity) else { return }
+
+        let availableIDs = Set(
+            ChatMessageScrollTargets.make(for: appState.messages).map(\.semanticID)
+        )
         guard !availableIDs.isEmpty else { return }
         guard let resolved = chatScrollState.restoration(
             for: pending.sessionID,
@@ -319,7 +359,10 @@ struct ChatView: View {
     /// so a long lazy transcript cannot inherit the old conversation's offset.
     private func recordNotificationHandoffLayout() {
         guard notificationHandoffPending,
-              notificationHandoffSessionID == appState.activeSessionId,
+              appState.activeChatScrollSessionIdentity.areEquivalent(
+                notificationHandoffSessionID,
+                activeScrollSessionID
+              ),
               bottomMarkerMaxY != nil,
               scrollViewportMaxY != nil else { return }
         notificationHandoffHasMeasuredLayout = true
@@ -328,7 +371,10 @@ struct ChatView: View {
     private func finishNotificationHandoffIfReady(using proxy: ScrollViewProxy) {
         guard notificationHandoffPending,
               !appState.isOpeningNotificationSession,
-              notificationHandoffSessionID == appState.activeSessionId,
+              appState.activeChatScrollSessionIdentity.areEquivalent(
+                notificationHandoffSessionID,
+                activeScrollSessionID
+              ),
               notificationHandoffHasMeasuredLayout else { return }
         notificationHandoffPending = false
         notificationHandoffSessionID = nil
@@ -355,6 +401,7 @@ struct ChatView: View {
 private struct PendingChatScrollRestoration: Equatable {
     let sessionID: String
     let snapshot: ChatScrollSnapshot
+    let gate: ChatScrollRestorationGate
 }
 
 private struct ChatBottomMarkerPreferenceKey: PreferenceKey {

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -176,19 +176,27 @@ struct ChatView: View {
                     let followsLatestState = $followsLatest
                     let topVisibleChatIDState = $topVisibleChatID
                     let targetCacheState = $chatMessageScrollTargetCache
+                    let renderedSessionKeyState = $renderedScrollSessionKey
                     appState.installChatViewportSnapshotProvider(
                         id: viewportSnapshotProviderID,
-                        snapshot: {
+                        capture: {
+                            guard let sessionKey = renderedSessionKeyState.wrappedValue else {
+                                return nil
+                            }
                             let followsLatest = followsLatestState.wrappedValue
                             let target = targetCacheState.wrappedValue.targets.first {
                                 $0.semanticID == topVisibleChatIDState.wrappedValue
                             }
                             guard followsLatest || target != nil else { return nil }
-                            return ChatScrollSnapshot(
+                            let snapshot = ChatScrollSnapshot(
                                 anchorMessageID: followsLatest ? nil : target?.semanticID,
                                 followsLatest: followsLatest,
                                 anchorMetadata: followsLatest ? nil : target?.restorationMetadata,
                                 anchorSourceMessageID: followsLatest ? nil : target?.id
+                            )
+                            return ChatRenderedViewportSnapshot(
+                                sessionKey: sessionKey,
+                                snapshot: snapshot
                             )
                         }
                     )

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -17,6 +17,8 @@ struct ChatView: View {
     @State private var chatMessageScrollTargetCache = ChatMessageScrollTargetCache()
     @State private var renderedScrollSessionKey: ChatScrollSessionKey?
     @State private var renderedScrollContent: ChatRenderedScrollContent?
+    @State private var renderedScrollTargets = ChatRenderedScrollTargets()
+    @State private var renderedTranscriptRevision: UInt64 = 0
     @State private var renderedViewportTransitionGeneration: UInt64 = 0
     @State private var viewportSnapshotProviderID = UUID()
     @State private var isDraggingChat = false
@@ -53,6 +55,18 @@ struct ChatView: View {
         appState.chatResumeRestorationRequest != nil
     }
 
+    private var renderedScrollScope: ChatRenderedScrollScope? {
+        renderedScrollSessionKey.map {
+            ChatRenderedScrollScope(
+                sessionKey: $0,
+                cacheRevision: chatMessageScrollTargetCache.renderingRevision,
+                restorationGeneration: appState.chatResumeRestorationRequest?.generation,
+                transcriptRevision: renderedTranscriptRevision,
+                viewportTransitionGeneration: renderedViewportTransitionGeneration
+            )
+        }
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             // Message list
@@ -64,7 +78,21 @@ struct ChatView: View {
                         }
 
                         ForEach(chatMessageScrollTargetCache.targets) { target in
-                            MessageBubble(message: target.message).id(target.semanticID)
+                            MessageBubble(message: target.message)
+                                .id(target.semanticID)
+                                .background {
+                                    GeometryReader { _ in
+                                        Color.clear.preference(
+                                            key: ChatRenderedScrollTargetsPreferenceKey.self,
+                                            value: renderedScrollScope.map {
+                                                ChatRenderedScrollTargets.row(
+                                                    semanticID: target.semanticID,
+                                                    scope: $0
+                                                )
+                                            } ?? ChatRenderedScrollTargets()
+                                        )
+                                    }
+                                }
                         }
 
                         if !appState.streamingText.isEmpty {
@@ -87,6 +115,19 @@ struct ChatView: View {
                             .frame(height: 1)
                             .padding(.bottom, 126)
                             .id(bottomAnchor)
+                            .background {
+                                GeometryReader { _ in
+                                    Color.clear.preference(
+                                        key: ChatRenderedScrollTargetsPreferenceKey.self,
+                                        value: renderedScrollScope.map {
+                                            ChatRenderedScrollTargets.bottom(
+                                                anchorID: bottomAnchor,
+                                                scope: $0
+                                            )
+                                        } ?? ChatRenderedScrollTargets()
+                                    )
+                                }
+                            }
                     }
                     .scrollTargetLayout()
                     .padding(.horizontal, 18)
@@ -104,16 +145,7 @@ struct ChatView: View {
                                 )
                                 .preference(
                                     key: ChatRenderedScrollContentPreferenceKey.self,
-                                    value: renderedScrollSessionKey.map {
-                                        ChatRenderedScrollContent(
-                                            sessionKey: $0,
-                                            cacheRevision: chatMessageScrollTargetCache.renderingRevision,
-                                            semanticTargetIDs: chatMessageScrollTargetCache.semanticTargetIDs,
-                                            bottomAnchorID: bottomAnchor,
-                                            restorationGeneration: appState.chatResumeRestorationRequest?.generation,
-                                            viewportTransitionGeneration: renderedViewportTransitionGeneration
-                                        )
-                                    }
+                                    value: renderedScrollScope.map(ChatRenderedScrollContent.init(scope:))
                                 )
                         }
                     }
@@ -139,6 +171,7 @@ struct ChatView: View {
                 .onAppear {
                     renderedScrollSessionKey = activeScrollSessionKey
                     chatMessageScrollTargetCache.update(for: appState.messages)
+                    renderedTranscriptRevision = appState.chatTranscriptRevision
                     renderedViewportTransitionGeneration = appState.chatViewportTransitionGeneration
                     let followsLatestState = $followsLatest
                     let topVisibleChatIDState = $topVisibleChatID
@@ -181,12 +214,18 @@ struct ChatView: View {
                     renderedScrollContent = value
                     guard let value else { return }
                     appState.chatViewportLayoutDidSettle(
-                        sessionKey: value.sessionKey,
-                        transitionGeneration: value.viewportTransitionGeneration
+                        sessionKey: value.scope.sessionKey,
+                        transitionGeneration: value.scope.viewportTransitionGeneration,
+                        transcriptRevision: value.scope.transcriptRevision,
+                        renderRevision: value.scope.cacheRevision
                     )
+                }
+                .onPreferenceChange(ChatRenderedScrollTargetsPreferenceKey.self) { value in
+                    renderedScrollTargets = value
                 }
                 .onChange(of: appState.messages) { _, newMessages in
                     let cacheUpdate = chatMessageScrollTargetCache.update(for: newMessages)
+                    renderedTranscriptRevision = appState.chatTranscriptRevision
                     renderedViewportTransitionGeneration = appState.chatViewportTransitionGeneration
                     guard !appState.isOpeningNotificationSession else {
                         notificationHandoffPending = true
@@ -208,6 +247,13 @@ struct ChatView: View {
                         ) else { return }
                         scrollToLatest(using: proxy)
                     }
+                }
+                .onChange(of: appState.chatTranscriptRevision) { _, revision in
+                    if chatMessageScrollTargetCache.targets.map(\.message) != appState.messages {
+                        chatMessageScrollTargetCache.update(for: appState.messages)
+                    }
+                    renderedTranscriptRevision = revision
+                    renderedViewportTransitionGeneration = appState.chatViewportTransitionGeneration
                 }
                 .onChange(of: topVisibleChatID) { _, _ in
                     // Persist the browsing position while the old transcript
@@ -263,6 +309,7 @@ struct ChatView: View {
                     topVisibleChatID = nil
                     chatMessageScrollTargetCache = ChatMessageScrollTargetCache()
                     chatMessageScrollTargetCache.update(for: appState.messages)
+                    renderedTranscriptRevision = appState.chatTranscriptRevision
                     renderedScrollSessionKey = newKey
                     if followsLatest {
                         renderedViewportTransitionGeneration = appState.chatViewportTransitionGeneration
@@ -399,6 +446,7 @@ struct ChatView: View {
         guard restorationRequestIsCurrent(request) else { return }
         if chatMessageScrollTargetCache.targets.map(\.message) != appState.messages {
             chatMessageScrollTargetCache.update(for: appState.messages)
+            renderedTranscriptRevision = appState.chatTranscriptRevision
         }
 
         var destination = restorationDestination(
@@ -415,6 +463,7 @@ struct ChatView: View {
         while restorationRequestIsCurrent(request) {
             if chatMessageScrollTargetCache.targets.map(\.message) != appState.messages {
                 chatMessageScrollTargetCache.update(for: appState.messages)
+                renderedTranscriptRevision = appState.chatTranscriptRevision
             }
             destination = restorationDestination(
                 for: request,
@@ -424,7 +473,9 @@ struct ChatView: View {
 
             switch restoration.nextAction(
                 renderedContent: renderedScrollContent,
+                installedTargets: renderedScrollTargets,
                 cacheRevision: chatMessageScrollTargetCache.renderingRevision,
+                transcriptRevision: appState.chatTranscriptRevision,
                 topVisibleID: topVisibleChatID,
                 isNearBottom: bottomMarkerMaxY != nil
                     && scrollViewportMaxY != nil
@@ -568,6 +619,17 @@ private struct ChatRenderedScrollContentPreferenceKey: PreferenceKey {
         nextValue: () -> ChatRenderedScrollContent?
     ) {
         value = nextValue() ?? value
+    }
+}
+
+private struct ChatRenderedScrollTargetsPreferenceKey: PreferenceKey {
+    static var defaultValue = ChatRenderedScrollTargets()
+
+    static func reduce(
+        value: inout ChatRenderedScrollTargets,
+        nextValue: () -> ChatRenderedScrollTargets
+    ) {
+        ChatRenderedScrollTargets.reduce(value: &value, nextValue: nextValue())
     }
 }
 // MARK: - Message Bubble

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -10,16 +10,13 @@ import UIKit
 
 struct ChatView: View {
     @EnvironmentObject var appState: AppState
-    @Environment(\.scenePhase) private var scenePhase
     @State private var bottomMarkerMaxY: CGFloat?
     @State private var scrollViewportMaxY: CGFloat?
     @State private var followsLatest = true
     @State private var topVisibleChatID: String?
-    @State private var chatScrollState = ChatScrollStateStore()
     @State private var chatMessageScrollTargetCache = ChatMessageScrollTargetCache()
-    @State private var pendingScrollRestoration: ChatScrollPendingRestoration?
     @State private var renderedScrollSessionKey: ChatScrollSessionKey?
-    @State private var scheduledLatestScrollGeneration = 0
+    @State private var isDraggingChat = false
     @State private var notificationHandoffPending = false
     @State private var notificationHandoffSessionKey: ChatScrollSessionKey?
     @State private var notificationHandoffHasMeasuredLayout = false
@@ -49,15 +46,8 @@ struct ChatView: View {
         return bottomMarkerMaxY <= scrollViewportMaxY + 40
     }
 
-    private var hasPendingNonLatestRestoration: Bool {
-        guard let pendingScrollRestoration,
-              appState.activeChatScrollSessionIdentity.areEquivalent(
-                pendingScrollRestoration.sessionKey,
-                activeScrollSessionKey
-              ) else {
-            return false
-        }
-        return !pendingScrollRestoration.snapshot.followsLatest
+    private var hasPendingRestoration: Bool {
+        appState.chatResumeRestorationRequest != nil
     }
 
     var body: some View {
@@ -133,32 +123,22 @@ struct ChatView: View {
                     renderedScrollSessionKey = activeScrollSessionKey
                     chatMessageScrollTargetCache.update(for: appState.messages)
                 }
+                .task(id: appState.chatResumeRestorationRequest?.generation) {
+                    guard let request = appState.chatResumeRestorationRequest else { return }
+                    await applyChatResumeRestoration(request, using: proxy)
+                }
                 .onPreferenceChange(ChatBottomMarkerPreferenceKey.self) { value in
                     updateBottomMarker(value)
                     recordNotificationHandoffLayout()
                     finishNotificationHandoffIfReady(using: proxy)
-                    if !appState.isOpeningNotificationSession {
-                        finishChatScrollRestorationIfReady(using: proxy)
-                    }
                 }
                 .onPreferenceChange(ChatViewportBottomPreferenceKey.self) { value in
                     updateViewportBottom(value)
                     recordNotificationHandoffLayout()
                     finishNotificationHandoffIfReady(using: proxy)
-                    if !appState.isOpeningNotificationSession {
-                        finishChatScrollRestorationIfReady(using: proxy)
-                    }
                 }
                 .onChange(of: appState.messages) { _, newMessages in
                     let cacheUpdate = chatMessageScrollTargetCache.update(for: newMessages)
-                    let hasNotificationHandoff = appState.isOpeningNotificationSession
-                        || notificationHandoffPending
-                    if pendingScrollRestoration != nil,
-                       !hasNotificationHandoff {
-                        DispatchQueue.main.async {
-                            finishChatScrollRestorationIfReady(using: proxy)
-                        }
-                    }
                     guard !appState.isOpeningNotificationSession else {
                         notificationHandoffPending = true
                         return
@@ -166,14 +146,14 @@ struct ChatView: View {
                     guard ChatMessageScrollUpdatePolicy.shouldReassertLatest(
                         after: cacheUpdate,
                         followsLatest: followsLatest,
-                        hasPendingNonLatestRestoration: hasPendingNonLatestRestoration,
+                        hasPendingRestoration: hasPendingRestoration,
                         hasNotificationHandoff: notificationHandoffPending
                     ) else { return }
                     DispatchQueue.main.async {
                         guard ChatMessageScrollUpdatePolicy.shouldReassertLatest(
                             after: cacheUpdate,
                             followsLatest: followsLatest,
-                            hasPendingNonLatestRestoration: hasPendingNonLatestRestoration,
+                            hasPendingRestoration: appState.chatResumeRestorationRequest != nil,
                             hasNotificationHandoff: appState.isOpeningNotificationSession
                                 || notificationHandoffPending
                         ) else { return }
@@ -185,17 +165,19 @@ struct ChatView: View {
                     // is still rendered. A session switch clears messages in
                     // the same main-actor turn, so waiting until the switch
                     // callback would leave us with no anchor to save.
-                    guard pendingScrollRestoration == nil else { return }
+                    saveChatScrollPosition(for: renderedScrollSessionKey)
+                }
+                .onChange(of: followsLatest) { _, _ in
                     saveChatScrollPosition(for: renderedScrollSessionKey)
                 }
                 .onChange(of: appState.chatScrollRequest) { _, _ in
-                    cancelPendingChatScrollRestoration()
+                    cancelAutomaticRestoration()
                     followsLatest = true
                     scrollToLatest(using: proxy)
                 }
                 .onChange(of: appState.activeSessionId) { oldSessionID, newSessionID in
                     guard !appState.isOpeningNotificationSession else {
-                        cancelPendingChatScrollRestoration()
+                        cancelAutomaticRestoration()
                         notificationHandoffPending = true
                         notificationHandoffSessionKey = activeScrollSessionKey
                         notificationHandoffHasMeasuredLayout = false
@@ -204,42 +186,29 @@ struct ChatView: View {
                     let identity = appState.activeChatScrollSessionIdentity
                     let oldKey = renderedScrollSessionKey ?? identity.key(for: oldSessionID)
                     let newKey = activeScrollSessionKey
+                    if let request = appState.chatResumeRestorationRequest,
+                       !identity.areEquivalent(request.sessionKey, newKey) {
+                        cancelAutomaticRestoration()
+                    }
                     saveChatScrollPosition(for: oldKey)
                     let keysAreEquivalent = identity.areEquivalent(oldKey, newKey)
-                    if keysAreEquivalent,
-                       let oldKey,
-                       let newKey {
-                        chatScrollState.migrateSnapshot(from: oldKey, to: newKey)
-                    }
                     renderedScrollSessionKey = newKey
                     guard !keysAreEquivalent else { return }
-
-                    let action = ChatScrollSessionTransitionPolicy.action(
-                        from: oldKey,
-                        to: newKey,
-                        snapshot: newKey.flatMap { chatScrollState.snapshot(for: $0) }
-                    )
-                    switch action {
-                    case .ignore:
-                        break
-                    case .latest:
-                        cancelPendingChatScrollRestoration()
-                        followsLatest = true
-                        scrollToLatest(using: proxy)
-                    case .restore:
-                        beginChatScrollRestoration()
-                        DispatchQueue.main.async {
-                            finishChatScrollRestorationIfReady(using: proxy)
-                        }
-                    }
+                    topVisibleChatID = nil
+                    followsLatest = true
+                    scrollToLatest(using: proxy)
                 }
                 .onChange(of: appState.activeProfile) { _, _ in
-                    saveChatScrollPosition(for: renderedScrollSessionKey)
+                    let oldKey = renderedScrollSessionKey
+                    let newKey = activeScrollSessionKey
+                    if let request = appState.chatResumeRestorationRequest,
+                       request.sessionKey != newKey {
+                        cancelAutomaticRestoration()
+                    }
+                    saveChatScrollPosition(for: oldKey)
                     topVisibleChatID = nil
                     chatMessageScrollTargetCache = ChatMessageScrollTargetCache()
                     chatMessageScrollTargetCache.update(for: appState.messages)
-                    let oldKey = renderedScrollSessionKey
-                    let newKey = activeScrollSessionKey
                     renderedScrollSessionKey = newKey
                     guard !appState.isOpeningNotificationSession else {
                         notificationHandoffPending = true
@@ -248,24 +217,9 @@ struct ChatView: View {
                         followsLatest = false
                         return
                     }
-                    let action = ChatScrollSessionTransitionPolicy.action(
-                        from: oldKey,
-                        to: newKey,
-                        snapshot: newKey.flatMap { chatScrollState.snapshot(for: $0) }
-                    )
-                    switch action {
-                    case .ignore:
-                        break
-                    case .latest:
-                        cancelPendingChatScrollRestoration()
-                        followsLatest = true
-                        scrollToLatest(using: proxy)
-                    case .restore:
-                        beginChatScrollRestoration()
-                        DispatchQueue.main.async {
-                            finishChatScrollRestorationIfReady(using: proxy)
-                        }
-                    }
+                    guard oldKey != newKey else { return }
+                    followsLatest = true
+                    scrollToLatest(using: proxy)
                 }
                 .onChange(of: appState.activeChatScrollSessionIdentity) { _, _ in
                     guard !appState.isOpeningNotificationSession else { return }
@@ -274,23 +228,12 @@ struct ChatView: View {
                            renderedScrollSessionKey,
                            activeScrollSessionKey
                        ) {
-                        if let renderedScrollSessionKey {
-                            chatScrollState.migrateSnapshot(
-                                from: renderedScrollSessionKey,
-                                to: activeScrollSessionKey
-                            )
-                        }
                         renderedScrollSessionKey = activeScrollSessionKey
-                    }
-                    // Reconciliation publishes after replacing the transcript.
-                    // Let SwiftUI install the new semantic targets, then retry.
-                    DispatchQueue.main.async {
-                        finishChatScrollRestorationIfReady(using: proxy)
                     }
                 }
                 .onChange(of: appState.isOpeningNotificationSession) { _, isOpening in
                     if isOpening {
-                        cancelPendingChatScrollRestoration()
+                        cancelAutomaticRestoration()
                         notificationHandoffPending = true
                         notificationHandoffSessionKey = nil
                         notificationHandoffHasMeasuredLayout = false
@@ -304,26 +247,13 @@ struct ChatView: View {
                     }
                 }
                 .onChange(of: appState.streamingText) { _, _ in
-                    if followsLatest {
+                    if followsLatest && !hasPendingRestoration {
                         proxy.scrollTo(bottomAnchor, anchor: .bottom)
                     }
                 }
                 .onChange(of: appState.isBusy) { _, isBusy in
-                    if !isBusy, followsLatest {
+                    if !isBusy, followsLatest, !hasPendingRestoration {
                         scrollToLatest(using: proxy)
-                    }
-                }
-                .onChange(of: scenePhase) { _, phase in
-                    switch phase {
-                    case .inactive, .background:
-                        saveChatScrollPosition()
-                    case .active:
-                        beginChatScrollRestoration()
-                        DispatchQueue.main.async {
-                            finishChatScrollRestorationIfReady(using: proxy)
-                        }
-                    default:
-                        break
                     }
                 }
                 .simultaneousGesture(
@@ -332,14 +262,21 @@ struct ChatView: View {
                             // Only a deliberate user drag opts out of the
                             // stream-following behavior. Content growth alone
                             // must not make a live conversation appear stale.
-                            cancelPendingChatScrollRestoration()
+                            guard !isDraggingChat else { return }
+                            isDraggingChat = true
+                            cancelAutomaticRestoration()
                             followsLatest = false
+                        }
+                        .onEnded { _ in
+                            isDraggingChat = false
+                            saveChatScrollPosition(for: renderedScrollSessionKey)
+                            appState.flushChatResumeViewport()
                         }
                 )
                 .overlay(alignment: .bottomTrailing) {
                     if !followsLatest && !isNearBottom {
                         Button {
-                            cancelPendingChatScrollRestoration()
+                            cancelAutomaticRestoration()
                             followsLatest = true
                             scrollToLatest(using: proxy)
                         } label: {
@@ -380,7 +317,7 @@ struct ChatView: View {
             $0.semanticID == topVisibleChatID
         }
         guard followsLatest || anchorTarget != nil else { return }
-        chatScrollState.save(
+        appState.recordChatViewport(
             ChatScrollSnapshot(
                 anchorMessageID: followsLatest ? nil : anchorTarget?.semanticID,
                 followsLatest: followsLatest,
@@ -391,86 +328,93 @@ struct ChatView: View {
         )
     }
 
-    private func beginChatScrollRestoration() {
-        scheduledLatestScrollGeneration &+= 1
-        let identity = appState.activeChatScrollSessionIdentity
-        guard let sessionKey = activeScrollSessionKey,
-              let snapshot = chatScrollState.snapshot(for: sessionKey) else {
-            pendingScrollRestoration = nil
-            return
+    private func cancelAutomaticRestoration() {
+        appState.cancelChatResumeRestoration()
+    }
+
+    @MainActor
+    private func applyChatResumeRestoration(
+        _ request: ChatResumeRestorationRequest,
+        using proxy: ScrollViewProxy
+    ) async {
+        guard restorationRequestIsCurrent(request) else { return }
+
+        let destination: ChatResumeViewportDestination
+        switch request.destination {
+        case .latest:
+            followsLatest = true
+            await Task.yield()
+            guard restorationRequestIsCurrent(request) else { return }
+            destination = .latest
+
+        case .snapshot(let snapshot):
+            followsLatest = snapshot.followsLatest
+            guard await waitForRestorationTargets(for: request) else { return }
+            destination = ChatResumeViewportResolver.destination(
+                for: snapshot,
+                availableTargets: ChatScrollTargetAvailability(
+                    targets: chatMessageScrollTargetCache.targets
+                )
+            )
         }
 
-        pendingScrollRestoration = ChatScrollPendingRestoration(
-            sessionKey: sessionKey,
-            snapshot: snapshot,
-            gate: ChatScrollRestorationGate(
-                observing: identity,
-                // A configured foreground scene always asks AppState to
-                // reconcile. This also closes any SwiftUI callback-order gap
-                // before AppState publishes its synchronous in-progress state.
-                reconciliationExpected: appState.connection != nil
-            )
-        )
-        followsLatest = snapshot.followsLatest
-    }
-
-    private func cancelPendingChatScrollRestoration() {
-        pendingScrollRestoration = nil
-        scheduledLatestScrollGeneration &+= 1
-    }
-
-    private func finishChatScrollRestorationIfReady(using proxy: ScrollViewProxy) {
-        guard let pending = pendingScrollRestoration else { return }
-        let identity = appState.activeChatScrollSessionIdentity
-        let decision = ChatScrollRestorationResolver.decision(
-            for: pending,
-            identity: identity,
-            activeSessionKey: activeScrollSessionKey,
-            store: chatScrollState,
-            availableTargets: ChatScrollTargetAvailability(
-                targets: chatMessageScrollTargetCache.targets
-            )
-        )
-
-        switch decision {
-        case .wait:
-            return
-        case .cancel:
-            pendingScrollRestoration = nil
-        case .latest:
-            pendingScrollRestoration = nil
-            followsLatest = true
-            scrollToLatest(using: proxy)
-        case .anchor(let anchor):
-            pendingScrollRestoration = nil
-            var transaction = Transaction()
-            transaction.animation = nil
-            withTransaction(transaction) {
+        guard restorationRequestIsCurrent(request) else { return }
+        var transaction = Transaction()
+        transaction.animation = nil
+        withTransaction(transaction) {
+            switch destination {
+            case .latest:
+                followsLatest = true
+                proxy.scrollTo(bottomAnchor, anchor: .bottom)
+            case .anchor(let anchor):
+                followsLatest = false
                 proxy.scrollTo(anchor, anchor: .top)
             }
         }
+
+        guard restorationRequestIsCurrent(request) else { return }
+        appState.completeChatResumeRestoration(generation: request.generation)
+        if destination == .latest {
+            saveChatScrollPosition(for: request.sessionKey)
+        }
+    }
+
+    @MainActor
+    private func waitForRestorationTargets(
+        for request: ChatResumeRestorationRequest
+    ) async -> Bool {
+        while restorationRequestIsCurrent(request) {
+            if chatMessageScrollTargetCache.targets.map(\.message) != appState.messages {
+                chatMessageScrollTargetCache.update(for: appState.messages)
+                await Task.yield()
+                continue
+            }
+
+            // Give SwiftUI one update cycle to install the semantic rows that
+            // correspond to the now-current target cache.
+            await Task.yield()
+            if chatMessageScrollTargetCache.targets.map(\.message) == appState.messages {
+                return restorationRequestIsCurrent(request)
+            }
+        }
+        return false
+    }
+
+    private func restorationRequestIsCurrent(
+        _ request: ChatResumeRestorationRequest
+    ) -> Bool {
+        guard !Task.isCancelled,
+              appState.chatResumeRestorationRequest?.generation == request.generation else {
+            return false
+        }
+        let identity = appState.activeChatScrollSessionIdentity
+        return identity.areEquivalent(request.sessionKey, activeScrollSessionKey)
     }
 
     private func scrollToLatest(using proxy: ScrollViewProxy) {
-        guard pendingScrollRestoration == nil else { return }
-        scheduledLatestScrollGeneration &+= 1
-        let generation = scheduledLatestScrollGeneration
+        guard !hasPendingRestoration else { return }
         withAnimation(ConduitMotion.response) {
             proxy.scrollTo(bottomAnchor, anchor: .bottom)
-        }
-        DispatchQueue.main.async {
-            guard self.scheduledLatestScrollGeneration == generation,
-                  self.pendingScrollRestoration == nil else { return }
-            withAnimation(ConduitMotion.response) {
-                proxy.scrollTo(bottomAnchor, anchor: .bottom)
-            }
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) {
-            guard self.scheduledLatestScrollGeneration == generation,
-                  self.pendingScrollRestoration == nil else { return }
-            withAnimation(ConduitMotion.response) {
-                proxy.scrollTo(bottomAnchor, anchor: .bottom)
-            }
         }
     }
 
@@ -498,7 +442,7 @@ struct ChatView: View {
               notificationHandoffHasMeasuredLayout else { return }
         notificationHandoffPending = false
         notificationHandoffSessionKey = nil
-        cancelPendingChatScrollRestoration()
+        cancelAutomaticRestoration()
         followsLatest = true
         var transaction = Transaction()
         transaction.animation = nil
@@ -509,12 +453,12 @@ struct ChatView: View {
 
     private func updateBottomMarker(_ value: CGFloat?) {
         bottomMarkerMaxY = value
-        if isNearBottom && !hasPendingNonLatestRestoration { followsLatest = true }
+        if isNearBottom && !hasPendingRestoration { followsLatest = true }
     }
 
     private func updateViewportBottom(_ value: CGFloat?) {
         scrollViewportMaxY = value
-        if isNearBottom && !hasPendingNonLatestRestoration { followsLatest = true }
+        if isNearBottom && !hasPendingRestoration { followsLatest = true }
     }
 }
 

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -16,17 +16,31 @@ struct ChatView: View {
     @State private var followsLatest = true
     @State private var topVisibleChatID: String?
     @State private var chatScrollState = ChatScrollStateStore()
-    @State private var pendingScrollRestoration: PendingChatScrollRestoration?
+    @State private var chatMessageScrollTargetCache = ChatMessageScrollTargetCache()
+    @State private var pendingScrollRestoration: ChatScrollPendingRestoration?
     @State private var notificationHandoffPending = false
-    @State private var notificationHandoffSessionID: String?
+    @State private var notificationHandoffSessionKey: ChatScrollSessionKey?
     @State private var notificationHandoffHasMeasuredLayout = false
 
-    private var activeScrollSessionID: String? {
-        appState.activeChatScrollSessionIdentity.canonicalSessionID
-            ?? appState.activeSessionId
+    private var activeScrollSessionKey: ChatScrollSessionKey? {
+        if let canonical = appState.activeChatScrollSessionIdentity.canonicalSessionKey {
+            return canonical
+        }
+        guard let sessionID = appState.activeSessionId else { return nil }
+        let fallback = ChatScrollSessionKey(
+            profile: appState.activeProfile,
+            sessionID: sessionID
+        )
+        return fallback.isValid ? fallback : nil
     }
 
-    private var bottomAnchor: String { "chat-latest-\(activeScrollSessionID ?? "new")" }
+    private var bottomAnchor: String {
+        let scope = activeScrollSessionKey ?? ChatScrollSessionKey(
+            profile: appState.activeProfile,
+            sessionID: "new"
+        )
+        return "chat-latest-\(scope.profile)-\(scope.sessionID)"
+    }
 
     private var isNearBottom: Bool {
         guard let bottomMarkerMaxY, let scrollViewportMaxY else { return true }
@@ -36,8 +50,8 @@ struct ChatView: View {
     private var hasPendingNonLatestRestoration: Bool {
         guard let pendingScrollRestoration,
               appState.activeChatScrollSessionIdentity.areEquivalent(
-                pendingScrollRestoration.sessionID,
-                activeScrollSessionID
+                pendingScrollRestoration.sessionKey,
+                activeScrollSessionKey
               ) else {
             return false
         }
@@ -54,7 +68,7 @@ struct ChatView: View {
                             EmptyChatState().padding(.top, 60)
                         }
 
-                        ForEach(ChatMessageScrollTargets.make(for: appState.messages)) { target in
+                        ForEach(chatMessageScrollTargetCache.targets) { target in
                             MessageBubble(message: target.message).id(target.semanticID)
                         }
 
@@ -113,6 +127,9 @@ struct ChatView: View {
                         )
                     }
                 }
+                .onAppear {
+                    chatMessageScrollTargetCache.update(for: appState.messages)
+                }
                 .onPreferenceChange(ChatBottomMarkerPreferenceKey.self) { value in
                     updateBottomMarker(value)
                     recordNotificationHandoffLayout()
@@ -129,7 +146,15 @@ struct ChatView: View {
                         finishChatScrollRestorationIfReady(using: proxy)
                     }
                 }
-                .onChange(of: appState.messages.count) { _, _ in
+                .onChange(of: appState.messages) { oldMessages, newMessages in
+                    chatMessageScrollTargetCache.update(for: newMessages)
+                    if pendingScrollRestoration != nil,
+                       !appState.isOpeningNotificationSession {
+                        DispatchQueue.main.async {
+                            finishChatScrollRestorationIfReady(using: proxy)
+                        }
+                    }
+                    guard oldMessages.count != newMessages.count else { return }
                     guard !appState.isOpeningNotificationSession else {
                         notificationHandoffPending = true
                         return
@@ -147,15 +172,31 @@ struct ChatView: View {
                     guard !appState.isOpeningNotificationSession else {
                         cancelPendingChatScrollRestoration()
                         notificationHandoffPending = true
-                        notificationHandoffSessionID = activeScrollSessionID
+                        notificationHandoffSessionKey = activeScrollSessionKey
                         notificationHandoffHasMeasuredLayout = false
                         return
                     }
-                    guard !appState.activeChatScrollSessionIdentity.areEquivalent(
-                        oldSessionID,
-                        newSessionID
+                    let identity = appState.activeChatScrollSessionIdentity
+                    guard !identity.areEquivalent(
+                        identity.key(for: oldSessionID),
+                        identity.key(for: newSessionID)
                     ) else { return }
                     cancelPendingChatScrollRestoration()
+                    followsLatest = true
+                    scrollToLatest(using: proxy)
+                }
+                .onChange(of: appState.activeProfile) { _, _ in
+                    cancelPendingChatScrollRestoration()
+                    topVisibleChatID = nil
+                    chatMessageScrollTargetCache = ChatMessageScrollTargetCache()
+                    chatMessageScrollTargetCache.update(for: appState.messages)
+                    guard !appState.isOpeningNotificationSession else {
+                        notificationHandoffPending = true
+                        notificationHandoffSessionKey = activeScrollSessionKey
+                        notificationHandoffHasMeasuredLayout = false
+                        followsLatest = false
+                        return
+                    }
                     followsLatest = true
                     scrollToLatest(using: proxy)
                 }
@@ -171,12 +212,12 @@ struct ChatView: View {
                     if isOpening {
                         cancelPendingChatScrollRestoration()
                         notificationHandoffPending = true
-                        notificationHandoffSessionID = nil
+                        notificationHandoffSessionKey = nil
                         notificationHandoffHasMeasuredLayout = false
                         followsLatest = false
                     } else {
-                        if notificationHandoffPending, notificationHandoffSessionID == nil {
-                            notificationHandoffSessionID = activeScrollSessionID
+                        if notificationHandoffPending, notificationHandoffSessionKey == nil {
+                            notificationHandoffSessionKey = activeScrollSessionKey
                             notificationHandoffHasMeasuredLayout = bottomMarkerMaxY != nil && scrollViewportMaxY != nil
                         }
                         finishNotificationHandoffIfReady(using: proxy)
@@ -254,10 +295,8 @@ struct ChatView: View {
     }
 
     private func saveChatScrollPosition() {
-        guard let sessionID = activeScrollSessionID else { return }
-        let messageIDs = Set(
-            ChatMessageScrollTargets.make(for: appState.messages).map(\.semanticID)
-        )
+        guard let sessionKey = activeScrollSessionKey else { return }
+        let messageIDs = Set(chatMessageScrollTargetCache.targets.map(\.semanticID))
         let anchor = messageIDs.contains(topVisibleChatID ?? "")
             ? topVisibleChatID
             : nil
@@ -266,20 +305,20 @@ struct ChatView: View {
                 anchorMessageID: followsLatest ? nil : anchor,
                 followsLatest: followsLatest
             ),
-            for: sessionID
+            for: sessionKey
         )
     }
 
     private func beginChatScrollRestoration() {
         let identity = appState.activeChatScrollSessionIdentity
-        guard let sessionID = activeScrollSessionID,
-              let snapshot = chatScrollState.snapshot(for: sessionID) else {
+        guard let sessionKey = activeScrollSessionKey,
+              let snapshot = chatScrollState.snapshot(for: sessionKey) else {
             pendingScrollRestoration = nil
             return
         }
 
-        pendingScrollRestoration = PendingChatScrollRestoration(
-            sessionID: sessionID,
+        pendingScrollRestoration = ChatScrollPendingRestoration(
+            sessionKey: sessionKey,
             snapshot: snapshot,
             gate: ChatScrollRestorationGate(
                 observing: identity,
@@ -299,37 +338,25 @@ struct ChatView: View {
     private func finishChatScrollRestorationIfReady(using proxy: ScrollViewProxy) {
         guard let pending = pendingScrollRestoration else { return }
         let identity = appState.activeChatScrollSessionIdentity
-        guard identity.areEquivalent(pending.sessionID, activeScrollSessionID) else {
-            cancelPendingChatScrollRestoration()
-            return
-        }
-
-        if pending.snapshot.followsLatest {
-            pendingScrollRestoration = nil
-            followsLatest = true
-            scrollToLatest(using: proxy)
-            return
-        }
-
-        guard pending.gate.allowsNonLatestRestoration(using: identity) else { return }
-
-        let availableIDs = Set(
-            ChatMessageScrollTargets.make(for: appState.messages).map(\.semanticID)
+        let decision = ChatScrollRestorationResolver.decision(
+            for: pending,
+            identity: identity,
+            activeSessionKey: activeScrollSessionKey,
+            store: chatScrollState,
+            availableMessageIDs: Set(chatMessageScrollTargetCache.targets.map(\.semanticID))
         )
-        guard !availableIDs.isEmpty else { return }
-        guard let resolved = chatScrollState.restoration(
-            for: pending.sessionID,
-            availableMessageIDs: availableIDs
-        ) else {
-            pendingScrollRestoration = nil
-            return
-        }
 
-        pendingScrollRestoration = nil
-        if resolved.followsLatest {
+        switch decision {
+        case .wait:
+            return
+        case .cancel:
+            pendingScrollRestoration = nil
+        case .latest:
+            pendingScrollRestoration = nil
             followsLatest = true
             scrollToLatest(using: proxy)
-        } else if let anchor = resolved.anchorMessageID {
+        case .anchor(let anchor):
+            pendingScrollRestoration = nil
             var transaction = Transaction()
             transaction.animation = nil
             withTransaction(transaction) {
@@ -360,8 +387,8 @@ struct ChatView: View {
     private func recordNotificationHandoffLayout() {
         guard notificationHandoffPending,
               appState.activeChatScrollSessionIdentity.areEquivalent(
-                notificationHandoffSessionID,
-                activeScrollSessionID
+                notificationHandoffSessionKey,
+                activeScrollSessionKey
               ),
               bottomMarkerMaxY != nil,
               scrollViewportMaxY != nil else { return }
@@ -372,12 +399,12 @@ struct ChatView: View {
         guard notificationHandoffPending,
               !appState.isOpeningNotificationSession,
               appState.activeChatScrollSessionIdentity.areEquivalent(
-                notificationHandoffSessionID,
-                activeScrollSessionID
+                notificationHandoffSessionKey,
+                activeScrollSessionKey
               ),
               notificationHandoffHasMeasuredLayout else { return }
         notificationHandoffPending = false
-        notificationHandoffSessionID = nil
+        notificationHandoffSessionKey = nil
         cancelPendingChatScrollRestoration()
         followsLatest = true
         var transaction = Transaction()
@@ -396,12 +423,6 @@ struct ChatView: View {
         scrollViewportMaxY = value
         if isNearBottom && !hasPendingNonLatestRestoration { followsLatest = true }
     }
-}
-
-private struct PendingChatScrollRestoration: Equatable {
-    let sessionID: String
-    let snapshot: ChatScrollSnapshot
-    let gate: ChatScrollRestorationGate
 }
 
 private struct ChatBottomMarkerPreferenceKey: PreferenceKey {

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -131,10 +131,12 @@ struct ChatView: View {
                     }
                 }
                 .onChange(of: appState.chatScrollRequest) { _, _ in
+                    cancelPendingChatScrollRestoration()
                     followsLatest = true
                     scrollToLatest(using: proxy)
                 }
                 .onChange(of: appState.activeSessionId) { _, _ in
+                    cancelPendingChatScrollRestoration()
                     guard !appState.isOpeningNotificationSession else {
                         notificationHandoffPending = true
                         notificationHandoffSessionID = appState.activeSessionId
@@ -146,6 +148,7 @@ struct ChatView: View {
                 }
                 .onChange(of: appState.isOpeningNotificationSession) { _, isOpening in
                     if isOpening {
+                        cancelPendingChatScrollRestoration()
                         notificationHandoffPending = true
                         notificationHandoffSessionID = nil
                         notificationHandoffHasMeasuredLayout = false
@@ -190,6 +193,7 @@ struct ChatView: View {
                 .overlay(alignment: .bottomTrailing) {
                     if !followsLatest && !isNearBottom {
                         Button {
+                            cancelPendingChatScrollRestoration()
                             followsLatest = true
                             scrollToLatest(using: proxy)
                         } label: {
@@ -253,9 +257,16 @@ struct ChatView: View {
         followsLatest = snapshot.followsLatest
     }
 
+    private func cancelPendingChatScrollRestoration() {
+        pendingScrollRestoration = nil
+    }
+
     private func finishChatScrollRestorationIfReady(using proxy: ScrollViewProxy) {
-        guard let pending = pendingScrollRestoration,
-              pending.sessionID == appState.activeSessionId else { return }
+        guard let pending = pendingScrollRestoration else { return }
+        guard pending.sessionID == appState.activeSessionId else {
+            cancelPendingChatScrollRestoration()
+            return
+        }
 
         if pending.snapshot.followsLatest {
             pendingScrollRestoration = nil
@@ -321,6 +332,7 @@ struct ChatView: View {
               notificationHandoffHasMeasuredLayout else { return }
         notificationHandoffPending = false
         notificationHandoffSessionID = nil
+        cancelPendingChatScrollRestoration()
         followsLatest = true
         var transaction = Transaction()
         transaction.animation = nil

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -10,9 +10,13 @@ import UIKit
 
 struct ChatView: View {
     @EnvironmentObject var appState: AppState
+    @Environment(\.scenePhase) private var scenePhase
     @State private var bottomMarkerMaxY: CGFloat?
     @State private var scrollViewportMaxY: CGFloat?
     @State private var followsLatest = true
+    @State private var topVisibleChatID: String?
+    @State private var chatScrollState = ChatScrollStateStore()
+    @State private var pendingScrollRestoration: PendingChatScrollRestoration?
     @State private var notificationHandoffPending = false
     @State private var notificationHandoffSessionID: String?
     @State private var notificationHandoffHasMeasuredLayout = false
@@ -22,6 +26,14 @@ struct ChatView: View {
     private var isNearBottom: Bool {
         guard let bottomMarkerMaxY, let scrollViewportMaxY else { return true }
         return bottomMarkerMaxY <= scrollViewportMaxY + 40
+    }
+
+    private var hasPendingNonLatestRestoration: Bool {
+        guard let pendingScrollRestoration,
+              pendingScrollRestoration.sessionID == appState.activeSessionId else {
+            return false
+        }
+        return !pendingScrollRestoration.snapshot.followsLatest
     }
 
     var body: some View {
@@ -61,6 +73,7 @@ struct ChatView: View {
                     }
                     .padding(.horizontal, 18)
                     .padding(.top, 18)
+                    .scrollTargetLayout()
                     .background {
                         // Measure the lazy stack itself, not its final child.
                         // SwiftUI can unload that child after the user scrolls
@@ -75,6 +88,7 @@ struct ChatView: View {
                     }
                 }
                 .scrollDismissesKeyboard(.interactively)
+                .scrollPosition(id: $topVisibleChatID, anchor: .top)
                 .onTapGesture {
                     UIApplication.shared.sendAction(
                         #selector(UIResponder.resignFirstResponder),
@@ -95,11 +109,17 @@ struct ChatView: View {
                     updateBottomMarker(value)
                     recordNotificationHandoffLayout()
                     finishNotificationHandoffIfReady(using: proxy)
+                    if !appState.isOpeningNotificationSession {
+                        finishChatScrollRestorationIfReady(using: proxy)
+                    }
                 }
                 .onPreferenceChange(ChatViewportBottomPreferenceKey.self) { value in
                     updateViewportBottom(value)
                     recordNotificationHandoffLayout()
                     finishNotificationHandoffIfReady(using: proxy)
+                    if !appState.isOpeningNotificationSession {
+                        finishChatScrollRestorationIfReady(using: proxy)
+                    }
                 }
                 .onChange(of: appState.messages.count) { _, _ in
                     guard !appState.isOpeningNotificationSession else {
@@ -148,6 +168,16 @@ struct ChatView: View {
                         scrollToLatest(using: proxy)
                     }
                 }
+                .onChange(of: scenePhase) { _, phase in
+                    switch phase {
+                    case .inactive, .background:
+                        saveChatScrollPosition()
+                    case .active:
+                        beginChatScrollRestoration()
+                    default:
+                        break
+                    }
+                }
                 .simultaneousGesture(
                     DragGesture(minimumDistance: 3)
                         .onChanged { _ in
@@ -194,6 +224,69 @@ struct ChatView: View {
         .animation(.easeInOut(duration: 0.18), value: appState.isOpeningNotificationSession)
     }
 
+    private func saveChatScrollPosition() {
+        guard let sessionID = appState.activeSessionId else { return }
+        let messageIDs = Set(appState.messages.map(\.id))
+        let anchor = messageIDs.contains(topVisibleChatID ?? "")
+            ? topVisibleChatID
+            : nil
+        chatScrollState.save(
+            ChatScrollSnapshot(
+                anchorMessageID: followsLatest ? nil : anchor,
+                followsLatest: followsLatest
+            ),
+            for: sessionID
+        )
+    }
+
+    private func beginChatScrollRestoration() {
+        guard let sessionID = appState.activeSessionId,
+              let snapshot = chatScrollState.snapshot(for: sessionID) else {
+            pendingScrollRestoration = nil
+            return
+        }
+
+        pendingScrollRestoration = PendingChatScrollRestoration(
+            sessionID: sessionID,
+            snapshot: snapshot
+        )
+        followsLatest = snapshot.followsLatest
+    }
+
+    private func finishChatScrollRestorationIfReady(using proxy: ScrollViewProxy) {
+        guard let pending = pendingScrollRestoration,
+              pending.sessionID == appState.activeSessionId else { return }
+
+        if pending.snapshot.followsLatest {
+            pendingScrollRestoration = nil
+            followsLatest = true
+            scrollToLatest(using: proxy)
+            return
+        }
+
+        let availableIDs = Set(appState.messages.map(\.id))
+        guard !availableIDs.isEmpty else { return }
+        guard let resolved = chatScrollState.restoration(
+            for: pending.sessionID,
+            availableMessageIDs: availableIDs
+        ) else {
+            pendingScrollRestoration = nil
+            return
+        }
+
+        pendingScrollRestoration = nil
+        if resolved.followsLatest {
+            followsLatest = true
+            scrollToLatest(using: proxy)
+        } else if let anchor = resolved.anchorMessageID {
+            var transaction = Transaction()
+            transaction.animation = nil
+            withTransaction(transaction) {
+                proxy.scrollTo(anchor, anchor: .top)
+            }
+        }
+    }
+
     private func scrollToLatest(using proxy: ScrollViewProxy) {
         withAnimation(ConduitMotion.response) {
             proxy.scrollTo(bottomAnchor, anchor: .bottom)
@@ -238,13 +331,18 @@ struct ChatView: View {
 
     private func updateBottomMarker(_ value: CGFloat?) {
         bottomMarkerMaxY = value
-        if isNearBottom { followsLatest = true }
+        if isNearBottom && !hasPendingNonLatestRestoration { followsLatest = true }
     }
 
     private func updateViewportBottom(_ value: CGFloat?) {
         scrollViewportMaxY = value
-        if isNearBottom { followsLatest = true }
+        if isNearBottom && !hasPendingNonLatestRestoration { followsLatest = true }
     }
+}
+
+private struct PendingChatScrollRestoration: Equatable {
+    let sessionID: String
+    let snapshot: ChatScrollSnapshot
 }
 
 private struct ChatBottomMarkerPreferenceKey: PreferenceKey {

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -217,7 +217,8 @@ struct ChatView: View {
                         sessionKey: value.scope.sessionKey,
                         transitionGeneration: value.scope.viewportTransitionGeneration,
                         transcriptRevision: value.scope.transcriptRevision,
-                        renderRevision: value.scope.cacheRevision
+                        renderRevision: value.scope.cacheRevision,
+                        receivedScopedPreference: true
                     )
                 }
                 .onPreferenceChange(ChatRenderedScrollTargetsPreferenceKey.self) { value in

--- a/Conduit/Views/RootView.swift
+++ b/Conduit/Views/RootView.swift
@@ -147,6 +147,7 @@ struct MainView: View {
                 snapshot: snapshot,
                 saveTheme: { appState.themePreference = $0 },
                 persistBusyInputMode: { mode in await appState.setBusyInputMode(mode) },
+                persistChatResumeBehavior: { appState.setChatResumeBehavior($0) },
                 loadProfileSettings: { keys in await appState.loadProfileSettings(keys: keys) },
                 persistProfileSetting: { key, value in await appState.setProfileSetting(key, value: value) },
                 loadProfileConfigOptions: { await appState.loadProfileConfigOptions() },

--- a/Conduit/Views/SidebarView.swift
+++ b/Conduit/Views/SidebarView.swift
@@ -455,7 +455,7 @@ struct SessionList: View {
         Button {
             Haptics.light()
             appState.showSidebar = false
-            Task { await appState.openSession(session.id) }
+            appState.requestOpenSession(session.id)
         } label: {
             SessionRow(
                 session: session,
@@ -789,7 +789,7 @@ private struct ProjectSessionsSheet: View {
                                     Button {
                                         appState.showSidebar = false
                                         dismiss()
-                                        Task { await appState.openSession(session.id) }
+                                        appState.requestOpenSession(session.id)
                                     } label: {
                                         SessionRow(session: session, isSelected: session.id == appState.activeSessionId)
                                             .contentShape(Rectangle())
@@ -1071,7 +1071,7 @@ struct CronList: View {
                     ForEach(appState.activeProfileCronSessions.prefix(20)) { session in
                     Button {
                         appState.showSidebar = false
-                        Task { await appState.openSession(session.id) }
+                        appState.requestOpenSession(session.id)
                     } label: {
                         SessionRow(session: session, isSelected: session.id == appState.activeSessionId).contentShape(Rectangle())
                     }
@@ -1162,7 +1162,7 @@ private struct CronJobDetailSheet: View {
                         ConduitSettingsSection(title: "Run history", symbol: "clock.arrow.circlepath", tint: .conduitAura) {
                             if appState.cronRuns.isEmpty { Text("This job has not run yet.").font(.footnote).foregroundStyle(.secondary) }
                             ForEach(appState.cronRuns) { run in
-                                Button { appState.showSidebar = false; dismiss(); Task { await appState.openSession(run.id) } } label: {
+                                Button { appState.showSidebar = false; dismiss(); appState.requestOpenSession(run.id) } label: {
                                     HStack { VStack(alignment: .leading) { Text(run.title ?? run.preview ?? run.id).lineLimit(1); Text(run.model ?? "Hermes").font(.caption).foregroundStyle(.secondary) }; Spacer(); Text(run.lastActive.map(String.init) ?? "").font(.caption2).foregroundStyle(.tertiary) }
                                 }
                                 .buttonStyle(.plain)

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -696,6 +696,155 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertEqual(reconnectSpy.purposes, [.preserveCurrent])
     }
 
+    func testViewportCancellationDuringInitialConnectHandsOffToPreserveCurrentSynchronization() async {
+        let catalogGate = ControlledSuspension()
+        let scheduler = ControlledReconnectScheduler()
+        let active = session("stored-a")
+        let restoredMessages = [
+            ChatMessage(id: "restored", role: .assistant, content: "Restored", timestamp: "1")
+        ]
+        var catalogLoadCount = 0
+        var openedSessionIDs: [String] = []
+        let harness = makeHarness(
+            reconnectScheduler: scheduler.schedule(after:operation:),
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                connectClient: { _ in },
+                loadCatalog: { _, _ in
+                    catalogLoadCount += 1
+                    if catalogLoadCount == 1 {
+                        await catalogGate.suspend()
+                    }
+                    return [active]
+                },
+                openSession: { _, sessionID in
+                    openedSessionIDs.append(sessionID)
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: restoredMessages,
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                refreshContext: { _, _ in },
+                loadProfiles: {},
+                loadBusyInputMode: { _ in },
+                loadProfileDisplayPreferences: {},
+                loadSlashCommands: {}
+            )
+        )
+        harness.coordinator.rememberSessionID(active.id, for: "default")
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let connection = HermesConnection(
+            baseUrl: "https://one.example",
+            ticket: "initial-ticket"
+        )
+
+        let connecting = Task { @MainActor in
+            await harness.appState.connect(with: connection)
+        }
+        await catalogGate.waitUntilSuspended()
+        XCTAssertTrue(harness.appState.isConnected)
+        XCTAssertEqual(harness.appState.turnState, .synchronizing)
+
+        harness.appState.cancelChatResumeRestoration()
+        XCTAssertTrue(harness.appState.isConnected)
+        XCTAssertFalse(harness.appState.isConnecting)
+        XCTAssertEqual(harness.appState.turnState, .synchronizing)
+        catalogGate.resume()
+        await connecting.value
+
+        XCTAssertEqual(catalogLoadCount, 2)
+        XCTAssertEqual(openedSessionIDs, [active.id])
+        XCTAssertEqual(harness.appState.activeSessionId, active.id)
+        XCTAssertEqual(harness.appState.messages, restoredMessages)
+        XCTAssertTrue(harness.appState.isConnected)
+        XCTAssertFalse(harness.appState.isConnecting)
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        XCTAssertTrue(harness.appState.composerIsEnabled)
+        XCTAssertNil(harness.appState.chatResumeRestorationRequest)
+        XCTAssertEqual(scheduler.scheduledCount, 0)
+    }
+
+    func testBehaviorChangeDuringReconnectHandsOffToPreserveCurrentSynchronization() async {
+        let openGate = ControlledSuspension()
+        let scheduler = ControlledReconnectScheduler()
+        let active = session("stored-a")
+        let restoredMessages = [
+            ChatMessage(id: "restored", role: .assistant, content: "Restored", timestamp: "1")
+        ]
+        var catalogLoadCount = 0
+        var openCount = 0
+        let harness = makeHarness(
+            reconnectScheduler: scheduler.schedule(after:operation:),
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                connectClient: { _ in },
+                loadCatalog: { _, _ in
+                    catalogLoadCount += 1
+                    return [active]
+                },
+                mintTicket: { _ in "refreshed-ticket" },
+                openSession: { _, sessionID in
+                    openCount += 1
+                    if openCount == 1 {
+                        await openGate.suspend()
+                    }
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: restoredMessages,
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                refreshContext: { _, _ in },
+                loadProfiles: {},
+                loadBusyInputMode: { _ in },
+                loadProfileDisplayPreferences: {},
+                loadSlashCommands: {}
+            )
+        )
+        let savedConnection = HermesConnection(
+            baseUrl: "https://one.example",
+            ticket: "saved-ticket"
+        )
+        harness.appState.connection = savedConnection
+        harness.appState.client = HermesClient(connection: savedConnection, profile: "default")
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+
+        let reconnecting = Task { @MainActor in
+            await harness.appState.reconnectForRetry(purpose: .automaticReturn)
+        }
+        await openGate.waitUntilSuspended()
+        XCTAssertTrue(harness.appState.isConnected)
+        XCTAssertEqual(harness.appState.turnState, .synchronizing)
+
+        harness.appState.setChatResumeBehavior(.latestActivity)
+        XCTAssertTrue(harness.appState.isConnected)
+        XCTAssertFalse(harness.appState.isConnecting)
+        XCTAssertEqual(harness.appState.turnState, .reconnecting)
+        openGate.resume()
+        await reconnecting.value
+
+        XCTAssertEqual(catalogLoadCount, 2)
+        XCTAssertEqual(openCount, 2)
+        XCTAssertEqual(harness.appState.connection?.ticket, "refreshed-ticket")
+        XCTAssertEqual(harness.appState.activeSessionId, active.id)
+        XCTAssertEqual(harness.appState.messages, restoredMessages)
+        XCTAssertTrue(harness.appState.isConnected)
+        XCTAssertFalse(harness.appState.isConnecting)
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        XCTAssertTrue(harness.appState.composerIsEnabled)
+        XCTAssertNil(harness.appState.chatResumeRestorationRequest)
+        XCTAssertEqual(scheduler.scheduledCount, 0)
+    }
+
+    func testProfileSwitchRejectsSuccessfulStaleAutomaticReconnectMint() async {
+        await assertProfileSwitchCancelsStaleReconnectMint(outcome: .success)
+    }
+
+    func testProfileSwitchRejectsStaleAutomaticReconnectSignInFailure() async {
+        await assertProfileSwitchCancelsStaleReconnectMint(outcome: .signInRequired)
+    }
+
     func testUnchangedRefreshReleasesViewportTransitionForLaterWrites() async {
         let messages = [
             ChatMessage(id: "message-a", role: .assistant, content: "Stable", timestamp: "now")
@@ -1714,6 +1863,165 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertTrue(harness.coordinator.isCurrent(generation: request.generation))
     }
 
+    private func assertProfileSwitchCancelsStaleReconnectMint(
+        outcome: StaleReconnectMintOutcome,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        let staleMintGate = ControlledSuspension()
+        let scheduler = ControlledReconnectScheduler()
+        let defaultSession = session("default-session")
+        let workSession = session("work-session", profile: "work")
+        let defaultKey = ChatScrollSessionKey(
+            profile: "default",
+            sessionID: defaultSession.id
+        )
+        let workKey = ChatScrollSessionKey(profile: "work", sessionID: workSession.id)
+        let capturedDefaultViewport = ChatScrollSnapshot(
+            anchorMessageID: "default-anchor",
+            followsLatest: false
+        )
+        let workMessages = [
+            ChatMessage(id: "work-message", role: .assistant, content: "Work", timestamp: "2")
+        ]
+        var mintCount = 0
+        var connectedProfiles: [String] = []
+        var catalogProfiles: [String] = []
+        var openedProfiles: [String] = []
+        let harness = makeHarness(
+            reconnectScheduler: scheduler.schedule(after:operation:),
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                connectClient: { client in
+                    connectedProfiles.append(client.profile ?? "default")
+                },
+                loadCatalog: { client, _ in
+                    let profile = client.profile ?? "default"
+                    catalogProfiles.append(profile)
+                    return profile == "work" ? [workSession] : [defaultSession]
+                },
+                mintTicket: { _ in
+                    mintCount += 1
+                    if mintCount == 1 {
+                        await staleMintGate.suspend()
+                        switch outcome {
+                        case .success:
+                            return "stale-ticket"
+                        case .signInRequired:
+                            throw DashboardTicketBridgeError.signInRequired
+                        }
+                    }
+                    return "profile-ticket"
+                },
+                openSession: { client, sessionID in
+                    let profile = client.profile ?? "default"
+                    openedProfiles.append(profile)
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: profile == "work" ? workMessages : [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                refreshContext: { _, _ in },
+                loadProfiles: {},
+                loadBusyInputMode: { _ in },
+                loadProfileDisplayPreferences: {},
+                loadSlashCommands: {}
+            )
+        )
+        let savedConnection = HermesConnection(
+            baseUrl: "https://127.0.0.1:1",
+            ticket: "saved-ticket"
+        )
+        let originalClient = HermesClient(connection: savedConnection, profile: "default")
+        harness.coordinator.rememberSessionID(defaultSession.id, for: "default")
+        harness.coordinator.rememberSessionID(workSession.id, for: "work")
+        harness.appState.connection = savedConnection
+        harness.appState.client = originalClient
+        harness.appState.isConnected = true
+        harness.appState.showLogin = false
+        harness.appState.errorMessage = nil
+        harness.appState.sessions = [defaultSession]
+        harness.appState.activeSessionId = defaultSession.id
+        harness.appState.messages = [
+            ChatMessage(
+                id: "default-message",
+                role: .assistant,
+                content: "Default",
+                timestamp: "1"
+            )
+        ]
+        harness.appState.installChatViewportSnapshotProvider(id: UUID()) {
+            ChatRenderedViewportSnapshot(
+                sessionKey: defaultKey,
+                snapshot: capturedDefaultViewport
+            )
+        }
+
+        let staleReconnect = Task { @MainActor in
+            await harness.appState.reconnectForRetry(purpose: .automaticReturn)
+        }
+        await staleMintGate.waitUntilSuspended()
+        XCTAssertTrue(harness.appState.isConnecting, file: file, line: line)
+        XCTAssertEqual(harness.appState.turnState, .reconnecting, file: file, line: line)
+
+        await harness.appState.switchProfile(to: "work")
+
+        let transitionGeneration = harness.appState.chatViewportTransitionGeneration
+        let switchedConnection = harness.appState.connection
+        let switchedClient = harness.appState.client
+        XCTAssertEqual(harness.appState.activeProfile, "work", file: file, line: line)
+        XCTAssertEqual(switchedConnection?.ticket, "profile-ticket", file: file, line: line)
+        XCTAssertEqual(switchedClient?.profile, "work", file: file, line: line)
+        XCTAssertEqual(harness.appState.activeSessionId, workSession.id, file: file, line: line)
+        XCTAssertEqual(harness.appState.messages, workMessages, file: file, line: line)
+        XCTAssertTrue(harness.appState.isConnected, file: file, line: line)
+        XCTAssertFalse(harness.appState.isConnecting, file: file, line: line)
+        XCTAssertEqual(harness.appState.turnState, .idle, file: file, line: line)
+        XCTAssertTrue(harness.appState.composerIsEnabled, file: file, line: line)
+        XCTAssertFalse(harness.appState.showLogin, file: file, line: line)
+        XCTAssertNil(harness.appState.errorMessage, file: file, line: line)
+        XCTAssertEqual(harness.store.snapshot(for: defaultKey), capturedDefaultViewport, file: file, line: line)
+
+        harness.appState.recordChatViewport(.latest, for: workKey)
+        harness.appState.flushChatResumeViewport()
+        XCTAssertNil(harness.store.snapshot(for: workKey), file: file, line: line)
+
+        staleMintGate.resume()
+        await staleReconnect.value
+
+        XCTAssertEqual(mintCount, 2, file: file, line: line)
+        XCTAssertEqual(connectedProfiles, ["work"], file: file, line: line)
+        XCTAssertEqual(catalogProfiles, ["work"], file: file, line: line)
+        XCTAssertEqual(openedProfiles, ["work"], file: file, line: line)
+        XCTAssertEqual(harness.appState.activeProfile, "work", file: file, line: line)
+        XCTAssertEqual(harness.appState.connection, switchedConnection, file: file, line: line)
+        XCTAssertTrue(harness.appState.client === switchedClient, file: file, line: line)
+        XCTAssertEqual(harness.appState.activeSessionId, workSession.id, file: file, line: line)
+        XCTAssertEqual(harness.appState.messages, workMessages, file: file, line: line)
+        XCTAssertTrue(harness.appState.isConnected, file: file, line: line)
+        XCTAssertFalse(harness.appState.isConnecting, file: file, line: line)
+        XCTAssertEqual(harness.appState.turnState, .idle, file: file, line: line)
+        XCTAssertTrue(harness.appState.composerIsEnabled, file: file, line: line)
+        XCTAssertFalse(harness.appState.showLogin, file: file, line: line)
+        XCTAssertNil(harness.appState.errorMessage, file: file, line: line)
+        XCTAssertNil(harness.appState.chatResumeRestorationRequest, file: file, line: line)
+        XCTAssertEqual(harness.appState.chatViewportTransitionGeneration, transitionGeneration, file: file, line: line)
+        XCTAssertEqual(harness.store.snapshot(for: defaultKey), capturedDefaultViewport, file: file, line: line)
+        XCTAssertNil(harness.store.snapshot(for: workKey), file: file, line: line)
+        XCTAssertEqual(scheduler.scheduledCount, 0, file: file, line: line)
+
+        harness.appState.chatViewportLayoutDidSettle(
+            sessionKey: workKey,
+            transitionGeneration: transitionGeneration,
+            transcriptRevision: harness.appState.chatTranscriptRevision,
+            renderRevision: 1,
+            receivedScopedPreference: true
+        )
+        harness.appState.recordChatViewport(.latest, for: workKey)
+        harness.appState.flushChatResumeViewport()
+        XCTAssertEqual(harness.store.snapshot(for: workKey), .latest, file: file, line: line)
+    }
+
     private func makeHarness(
         behavior: ChatResumeBehavior = .continueWhereLeftOff,
         configureDefaults: (UserDefaults) -> Void = { _ in },
@@ -1820,14 +2128,18 @@ final class AppStateChatResumeTests: XCTestCase {
         )
     }
 
-    private func session(_ id: String, alternateIDs: [String] = []) -> SessionSummary {
+    private func session(
+        _ id: String,
+        alternateIDs: [String] = [],
+        profile: String = "default"
+    ) -> SessionSummary {
         SessionSummary(
             id: id,
             alternateIds: alternateIDs,
             title: id,
             model: "Hermes",
             updatedLabel: "now",
-            profile: "default",
+            profile: profile,
             source: .chat,
             isActive: false,
             isArchived: false,
@@ -1852,6 +2164,11 @@ final class AppStateChatResumeTests: XCTestCase {
 
 private enum ControlledLifecycleError: Error {
     case failed
+}
+
+private enum StaleReconnectMintOutcome {
+    case success
+    case signInRequired
 }
 
 @MainActor
@@ -1879,6 +2196,10 @@ private final class ControlledReconnectScheduler {
 
     var cancelledCount: Int {
         work.filter(\.isCancelled).count
+    }
+
+    var scheduledCount: Int {
+        work.count
     }
 
     func schedule(

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -3,6 +3,365 @@ import XCTest
 
 @MainActor
 final class AppStateChatResumeTests: XCTestCase {
+    func testCancelledAutomaticSyncRestoresComposerStateAfterCatalogReturns() async {
+        let gate = ControlledSuspension()
+        let catalog = [session("stored-b"), session("stored-a")]
+        let harness = makeHarness(
+            behavior: .latestActivity,
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    await gate.suspend()
+                    return catalog
+                }
+            )
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+        harness.appState.sessions = catalog
+        harness.appState.activeSessionId = "stored-a"
+        let automaticWork = harness.appState.beginAutomaticChatResumeWork()
+
+        let sync = Task { @MainActor in
+            await harness.appState.syncSession(
+                purpose: .automaticReturn,
+                using: nil,
+                automaticWorkToken: automaticWork
+            )
+        }
+        await gate.waitUntilSuspended()
+        XCTAssertEqual(harness.appState.turnState, .synchronizing)
+
+        harness.appState.cancelChatResumeRestoration()
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        gate.resume()
+        await sync.value
+
+        XCTAssertEqual(harness.appState.activeSessionId, "stored-a")
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        XCTAssertTrue(harness.appState.composerIsEnabled)
+        XCTAssertNil(harness.appState.chatResumeRestorationRequest)
+    }
+
+    func testStaleAutomaticSyncCleanupDoesNotOverwriteNewerSyncState() async {
+        let firstGate = ControlledSuspension()
+        let secondGate = ControlledSuspension()
+        var loadCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    loadCount += 1
+                    if loadCount == 1 {
+                        await firstGate.suspend()
+                    } else {
+                        await secondGate.suspend()
+                    }
+                    return []
+                }
+            )
+        )
+        harness.appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+        let automaticWork = harness.appState.beginAutomaticChatResumeWork()
+
+        let first = Task { @MainActor in
+            await harness.appState.syncSession(
+                purpose: .automaticReturn,
+                using: nil,
+                automaticWorkToken: automaticWork
+            )
+        }
+        await firstGate.waitUntilSuspended()
+        let second = Task { @MainActor in
+            await harness.appState.syncSession(
+                purpose: .automaticReturn,
+                using: nil,
+                automaticWorkToken: automaticWork
+            )
+        }
+        await secondGate.waitUntilSuspended()
+
+        firstGate.resume()
+        await first.value
+        XCTAssertEqual(harness.appState.turnState, .synchronizing)
+
+        harness.appState.cancelChatResumeRestoration()
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        secondGate.resume()
+        await second.value
+    }
+
+    func testCancelledAutomaticReconnectIgnoresLateSignInFailureAndRestoresConnectionState() async {
+        let gate = ControlledSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                mintTicket: { _ in
+                    await gate.suspend()
+                    throw DashboardTicketBridgeError.signInRequired
+                }
+            )
+        )
+        let savedConnection = HermesConnection(baseUrl: "https://one.example", ticket: "saved-ticket")
+        let originalClient = HermesClient(connection: savedConnection, profile: "default")
+        harness.appState.connection = savedConnection
+        harness.appState.client = originalClient
+        harness.appState.showLogin = false
+
+        let reconnect = Task { @MainActor in
+            await harness.appState.reconnectForRetry(purpose: .automaticReturn)
+        }
+        await gate.waitUntilSuspended()
+        XCTAssertTrue(harness.appState.isConnecting)
+        XCTAssertEqual(harness.appState.turnState, .reconnecting)
+
+        harness.appState.cancelChatResumeRestoration()
+        XCTAssertFalse(harness.appState.isConnecting)
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        gate.resume()
+        await reconnect.value
+
+        XCTAssertFalse(harness.appState.showLogin)
+        XCTAssertEqual(harness.appState.connection?.ticket, "saved-ticket")
+        XCTAssertTrue(harness.appState.client === originalClient)
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        XCTAssertTrue(harness.appState.composerIsEnabled)
+    }
+
+    func testUnchangedRefreshReleasesViewportTransitionForLaterWrites() async {
+        let messages = [
+            ChatMessage(id: "message-a", role: .assistant, content: "Stable", timestamp: "now")
+        ]
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [] },
+                openSession: { _, sessionID in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: messages,
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            )
+        )
+        let active = session("stored-a")
+        let key = ChatScrollSessionKey(profile: "default", sessionID: active.id)
+        harness.appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        harness.appState.messages = messages
+        harness.appState.installChatViewportSnapshotProvider(id: UUID()) {
+            ChatScrollSnapshot(anchorMessageID: "anchor-before-refresh", followsLatest: false)
+        }
+
+        await harness.appState.refreshActiveSession()
+        harness.appState.recordChatViewport(.latest, for: key)
+        harness.appState.flushChatResumeViewport()
+
+        XCTAssertEqual(harness.store.snapshot(for: key), .latest)
+    }
+
+    func testChangedRefreshReleasesOnlyForMatchingLayoutRevision() async {
+        let oldMessages = [
+            ChatMessage(id: "old", role: .assistant, content: "Old", timestamp: "1")
+        ]
+        let newMessages = [
+            ChatMessage(id: "new", role: .assistant, content: "New", timestamp: "2")
+        ]
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [] },
+                openSession: { _, sessionID in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: newMessages,
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            )
+        )
+        let active = session("stored-a")
+        let key = ChatScrollSessionKey(profile: "default", sessionID: active.id)
+        let captured = ChatScrollSnapshot(anchorMessageID: "old-anchor", followsLatest: false)
+        harness.appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        harness.appState.messages = oldMessages
+        harness.appState.installChatViewportSnapshotProvider(id: UUID()) { captured }
+
+        await harness.appState.refreshActiveSession()
+        let generation = harness.appState.chatViewportTransitionGeneration
+        let transcriptRevision = harness.appState.chatTranscriptRevision
+
+        harness.appState.chatViewportLayoutDidSettle(
+            sessionKey: key,
+            transitionGeneration: generation,
+            transcriptRevision: transcriptRevision - 1,
+            renderRevision: 7
+        )
+        harness.appState.recordChatViewport(.latest, for: key)
+        harness.appState.flushChatResumeViewport()
+        XCTAssertEqual(harness.store.snapshot(for: key), captured)
+
+        harness.appState.chatViewportLayoutDidSettle(
+            sessionKey: key,
+            transitionGeneration: generation,
+            transcriptRevision: transcriptRevision,
+            renderRevision: 7
+        )
+        harness.appState.recordChatViewport(.latest, for: key)
+        harness.appState.flushChatResumeViewport()
+        XCTAssertEqual(harness.store.snapshot(for: key), .latest)
+    }
+
+    func testOpenSessionTeardownLayoutCannotReleaseTransitionBeforeReconciliation() async {
+        let gate = ControlledSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID in
+                    await gate.suspend()
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [
+                            ChatMessage(id: "new", role: .assistant, content: "New", timestamp: "2")
+                        ],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            )
+        )
+        let sessionA = session("stored-a")
+        let sessionB = session("stored-b")
+        let keyA = ChatScrollSessionKey(profile: "default", sessionID: sessionA.id)
+        let keyB = ChatScrollSessionKey(profile: "default", sessionID: sessionB.id)
+        let captured = ChatScrollSnapshot(anchorMessageID: "exact-a-anchor", followsLatest: false)
+        harness.appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+        harness.appState.sessions = [sessionA, sessionB]
+        harness.appState.activeSessionId = sessionA.id
+        harness.appState.messages = [
+            ChatMessage(id: "old", role: .assistant, content: "Old", timestamp: "1")
+        ]
+        harness.appState.installChatViewportSnapshotProvider(id: UUID()) { captured }
+
+        let opening = Task { @MainActor in
+            await harness.appState.openSession(sessionB.id)
+        }
+        await gate.waitUntilSuspended()
+        harness.appState.chatViewportLayoutDidSettle(
+            sessionKey: keyB,
+            transitionGeneration: harness.appState.chatViewportTransitionGeneration,
+            transcriptRevision: harness.appState.chatTranscriptRevision,
+            renderRevision: 2
+        )
+        harness.appState.recordChatViewport(.latest, for: keyA)
+        harness.appState.flushChatResumeViewport()
+
+        XCTAssertEqual(harness.store.snapshot(for: keyA), captured)
+        gate.resume()
+        let opened = await opening.value
+        XCTAssertTrue(opened)
+    }
+
+    func testFailedBranchReconciliationReleasesViewportTransitionForLaterWrites() async {
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [] },
+                openSession: { _, _ in throw ControlledLifecycleError.failed },
+                branchSession: { _, _, _, _, _ in
+                    (sessionId: "branch-runtime", storedSessionId: "branch-stored", profile: "default")
+                },
+                setSessionTitle: { _, _, _ in }
+            )
+        )
+        let parent = session("stored-a")
+        let key = ChatScrollSessionKey(profile: "default", sessionID: parent.id)
+        harness.appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+        harness.appState.sessions = [parent]
+        harness.appState.activeSessionId = parent.id
+        harness.appState.messages = [
+            ChatMessage(id: "user", role: .user, content: "Question", timestamp: "1"),
+            ChatMessage(id: "assistant", role: .assistant, content: "Answer", timestamp: "2")
+        ]
+        harness.appState.installChatViewportSnapshotProvider(id: UUID()) {
+            ChatScrollSnapshot(anchorMessageID: "anchor-before-branch", followsLatest: false)
+        }
+
+        await harness.appState.branchFromAssistantMessage("assistant")
+        harness.appState.recordChatViewport(.latest, for: key)
+        harness.appState.flushChatResumeViewport()
+
+        XCTAssertEqual(harness.store.snapshot(for: key), .latest)
+    }
+
+    func testSupersededBranchCannotKeepNewerRefreshTransitionFrozen() async {
+        let branchGate = ControlledSuspension()
+        let parentMessages = [
+            ChatMessage(id: "user", role: .user, content: "Question", timestamp: "1"),
+            ChatMessage(id: "assistant", role: .assistant, content: "Answer", timestamp: "2")
+        ]
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [] },
+                openSession: { _, sessionID in
+                    if sessionID == "branch-runtime" {
+                        await branchGate.suspend()
+                    }
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: parentMessages,
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                branchSession: { _, _, _, _, _ in
+                    (sessionId: "branch-runtime", storedSessionId: "branch-stored", profile: "default")
+                },
+                setSessionTitle: { _, _, _ in },
+                refreshContext: { _, _ in }
+            )
+        )
+        let parent = session("stored-a")
+        let key = ChatScrollSessionKey(profile: "default", sessionID: parent.id)
+        harness.appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+        harness.appState.sessions = [parent]
+        harness.appState.activeSessionId = parent.id
+        harness.appState.messages = parentMessages
+        harness.appState.installChatViewportSnapshotProvider(id: UUID()) {
+            ChatScrollSnapshot(anchorMessageID: "anchor-before-branch", followsLatest: false)
+        }
+
+        let branch = Task { @MainActor in
+            await harness.appState.branchFromAssistantMessage("assistant")
+        }
+        await branchGate.waitUntilSuspended()
+        await harness.appState.refreshActiveSession()
+        branchGate.resume()
+        await branch.value
+
+        harness.appState.recordChatViewport(.latest, for: key)
+        harness.appState.flushChatResumeViewport()
+        XCTAssertEqual(harness.store.snapshot(for: key), .latest)
+        XCTAssertEqual(harness.appState.activeSessionId, parent.id)
+        XCTAssertEqual(harness.appState.messages, parentMessages)
+    }
+
     func testExplicitCancellationWhileAutomaticSyncWaitsBeforeSelectionPreventsRevival() async {
         let harness = makeHarness(behavior: .latestActivity)
         let gate = ControlledSuspension()
@@ -523,7 +882,8 @@ final class AppStateChatResumeTests: XCTestCase {
         behavior: ChatResumeBehavior = .continueWhereLeftOff,
         configureDefaults: (UserDefaults) -> Void = { _ in },
         reconnectScheduler: ChatResumeReconnectScheduler? = nil,
-        reconnectExecutor: ChatResumeReconnectExecutor? = nil
+        reconnectExecutor: ChatResumeReconnectExecutor? = nil,
+        lifecycleOperations: ChatResumeLifecycleOperations = .live
     ) -> (
         appState: AppState,
         coordinator: ChatResumeCoordinator,
@@ -551,7 +911,8 @@ final class AppStateChatResumeTests: XCTestCase {
             loadSavedConnection: false,
             clearSessionPresentationCache: { cacheClearSpy.count += 1 },
             reconnectScheduler: reconnectScheduler,
-            reconnectExecutor: reconnectExecutor
+            reconnectExecutor: reconnectExecutor,
+            chatResumeLifecycleOperations: lifecycleOperations
         )
         return (appState, coordinator, store, recoverySequence, cacheClearSpy, defaults, suite)
     }
@@ -632,6 +993,10 @@ final class AppStateChatResumeTests: XCTestCase {
             )
         )
     }
+}
+
+private enum ControlledLifecycleError: Error {
+    case failed
 }
 
 @MainActor

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -1697,7 +1697,7 @@ final class AppStateChatResumeTests: XCTestCase {
             configureDefaults: { defaults in
                 defaults.set("https://one.example", forKey: "conduit.chatResumeServerIdentity.v1")
                 defaults.set(
-                    try! JSONEncoder().encode([review]),  // test fixture, safe to force-try
+                    (try? JSONEncoder().encode([review])) ?? Data(),
                     forKey: "conduit.reviewSummaryCache.v1"
                 )
                 defaults.set(

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -115,7 +115,7 @@ final class AppStateChatResumeTests: XCTestCase {
         }
 
         XCTAssertEqual(harness.appState.activeSessionId, sessionIDs.last)
-        XCTAssertEqual(harness.appState.messages.map(\.content), [sessionIDs.last!])
+        XCTAssertEqual(harness.appState.messages.map(\.content), [sessionIDs.last ?? ""])
         XCTAssertEqual(harness.appState.turnState, .idle)
         XCTAssertFalse(harness.appState.activeChatScrollSessionIdentity.isReconciling)
     }
@@ -576,12 +576,13 @@ final class AppStateChatResumeTests: XCTestCase {
         let sessionA = session("stored-a")
         let sessionC = session("stored-c")
         let keyC = ChatScrollSessionKey(profile: "default", sessionID: sessionC.id)
-        harness.appState.connection = HermesConnection(
+        let connection = HermesConnection(
             baseUrl: "https://one.example",
             ticket: "ticket"
         )
+        harness.appState.connection = connection
         harness.appState.client = HermesClient(
-            connection: harness.appState.connection!,
+            connection: connection,
             profile: "default"
         )
         harness.appState.sessions = [sessionA, sessionC]

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -128,7 +128,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let reconnectSpy = ReconnectExecutionSpy()
         let harness = makeHarness(
             reconnectScheduler: scheduler.schedule(after:operation:),
-            scheduledReconnectExecutor: { purpose in
+            reconnectExecutor: { purpose in
                 reconnectSpy.purposes.append(purpose)
             }
         )
@@ -151,7 +151,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let reconnectSpy = ReconnectExecutionSpy()
         let harness = makeHarness(
             reconnectScheduler: scheduler.schedule(after:operation:),
-            scheduledReconnectExecutor: { purpose in
+            reconnectExecutor: { purpose in
                 reconnectSpy.purposes.append(purpose)
             }
         )
@@ -169,19 +169,18 @@ final class AppStateChatResumeTests: XCTestCase {
     }
 
     func testPublicReconnectOverridesPendingAutomaticIntent() async {
-        let harness = makeHarness(behavior: .latestActivity)
+        let reconnectSpy = ReconnectExecutionSpy()
+        let harness = makeHarness(
+            behavior: .latestActivity,
+            reconnectExecutor: { purpose in
+                reconnectSpy.purposes.append(purpose)
+            }
+        )
         _ = harness.appState.beginChatResumeRecovery(purpose: .automaticReturn)
 
         await harness.appState.reconnect()
 
-        let selected = harness.appState.selectChatResumeTarget(
-            in: [session("stored-b"), session("stored-a")],
-            profile: "default",
-            purpose: harness.recoverySequence.currentPurpose,
-            currentSessionID: "stored-a"
-        )
-        XCTAssertEqual(harness.recoverySequence.currentPurpose, .preserveCurrent)
-        XCTAssertEqual(selected?.id, "stored-a")
+        XCTAssertEqual(reconnectSpy.purposes, [.preserveCurrent])
     }
 
     func testCreatedFallbackRemainsFrozenAndPublishesAfterSettlement() {
@@ -239,14 +238,67 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertEqual(harness.cacheClearSpy.count, 1)
     }
 
-    func testEquivalentNormalizedServerKeepsResumeState() {
-        let harness = makeHarness()
-        XCTAssertFalse(harness.appState.prepareChatResumeForConnection(to: "https://one.example"))
-        harness.coordinator.rememberSessionID("stored-a", for: "default")
+    func testLegacySameServerLoginOrderingPreservesServerScopedState() throws {
+        let reviewData = try JSONEncoder().encode([serverScopedReviewSentinel()])
+        let knownProfiles = ["default", "sentinel-profile"]
+        let harness = makeHarness(
+            behavior: .latestActivity,
+            configureDefaults: { defaults in
+                defaults.set("HTTPS://One.Example:443/", forKey: "conduit.dashboardURL")
+                defaults.set(reviewData, forKey: "conduit.reviewSummaryCache.v1")
+                defaults.set(knownProfiles, forKey: "conduit.knownProfiles.v1")
+            }
+        )
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "sentinel-session")
+        let snapshot = ChatScrollSnapshot(
+            anchorMessageID: "sentinel-anchor",
+            followsLatest: false
+        )
+        harness.coordinator.rememberSessionID("sentinel-session", for: "default")
+        harness.coordinator.recordViewport(snapshot, for: key)
+        harness.coordinator.flush()
 
-        XCTAssertFalse(harness.appState.prepareChatResumeForConnection(to: "https://one.example/"))
-        XCTAssertEqual(harness.store.lastSessionID(for: "default"), "stored-a")
+        harness.appState.rememberDashboardURL("https://one.example")
+
+        XCTAssertFalse(harness.appState.prepareChatResumeForConnection(to: "https://one.example"))
+        XCTAssertEqual(harness.store.lastSessionID(for: "default"), "sentinel-session")
+        XCTAssertEqual(harness.store.snapshot(for: key), snapshot)
+        XCTAssertEqual(harness.defaults.data(forKey: "conduit.reviewSummaryCache.v1"), reviewData)
+        XCTAssertEqual(harness.defaults.stringArray(forKey: "conduit.knownProfiles.v1"), knownProfiles)
         XCTAssertEqual(harness.cacheClearSpy.count, 0)
+        XCTAssertEqual(harness.appState.chatResumeBehavior, .latestActivity)
+    }
+
+    func testFirstConnectionWithoutPersistedIdentityPreservesServerScopedState() throws {
+        let reviewData = try JSONEncoder().encode([serverScopedReviewSentinel()])
+        let knownProfiles = ["default", "sentinel-profile"]
+        let harness = makeHarness(
+            behavior: .latestActivity,
+            configureDefaults: { defaults in
+                defaults.set(reviewData, forKey: "conduit.reviewSummaryCache.v1")
+                defaults.set(knownProfiles, forKey: "conduit.knownProfiles.v1")
+            }
+        )
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "sentinel-session")
+        let snapshot = ChatScrollSnapshot(
+            anchorMessageID: "sentinel-anchor",
+            followsLatest: false
+        )
+        XCTAssertNil(harness.defaults.string(forKey: "conduit.chatResumeServerIdentity.v1"))
+        XCTAssertNil(harness.defaults.string(forKey: "conduit.dashboardURL"))
+        harness.coordinator.rememberSessionID("sentinel-session", for: "default")
+        harness.coordinator.recordViewport(snapshot, for: key)
+        harness.coordinator.flush()
+
+        harness.appState.rememberDashboardURL("https://first.example")
+
+        XCTAssertFalse(harness.appState.prepareChatResumeForConnection(to: "https://first.example"))
+        XCTAssertEqual(harness.store.lastSessionID(for: "default"), "sentinel-session")
+        XCTAssertEqual(harness.store.snapshot(for: key), snapshot)
+        XCTAssertEqual(harness.defaults.data(forKey: "conduit.reviewSummaryCache.v1"), reviewData)
+        XCTAssertEqual(harness.defaults.stringArray(forKey: "conduit.knownProfiles.v1"), knownProfiles)
+        XCTAssertEqual(harness.cacheClearSpy.count, 0)
+        XCTAssertEqual(harness.appState.chatResumeBehavior, .latestActivity)
     }
 
     func testLegacyDashboardIdentityCapturedBeforeLoginOverwritesURL() {
@@ -363,7 +415,7 @@ final class AppStateChatResumeTests: XCTestCase {
         behavior: ChatResumeBehavior = .continueWhereLeftOff,
         configureDefaults: (UserDefaults) -> Void = { _ in },
         reconnectScheduler: ChatResumeReconnectScheduler? = nil,
-        scheduledReconnectExecutor: (@MainActor (ChatResumeSyncPurpose) async -> Void)? = nil
+        reconnectExecutor: ChatResumeReconnectExecutor? = nil
     ) -> (
         appState: AppState,
         coordinator: ChatResumeCoordinator,
@@ -391,7 +443,7 @@ final class AppStateChatResumeTests: XCTestCase {
             loadSavedConnection: false,
             clearSessionPresentationCache: { cacheClearSpy.count += 1 },
             reconnectScheduler: reconnectScheduler,
-            scheduledReconnectExecutor: scheduledReconnectExecutor
+            reconnectExecutor: reconnectExecutor
         )
         return (appState, coordinator, store, recoverySequence, cacheClearSpy, defaults, suite)
     }
@@ -456,6 +508,20 @@ final class AppStateChatResumeTests: XCTestCase {
             isActive: false,
             isArchived: false,
             lineageRootId: nil
+        )
+    }
+
+    private func serverScopedReviewSentinel() -> ReviewSummaryRecord {
+        ReviewSummaryRecord(
+            id: "sentinel-review",
+            profile: "default",
+            sessionId: "sentinel-session",
+            timestamp: "2026-08-09T12:00:00Z",
+            activity: ReviewActivity(
+                summary: "Sentinel review",
+                details: ["Sentinel detail"],
+                fullSessionId: "sentinel-child"
+            )
         )
     }
 }

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -1,0 +1,359 @@
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class AppStateChatResumeTests: XCTestCase {
+    func testStaleReconciliationCannotPublishNewerAutomaticRestoration() {
+        let harness = makeHarness(behavior: .latestActivity)
+        let catalog = [session("stored-b"), session("stored-a")]
+        harness.appState.sessions = catalog
+        harness.appState.activeSessionId = "stored-a"
+
+        let staleToken = harness.appState.beginReconciliation()
+        let staleTarget = harness.appState.selectChatResumeTarget(
+            in: catalog,
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: "stored-a"
+        )
+        harness.appState.activeSessionId = staleTarget?.id
+
+        let currentToken = harness.appState.beginReconciliation()
+        _ = harness.appState.selectChatResumeTarget(
+            in: catalog,
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: staleTarget?.id
+        )
+
+        XCTAssertFalse(harness.appState.settleReconciliationAndPublish(staleToken))
+        XCTAssertNil(harness.appState.chatResumeRestorationRequest)
+
+        XCTAssertTrue(harness.appState.settleReconciliationAndPublish(currentToken))
+        XCTAssertEqual(harness.appState.chatResumeRestorationRequest?.sessionKey.sessionID, "stored-b")
+    }
+
+    func testSecondAutomaticReturnImmediatelySupersedesPublishedGeneration() {
+        let harness = makeHarness(behavior: .latestActivity)
+        let catalog = [session("stored-b"), session("stored-a")]
+        harness.appState.sessions = catalog
+        harness.appState.activeSessionId = "stored-a"
+
+        let firstToken = harness.appState.beginReconciliation()
+        let firstTarget = harness.appState.selectChatResumeTarget(
+            in: catalog,
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: "stored-a"
+        )
+        harness.appState.activeSessionId = firstTarget?.id
+        XCTAssertTrue(harness.appState.settleReconciliationAndPublish(firstToken))
+        let firstRequest = harness.appState.chatResumeRestorationRequest!
+
+        let secondToken = harness.appState.beginReconciliation()
+        _ = harness.appState.selectChatResumeTarget(
+            in: catalog,
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: firstTarget?.id
+        )
+
+        XCTAssertNil(harness.appState.chatResumeRestorationRequest)
+        XCTAssertFalse(harness.coordinator.isCurrent(generation: firstRequest.generation))
+
+        XCTAssertTrue(harness.appState.settleReconciliationAndPublish(secondToken))
+        XCTAssertGreaterThan(
+            harness.appState.chatResumeRestorationRequest!.generation,
+            firstRequest.generation
+        )
+    }
+
+    func testCatalogFailureRetainsAutomaticPurposeForRetry() {
+        let harness = makeHarness(behavior: .latestActivity)
+        let catalog = [session("stored-b"), session("stored-a")]
+
+        XCTAssertEqual(
+            harness.appState.beginChatResumeRecovery(purpose: .automaticReturn),
+            .automaticReturn
+        )
+        XCTAssertEqual(
+            harness.appState.planChatResumeReconnect(purpose: .preserveCurrent),
+            .schedule(.automaticReturn)
+        )
+
+        let selected = harness.appState.selectChatResumeTarget(
+            in: catalog,
+            profile: "default",
+            purpose: harness.recoverySequence.currentPurpose,
+            currentSessionID: "stored-a"
+        )
+        XCTAssertEqual(selected?.id, "stored-b")
+    }
+
+    func testDisconnectDuringAutomaticReconnectKeepsLatestActivityPurpose() {
+        let harness = makeHarness(behavior: .latestActivity)
+        let catalog = [session("stored-b"), session("stored-a")]
+        _ = harness.appState.beginChatResumeRecovery(purpose: .automaticReturn)
+
+        let retryPurpose = harness.appState.chatResumePurposeForDisconnect()
+        let selected = harness.appState.selectChatResumeTarget(
+            in: catalog,
+            profile: "default",
+            purpose: retryPurpose,
+            currentSessionID: "stored-a"
+        )
+
+        XCTAssertEqual(retryPurpose, .automaticReturn)
+        XCTAssertEqual(selected?.id, "stored-b")
+    }
+
+    func testAutomaticRetryReplacesQueuedPreserveCurrentRetry() {
+        let harness = makeHarness()
+
+        XCTAssertEqual(
+            harness.appState.planChatResumeReconnect(purpose: .preserveCurrent),
+            .schedule(.preserveCurrent)
+        )
+        _ = harness.appState.beginChatResumeRecovery(purpose: .automaticReturn)
+
+        XCTAssertEqual(
+            harness.appState.planChatResumeReconnect(purpose: .automaticReturn),
+            .replace(.automaticReturn)
+        )
+        XCTAssertEqual(harness.recoverySequence.queuedReconnectPurpose, .automaticReturn)
+    }
+
+    func testCreatedFallbackRemainsFrozenAndPublishesAfterSettlement() {
+        let harness = makeHarness()
+        let oldKey = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        let oldReading = ChatScrollSnapshot(anchorMessageID: "anchor-12", followsLatest: false)
+        harness.coordinator.rememberSessionID("stored-a", for: "default")
+        harness.appState.recordChatViewport(oldReading, for: oldKey)
+        harness.coordinator.freezeViewport()
+
+        let token = harness.appState.beginReconciliation()
+        XCTAssertNil(harness.appState.selectChatResumeTarget(
+            in: [],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: "stored-a"
+        ))
+        harness.appState.recordChatViewport(.latest, for: oldKey)
+
+        let created = session("stored-created")
+        harness.appState.sessions = [created]
+        harness.appState.activeSessionId = created.id
+        _ = harness.appState.selectChatResumeTarget(
+            in: [created],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: created.id
+        )
+
+        XCTAssertTrue(harness.appState.settleReconciliationAndPublish(token))
+        harness.appState.flushChatResumeViewport()
+        XCTAssertEqual(harness.store.snapshot(for: oldKey), oldReading)
+        XCTAssertEqual(harness.appState.chatResumeRestorationRequest?.destination, .latest)
+    }
+
+    func testServerChangeClearsServerScopedResumeAndSessionCaches() {
+        let harness = makeHarness()
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "same-session")
+
+        XCTAssertFalse(harness.appState.prepareChatResumeForConnection(to: "https://one.example"))
+        harness.coordinator.rememberSessionID("same-session", for: "default")
+        harness.coordinator.recordViewport(
+            ChatScrollSnapshot(anchorMessageID: "server-one-anchor", followsLatest: false),
+            for: key
+        )
+        harness.coordinator.flush()
+        harness.appState.sessions = [session("same-session")]
+        harness.appState.activeSessionId = "same-session"
+
+        XCTAssertTrue(harness.appState.prepareChatResumeForConnection(to: "https://two.example"))
+        XCTAssertNil(harness.store.lastSessionID(for: "default"))
+        XCTAssertNil(harness.store.snapshot(for: key))
+        XCTAssertNil(harness.appState.activeSessionId)
+        XCTAssertTrue(harness.appState.sessions.isEmpty)
+        XCTAssertEqual(harness.cacheClearSpy.count, 1)
+    }
+
+    func testEquivalentNormalizedServerKeepsResumeState() {
+        let harness = makeHarness()
+        XCTAssertFalse(harness.appState.prepareChatResumeForConnection(to: "https://one.example"))
+        harness.coordinator.rememberSessionID("stored-a", for: "default")
+
+        XCTAssertFalse(harness.appState.prepareChatResumeForConnection(to: "https://one.example/"))
+        XCTAssertEqual(harness.store.lastSessionID(for: "default"), "stored-a")
+        XCTAssertEqual(harness.cacheClearSpy.count, 0)
+    }
+
+    func testLegacyDashboardIdentityGuardsFirstServerChange() {
+        let harness = makeHarness()
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "same-session")
+        harness.defaults.set("https://one.example", forKey: "conduit.dashboardURL")
+        harness.coordinator.rememberSessionID("same-session", for: "default")
+        harness.coordinator.recordViewport(.latest, for: key)
+        harness.coordinator.flush()
+
+        XCTAssertTrue(harness.appState.prepareChatResumeForConnection(to: "https://two.example"))
+        XCTAssertNil(harness.store.lastSessionID(for: "default"))
+        XCTAssertNil(harness.store.snapshot(for: key))
+    }
+
+    func testManualRecoveryOverridesPendingAutomaticPurpose() async {
+        let harness = makeHarness(behavior: .latestActivity)
+        _ = harness.appState.beginChatResumeRecovery(purpose: .automaticReturn)
+
+        await harness.appState.syncSession()
+
+        XCTAssertEqual(harness.recoverySequence.currentPurpose, .preserveCurrent)
+    }
+
+    func testAppStateRestoresDeviceLocalSessionIDPerProfile() {
+        let harness = makeHarness()
+        harness.store.setLastSessionID("default-session", for: "default")
+        harness.store.setLastSessionID("work-session", for: "work")
+        harness.defaults.set("work", forKey: "conduit.activeProfile")
+
+        let recreated = AppState(
+            defaults: harness.defaults,
+            loadSavedConnection: false,
+            clearSessionPresentationCache: {}
+        )
+        XCTAssertEqual(recreated.activeSessionId, "work-session")
+
+        recreated.restoreActiveSessionState(for: "default")
+        XCTAssertEqual(recreated.activeSessionId, "default-session")
+    }
+
+    func testAcceptedBranchCancelsPendingRestoration() {
+        let harness = makeHarness()
+        let request = publishRestoration(in: harness)
+
+        harness.appState.acceptChatResumeConversationReplacement(.branch)
+
+        assertRestorationCancelled(request, in: harness)
+    }
+
+    func testAcceptedArchiveOfActiveSessionCancelsPendingRestoration() {
+        let harness = makeHarness()
+        let active = session("stored-a")
+        let request = publishRestoration(in: harness, session: active)
+
+        harness.appState.clearActiveSessionIfNeeded(active, replacement: .archive)
+
+        assertRestorationCancelled(request, in: harness)
+        XCTAssertNil(harness.appState.activeSessionId)
+    }
+
+    func testAcceptedDeleteOfActiveSessionCancelsPendingRestoration() {
+        let harness = makeHarness()
+        let active = session("stored-a")
+        let request = publishRestoration(in: harness, session: active)
+
+        harness.appState.clearActiveSessionIfNeeded(active, replacement: .delete)
+
+        assertRestorationCancelled(request, in: harness)
+        XCTAssertNil(harness.appState.activeSessionId)
+    }
+
+    private func makeHarness(
+        behavior: ChatResumeBehavior = .continueWhereLeftOff
+    ) -> (
+        appState: AppState,
+        coordinator: ChatResumeCoordinator,
+        store: ChatResumeStore,
+        recoverySequence: ChatResumeRecoverySequence,
+        cacheClearSpy: CacheClearSpy,
+        defaults: UserDefaults,
+        suite: String
+    ) {
+        let suite = "AppStateChatResumeTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suite)
+        }
+        let store = ChatResumeStore(defaults: defaults)
+        store.setBehavior(behavior)
+        let coordinator = ChatResumeCoordinator(store: store)
+        let recoverySequence = ChatResumeRecoverySequence()
+        let cacheClearSpy = CacheClearSpy()
+        let appState = AppState(
+            defaults: defaults,
+            chatResumeCoordinator: coordinator,
+            recoverySequence: recoverySequence,
+            loadSavedConnection: false,
+            clearSessionPresentationCache: { cacheClearSpy.count += 1 }
+        )
+        return (appState, coordinator, store, recoverySequence, cacheClearSpy, defaults, suite)
+    }
+
+    private func publishRestoration(
+        in harness: (
+            appState: AppState,
+            coordinator: ChatResumeCoordinator,
+            store: ChatResumeStore,
+            recoverySequence: ChatResumeRecoverySequence,
+            cacheClearSpy: CacheClearSpy,
+            defaults: UserDefaults,
+            suite: String
+        ),
+        session active: SessionSummary? = nil
+    ) -> ChatResumeRestorationRequest {
+        let active = active ?? session("stored-a")
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let token = harness.appState.beginReconciliation()
+        _ = harness.appState.selectChatResumeTarget(
+            in: [active],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: active.id
+        )
+        XCTAssertTrue(harness.appState.settleReconciliationAndPublish(token))
+        return harness.appState.chatResumeRestorationRequest!
+    }
+
+    private func assertRestorationCancelled(
+        _ request: ChatResumeRestorationRequest,
+        in harness: (
+            appState: AppState,
+            coordinator: ChatResumeCoordinator,
+            store: ChatResumeStore,
+            recoverySequence: ChatResumeRecoverySequence,
+            cacheClearSpy: CacheClearSpy,
+            defaults: UserDefaults,
+            suite: String
+        ),
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertNil(harness.appState.chatResumeRestorationRequest, file: file, line: line)
+        XCTAssertFalse(
+            harness.coordinator.isCurrent(generation: request.generation),
+            file: file,
+            line: line
+        )
+    }
+
+    private func session(_ id: String) -> SessionSummary {
+        SessionSummary(
+            id: id,
+            alternateIds: [],
+            title: id,
+            model: "Hermes",
+            updatedLabel: "now",
+            profile: "default",
+            source: .chat,
+            isActive: false,
+            isArchived: false,
+            lineageRootId: nil
+        )
+    }
+}
+
+@MainActor
+private final class CacheClearSpy {
+    var count = 0
+}

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -123,6 +123,67 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertEqual(harness.recoverySequence.queuedReconnectPurpose, .automaticReturn)
     }
 
+    func testSuccessfulSettlementCancelsQueuedReconnectExecution() async {
+        let scheduler = ControlledReconnectScheduler()
+        let reconnectSpy = ReconnectExecutionSpy()
+        let harness = makeHarness(
+            reconnectScheduler: scheduler.schedule(after:operation:),
+            scheduledReconnectExecutor: { purpose in
+                reconnectSpy.purposes.append(purpose)
+            }
+        )
+        harness.appState.connection = HermesConnection(
+            baseUrl: "https://one.example",
+            ticket: "ticket"
+        )
+        harness.appState.scheduleReconnect(purpose: .automaticReturn)
+        let token = harness.appState.beginReconciliation()
+
+        XCTAssertTrue(harness.appState.settleReconciliationAndPublish(token))
+        await scheduler.runAll()
+
+        XCTAssertEqual(scheduler.cancelledCount, 1)
+        XCTAssertTrue(reconnectSpy.purposes.isEmpty)
+    }
+
+    func testExplicitCancellationCancelsQueuedReconnectExecution() async {
+        let scheduler = ControlledReconnectScheduler()
+        let reconnectSpy = ReconnectExecutionSpy()
+        let harness = makeHarness(
+            reconnectScheduler: scheduler.schedule(after:operation:),
+            scheduledReconnectExecutor: { purpose in
+                reconnectSpy.purposes.append(purpose)
+            }
+        )
+        harness.appState.connection = HermesConnection(
+            baseUrl: "https://one.example",
+            ticket: "ticket"
+        )
+        harness.appState.scheduleReconnect(purpose: .automaticReturn)
+
+        harness.appState.cancelChatResumeRestoration()
+        await scheduler.runAll()
+
+        XCTAssertEqual(scheduler.cancelledCount, 1)
+        XCTAssertTrue(reconnectSpy.purposes.isEmpty)
+    }
+
+    func testPublicReconnectOverridesPendingAutomaticIntent() async {
+        let harness = makeHarness(behavior: .latestActivity)
+        _ = harness.appState.beginChatResumeRecovery(purpose: .automaticReturn)
+
+        await harness.appState.reconnect()
+
+        let selected = harness.appState.selectChatResumeTarget(
+            in: [session("stored-b"), session("stored-a")],
+            profile: "default",
+            purpose: harness.recoverySequence.currentPurpose,
+            currentSessionID: "stored-a"
+        )
+        XCTAssertEqual(harness.recoverySequence.currentPurpose, .preserveCurrent)
+        XCTAssertEqual(selected?.id, "stored-a")
+    }
+
     func testCreatedFallbackRemainsFrozenAndPublishesAfterSettlement() {
         let harness = makeHarness()
         let oldKey = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
@@ -188,17 +249,57 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertEqual(harness.cacheClearSpy.count, 0)
     }
 
-    func testLegacyDashboardIdentityGuardsFirstServerChange() {
-        let harness = makeHarness()
+    func testLegacyDashboardIdentityCapturedBeforeLoginOverwritesURL() {
+        let harness = makeHarness(
+            behavior: .latestActivity,
+            configureDefaults: { defaults in
+                defaults.set("https://one.example", forKey: "conduit.dashboardURL")
+            }
+        )
         let key = ChatScrollSessionKey(profile: "default", sessionID: "same-session")
-        harness.defaults.set("https://one.example", forKey: "conduit.dashboardURL")
         harness.coordinator.rememberSessionID("same-session", for: "default")
         harness.coordinator.recordViewport(.latest, for: key)
         harness.coordinator.flush()
+        harness.appState.rememberDashboardURL("https://two.example")
 
         XCTAssertTrue(harness.appState.prepareChatResumeForConnection(to: "https://two.example"))
         XCTAssertNil(harness.store.lastSessionID(for: "default"))
         XCTAssertNil(harness.store.snapshot(for: key))
+        XCTAssertEqual(harness.appState.chatResumeBehavior, .latestActivity)
+    }
+
+    func testServerChangeClearsReviewAndKnownProfileCachesButPreservesBehavior() throws {
+        let review = ReviewSummaryRecord(
+            id: "old-review",
+            profile: "default",
+            sessionId: "same-session",
+            timestamp: "2026-08-09T12:00:00Z",
+            activity: ReviewActivity(
+                summary: "Old server review",
+                details: ["Old server detail"],
+                fullSessionId: "same-child"
+            )
+        )
+        let harness = makeHarness(
+            behavior: .latestActivity,
+            configureDefaults: { defaults in
+                defaults.set("https://one.example", forKey: "conduit.chatResumeServerIdentity.v1")
+                defaults.set(
+                    try! JSONEncoder().encode([review]),
+                    forKey: "conduit.reviewSummaryCache.v1"
+                )
+                defaults.set(
+                    ["default", "old-profile"],
+                    forKey: "conduit.knownProfiles.v1"
+                )
+            }
+        )
+        harness.appState.rememberDashboardURL("https://two.example")
+
+        XCTAssertTrue(harness.appState.prepareChatResumeForConnection(to: "https://two.example"))
+        XCTAssertNil(harness.defaults.data(forKey: "conduit.reviewSummaryCache.v1"))
+        XCTAssertNil(harness.defaults.stringArray(forKey: "conduit.knownProfiles.v1"))
+        XCTAssertEqual(harness.appState.chatResumeBehavior, .latestActivity)
     }
 
     func testManualRecoveryOverridesPendingAutomaticPurpose() async {
@@ -259,7 +360,10 @@ final class AppStateChatResumeTests: XCTestCase {
     }
 
     private func makeHarness(
-        behavior: ChatResumeBehavior = .continueWhereLeftOff
+        behavior: ChatResumeBehavior = .continueWhereLeftOff,
+        configureDefaults: (UserDefaults) -> Void = { _ in },
+        reconnectScheduler: ChatResumeReconnectScheduler? = nil,
+        scheduledReconnectExecutor: (@MainActor (ChatResumeSyncPurpose) async -> Void)? = nil
     ) -> (
         appState: AppState,
         coordinator: ChatResumeCoordinator,
@@ -274,6 +378,7 @@ final class AppStateChatResumeTests: XCTestCase {
         addTeardownBlock {
             defaults.removePersistentDomain(forName: suite)
         }
+        configureDefaults(defaults)
         let store = ChatResumeStore(defaults: defaults)
         store.setBehavior(behavior)
         let coordinator = ChatResumeCoordinator(store: store)
@@ -284,7 +389,9 @@ final class AppStateChatResumeTests: XCTestCase {
             chatResumeCoordinator: coordinator,
             recoverySequence: recoverySequence,
             loadSavedConnection: false,
-            clearSessionPresentationCache: { cacheClearSpy.count += 1 }
+            clearSessionPresentationCache: { cacheClearSpy.count += 1 },
+            reconnectScheduler: reconnectScheduler,
+            scheduledReconnectExecutor: scheduledReconnectExecutor
         )
         return (appState, coordinator, store, recoverySequence, cacheClearSpy, defaults, suite)
     }
@@ -356,4 +463,44 @@ final class AppStateChatResumeTests: XCTestCase {
 @MainActor
 private final class CacheClearSpy {
     var count = 0
+}
+
+@MainActor
+private final class ControlledReconnectScheduler {
+    private final class Work {
+        let operation: @MainActor () async -> Void
+        var isCancelled = false
+
+        init(operation: @escaping @MainActor () async -> Void) {
+            self.operation = operation
+        }
+    }
+
+    private var work: [Work] = []
+
+    var cancelledCount: Int {
+        work.filter(\.isCancelled).count
+    }
+
+    func schedule(
+        after delay: TimeInterval,
+        operation: @escaping @MainActor () async -> Void
+    ) -> ChatResumeReconnectCancellation {
+        let item = Work(operation: operation)
+        work.append(item)
+        return {
+            item.isCancelled = true
+        }
+    }
+
+    func runAll() async {
+        for item in work where !item.isCancelled {
+            await item.operation()
+        }
+    }
+}
+
+@MainActor
+private final class ReconnectExecutionSpy {
+    var purposes: [ChatResumeSyncPurpose] = []
 }

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -3,6 +3,216 @@ import XCTest
 
 @MainActor
 final class AppStateChatResumeTests: XCTestCase {
+    func testSupersededBranchWaitingForTitleCannotMutateNewerSession() async {
+        let titleGate = ControlledSuspension()
+        let newerMessages = [
+            ChatMessage(id: "newer", role: .assistant, content: "Newer session", timestamp: "3")
+        ]
+        let staleCatalog = session("stale-catalog")
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [staleCatalog] },
+                openSession: { _, sessionID in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: newerMessages,
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                branchSession: { _, _, _, _, _ in
+                    (sessionId: "branch-runtime", storedSessionId: "branch-stored", profile: "default")
+                },
+                setSessionTitle: { _, _, _ in
+                    await titleGate.suspend()
+                },
+                refreshContext: { _, _ in }
+            )
+        )
+        let parent = session("stored-a")
+        let newer = session("stored-c")
+        let newerKey = ChatScrollSessionKey(profile: "default", sessionID: newer.id)
+        harness.appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+        harness.appState.sessions = [parent, newer]
+        harness.appState.activeSessionId = parent.id
+        harness.appState.messages = [
+            ChatMessage(id: "user", role: .user, content: "Question", timestamp: "1"),
+            ChatMessage(id: "assistant", role: .assistant, content: "Answer", timestamp: "2")
+        ]
+
+        let branch = Task { @MainActor in
+            await harness.appState.branchFromAssistantMessage("assistant")
+        }
+        await titleGate.waitUntilSuspended()
+
+        let openedNewer = await harness.appState.openSession(newer.id)
+        XCTAssertTrue(openedNewer)
+        harness.appState.chatViewportLayoutDidSettle(
+            sessionKey: newerKey,
+            transitionGeneration: harness.appState.chatViewportTransitionGeneration,
+            transcriptRevision: harness.appState.chatTranscriptRevision,
+            renderRevision: 1,
+            receivedScopedPreference: true
+        )
+
+        titleGate.resume()
+        await branch.value
+
+        XCTAssertEqual(harness.appState.activeSessionId, newer.id)
+        XCTAssertEqual(harness.appState.activeSessionTitle, newer.title)
+        XCTAssertEqual(harness.appState.messages, newerMessages)
+        XCTAssertEqual(harness.appState.sessions.map(\.id), [parent.id, newer.id])
+        XCTAssertFalse(harness.appState.activeChatScrollSessionIdentity.isReconciling)
+
+        harness.appState.recordChatViewport(.latest, for: newerKey)
+        harness.appState.flushChatResumeViewport()
+        XCTAssertEqual(harness.store.snapshot(for: newerKey), .latest)
+    }
+
+    func testOlderNotificationCleanupCannotClearNewerNotificationBusyState() async {
+        let firstCatalogGate = ControlledSuspension()
+        let secondCatalogGate = ControlledSuspension()
+        var catalogLoadCount = 0
+        let firstMessages = [
+            ChatMessage(id: "b", role: .assistant, content: "First", timestamp: "1")
+        ]
+        let secondMessages = [
+            ChatMessage(id: "c", role: .assistant, content: "Second", timestamp: "2")
+        ]
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    catalogLoadCount += 1
+                    if catalogLoadCount == 1 {
+                        await firstCatalogGate.suspend()
+                        return [self.session("stored-b")]
+                    }
+                    await secondCatalogGate.suspend()
+                    return [self.session("stored-c")]
+                },
+                openSession: { _, sessionID in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: sessionID == "stored-c" ? secondMessages : firstMessages,
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            )
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.connection = connection
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+        harness.appState.sessions = [session("stored-a")]
+        harness.appState.activeSessionId = "stored-a"
+
+        let firstNotification = Task { @MainActor in
+            await harness.appState.openNotificationTarget(
+                ConduitNotificationTarget(profile: nil, sessionId: "stored-b", type: nil)
+            )
+        }
+        await firstCatalogGate.waitUntilSuspended()
+
+        let secondNotification = Task { @MainActor in
+            await harness.appState.openNotificationTarget(
+                ConduitNotificationTarget(profile: nil, sessionId: "stored-c", type: nil)
+            )
+        }
+        await secondCatalogGate.waitUntilSuspended()
+        XCTAssertTrue(harness.appState.isOpeningNotificationSession)
+
+        firstCatalogGate.resume()
+        let openedFirstNotification = await firstNotification.value
+        XCTAssertFalse(openedFirstNotification)
+        XCTAssertTrue(harness.appState.isOpeningNotificationSession)
+
+        secondCatalogGate.resume()
+        let openedSecondNotification = await secondNotification.value
+        XCTAssertTrue(openedSecondNotification)
+        XCTAssertFalse(harness.appState.isOpeningNotificationSession)
+        XCTAssertEqual(harness.appState.activeSessionId, "stored-c")
+        XCTAssertEqual(harness.appState.messages, secondMessages)
+    }
+
+    func testStaleSameTokenSyncCannotSettleNewerOpeningReconciliation() async {
+        let staleCatalogGate = ControlledSuspension()
+        let newerOpenGate = ControlledSuspension()
+        var catalogLoadCount = 0
+        let currentMessages = [
+            ChatMessage(id: "current", role: .assistant, content: "Current", timestamp: "2")
+        ]
+        let harness = makeHarness(
+            behavior: .latestActivity,
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    catalogLoadCount += 1
+                    if catalogLoadCount == 1 {
+                        await staleCatalogGate.suspend()
+                        return [self.session("stored-stale")]
+                    }
+                    return [self.session("stored-current")]
+                },
+                openSession: { _, sessionID in
+                    if sessionID == "stored-current" {
+                        await newerOpenGate.suspend()
+                    }
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: currentMessages,
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            )
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+        harness.appState.sessions = [session("stored-a")]
+        harness.appState.activeSessionId = "stored-a"
+        let automaticWork = harness.appState.beginAutomaticChatResumeWork()
+        let reconciliation = harness.appState.beginReconciliation()
+
+        let staleSync = Task { @MainActor in
+            await harness.appState.syncSession(
+                purpose: .automaticReturn,
+                using: reconciliation,
+                automaticWorkToken: automaticWork
+            )
+        }
+        await staleCatalogGate.waitUntilSuspended()
+
+        let newerSync = Task { @MainActor in
+            await harness.appState.syncSession(
+                purpose: .automaticReturn,
+                using: reconciliation,
+                automaticWorkToken: automaticWork
+            )
+        }
+        await newerOpenGate.waitUntilSuspended()
+        XCTAssertTrue(harness.appState.activeChatScrollSessionIdentity.isReconciling)
+        harness.appState.handleStreamEvent(
+            .contextUpdate(sessionId: "stored-current", percent: 42, used: 42, max: 100)
+        )
+        XCTAssertNotEqual(harness.appState.runtime.contextUsed, 42)
+
+        staleCatalogGate.resume()
+        await staleSync.value
+
+        XCTAssertTrue(harness.appState.activeChatScrollSessionIdentity.isReconciling)
+        XCTAssertEqual(harness.appState.activeSessionId, "stored-a")
+        XCTAssertNotEqual(harness.appState.runtime.contextUsed, 42)
+
+        newerOpenGate.resume()
+        await newerSync.value
+
+        XCTAssertFalse(harness.appState.activeChatScrollSessionIdentity.isReconciling)
+        XCTAssertEqual(harness.appState.activeSessionId, "stored-current")
+        XCTAssertEqual(harness.appState.messages, currentMessages)
+        XCTAssertEqual(harness.appState.runtime.contextUsed, 42)
+    }
+
     func testCancellingSceneReconnectTaskWhileMintingIgnoresLateSignInFailure() async {
         let mintGate = ControlledSuspension()
         let harness = makeHarness(

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -324,6 +324,7 @@ final class AppStateChatResumeTests: XCTestCase {
         )
         let sessionA = session("stored-a")
         let sessionB = session("stored-b")
+        let keyA = ChatScrollSessionKey(profile: "default", sessionID: sessionA.id)
         let keyB = ChatScrollSessionKey(profile: "default", sessionID: sessionB.id)
         harness.appState.client = HermesClient(
             connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
@@ -332,7 +333,10 @@ final class AppStateChatResumeTests: XCTestCase {
         harness.appState.sessions = [sessionA, sessionB]
         harness.appState.activeSessionId = sessionA.id
         harness.appState.installChatViewportSnapshotProvider(id: UUID()) {
-            ChatScrollSnapshot(anchorMessageID: "old-anchor", followsLatest: false)
+            ChatRenderedViewportSnapshot(
+                sessionKey: keyA,
+                snapshot: ChatScrollSnapshot(anchorMessageID: "old-anchor", followsLatest: false)
+            )
         }
 
         let openedEmptySession = await harness.appState.openSession(sessionB.id)
@@ -389,7 +393,9 @@ final class AppStateChatResumeTests: XCTestCase {
         harness.appState.sessions = [active]
         harness.appState.activeSessionId = active.id
         harness.appState.messages = oldMessages
-        harness.appState.installChatViewportSnapshotProvider(id: UUID()) { captured }
+        harness.appState.installChatViewportSnapshotProvider(id: UUID()) {
+            ChatRenderedViewportSnapshot(sessionKey: key, snapshot: captured)
+        }
 
         await harness.appState.refreshActiveSession()
         let generation = harness.appState.chatViewportTransitionGeneration
@@ -571,7 +577,7 @@ final class AppStateChatResumeTests: XCTestCase {
         await second.value
     }
 
-    func testCancelledAutomaticReconnectIgnoresLateSignInFailureAndRestoresConnectionState() async {
+    func testViewportCancellationLetsReconnectFinishWithAuthoritativeSignInFailure() async {
         let gate = ControlledSuspension()
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
@@ -595,16 +601,99 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertEqual(harness.appState.turnState, .reconnecting)
 
         harness.appState.cancelChatResumeRestoration()
-        XCTAssertFalse(harness.appState.isConnecting)
-        XCTAssertEqual(harness.appState.turnState, .idle)
+        XCTAssertTrue(harness.appState.isConnecting)
+        XCTAssertEqual(harness.appState.turnState, .reconnecting)
         gate.resume()
         await reconnect.value
 
-        XCTAssertFalse(harness.appState.showLogin)
-        XCTAssertEqual(harness.appState.connection?.ticket, "saved-ticket")
-        XCTAssertTrue(harness.appState.client === originalClient)
+        XCTAssertTrue(harness.appState.showLogin)
+        XCTAssertNil(harness.appState.connection)
+        XCTAssertNil(harness.appState.client)
+        XCTAssertFalse(harness.appState.isConnecting)
         XCTAssertEqual(harness.appState.turnState, .idle)
         XCTAssertTrue(harness.appState.composerIsEnabled)
+    }
+
+    func testViewportCancellationDuringInitialConnectHandsOffToOnePreserveCurrentRetry() async {
+        let connectGate = ControlledSuspension()
+        let scheduler = ControlledReconnectScheduler()
+        let reconnectSpy = ReconnectExecutionSpy()
+        let harness = makeHarness(
+            reconnectScheduler: scheduler.schedule(after:operation:),
+            reconnectExecutor: { purpose in
+                reconnectSpy.purposes.append(purpose)
+            },
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                connectClient: { _ in
+                    await connectGate.suspend()
+                    throw ControlledLifecycleError.failed
+                }
+            )
+        )
+        let connection = HermesConnection(
+            baseUrl: "https://one.example",
+            ticket: "initial-ticket"
+        )
+
+        let connect = Task { @MainActor in
+            await harness.appState.connect(with: connection)
+        }
+        await connectGate.waitUntilSuspended()
+        XCTAssertTrue(harness.appState.isConnecting)
+
+        harness.appState.cancelChatResumeRestoration()
+        XCTAssertTrue(harness.appState.isConnecting)
+
+        connectGate.resume()
+        await connect.value
+        XCTAssertFalse(harness.appState.isConnecting)
+        XCTAssertEqual(harness.appState.turnState, .reconnecting)
+
+        await scheduler.runAll()
+        XCTAssertEqual(scheduler.cancelledCount, 0)
+        XCTAssertEqual(reconnectSpy.purposes, [.preserveCurrent])
+    }
+
+    func testBehaviorChangeDuringReconnectHandsOffToOnePreserveCurrentRetry() async {
+        let connectGate = ControlledSuspension()
+        let scheduler = ControlledReconnectScheduler()
+        let reconnectSpy = ReconnectExecutionSpy()
+        let harness = makeHarness(
+            reconnectScheduler: scheduler.schedule(after:operation:),
+            reconnectExecutor: { purpose in
+                reconnectSpy.purposes.append(purpose)
+            },
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                connectClient: { _ in
+                    await connectGate.suspend()
+                    throw ControlledLifecycleError.failed
+                },
+                mintTicket: { _ in "refreshed-ticket" }
+            )
+        )
+        harness.appState.connection = HermesConnection(
+            baseUrl: "https://one.example",
+            ticket: "saved-ticket"
+        )
+
+        let reconnect = Task { @MainActor in
+            await harness.appState.reconnectForRetry(purpose: .automaticReturn)
+        }
+        await connectGate.waitUntilSuspended()
+        XCTAssertTrue(harness.appState.isConnecting)
+        XCTAssertEqual(harness.appState.turnState, .reconnecting)
+
+        harness.appState.setChatResumeBehavior(.latestActivity)
+        XCTAssertTrue(harness.appState.isConnecting)
+
+        connectGate.resume()
+        await reconnect.value
+        XCTAssertFalse(harness.appState.isConnecting)
+        XCTAssertEqual(harness.appState.turnState, .reconnecting)
+
+        await scheduler.runAll()
+        XCTAssertEqual(scheduler.cancelledCount, 0)
+        XCTAssertEqual(reconnectSpy.purposes, [.preserveCurrent])
     }
 
     func testUnchangedRefreshReleasesViewportTransitionForLaterWrites() async {
@@ -634,7 +723,13 @@ final class AppStateChatResumeTests: XCTestCase {
         harness.appState.activeSessionId = active.id
         harness.appState.messages = messages
         harness.appState.installChatViewportSnapshotProvider(id: UUID()) {
-            ChatScrollSnapshot(anchorMessageID: "anchor-before-refresh", followsLatest: false)
+            ChatRenderedViewportSnapshot(
+                sessionKey: key,
+                snapshot: ChatScrollSnapshot(
+                    anchorMessageID: "anchor-before-refresh",
+                    followsLatest: false
+                )
+            )
         }
 
         await harness.appState.refreshActiveSession()
@@ -674,7 +769,9 @@ final class AppStateChatResumeTests: XCTestCase {
         harness.appState.sessions = [active]
         harness.appState.activeSessionId = active.id
         harness.appState.messages = oldMessages
-        harness.appState.installChatViewportSnapshotProvider(id: UUID()) { captured }
+        harness.appState.installChatViewportSnapshotProvider(id: UUID()) {
+            ChatRenderedViewportSnapshot(sessionKey: key, snapshot: captured)
+        }
 
         await harness.appState.refreshActiveSession()
         let generation = harness.appState.chatViewportTransitionGeneration
@@ -734,7 +831,9 @@ final class AppStateChatResumeTests: XCTestCase {
         harness.appState.messages = [
             ChatMessage(id: "old", role: .assistant, content: "Old", timestamp: "1")
         ]
-        harness.appState.installChatViewportSnapshotProvider(id: UUID()) { captured }
+        harness.appState.installChatViewportSnapshotProvider(id: UUID()) {
+            ChatRenderedViewportSnapshot(sessionKey: keyA, snapshot: captured)
+        }
 
         let opening = Task { @MainActor in
             await harness.appState.openSession(sessionB.id)
@@ -751,6 +850,7 @@ final class AppStateChatResumeTests: XCTestCase {
         harness.appState.flushChatResumeViewport()
 
         XCTAssertEqual(harness.store.snapshot(for: keyA), captured)
+        XCTAssertNil(harness.store.snapshot(for: keyB))
         gate.resume()
         let opened = await opening.value
         XCTAssertTrue(opened)
@@ -780,7 +880,13 @@ final class AppStateChatResumeTests: XCTestCase {
             ChatMessage(id: "assistant", role: .assistant, content: "Answer", timestamp: "2")
         ]
         harness.appState.installChatViewportSnapshotProvider(id: UUID()) {
-            ChatScrollSnapshot(anchorMessageID: "anchor-before-branch", followsLatest: false)
+            ChatRenderedViewportSnapshot(
+                sessionKey: key,
+                snapshot: ChatScrollSnapshot(
+                    anchorMessageID: "anchor-before-branch",
+                    followsLatest: false
+                )
+            )
         }
 
         await harness.appState.branchFromAssistantMessage("assistant")
@@ -826,7 +932,13 @@ final class AppStateChatResumeTests: XCTestCase {
         harness.appState.activeSessionId = parent.id
         harness.appState.messages = parentMessages
         harness.appState.installChatViewportSnapshotProvider(id: UUID()) {
-            ChatScrollSnapshot(anchorMessageID: "anchor-before-branch", followsLatest: false)
+            ChatRenderedViewportSnapshot(
+                sessionKey: key,
+                snapshot: ChatScrollSnapshot(
+                    anchorMessageID: "anchor-before-branch",
+                    followsLatest: false
+                )
+            )
         }
 
         let branch = Task { @MainActor in
@@ -941,7 +1053,9 @@ final class AppStateChatResumeTests: XCTestCase {
         )
         harness.appState.sessions = [sessionA, sessionB]
         harness.appState.activeSessionId = sessionA.id
-        harness.appState.installChatViewportSnapshotProvider(id: UUID()) { exactAnchor }
+        harness.appState.installChatViewportSnapshotProvider(id: UUID()) {
+            ChatRenderedViewportSnapshot(sessionKey: keyA, snapshot: exactAnchor)
+        }
 
         harness.appState.beginExplicitChatViewportTransition()
         harness.appState.activeSessionId = sessionB.id
@@ -950,6 +1064,30 @@ final class AppStateChatResumeTests: XCTestCase {
         harness.appState.flushChatResumeViewport()
 
         XCTAssertEqual(harness.store.snapshot(for: keyA), exactAnchor)
+    }
+
+    func testPreTransitionCaptureUsesRenderedKeyDuringModelOverlap() {
+        let harness = makeHarness()
+        let sessionA = session("stored-a")
+        let sessionB = session("stored-b")
+        let keyA = ChatScrollSessionKey(profile: "default", sessionID: sessionA.id)
+        let keyB = ChatScrollSessionKey(profile: "default", sessionID: sessionB.id)
+        let renderedSnapshot = ChatScrollSnapshot(
+            anchorMessageID: "rendered-a-anchor",
+            followsLatest: false
+        )
+        harness.appState.sessions = [sessionA, sessionB]
+        harness.appState.activeSessionId = sessionA.id
+        harness.appState.installChatViewportSnapshotProvider(id: UUID()) {
+            ChatRenderedViewportSnapshot(sessionKey: keyA, snapshot: renderedSnapshot)
+        }
+
+        harness.appState.activeSessionId = sessionB.id
+        harness.appState.beginExplicitChatViewportTransition()
+        harness.appState.flushChatResumeViewport()
+
+        XCTAssertEqual(harness.store.snapshot(for: keyA), renderedSnapshot)
+        XCTAssertNil(harness.store.snapshot(for: keyB))
     }
 
     func testStaleReconciliationCannotPublishNewerAutomaticRestoration() {
@@ -1095,7 +1233,7 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertTrue(reconnectSpy.purposes.isEmpty)
     }
 
-    func testExplicitCancellationCancelsQueuedReconnectExecution() async {
+    func testViewportCancellationPreservesQueuedReconnectAsPreserveCurrent() async {
         let scheduler = ControlledReconnectScheduler()
         let reconnectSpy = ReconnectExecutionSpy()
         let harness = makeHarness(
@@ -1113,8 +1251,8 @@ final class AppStateChatResumeTests: XCTestCase {
         harness.appState.cancelChatResumeRestoration()
         await scheduler.runAll()
 
-        XCTAssertEqual(scheduler.cancelledCount, 1)
-        XCTAssertTrue(reconnectSpy.purposes.isEmpty)
+        XCTAssertEqual(scheduler.cancelledCount, 0)
+        XCTAssertEqual(reconnectSpy.purposes, [.preserveCurrent])
     }
 
     func testPublicReconnectOverridesPendingAutomaticIntent() async {
@@ -1329,6 +1467,61 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertEqual(recreated.activeSessionId, "default-session")
     }
 
+    func testCanonicalIdentityRefreshMigratesRuntimePersistenceBeforeColdRestore() {
+        let harness = makeHarness()
+        let runtimeKey = ChatScrollSessionKey(profile: "default", sessionID: "runtime-a")
+        let canonicalKey = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        let snapshot = ChatScrollSnapshot(
+            anchorMessageID: "runtime-anchor",
+            followsLatest: false,
+            anchorMetadata: .init(fingerprint: "runtime-fingerprint", duplicateCount: 2),
+            anchorSourceMessageID: "runtime-source"
+        )
+        harness.store.setLastSessionID(runtimeKey.sessionID, for: runtimeKey.profile)
+        harness.store.save(snapshot, for: runtimeKey, at: Date(timeIntervalSince1970: 100))
+        harness.store.flush()
+
+        let migrationStore = ChatResumeStore(defaults: harness.defaults)
+        let migrationState = AppState(
+            defaults: harness.defaults,
+            chatResumeCoordinator: ChatResumeCoordinator(store: migrationStore),
+            loadSavedConnection: false,
+            clearSessionPresentationCache: {}
+        )
+        XCTAssertEqual(migrationState.activeSessionId, runtimeKey.sessionID)
+
+        let canonicalSession = session(
+            canonicalKey.sessionID,
+            alternateIDs: [runtimeKey.sessionID]
+        )
+        migrationState.sessions = [canonicalSession]
+
+        let restoredStore = ChatResumeStore(defaults: harness.defaults)
+        let restoredCoordinator = ChatResumeCoordinator(store: restoredStore)
+        let restoredState = AppState(
+            defaults: harness.defaults,
+            chatResumeCoordinator: restoredCoordinator,
+            loadSavedConnection: false,
+            clearSessionPresentationCache: {}
+        )
+        XCTAssertEqual(restoredState.activeSessionId, canonicalKey.sessionID)
+        XCTAssertNil(restoredStore.snapshot(for: runtimeKey))
+        XCTAssertEqual(restoredStore.snapshot(for: canonicalKey), snapshot)
+
+        restoredState.sessions = [canonicalSession]
+        let token = restoredState.beginReconciliation()
+        let selected = restoredState.selectChatResumeTarget(
+            in: [canonicalSession],
+            profile: canonicalKey.profile,
+            purpose: .automaticReturn,
+            currentSessionID: restoredState.activeSessionId
+        )
+        XCTAssertEqual(selected?.id, canonicalKey.sessionID)
+        XCTAssertTrue(restoredState.settleReconciliationAndPublish(token))
+        XCTAssertEqual(restoredState.chatResumeRestorationRequest?.sessionKey, canonicalKey)
+        XCTAssertEqual(restoredState.chatResumeRestorationRequest?.destination, .snapshot(snapshot))
+    }
+
     func testAcceptedBranchCancelsPendingRestoration() {
         let harness = makeHarness()
         let request = publishRestoration(in: harness)
@@ -1358,6 +1551,167 @@ final class AppStateChatResumeTests: XCTestCase {
 
         assertRestorationCancelled(request, in: harness)
         XCTAssertNil(harness.appState.activeSessionId)
+    }
+
+    func testAcceptedSendInvalidatesRestorationBeforePromptRPCResumes() async {
+        let rpcGate = ControlledSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                sendPrompt: { _, _, _ in await rpcGate.suspend() }
+            )
+        )
+        let request = publishRestoration(in: harness)
+        installComposerClient(in: harness)
+
+        let submission = Task { @MainActor in
+            await harness.appState.submitComposer(text: "Hello")
+        }
+        await rpcGate.waitUntilSuspended()
+
+        assertRestorationCancelled(request, in: harness)
+        rpcGate.resume()
+        let submitted = await submission.value
+        XCTAssertTrue(submitted)
+    }
+
+    func testAcceptedSteerInvalidatesRestorationBeforeSteerRPCResumes() async {
+        let rpcGate = ControlledSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                steer: { _, _, _ in await rpcGate.suspend() }
+            )
+        )
+        let active = session("stored-a")
+        let request = publishRestoration(in: harness, session: active)
+        installComposerClient(in: harness)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+
+        let submission = Task { @MainActor in
+            await harness.appState.submitComposer(text: "Adjust course")
+        }
+        await rpcGate.waitUntilSuspended()
+
+        assertRestorationCancelled(request, in: harness)
+        rpcGate.resume()
+        let submitted = await submission.value
+        XCTAssertTrue(submitted)
+    }
+
+    func testAcceptedRedirectOutcomesInvalidateRestorationBeforeRedirectRPCResumes() async {
+        for outcome in [SessionRedirectOutcome.redirected, .queued] {
+            let rpcGate = ControlledSuspension()
+            let harness = makeHarness(
+                lifecycleOperations: ChatResumeLifecycleOperations(
+                    redirect: { _, _, _ in
+                        await rpcGate.suspend()
+                        return outcome
+                    },
+                    setBusyInputMode: { _, _ in }
+                )
+            )
+            let active = session("stored-a")
+            installComposerClient(in: harness)
+            let changedMode = await harness.appState.setBusyInputMode(.interrupt)
+            XCTAssertTrue(changedMode)
+            let request = publishRestoration(in: harness, session: active)
+            harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+
+            let submission = Task { @MainActor in
+                await harness.appState.submitComposer(text: "Replace this")
+            }
+            await rpcGate.waitUntilSuspended()
+
+            assertRestorationCancelled(request, in: harness)
+            rpcGate.resume()
+            let submitted = await submission.value
+            XCTAssertTrue(submitted)
+        }
+    }
+
+    func testAcceptedSlashCommandInvalidatesRestorationBeforeSlashRPCResumes() async {
+        let rpcGate = ControlledSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                executeSlash: { _, _, _ in
+                    await rpcGate.suspend()
+                    return .object(["type": .string("exec")])
+                }
+            )
+        )
+        let request = publishRestoration(in: harness)
+        installComposerClient(in: harness)
+
+        let submission = Task { @MainActor in
+            await harness.appState.submitComposer(text: "/status")
+        }
+        await rpcGate.waitUntilSuspended()
+
+        assertRestorationCancelled(request, in: harness)
+        rpcGate.resume()
+        let submitted = await submission.value
+        XCTAssertTrue(submitted)
+    }
+
+    func testLegacyInterruptAndSendKeepsRestorationInvalidAcrossBothRPCs() async {
+        let interruptGate = ControlledSuspension()
+        let sendGate = ControlledSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                sendPrompt: { _, _, _ in await sendGate.suspend() },
+                redirect: { _, _, _ in
+                    throw RpcError(
+                        code: 4010,
+                        message: "Gateway does not support active-turn redirect"
+                    )
+                },
+                interrupt: { _, _ in await interruptGate.suspend() },
+                setBusyInputMode: { _, _ in }
+            )
+        )
+        let active = session("stored-a")
+        installComposerClient(in: harness)
+        let changedMode = await harness.appState.setBusyInputMode(.interrupt)
+        XCTAssertTrue(changedMode)
+        let request = publishRestoration(in: harness, session: active)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+
+        let submission = Task { @MainActor in
+            await harness.appState.submitComposer(text: "Use the legacy path")
+        }
+        await interruptGate.waitUntilSuspended()
+        assertRestorationCancelled(request, in: harness)
+
+        interruptGate.resume()
+        await sendGate.waitUntilSuspended()
+        assertRestorationCancelled(request, in: harness)
+
+        sendGate.resume()
+        let submitted = await submission.value
+        XCTAssertTrue(submitted)
+    }
+
+    func testRejectedBusyAttachmentPreservesPendingRestoration() async {
+        let harness = makeHarness()
+        let active = session("stored-a")
+        let request = publishRestoration(in: harness, session: active)
+        installComposerClient(in: harness)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        let attachment = Attachment(
+            id: "notes",
+            name: "notes.txt",
+            uri: "file:///tmp/notes.txt",
+            mimeType: "text/plain",
+            kind: .document
+        )
+
+        let submitted = await harness.appState.submitComposer(
+            text: "Not accepted yet",
+            attachments: [attachment]
+        )
+
+        XCTAssertFalse(submitted)
+        XCTAssertEqual(harness.appState.chatResumeRestorationRequest, request)
+        XCTAssertTrue(harness.coordinator.isCurrent(generation: request.generation))
     }
 
     private func makeHarness(
@@ -1425,6 +1779,25 @@ final class AppStateChatResumeTests: XCTestCase {
         return harness.appState.chatResumeRestorationRequest!
     }
 
+    private func installComposerClient(
+        in harness: (
+            appState: AppState,
+            coordinator: ChatResumeCoordinator,
+            store: ChatResumeStore,
+            recoverySequence: ChatResumeRecoverySequence,
+            cacheClearSpy: CacheClearSpy,
+            defaults: UserDefaults,
+            suite: String
+        )
+    ) {
+        let connection = HermesConnection(
+            baseUrl: "https://one.example",
+            ticket: "ticket"
+        )
+        harness.appState.connection = connection
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+    }
+
     private func assertRestorationCancelled(
         _ request: ChatResumeRestorationRequest,
         in harness: (
@@ -1447,10 +1820,10 @@ final class AppStateChatResumeTests: XCTestCase {
         )
     }
 
-    private func session(_ id: String) -> SessionSummary {
+    private func session(_ id: String, alternateIDs: [String] = []) -> SessionSummary {
         SessionSummary(
             id: id,
-            alternateIds: [],
+            alternateIds: alternateIDs,
             title: id,
             model: "Hermes",
             updatedLabel: "now",

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -3,6 +3,114 @@ import XCTest
 
 @MainActor
 final class AppStateChatResumeTests: XCTestCase {
+    func testExplicitCancellationWhileAutomaticSyncWaitsBeforeSelectionPreventsRevival() async {
+        let harness = makeHarness(behavior: .latestActivity)
+        let gate = ControlledSuspension()
+        let catalog = [session("stored-b"), session("stored-a")]
+        harness.appState.sessions = catalog
+        harness.appState.activeSessionId = "stored-a"
+        let automaticWork = harness.appState.beginAutomaticChatResumeWork()
+
+        let selection = Task { @MainActor in
+            await gate.suspend()
+            return harness.appState.selectChatResumeTarget(
+                in: catalog,
+                profile: "default",
+                purpose: .automaticReturn,
+                currentSessionID: "stored-a",
+                automaticWorkToken: automaticWork
+            )
+        }
+        await gate.waitUntilSuspended()
+
+        harness.appState.cancelChatResumeRestoration()
+        gate.resume()
+        let selected = await selection.value
+
+        XCTAssertNil(selected)
+        XCTAssertEqual(harness.appState.activeSessionId, "stored-a")
+        XCTAssertNil(harness.appState.chatResumeRestorationRequest)
+    }
+
+    func testExplicitCancellationDuringAutomaticReconciliationPreventsTranscriptReplacementAndPublication() async {
+        let harness = makeHarness(behavior: .latestActivity)
+        let gate = ControlledSuspension()
+        let catalog = [session("stored-b"), session("stored-a")]
+        let originalMessages = [
+            ChatMessage(id: "a-message", role: .assistant, content: "Session A", timestamp: "now")
+        ]
+        harness.appState.sessions = catalog
+        harness.appState.activeSessionId = "stored-a"
+        harness.appState.messages = originalMessages
+        let automaticWork = harness.appState.beginAutomaticChatResumeWork()
+        let reconciliation = harness.appState.beginReconciliation()
+        XCTAssertEqual(
+            harness.appState.selectChatResumeTarget(
+                in: catalog,
+                profile: "default",
+                purpose: .automaticReturn,
+                currentSessionID: "stored-a",
+                automaticWorkToken: automaticWork
+            )?.id,
+            "stored-b"
+        )
+        let replacement = SessionResumeResult(
+            sessionId: "stored-b",
+            messages: [
+                ChatMessage(id: "b-message", role: .assistant, content: "Session B", timestamp: "later")
+            ],
+            snapshot: SessionRuntimeSnapshot(object: [:])
+        )
+
+        let result = Task { @MainActor in
+            await gate.suspend()
+            let replaced = harness.appState.applyChatResume(
+                replacement,
+                automaticWorkToken: automaticWork
+            )
+            let published = harness.appState.settleReconciliationAndPublish(
+                reconciliation,
+                automaticWorkToken: automaticWork
+            )
+            return (replaced, published)
+        }
+        await gate.waitUntilSuspended()
+
+        harness.appState.cancelChatResumeRestoration()
+        gate.resume()
+        let outcome = await result.value
+
+        XCTAssertFalse(outcome.0)
+        XCTAssertFalse(outcome.1)
+        XCTAssertEqual(harness.appState.activeSessionId, "stored-a")
+        XCTAssertEqual(harness.appState.messages, originalMessages)
+        XCTAssertNil(harness.appState.chatResumeRestorationRequest)
+    }
+
+    func testPreTransitionCapturePreservesOldAnchorAgainstLateTeardownGeometry() {
+        let harness = makeHarness()
+        let sessionA = session("stored-a")
+        let sessionB = session("stored-b")
+        let keyA = ChatScrollSessionKey(profile: "default", sessionID: sessionA.id)
+        let exactAnchor = ChatScrollSnapshot(
+            anchorMessageID: "chat-message-exact-anchor-0",
+            followsLatest: false,
+            anchorMetadata: ChatScrollAnchorMetadata(fingerprint: "exact-anchor", duplicateCount: 1),
+            anchorSourceMessageID: "source-a"
+        )
+        harness.appState.sessions = [sessionA, sessionB]
+        harness.appState.activeSessionId = sessionA.id
+        harness.appState.installChatViewportSnapshotProvider(id: UUID()) { exactAnchor }
+
+        harness.appState.beginExplicitChatViewportTransition()
+        harness.appState.activeSessionId = sessionB.id
+        harness.appState.messages = []
+        harness.appState.recordChatViewport(.latest, for: keyA)
+        harness.appState.flushChatResumeViewport()
+
+        XCTAssertEqual(harness.store.snapshot(for: keyA), exactAnchor)
+    }
+
     func testStaleReconciliationCannotPublishNewerAutomaticRestoration() {
         let harness = makeHarness(behavior: .latestActivity)
         let catalog = [session("stored-b"), session("stored-a")]
@@ -569,4 +677,30 @@ private final class ControlledReconnectScheduler {
 @MainActor
 private final class ReconnectExecutionSpy {
     var purposes: [ChatResumeSyncPurpose] = []
+}
+
+@MainActor
+private final class ControlledSuspension {
+    private var suspension: CheckedContinuation<Void, Never>?
+    private var observer: CheckedContinuation<Void, Never>?
+
+    func suspend() async {
+        await withCheckedContinuation { continuation in
+            suspension = continuation
+            observer?.resume()
+            observer = nil
+        }
+    }
+
+    func waitUntilSuspended() async {
+        guard suspension == nil else { return }
+        await withCheckedContinuation { continuation in
+            observer = continuation
+        }
+    }
+
+    func resume() {
+        suspension?.resume()
+        suspension = nil
+    }
 }

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -71,6 +71,130 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertEqual(harness.store.snapshot(for: newerKey), .latest)
     }
 
+    func testRapidExplicitSessionSwitchingSettlesTheLatestSession() async {
+        let sessionIDs = (1...8).map { "stored-\($0)" }
+        let gates = SessionOpenGates(sessionIDs: sessionIDs)
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID in
+                    await gates.suspend(sessionID)
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [ChatMessage(
+                            id: "message-\(sessionID)",
+                            role: .assistant,
+                            content: sessionID,
+                            timestamp: sessionID
+                        )],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                refreshContext: { _, _ in }
+            )
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.connection = connection
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+        harness.appState.sessions = sessionIDs.map { session($0) }
+        harness.appState.activeSessionId = sessionIDs[0]
+
+        let tasks = sessionIDs.dropFirst().map { sessionID in
+            Task { @MainActor in
+                await harness.appState.openSession(sessionID)
+            }
+        }
+        for sessionID in sessionIDs.dropFirst() {
+            await gates.waitUntilSuspended(sessionID)
+        }
+
+        for sessionID in sessionIDs.dropFirst().reversed() {
+            gates.resume(sessionID)
+        }
+        for task in tasks {
+            _ = await task.value
+        }
+
+        XCTAssertEqual(harness.appState.activeSessionId, sessionIDs.last)
+        XCTAssertEqual(harness.appState.messages.map(\.content), [sessionIDs.last!])
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        XCTAssertFalse(harness.appState.activeChatScrollSessionIdentity.isReconciling)
+    }
+
+    func testCancelledExplicitSessionSwitchDoesNotLeaveSynchronizationStuck() async {
+        let openGate = ControlledSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID in
+                    await openGate.suspend()
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                refreshContext: { _, _ in }
+            )
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.connection = connection
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+        harness.appState.sessions = [session("stored-a"), session("stored-b")]
+        harness.appState.activeSessionId = "stored-a"
+
+        let task = Task { @MainActor in
+            await harness.appState.openSession("stored-b")
+        }
+        await openGate.waitUntilSuspended()
+        task.cancel()
+        openGate.resume()
+        _ = await task.value
+
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        XCTAssertFalse(harness.appState.activeChatScrollSessionIdentity.isReconciling)
+    }
+
+    func testRequestingAnotherSessionCancelsThePreviousOpen() async {
+        let firstGate = ControlledSuspension()
+        let secondGate = ControlledSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID in
+                    if sessionID == "stored-b" {
+                        await firstGate.suspend()
+                    } else {
+                        await secondGate.suspend()
+                    }
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                refreshContext: { _, _ in }
+            )
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.connection = connection
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+        harness.appState.sessions = [session("stored-a"), session("stored-b"), session("stored-c")]
+        harness.appState.activeSessionId = "stored-a"
+
+        let firstTask = harness.appState.requestOpenSession("stored-b")
+        await firstGate.waitUntilSuspended()
+        let secondTask = harness.appState.requestOpenSession("stored-c")
+        await secondGate.waitUntilSuspended()
+
+        XCTAssertTrue(firstTask.isCancelled)
+        firstGate.resume()
+        secondGate.resume()
+        _ = await firstTask.value
+        let secondOpened = await secondTask.value
+        XCTAssertTrue(secondOpened)
+
+        XCTAssertEqual(harness.appState.activeSessionId, "stored-c")
+        XCTAssertEqual(harness.appState.turnState, .idle)
+    }
+
     func testOlderNotificationCleanupCannotClearNewerNotificationBusyState() async {
         let firstCatalogGate = ControlledSuspension()
         let secondCatalogGate = ControlledSuspension()
@@ -2248,5 +2372,26 @@ private final class ControlledSuspension {
     func resume() {
         suspension?.resume()
         suspension = nil
+    }
+}
+
+@MainActor
+private final class SessionOpenGates {
+    private var gates: [String: ControlledSuspension]
+
+    init(sessionIDs: [String]) {
+        gates = Dictionary(uniqueKeysWithValues: sessionIDs.map { ($0, ControlledSuspension()) })
+    }
+
+    func suspend(_ sessionID: String) async {
+        await gates[sessionID]?.suspend()
+    }
+
+    func waitUntilSuspended(_ sessionID: String) async {
+        await gates[sessionID]?.waitUntilSuspended()
+    }
+
+    func resume(_ sessionID: String) {
+        gates[sessionID]?.resume()
     }
 }

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -1393,7 +1393,7 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertEqual(harness.appState.chatResumeRestorationRequest?.sessionKey.sessionID, "stored-b")
     }
 
-    func testSecondAutomaticReturnImmediatelySupersedesPublishedGeneration() {
+    func testSecondAutomaticReturnImmediatelySupersedesPublishedGeneration() throws {
         let harness = makeHarness(behavior: .latestActivity)
         let catalog = [session("stored-b"), session("stored-a")]
         harness.appState.sessions = catalog
@@ -1408,7 +1408,7 @@ final class AppStateChatResumeTests: XCTestCase {
         )
         harness.appState.activeSessionId = firstTarget?.id
         XCTAssertTrue(harness.appState.settleReconciliationAndPublish(firstToken))
-        let firstRequest = harness.appState.chatResumeRestorationRequest!
+        let firstRequest = try XCTUnwrap(harness.appState.chatResumeRestorationRequest)
 
         let secondToken = harness.appState.beginReconciliation()
         _ = harness.appState.selectChatResumeTarget(
@@ -1423,7 +1423,7 @@ final class AppStateChatResumeTests: XCTestCase {
 
         XCTAssertTrue(harness.appState.settleReconciliationAndPublish(secondToken))
         XCTAssertGreaterThan(
-            harness.appState.chatResumeRestorationRequest!.generation,
+            try XCTUnwrap(harness.appState.chatResumeRestorationRequest).generation,
             firstRequest.generation
         )
     }
@@ -1697,7 +1697,7 @@ final class AppStateChatResumeTests: XCTestCase {
             configureDefaults: { defaults in
                 defaults.set("https://one.example", forKey: "conduit.chatResumeServerIdentity.v1")
                 defaults.set(
-                    try! JSONEncoder().encode([review]),
+                    try! JSONEncoder().encode([review]),  // test fixture, safe to force-try
                     forKey: "conduit.reviewSummaryCache.v1"
                 )
                 defaults.set(
@@ -2162,7 +2162,9 @@ final class AppStateChatResumeTests: XCTestCase {
         suite: String
     ) {
         let suite = "AppStateChatResumeTests.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suite)!
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Failed to create test UserDefaults suite")
+        }
         addTeardownBlock {
             defaults.removePersistentDomain(forName: suite)
         }
@@ -2208,7 +2210,11 @@ final class AppStateChatResumeTests: XCTestCase {
             currentSessionID: active.id
         )
         XCTAssertTrue(harness.appState.settleReconciliationAndPublish(token))
-        return harness.appState.chatResumeRestorationRequest!
+        guard let request = harness.appState.chatResumeRestorationRequest else {
+            XCTFail("Expected restoration request to be published")
+            return ChatResumeRestorationRequest(generation: 0, sessionKey: .init(profile: "", sessionID: ""), destination: .latest)
+        }
+        return request
     }
 
     private func installComposerClient(

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -3,6 +3,275 @@ import XCTest
 
 @MainActor
 final class AppStateChatResumeTests: XCTestCase {
+    func testCancellingSceneReconnectTaskWhileMintingIgnoresLateSignInFailure() async {
+        let mintGate = ControlledSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                mintTicket: { _ in
+                    await mintGate.suspend()
+                    throw DashboardTicketBridgeError.signInRequired
+                }
+            )
+        )
+        let savedConnection = HermesConnection(
+            baseUrl: "https://one.example",
+            ticket: "saved-ticket"
+        )
+        let originalClient = HermesClient(connection: savedConnection, profile: "default")
+        harness.appState.connection = savedConnection
+        harness.appState.client = originalClient
+        harness.appState.showLogin = false
+
+        let sceneReconnect = harness.appState.handleScenePhase(.active)
+        await mintGate.waitUntilSuspended()
+        XCTAssertTrue(harness.appState.isConnecting)
+
+        harness.appState.handleScenePhase(.background)
+        mintGate.resume()
+        await sceneReconnect?.value
+
+        XCTAssertFalse(harness.appState.showLogin)
+        XCTAssertEqual(harness.appState.connection, savedConnection)
+        XCTAssertTrue(harness.appState.client === originalClient)
+        XCTAssertFalse(harness.appState.isConnecting)
+        XCTAssertEqual(harness.appState.turnState, .idle)
+    }
+
+    func testSameEpochAutomaticSyncAttemptCannotOverwriteNewerAttempt() async {
+        let staleCatalogGate = ControlledSuspension()
+        var catalogLoadCount = 0
+        let staleMessages = [
+            ChatMessage(id: "stale", role: .assistant, content: "Stale", timestamp: "1")
+        ]
+        let currentMessages = [
+            ChatMessage(id: "current", role: .assistant, content: "Current", timestamp: "2")
+        ]
+        let harness = makeHarness(
+            behavior: .latestActivity,
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    catalogLoadCount += 1
+                    if catalogLoadCount == 1 {
+                        await staleCatalogGate.suspend()
+                        return [self.session("stored-stale")]
+                    }
+                    return [self.session("stored-current")]
+                },
+                openSession: { _, sessionID in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: sessionID == "stored-current" ? currentMessages : staleMessages,
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            )
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+        harness.appState.sessions = [session("stored-a")]
+        harness.appState.activeSessionId = "stored-a"
+        let automaticWork = harness.appState.beginAutomaticChatResumeWork()
+        let reconciliation = harness.appState.beginReconciliation()
+
+        let staleSync = Task { @MainActor in
+            await harness.appState.syncSession(
+                purpose: .automaticReturn,
+                using: reconciliation,
+                automaticWorkToken: automaticWork
+            )
+        }
+        await staleCatalogGate.waitUntilSuspended()
+
+        await harness.appState.syncSession(
+            purpose: .automaticReturn,
+            using: reconciliation,
+            automaticWorkToken: automaticWork
+        )
+        XCTAssertEqual(harness.appState.activeSessionId, "stored-current")
+        XCTAssertEqual(harness.appState.messages, currentMessages)
+
+        staleCatalogGate.resume()
+        await staleSync.value
+
+        XCTAssertEqual(harness.appState.sessions.map(\.id), ["stored-current"])
+        XCTAssertEqual(harness.appState.activeSessionId, "stored-current")
+        XCTAssertEqual(harness.appState.messages, currentMessages)
+    }
+
+    func testAuthoritativeEmptyTranscriptSettlesFromScopedRevisionZeroLayout() async {
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            )
+        )
+        let sessionA = session("stored-a")
+        let sessionB = session("stored-b")
+        let keyB = ChatScrollSessionKey(profile: "default", sessionID: sessionB.id)
+        harness.appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+        harness.appState.sessions = [sessionA, sessionB]
+        harness.appState.activeSessionId = sessionA.id
+        harness.appState.installChatViewportSnapshotProvider(id: UUID()) {
+            ChatScrollSnapshot(anchorMessageID: "old-anchor", followsLatest: false)
+        }
+
+        let openedEmptySession = await harness.appState.openSession(sessionB.id)
+        XCTAssertTrue(openedEmptySession)
+        harness.appState.chatViewportLayoutDidSettle(
+            sessionKey: keyB,
+            transitionGeneration: harness.appState.chatViewportTransitionGeneration,
+            transcriptRevision: harness.appState.chatTranscriptRevision,
+            renderRevision: 0,
+            receivedScopedPreference: true
+        )
+        harness.appState.recordChatViewport(.latest, for: keyB)
+        harness.appState.flushChatResumeViewport()
+
+        XCTAssertEqual(harness.store.snapshot(for: keyB), .latest)
+    }
+
+    func testPostAuthoritativeTranscriptMutationAdvancesExpectedLayoutRevision() async {
+        let appReference = WeakAppStateReference()
+        let oldMessages = [
+            ChatMessage(id: "old", role: .assistant, content: "Old", timestamp: "1")
+        ]
+        let authoritativeMessages = [
+            ChatMessage(id: "new", role: .assistant, content: "New", timestamp: "2")
+        ]
+        let lateMessage = ChatMessage(
+            id: "late",
+            role: .assistant,
+            content: "Late authoritative event",
+            timestamp: "3"
+        )
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: authoritativeMessages,
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in
+                    appReference.value?.messages.append(lateMessage)
+                }
+            )
+        )
+        appReference.value = harness.appState
+        let active = session("stored-a")
+        let key = ChatScrollSessionKey(profile: "default", sessionID: active.id)
+        let captured = ChatScrollSnapshot(anchorMessageID: "old-anchor", followsLatest: false)
+        harness.appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        harness.appState.messages = oldMessages
+        harness.appState.installChatViewportSnapshotProvider(id: UUID()) { captured }
+
+        await harness.appState.refreshActiveSession()
+        let generation = harness.appState.chatViewportTransitionGeneration
+        let currentRevision = harness.appState.chatTranscriptRevision
+        XCTAssertEqual(harness.appState.messages, authoritativeMessages + [lateMessage])
+
+        harness.appState.chatViewportLayoutDidSettle(
+            sessionKey: key,
+            transitionGeneration: generation,
+            transcriptRevision: currentRevision - 1,
+            renderRevision: 8,
+            receivedScopedPreference: true
+        )
+        harness.appState.recordChatViewport(.latest, for: key)
+        harness.appState.flushChatResumeViewport()
+        XCTAssertEqual(harness.store.snapshot(for: key), captured)
+
+        harness.appState.chatViewportLayoutDidSettle(
+            sessionKey: key,
+            transitionGeneration: generation,
+            transcriptRevision: currentRevision,
+            renderRevision: 9,
+            receivedScopedPreference: true
+        )
+        harness.appState.recordChatViewport(.latest, for: key)
+        harness.appState.flushChatResumeViewport()
+        XCTAssertEqual(harness.store.snapshot(for: key), .latest)
+    }
+
+    func testStaleNotificationContinuationCannotSupersedeNewerSessionTransition() async {
+        let notificationCatalogGate = ControlledSuspension()
+        let messagesB = [
+            ChatMessage(id: "b", role: .assistant, content: "B", timestamp: "1")
+        ]
+        let messagesC = [
+            ChatMessage(id: "c", role: .assistant, content: "C", timestamp: "2")
+        ]
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    await notificationCatalogGate.suspend()
+                    return [self.session("stored-b")]
+                },
+                openSession: { _, sessionID in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: sessionID == "stored-c" ? messagesC : messagesB,
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            )
+        )
+        let sessionA = session("stored-a")
+        let sessionC = session("stored-c")
+        let keyC = ChatScrollSessionKey(profile: "default", sessionID: sessionC.id)
+        harness.appState.connection = HermesConnection(
+            baseUrl: "https://one.example",
+            ticket: "ticket"
+        )
+        harness.appState.client = HermesClient(
+            connection: harness.appState.connection!,
+            profile: "default"
+        )
+        harness.appState.sessions = [sessionA, sessionC]
+        harness.appState.activeSessionId = sessionA.id
+
+        let notification = Task { @MainActor in
+            await harness.appState.openNotificationTarget(
+                ConduitNotificationTarget(profile: nil, sessionId: "stored-b", type: nil)
+            )
+        }
+        await notificationCatalogGate.waitUntilSuspended()
+
+        let openedNewerSession = await harness.appState.openSession(sessionC.id)
+        XCTAssertTrue(openedNewerSession)
+        harness.appState.chatViewportLayoutDidSettle(
+            sessionKey: keyC,
+            transitionGeneration: harness.appState.chatViewportTransitionGeneration,
+            transcriptRevision: harness.appState.chatTranscriptRevision,
+            renderRevision: 4,
+            receivedScopedPreference: true
+        )
+        notificationCatalogGate.resume()
+        let openedNotification = await notification.value
+        XCTAssertFalse(openedNotification)
+
+        XCTAssertEqual(harness.appState.activeSessionId, sessionC.id)
+        XCTAssertEqual(harness.appState.messages, messagesC)
+        XCTAssertEqual(harness.appState.sessions.map(\.id), [sessionA.id, sessionC.id])
+    }
+
     func testCancelledAutomaticSyncRestoresComposerStateAfterCatalogReturns() async {
         let gate = ControlledSuspension()
         let catalog = [session("stored-b"), session("stored-a")]
@@ -205,7 +474,8 @@ final class AppStateChatResumeTests: XCTestCase {
             sessionKey: key,
             transitionGeneration: generation,
             transcriptRevision: transcriptRevision - 1,
-            renderRevision: 7
+            renderRevision: 7,
+            receivedScopedPreference: true
         )
         harness.appState.recordChatViewport(.latest, for: key)
         harness.appState.flushChatResumeViewport()
@@ -215,7 +485,8 @@ final class AppStateChatResumeTests: XCTestCase {
             sessionKey: key,
             transitionGeneration: generation,
             transcriptRevision: transcriptRevision,
-            renderRevision: 7
+            renderRevision: 7,
+            receivedScopedPreference: true
         )
         harness.appState.recordChatViewport(.latest, for: key)
         harness.appState.flushChatResumeViewport()
@@ -263,7 +534,8 @@ final class AppStateChatResumeTests: XCTestCase {
             sessionKey: keyB,
             transitionGeneration: harness.appState.chatViewportTransitionGeneration,
             transcriptRevision: harness.appState.chatTranscriptRevision,
-            renderRevision: 2
+            renderRevision: 2,
+            receivedScopedPreference: true
         )
         harness.appState.recordChatViewport(.latest, for: keyA)
         harness.appState.flushChatResumeViewport()
@@ -1002,6 +1274,11 @@ private enum ControlledLifecycleError: Error {
 @MainActor
 private final class CacheClearSpy {
     var count = 0
+}
+
+@MainActor
+private final class WeakAppStateReference {
+    weak var value: AppState?
 }
 
 @MainActor

--- a/ConduitTests/ChatResumeCoordinatorTests.swift
+++ b/ConduitTests/ChatResumeCoordinatorTests.swift
@@ -315,7 +315,7 @@ final class ChatResumeCoordinatorTests: XCTestCase {
         XCTAssertEqual(harness.store.snapshot(for: otherKey), .latest)
     }
 
-    func testReconciliationSettledWithMismatchedKeyClearsPendingButDoesNotUnfreeze() {
+    func testReconciliationSettledWithMismatchedKeyClearsPendingViaCaller() {
         let harness = makeHarness()
         let wrongKey = ChatScrollSessionKey(profile: "default", sessionID: "stored-b")
 
@@ -329,17 +329,14 @@ final class ChatResumeCoordinatorTests: XCTestCase {
         harness.coordinator.recordViewport(.latest, for: wrongKey)
         XCTAssertNil(harness.store.snapshot(for: wrongKey))
 
-        // Settle with the wrong key → nil. Pending is cleared but freeze
-        // stays intact (avoids `.latest` overwriting old readings during
-        // ID remapping). Use abandonPendingAutomaticSync to unfreeze.
+        // Settle with the wrong key → nil. pendingSessionKey stays set
+        // so the caller can detect the mismatch and clean up.
         XCTAssertNil(harness.coordinator.reconciliationSettled(sessionKey: wrongKey))
 
-        // Still frozen — recordViewport is still a no-op.
-        harness.coordinator.recordViewport(.latest, for: wrongKey)
-        XCTAssertNil(harness.store.snapshot(for: wrongKey))
+        // Caller detects pending key and unfreezes.
+        harness.coordinator.abandonPendingAutomaticSyncIfPending()
 
-        // Abandon to unfreeze.
-        harness.coordinator.abandonPendingAutomaticSync()
+        // Now recordViewport should work again.
         harness.coordinator.recordViewport(.latest, for: wrongKey)
         XCTAssertEqual(harness.store.snapshot(for: wrongKey), .latest)
     }

--- a/ConduitTests/ChatResumeCoordinatorTests.swift
+++ b/ConduitTests/ChatResumeCoordinatorTests.swift
@@ -1,0 +1,217 @@
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class ChatResumeCoordinatorTests: XCTestCase {
+    func testInactiveFreezeRejectsLateGeometryOverwrite() {
+        let harness = makeHarness()
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        let reading = ChatScrollSnapshot(anchorMessageID: "anchor-12", followsLatest: false)
+
+        harness.coordinator.recordViewport(reading, for: key)
+        harness.coordinator.freezeViewport()
+        harness.coordinator.recordViewport(.latest, for: key)
+        harness.coordinator.flush()
+
+        XCTAssertEqual(harness.store.snapshot(for: key), reading)
+    }
+
+    func testContinueRequestIsEmittedOnlyAfterReconciliationSettles() {
+        let harness = makeHarness()
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        let reading = ChatScrollSnapshot(anchorMessageID: "anchor-12", followsLatest: false)
+        harness.store.save(reading, for: key, at: Date())
+        harness.store.setLastSessionID("stored-a", for: "default")
+
+        _ = harness.coordinator.selectTarget(
+            in: [session("stored-b"), session("stored-a")],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: "stored-a"
+        )
+        XCTAssertNil(harness.coordinator.pendingRestoration)
+
+        let request = harness.coordinator.reconciliationSettled(sessionKey: key)
+        XCTAssertEqual(request?.destination, .snapshot(reading))
+    }
+
+    func testExplicitActionCancelsAnOlderGeneration() {
+        let harness = makeHarness()
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        _ = harness.coordinator.selectTarget(
+            in: [session("stored-a")],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: "stored-a"
+        )
+        let request = harness.coordinator.reconciliationSettled(sessionKey: key)!
+
+        harness.coordinator.cancelRestoration()
+
+        XCTAssertFalse(harness.coordinator.isCurrent(generation: request.generation))
+    }
+
+    func testLatestModeSelectsNewestAndEmitsLatest() {
+        let harness = makeHarness()
+        harness.coordinator.setBehavior(.latestActivity)
+        let selected = harness.coordinator.selectTarget(
+            in: [session("stored-b"), session("stored-a")],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: "stored-a"
+        )
+        let request = harness.coordinator.reconciliationSettled(
+            sessionKey: .init(profile: "default", sessionID: selected!.id)
+        )
+
+        XCTAssertEqual(selected?.id, "stored-b")
+        XCTAssertEqual(request?.destination, .latest)
+    }
+
+    func testColdLaunchRestoresPersistedSnapshot() {
+        let harness = makeHarness()
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        let snapshot = ChatScrollSnapshot(anchorMessageID: "anchor-12", followsLatest: false)
+        harness.store.save(snapshot, for: key, at: Date())
+        harness.store.setLastSessionID("stored-a", for: "default")
+        harness.store.flush()
+        let recreated = ChatResumeCoordinator(store: ChatResumeStore(defaults: harness.defaults))
+
+        _ = recreated.selectTarget(
+            in: [session("stored-b"), session("stored-a")],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: nil
+        )
+
+        XCTAssertEqual(recreated.reconciliationSettled(sessionKey: key)?.destination, .snapshot(snapshot))
+    }
+
+    func testCompletingCurrentRequestAllowsViewportWritesAgain() {
+        let harness = makeHarness()
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        _ = harness.coordinator.selectTarget(
+            in: [session("stored-a")],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: "stored-a"
+        )
+        let request = harness.coordinator.reconciliationSettled(sessionKey: key)!
+        harness.coordinator.completeRestoration(generation: request.generation)
+        harness.coordinator.recordViewport(.latest, for: key)
+        harness.coordinator.flush()
+
+        XCTAssertEqual(harness.store.snapshot(for: key), .latest)
+    }
+
+    func testMissingContinueTargetSelectsNewestChat() {
+        let harness = makeHarness()
+        harness.store.setLastSessionID("deleted-a", for: "default")
+
+        let selected = harness.coordinator.selectTarget(
+            in: [session("stored-b")],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: "deleted-a"
+        )
+
+        XCTAssertEqual(selected?.id, "stored-b")
+    }
+
+    func testPreservingCurrentSessionDoesNotCreateARestorationRequest() {
+        let harness = makeHarness()
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+
+        let selected = harness.coordinator.selectTarget(
+            in: [session("stored-a")],
+            profile: "default",
+            purpose: .preserveCurrent,
+            currentSessionID: "stored-a"
+        )
+
+        XCTAssertEqual(selected?.id, "stored-a")
+        XCTAssertNil(harness.coordinator.reconciliationSettled(sessionKey: key))
+    }
+
+    func testChangingBehaviorCancelsCurrentRequestBeforeSavingPreference() {
+        let harness = makeHarness()
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        _ = harness.coordinator.selectTarget(
+            in: [session("stored-a")],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: "stored-a"
+        )
+        let request = harness.coordinator.reconciliationSettled(sessionKey: key)!
+
+        harness.coordinator.setBehavior(.latestActivity)
+
+        XCTAssertFalse(harness.coordinator.isCurrent(generation: request.generation))
+        XCTAssertEqual(harness.store.behavior, .latestActivity)
+    }
+
+    func testClearResumeStateCancelsRequestAndPreservesBehavior() {
+        let harness = makeHarness()
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        harness.coordinator.setBehavior(.latestActivity)
+        harness.coordinator.rememberSessionID("stored-a", for: "default")
+        harness.coordinator.recordViewport(.latest, for: key)
+        _ = harness.coordinator.selectTarget(
+            in: [session("stored-a")],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: "stored-a"
+        )
+        let request = harness.coordinator.reconciliationSettled(sessionKey: key)!
+
+        harness.coordinator.clearResumeState()
+
+        XCTAssertFalse(harness.coordinator.isCurrent(generation: request.generation))
+        XCTAssertEqual(harness.coordinator.behavior, .latestActivity)
+        XCTAssertNil(harness.store.lastSessionID(for: "default"))
+        XCTAssertNil(harness.store.snapshot(for: key))
+    }
+
+    func testMigratingSnapshotUsesStoreMigration() {
+        let harness = makeHarness()
+        let oldKey = ChatScrollSessionKey(profile: "default", sessionID: "runtime-a")
+        let newKey = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        let snapshot = ChatScrollSnapshot(anchorMessageID: "anchor-12", followsLatest: false)
+        harness.coordinator.recordViewport(snapshot, for: oldKey)
+
+        harness.coordinator.migrateSnapshot(from: oldKey, to: newKey)
+
+        XCTAssertNil(harness.store.snapshot(for: oldKey))
+        XCTAssertEqual(harness.store.snapshot(for: newKey), snapshot)
+    }
+
+    private func makeHarness() -> (
+        coordinator: ChatResumeCoordinator,
+        store: ChatResumeStore,
+        defaults: UserDefaults,
+        suite: String
+    ) {
+        let suite = "ChatResumeCoordinatorTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suite)
+        }
+        let store = ChatResumeStore(defaults: defaults)
+        return (ChatResumeCoordinator(store: store), store, defaults, suite)
+    }
+
+    private func session(_ id: String) -> SessionSummary {
+        SessionSummary(
+            id: id,
+            alternateIds: [],
+            title: id,
+            model: "Hermes",
+            updatedLabel: "now",
+            profile: "default",
+            source: .chat,
+            isActive: false,
+            isArchived: false,
+            lineageRootId: nil
+        )
+    }
+}

--- a/ConduitTests/ChatResumeCoordinatorTests.swift
+++ b/ConduitTests/ChatResumeCoordinatorTests.swift
@@ -46,7 +46,7 @@ final class ChatResumeCoordinatorTests: XCTestCase {
         )
         let request = harness.coordinator.reconciliationSettled(sessionKey: key)!
 
-        harness.coordinator.cancelRestoration()
+        harness.coordinator.cancelViewportRestoration()
 
         XCTAssertFalse(harness.coordinator.isCurrent(generation: request.generation))
     }
@@ -226,7 +226,7 @@ final class ChatResumeCoordinatorTests: XCTestCase {
             purpose: .automaticReturn,
             currentSessionID: "stored-a"
         )
-        harness.coordinator.cancelRestoration()
+        harness.coordinator.cancelViewportRestoration()
         let recovery = harness.coordinator.selectTarget(
             in: catalog,
             profile: "default",

--- a/ConduitTests/ChatResumeCoordinatorTests.swift
+++ b/ConduitTests/ChatResumeCoordinatorTests.swift
@@ -166,6 +166,29 @@ final class ChatResumeCoordinatorTests: XCTestCase {
         XCTAssertNil(harness.coordinator.reconciliationSettled(sessionKey: key))
     }
 
+    func testRecoverySyncPreservesCurrentWhileAutomaticReturnUsesPreference() {
+        let harness = makeHarness()
+        harness.coordinator.setBehavior(.latestActivity)
+        let catalog = [session("stored-b"), session("stored-a")]
+
+        let automatic = harness.coordinator.selectTarget(
+            in: catalog,
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: "stored-a"
+        )
+        harness.coordinator.cancelRestoration()
+        let recovery = harness.coordinator.selectTarget(
+            in: catalog,
+            profile: "default",
+            purpose: .preserveCurrent,
+            currentSessionID: "stored-a"
+        )
+
+        XCTAssertEqual(automatic?.id, "stored-b")
+        XCTAssertEqual(recovery?.id, "stored-a")
+    }
+
     func testChangingBehaviorCancelsCurrentRequestBeforeSavingPreference() {
         let harness = makeHarness()
         let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")

--- a/ConduitTests/ChatResumeCoordinatorTests.swift
+++ b/ConduitTests/ChatResumeCoordinatorTests.swift
@@ -104,6 +104,24 @@ final class ChatResumeCoordinatorTests: XCTestCase {
         XCTAssertEqual(harness.store.snapshot(for: key), .latest)
     }
 
+    func testAbandoningCurrentRequestAllowsViewportWritesAgain() {
+        let harness = makeHarness()
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        _ = harness.coordinator.selectTarget(
+            in: [session("stored-a")],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: "stored-a"
+        )
+        let request = harness.coordinator.reconciliationSettled(sessionKey: key)!
+
+        harness.coordinator.abandonRestoration(generation: request.generation)
+        harness.coordinator.recordViewport(.latest, for: key)
+        harness.coordinator.flush()
+
+        XCTAssertEqual(harness.store.snapshot(for: key), .latest)
+    }
+
     func testMissingContinueTargetSelectsNewestChat() {
         let harness = makeHarness()
         harness.store.setLastSessionID("deleted-a", for: "default")

--- a/ConduitTests/ChatResumeCoordinatorTests.swift
+++ b/ConduitTests/ChatResumeCoordinatorTests.swift
@@ -51,7 +51,7 @@ final class ChatResumeCoordinatorTests: XCTestCase {
         XCTAssertFalse(harness.coordinator.isCurrent(generation: request.generation))
     }
 
-    func testLatestModeSelectsNewestAndEmitsLatest() {
+    func testLatestModeSelectsNewestAndEmitsLatest() throws {
         let harness = makeHarness()
         harness.coordinator.setBehavior(.latestActivity)
         let selected = harness.coordinator.selectTarget(
@@ -60,8 +60,9 @@ final class ChatResumeCoordinatorTests: XCTestCase {
             purpose: .automaticReturn,
             currentSessionID: "stored-a"
         )
+        let selectedID = try XCTUnwrap(selected).id
         let request = harness.coordinator.reconciliationSettled(
-            sessionKey: .init(profile: "default", sessionID: selected!.id)
+            sessionKey: .init(profile: "default", sessionID: selectedID)
         )
 
         XCTAssertEqual(selected?.id, "stored-b")
@@ -288,6 +289,53 @@ final class ChatResumeCoordinatorTests: XCTestCase {
 
         XCTAssertNil(harness.store.snapshot(for: oldKey))
         XCTAssertEqual(harness.store.snapshot(for: newKey), snapshot)
+    }
+
+    func testAbandonPendingAutomaticSyncUnfreezesViewport() {
+        let harness = makeHarness()
+        let pendingKey = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        let otherKey = ChatScrollSessionKey(profile: "default", sessionID: "other")
+
+        // Simulate selectTarget with a valid target → viewport frozen.
+        _ = harness.coordinator.selectTarget(
+            in: [session("stored-a")],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: "stored-a"
+        )
+        // recordViewport should be a no-op (frozen).
+        harness.coordinator.recordViewport(.latest, for: otherKey)
+        XCTAssertNil(harness.store.snapshot(for: otherKey))
+
+        // Abandon: unfreeze without canceling automatic work epoch.
+        harness.coordinator.abandonPendingAutomaticSync()
+
+        // Now recordViewport should work again.
+        harness.coordinator.recordViewport(.latest, for: otherKey)
+        XCTAssertEqual(harness.store.snapshot(for: otherKey), .latest)
+    }
+
+    func testReconciliationSettledWithMismatchedKeyUnfreezes() {
+        let harness = makeHarness()
+        let pendingKey = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        let wrongKey = ChatScrollSessionKey(profile: "default", sessionID: "stored-b")
+
+        _ = harness.coordinator.selectTarget(
+            in: [session("stored-a")],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: "stored-a"
+        )
+        // recordViewport is a no-op while frozen.
+        harness.coordinator.recordViewport(.latest, for: wrongKey)
+        XCTAssertNil(harness.store.snapshot(for: wrongKey))
+
+        // Settle with the wrong key → nil + unfreeze.
+        XCTAssertNil(harness.coordinator.reconciliationSettled(sessionKey: wrongKey))
+
+        // Now recordViewport should work again.
+        harness.coordinator.recordViewport(.latest, for: wrongKey)
+        XCTAssertEqual(harness.store.snapshot(for: wrongKey), .latest)
     }
 
     private func makeHarness() -> (

--- a/ConduitTests/ChatResumeCoordinatorTests.swift
+++ b/ConduitTests/ChatResumeCoordinatorTests.swift
@@ -137,6 +137,37 @@ final class ChatResumeCoordinatorTests: XCTestCase {
         XCTAssertEqual(request?.destination, .latest)
     }
 
+    func testAutomaticNilTargetKeepsViewportFrozenUntilCreatedSessionSettles() {
+        let harness = makeHarness()
+        let oldKey = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        let oldReading = ChatScrollSnapshot(anchorMessageID: "anchor-12", followsLatest: false)
+        harness.coordinator.recordViewport(oldReading, for: oldKey)
+        harness.coordinator.freezeViewport()
+
+        let missingTarget = harness.coordinator.selectTarget(
+            in: [],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: "stored-a"
+        )
+        XCTAssertNil(missingTarget)
+
+        harness.coordinator.recordViewport(.latest, for: oldKey)
+        let created = session("stored-created")
+        _ = harness.coordinator.selectTarget(
+            in: [created],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: nil
+        )
+        let createdKey = ChatScrollSessionKey(profile: "default", sessionID: created.id)
+        let request = harness.coordinator.reconciliationSettled(sessionKey: createdKey)
+        harness.coordinator.flush()
+
+        XCTAssertEqual(harness.store.snapshot(for: oldKey), oldReading)
+        XCTAssertEqual(request?.destination, .latest)
+    }
+
     func testViewportUpdatePersistsOnlyAfterExplicitFlush() {
         let harness = makeHarness()
         let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")

--- a/ConduitTests/ChatResumeCoordinatorTests.swift
+++ b/ConduitTests/ChatResumeCoordinatorTests.swift
@@ -118,6 +118,39 @@ final class ChatResumeCoordinatorTests: XCTestCase {
         XCTAssertEqual(selected?.id, "stored-b")
     }
 
+    func testMissingContinueTargetEmitsLatestDespiteFallbackSnapshot() {
+        let harness = makeHarness()
+        let fallbackKey = ChatScrollSessionKey(profile: "default", sessionID: "stored-b")
+        let oldReading = ChatScrollSnapshot(anchorMessageID: "anchor-12", followsLatest: false)
+        harness.store.setLastSessionID("deleted-a", for: "default")
+        harness.store.save(oldReading, for: fallbackKey, at: Date())
+
+        let selected = harness.coordinator.selectTarget(
+            in: [session("stored-b")],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: "deleted-a"
+        )
+        let request = harness.coordinator.reconciliationSettled(sessionKey: fallbackKey)
+
+        XCTAssertEqual(selected?.id, "stored-b")
+        XCTAssertEqual(request?.destination, .latest)
+    }
+
+    func testViewportUpdatePersistsOnlyAfterExplicitFlush() {
+        let harness = makeHarness()
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        let reading = ChatScrollSnapshot(anchorMessageID: "anchor-12", followsLatest: false)
+
+        harness.coordinator.recordViewport(reading, for: key)
+
+        XCTAssertNil(ChatResumeStore(defaults: harness.defaults).snapshot(for: key))
+
+        harness.coordinator.flush()
+
+        XCTAssertEqual(ChatResumeStore(defaults: harness.defaults).snapshot(for: key), reading)
+    }
+
     func testPreservingCurrentSessionDoesNotCreateARestorationRequest() {
         let harness = makeHarness()
         let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")

--- a/ConduitTests/ChatResumeCoordinatorTests.swift
+++ b/ConduitTests/ChatResumeCoordinatorTests.swift
@@ -297,7 +297,9 @@ final class ChatResumeCoordinatorTests: XCTestCase {
         suite: String
     ) {
         let suite = "ChatResumeCoordinatorTests.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suite)!
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Failed to create test UserDefaults suite")
+        }
         addTeardownBlock {
             defaults.removePersistentDomain(forName: suite)
         }

--- a/ConduitTests/ChatResumeCoordinatorTests.swift
+++ b/ConduitTests/ChatResumeCoordinatorTests.swift
@@ -315,9 +315,8 @@ final class ChatResumeCoordinatorTests: XCTestCase {
         XCTAssertEqual(harness.store.snapshot(for: otherKey), .latest)
     }
 
-    func testReconciliationSettledWithMismatchedKeyUnfreezes() {
+    func testReconciliationSettledWithMismatchedKeyClearsPendingButDoesNotUnfreeze() {
         let harness = makeHarness()
-        let pendingKey = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
         let wrongKey = ChatScrollSessionKey(profile: "default", sessionID: "stored-b")
 
         _ = harness.coordinator.selectTarget(
@@ -330,10 +329,17 @@ final class ChatResumeCoordinatorTests: XCTestCase {
         harness.coordinator.recordViewport(.latest, for: wrongKey)
         XCTAssertNil(harness.store.snapshot(for: wrongKey))
 
-        // Settle with the wrong key → nil + unfreeze.
+        // Settle with the wrong key → nil. Pending is cleared but freeze
+        // stays intact (avoids `.latest` overwriting old readings during
+        // ID remapping). Use abandonPendingAutomaticSync to unfreeze.
         XCTAssertNil(harness.coordinator.reconciliationSettled(sessionKey: wrongKey))
 
-        // Now recordViewport should work again.
+        // Still frozen — recordViewport is still a no-op.
+        harness.coordinator.recordViewport(.latest, for: wrongKey)
+        XCTAssertNil(harness.store.snapshot(for: wrongKey))
+
+        // Abandon to unfreeze.
+        harness.coordinator.abandonPendingAutomaticSync()
         harness.coordinator.recordViewport(.latest, for: wrongKey)
         XCTAssertEqual(harness.store.snapshot(for: wrongKey), .latest)
     }

--- a/ConduitTests/ChatResumeCoordinatorTests.swift
+++ b/ConduitTests/ChatResumeCoordinatorTests.swift
@@ -35,7 +35,7 @@ final class ChatResumeCoordinatorTests: XCTestCase {
         XCTAssertEqual(request?.destination, .snapshot(reading))
     }
 
-    func testExplicitActionCancelsAnOlderGeneration() {
+    func testExplicitActionCancelsAnOlderGeneration() throws {
         let harness = makeHarness()
         let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
         _ = harness.coordinator.selectTarget(
@@ -44,7 +44,7 @@ final class ChatResumeCoordinatorTests: XCTestCase {
             purpose: .automaticReturn,
             currentSessionID: "stored-a"
         )
-        let request = harness.coordinator.reconciliationSettled(sessionKey: key)!
+        let request = try XCTUnwrap(harness.coordinator.reconciliationSettled(sessionKey: key))
 
         harness.coordinator.cancelViewportRestoration()
 
@@ -87,7 +87,7 @@ final class ChatResumeCoordinatorTests: XCTestCase {
         XCTAssertEqual(recreated.reconciliationSettled(sessionKey: key)?.destination, .snapshot(snapshot))
     }
 
-    func testCompletingCurrentRequestAllowsViewportWritesAgain() {
+    func testCompletingCurrentRequestAllowsViewportWritesAgain() throws {
         let harness = makeHarness()
         let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
         _ = harness.coordinator.selectTarget(
@@ -96,7 +96,7 @@ final class ChatResumeCoordinatorTests: XCTestCase {
             purpose: .automaticReturn,
             currentSessionID: "stored-a"
         )
-        let request = harness.coordinator.reconciliationSettled(sessionKey: key)!
+        let request = try XCTUnwrap(harness.coordinator.reconciliationSettled(sessionKey: key))
         harness.coordinator.completeRestoration(generation: request.generation)
         harness.coordinator.recordViewport(.latest, for: key)
         harness.coordinator.flush()
@@ -104,7 +104,7 @@ final class ChatResumeCoordinatorTests: XCTestCase {
         XCTAssertEqual(harness.store.snapshot(for: key), .latest)
     }
 
-    func testAbandoningCurrentRequestAllowsViewportWritesAgain() {
+    func testAbandoningCurrentRequestAllowsViewportWritesAgain() throws {
         let harness = makeHarness()
         let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
         _ = harness.coordinator.selectTarget(
@@ -113,7 +113,7 @@ final class ChatResumeCoordinatorTests: XCTestCase {
             purpose: .automaticReturn,
             currentSessionID: "stored-a"
         )
-        let request = harness.coordinator.reconciliationSettled(sessionKey: key)!
+        let request = try XCTUnwrap(harness.coordinator.reconciliationSettled(sessionKey: key))
 
         harness.coordinator.abandonRestoration(generation: request.generation)
         harness.coordinator.recordViewport(.latest, for: key)
@@ -238,7 +238,7 @@ final class ChatResumeCoordinatorTests: XCTestCase {
         XCTAssertEqual(recovery?.id, "stored-a")
     }
 
-    func testChangingBehaviorCancelsCurrentRequestBeforeSavingPreference() {
+    func testChangingBehaviorCancelsCurrentRequestBeforeSavingPreference() throws {
         let harness = makeHarness()
         let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
         _ = harness.coordinator.selectTarget(
@@ -247,7 +247,7 @@ final class ChatResumeCoordinatorTests: XCTestCase {
             purpose: .automaticReturn,
             currentSessionID: "stored-a"
         )
-        let request = harness.coordinator.reconciliationSettled(sessionKey: key)!
+        let request = try XCTUnwrap(harness.coordinator.reconciliationSettled(sessionKey: key))
 
         harness.coordinator.setBehavior(.latestActivity)
 
@@ -255,7 +255,7 @@ final class ChatResumeCoordinatorTests: XCTestCase {
         XCTAssertEqual(harness.store.behavior, .latestActivity)
     }
 
-    func testClearResumeStateCancelsRequestAndPreservesBehavior() {
+    func testClearResumeStateCancelsRequestAndPreservesBehavior() throws {
         let harness = makeHarness()
         let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
         harness.coordinator.setBehavior(.latestActivity)
@@ -267,7 +267,7 @@ final class ChatResumeCoordinatorTests: XCTestCase {
             purpose: .automaticReturn,
             currentSessionID: "stored-a"
         )
-        let request = harness.coordinator.reconciliationSettled(sessionKey: key)!
+        let request = try XCTUnwrap(harness.coordinator.reconciliationSettled(sessionKey: key))
 
         harness.coordinator.clearResumeState()
 

--- a/ConduitTests/ChatResumePolicyTests.swift
+++ b/ConduitTests/ChatResumePolicyTests.swift
@@ -104,6 +104,11 @@ final class ChatResumePolicyTests: XCTestCase {
         XCTAssertEqual(selected?.id, "cron-a")
     }
 
+    func testResumeBehaviorPresentationCopyIsStable() {
+        XCTAssertEqual(ChatResumeBehavior.continueWhereLeftOff.title, "Continue where I left off")
+        XCTAssertEqual(ChatResumeBehavior.latestActivity.title, "Jump to latest activity")
+    }
+
     func testPersistedAnchorSurvivesWhenTargetExists() {
         let message = ChatMessage(
             id: "source-12",

--- a/ConduitTests/ChatResumePolicyTests.swift
+++ b/ConduitTests/ChatResumePolicyTests.swift
@@ -103,4 +103,38 @@ final class ChatResumePolicyTests: XCTestCase {
         )
         XCTAssertEqual(selected?.id, "cron-a")
     }
+
+    func testPersistedAnchorSurvivesWhenTargetExists() {
+        let message = ChatMessage(
+            id: "source-12",
+            role: .assistant,
+            content: "Stable",
+            timestamp: "now"
+        )
+        let target = ChatMessageScrollTargets.make(for: [message])[0]
+        let snapshot = ChatScrollSnapshot(
+            anchorMessageID: target.semanticID,
+            followsLatest: false,
+            anchorMetadata: target.restorationMetadata,
+            anchorSourceMessageID: target.id
+        )
+
+        XCTAssertEqual(
+            ChatResumeViewportResolver.destination(
+                for: snapshot,
+                availableTargets: .init(targets: [target])
+            ),
+            .anchor(target.semanticID)
+        )
+    }
+
+    func testMissingAnchorFallsBackToLatestWithinSelectedConversation() {
+        XCTAssertEqual(
+            ChatResumeViewportResolver.destination(
+                for: .init(anchorMessageID: "deleted", followsLatest: false),
+                availableTargets: .init(targets: [])
+            ),
+            .latest
+        )
+    }
 }

--- a/ConduitTests/ChatResumePolicyTests.swift
+++ b/ConduitTests/ChatResumePolicyTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import Conduit
+
+final class ChatResumePolicyTests: XCTestCase {
+    private func session(
+        _ id: String,
+        alternates: [String] = [],
+        source: SessionSource = .chat
+    ) -> SessionSummary {
+        SessionSummary(
+            id: id,
+            alternateIds: alternates,
+            title: id,
+            model: "Hermes",
+            updatedLabel: "now",
+            profile: "default",
+            source: source,
+            isActive: false,
+            isArchived: false,
+            lineageRootId: nil
+        )
+    }
+
+    func testContinueReturnsSavedConversationWhenAnotherConversationIsNewer() {
+        let newestB = session("stored-b", alternates: ["runtime-b"])
+        let savedA = session("stored-a", alternates: ["runtime-a"])
+
+        let selected = ChatResumeSessionResolver.target(
+            in: [newestB, savedA],
+            behavior: .continueWhereLeftOff,
+            purpose: .automaticReturn,
+            savedSessionID: "runtime-a",
+            currentSessionID: "runtime-a"
+        )
+
+        XCTAssertEqual(selected?.id, "stored-a")
+    }
+
+    func testLatestReturnDeliberatelyIgnoresSavedConversation() {
+        let selected = ChatResumeSessionResolver.target(
+            in: [session("stored-b"), session("stored-a")],
+            behavior: .latestActivity,
+            purpose: .automaticReturn,
+            savedSessionID: "stored-a",
+            currentSessionID: "stored-a"
+        )
+
+        XCTAssertEqual(selected?.id, "stored-b")
+    }
+
+    func testRecoverySyncPreservesCurrentConversationRegardlessOfPreference() {
+        let selected = ChatResumeSessionResolver.target(
+            in: [session("stored-b"), session("stored-a")],
+            behavior: .latestActivity,
+            purpose: .preserveCurrent,
+            savedSessionID: "stored-a",
+            currentSessionID: "stored-a"
+        )
+
+        XCTAssertEqual(selected?.id, "stored-a")
+    }
+
+    func testUnavailableSavedConversationFallsBackToNewestOrdinaryChat() {
+        let selected = ChatResumeSessionResolver.target(
+            in: [session("cron", source: .cron), session("stored-b")],
+            behavior: .continueWhereLeftOff,
+            purpose: .automaticReturn,
+            savedSessionID: "deleted-a",
+            currentSessionID: "deleted-a"
+        )
+
+        XCTAssertEqual(selected?.id, "stored-b")
+    }
+
+    func testLatestReturnsNilWhenNoOrdinaryChatExists() {
+        XCTAssertNil(ChatResumeSessionResolver.target(
+            in: [session("cron", source: .cron)],
+            behavior: .latestActivity,
+            purpose: .automaticReturn,
+            savedSessionID: "cron",
+            currentSessionID: "cron"
+        ))
+    }
+
+    func testRecoveryMatchesAlternateCurrentID() {
+        let selected = ChatResumeSessionResolver.target(
+            in: [session("stored-a", alternates: ["runtime-a"])],
+            behavior: .latestActivity,
+            purpose: .preserveCurrent,
+            savedSessionID: nil,
+            currentSessionID: "runtime-a"
+        )
+        XCTAssertEqual(selected?.id, "stored-a")
+    }
+
+    func testContinueCanRestoreSavedCronConversation() {
+        let selected = ChatResumeSessionResolver.target(
+            in: [session("stored-b"), session("cron-a", source: .cron)],
+            behavior: .continueWhereLeftOff,
+            purpose: .automaticReturn,
+            savedSessionID: "cron-a",
+            currentSessionID: "cron-a"
+        )
+        XCTAssertEqual(selected?.id, "cron-a")
+    }
+}

--- a/ConduitTests/ChatResumeStoreTests.swift
+++ b/ConduitTests/ChatResumeStoreTests.swift
@@ -140,6 +140,26 @@ final class ChatResumeStoreTests: XCTestCase {
         XCTAssertEqual(store.snapshot(for: canonical), canonicalSnapshot)
     }
 
+    func testSessionIdentityMigrationMovesLastSessionAndPreservesNewerCanonicalSnapshot() {
+        let (defaults, suite) = defaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = ChatResumeStore(defaults: defaults)
+        let runtime = ChatScrollSessionKey(profile: "default", sessionID: "runtime-a")
+        let canonical = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        let runtimeSnapshot = ChatScrollSnapshot(anchorMessageID: "runtime-anchor", followsLatest: false)
+        let canonicalSnapshot = ChatScrollSnapshot(anchorMessageID: "canonical-anchor", followsLatest: false)
+        store.setLastSessionID(runtime.sessionID, for: runtime.profile)
+        store.save(runtimeSnapshot, for: runtime, at: Date(timeIntervalSince1970: 100))
+        store.save(canonicalSnapshot, for: canonical, at: Date(timeIntervalSince1970: 200))
+
+        store.migrateSessionIdentity(from: runtime, to: canonical)
+
+        let restored = ChatResumeStore(defaults: defaults)
+        XCTAssertEqual(restored.lastSessionID(for: canonical.profile), canonical.sessionID)
+        XCTAssertNil(restored.snapshot(for: runtime))
+        XCTAssertEqual(restored.snapshot(for: canonical), canonicalSnapshot)
+    }
+
     func testEqualTimestampPruningUsesDeterministicKeyOrder() throws {
         let (defaults, suite) = defaults()
         defer { defaults.removePersistentDomain(forName: suite) }

--- a/ConduitTests/ChatResumeStoreTests.swift
+++ b/ConduitTests/ChatResumeStoreTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Conduit
 
+@MainActor
 final class ChatResumeStoreTests: XCTestCase {
     private func defaults() throws -> (UserDefaults, String) {
         let suite = "ChatResumeStoreTests.\(UUID().uuidString)"

--- a/ConduitTests/ChatResumeStoreTests.swift
+++ b/ConduitTests/ChatResumeStoreTests.swift
@@ -2,20 +2,21 @@ import XCTest
 @testable import Conduit
 
 final class ChatResumeStoreTests: XCTestCase {
-    private func defaults() -> (UserDefaults, String) {
+    private func defaults() throws -> (UserDefaults, String) {
         let suite = "ChatResumeStoreTests.\(UUID().uuidString)"
-        return (UserDefaults(suiteName: suite)!, suite)
+        let ud = try XCTUnwrap(UserDefaults(suiteName: suite), "Failed to create test UserDefaults suite")
+        return (ud, suite)
     }
 
-    func testUnsavedBehaviorDefaultsToContinueWhereLeftOff() {
-        let (defaults, suite) = defaults()
+    func testUnsavedBehaviorDefaultsToContinueWhereLeftOff() throws {
+        let (defaults, suite) = try defaults()
         defer { defaults.removePersistentDomain(forName: suite) }
 
         XCTAssertEqual(ChatResumeStore(defaults: defaults).behavior, .continueWhereLeftOff)
     }
 
-    func testPreferenceSessionAndAnchorSurviveStoreRecreation() {
-        let (defaults, suite) = defaults()
+    func testPreferenceSessionAndAnchorSurviveStoreRecreation() throws {
+        let (defaults, suite) = try defaults()
         defer { defaults.removePersistentDomain(forName: suite) }
         let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
         let snapshot = ChatScrollSnapshot(
@@ -37,8 +38,8 @@ final class ChatResumeStoreTests: XCTestCase {
         XCTAssertEqual(restored.snapshot(for: key), snapshot)
     }
 
-    func testCorruptPayloadFallsBackWithoutThrowing() {
-        let (defaults, suite) = defaults()
+    func testCorruptPayloadFallsBackWithoutThrowing() throws {
+        let (defaults, suite) = try defaults()
         defer { defaults.removePersistentDomain(forName: suite) }
         defaults.set(Data("not-json".utf8), forKey: ChatResumeStore.defaultStorageKey)
 
@@ -48,8 +49,8 @@ final class ChatResumeStoreTests: XCTestCase {
         XCTAssertNil(store.lastSessionID(for: "default"))
     }
 
-    func testLegacySessionMapImportsOnlyOnce() {
-        let (defaults, suite) = defaults()
+    func testLegacySessionMapImportsOnlyOnce() throws {
+        let (defaults, suite) = try defaults()
         defer { defaults.removePersistentDomain(forName: suite) }
         defaults.set(["default": "stored-a"], forKey: "legacy")
         _ = ChatResumeStore(defaults: defaults, legacyActiveSessionsKey: "legacy")
@@ -62,7 +63,7 @@ final class ChatResumeStoreTests: XCTestCase {
     }
 
     func testUnknownVersionResetsToDefault() throws {
-        let (defaults, suite) = defaults()
+        let (defaults, suite) = try defaults()
         defer { defaults.removePersistentDomain(forName: suite) }
         let data = try JSONSerialization.data(withJSONObject: [
             "version": 999,
@@ -75,8 +76,8 @@ final class ChatResumeStoreTests: XCTestCase {
         XCTAssertEqual(ChatResumeStore(defaults: defaults).behavior, .continueWhereLeftOff)
     }
 
-    func testPruningKeepsNewestHundredSnapshots() {
-        let (defaults, suite) = defaults()
+    func testPruningKeepsNewestHundredSnapshots() throws {
+        let (defaults, suite) = try defaults()
         defer { defaults.removePersistentDomain(forName: suite) }
         let store = ChatResumeStore(defaults: defaults)
         for index in 0...100 {
@@ -90,8 +91,8 @@ final class ChatResumeStoreTests: XCTestCase {
         XCTAssertNotNil(store.snapshot(for: .init(profile: "default", sessionID: "session-100")))
     }
 
-    func testClearResumeStatePreservesBehavior() {
-        let (defaults, suite) = defaults()
+    func testClearResumeStatePreservesBehavior() throws {
+        let (defaults, suite) = try defaults()
         defer { defaults.removePersistentDomain(forName: suite) }
         let store = ChatResumeStore(defaults: defaults)
         store.setBehavior(.latestActivity)
@@ -104,8 +105,8 @@ final class ChatResumeStoreTests: XCTestCase {
         XCTAssertNil(store.snapshot(for: .init(profile: "default", sessionID: "stored-a")))
     }
 
-    func testSnapshotMigratesFromRuntimeToCanonicalKey() {
-        let (defaults, suite) = defaults()
+    func testSnapshotMigratesFromRuntimeToCanonicalKey() throws {
+        let (defaults, suite) = try defaults()
         defer { defaults.removePersistentDomain(forName: suite) }
         let store = ChatResumeStore(defaults: defaults)
         let runtime = ChatScrollSessionKey(profile: "default", sessionID: "runtime-a")
@@ -123,8 +124,8 @@ final class ChatResumeStoreTests: XCTestCase {
         XCTAssertEqual(store.snapshot(for: canonical), snapshot)
     }
 
-    func testMigrationRemovesRuntimeSnapshotAndPreservesNewerCanonicalSnapshot() {
-        let (defaults, suite) = defaults()
+    func testMigrationRemovesRuntimeSnapshotAndPreservesNewerCanonicalSnapshot() throws {
+        let (defaults, suite) = try defaults()
         defer { defaults.removePersistentDomain(forName: suite) }
         let store = ChatResumeStore(defaults: defaults)
         let runtime = ChatScrollSessionKey(profile: "default", sessionID: "runtime-a")
@@ -140,8 +141,8 @@ final class ChatResumeStoreTests: XCTestCase {
         XCTAssertEqual(store.snapshot(for: canonical), canonicalSnapshot)
     }
 
-    func testSessionIdentityMigrationMovesLastSessionAndPreservesNewerCanonicalSnapshot() {
-        let (defaults, suite) = defaults()
+    func testSessionIdentityMigrationMovesLastSessionAndPreservesNewerCanonicalSnapshot() throws {
+        let (defaults, suite) = try defaults()
         defer { defaults.removePersistentDomain(forName: suite) }
         let store = ChatResumeStore(defaults: defaults)
         let runtime = ChatScrollSessionKey(profile: "default", sessionID: "runtime-a")
@@ -161,7 +162,7 @@ final class ChatResumeStoreTests: XCTestCase {
     }
 
     func testEqualTimestampPruningUsesDeterministicKeyOrder() throws {
-        let (defaults, suite) = defaults()
+        let (defaults, suite) = try defaults()
         defer { defaults.removePersistentDomain(forName: suite) }
         let snapshots = (0...100).reversed().map { index in
             storedSnapshot(
@@ -179,7 +180,7 @@ final class ChatResumeStoreTests: XCTestCase {
     }
 
     func testEqualTimestampDuplicateSnapshotsUseDeterministicAnchorOrder() throws {
-        let (defaults, suite) = defaults()
+        let (defaults, suite) = try defaults()
         defer { defaults.removePersistentDomain(forName: suite) }
         defaults.set(try payloadData(snapshots: [
             storedSnapshot(sessionID: "session", anchorMessageID: "anchor-z", updatedAt: 0),
@@ -192,8 +193,8 @@ final class ChatResumeStoreTests: XCTestCase {
         )
     }
 
-    func testNormalizationCollisionUsesLexicographicallyFirstSessionID() {
-        let (defaults, suite) = defaults()
+    func testNormalizationCollisionUsesLexicographicallyFirstSessionID() throws {
+        let (defaults, suite) = try defaults()
         defer { defaults.removePersistentDomain(forName: suite) }
         defaults.set([
             "Default": "stored-z",

--- a/ConduitTests/ChatResumeStoreTests.swift
+++ b/ConduitTests/ChatResumeStoreTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+@testable import Conduit
+
+final class ChatResumeStoreTests: XCTestCase {
+    private func defaults() -> (UserDefaults, String) {
+        let suite = "ChatResumeStoreTests.\(UUID().uuidString)"
+        return (UserDefaults(suiteName: suite)!, suite)
+    }
+
+    func testUnsavedBehaviorDefaultsToContinueWhereLeftOff() {
+        let (defaults, suite) = defaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertEqual(ChatResumeStore(defaults: defaults).behavior, .continueWhereLeftOff)
+    }
+
+    func testPreferenceSessionAndAnchorSurviveStoreRecreation() {
+        let (defaults, suite) = defaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        let snapshot = ChatScrollSnapshot(
+            anchorMessageID: "anchor-12",
+            followsLatest: false,
+            anchorMetadata: .init(fingerprint: "fingerprint", duplicateCount: 1),
+            anchorSourceMessageID: "source-12"
+        )
+        let store = ChatResumeStore(defaults: defaults)
+
+        store.setBehavior(.latestActivity)
+        store.setLastSessionID("stored-a", for: "default")
+        store.save(snapshot, for: key, at: Date(timeIntervalSince1970: 100))
+        store.flush()
+
+        let restored = ChatResumeStore(defaults: defaults)
+        XCTAssertEqual(restored.behavior, .latestActivity)
+        XCTAssertEqual(restored.lastSessionID(for: "default"), "stored-a")
+        XCTAssertEqual(restored.snapshot(for: key), snapshot)
+    }
+
+    func testCorruptPayloadFallsBackWithoutThrowing() {
+        let (defaults, suite) = defaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(Data("not-json".utf8), forKey: ChatResumeStore.defaultStorageKey)
+
+        let store = ChatResumeStore(defaults: defaults)
+
+        XCTAssertEqual(store.behavior, .continueWhereLeftOff)
+        XCTAssertNil(store.lastSessionID(for: "default"))
+    }
+
+    func testLegacySessionMapImportsOnlyOnce() {
+        let (defaults, suite) = defaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(["default": "stored-a"], forKey: "legacy")
+        _ = ChatResumeStore(defaults: defaults, legacyActiveSessionsKey: "legacy")
+        defaults.set(["default": "stored-b"], forKey: "legacy")
+
+        XCTAssertEqual(
+            ChatResumeStore(defaults: defaults, legacyActiveSessionsKey: "legacy").lastSessionID(for: "default"),
+            "stored-a"
+        )
+    }
+
+    func testUnknownVersionResetsToDefault() throws {
+        let (defaults, suite) = defaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let data = try JSONSerialization.data(withJSONObject: [
+            "version": 999,
+            "behavior": "latestActivity",
+            "lastSessionIDsByProfile": ["default": "stored-a"],
+            "snapshots": []
+        ])
+        defaults.set(data, forKey: ChatResumeStore.defaultStorageKey)
+
+        XCTAssertEqual(ChatResumeStore(defaults: defaults).behavior, .continueWhereLeftOff)
+    }
+
+    func testPruningKeepsNewestHundredSnapshots() {
+        let (defaults, suite) = defaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = ChatResumeStore(defaults: defaults)
+        for index in 0...100 {
+            store.save(
+                .init(anchorMessageID: "anchor-\(index)", followsLatest: false),
+                for: .init(profile: "default", sessionID: "session-\(index)"),
+                at: Date(timeIntervalSince1970: TimeInterval(index))
+            )
+        }
+        XCTAssertNil(store.snapshot(for: .init(profile: "default", sessionID: "session-0")))
+        XCTAssertNotNil(store.snapshot(for: .init(profile: "default", sessionID: "session-100")))
+    }
+
+    func testClearResumeStatePreservesBehavior() {
+        let (defaults, suite) = defaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = ChatResumeStore(defaults: defaults)
+        store.setBehavior(.latestActivity)
+        store.setLastSessionID("stored-a", for: "default")
+        store.save(.latest, for: .init(profile: "default", sessionID: "stored-a"), at: Date())
+        store.clearResumeState()
+
+        XCTAssertEqual(store.behavior, .latestActivity)
+        XCTAssertNil(store.lastSessionID(for: "default"))
+        XCTAssertNil(store.snapshot(for: .init(profile: "default", sessionID: "stored-a")))
+    }
+
+    func testSnapshotMigratesFromRuntimeToCanonicalKey() {
+        let (defaults, suite) = defaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = ChatResumeStore(defaults: defaults)
+        let runtime = ChatScrollSessionKey(profile: "default", sessionID: "runtime-a")
+        let canonical = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        let snapshot = ChatScrollSnapshot(
+            anchorMessageID: "anchor-12",
+            followsLatest: false,
+            anchorMetadata: .init(fingerprint: "fingerprint", duplicateCount: 2),
+            anchorSourceMessageID: "source-12"
+        )
+        store.save(snapshot, for: runtime, at: Date())
+
+        store.migrateSnapshot(from: runtime, to: canonical)
+
+        XCTAssertEqual(store.snapshot(for: canonical), snapshot)
+    }
+}

--- a/ConduitTests/ChatResumeStoreTests.swift
+++ b/ConduitTests/ChatResumeStoreTests.swift
@@ -122,4 +122,95 @@ final class ChatResumeStoreTests: XCTestCase {
 
         XCTAssertEqual(store.snapshot(for: canonical), snapshot)
     }
+
+    func testMigrationRemovesRuntimeSnapshotAndPreservesNewerCanonicalSnapshot() {
+        let (defaults, suite) = defaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = ChatResumeStore(defaults: defaults)
+        let runtime = ChatScrollSessionKey(profile: "default", sessionID: "runtime-a")
+        let canonical = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        let runtimeSnapshot = ChatScrollSnapshot(anchorMessageID: "runtime-anchor", followsLatest: false)
+        let canonicalSnapshot = ChatScrollSnapshot(anchorMessageID: "canonical-anchor", followsLatest: false)
+        store.save(runtimeSnapshot, for: runtime, at: Date(timeIntervalSince1970: 100))
+        store.save(canonicalSnapshot, for: canonical, at: Date(timeIntervalSince1970: 200))
+
+        store.migrateSnapshot(from: runtime, to: canonical)
+
+        XCTAssertNil(store.snapshot(for: runtime))
+        XCTAssertEqual(store.snapshot(for: canonical), canonicalSnapshot)
+    }
+
+    func testEqualTimestampPruningUsesDeterministicKeyOrder() throws {
+        let (defaults, suite) = defaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let snapshots = (0...100).reversed().map { index in
+            storedSnapshot(
+                sessionID: String(format: "session-%03d", index),
+                anchorMessageID: "anchor-\(index)",
+                updatedAt: 0
+            )
+        }
+        defaults.set(try payloadData(snapshots: snapshots), forKey: ChatResumeStore.defaultStorageKey)
+
+        let store = ChatResumeStore(defaults: defaults)
+
+        XCTAssertNotNil(store.snapshot(for: .init(profile: "default", sessionID: "session-000")))
+        XCTAssertNil(store.snapshot(for: .init(profile: "default", sessionID: "session-100")))
+    }
+
+    func testEqualTimestampDuplicateSnapshotsUseDeterministicAnchorOrder() throws {
+        let (defaults, suite) = defaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(try payloadData(snapshots: [
+            storedSnapshot(sessionID: "session", anchorMessageID: "anchor-z", updatedAt: 0),
+            storedSnapshot(sessionID: "session", anchorMessageID: "anchor-a", updatedAt: 0)
+        ]), forKey: ChatResumeStore.defaultStorageKey)
+
+        XCTAssertEqual(
+            ChatResumeStore(defaults: defaults).snapshot(for: .init(profile: "default", sessionID: "session")),
+            ChatScrollSnapshot(anchorMessageID: "anchor-a", followsLatest: false)
+        )
+    }
+
+    func testNormalizationCollisionUsesLexicographicallyFirstSessionID() {
+        let (defaults, suite) = defaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set([
+            "Default": "stored-z",
+            " default ": "stored-y",
+            "DEFAULT": "stored-x",
+            " default": "stored-a"
+        ], forKey: "legacy")
+
+        XCTAssertEqual(
+            ChatResumeStore(defaults: defaults, legacyActiveSessionsKey: "legacy").lastSessionID(for: "DEFAULT"),
+            "stored-a"
+        )
+    }
+
+    private func payloadData(snapshots: [[String: Any]]) throws -> Data {
+        try JSONSerialization.data(withJSONObject: [
+            "version": 1,
+            "behavior": "continueWhereLeftOff",
+            "lastSessionIDsByProfile": [:],
+            "snapshots": snapshots
+        ])
+    }
+
+    private func storedSnapshot(
+        sessionID: String,
+        anchorMessageID: String,
+        updatedAt: TimeInterval
+    ) -> [String: Any] {
+        [
+            "key": ["profile": "default", "sessionID": sessionID],
+            "snapshot": [
+                "anchorMessageID": anchorMessageID,
+                "followsLatest": false,
+                "anchorMetadata": NSNull(),
+                "anchorSourceMessageID": NSNull()
+            ],
+            "updatedAt": updatedAt
+        ]
+    }
 }

--- a/ConduitTests/ChatScrollStateTests.swift
+++ b/ConduitTests/ChatScrollStateTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import Conduit
+
+final class ChatScrollStateTests: XCTestCase {
+    func testSnapshotsAreIsolatedBySession() {
+        var store = ChatScrollStateStore()
+        store.save(
+            ChatScrollSnapshot(anchorMessageID: "a-3", followsLatest: false),
+            for: "session-a"
+        )
+        store.save(
+            ChatScrollSnapshot(anchorMessageID: "b-1", followsLatest: false),
+            for: "session-b"
+        )
+
+        XCTAssertEqual(store.snapshot(for: "session-a")?.anchorMessageID, "a-3")
+        XCTAssertEqual(store.snapshot(for: "session-b")?.anchorMessageID, "b-1")
+    }
+
+    func testRestorationKeepsAnchorWhenMessageStillExists() {
+        var store = ChatScrollStateStore()
+        let expected = ChatScrollSnapshot(anchorMessageID: "message-4", followsLatest: false)
+        store.save(expected, for: "session")
+
+        XCTAssertEqual(
+            store.restoration(
+                for: "session",
+                availableMessageIDs: ["message-3", "message-4", "message-5"]
+            ),
+            expected
+        )
+    }
+
+    func testRestorationFallsBackToLatestWhenAnchorDisappears() {
+        var store = ChatScrollStateStore()
+        store.save(
+            ChatScrollSnapshot(anchorMessageID: "deleted", followsLatest: false),
+            for: "session"
+        )
+
+        XCTAssertEqual(
+            store.restoration(for: "session", availableMessageIDs: ["message-1"]),
+            .latest
+        )
+    }
+
+    func testLatestSnapshotRemainsLatestRegardlessOfAvailableMessages() {
+        var store = ChatScrollStateStore()
+        store.save(ChatScrollSnapshot.latest, for: "session")
+
+        XCTAssertEqual(
+            store.restoration(for: "session", availableMessageIDs: []),
+            .latest
+        )
+    }
+
+    func testSessionKeysAreTrimmedForSaveAndLookup() {
+        var store = ChatScrollStateStore()
+        let expected = ChatScrollSnapshot(anchorMessageID: "message-1", followsLatest: false)
+        store.save(expected, for: "  session  ")
+
+        XCTAssertEqual(store.snapshot(for: "session"), expected)
+        XCTAssertEqual(store.snapshot(for: "\n session \t"), expected)
+    }
+
+    func testWhitespaceOnlySessionKeysAreIgnored() {
+        var store = ChatScrollStateStore()
+        store.save(ChatScrollSnapshot.latest, for: " \n\t ")
+
+        XCTAssertNil(store.snapshot(for: " \n\t "))
+    }
+}

--- a/ConduitTests/ChatScrollStateTests.swift
+++ b/ConduitTests/ChatScrollStateTests.swift
@@ -13,18 +13,22 @@ final class ChatScrollStateTests: XCTestCase {
             maximumChecks: 8,
             retryInterval: 2
         )
-        let staleContent = ChatRenderedScrollContent(
+        let staleScope = ChatRenderedScrollScope(
             sessionKey: sessionB,
             cacheRevision: 7,
-            semanticTargetIDs: [anchor],
-            bottomAnchorID: "chat-latest-default-session-b",
-            restorationGeneration: 41
+            restorationGeneration: 41,
+            transcriptRevision: 12,
+            viewportTransitionGeneration: 2
         )
+        let staleContent = ChatRenderedScrollContent(scope: staleScope)
+        var installedTargets = ChatRenderedScrollTargets()
 
         XCTAssertEqual(
             restoration.nextAction(
                 renderedContent: staleContent,
+                installedTargets: installedTargets,
                 cacheRevision: 7,
+                transcriptRevision: 12,
                 topVisibleID: nil,
                 isNearBottom: false
             ),
@@ -33,7 +37,9 @@ final class ChatScrollStateTests: XCTestCase {
         XCTAssertEqual(
             restoration.nextAction(
                 renderedContent: staleContent,
+                installedTargets: installedTargets,
                 cacheRevision: 7,
+                transcriptRevision: 12,
                 topVisibleID: nil,
                 isNearBottom: false
             ),
@@ -41,70 +47,92 @@ final class ChatScrollStateTests: XCTestCase {
             "A delayed row must not be treated as installed after one task yield"
         )
 
-        let staleGeneration = ChatRenderedScrollContent(
+        let staleGenerationScope = ChatRenderedScrollScope(
             sessionKey: sessionA,
             cacheRevision: 8,
-            semanticTargetIDs: [anchor],
-            bottomAnchorID: "chat-latest-default-session-a",
-            restorationGeneration: 40
+            restorationGeneration: 40,
+            transcriptRevision: 13,
+            viewportTransitionGeneration: 2
         )
+        let staleGeneration = ChatRenderedScrollContent(scope: staleGenerationScope)
         XCTAssertEqual(
             restoration.nextAction(
                 renderedContent: staleGeneration,
+                installedTargets: installedTargets,
                 cacheRevision: 8,
+                transcriptRevision: 13,
                 topVisibleID: anchor,
                 isNearBottom: false
             ),
             .wait
         )
 
-        let matchingContentWithoutAnchor = ChatRenderedScrollContent(
+        let matchingScope = ChatRenderedScrollScope(
             sessionKey: sessionA,
             cacheRevision: 8,
-            semanticTargetIDs: ["different-anchor"],
-            bottomAnchorID: "chat-latest-default-session-a",
-            restorationGeneration: 41
+            restorationGeneration: 41,
+            transcriptRevision: 13,
+            viewportTransitionGeneration: 2
+        )
+        let matchingContentWithoutAnchor = ChatRenderedScrollContent(scope: matchingScope)
+        XCTAssertEqual(
+            restoration.nextAction(
+                renderedContent: matchingContentWithoutAnchor,
+                installedTargets: installedTargets,
+                cacheRevision: 8,
+                transcriptRevision: 13,
+                topVisibleID: nil,
+                isNearBottom: false
+            ),
+            .scroll(.anchor(anchor)),
+            "A matching container may bootstrap an offscreen lazy target"
+        )
+
+        ChatRenderedScrollTargets.reduce(
+            value: &installedTargets,
+            nextValue: ChatRenderedScrollTargets.row(
+                semanticID: "different-anchor",
+                scope: matchingScope
+            )
         )
         XCTAssertEqual(
             restoration.nextAction(
                 renderedContent: matchingContentWithoutAnchor,
+                installedTargets: installedTargets,
                 cacheRevision: 8,
-                topVisibleID: nil,
-                isNearBottom: false
-            ),
-            .wait
-        )
-
-        let installedContent = ChatRenderedScrollContent(
-            sessionKey: sessionA,
-            cacheRevision: 8,
-            semanticTargetIDs: [anchor],
-            bottomAnchorID: "chat-latest-default-session-a",
-            restorationGeneration: 41
-        )
-        XCTAssertEqual(
-            restoration.nextAction(
-                renderedContent: installedContent,
-                cacheRevision: 8,
-                topVisibleID: nil,
-                isNearBottom: false
-            ),
-            .scroll(.anchor(anchor))
-        )
-        XCTAssertEqual(
-            restoration.nextAction(
-                renderedContent: installedContent,
-                cacheRevision: 8,
+                transcriptRevision: 13,
                 topVisibleID: nil,
                 isNearBottom: false
             ),
             .wait,
-            "A scroll request that did not move geometry must not complete restoration"
+            "A different rendered row must not confirm an offscreen cache target"
+        )
+
+        ChatRenderedScrollTargets.reduce(
+            value: &installedTargets,
+            nextValue: ChatRenderedScrollTargets.row(
+                semanticID: anchor,
+                scope: matchingScope
+            )
         )
         XCTAssertEqual(
             restoration.nextAction(
-                renderedContent: installedContent,
+                renderedContent: matchingContentWithoutAnchor,
+                installedTargets: installedTargets,
                 cacheRevision: 8,
+                transcriptRevision: 13,
+                topVisibleID: nil,
+                isNearBottom: false
+            ),
+            .scroll(.anchor(anchor)),
+            "Installing the delayed target retries the scroll but does not complete it"
+        )
+        XCTAssertEqual(
+            restoration.nextAction(
+                renderedContent: matchingContentWithoutAnchor,
+                installedTargets: installedTargets,
+                cacheRevision: 8,
+                transcriptRevision: 13,
                 topVisibleID: anchor,
                 isNearBottom: false
             ),
@@ -124,21 +152,84 @@ final class ChatScrollStateTests: XCTestCase {
         )
         restoration.cancel()
 
-        let installedContent = ChatRenderedScrollContent(
+        let scope = ChatRenderedScrollScope(
             sessionKey: session,
             cacheRevision: 3,
-            semanticTargetIDs: [anchor],
-            bottomAnchorID: "chat-latest-default-session-a",
-            restorationGeneration: 42
+            restorationGeneration: 42,
+            transcriptRevision: 1,
+            viewportTransitionGeneration: 0
         )
+        let installedContent = ChatRenderedScrollContent(scope: scope)
+        let installedTargets = ChatRenderedScrollTargets.row(semanticID: anchor, scope: scope)
         XCTAssertEqual(
             restoration.nextAction(
                 renderedContent: installedContent,
+                installedTargets: installedTargets,
                 cacheRevision: 3,
+                transcriptRevision: 1,
                 topVisibleID: anchor,
                 isNearBottom: false
             ),
             .cancelled
+        )
+    }
+
+    func testMatchingScrollPositionCannotCompleteBeforeActualRowRegistration() {
+        let session = ChatScrollSessionKey(profile: "default", sessionID: "session-a")
+        let anchor = "offscreen-anchor"
+        let scope = ChatRenderedScrollScope(
+            sessionKey: session,
+            cacheRevision: 5,
+            restorationGeneration: 45,
+            transcriptRevision: 2,
+            viewportTransitionGeneration: 0
+        )
+        let content = ChatRenderedScrollContent(scope: scope)
+        var restoration = ChatResumeRenderRestorationState(
+            generation: 45,
+            sessionKey: session,
+            destination: .anchor(anchor),
+            maximumChecks: 8,
+            retryInterval: 4
+        )
+
+        XCTAssertEqual(
+            restoration.nextAction(
+                renderedContent: content,
+                installedTargets: ChatRenderedScrollTargets(),
+                cacheRevision: 5,
+                transcriptRevision: 2,
+                topVisibleID: nil,
+                isNearBottom: false
+            ),
+            .scroll(.anchor(anchor))
+        )
+        XCTAssertEqual(
+            restoration.nextAction(
+                renderedContent: content,
+                installedTargets: ChatRenderedScrollTargets(),
+                cacheRevision: 5,
+                transcriptRevision: 2,
+                topVisibleID: anchor,
+                isNearBottom: false
+            ),
+            .wait
+        )
+
+        let installed = ChatRenderedScrollTargets.row(
+            semanticID: anchor,
+            scope: scope
+        )
+        XCTAssertEqual(
+            restoration.nextAction(
+                renderedContent: content,
+                installedTargets: installed,
+                cacheRevision: 5,
+                transcriptRevision: 2,
+                topVisibleID: anchor,
+                isNearBottom: false
+            ),
+            .complete
         )
     }
 
@@ -151,18 +242,25 @@ final class ChatScrollStateTests: XCTestCase {
             maximumChecks: 8,
             retryInterval: 2
         )
-        let installedContent = ChatRenderedScrollContent(
+        let scope = ChatRenderedScrollScope(
             sessionKey: session,
             cacheRevision: 4,
-            semanticTargetIDs: [],
-            bottomAnchorID: "chat-latest-default-session-a",
-            restorationGeneration: 43
+            restorationGeneration: 43,
+            transcriptRevision: 1,
+            viewportTransitionGeneration: 0
+        )
+        let installedContent = ChatRenderedScrollContent(scope: scope)
+        let installedTargets = ChatRenderedScrollTargets.bottom(
+            anchorID: "chat-latest-default-session-a",
+            scope: scope
         )
 
         XCTAssertEqual(
             restoration.nextAction(
                 renderedContent: installedContent,
+                installedTargets: installedTargets,
                 cacheRevision: 4,
+                transcriptRevision: 1,
                 topVisibleID: nil,
                 isNearBottom: false
             ),
@@ -171,7 +269,9 @@ final class ChatScrollStateTests: XCTestCase {
         XCTAssertEqual(
             restoration.nextAction(
                 renderedContent: installedContent,
+                installedTargets: installedTargets,
                 cacheRevision: 4,
+                transcriptRevision: 1,
                 topVisibleID: nil,
                 isNearBottom: false
             ),
@@ -180,11 +280,66 @@ final class ChatScrollStateTests: XCTestCase {
         XCTAssertEqual(
             restoration.nextAction(
                 renderedContent: installedContent,
+                installedTargets: installedTargets,
                 cacheRevision: 4,
+                transcriptRevision: 1,
                 topVisibleID: nil,
                 isNearBottom: true
             ),
             .complete
+        )
+    }
+
+    func testRenderRestorationTimesOutWithoutAnActuallyRegisteredTarget() {
+        let session = ChatScrollSessionKey(profile: "default", sessionID: "session-a")
+        let scope = ChatRenderedScrollScope(
+            sessionKey: session,
+            cacheRevision: 9,
+            restorationGeneration: 44,
+            transcriptRevision: 3,
+            viewportTransitionGeneration: 0
+        )
+        let content = ChatRenderedScrollContent(scope: scope)
+        var restoration = ChatResumeRenderRestorationState(
+            generation: 44,
+            sessionKey: session,
+            destination: .anchor("offscreen-anchor"),
+            maximumChecks: 2,
+            retryInterval: 1
+        )
+
+        XCTAssertEqual(
+            restoration.nextAction(
+                renderedContent: content,
+                installedTargets: ChatRenderedScrollTargets(),
+                cacheRevision: 9,
+                transcriptRevision: 3,
+                topVisibleID: nil,
+                isNearBottom: false
+            ),
+            .scroll(.anchor("offscreen-anchor"))
+        )
+        XCTAssertEqual(
+            restoration.nextAction(
+                renderedContent: content,
+                installedTargets: ChatRenderedScrollTargets(),
+                cacheRevision: 9,
+                transcriptRevision: 3,
+                topVisibleID: nil,
+                isNearBottom: false
+            ),
+            .scroll(.anchor("offscreen-anchor"))
+        )
+        XCTAssertEqual(
+            restoration.nextAction(
+                renderedContent: content,
+                installedTargets: ChatRenderedScrollTargets(),
+                cacheRevision: 9,
+                transcriptRevision: 3,
+                topVisibleID: nil,
+                isNearBottom: false
+            ),
+            .abandon
         )
     }
 

--- a/ConduitTests/ChatScrollStateTests.swift
+++ b/ConduitTests/ChatScrollStateTests.swift
@@ -908,4 +908,102 @@ final class ChatScrollStateTests: XCTestCase {
 
         XCTAssertNil(store.snapshot(for: key))
     }
+
+    func testSessionSwitchPreservesSavedBrowsePositionInsteadOfForcingLatest() {
+        let oldKey = ChatScrollSessionKey(profile: "default", sessionID: "old")
+        let newKey = ChatScrollSessionKey(profile: "default", sessionID: "new")
+        let snapshot = ChatScrollSnapshot(anchorMessageID: "message-12", followsLatest: false)
+
+        XCTAssertEqual(
+            ChatScrollSessionTransitionPolicy.action(
+                from: oldKey,
+                to: newKey,
+                snapshot: snapshot
+            ),
+            .restore
+        )
+    }
+
+    func testSessionSwitchWithoutSavedBrowsePositionStillUsesLatest() {
+        let oldKey = ChatScrollSessionKey(profile: "default", sessionID: "old")
+        let newKey = ChatScrollSessionKey(profile: "default", sessionID: "new")
+
+        XCTAssertEqual(
+            ChatScrollSessionTransitionPolicy.action(
+                from: oldKey,
+                to: newKey,
+                snapshot: nil
+            ),
+            .latest
+        )
+    }
+
+    func testRestorationReanchorsBySourceMessageWhenContentProjectionChanges() {
+        let original = ChatMessage(
+            id: "stable-source-id",
+            role: .assistant,
+            content: "The response is still streaming",
+            timestamp: "now"
+        )
+        let refreshed = ChatMessage(
+            id: "stable-source-id",
+            role: .assistant,
+            content: "The response is still streaming, but now complete",
+            timestamp: "stored"
+        )
+        let originalTarget = ChatMessageScrollTargets.make(for: [original])[0]
+        let refreshedTarget = ChatMessageScrollTargets.make(for: [refreshed])[0]
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
+        var store = ChatScrollStateStore()
+        store.save(
+            ChatScrollSnapshot(
+                anchorMessageID: originalTarget.semanticID,
+                followsLatest: false,
+                anchorMetadata: originalTarget.restorationMetadata,
+                anchorSourceMessageID: originalTarget.id
+            ),
+            for: key
+        )
+
+        let restored = store.restoration(
+            for: key,
+            availableTargets: ChatScrollTargetAvailability(targets: [refreshedTarget])
+        )
+
+        XCTAssertEqual(restored?.anchorMessageID, refreshedTarget.semanticID)
+        XCTAssertEqual(restored?.anchorSourceMessageID, "stable-source-id")
+    }
+
+    func testRuntimeSessionIDPersistsAsCatalogCanonicalID() {
+        let identity = ChatScrollSessionIdentity(
+            profile: "default",
+            canonicalSessionID: "catalog-session",
+            equivalentSessionIDs: ["runtime-session"],
+            isReconciling: true,
+            settledRevision: 0
+        )
+        let catalog = [
+            SessionSummary(
+                id: "catalog-session",
+                alternateIds: [],
+                title: "Conversation",
+                model: "Hermes",
+                updatedLabel: "now",
+                profile: "default",
+                source: .chat,
+                isActive: true,
+                isArchived: false,
+                lineageRootId: nil
+            )
+        ]
+
+        XCTAssertEqual(
+            ChatSessionPersistenceIdentity.canonicalID(
+                for: "runtime-session",
+                identity: identity,
+                catalog: catalog
+            ),
+            "catalog-session"
+        )
+    }
 }

--- a/ConduitTests/ChatScrollStateTests.swift
+++ b/ConduitTests/ChatScrollStateTests.swift
@@ -2,6 +2,294 @@ import XCTest
 @testable import Conduit
 
 final class ChatScrollStateTests: XCTestCase {
+    func testSemanticAnchorsIgnoreSourceSpecificMessageIdentity() {
+        let localMessages = [
+            ChatMessage(
+                id: "local-user",
+                role: .user,
+                content: "Compare these files",
+                timestamp: "2026-08-08T12:00:00Z",
+                author: "Local user",
+                attachments: [
+                    Attachment(
+                        id: "picker-attachment",
+                        name: "diagram.png",
+                        uri: "file:///tmp/diagram.png",
+                        mimeType: "image/png",
+                        kind: .image
+                    )
+                ]
+            ),
+            ChatMessage(
+                id: "live-assistant",
+                role: .assistant,
+                content: "The files match.",
+                rawContent: "live projection",
+                timestamp: "2026-08-08T12:00:01Z",
+                author: "Hermes",
+                code: "diff --brief a b"
+            )
+        ]
+        let persistedMessages = [
+            ChatMessage(
+                id: "481",
+                role: .user,
+                content: "Compare these files",
+                timestamp: "2026-08-08 12:00:00",
+                author: nil,
+                attachments: [
+                    Attachment(
+                        id: "481-gateway-image-0",
+                        name: "diagram.png",
+                        uri: "/gateway/uploads/diagram.png",
+                        mimeType: "image/png",
+                        kind: .image
+                    )
+                ]
+            ),
+            ChatMessage(
+                id: "482",
+                role: .assistant,
+                content: "The files match.",
+                rawContent: nil,
+                timestamp: "2026-08-08 12:00:01",
+                author: "assistant",
+                code: "diff --brief a b"
+            )
+        ]
+
+        XCTAssertEqual(
+            ChatMessageScrollTargets.make(for: localMessages).map(\.semanticID),
+            ChatMessageScrollTargets.make(for: persistedMessages).map(\.semanticID)
+        )
+    }
+
+    func testDuplicateSemanticRowsReceiveDistinctOccurrenceQualifiedAnchors() {
+        let firstProjection = [
+            ChatMessage(id: "live-1", role: .assistant, content: "Repeated", timestamp: "now"),
+            ChatMessage(id: "live-2", role: .assistant, content: "Repeated", timestamp: "later")
+        ]
+        let secondProjection = [
+            ChatMessage(id: "stored-91", role: .assistant, content: "Repeated", timestamp: "1"),
+            ChatMessage(id: "stored-92", role: .assistant, content: "Repeated", timestamp: "2")
+        ]
+
+        let firstIDs = ChatMessageScrollTargets.make(for: firstProjection).map(\.semanticID)
+        let secondIDs = ChatMessageScrollTargets.make(for: secondProjection).map(\.semanticID)
+
+        XCTAssertNotEqual(firstIDs[0], firstIDs[1])
+        XCTAssertEqual(firstIDs, secondIDs)
+    }
+
+    func testStableActivityAndAttachmentFieldsParticipateInSemanticFingerprint() {
+        func semanticID(for message: ChatMessage) -> String {
+            ChatMessageScrollTargets.make(for: [message])[0].semanticID
+        }
+
+        let toolA = ChatMessage(
+            id: "tool-a",
+            role: .tool,
+            content: "",
+            timestamp: "now",
+            tool: ToolActivity(id: "call-a", name: "read", input: "a.txt", output: nil, status: .running)
+        )
+        let toolB = ChatMessage(
+            id: "tool-b",
+            role: .tool,
+            content: "",
+            timestamp: "now",
+            tool: ToolActivity(id: "call-b", name: "read", input: "b.txt", output: nil, status: .running)
+        )
+        let clarifyA = ChatMessage(
+            id: "clarify-a",
+            role: .clarify,
+            content: "Choose one",
+            timestamp: "now",
+            clarify: ClarifyActivity(
+                requestId: "request-a",
+                question: "Choose one",
+                choices: [ClarifyChoice(label: "Alpha", value: "a")],
+                status: .pending,
+                answer: nil,
+                error: nil
+            )
+        )
+        let clarifyB = ChatMessage(
+            id: "clarify-b",
+            role: .clarify,
+            content: "Choose one",
+            timestamp: "now",
+            clarify: ClarifyActivity(
+                requestId: "request-b",
+                question: "Choose one",
+                choices: [ClarifyChoice(label: "Beta", value: "b")],
+                status: .pending,
+                answer: nil,
+                error: nil
+            )
+        )
+        let approvalA = ChatMessage(
+            id: "approval-a",
+            role: .approval,
+            content: "Approval required",
+            timestamp: "now",
+            approval: ApprovalActivity(
+                sessionId: "runtime-a",
+                command: "git status",
+                description: "Approval required",
+                choices: ["allow", "deny"],
+                allowPermanent: true,
+                smartDenied: false,
+                status: .pending,
+                choice: nil,
+                error: nil
+            )
+        )
+        let approvalB = ChatMessage(
+            id: "approval-b",
+            role: .approval,
+            content: "Approval required",
+            timestamp: "now",
+            approval: ApprovalActivity(
+                sessionId: "runtime-b",
+                command: "git diff",
+                description: "Approval required",
+                choices: ["allow", "deny"],
+                allowPermanent: true,
+                smartDenied: false,
+                status: .pending,
+                choice: nil,
+                error: nil
+            )
+        )
+        let reviewA = ChatMessage(
+            id: "review-a",
+            role: .system,
+            content: "Review complete",
+            timestamp: "now",
+            review: ReviewActivity(summary: "Review complete", details: ["Memory updated"], fullSessionId: "child-a")
+        )
+        let reviewB = ChatMessage(
+            id: "review-b",
+            role: .system,
+            content: "Review complete",
+            timestamp: "now",
+            review: ReviewActivity(summary: "Review complete", details: ["Skill updated"], fullSessionId: "child-b")
+        )
+        let attachmentA = ChatMessage(
+            id: "attachment-a",
+            role: .user,
+            content: "Attached",
+            timestamp: "now",
+            attachments: [Attachment(id: "a", name: "a.pdf", uri: "/tmp/a.pdf", mimeType: "application/pdf", kind: .document)]
+        )
+        let attachmentB = ChatMessage(
+            id: "attachment-b",
+            role: .user,
+            content: "Attached",
+            timestamp: "now",
+            attachments: [Attachment(id: "b", name: "b.pdf", uri: "/tmp/b.pdf", mimeType: "application/pdf", kind: .document)]
+        )
+
+        XCTAssertNotEqual(semanticID(for: toolA), semanticID(for: toolB))
+        XCTAssertNotEqual(semanticID(for: clarifyA), semanticID(for: clarifyB))
+        XCTAssertNotEqual(semanticID(for: approvalA), semanticID(for: approvalB))
+        XCTAssertNotEqual(semanticID(for: reviewA), semanticID(for: reviewB))
+        XCTAssertNotEqual(semanticID(for: attachmentA), semanticID(for: attachmentB))
+    }
+
+    func testVolatileActivityIdentityAndStateDoNotChangeSemanticAnchor() {
+        let pending = ChatMessage(
+            id: "live",
+            role: .approval,
+            content: "Run command?",
+            timestamp: "now",
+            approval: ApprovalActivity(
+                sessionId: "runtime-old",
+                command: "make test",
+                description: "Run command?",
+                choices: ["allow", "deny"],
+                allowPermanent: true,
+                smartDenied: false,
+                status: .pending,
+                choice: nil,
+                error: nil
+            )
+        )
+        let persisted = ChatMessage(
+            id: "stored",
+            role: .approval,
+            content: "Run command?",
+            timestamp: "stored timestamp",
+            approval: ApprovalActivity(
+                sessionId: "runtime-new",
+                command: "make test",
+                description: "Run command?",
+                choices: ["allow", "deny"],
+                allowPermanent: true,
+                smartDenied: false,
+                status: .approved,
+                choice: "allow",
+                error: nil
+            )
+        )
+
+        XCTAssertEqual(
+            ChatMessageScrollTargets.make(for: [pending]).map(\.semanticID),
+            ChatMessageScrollTargets.make(for: [persisted]).map(\.semanticID)
+        )
+    }
+
+    func testEquivalentSessionIDsShareCanonicalIdentity() {
+        let identity = ChatScrollSessionIdentity(
+            canonicalSessionID: "catalog-id",
+            equivalentSessionIDs: ["runtime-old", "runtime-new"],
+            isReconciling: false,
+            settledRevision: 4
+        )
+
+        XCTAssertEqual(identity.canonicalSessionID, "catalog-id")
+        XCTAssertTrue(identity.areEquivalent("catalog-id", "runtime-old"))
+        XCTAssertTrue(identity.areEquivalent("runtime-old", "runtime-new"))
+        XCTAssertFalse(identity.areEquivalent("runtime-old", "different-session"))
+    }
+
+    func testNonLatestRestorationWaitsForReconciliationToSettleAtNewRevision() {
+        let activeIdentity = ChatScrollSessionIdentity(
+            canonicalSessionID: "catalog-id",
+            equivalentSessionIDs: ["runtime-id"],
+            isReconciling: true,
+            settledRevision: 7
+        )
+        let gate = ChatScrollRestorationGate(observing: activeIdentity)
+
+        XCTAssertFalse(gate.allowsNonLatestRestoration(using: activeIdentity))
+        XCTAssertFalse(gate.allowsNonLatestRestoration(using: ChatScrollSessionIdentity(
+            canonicalSessionID: "catalog-id",
+            equivalentSessionIDs: ["runtime-id"],
+            isReconciling: false,
+            settledRevision: 7
+        )))
+        XCTAssertTrue(gate.allowsNonLatestRestoration(using: ChatScrollSessionIdentity(
+            canonicalSessionID: "catalog-id",
+            equivalentSessionIDs: ["runtime-id"],
+            isReconciling: false,
+            settledRevision: 8
+        )))
+    }
+
+    func testNonLatestRestorationCanUseCurrentRevisionWhenNoReconciliationIsExpected() {
+        let settledIdentity = ChatScrollSessionIdentity(
+            canonicalSessionID: "catalog-id",
+            equivalentSessionIDs: [],
+            isReconciling: false,
+            settledRevision: 3
+        )
+        let gate = ChatScrollRestorationGate(observing: settledIdentity)
+
+        XCTAssertTrue(gate.allowsNonLatestRestoration(using: settledIdentity))
+    }
+
     func testSnapshotsAreIsolatedBySession() {
         var store = ChatScrollStateStore()
         store.save(

--- a/ConduitTests/ChatScrollStateTests.swift
+++ b/ConduitTests/ChatScrollStateTests.swift
@@ -98,7 +98,7 @@ final class ChatScrollStateTests: XCTestCase {
             role: .tool,
             content: "",
             timestamp: "now",
-            tool: ToolActivity(id: "call-b", name: "read", input: "b.txt", output: nil, status: .running)
+            tool: ToolActivity(id: "call-b", name: "write", input: "b.txt", output: nil, status: .running)
         )
         let clarifyA = ChatMessage(
             id: "clarify-a",
@@ -240,8 +240,133 @@ final class ChatScrollStateTests: XCTestCase {
         )
     }
 
+    func testToolSemanticAnchorsIgnoreProjectionSpecificInputPreviews() {
+        let fullProjection = [
+            ChatMessage(
+                id: "live-1",
+                role: .tool,
+                content: "",
+                timestamp: "now",
+                tool: ToolActivity(
+                    id: "call-1",
+                    name: "read_file",
+                    input: "A complete request body that only the durable transcript retains",
+                    output: nil,
+                    status: .running
+                )
+            ),
+            ChatMessage(
+                id: "live-2",
+                role: .tool,
+                content: "",
+                timestamp: "later",
+                tool: ToolActivity(
+                    id: "call-2",
+                    name: "read_file",
+                    input: "A second complete request body",
+                    output: nil,
+                    status: .running
+                )
+            )
+        ]
+        let compactProjection = [
+            ChatMessage(
+                id: "stored-91",
+                role: .tool,
+                content: "",
+                timestamp: "stored",
+                tool: ToolActivity(
+                    id: nil,
+                    name: "read_file",
+                    input: nil,
+                    output: "first result",
+                    status: .complete
+                )
+            ),
+            ChatMessage(
+                id: "stored-92",
+                role: .tool,
+                content: "",
+                timestamp: "stored later",
+                tool: ToolActivity(
+                    id: nil,
+                    name: "read_file",
+                    input: "A second complete request…",
+                    output: "second result",
+                    status: .complete
+                )
+            )
+        ]
+
+        let fullIDs = ChatMessageScrollTargets.make(for: fullProjection).map(\.semanticID)
+        let compactIDs = ChatMessageScrollTargets.make(for: compactProjection).map(\.semanticID)
+
+        XCTAssertEqual(fullIDs, compactIDs)
+        XCTAssertNotEqual(fullIDs[0], fullIDs[1])
+    }
+
+    func testTargetCacheDoesNotRegenerateForRepeatedUnchangedMessages() {
+        let messages = [
+            ChatMessage(id: "message-1", role: .assistant, content: "Stable", timestamp: "now")
+        ]
+        var cache = ChatMessageScrollTargetCache()
+
+        XCTAssertEqual(cache.update(for: messages), .semanticsChanged)
+        for _ in 0..<100 {
+            XCTAssertEqual(cache.update(for: messages), .unchanged)
+        }
+    }
+
+    func testTargetCacheRefreshesRenderingIdentityWithoutChangingScrollIdentity() {
+        let live = [
+            ChatMessage(
+                id: "live-message",
+                role: .assistant,
+                content: "Same response",
+                rawContent: "live projection",
+                timestamp: "now",
+                author: "Hermes"
+            )
+        ]
+        let stored = [
+            ChatMessage(
+                id: "stored-message",
+                role: .assistant,
+                content: "Same response",
+                rawContent: nil,
+                timestamp: "stored timestamp",
+                author: "assistant"
+            )
+        ]
+        var cache = ChatMessageScrollTargetCache()
+
+        XCTAssertEqual(cache.update(for: live), .semanticsChanged)
+        let liveScrollID = cache.targets[0].semanticID
+
+        XCTAssertEqual(cache.update(for: stored), .renderingChanged)
+        XCTAssertEqual(cache.targets[0].id, "stored-message")
+        XCTAssertEqual(cache.targets[0].semanticID, liveScrollID)
+    }
+
+    func testTargetCacheRegeneratesWhenMessageSemanticsChange() {
+        var cache = ChatMessageScrollTargetCache()
+        let original = [
+            ChatMessage(id: "message", role: .assistant, content: "Before", timestamp: "now")
+        ]
+        let edited = [
+            ChatMessage(id: "message", role: .assistant, content: "After", timestamp: "now")
+        ]
+
+        XCTAssertEqual(cache.update(for: original), .semanticsChanged)
+        let originalScrollID = cache.targets[0].semanticID
+
+        XCTAssertEqual(cache.update(for: edited), .semanticsChanged)
+        XCTAssertNotEqual(cache.targets[0].semanticID, originalScrollID)
+    }
+
     func testEquivalentSessionIDsShareCanonicalIdentity() {
         let identity = ChatScrollSessionIdentity(
+            profile: "alpha",
             canonicalSessionID: "catalog-id",
             equivalentSessionIDs: ["runtime-old", "runtime-new"],
             isReconciling: false,
@@ -254,8 +379,211 @@ final class ChatScrollStateTests: XCTestCase {
         XCTAssertFalse(identity.areEquivalent("runtime-old", "different-session"))
     }
 
+    func testEquivalentRawSessionIDsRemainSeparatedByProfile() {
+        let identity = ChatScrollSessionIdentity(
+            profile: "alpha",
+            canonicalSessionID: "shared-id",
+            equivalentSessionIDs: ["runtime-id"],
+            isReconciling: false,
+            settledRevision: 2
+        )
+        let alphaRuntime = ChatScrollSessionKey(profile: "alpha", sessionID: "runtime-id")
+        let betaRuntime = ChatScrollSessionKey(profile: "beta", sessionID: "runtime-id")
+
+        XCTAssertTrue(identity.contains(alphaRuntime))
+        XCTAssertFalse(identity.contains(betaRuntime))
+        XCTAssertFalse(identity.areEquivalent(alphaRuntime, betaRuntime))
+    }
+
+    func testResolverUsesCatalogCanonicalIDAndAliases() {
+        let identity = ChatScrollSessionIdentityResolver.resolve(
+            profile: "alpha",
+            activeSessionID: "runtime-id",
+            catalog: [
+                ChatScrollSessionCatalogIdentity(
+                    profile: "alpha",
+                    canonicalSessionID: "catalog-id",
+                    alternateSessionIDs: ["runtime-id", "legacy-id"]
+                )
+            ],
+            previousIdentity: .none,
+            isReconciling: false
+        )
+
+        XCTAssertEqual(identity.canonicalSessionKey, ChatScrollSessionKey(
+            profile: "alpha",
+            sessionID: "catalog-id"
+        ))
+        XCTAssertTrue(identity.contains("runtime-id"))
+        XCTAssertTrue(identity.contains("legacy-id"))
+    }
+
+    func testResolverTreatsUntaggedCatalogRowsAsBelongingToTheActiveProfile() {
+        let identity = ChatScrollSessionIdentityResolver.resolve(
+            profile: "alpha",
+            activeSessionID: "runtime-id",
+            catalog: [
+                ChatScrollSessionCatalogIdentity(
+                    profile: "  ",
+                    canonicalSessionID: "catalog-id",
+                    alternateSessionIDs: ["runtime-id"]
+                )
+            ],
+            previousIdentity: .none,
+            isReconciling: false
+        )
+
+        XCTAssertEqual(identity.canonicalSessionKey, ChatScrollSessionKey(
+            profile: "alpha",
+            sessionID: "catalog-id"
+        ))
+    }
+
+    func testResolverKeepsRuntimeRotationInTheExistingCanonicalIdentity() {
+        let catalog = [
+            ChatScrollSessionCatalogIdentity(
+                profile: "alpha",
+                canonicalSessionID: "catalog-id",
+                alternateSessionIDs: ["runtime-old"]
+            )
+        ]
+        let previous = ChatScrollSessionIdentityResolver.resolve(
+            profile: "alpha",
+            activeSessionID: "runtime-old",
+            catalog: catalog,
+            previousIdentity: .none,
+            isReconciling: false
+        )
+
+        let rotated = ChatScrollSessionIdentityResolver.resolve(
+            profile: "alpha",
+            activeSessionID: "runtime-old",
+            catalog: catalog,
+            requestedSessionID: "catalog-id",
+            resolvedSessionID: "runtime-new",
+            previousIdentity: previous,
+            isReconciling: true
+        )
+
+        XCTAssertEqual(rotated.canonicalSessionID, "catalog-id")
+        XCTAssertTrue(rotated.areEquivalent("runtime-old", "runtime-new"))
+    }
+
+    func testResolverDropsPreviousAliasesForAnUnrelatedSession() {
+        let catalog = [
+            ChatScrollSessionCatalogIdentity(
+                profile: "alpha",
+                canonicalSessionID: "catalog-a",
+                alternateSessionIDs: ["runtime-a"]
+            ),
+            ChatScrollSessionCatalogIdentity(
+                profile: "alpha",
+                canonicalSessionID: "catalog-b",
+                alternateSessionIDs: ["runtime-b"]
+            )
+        ]
+        let previous = ChatScrollSessionIdentityResolver.resolve(
+            profile: "alpha",
+            activeSessionID: "runtime-a",
+            catalog: catalog,
+            previousIdentity: .none,
+            isReconciling: false
+        )
+
+        let unrelated = ChatScrollSessionIdentityResolver.resolve(
+            profile: "alpha",
+            activeSessionID: "runtime-b",
+            catalog: catalog,
+            previousIdentity: previous,
+            isReconciling: false
+        )
+
+        XCTAssertEqual(unrelated.canonicalSessionID, "catalog-b")
+        XCTAssertTrue(unrelated.contains("runtime-b"))
+        XCTAssertFalse(unrelated.contains("runtime-a"))
+    }
+
+    func testResolverDoesNotCarryIdentityAcrossProfilesWithEqualRawIDs() {
+        let previous = ChatScrollSessionIdentityResolver.resolve(
+            profile: "alpha",
+            activeSessionID: "shared-runtime",
+            catalog: [
+                ChatScrollSessionCatalogIdentity(
+                    profile: "alpha",
+                    canonicalSessionID: "alpha-catalog",
+                    alternateSessionIDs: ["shared-runtime"]
+                )
+            ],
+            previousIdentity: .none,
+            isReconciling: false
+        )
+
+        let switched = ChatScrollSessionIdentityResolver.resolve(
+            profile: "beta",
+            activeSessionID: "shared-runtime",
+            catalog: [
+                ChatScrollSessionCatalogIdentity(
+                    profile: "alpha",
+                    canonicalSessionID: "alpha-catalog",
+                    alternateSessionIDs: ["shared-runtime"]
+                ),
+                ChatScrollSessionCatalogIdentity(
+                    profile: "beta",
+                    canonicalSessionID: "beta-catalog",
+                    alternateSessionIDs: ["shared-runtime"]
+                )
+            ],
+            previousIdentity: previous,
+            isReconciling: false
+        )
+
+        XCTAssertEqual(switched.profile, "beta")
+        XCTAssertEqual(switched.canonicalSessionID, "beta-catalog")
+        XCTAssertFalse(switched.contains(ChatScrollSessionKey(
+            profile: "alpha",
+            sessionID: "shared-runtime"
+        )))
+        XCTAssertTrue(switched.contains(ChatScrollSessionKey(
+            profile: "beta",
+            sessionID: "shared-runtime"
+        )))
+    }
+
+    func testResolverOwnsReconciliationStateAndSettledRevisionTransitions() {
+        let settled = ChatScrollSessionIdentityResolver.resolve(
+            profile: "alpha",
+            activeSessionID: "session",
+            catalog: [],
+            previousIdentity: .none,
+            isReconciling: false
+        )
+        let reconciling = ChatScrollSessionIdentityResolver.resolve(
+            profile: "alpha",
+            activeSessionID: "session",
+            catalog: [],
+            previousIdentity: settled,
+            isReconciling: true
+        )
+        let resettled = ChatScrollSessionIdentityResolver.resolve(
+            profile: "alpha",
+            activeSessionID: "session",
+            catalog: [],
+            previousIdentity: reconciling,
+            isReconciling: false,
+            advanceSettledRevision: true
+        )
+
+        XCTAssertFalse(settled.isReconciling)
+        XCTAssertEqual(settled.settledRevision, 0)
+        XCTAssertTrue(reconciling.isReconciling)
+        XCTAssertEqual(reconciling.settledRevision, 0)
+        XCTAssertFalse(resettled.isReconciling)
+        XCTAssertEqual(resettled.settledRevision, 1)
+    }
+
     func testNonLatestRestorationWaitsForReconciliationToSettleAtNewRevision() {
         let activeIdentity = ChatScrollSessionIdentity(
+            profile: "default",
             canonicalSessionID: "catalog-id",
             equivalentSessionIDs: ["runtime-id"],
             isReconciling: true,
@@ -265,12 +593,14 @@ final class ChatScrollStateTests: XCTestCase {
 
         XCTAssertFalse(gate.allowsNonLatestRestoration(using: activeIdentity))
         XCTAssertFalse(gate.allowsNonLatestRestoration(using: ChatScrollSessionIdentity(
+            profile: "default",
             canonicalSessionID: "catalog-id",
             equivalentSessionIDs: ["runtime-id"],
             isReconciling: false,
             settledRevision: 7
         )))
         XCTAssertTrue(gate.allowsNonLatestRestoration(using: ChatScrollSessionIdentity(
+            profile: "default",
             canonicalSessionID: "catalog-id",
             equivalentSessionIDs: ["runtime-id"],
             isReconciling: false,
@@ -280,6 +610,7 @@ final class ChatScrollStateTests: XCTestCase {
 
     func testNonLatestRestorationCanUseCurrentRevisionWhenNoReconciliationIsExpected() {
         let settledIdentity = ChatScrollSessionIdentity(
+            profile: "default",
             canonicalSessionID: "catalog-id",
             equivalentSessionIDs: [],
             isReconciling: false,
@@ -292,27 +623,47 @@ final class ChatScrollStateTests: XCTestCase {
 
     func testSnapshotsAreIsolatedBySession() {
         var store = ChatScrollStateStore()
+        let sessionA = ChatScrollSessionKey(profile: "default", sessionID: "session-a")
+        let sessionB = ChatScrollSessionKey(profile: "default", sessionID: "session-b")
         store.save(
             ChatScrollSnapshot(anchorMessageID: "a-3", followsLatest: false),
-            for: "session-a"
+            for: sessionA
         )
         store.save(
             ChatScrollSnapshot(anchorMessageID: "b-1", followsLatest: false),
-            for: "session-b"
+            for: sessionB
         )
 
-        XCTAssertEqual(store.snapshot(for: "session-a")?.anchorMessageID, "a-3")
-        XCTAssertEqual(store.snapshot(for: "session-b")?.anchorMessageID, "b-1")
+        XCTAssertEqual(store.snapshot(for: sessionA)?.anchorMessageID, "a-3")
+        XCTAssertEqual(store.snapshot(for: sessionB)?.anchorMessageID, "b-1")
+    }
+
+    func testSnapshotsWithEqualRawSessionIDsAreIsolatedByProfile() {
+        var store = ChatScrollStateStore()
+        let alpha = ChatScrollSessionKey(profile: "alpha", sessionID: "shared-session")
+        let beta = ChatScrollSessionKey(profile: "beta", sessionID: "shared-session")
+        store.save(
+            ChatScrollSnapshot(anchorMessageID: "alpha-anchor", followsLatest: false),
+            for: alpha
+        )
+        store.save(
+            ChatScrollSnapshot(anchorMessageID: "beta-anchor", followsLatest: false),
+            for: beta
+        )
+
+        XCTAssertEqual(store.snapshot(for: alpha)?.anchorMessageID, "alpha-anchor")
+        XCTAssertEqual(store.snapshot(for: beta)?.anchorMessageID, "beta-anchor")
     }
 
     func testRestorationKeepsAnchorWhenMessageStillExists() {
         var store = ChatScrollStateStore()
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
         let expected = ChatScrollSnapshot(anchorMessageID: "message-4", followsLatest: false)
-        store.save(expected, for: "session")
+        store.save(expected, for: key)
 
         XCTAssertEqual(
             store.restoration(
-                for: "session",
+                for: key,
                 availableMessageIDs: ["message-3", "message-4", "message-5"]
             ),
             expected
@@ -321,23 +672,100 @@ final class ChatScrollStateTests: XCTestCase {
 
     func testRestorationFallsBackToLatestWhenAnchorDisappears() {
         var store = ChatScrollStateStore()
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
         store.save(
             ChatScrollSnapshot(anchorMessageID: "deleted", followsLatest: false),
-            for: "session"
+            for: key
         )
 
         XCTAssertEqual(
-            store.restoration(for: "session", availableMessageIDs: ["message-1"]),
+            store.restoration(for: key, availableMessageIDs: ["message-1"]),
             .latest
+        )
+    }
+
+    func testSettledPendingRestorationFallsBackToLatestForEmptyTranscript() {
+        var store = ChatScrollStateStore()
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
+        let reconcilingIdentity = ChatScrollSessionIdentity(
+            profile: "default",
+            canonicalSessionID: "session",
+            equivalentSessionIDs: [],
+            isReconciling: true,
+            settledRevision: 3
+        )
+        let settledIdentity = ChatScrollSessionIdentity(
+            profile: "default",
+            canonicalSessionID: "session",
+            equivalentSessionIDs: [],
+            isReconciling: false,
+            settledRevision: 4
+        )
+        let snapshot = ChatScrollSnapshot(anchorMessageID: "deleted", followsLatest: false)
+        store.save(snapshot, for: key)
+        let pending = ChatScrollPendingRestoration(
+            sessionKey: key,
+            snapshot: snapshot,
+            gate: ChatScrollRestorationGate(observing: reconcilingIdentity)
+        )
+
+        XCTAssertEqual(
+            ChatScrollRestorationResolver.decision(
+                for: pending,
+                identity: settledIdentity,
+                activeSessionKey: key,
+                store: store,
+                availableMessageIDs: []
+            ),
+            .latest
+        )
+    }
+
+    func testPendingRestorationCancelsAcrossProfilesWithEqualSessionIDs() {
+        var store = ChatScrollStateStore()
+        let alphaKey = ChatScrollSessionKey(profile: "alpha", sessionID: "shared-session")
+        let betaKey = ChatScrollSessionKey(profile: "beta", sessionID: "shared-session")
+        let alphaIdentity = ChatScrollSessionIdentity(
+            profile: "alpha",
+            canonicalSessionID: "shared-session",
+            equivalentSessionIDs: [],
+            isReconciling: false,
+            settledRevision: 1
+        )
+        let betaIdentity = ChatScrollSessionIdentity(
+            profile: "beta",
+            canonicalSessionID: "shared-session",
+            equivalentSessionIDs: [],
+            isReconciling: false,
+            settledRevision: 1
+        )
+        let snapshot = ChatScrollSnapshot(anchorMessageID: "alpha-anchor", followsLatest: false)
+        store.save(snapshot, for: alphaKey)
+        let pending = ChatScrollPendingRestoration(
+            sessionKey: alphaKey,
+            snapshot: snapshot,
+            gate: ChatScrollRestorationGate(observing: alphaIdentity)
+        )
+
+        XCTAssertEqual(
+            ChatScrollRestorationResolver.decision(
+                for: pending,
+                identity: betaIdentity,
+                activeSessionKey: betaKey,
+                store: store,
+                availableMessageIDs: ["alpha-anchor"]
+            ),
+            .cancel
         )
     }
 
     func testLatestSnapshotRemainsLatestRegardlessOfAvailableMessages() {
         var store = ChatScrollStateStore()
-        store.save(ChatScrollSnapshot.latest, for: "session")
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
+        store.save(ChatScrollSnapshot.latest, for: key)
 
         XCTAssertEqual(
-            store.restoration(for: "session", availableMessageIDs: []),
+            store.restoration(for: key, availableMessageIDs: []),
             .latest
         )
     }
@@ -345,16 +773,26 @@ final class ChatScrollStateTests: XCTestCase {
     func testSessionKeysAreTrimmedForSaveAndLookup() {
         var store = ChatScrollStateStore()
         let expected = ChatScrollSnapshot(anchorMessageID: "message-1", followsLatest: false)
-        store.save(expected, for: "  session  ")
+        store.save(
+            expected,
+            for: ChatScrollSessionKey(profile: "  Alpha  ", sessionID: "  session  ")
+        )
 
-        XCTAssertEqual(store.snapshot(for: "session"), expected)
-        XCTAssertEqual(store.snapshot(for: "\n session \t"), expected)
+        XCTAssertEqual(
+            store.snapshot(for: ChatScrollSessionKey(profile: "alpha", sessionID: "session")),
+            expected
+        )
+        XCTAssertEqual(
+            store.snapshot(for: ChatScrollSessionKey(profile: "ALPHA", sessionID: "\n session \t")),
+            expected
+        )
     }
 
     func testWhitespaceOnlySessionKeysAreIgnored() {
         var store = ChatScrollStateStore()
-        store.save(ChatScrollSnapshot.latest, for: " \n\t ")
+        let key = ChatScrollSessionKey(profile: "default", sessionID: " \n\t ")
+        store.save(ChatScrollSnapshot.latest, for: key)
 
-        XCTAssertNil(store.snapshot(for: " \n\t "))
+        XCTAssertNil(store.snapshot(for: key))
     }
 }

--- a/ConduitTests/ChatScrollStateTests.swift
+++ b/ConduitTests/ChatScrollStateTests.swift
@@ -2,6 +2,192 @@ import XCTest
 @testable import Conduit
 
 final class ChatScrollStateTests: XCTestCase {
+    func testRestorationWaitsForMatchingRenderedTargetAndGeometryConfirmation() {
+        let sessionA = ChatScrollSessionKey(profile: "default", sessionID: "session-a")
+        let sessionB = ChatScrollSessionKey(profile: "default", sessionID: "session-b")
+        let anchor = "chat-message-anchor-0"
+        var restoration = ChatResumeRenderRestorationState(
+            generation: 41,
+            sessionKey: sessionA,
+            destination: .anchor(anchor),
+            maximumChecks: 8,
+            retryInterval: 2
+        )
+        let staleContent = ChatRenderedScrollContent(
+            sessionKey: sessionB,
+            cacheRevision: 7,
+            semanticTargetIDs: [anchor],
+            bottomAnchorID: "chat-latest-default-session-b",
+            restorationGeneration: 41
+        )
+
+        XCTAssertEqual(
+            restoration.nextAction(
+                renderedContent: staleContent,
+                cacheRevision: 7,
+                topVisibleID: nil,
+                isNearBottom: false
+            ),
+            .wait
+        )
+        XCTAssertEqual(
+            restoration.nextAction(
+                renderedContent: staleContent,
+                cacheRevision: 7,
+                topVisibleID: nil,
+                isNearBottom: false
+            ),
+            .wait,
+            "A delayed row must not be treated as installed after one task yield"
+        )
+
+        let staleGeneration = ChatRenderedScrollContent(
+            sessionKey: sessionA,
+            cacheRevision: 8,
+            semanticTargetIDs: [anchor],
+            bottomAnchorID: "chat-latest-default-session-a",
+            restorationGeneration: 40
+        )
+        XCTAssertEqual(
+            restoration.nextAction(
+                renderedContent: staleGeneration,
+                cacheRevision: 8,
+                topVisibleID: anchor,
+                isNearBottom: false
+            ),
+            .wait
+        )
+
+        let matchingContentWithoutAnchor = ChatRenderedScrollContent(
+            sessionKey: sessionA,
+            cacheRevision: 8,
+            semanticTargetIDs: ["different-anchor"],
+            bottomAnchorID: "chat-latest-default-session-a",
+            restorationGeneration: 41
+        )
+        XCTAssertEqual(
+            restoration.nextAction(
+                renderedContent: matchingContentWithoutAnchor,
+                cacheRevision: 8,
+                topVisibleID: nil,
+                isNearBottom: false
+            ),
+            .wait
+        )
+
+        let installedContent = ChatRenderedScrollContent(
+            sessionKey: sessionA,
+            cacheRevision: 8,
+            semanticTargetIDs: [anchor],
+            bottomAnchorID: "chat-latest-default-session-a",
+            restorationGeneration: 41
+        )
+        XCTAssertEqual(
+            restoration.nextAction(
+                renderedContent: installedContent,
+                cacheRevision: 8,
+                topVisibleID: nil,
+                isNearBottom: false
+            ),
+            .scroll(.anchor(anchor))
+        )
+        XCTAssertEqual(
+            restoration.nextAction(
+                renderedContent: installedContent,
+                cacheRevision: 8,
+                topVisibleID: nil,
+                isNearBottom: false
+            ),
+            .wait,
+            "A scroll request that did not move geometry must not complete restoration"
+        )
+        XCTAssertEqual(
+            restoration.nextAction(
+                renderedContent: installedContent,
+                cacheRevision: 8,
+                topVisibleID: anchor,
+                isNearBottom: false
+            ),
+            .complete
+        )
+    }
+
+    func testCancellingRenderRestorationStopsWithoutScrollingOrCompleting() {
+        let session = ChatScrollSessionKey(profile: "default", sessionID: "session-a")
+        let anchor = "chat-message-anchor-0"
+        var restoration = ChatResumeRenderRestorationState(
+            generation: 42,
+            sessionKey: session,
+            destination: .anchor(anchor),
+            maximumChecks: 8,
+            retryInterval: 2
+        )
+        restoration.cancel()
+
+        let installedContent = ChatRenderedScrollContent(
+            sessionKey: session,
+            cacheRevision: 3,
+            semanticTargetIDs: [anchor],
+            bottomAnchorID: "chat-latest-default-session-a",
+            restorationGeneration: 42
+        )
+        XCTAssertEqual(
+            restoration.nextAction(
+                renderedContent: installedContent,
+                cacheRevision: 3,
+                topVisibleID: anchor,
+                isNearBottom: false
+            ),
+            .cancelled
+        )
+    }
+
+    func testLatestRestorationRequiresMatchingBottomLayoutAndNearBottomConfirmation() {
+        let session = ChatScrollSessionKey(profile: "default", sessionID: "session-a")
+        var restoration = ChatResumeRenderRestorationState(
+            generation: 43,
+            sessionKey: session,
+            destination: .latest,
+            maximumChecks: 8,
+            retryInterval: 2
+        )
+        let installedContent = ChatRenderedScrollContent(
+            sessionKey: session,
+            cacheRevision: 4,
+            semanticTargetIDs: [],
+            bottomAnchorID: "chat-latest-default-session-a",
+            restorationGeneration: 43
+        )
+
+        XCTAssertEqual(
+            restoration.nextAction(
+                renderedContent: installedContent,
+                cacheRevision: 4,
+                topVisibleID: nil,
+                isNearBottom: false
+            ),
+            .scroll(.latest)
+        )
+        XCTAssertEqual(
+            restoration.nextAction(
+                renderedContent: installedContent,
+                cacheRevision: 4,
+                topVisibleID: nil,
+                isNearBottom: false
+            ),
+            .wait
+        )
+        XCTAssertEqual(
+            restoration.nextAction(
+                renderedContent: installedContent,
+                cacheRevision: 4,
+                topVisibleID: nil,
+                isNearBottom: true
+            ),
+            .complete
+        )
+    }
+
     func testSemanticAnchorsIgnoreSourceSpecificMessageIdentity() {
         let localMessages = [
             ChatMessage(

--- a/ConduitTests/ChatScrollStateTests.swift
+++ b/ConduitTests/ChatScrollStateTests.swift
@@ -81,6 +81,82 @@ final class ChatScrollStateTests: XCTestCase {
         XCTAssertEqual(firstIDs, secondIDs)
     }
 
+    func testRestorationFallsBackWhenDuplicateMultiplicityChanges() {
+        let originalTargets = ChatMessageScrollTargets.make(for: [
+            ChatMessage(id: "live-first", role: .assistant, content: "Repeated", timestamp: "now"),
+            ChatMessage(id: "live-second", role: .assistant, content: "Repeated", timestamp: "later")
+        ])
+        let compactedTargets = ChatMessageScrollTargets.make(for: [
+            ChatMessage(id: "stored-second", role: .assistant, content: "Repeated", timestamp: "stored")
+        ])
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
+        let snapshot = ChatScrollSnapshot(
+            anchorMessageID: originalTargets[0].semanticID,
+            followsLatest: false,
+            anchorMetadata: originalTargets[0].restorationMetadata
+        )
+        var store = ChatScrollStateStore()
+        store.save(snapshot, for: key)
+
+        XCTAssertEqual(originalTargets[0].semanticID, compactedTargets[0].semanticID)
+        XCTAssertEqual(
+            store.restoration(
+                for: key,
+                availableTargets: ChatScrollTargetAvailability(targets: compactedTargets)
+            ),
+            .latest
+        )
+    }
+
+    func testRestorationKeepsQualifiedAnchorWhenDuplicateMultiplicityIsUnchanged() {
+        let liveTargets = ChatMessageScrollTargets.make(for: [
+            ChatMessage(id: "live-first", role: .assistant, content: "Repeated", timestamp: "now"),
+            ChatMessage(id: "live-second", role: .assistant, content: "Repeated", timestamp: "later")
+        ])
+        let storedTargets = ChatMessageScrollTargets.make(for: [
+            ChatMessage(id: "stored-first", role: .assistant, content: "Repeated", timestamp: "stored"),
+            ChatMessage(id: "stored-second", role: .assistant, content: "Repeated", timestamp: "stored later")
+        ])
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
+        let snapshot = ChatScrollSnapshot(
+            anchorMessageID: liveTargets[0].semanticID,
+            followsLatest: false,
+            anchorMetadata: liveTargets[0].restorationMetadata
+        )
+        var store = ChatScrollStateStore()
+        store.save(snapshot, for: key)
+
+        XCTAssertEqual(
+            store.restoration(
+                for: key,
+                availableTargets: ChatScrollTargetAvailability(targets: storedTargets)
+            ),
+            snapshot
+        )
+    }
+
+    func testQualifiedRestorationFallsBackForEmptyTranscript() {
+        let target = ChatMessageScrollTargets.make(for: [
+            ChatMessage(id: "live", role: .assistant, content: "Repeated", timestamp: "now")
+        ])[0]
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
+        let snapshot = ChatScrollSnapshot(
+            anchorMessageID: target.semanticID,
+            followsLatest: false,
+            anchorMetadata: target.restorationMetadata
+        )
+        var store = ChatScrollStateStore()
+        store.save(snapshot, for: key)
+
+        XCTAssertEqual(
+            store.restoration(
+                for: key,
+                availableTargets: ChatScrollTargetAvailability(targets: [])
+            ),
+            .latest
+        )
+    }
+
     func testStableActivityAndAttachmentFieldsParticipateInSemanticFingerprint() {
         func semanticID(for message: ChatMessage) -> String {
             ChatMessageScrollTargets.make(for: [message])[0].semanticID
@@ -362,6 +438,43 @@ final class ChatScrollStateTests: XCTestCase {
 
         XCTAssertEqual(cache.update(for: edited), .semanticsChanged)
         XCTAssertNotEqual(cache.targets[0].semanticID, originalScrollID)
+    }
+
+    func testEqualCountProjectionReplacementReassertsLatestAfterCacheUpdate() {
+        var cache = ChatMessageScrollTargetCache()
+        cache.update(for: [
+            ChatMessage(id: "live", role: .assistant, content: "Stable", timestamp: "now")
+        ])
+
+        let update = cache.update(for: [
+            ChatMessage(id: "stored", role: .assistant, content: "Stable", timestamp: "stored")
+        ])
+
+        XCTAssertEqual(update, .renderingChanged)
+        XCTAssertTrue(ChatMessageScrollUpdatePolicy.shouldReassertLatest(
+            after: update,
+            followsLatest: true,
+            hasPendingNonLatestRestoration: false,
+            hasNotificationHandoff: false
+        ))
+    }
+
+    func testLatestReassertionYieldsToPendingNonLatestRestoration() {
+        XCTAssertFalse(ChatMessageScrollUpdatePolicy.shouldReassertLatest(
+            after: .semanticsChanged,
+            followsLatest: true,
+            hasPendingNonLatestRestoration: true,
+            hasNotificationHandoff: false
+        ))
+    }
+
+    func testLatestReassertionYieldsToNotificationHandoff() {
+        XCTAssertFalse(ChatMessageScrollUpdatePolicy.shouldReassertLatest(
+            after: .semanticsChanged,
+            followsLatest: true,
+            hasPendingNonLatestRestoration: false,
+            hasNotificationHandoff: true
+        ))
     }
 
     func testEquivalentSessionIDsShareCanonicalIdentity() {

--- a/ConduitTests/ChatScrollStateTests.swift
+++ b/ConduitTests/ChatScrollStateTests.swift
@@ -1006,4 +1006,16 @@ final class ChatScrollStateTests: XCTestCase {
             "catalog-session"
         )
     }
+
+    func testSessionSnapshotMigratesWhenRuntimeIDBecomesCanonicalID() {
+        let runtimeKey = ChatScrollSessionKey(profile: "default", sessionID: "runtime-session")
+        let canonicalKey = ChatScrollSessionKey(profile: "default", sessionID: "catalog-session")
+        let snapshot = ChatScrollSnapshot(anchorMessageID: "message-12", followsLatest: false)
+        var store = ChatScrollStateStore()
+
+        store.save(snapshot, for: runtimeKey)
+        store.migrateSnapshot(from: runtimeKey, to: canonicalKey)
+
+        XCTAssertEqual(store.snapshot(for: canonicalKey), snapshot)
+    }
 }

--- a/ConduitTests/ChatScrollStateTests.swift
+++ b/ConduitTests/ChatScrollStateTests.swift
@@ -824,6 +824,13 @@ final class ChatScrollStateTests: XCTestCase {
         XCTAssertFalse(identity.areEquivalent("runtime-old", "different-session"))
     }
 
+    func testRenderedViewportSnapshotRejectsInvalidSessionScope() {
+        XCTAssertNil(ChatRenderedViewportSnapshot(
+            sessionKey: ChatScrollSessionKey(profile: "default", sessionID: "   "),
+            snapshot: .latest
+        ))
+    }
+
     func testEquivalentRawSessionIDsRemainSeparatedByProfile() {
         let identity = ChatScrollSessionIdentity(
             profile: "alpha",

--- a/ConduitTests/ChatScrollStateTests.swift
+++ b/ConduitTests/ChatScrollStateTests.swift
@@ -89,19 +89,16 @@ final class ChatScrollStateTests: XCTestCase {
         let compactedTargets = ChatMessageScrollTargets.make(for: [
             ChatMessage(id: "stored-second", role: .assistant, content: "Repeated", timestamp: "stored")
         ])
-        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
         let snapshot = ChatScrollSnapshot(
             anchorMessageID: originalTargets[0].semanticID,
             followsLatest: false,
             anchorMetadata: originalTargets[0].restorationMetadata
         )
-        var store = ChatScrollStateStore()
-        store.save(snapshot, for: key)
 
         XCTAssertEqual(originalTargets[0].semanticID, compactedTargets[0].semanticID)
         XCTAssertEqual(
-            store.restoration(
-                for: key,
+            ChatResumeViewportResolver.destination(
+                for: snapshot,
                 availableTargets: ChatScrollTargetAvailability(targets: compactedTargets)
             ),
             .latest
@@ -117,21 +114,18 @@ final class ChatScrollStateTests: XCTestCase {
             ChatMessage(id: "stored-first", role: .assistant, content: "Repeated", timestamp: "stored"),
             ChatMessage(id: "stored-second", role: .assistant, content: "Repeated", timestamp: "stored later")
         ])
-        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
         let snapshot = ChatScrollSnapshot(
             anchorMessageID: liveTargets[0].semanticID,
             followsLatest: false,
             anchorMetadata: liveTargets[0].restorationMetadata
         )
-        var store = ChatScrollStateStore()
-        store.save(snapshot, for: key)
 
         XCTAssertEqual(
-            store.restoration(
-                for: key,
+            ChatResumeViewportResolver.destination(
+                for: snapshot,
                 availableTargets: ChatScrollTargetAvailability(targets: storedTargets)
             ),
-            snapshot
+            .anchor(storedTargets[0].semanticID)
         )
     }
 
@@ -139,18 +133,15 @@ final class ChatScrollStateTests: XCTestCase {
         let target = ChatMessageScrollTargets.make(for: [
             ChatMessage(id: "live", role: .assistant, content: "Repeated", timestamp: "now")
         ])[0]
-        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
         let snapshot = ChatScrollSnapshot(
             anchorMessageID: target.semanticID,
             followsLatest: false,
             anchorMetadata: target.restorationMetadata
         )
-        var store = ChatScrollStateStore()
-        store.save(snapshot, for: key)
 
         XCTAssertEqual(
-            store.restoration(
-                for: key,
+            ChatResumeViewportResolver.destination(
+                for: snapshot,
                 availableTargets: ChatScrollTargetAvailability(targets: [])
             ),
             .latest
@@ -454,16 +445,16 @@ final class ChatScrollStateTests: XCTestCase {
         XCTAssertTrue(ChatMessageScrollUpdatePolicy.shouldReassertLatest(
             after: update,
             followsLatest: true,
-            hasPendingNonLatestRestoration: false,
+            hasPendingRestoration: false,
             hasNotificationHandoff: false
         ))
     }
 
-    func testLatestReassertionYieldsToPendingNonLatestRestoration() {
+    func testLatestReassertionYieldsToPendingRestoration() {
         XCTAssertFalse(ChatMessageScrollUpdatePolicy.shouldReassertLatest(
             after: .semanticsChanged,
             followsLatest: true,
-            hasPendingNonLatestRestoration: true,
+            hasPendingRestoration: true,
             hasNotificationHandoff: false
         ))
     }
@@ -472,7 +463,7 @@ final class ChatScrollStateTests: XCTestCase {
         XCTAssertFalse(ChatMessageScrollUpdatePolicy.shouldReassertLatest(
             after: .semanticsChanged,
             followsLatest: true,
-            hasPendingNonLatestRestoration: false,
+            hasPendingRestoration: false,
             hasNotificationHandoff: true
         ))
     }
@@ -694,248 +685,31 @@ final class ChatScrollStateTests: XCTestCase {
         XCTAssertEqual(resettled.settledRevision, 1)
     }
 
-    func testNonLatestRestorationWaitsForReconciliationToSettleAtNewRevision() {
-        let activeIdentity = ChatScrollSessionIdentity(
-            profile: "default",
-            canonicalSessionID: "catalog-id",
-            equivalentSessionIDs: ["runtime-id"],
-            isReconciling: true,
-            settledRevision: 7
-        )
-        let gate = ChatScrollRestorationGate(observing: activeIdentity)
-
-        XCTAssertFalse(gate.allowsNonLatestRestoration(using: activeIdentity))
-        XCTAssertFalse(gate.allowsNonLatestRestoration(using: ChatScrollSessionIdentity(
-            profile: "default",
-            canonicalSessionID: "catalog-id",
-            equivalentSessionIDs: ["runtime-id"],
-            isReconciling: false,
-            settledRevision: 7
-        )))
-        XCTAssertTrue(gate.allowsNonLatestRestoration(using: ChatScrollSessionIdentity(
-            profile: "default",
-            canonicalSessionID: "catalog-id",
-            equivalentSessionIDs: ["runtime-id"],
-            isReconciling: false,
-            settledRevision: 8
-        )))
-    }
-
-    func testNonLatestRestorationCanUseCurrentRevisionWhenNoReconciliationIsExpected() {
-        let settledIdentity = ChatScrollSessionIdentity(
-            profile: "default",
-            canonicalSessionID: "catalog-id",
-            equivalentSessionIDs: [],
-            isReconciling: false,
-            settledRevision: 3
-        )
-        let gate = ChatScrollRestorationGate(observing: settledIdentity)
-
-        XCTAssertTrue(gate.allowsNonLatestRestoration(using: settledIdentity))
-    }
-
-    func testSnapshotsAreIsolatedBySession() {
-        var store = ChatScrollStateStore()
-        let sessionA = ChatScrollSessionKey(profile: "default", sessionID: "session-a")
-        let sessionB = ChatScrollSessionKey(profile: "default", sessionID: "session-b")
-        store.save(
-            ChatScrollSnapshot(anchorMessageID: "a-3", followsLatest: false),
-            for: sessionA
-        )
-        store.save(
-            ChatScrollSnapshot(anchorMessageID: "b-1", followsLatest: false),
-            for: sessionB
-        )
-
-        XCTAssertEqual(store.snapshot(for: sessionA)?.anchorMessageID, "a-3")
-        XCTAssertEqual(store.snapshot(for: sessionB)?.anchorMessageID, "b-1")
-    }
-
-    func testSnapshotsWithEqualRawSessionIDsAreIsolatedByProfile() {
-        var store = ChatScrollStateStore()
-        let alpha = ChatScrollSessionKey(profile: "alpha", sessionID: "shared-session")
-        let beta = ChatScrollSessionKey(profile: "beta", sessionID: "shared-session")
-        store.save(
-            ChatScrollSnapshot(anchorMessageID: "alpha-anchor", followsLatest: false),
-            for: alpha
-        )
-        store.save(
-            ChatScrollSnapshot(anchorMessageID: "beta-anchor", followsLatest: false),
-            for: beta
-        )
-
-        XCTAssertEqual(store.snapshot(for: alpha)?.anchorMessageID, "alpha-anchor")
-        XCTAssertEqual(store.snapshot(for: beta)?.anchorMessageID, "beta-anchor")
-    }
-
-    func testRestorationKeepsAnchorWhenMessageStillExists() {
-        var store = ChatScrollStateStore()
-        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
-        let expected = ChatScrollSnapshot(anchorMessageID: "message-4", followsLatest: false)
-        store.save(expected, for: key)
-
-        XCTAssertEqual(
-            store.restoration(
-                for: key,
-                availableMessageIDs: ["message-3", "message-4", "message-5"]
-            ),
-            expected
-        )
-    }
-
-    func testRestorationFallsBackToLatestWhenAnchorDisappears() {
-        var store = ChatScrollStateStore()
-        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
-        store.save(
-            ChatScrollSnapshot(anchorMessageID: "deleted", followsLatest: false),
-            for: key
-        )
-
-        XCTAssertEqual(
-            store.restoration(for: key, availableMessageIDs: ["message-1"]),
-            .latest
-        )
-    }
-
-    func testSettledPendingRestorationFallsBackToLatestForEmptyTranscript() {
-        var store = ChatScrollStateStore()
-        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
-        let reconcilingIdentity = ChatScrollSessionIdentity(
-            profile: "default",
-            canonicalSessionID: "session",
-            equivalentSessionIDs: [],
-            isReconciling: true,
-            settledRevision: 3
-        )
-        let settledIdentity = ChatScrollSessionIdentity(
-            profile: "default",
-            canonicalSessionID: "session",
-            equivalentSessionIDs: [],
-            isReconciling: false,
-            settledRevision: 4
-        )
-        let snapshot = ChatScrollSnapshot(anchorMessageID: "deleted", followsLatest: false)
-        store.save(snapshot, for: key)
-        let pending = ChatScrollPendingRestoration(
-            sessionKey: key,
-            snapshot: snapshot,
-            gate: ChatScrollRestorationGate(observing: reconcilingIdentity)
-        )
-
-        XCTAssertEqual(
-            ChatScrollRestorationResolver.decision(
-                for: pending,
-                identity: settledIdentity,
-                activeSessionKey: key,
-                store: store,
-                availableMessageIDs: []
-            ),
-            .latest
-        )
-    }
-
-    func testPendingRestorationCancelsAcrossProfilesWithEqualSessionIDs() {
-        var store = ChatScrollStateStore()
-        let alphaKey = ChatScrollSessionKey(profile: "alpha", sessionID: "shared-session")
-        let betaKey = ChatScrollSessionKey(profile: "beta", sessionID: "shared-session")
-        let alphaIdentity = ChatScrollSessionIdentity(
-            profile: "alpha",
-            canonicalSessionID: "shared-session",
-            equivalentSessionIDs: [],
-            isReconciling: false,
-            settledRevision: 1
-        )
-        let betaIdentity = ChatScrollSessionIdentity(
-            profile: "beta",
-            canonicalSessionID: "shared-session",
-            equivalentSessionIDs: [],
-            isReconciling: false,
-            settledRevision: 1
-        )
-        let snapshot = ChatScrollSnapshot(anchorMessageID: "alpha-anchor", followsLatest: false)
-        store.save(snapshot, for: alphaKey)
-        let pending = ChatScrollPendingRestoration(
-            sessionKey: alphaKey,
-            snapshot: snapshot,
-            gate: ChatScrollRestorationGate(observing: alphaIdentity)
-        )
-
-        XCTAssertEqual(
-            ChatScrollRestorationResolver.decision(
-                for: pending,
-                identity: betaIdentity,
-                activeSessionKey: betaKey,
-                store: store,
-                availableMessageIDs: ["alpha-anchor"]
-            ),
-            .cancel
-        )
-    }
-
     func testLatestSnapshotRemainsLatestRegardlessOfAvailableMessages() {
-        var store = ChatScrollStateStore()
-        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
-        store.save(ChatScrollSnapshot.latest, for: key)
-
         XCTAssertEqual(
-            store.restoration(for: key, availableMessageIDs: []),
+            ChatResumeViewportResolver.destination(
+                for: .latest,
+                availableTargets: .init(targets: [])
+            ),
             .latest
         )
     }
 
-    func testSessionKeysAreTrimmedForSaveAndLookup() {
-        var store = ChatScrollStateStore()
-        let expected = ChatScrollSnapshot(anchorMessageID: "message-1", followsLatest: false)
-        store.save(
-            expected,
-            for: ChatScrollSessionKey(profile: "  Alpha  ", sessionID: "  session  ")
-        )
-
+    func testSessionKeysAreNormalized() {
         XCTAssertEqual(
-            store.snapshot(for: ChatScrollSessionKey(profile: "alpha", sessionID: "session")),
-            expected
+            ChatScrollSessionKey(profile: "  Alpha  ", sessionID: "  session  "),
+            ChatScrollSessionKey(profile: "alpha", sessionID: "session")
         )
         XCTAssertEqual(
-            store.snapshot(for: ChatScrollSessionKey(profile: "ALPHA", sessionID: "\n session \t")),
-            expected
+            ChatScrollSessionKey(profile: "ALPHA", sessionID: "\n session \t"),
+            ChatScrollSessionKey(profile: "alpha", sessionID: "session")
         )
     }
 
-    func testWhitespaceOnlySessionKeysAreIgnored() {
-        var store = ChatScrollStateStore()
+    func testWhitespaceOnlySessionKeysAreInvalid() {
         let key = ChatScrollSessionKey(profile: "default", sessionID: " \n\t ")
-        store.save(ChatScrollSnapshot.latest, for: key)
 
-        XCTAssertNil(store.snapshot(for: key))
-    }
-
-    func testSessionSwitchPreservesSavedBrowsePositionInsteadOfForcingLatest() {
-        let oldKey = ChatScrollSessionKey(profile: "default", sessionID: "old")
-        let newKey = ChatScrollSessionKey(profile: "default", sessionID: "new")
-        let snapshot = ChatScrollSnapshot(anchorMessageID: "message-12", followsLatest: false)
-
-        XCTAssertEqual(
-            ChatScrollSessionTransitionPolicy.action(
-                from: oldKey,
-                to: newKey,
-                snapshot: snapshot
-            ),
-            .restore
-        )
-    }
-
-    func testSessionSwitchWithoutSavedBrowsePositionStillUsesLatest() {
-        let oldKey = ChatScrollSessionKey(profile: "default", sessionID: "old")
-        let newKey = ChatScrollSessionKey(profile: "default", sessionID: "new")
-
-        XCTAssertEqual(
-            ChatScrollSessionTransitionPolicy.action(
-                from: oldKey,
-                to: newKey,
-                snapshot: nil
-            ),
-            .latest
-        )
+        XCTAssertFalse(key.isValid)
     }
 
     func testRestorationReanchorsBySourceMessageWhenContentProjectionChanges() {
@@ -953,25 +727,19 @@ final class ChatScrollStateTests: XCTestCase {
         )
         let originalTarget = ChatMessageScrollTargets.make(for: [original])[0]
         let refreshedTarget = ChatMessageScrollTargets.make(for: [refreshed])[0]
-        let key = ChatScrollSessionKey(profile: "default", sessionID: "session")
-        var store = ChatScrollStateStore()
-        store.save(
-            ChatScrollSnapshot(
-                anchorMessageID: originalTarget.semanticID,
-                followsLatest: false,
-                anchorMetadata: originalTarget.restorationMetadata,
-                anchorSourceMessageID: originalTarget.id
-            ),
-            for: key
+        let snapshot = ChatScrollSnapshot(
+            anchorMessageID: originalTarget.semanticID,
+            followsLatest: false,
+            anchorMetadata: originalTarget.restorationMetadata,
+            anchorSourceMessageID: originalTarget.id
         )
 
-        let restored = store.restoration(
-            for: key,
+        let destination = ChatResumeViewportResolver.destination(
+            for: snapshot,
             availableTargets: ChatScrollTargetAvailability(targets: [refreshedTarget])
         )
 
-        XCTAssertEqual(restored?.anchorMessageID, refreshedTarget.semanticID)
-        XCTAssertEqual(restored?.anchorSourceMessageID, "stable-source-id")
+        XCTAssertEqual(destination, .anchor(refreshedTarget.semanticID))
     }
 
     func testRuntimeSessionIDPersistsAsCatalogCanonicalID() {
@@ -1007,15 +775,4 @@ final class ChatScrollStateTests: XCTestCase {
         )
     }
 
-    func testSessionSnapshotMigratesWhenRuntimeIDBecomesCanonicalID() {
-        let runtimeKey = ChatScrollSessionKey(profile: "default", sessionID: "runtime-session")
-        let canonicalKey = ChatScrollSessionKey(profile: "default", sessionID: "catalog-session")
-        let snapshot = ChatScrollSnapshot(anchorMessageID: "message-12", followsLatest: false)
-        var store = ChatScrollStateStore()
-
-        store.save(snapshot, for: runtimeKey)
-        store.migrateSnapshot(from: runtimeKey, to: canonicalKey)
-
-        XCTAssertEqual(store.snapshot(for: canonicalKey), snapshot)
-    }
 }

--- a/ConduitTests/SessionRenameTests.swift
+++ b/ConduitTests/SessionRenameTests.swift
@@ -166,7 +166,7 @@ final class SessionRenameTests: XCTestCase {
                 forcedRefresh = forceRefresh
                 return remoteCatalog
             },
-            restoreSavedConnection: false
+            loadSavedConnection: false
         )
         let target = makeSession(profile: appState.activeProfile)
         let active = makeSession(
@@ -196,7 +196,7 @@ final class SessionRenameTests: XCTestCase {
                 renameRuntime: { _, _ in throw TestError.rejected },
                 renameStored: { _, _ in throw TestError.rejected }
             ),
-            restoreSavedConnection: false
+            loadSavedConnection: false
         )
         let session = makeSession(profile: appState.activeProfile)
         appState.sessions = [session]

--- a/ConduitTests/SessionRenameTests.swift
+++ b/ConduitTests/SessionRenameTests.swift
@@ -151,6 +151,7 @@ final class SessionRenameTests: XCTestCase {
         var remoteCatalog: [SessionSummary] = []
         var forcedRefresh = false
         let appState = AppState(
+            loadSavedConnection: false,
             sessionRenameOperations: .init(
                 renameRuntime: { _, _ in XCTFail("Inactive rename must not use the runtime RPC") },
                 renameStored: { sessionID, title in
@@ -165,8 +166,7 @@ final class SessionRenameTests: XCTestCase {
             sessionCatalogLoader: { forceRefresh in
                 forcedRefresh = forceRefresh
                 return remoteCatalog
-            },
-            loadSavedConnection: false
+            }
         )
         let target = makeSession(profile: appState.activeProfile)
         let active = makeSession(
@@ -192,11 +192,11 @@ final class SessionRenameTests: XCTestCase {
 
     func testTerminalFailurePreservesAppStateAndSurfacesExistingError() async {
         let appState = AppState(
+            loadSavedConnection: false,
             sessionRenameOperations: .init(
                 renameRuntime: { _, _ in throw TestError.rejected },
                 renameStored: { _, _ in throw TestError.rejected }
-            ),
-            loadSavedConnection: false
+            )
         )
         let session = makeSession(profile: appState.activeProfile)
         appState.sessions = [session]

--- a/docs/superpowers/plans/2026-08-09-chat-resume-behavior.md
+++ b/docs/superpowers/plans/2026-08-09-chat-resume-behavior.md
@@ -1,0 +1,1205 @@
+# Chat Resume Behavior Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a device-local return behavior that either restores the exact conversation and reading position or deliberately opens the newest chat at its bottom across foregrounding and cold launch.
+
+**Architecture:** A focused `ChatResumeCoordinator` composes a pure session-selection policy with a versioned `ChatResumeStore`. `AppState` remains authoritative for catalog and transcript reconciliation, while `ChatView` only reports stable viewport snapshots and applies generation-scoped restoration requests after reconciliation settles.
+
+**Tech Stack:** Swift 5.9, SwiftUI, Foundation `UserDefaults`/`Codable`, XCTest, XcodeGen, iOS 17+
+
+## Global Constraints
+
+- **Continue where I left off** is the default for existing and new installations.
+- The preference and viewport snapshots are device-local and must not change Hermes profile configuration.
+- Notification taps, explicit session/profile choices, new-conversation actions, user scrolling, and message submission override automatic restoration.
+- `RootView` is the only scene-phase observer after this change.
+- Resume metadata must never block login, connection, session selection, or manual navigation.
+- The store retains at most 100 snapshots and treats corrupt or unknown-version data as empty/default state.
+- Runtime, stored, and alternate session IDs must resolve to one canonical stored identity.
+- Do not add dependencies or raise the iOS 17.0 deployment target.
+- Preserve unrelated user changes; implementation stays in `/private/tmp/hermes-conduit-chat-scroll-restoration-fix`.
+- Never hardcode a Simulator model. Before test commands, resolve `CONDUIT_SIMULATOR_ID` with the same available-device JSON selection used by `.github/workflows/ci.yml`:
+
+```bash
+CONDUIT_SIMULATOR_ID=$(xcrun simctl list devices available -j | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+for runtime, devices in data["devices"].items():
+    if "iOS" not in runtime:
+        continue
+    for device in devices:
+        if "iPhone" in device["name"]:
+            print(device["udid"])
+            raise SystemExit(0)
+raise SystemExit(1)
+')
+```
+
+## File map
+
+- Create `Conduit/Services/ChatResumePolicy.swift`: behavior enum, sync purpose, pure automatic-session resolver, and viewport fallback resolver.
+- Create `Conduit/Services/ChatResumeStore.swift`: versioned device-local payload, one-time legacy active-session import, snapshot conversion, pruning, and explicit flush.
+- Create `Conduit/Services/ChatResumeCoordinator.swift`: lifecycle freeze/thaw, 300 ms write scheduling, restoration generations, and restoration request production.
+- Create `ConduitTests/ChatResumePolicyTests.swift`: session-selection and viewport-resolution policy tests.
+- Create `ConduitTests/ChatResumeStoreTests.swift`: persistence, migration, corruption, versioning, and pruning tests.
+- Create `ConduitTests/ChatResumeCoordinatorTests.swift`: lifecycle ordering, freeze, cancellation, and cold-launch restoration tests.
+- Modify `Conduit/Services/ChatScrollState.swift`: make persisted anchor conversion reusable and remove in-memory ownership superseded by the coordinator.
+- Modify `Conduit/Services/AppState.swift`: own the coordinator, distinguish automatic return from recovery sync, migrate active-session persistence, and publish restoration requests.
+- Modify `Conduit/Views/ChatView.swift`: report stable snapshots, consume restoration requests, and remove its independent scene observer/store.
+- Modify `Conduit/Views/AuxiliaryViews.swift`: expose the device-local return behavior in Chat settings.
+- Modify `Conduit/Views/RootView.swift`: pass the settings save action and remain the sole scene-phase source.
+- Modify `ConduitTests/ChatScrollStateTests.swift`: retain semantic-anchor coverage while removing tests tied to superseded local-store ownership.
+
+---
+
+### Task 0: Establish the PR #19 baseline
+
+**Files:**
+- Verify only; do not modify production or test files.
+
+**Interfaces:**
+- Consumes: current `agent/chat-scroll-restoration-fix` branch at design commit `7ebdd59` or its descendant.
+- Produces: a known-green baseline before any TDD change.
+
+- [ ] **Step 1: Confirm the isolated worktree and branch state**
+
+Run:
+
+```bash
+git status --short --branch
+git worktree list
+```
+
+Expected: the current directory is `/private/tmp/hermes-conduit-chat-scroll-restoration-fix`, branch `agent/chat-scroll-restoration-fix` is checked out only there, and only the committed plan/design documentation differs from the remote branch.
+
+- [ ] **Step 2: Regenerate the project and run the existing full suite**
+
+Resolve `CONDUIT_SIMULATOR_ID` using the Global Constraints command, then run:
+
+```bash
+xcodegen generate
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination "platform=iOS Simulator,id=$CONDUIT_SIMULATOR_ID" -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO DEVELOPMENT_TEAM="" PROVISIONING_PROFILE_SPECIFIER=""
+```
+
+Expected: all existing tests pass. If any existing test fails, stop implementation and report the baseline failure separately rather than attributing it to the first TDD change.
+
+- [ ] **Step 3: Confirm regeneration did not introduce an unintended diff**
+
+Run:
+
+```bash
+git status --short
+git diff --check
+```
+
+Expected: only intentional XcodeGen output, if any, is present. Do not create a baseline commit.
+
+---
+
+### Task 1: Pure return behavior and session-selection policy
+
+**Files:**
+- Create: `Conduit/Services/ChatResumePolicy.swift`
+- Create: `ConduitTests/ChatResumePolicyTests.swift`
+
+**Interfaces:**
+- Produces: `ChatResumeBehavior`, `ChatResumeSyncPurpose`, `ChatResumeSessionResolver.target(in:behavior:purpose:savedSessionID:currentSessionID:)`.
+- Consumes: existing `SessionSummary`, `SessionSource`, and catalog ordering (most recent first).
+
+- [ ] **Step 1: Write failing selection-policy tests**
+
+Create `ConduitTests/ChatResumePolicyTests.swift` with a local session factory and the exact A/B regression:
+
+```swift
+import XCTest
+@testable import Conduit
+
+final class ChatResumePolicyTests: XCTestCase {
+    private func session(
+        _ id: String,
+        alternates: [String] = [],
+        source: SessionSource = .chat
+    ) -> SessionSummary {
+        SessionSummary(
+            id: id,
+            alternateIds: alternates,
+            title: id,
+            model: "Hermes",
+            updatedLabel: "now",
+            profile: "default",
+            source: source,
+            isActive: false,
+            isArchived: false,
+            lineageRootId: nil
+        )
+    }
+
+    func testContinueReturnsSavedConversationWhenAnotherConversationIsNewer() {
+        let newestB = session("stored-b", alternates: ["runtime-b"])
+        let savedA = session("stored-a", alternates: ["runtime-a"])
+
+        let selected = ChatResumeSessionResolver.target(
+            in: [newestB, savedA],
+            behavior: .continueWhereLeftOff,
+            purpose: .automaticReturn,
+            savedSessionID: "runtime-a",
+            currentSessionID: "runtime-a"
+        )
+
+        XCTAssertEqual(selected?.id, "stored-a")
+    }
+
+    func testLatestReturnDeliberatelyIgnoresSavedConversation() {
+        let selected = ChatResumeSessionResolver.target(
+            in: [session("stored-b"), session("stored-a")],
+            behavior: .latestActivity,
+            purpose: .automaticReturn,
+            savedSessionID: "stored-a",
+            currentSessionID: "stored-a"
+        )
+
+        XCTAssertEqual(selected?.id, "stored-b")
+    }
+
+    func testRecoverySyncPreservesCurrentConversationRegardlessOfPreference() {
+        let selected = ChatResumeSessionResolver.target(
+            in: [session("stored-b"), session("stored-a")],
+            behavior: .latestActivity,
+            purpose: .preserveCurrent,
+            savedSessionID: "stored-a",
+            currentSessionID: "stored-a"
+        )
+
+        XCTAssertEqual(selected?.id, "stored-a")
+    }
+
+    func testUnavailableSavedConversationFallsBackToNewestOrdinaryChat() {
+        let selected = ChatResumeSessionResolver.target(
+            in: [session("cron", source: .cron), session("stored-b")],
+            behavior: .continueWhereLeftOff,
+            purpose: .automaticReturn,
+            savedSessionID: "deleted-a",
+            currentSessionID: "deleted-a"
+        )
+
+        XCTAssertEqual(selected?.id, "stored-b")
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate the project and run the new tests to verify RED**
+
+Run:
+
+```bash
+xcodegen generate
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination "platform=iOS Simulator,id=$CONDUIT_SIMULATOR_ID" -only-testing:ConduitTests/ChatResumePolicyTests CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: compilation fails because `ChatResumeBehavior`, `ChatResumeSyncPurpose`, and `ChatResumeSessionResolver` do not exist.
+
+- [ ] **Step 3: Implement the minimal pure policy**
+
+Create `Conduit/Services/ChatResumePolicy.swift`:
+
+```swift
+import Foundation
+
+enum ChatResumeBehavior: String, Codable, CaseIterable {
+    case continueWhereLeftOff
+    case latestActivity
+}
+
+enum ChatResumeSyncPurpose: Equatable {
+    case automaticReturn
+    case preserveCurrent
+}
+
+enum ChatResumeSessionResolver {
+    static func target(
+        in catalog: [SessionSummary],
+        behavior: ChatResumeBehavior,
+        purpose: ChatResumeSyncPurpose,
+        savedSessionID: String?,
+        currentSessionID: String?
+    ) -> SessionSummary? {
+        let requestedID = purpose == .preserveCurrent ? currentSessionID : savedSessionID
+        if purpose == .preserveCurrent || behavior == .continueWhereLeftOff,
+           let requestedID,
+           let matched = catalog.first(where: {
+               $0.id == requestedID || $0.alternateIds.contains(requestedID)
+           }) {
+            return matched
+        }
+        return catalog.first(where: { $0.source == .chat })
+    }
+}
+```
+
+- [ ] **Step 4: Add edge tests and run GREEN**
+
+Add these cases to `ChatResumePolicyTests`:
+
+```swift
+func testLatestReturnsNilWhenNoOrdinaryChatExists() {
+    XCTAssertNil(ChatResumeSessionResolver.target(
+        in: [session("cron", source: .cron)],
+        behavior: .latestActivity,
+        purpose: .automaticReturn,
+        savedSessionID: "cron",
+        currentSessionID: "cron"
+    ))
+}
+
+func testRecoveryMatchesAlternateCurrentID() {
+    let selected = ChatResumeSessionResolver.target(
+        in: [session("stored-a", alternates: ["runtime-a"])],
+        behavior: .latestActivity,
+        purpose: .preserveCurrent,
+        savedSessionID: nil,
+        currentSessionID: "runtime-a"
+    )
+    XCTAssertEqual(selected?.id, "stored-a")
+}
+
+func testContinueCanRestoreSavedCronConversation() {
+    let selected = ChatResumeSessionResolver.target(
+        in: [session("stored-b"), session("cron-a", source: .cron)],
+        behavior: .continueWhereLeftOff,
+        purpose: .automaticReturn,
+        savedSessionID: "cron-a",
+        currentSessionID: "cron-a"
+    )
+    XCTAssertEqual(selected?.id, "cron-a")
+}
+```
+
+Rerun the Step 2 command. Expected: all `ChatResumePolicyTests` pass.
+
+- [ ] **Step 5: Commit the policy**
+
+```bash
+git add Conduit/Services/ChatResumePolicy.swift ConduitTests/ChatResumePolicyTests.swift Conduit.xcodeproj/project.pbxproj
+git commit -m "feat: define chat resume selection policy"
+```
+
+---
+
+### Task 2: Versioned device-local resume store
+
+**Files:**
+- Create: `Conduit/Services/ChatResumeStore.swift`
+- Create: `ConduitTests/ChatResumeStoreTests.swift`
+- Modify: `Conduit/Services/ChatScrollState.swift`
+
+**Interfaces:**
+- Consumes: `ChatResumeBehavior`, `ChatScrollSessionKey`, `ChatScrollSnapshot`, and `ChatScrollAnchorMetadata`.
+- Produces: `ChatResumeStore.behavior`, `setBehavior(_:)`, `lastSessionID(for:)`, `setLastSessionID(_:for:)`, `snapshot(for:)`, `save(_:for:at:)`, `migrateSnapshot(from:to:)`, `clearResumeState()`, and `flush()`.
+
+- [ ] **Step 1: Write failing store tests with isolated defaults**
+
+Create `ConduitTests/ChatResumeStoreTests.swift`:
+
+```swift
+import XCTest
+@testable import Conduit
+
+final class ChatResumeStoreTests: XCTestCase {
+    private func defaults() -> (UserDefaults, String) {
+        let suite = "ChatResumeStoreTests.\(UUID().uuidString)"
+        return (UserDefaults(suiteName: suite)!, suite)
+    }
+
+    func testUnsavedBehaviorDefaultsToContinueWhereLeftOff() {
+        let (defaults, suite) = defaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertEqual(ChatResumeStore(defaults: defaults).behavior, .continueWhereLeftOff)
+    }
+
+    func testPreferenceSessionAndAnchorSurviveStoreRecreation() {
+        let (defaults, suite) = defaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        let snapshot = ChatScrollSnapshot(
+            anchorMessageID: "anchor-12",
+            followsLatest: false,
+            anchorMetadata: .init(fingerprint: "fingerprint", duplicateCount: 1),
+            anchorSourceMessageID: "source-12"
+        )
+        let store = ChatResumeStore(defaults: defaults)
+
+        store.setBehavior(.latestActivity)
+        store.setLastSessionID("stored-a", for: "default")
+        store.save(snapshot, for: key, at: Date(timeIntervalSince1970: 100))
+        store.flush()
+
+        let restored = ChatResumeStore(defaults: defaults)
+        XCTAssertEqual(restored.behavior, .latestActivity)
+        XCTAssertEqual(restored.lastSessionID(for: "default"), "stored-a")
+        XCTAssertEqual(restored.snapshot(for: key), snapshot)
+    }
+
+    func testCorruptPayloadFallsBackWithoutThrowing() {
+        let (defaults, suite) = defaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(Data("not-json".utf8), forKey: ChatResumeStore.defaultStorageKey)
+
+        let store = ChatResumeStore(defaults: defaults)
+
+        XCTAssertEqual(store.behavior, .continueWhereLeftOff)
+        XCTAssertNil(store.lastSessionID(for: "default"))
+    }
+}
+```
+
+- [ ] **Step 2: Run the store tests to verify RED**
+
+Run:
+
+```bash
+xcodegen generate
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination "platform=iOS Simulator,id=$CONDUIT_SIMULATOR_ID" -only-testing:ConduitTests/ChatResumeStoreTests CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: compilation fails because `ChatResumeStore` does not exist.
+
+- [ ] **Step 3: Make scroll anchor values persistable without persisting messages**
+
+Update the declarations in `ChatScrollState.swift`:
+
+```swift
+struct ChatScrollAnchorMetadata: Codable, Equatable { /* existing fields */ }
+struct ChatScrollSessionKey: Codable, Hashable { /* existing normalization */ }
+struct ChatScrollSnapshot: Codable, Equatable { /* existing fields */ }
+```
+
+Do not make `ChatMessage` or `ChatMessageScrollTarget` part of the stored payload.
+
+- [ ] **Step 4: Implement the versioned store**
+
+Create a `final class ChatResumeStore` with a private payload matching these exact persisted fields:
+
+```swift
+final class ChatResumeStore {
+    static let defaultStorageKey = "conduit.chatResume.v1"
+    static let schemaVersion = 1
+    static let maximumSnapshots = 100
+
+    private struct StoredSnapshot: Codable, Equatable {
+        let key: ChatScrollSessionKey
+        let snapshot: ChatScrollSnapshot
+        let updatedAt: Date
+    }
+
+    private struct Payload: Codable, Equatable {
+        let version: Int
+        var behavior: ChatResumeBehavior
+        var lastSessionIDsByProfile: [String: String]
+        var snapshots: [StoredSnapshot]
+    }
+
+    init(
+        defaults: UserDefaults = .standard,
+        storageKey: String = ChatResumeStore.defaultStorageKey,
+        legacyActiveSessionsKey: String = "conduit.activeSessionIdsByProfile.v1"
+    )
+}
+```
+
+Load only payloads whose `version == schemaVersion`. If the storage key is absent, import `[String: String]` from `legacyActiveSessionsKey`, write a version-1 payload, and never consult the legacy key again. If the storage key exists but is corrupt or has an unknown version, replace it with an empty version-1 payload using continue mode; do not re-import legacy state. Normalize profiles through `ChatScrollSessionKey`, prune by descending `updatedAt`, and keep the newest 100 entries.
+
+- [ ] **Step 5: Add migration, unknown-version, alias-migration, pruning, and clearing tests**
+
+Add concrete tests with these assertions (use `JSONSerialization` for the unknown-version payload so tests do not access private store types):
+
+```swift
+func testLegacySessionMapImportsOnlyOnce() {
+    let (defaults, suite) = defaults()
+    defer { defaults.removePersistentDomain(forName: suite) }
+    defaults.set(["default": "stored-a"], forKey: "legacy")
+    _ = ChatResumeStore(defaults: defaults, legacyActiveSessionsKey: "legacy")
+    defaults.set(["default": "stored-b"], forKey: "legacy")
+
+    XCTAssertEqual(
+        ChatResumeStore(defaults: defaults, legacyActiveSessionsKey: "legacy").lastSessionID(for: "default"),
+        "stored-a"
+    )
+}
+
+func testUnknownVersionResetsToDefault() throws {
+    let (defaults, suite) = defaults()
+    defer { defaults.removePersistentDomain(forName: suite) }
+    let data = try JSONSerialization.data(withJSONObject: [
+        "version": 999,
+        "behavior": "latestActivity",
+        "lastSessionIDsByProfile": ["default": "stored-a"],
+        "snapshots": []
+    ])
+    defaults.set(data, forKey: ChatResumeStore.defaultStorageKey)
+
+    XCTAssertEqual(ChatResumeStore(defaults: defaults).behavior, .continueWhereLeftOff)
+}
+
+func testPruningKeepsNewestHundredSnapshots() {
+    let (defaults, suite) = defaults()
+    defer { defaults.removePersistentDomain(forName: suite) }
+    let store = ChatResumeStore(defaults: defaults)
+    for index in 0...100 {
+        store.save(
+            .init(anchorMessageID: "anchor-\(index)", followsLatest: false),
+            for: .init(profile: "default", sessionID: "session-\(index)"),
+            at: Date(timeIntervalSince1970: TimeInterval(index))
+        )
+    }
+    XCTAssertNil(store.snapshot(for: .init(profile: "default", sessionID: "session-0")))
+    XCTAssertNotNil(store.snapshot(for: .init(profile: "default", sessionID: "session-100")))
+}
+
+func testClearResumeStatePreservesBehavior() {
+    let (defaults, suite) = defaults()
+    defer { defaults.removePersistentDomain(forName: suite) }
+    let store = ChatResumeStore(defaults: defaults)
+    store.setBehavior(.latestActivity)
+    store.setLastSessionID("stored-a", for: "default")
+    store.save(.latest, for: .init(profile: "default", sessionID: "stored-a"), at: Date())
+    store.clearResumeState()
+
+    XCTAssertEqual(store.behavior, .latestActivity)
+    XCTAssertNil(store.lastSessionID(for: "default"))
+    XCTAssertNil(store.snapshot(for: .init(profile: "default", sessionID: "stored-a")))
+}
+```
+
+Add the alias migration assertion:
+
+```swift
+func testSnapshotMigratesFromRuntimeToCanonicalKey() {
+    let (defaults, suite) = defaults()
+    defer { defaults.removePersistentDomain(forName: suite) }
+    let store = ChatResumeStore(defaults: defaults)
+    let runtime = ChatScrollSessionKey(profile: "default", sessionID: "runtime-a")
+    let canonical = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+    let snapshot = ChatScrollSnapshot(
+        anchorMessageID: "anchor-12",
+        followsLatest: false,
+        anchorMetadata: .init(fingerprint: "fingerprint", duplicateCount: 2),
+        anchorSourceMessageID: "source-12"
+    )
+    store.save(snapshot, for: runtime, at: Date())
+
+    store.migrateSnapshot(from: runtime, to: canonical)
+
+    XCTAssertEqual(store.snapshot(for: canonical), snapshot)
+}
+```
+
+- [ ] **Step 6: Run focused store and existing scroll tests**
+
+Run:
+
+```bash
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination "platform=iOS Simulator,id=$CONDUIT_SIMULATOR_ID" -only-testing:ConduitTests/ChatResumeStoreTests -only-testing:ConduitTests/ChatScrollStateTests CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: all store and scroll-state tests pass.
+
+- [ ] **Step 7: Commit the store**
+
+```bash
+git add Conduit/Services/ChatResumeStore.swift Conduit/Services/ChatScrollState.swift ConduitTests/ChatResumeStoreTests.swift Conduit.xcodeproj/project.pbxproj
+git commit -m "feat: persist chat resume state"
+```
+
+---
+
+### Task 3: Focused lifecycle coordinator
+
+**Files:**
+- Create: `Conduit/Services/ChatResumeCoordinator.swift`
+- Create: `ConduitTests/ChatResumeCoordinatorTests.swift`
+
+**Interfaces:**
+- Consumes: `ChatResumeStore`, `ChatResumeSessionResolver`, `ChatScrollSessionIdentity`, and `ChatScrollSnapshot`.
+- Produces: `ChatResumeRestorationRequest`, `selectTarget(in:profile:purpose:currentSessionID:)`, `recordViewport(_:for:)`, `freezeViewport()`, `reconciliationSettled(sessionKey:)`, `cancelRestoration()`, `completeRestoration(generation:)`, `clearResumeState()`, and `flush()`.
+
+- [ ] **Step 1: Write failing lifecycle tests**
+
+Create tests using isolated `UserDefaults`:
+
+```swift
+@MainActor
+final class ChatResumeCoordinatorTests: XCTestCase {
+    func testInactiveFreezeRejectsLateGeometryOverwrite() {
+        let harness = makeHarness()
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        let reading = ChatScrollSnapshot(anchorMessageID: "anchor-12", followsLatest: false)
+
+        harness.coordinator.recordViewport(reading, for: key)
+        harness.coordinator.freezeViewport()
+        harness.coordinator.recordViewport(.latest, for: key)
+        harness.coordinator.flush()
+
+        XCTAssertEqual(harness.store.snapshot(for: key), reading)
+    }
+
+    func testContinueRequestIsEmittedOnlyAfterReconciliationSettles() {
+        let harness = makeHarness()
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        let reading = ChatScrollSnapshot(anchorMessageID: "anchor-12", followsLatest: false)
+        harness.store.save(reading, for: key, at: Date())
+        harness.store.setLastSessionID("stored-a", for: "default")
+
+        _ = harness.coordinator.selectTarget(
+            in: [session("stored-b"), session("stored-a")],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: "stored-a"
+        )
+        XCTAssertNil(harness.coordinator.pendingRestoration)
+
+        let request = harness.coordinator.reconciliationSettled(sessionKey: key)
+        XCTAssertEqual(request?.destination, .snapshot(reading))
+    }
+
+    func testExplicitActionCancelsAnOlderGeneration() {
+        let harness = makeHarness()
+        let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        _ = harness.coordinator.selectTarget(
+            in: [session("stored-a")],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: "stored-a"
+        )
+        let request = harness.coordinator.reconciliationSettled(sessionKey: key)!
+
+        harness.coordinator.cancelRestoration()
+
+        XCTAssertFalse(harness.coordinator.isCurrent(generation: request.generation))
+    }
+}
+```
+
+The harness returns `(coordinator, store, defaults, suite)` and removes its persistent domain in teardown.
+
+- [ ] **Step 2: Run lifecycle tests to verify RED**
+
+Run:
+
+```bash
+xcodegen generate
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination "platform=iOS Simulator,id=$CONDUIT_SIMULATOR_ID" -only-testing:ConduitTests/ChatResumeCoordinatorTests CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: compilation fails because the coordinator and request types do not exist.
+
+- [ ] **Step 3: Implement generation-scoped restoration requests**
+
+Create these public module-internal types:
+
+```swift
+enum ChatResumeRestorationDestination: Equatable {
+    case latest
+    case snapshot(ChatScrollSnapshot)
+}
+
+struct ChatResumeRestorationRequest: Identifiable, Equatable {
+    let generation: UInt64
+    let sessionKey: ChatScrollSessionKey
+    let destination: ChatResumeRestorationDestination
+    var id: UInt64 { generation }
+}
+
+@MainActor
+final class ChatResumeCoordinator {
+    private(set) var pendingRestoration: ChatResumeRestorationRequest?
+    var behavior: ChatResumeBehavior { store.behavior }
+
+    init(store: ChatResumeStore)
+    func setBehavior(_ behavior: ChatResumeBehavior)
+    func lastSessionID(for profile: String) -> String?
+    func rememberSessionID(_ sessionID: String?, for profile: String)
+    func selectTarget(in catalog: [SessionSummary], profile: String, purpose: ChatResumeSyncPurpose, currentSessionID: String?) -> SessionSummary?
+    func recordViewport(_ snapshot: ChatScrollSnapshot, for key: ChatScrollSessionKey)
+    func migrateSnapshot(from oldKey: ChatScrollSessionKey, to newKey: ChatScrollSessionKey)
+    func freezeViewport()
+    func reconciliationSettled(sessionKey: ChatScrollSessionKey) -> ChatResumeRestorationRequest?
+    func cancelRestoration()
+    func completeRestoration(generation: UInt64)
+    func isCurrent(generation: UInt64) -> Bool
+    func clearResumeState()
+    func flush()
+}
+```
+
+`selectTarget` marks an automatic return as pending only for `.automaticReturn`. `reconciliationSettled` emits `.latest` for latest mode, otherwise emits the stored snapshot or `.latest`. Keep snapshot mutation frozen until the matching request completes or any explicit cancellation occurs. `setBehavior(_:)` cancels an in-flight restoration before saving the new behavior. `clearResumeState()` cancels work and delegates to the store while preserving the selected behavior.
+
+- [ ] **Step 4: Add the 300 ms coalesced write without timing-dependent tests**
+
+On accepted `recordViewport`, update the store's in-memory payload immediately, cancel the previous write task, and schedule:
+
+```swift
+pendingFlushTask = Task { [weak self] in
+    do { try await Task.sleep(for: .milliseconds(300)) }
+    catch { return }
+    guard !Task.isCancelled else { return }
+    self?.store.flush()
+}
+```
+
+`freezeViewport()` and `flush()` cancel this task and call `store.flush()` synchronously. Tests should invoke `flush()` directly rather than sleep.
+
+- [ ] **Step 5: Add latest-mode, cold-launch, fallback, and completion tests**
+
+Add these explicit assertions to `ChatResumeCoordinatorTests`:
+
+```swift
+func testLatestModeSelectsNewestAndEmitsLatest() {
+    let harness = makeHarness()
+    harness.coordinator.setBehavior(.latestActivity)
+    let selected = harness.coordinator.selectTarget(
+        in: [session("stored-b"), session("stored-a")],
+        profile: "default",
+        purpose: .automaticReturn,
+        currentSessionID: "stored-a"
+    )
+    let request = harness.coordinator.reconciliationSettled(
+        sessionKey: .init(profile: "default", sessionID: selected!.id)
+    )
+
+    XCTAssertEqual(selected?.id, "stored-b")
+    XCTAssertEqual(request?.destination, .latest)
+}
+
+func testColdLaunchRestoresPersistedSnapshot() {
+    let harness = makeHarness()
+    let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+    let snapshot = ChatScrollSnapshot(anchorMessageID: "anchor-12", followsLatest: false)
+    harness.store.save(snapshot, for: key, at: Date())
+    harness.store.setLastSessionID("stored-a", for: "default")
+    harness.store.flush()
+    let recreated = ChatResumeCoordinator(store: ChatResumeStore(defaults: harness.defaults))
+
+    _ = recreated.selectTarget(
+        in: [session("stored-b"), session("stored-a")],
+        profile: "default",
+        purpose: .automaticReturn,
+        currentSessionID: nil
+    )
+
+    XCTAssertEqual(recreated.reconciliationSettled(sessionKey: key)?.destination, .snapshot(snapshot))
+}
+
+func testCompletingCurrentRequestAllowsViewportWritesAgain() {
+    let harness = makeHarness()
+    let key = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+    _ = harness.coordinator.selectTarget(
+        in: [session("stored-a")],
+        profile: "default",
+        purpose: .automaticReturn,
+        currentSessionID: "stored-a"
+    )
+    let request = harness.coordinator.reconciliationSettled(sessionKey: key)!
+    harness.coordinator.completeRestoration(generation: request.generation)
+    harness.coordinator.recordViewport(.latest, for: key)
+    harness.coordinator.flush()
+
+    XCTAssertEqual(harness.store.snapshot(for: key), .latest)
+}
+```
+
+Add the missing-A coordinator boundary case:
+
+```swift
+func testMissingContinueTargetSelectsNewestChat() {
+    let harness = makeHarness()
+    harness.store.setLastSessionID("deleted-a", for: "default")
+
+    let selected = harness.coordinator.selectTarget(
+        in: [session("stored-b")],
+        profile: "default",
+        purpose: .automaticReturn,
+        currentSessionID: "deleted-a"
+    )
+
+    XCTAssertEqual(selected?.id, "stored-b")
+}
+```
+
+- [ ] **Step 6: Run all three focused resume suites**
+
+Run:
+
+```bash
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination "platform=iOS Simulator,id=$CONDUIT_SIMULATOR_ID" -only-testing:ConduitTests/ChatResumePolicyTests -only-testing:ConduitTests/ChatResumeStoreTests -only-testing:ConduitTests/ChatResumeCoordinatorTests CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: all pass without fixed-delay test waits.
+
+- [ ] **Step 7: Commit the coordinator**
+
+```bash
+git add Conduit/Services/ChatResumeCoordinator.swift ConduitTests/ChatResumeCoordinatorTests.swift Conduit.xcodeproj/project.pbxproj
+git commit -m "feat: coordinate durable chat restoration"
+```
+
+---
+
+### Task 4: Integrate automatic session selection with AppState
+
+**Files:**
+- Modify: `Conduit/Services/AppState.swift`
+- Modify: `ConduitTests/ChatResumeCoordinatorTests.swift`
+
+**Interfaces:**
+- Consumes: all coordinator APIs from Task 3.
+- Produces: `AppState.chatResumeBehavior`, `chatResumeRestorationRequest`, `setChatResumeBehavior(_:)`, `recordChatViewport(_:for:)`, `flushChatResumeViewport()`, `completeChatResumeRestoration(generation:)`, and `cancelChatResumeRestoration()` for Settings and ChatView.
+
+- [ ] **Step 1: Add a failing test for automatic-versus-recovery sync intent**
+
+Extend coordinator tests with:
+
+```swift
+func testRecoverySyncPreservesCurrentWhileAutomaticReturnUsesPreference() {
+    let harness = makeHarness()
+    harness.coordinator.setBehavior(.latestActivity)
+    let catalog = [session("stored-b"), session("stored-a")]
+
+    let automatic = harness.coordinator.selectTarget(
+        in: catalog,
+        profile: "default",
+        purpose: .automaticReturn,
+        currentSessionID: "stored-a"
+    )
+    harness.coordinator.cancelRestoration()
+    let recovery = harness.coordinator.selectTarget(
+        in: catalog,
+        profile: "default",
+        purpose: .preserveCurrent,
+        currentSessionID: "stored-a"
+    )
+
+    XCTAssertEqual(automatic?.id, "stored-b")
+    XCTAssertEqual(recovery?.id, "stored-a")
+}
+```
+
+This protects send/interrupt recovery paths from unexpectedly changing sessions.
+
+- [ ] **Step 2: Add coordinator-owned published surfaces to AppState**
+
+Add:
+
+```swift
+@Published private(set) var chatResumeBehavior: ChatResumeBehavior = .continueWhereLeftOff
+@Published private(set) var chatResumeRestorationRequest: ChatResumeRestorationRequest?
+private let chatResumeCoordinator = ChatResumeCoordinator(store: ChatResumeStore())
+```
+
+At the start of `init()`, assign `chatResumeBehavior = chatResumeCoordinator.behavior`. Add forwarding methods that update the published request after `reconciliationSettled` and clear it only when the matching generation completes or cancellation occurs.
+
+- [ ] **Step 3: Make the coordinator the sole active-session persistence source**
+
+Remove `activeSessionIDsByProfileKey`, `activeSessionIDsByProfile`, and `migrateLegacyActiveSessionStateIfNeeded()` from `AppState`; Task 2 performs the one-time import. Change:
+
+```swift
+private func restoreActiveSessionState(for profile: String) {
+    activeSessionId = chatResumeCoordinator.lastSessionID(for: profile)
+    activeSessionTitle = activeSessionTitlesByProfile[profile] ?? "New conversation"
+}
+```
+
+After canonicalizing inside `setActiveSessionState`, call `chatResumeCoordinator.rememberSessionID(persistedID, for: activeProfile)`. Keep title persistence in `activeSessionTitlesByProfile`.
+
+In `disconnect()`, call `chatResumeCoordinator.clearResumeState()` and remove the obsolete active-session-map reset. This preserves the device-local behavior choice while preventing snapshots from one server being reused after connecting to another.
+
+- [ ] **Step 4: Thread an explicit sync purpose through catalog reconciliation**
+
+Replace the overloads with:
+
+```swift
+func syncSession() async {
+    await syncSession(purpose: .preserveCurrent, using: nil)
+}
+
+private func syncSession(
+    purpose: ChatResumeSyncPurpose,
+    using existingReconciliationToken: UUID?
+) async
+```
+
+After loading `allSessions`, choose the target through:
+
+```swift
+let target = chatResumeCoordinator.selectTarget(
+    in: allSessions,
+    profile: profile,
+    purpose: purpose,
+    currentSessionID: activeSessionId
+)
+```
+
+Use `.automaticReturn` only for saved-connection launch, explicit connect completion, and foreground recovery. Keep `.preserveCurrent` for send/attachment/steer/interrupt error recovery, manual refresh, and profile switching.
+
+- [ ] **Step 5: Preserve automatic purpose across reconnect retries**
+
+Change signatures to:
+
+```swift
+private func scheduleReconnect(
+    immediately: Bool = false,
+    purpose: ChatResumeSyncPurpose = .preserveCurrent
+)
+
+func reconnect(
+    purpose: ChatResumeSyncPurpose = .preserveCurrent
+) async
+```
+
+Capture `purpose` in the retry task. Foreground health-check failure calls `reconnect(purpose: .automaticReturn)`; a failed automatic reconnect schedules another automatic retry. Other reconnect callers retain the default preserve-current behavior.
+
+- [ ] **Step 6: Publish restoration only after successful reconciliation**
+
+After `applyResume`, buffered-event replay, and `settleReconciliation(token)`, call a helper that:
+
+1. obtains the canonical `activeChatScrollSessionIdentity.canonicalSessionKey`;
+2. calls `chatResumeCoordinator.reconciliationSettled(sessionKey:)`;
+3. assigns the result to `chatResumeRestorationRequest`.
+
+Do not consume the pending automatic return on catalog or reconcile failure; retain it for the retry. Creating a new fallback session should publish `.latest` after the created session settles.
+
+- [ ] **Step 7: Freeze viewport state from the single scene-phase path**
+
+In `handleScenePhase`:
+
+- call `chatResumeCoordinator.freezeViewport()` on `.inactive` before layout can collapse;
+- retain presentation-cache flushing and reconciliation invalidation on `.background`;
+- call `syncSession(purpose: .automaticReturn, using: token)` on `.active`;
+- cancel stale resume requests when disconnecting, switching profile, handling a notification target, or starting a new conversation.
+
+- [ ] **Step 8: Run resume suites and the existing reconciliation-related suites**
+
+Run:
+
+```bash
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination "platform=iOS Simulator,id=$CONDUIT_SIMULATOR_ID" -only-testing:ConduitTests/ChatResumePolicyTests -only-testing:ConduitTests/ChatResumeStoreTests -only-testing:ConduitTests/ChatResumeCoordinatorTests -only-testing:ConduitTests/ChatScrollStateTests -only-testing:ConduitTests/StreamEventParserTests -only-testing:ConduitTests/TurnStateTests CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: all selected suites pass.
+
+- [ ] **Step 9: Commit AppState integration**
+
+```bash
+git add Conduit/Services/AppState.swift ConduitTests/ChatResumeCoordinatorTests.swift
+git commit -m "feat: apply resume policy during session sync"
+```
+
+---
+
+### Task 5: Make ChatView a restoration consumer
+
+**Files:**
+- Modify: `Conduit/Views/ChatView.swift`
+- Modify: `Conduit/Services/ChatScrollState.swift`
+- Modify: `ConduitTests/ChatScrollStateTests.swift`
+- Modify: `ConduitTests/ChatResumePolicyTests.swift`
+
+**Interfaces:**
+- Consumes: `AppState.chatResumeRestorationRequest`, viewport reporting/cancellation/completion methods, and semantic targets.
+- Produces: no new global state; `ChatView` only reports snapshots and applies requests.
+
+- [ ] **Step 1: Write failing viewport-resolution policy tests**
+
+Add `ChatResumeViewportResolver` expectations:
+
+```swift
+func testPersistedAnchorSurvivesWhenTargetExists() {
+    let message = ChatMessage(id: "source-12", role: .assistant, content: "Stable", timestamp: "now")
+    let target = ChatMessageScrollTargets.make(for: [message])[0]
+    let snapshot = ChatScrollSnapshot(
+        anchorMessageID: target.semanticID,
+        followsLatest: false,
+        anchorMetadata: target.restorationMetadata,
+        anchorSourceMessageID: target.id
+    )
+
+    XCTAssertEqual(
+        ChatResumeViewportResolver.destination(
+            for: snapshot,
+            availableTargets: .init(targets: [target])
+        ),
+        .anchor(target.semanticID)
+    )
+}
+
+func testMissingAnchorFallsBackToLatestWithinSelectedConversation() {
+    XCTAssertEqual(
+        ChatResumeViewportResolver.destination(
+            for: .init(anchorMessageID: "deleted", followsLatest: false),
+            availableTargets: .init(targets: [])
+        ),
+        .latest
+    )
+}
+```
+
+Retain the existing source-message re-anchor and duplicate-fingerprint cases.
+
+- [ ] **Step 2: Run focused policy/scroll tests to verify RED**
+
+Run:
+
+```bash
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination "platform=iOS Simulator,id=$CONDUIT_SIMULATOR_ID" -only-testing:ConduitTests/ChatResumePolicyTests -only-testing:ConduitTests/ChatScrollStateTests CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: compilation fails because `ChatResumeViewportResolver` does not exist.
+
+- [ ] **Step 3: Extract the reusable viewport resolver**
+
+In `ChatResumePolicy.swift`, add:
+
+```swift
+enum ChatResumeViewportDestination: Equatable {
+    case latest
+    case anchor(String)
+}
+
+enum ChatResumeViewportResolver {
+    static func destination(
+        for snapshot: ChatScrollSnapshot,
+        availableTargets: ChatScrollTargetAvailability
+    ) -> ChatResumeViewportDestination
+}
+```
+
+Move the exact-anchor, metadata validation, and source-message re-anchor logic out of `ChatScrollStateStore.restoration` into this pure resolver. Keep semantic target generation in `ChatScrollState.swift`.
+
+Change `ChatScrollTargetAvailability.contains`, `metadata(for:)`, and `semanticID(forSourceMessageID:)` from `fileprivate` to module-internal so `ChatResumePolicy.swift` can use them without duplicating target maps.
+
+- [ ] **Step 4: Remove ChatView's independent lifecycle ownership**
+
+Delete:
+
+- `@Environment(\.scenePhase)`;
+- local `ChatScrollStateStore` persistence ownership;
+- the `.onChange(of: scenePhase)` handler;
+- reconciliation gates that duplicate the coordinator's settled request;
+- delayed scroll callbacks that are not generation-checked.
+
+Keep semantic target caching, bottom/viewport geometry, notification handoff, and the user-facing jump-to-latest button.
+
+- [ ] **Step 5: Report stable viewport snapshots through AppState**
+
+Refactor `saveChatScrollPosition` so it builds the existing semantic snapshot and calls:
+
+```swift
+appState.recordChatViewport(snapshot, for: sessionKey)
+```
+
+Report when `topVisibleChatID` changes, after stable drag completion, before explicit session/profile switches while the old transcript is still rendered, and whenever `followsLatest` changes. The coordinator ignores suspension-time callbacks while frozen.
+
+On stable drag completion, call `appState.flushChatResumeViewport()` immediately after reporting the snapshot. `AppState` forwards this to `ChatResumeCoordinator.flush()`.
+
+- [ ] **Step 6: Consume generation-scoped restoration requests**
+
+Observe `appState.chatResumeRestorationRequest`. For `.latest`, scroll to `bottomAnchor` only if the generation remains current. For `.snapshot`, wait until the target cache reflects the reconciled `messages`, resolve through `ChatResumeViewportResolver`, and perform a nonanimated anchor scroll or latest fallback.
+
+After success call:
+
+```swift
+appState.completeChatResumeRestoration(generation: request.generation)
+```
+
+On drag, jump-to-latest, composer request, session/profile switch, or notification handoff, call `appState.cancelChatResumeRestoration()` before the explicit action.
+
+- [ ] **Step 7: Prevent message updates from stealing a restored viewport**
+
+Update `ChatMessageScrollUpdatePolicy.shouldReassertLatest` calls so any pending resume request suppresses latest reassertion. Continue mode with `followsLatest == false` must retain the anchor when new messages arrive and leave the down-arrow visible.
+
+- [ ] **Step 8: Remove superseded local-store tests and run focused suites**
+
+Delete only tests that assert the old in-memory `ChatScrollStateStore` owns session persistence. Retain and adapt semantic-anchor, duplicate-content, projection replacement, latest-reassertion, notification handoff, and source-ID re-anchor tests.
+
+Run:
+
+```bash
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination "platform=iOS Simulator,id=$CONDUIT_SIMULATOR_ID" -only-testing:ConduitTests/ChatScrollStateTests -only-testing:ConduitTests/ChatResumePolicyTests -only-testing:ConduitTests/ChatResumeCoordinatorTests CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: all selected suites pass.
+
+- [ ] **Step 9: Commit the view integration**
+
+```bash
+git add Conduit/Views/ChatView.swift Conduit/Services/ChatScrollState.swift Conduit/Services/ChatResumePolicy.swift ConduitTests/ChatScrollStateTests.swift ConduitTests/ChatResumePolicyTests.swift
+git commit -m "fix: restore chat viewport through coordinator"
+```
+
+---
+
+### Task 6: Add the Chat settings control
+
+**Files:**
+- Modify: `Conduit/Views/AuxiliaryViews.swift`
+- Modify: `Conduit/Views/RootView.swift`
+- Modify: `Conduit/Services/AppState.swift`
+- Modify: `ConduitTests/ChatResumePolicyTests.swift`
+
+**Interfaces:**
+- Consumes: `AppState.chatResumeBehavior` and `setChatResumeBehavior(_:)`.
+- Produces: `SettingsSnapshot.chatResumeBehavior` and a device-local segmented control.
+
+- [ ] **Step 1: Add failing copy/default tests**
+
+Give `ChatResumeBehavior` stable presentation values and test them:
+
+```swift
+func testResumeBehaviorPresentationCopyIsStable() {
+    XCTAssertEqual(ChatResumeBehavior.continueWhereLeftOff.title, "Continue where I left off")
+    XCTAssertEqual(ChatResumeBehavior.latestActivity.title, "Jump to latest activity")
+}
+```
+
+- [ ] **Step 2: Implement stable behavior copy**
+
+Add to `ChatResumePolicy.swift`:
+
+```swift
+extension ChatResumeBehavior {
+    var title: String {
+        switch self {
+        case .continueWhereLeftOff: return "Continue where I left off"
+        case .latestActivity: return "Jump to latest activity"
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Thread the device-local setting through SettingsSnapshot**
+
+Add `chatResumeBehavior: ChatResumeBehavior` to `SettingsSnapshot` and `makeSettingsSnapshot()`. Add `persistChatResumeBehavior: (ChatResumeBehavior) -> Void` to `SettingsView`, pass it into `ChatSettingsDetail`, and supply this closure from `RootView`:
+
+```swift
+persistChatResumeBehavior: { appState.setChatResumeBehavior($0) }
+```
+
+- [ ] **Step 4: Add the segmented Chat settings section**
+
+Before profile-backed chat fields, render:
+
+```swift
+ConduitSettingsSection(
+    title: "When returning to Conduit",
+    symbol: "arrow.uturn.backward.circle",
+    tint: .conduitAccent
+) {
+    Text("Choose whether Conduit preserves your exact reading position or follows the newest conversation.")
+        .font(.footnote)
+        .foregroundStyle(.secondary)
+    Picker("When returning to Conduit", selection: $behavior) {
+        Text("Continue").tag(ChatResumeBehavior.continueWhereLeftOff)
+        Text("Latest").tag(ChatResumeBehavior.latestActivity)
+    }
+    .pickerStyle(.segmented)
+}
+```
+
+Initialize local state from the snapshot and persist immediately on selection. Label the section as device-local so it is not confused with Hermes profile settings.
+
+- [ ] **Step 5: Run policy tests and build the app**
+
+Run the focused policy tests, then:
+
+```bash
+xcodebuild build -project Conduit.xcodeproj -scheme Conduit -destination "platform=iOS Simulator,id=$CONDUIT_SIMULATOR_ID" CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: tests pass and the app builds.
+
+- [ ] **Step 6: Commit Settings integration**
+
+```bash
+git add Conduit/Views/AuxiliaryViews.swift Conduit/Views/RootView.swift Conduit/Services/AppState.swift Conduit/Services/ChatResumePolicy.swift ConduitTests/ChatResumePolicyTests.swift
+git commit -m "feat: add chat return behavior setting"
+```
+
+---
+
+### Task 7: Full regression and simulator acceptance
+
+**Files:**
+- Modify only files required by failures directly caused by Tasks 1-6.
+- Verify: all `ConduitTests` and both user-facing behavior modes.
+
+**Interfaces:**
+- Consumes: completed implementation from Tasks 1-6.
+- Produces: evidence that PR #19 satisfies the design and introduces no test regression.
+
+- [ ] **Step 1: Regenerate and inspect the final diff**
+
+Run:
+
+```bash
+xcodegen generate
+git diff --check
+git status --short
+git diff --stat 609fef2...HEAD
+```
+
+Confirm `ChatView` no longer observes scene phase, the coordinator store is the only automatic-session persistence source, and no production file contains duplicate restoration callbacks.
+
+- [ ] **Step 2: Run the full unit-test suite with a dynamically selected simulator**
+
+Resolve an available iPhone UDID using the same JSON selection strategy as `.github/workflows/ci.yml`, then run:
+
+```bash
+CONDUIT_RESULT_DIR=$(mktemp -d /tmp/conduit-chat-resume.XXXXXX)
+xcodebuild test \
+  -project Conduit.xcodeproj \
+  -scheme Conduit \
+  -destination "platform=iOS Simulator,id=$CONDUIT_SIMULATOR_ID" \
+  -configuration Debug \
+  -resultBundlePath "$CONDUIT_RESULT_DIR/TestResults.xcresult" \
+  CODE_SIGN_IDENTITY="" \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  DEVELOPMENT_TEAM="" \
+  PROVISIONING_PROFILE_SPECIFIER=""
+```
+
+Expected: all tests pass. Preserve the `.xcresult` if any test fails.
+
+- [ ] **Step 3: Run simulator acceptance in continue mode**
+
+On an iPhone Simulator connected to a test Hermes instance:
+
+1. Select A and scroll to an older message.
+2. Background Conduit and create or receive newer activity in B.
+3. Return and verify A remains selected at the same anchor with jump-to-latest available.
+4. Terminate and relaunch Conduit; verify A and its anchor restore again.
+5. Add messages to A while backgrounded and verify the viewport does not move.
+
+- [ ] **Step 4: Run simulator acceptance in latest mode**
+
+Change the Chat setting to **Jump to latest activity**, repeat background/foreground and terminate/relaunch, and verify B opens at its bottom both times.
+
+- [ ] **Step 5: Verify precedence and fallback**
+
+Verify a notification destination wins while automatic restoration is pending, a manual session tap cancels restoration, and deleting saved A causes a clean fallback to the newest ordinary chat without an error.
+
+- [ ] **Step 6: Commit only direct verification fixes**
+
+If verification required a direct fix, rerun the focused failing test and full suite before committing it with a narrow message. If no code changed, do not create an empty commit.
+
+- [ ] **Step 7: Review branch history and hand off PR #19**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline --decorate 609fef2..HEAD
+```
+
+Expected: clean worktree, focused commits, and no uncommitted generated/test artifacts. Push and update PR #19 only after code review and user approval.

--- a/docs/superpowers/specs/2026-08-09-chat-resume-behavior-design.md
+++ b/docs/superpowers/specs/2026-08-09-chat-resume-behavior-design.md
@@ -51,8 +51,8 @@ The coordinator is composed from small value-oriented pieces:
 - `ChatResumeBehavior`: a codable enum for continue or latest behavior.
 - `ChatResumeSessionResolver`: a pure policy that chooses a catalog session from the behavior, saved identity, refreshed catalog, and any higher-priority destination.
 - `ChatResumeStore`: a versioned device-local store for the preference, last active session per profile, and viewport snapshots.
-- `ChatResumeSnapshot`: the canonical session key, semantic anchor, source message ID, duplicate/fingerprint metadata, whether the viewport follows latest, and the update timestamp.
-- `ChatResumeRestorationIntent`: a generation-scoped instruction to wait, restore an anchor, follow latest, or cancel.
+- `ChatScrollSnapshot`: the canonical session key, semantic anchor, source message ID, duplicate/fingerprint metadata, whether the viewport follows latest, and the update timestamp.
+- `ChatResumeRestorationRequest`: a generation-scoped instruction to wait, restore an anchor, follow latest, or cancel.
 
 `AppState` remains authoritative for connection, catalog loading, and transcript reconciliation. It asks the coordinator which session should be automatically reconciled after loading the catalog and reports reconciliation completion. `ChatView` remains responsible for performing `ScrollViewProxy` operations and reporting stable viewport state, but it no longer observes scene phase or owns automatic-resume policy.
 

--- a/docs/superpowers/specs/2026-08-09-chat-resume-behavior-design.md
+++ b/docs/superpowers/specs/2026-08-09-chat-resume-behavior-design.md
@@ -1,0 +1,167 @@
+# Chat Resume Behavior Design
+
+## Context
+
+Conduit currently performs an authoritative session reconciliation whenever it launches or returns to the foreground. If the locally remembered session uses a runtime ID that no longer matches the stored ID in the refreshed catalog, session selection falls back to the first and newest chat. A user who left Conduit while reading conversation A can therefore return to conversation B.
+
+PR #19 added semantic scroll anchors, session-ID aliases, and several restoration callbacks, but it does not model the complete launch/foreground decision. Session selection and viewport restoration are currently split between `AppState`, `RootView`, and `ChatView`, and both `RootView` and `ChatView` independently observe scene changes. This makes callback ordering part of correctness and leaves the reported A-to-B regression without an end-to-end policy test.
+
+## Goals
+
+- Give users an explicit, device-local choice for automatic launch and foreground behavior.
+- Make **Continue where I left off** the default for existing and new installations.
+- Apply the selected behavior consistently after ordinary foregrounding, process termination, and cold launch.
+- In continue mode, reopen the same profile and conversation and restore the last stable reading position.
+- In latest mode, deliberately open the newest available chat and follow its bottom.
+- Preserve notification routing and explicit user navigation as higher-priority actions.
+- Make session choice, snapshot persistence, and restoration sequencing independently testable.
+- Reuse the resulting components if Conduit later adopts a broader navigation coordinator.
+
+## Non-goals
+
+- Rewriting Conduit's complete navigation stack.
+- Changing Hermes server configuration or synchronizing this preference across devices.
+- Restoring a deleted message or conversation.
+- Changing how sessions are ordered in the sidebar.
+- Changing notification destination behavior.
+
+## User-facing behavior
+
+Chat settings gain a device-local segmented choice titled **When returning to Conduit**:
+
+- **Continue where I left off**: reopen the last visible conversation and restore its last stable viewport anchor. New activity in another conversation does not steal focus. New messages in the restored conversation do not move the reader; the existing jump-to-latest control remains available.
+- **Jump to latest activity**: refresh the session catalog, select its newest ordinary chat, and scroll that conversation to the bottom.
+
+Continue mode is the default when no preference has been saved. The setting governs automatic restoration on launch and foregrounding. A notification tap, an explicit session tap, profile selection, or new-conversation action always wins over an automatic resume already in progress.
+
+If a saved conversation no longer exists or is no longer eligible, continue mode falls back to the newest available chat at its bottom. If the conversation still exists but only its saved message anchor is unavailable, Conduit keeps that conversation selected and falls back to its bottom.
+
+## Architecture
+
+Introduce a focused `ChatResumeCoordinator`. It is not a general navigation coordinator. Its responsibilities are limited to:
+
+1. Owning the device-local resume behavior preference.
+2. Persisting and retrieving profile/session viewport snapshots.
+3. Resolving the automatic session target after the authoritative catalog refresh.
+4. Tracking one restoration generation so stale asynchronous work can be cancelled.
+5. Emitting a restoration intent only after session reconciliation has settled.
+
+The coordinator is composed from small value-oriented pieces:
+
+- `ChatResumeBehavior`: a codable enum for continue or latest behavior.
+- `ChatResumeSessionResolver`: a pure policy that chooses a catalog session from the behavior, saved identity, refreshed catalog, and any higher-priority destination.
+- `ChatResumeStore`: a versioned device-local store for the preference, last active session per profile, and viewport snapshots.
+- `ChatResumeSnapshot`: the canonical session key, semantic anchor, source message ID, duplicate/fingerprint metadata, whether the viewport follows latest, and the update timestamp.
+- `ChatResumeRestorationIntent`: a generation-scoped instruction to wait, restore an anchor, follow latest, or cancel.
+
+`AppState` remains authoritative for connection, catalog loading, and transcript reconciliation. It asks the coordinator which session should be automatically reconciled after loading the catalog and reports reconciliation completion. `ChatView` remains responsible for performing `ScrollViewProxy` operations and reporting stable viewport state, but it no longer observes scene phase or owns automatic-resume policy.
+
+`RootView` remains the single scene-phase entry point. It forwards lifecycle transitions to `AppState`, which coordinates network reconciliation and the resume coordinator in a defined sequence.
+
+## Persistence
+
+The device-local store uses a versioned `Codable` payload in `UserDefaults`. It contains no transcript content or credentials.
+
+Snapshots are keyed by normalized profile plus canonical stored session ID. Runtime and alternate IDs are resolved against the refreshed catalog before lookup. When the version-1 resume store is absent, it imports the existing per-profile active-session map once. After a successful import, the coordinator store becomes the sole automatic-resume source; the legacy map is no longer read or written.
+
+The store retains at most 100 session snapshots, pruning least-recently-updated entries after a successful save. Viewport changes update the in-memory snapshot immediately and persist after a 300-millisecond debounce. A stable drag completion and the inactive transition flush immediately, allowing restoration after both normal backgrounding and process termination without writing on every scroll frame.
+
+## Lifecycle data flow
+
+### Inactive or background
+
+1. `RootView` reports the scene transition once.
+2. The coordinator freezes the last valid snapshot for the currently rendered canonical session.
+3. Pending viewport writes are flushed.
+4. Further geometry and `scrollPosition` callbacks are ignored for snapshot mutation until foreground restoration starts, preventing suspension layout from replacing a reading anchor with `followsLatest`.
+5. `AppState` flushes presentation state and invalidates stale network reconciliation as it does today.
+
+### Foreground or cold launch
+
+1. Any notification or explicit navigation destination is checked first.
+2. `AppState` refreshes the authoritative profile-scoped session catalog.
+3. The pure resolver selects a target:
+   - continue mode resolves the saved canonical/alternate identity and chooses that session;
+   - latest mode chooses the newest eligible ordinary chat;
+   - an unavailable continue target falls back to the newest eligible chat.
+4. `AppState` reconciles the selected session and publishes the settled transcript identity.
+5. The coordinator emits a generation-scoped restoration intent:
+   - restore the semantic anchor in continue mode when available;
+   - re-anchor by source message ID if a streaming projection changed the semantic fingerprint;
+   - follow latest when requested by policy or required by fallback.
+6. `ChatView` performs the nonanimated anchor restoration after SwiftUI installs the target rows. A delayed scroll from an older generation cannot run after restoration or user interaction.
+7. Snapshot mutation resumes after the restoration intent completes or cancels.
+
+## Explicit-action precedence
+
+Automatic resume must never override intent expressed after it starts. The following actions increment the restoration generation and cancel older work:
+
+- notification routing;
+- tapping a session or changing profile;
+- creating a conversation;
+- submitting a message or invoking jump-to-latest;
+- deliberately dragging the chat;
+- disconnecting or changing servers.
+
+Notification routing continues to use its existing destination preparation and layout handoff. The resume coordinator supplies cancellation and does not replace that flow.
+
+## Failure handling
+
+- Missing or ineligible saved session: remove or supersede the stale last-session reference and open the newest eligible chat at its bottom.
+- Missing saved anchor in an otherwise valid session: keep the session and follow its bottom.
+- Corrupt, unknown-version, or partially decoded local payload: discard the payload, restore the default behavior, and continue without presenting an error.
+- Catalog or reconciliation failure: retain the frozen snapshot for a later attempt and use existing connection error handling.
+- Runtime/stored ID disagreement: resolve through catalog aliases and the reconciliation-request/resolution pair before declaring the saved session missing.
+- Stale callback or task: reject it by restoration generation and active profile/session identity.
+
+Resume metadata is a convenience layer and must never prevent login, connection, session selection, or manual navigation.
+
+## Testing
+
+### Policy tests
+
+- Continue mode chooses conversation A even when conversation B is newer.
+- Latest mode deliberately chooses conversation B even when A is saved.
+- Runtime, stored, and alternate IDs select the same canonical conversation.
+- A missing or ineligible saved session falls back to the newest eligible chat.
+- A notification or explicit destination overrides either automatic behavior.
+- Profile-scoped IDs do not leak across profiles.
+
+### Lifecycle and coordination tests
+
+- A stable anchor is frozen on inactive and survives background/foreground.
+- Suspension-time geometry callbacks cannot overwrite the frozen snapshot.
+- Continue mode restores after cold launch and process recreation.
+- New activity in B does not replace A in continue mode.
+- New messages in A do not move a non-latest restored viewport.
+- Latest mode selects B and follows its bottom after foreground and cold launch.
+- Reconciliation must settle before a non-latest anchor is applied.
+- User interaction, notification routing, and session/profile changes cancel stale restoration generations.
+- A changed streaming projection re-anchors by source message ID.
+- A missing anchor stays in the selected conversation and follows its bottom.
+
+### Store tests
+
+- Continue mode is the unsaved/default behavior.
+- Preference and snapshots survive a new store instance.
+- Encoding and decoding preserve all restoration metadata.
+- Corrupt and unknown-version payloads reset safely.
+- Snapshot pruning retains the 100 most recently updated entries.
+- Runtime aliases migrate to canonical keys without losing snapshots.
+
+### Acceptance testing
+
+Run the focused unit tests and the complete Conduit test suite, then verify on Simulator:
+
+1. Open A, scroll to an older message, background Conduit, create or receive newer activity in B, and return in continue mode. Conduit must show A at the saved message.
+2. Repeat after terminating and relaunching Conduit.
+3. Repeat both flows in latest mode. Conduit must show B at its bottom.
+4. Add new messages to A while backgrounded. Continue mode must preserve the reading position and expose jump-to-latest.
+5. Delete the saved conversation and relaunch. Conduit must open the newest eligible chat without an error.
+6. Trigger a notification while automatic restoration is pending. The notification destination must win.
+
+## Implementation boundary for PR #19
+
+PR #19 should replace or simplify callback-driven restoration code where the coordinator assumes ownership. It should not add another independent scene observer or retain two sources of automatic session selection. Existing semantic-anchor and alias-resolution code may be reused when it fits these boundaries; code introduced by earlier attempts should be removed when the coordinator makes it redundant.
+
+The PR is complete when both behaviors work across foregrounding and cold launch, the A-to-B regression has an automated policy/lifecycle reproduction, and all existing tests remain green.


### PR DESCRIPTION
## Summary

Restores PR #19 (scroll restoration) onto current main. Originally merged into the old integration branch (#9) but orphaned when main was rebuilt.

This was Codex's 1.5-week refactor that consumed significant quota — it implements durable chat scroll position persistence across sessions, foregrounding, and app restarts.

## Changes
- **ChatScrollState.swift** — per-session scroll position tracking
- **ChatResumeCoordinator.swift** — orchestrates durable chat restoration
- **ChatResumePolicy.swift** — resume selection policy (continue vs latest)
- **ChatResumeStore.swift** — persistence layer for resume state
- **AppState.swift** — viewport transition tracking, session sync integration
- **AuxiliaryViews.swift** — new "When returning to Conduit" setting
- **ChatView.swift** — coordinator-driven scroll restoration
- 5 new test files (~3,800 lines of test coverage)

## Conflicts resolved
- AppState `init()` — merged main's `sessionRenameOperations` params with scroll restoration's `chatResumeCoordinator` injection params
- `loadSessions()` — merged main's `sessionCatalogLoaderOverride` with viewport transition generation tracking
- `AuxiliaryViews.swift` — kept both DeviceHapticsSettings (main) and ChatReturnBehaviorSettings (restored)

## Testing
- This is a large change that needs device testing before release
- 27 cherry-picked commits, conflict-resolved against current main
- Original PR was reviewed by prdcrman during TestFlight testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Choose whether returning opens the previous conversation or the latest chat.
  * Preserve and restore chat positions across sessions, transcript updates, and app relaunches.
  * Added chat settings for selecting return behavior.
  * Improved session switching with reliable restoration, fallback handling, and cancellation.

* **Bug Fixes**
  * Improved cancellation of pending requests and prevented stale scroll restorations.

* **Tests**
  * Added comprehensive coverage for resume behavior, persistence, migration, session selection, and scroll restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->