### PR TITLE
fix: restore pending clarify/approval cards on foreground recovery

### DIFF
--- a/Conduit/Models/Models.swift
+++ b/Conduit/Models/Models.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 // MARK: - Core Types
 
-enum MessageRole: String, Codable {
+enum MessageRole: String, Codable, Equatable {
     case user
     case assistant
     case reasoning

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -507,6 +507,7 @@ final class AppState: ObservableObject {
         let profile: String
         let sessionID: String
         let pendingDecisionKeys: Set<String>
+        let restoredAt: Date
         let messages: [ChatMessage]
     }
 
@@ -785,6 +786,12 @@ final class AppState: ObservableObject {
         guard let restorationGuard = restoredPendingDecisionCardsAwaitingConfirmation,
               restorationGuard.profile == activeProfile,
               restorationGuard.sessionID == sessionID else {
+            return []
+        }
+        guard !sessionPresentationCache.isUnconfirmedPendingDecisionExpired(
+            since: restorationGuard.restoredAt
+        ) else {
+            clearPendingDecisionRestorationGuard()
             return []
         }
         return restorationGuard.messages
@@ -2474,36 +2481,37 @@ final class AppState: ObservableObject {
         messages = mergeCachedReviews(into: restored, sessionId: result.sessionId)
         noteChatViewportTranscriptReplacement()
         let gatewayPendingDecisionKeys = SessionPresentationCache.pendingDecisionKeys(in: result.messages)
+        if result.snapshot.running == false && !gatewayPendingDecisionKeys.isEmpty {
+            messages = SessionPresentationCache.removingPendingDecisionPresentation(
+                from: messages,
+                matching: gatewayPendingDecisionKeys
+            )
+        }
         let restoredPendingDecisionKeys = SessionPresentationCache
             .pendingDecisionKeys(in: messages)
             .subtracting(gatewayPendingDecisionKeys)
         let gatewaySentPendingDecision = !gatewayPendingDecisionKeys.isEmpty
+        var restoredMessagesAwaitingConfirmation: [ChatMessage] = []
         if result.snapshot.running != true && !restoredPendingDecisionKeys.isEmpty {
             Self.resetSubmittingRestoredDecisions(
                 in: &messages,
                 matching: restoredPendingDecisionKeys
             )
-            let restoredMessages = messages.filter {
+            restoredMessagesAwaitingConfirmation = messages.filter {
                 guard let key = SessionPresentationCache.decisionKey(for: $0),
                       restoredPendingDecisionKeys.contains(key) else {
                     return false
                 }
                 return SessionPresentationCache.pendingDecisionKey(for: $0) != nil
             }
-            restoredPendingDecisionCardsAwaitingConfirmation = PendingDecisionRestorationGuard(
-                profile: activeProfile,
-                sessionID: result.sessionId,
-                pendingDecisionKeys: restoredPendingDecisionKeys,
-                messages: restoredMessages
-            )
         } else {
             clearPendingDecisionRestorationGuard()
         }
         let hasPendingDecision = Self.hasPendingDecision(in: messages)
         // Persist the gateway transcript on every resume so fresh rows are not
         // lost. A locally restored card remains in the active AppState for the
-        // next foreground cycle, but is not written back until Hermes confirms
-        // the turn or the user interacts with it.
+        // next foreground cycle and is persisted with a bounded unconfirmed
+        // marker until Hermes confirms the turn or the user interacts with it.
         let gatewayConfirmsActiveTurn = result.snapshot.running == true
             || (result.snapshot.running != false && gatewaySentPendingDecision)
         let unconfirmedPendingDecisionKeys = result.snapshot.running != true
@@ -2518,6 +2526,19 @@ final class AppState: ObservableObject {
             preservePendingDecisionCards: gatewayConfirmsActiveTurn || !unconfirmedPendingDecisionKeys.isEmpty,
             unconfirmedPendingDecisionKeys: unconfirmedPendingDecisionKeys
         )
+        if result.snapshot.running != true && !restoredPendingDecisionKeys.isEmpty {
+            let restoredAt = sessionPresentationCache.unconfirmedPendingDecisionDate(
+                profile: activeProfile,
+                sessionIDs: sessionIDs
+            ) ?? Date()
+            restoredPendingDecisionCardsAwaitingConfirmation = PendingDecisionRestorationGuard(
+                profile: activeProfile,
+                sessionID: result.sessionId,
+                pendingDecisionKeys: restoredPendingDecisionKeys,
+                restoredAt: restoredAt,
+                messages: restoredMessagesAwaitingConfirmation
+            )
+        }
         scheduleSecondaryProfileTitleRecovery(
             sessionId: result.sessionId,
             messages: messages

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2410,7 +2410,13 @@ final class AppState: ObservableObject {
         )
         messages = mergeCachedReviews(into: restored, sessionId: result.sessionId)
         noteChatViewportTranscriptReplacement()
-        cacheMessagePresentation(for: [result.sessionId])
+        // Only re-save to cache when the gateway confirms the turn is still
+        // active.  When `running` is `nil` or `false`, restored pending cards
+        // may be stale (e.g. the turn completed while backgrounded). Skipping
+        // the save avoids perpetuating stale cards across launches.
+        if result.snapshot.running == true {
+            cacheMessagePresentation(for: [result.sessionId])
+        }
         scheduleSecondaryProfileTitleRecovery(
             sessionId: result.sessionId,
             messages: messages

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2395,29 +2395,35 @@ final class AppState: ObservableObject {
             for: result.sessionId,
             fallbackSessionId: reconciliation?.requestedSessionId
         )
-        // Always restore pending clarifications and approvals from the
-        // presentation cache.  The gateway's `session.resume` response may
-        // omit `running: true` (returning nil) even while a turn is active,
-        // which previously caused user-visible clarify/approval cards to be
-        // silently dropped on foreground recovery.
-        let restorePendingCards = result.snapshot.running != false
+        // Only restore pending clarifications and approvals when the gateway
+        // explicitly confirms the turn is still active (`running == true`).
+        // When `running` is `nil` (omitted) the turn may have already
+        // completed while the app was backgrounded; restoring cached cards
+        // in that case risks displaying stale, answerable UI for an
+        // already-resolved request.
+        let restorePendingCards = result.snapshot.running == true
+        let sessionIDs = [result.sessionId, reconciliation?.requestedSessionId].compactMap { $0 }
         let restored = sessionPresentationCache.merge(
             result.messages,
             profile: activeProfile,
-            sessionIDs: [result.sessionId, reconciliation?.requestedSessionId].compactMap { $0 },
+            sessionIDs: sessionIDs,
             includePendingClarifications: restorePendingCards,
             includePendingApprovals: restorePendingCards
         )
         messages = mergeCachedReviews(into: restored, sessionId: result.sessionId)
         noteChatViewportTranscriptReplacement()
-        // Save only the gateway-provided messages to the cache, not restored
-        // cards.  This preserves timestamps and tool previews for server
-        // messages without re-persisting potentially stale pending cards.
-        sessionPresentationCache.save(
-            result.messages,
-            profile: activeProfile,
-            sessionIDs: [result.sessionId, reconciliation?.requestedSessionId].compactMap { $0 }
-        )
+        // When `running == true`, save the merged messages (including any
+        // restored pending cards) so they survive in the cache if the user
+        // backgrounds again before the next flush.  When `running` is `nil`
+        // or `false`, skip the save to avoid dropping restored cards or
+        // overwriting the cache with a compact history that omits them.
+        if result.snapshot.running == true {
+            sessionPresentationCache.save(
+                messages,
+                profile: activeProfile,
+                sessionIDs: sessionIDs
+            )
+        }
         scheduleSecondaryProfileTitleRecovery(
             sessionId: result.sessionId,
             messages: messages
@@ -2437,14 +2443,10 @@ final class AppState: ObservableObject {
         applyRuntime(result.snapshot)
 
         // When `running` is `nil`, derive the turn state from the live
-        // projection or restored pending cards rather than declaring the
-        // gateway unsupported.  A nil value can mean the gateway omits the
-        // field while still being turn-state-capable.
-        let hasRestoredPendingCards = messages.contains {
-            ($0.clarify?.status == .pending || $0.clarify?.status == .submitting)
-                || ($0.approval?.status == .pending || $0.approval?.status == .submitting)
-        }
-        if result.snapshot.running == nil && (result.snapshot.hasLiveProjection || hasRestoredPendingCards) {
+        // projection alone.  A live projection is authoritative evidence
+        // that the gateway is actively streaming; mere cached card presence
+        // is not, because the turn may have completed while backgrounded.
+        if result.snapshot.running == nil && result.snapshot.hasLiveProjection {
             turnState = .running
         } else if TurnState.fromGatewayRunning(result.snapshot.running) == .unsupportedGateway {
             turnState = .unsupportedGateway
@@ -2454,6 +2456,15 @@ final class AppState: ObservableObject {
             turnState = TurnState.fromGatewayRunning(result.snapshot.running)
         }
         return true
+    }
+
+    /// Testable helper: derives whether pending clarify/approval cards should
+    /// be restored from the presentation cache on resume.  Only `true` when
+    /// the gateway explicitly confirms the turn is still active; `nil`
+    /// (omitted) is treated as "don't restore" to avoid displaying stale
+    /// cards for a turn that may have completed while backgrounded.
+    static func shouldRestorePendingCards(running: Bool?) -> Bool {
+        running == true
     }
 
     /// `session.resume.inflight` is a cumulative projection on some gateways.

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -499,12 +499,15 @@ final class AppState: ObservableObject {
     /// don't serialize and write UserDefaults on every WebSocket frame.
     private var presentationCacheFlushTask: Task<Void, Never>?
     /// A nil resume can restore a decision card from local presentation data.
-    /// Keep the guard scoped to the session/profile that produced the restored
-    /// card so a session switch cannot affect another session's presentation.
+    /// Keep the card in memory for this AppState so another foreground resume
+    /// can still show it, but strip it from cache writes until Hermes confirms
+    /// the turn. Scope the guard to the session/profile that produced it so a
+    /// session switch cannot affect another session's presentation.
     private struct PendingDecisionRestorationGuard {
         let profile: String
         let sessionID: String
         let pendingDecisionKeys: Set<String>
+        let messages: [ChatMessage]
     }
 
     private var restoredPendingDecisionCardsAwaitingConfirmation: PendingDecisionRestorationGuard?
@@ -558,11 +561,16 @@ final class AppState: ObservableObject {
             }
             return restorationGuard.pendingDecisionKeys
         }()
-        let pendingDecisionKeys = SessionPresentationCache.pendingDecisionKeys(in: messages)
-        let hasScopedRestorationGuard = restorationKeys?.isEmpty == false
-        let preservePendingDecisionCards = !hasScopedRestorationGuard || !pendingDecisionKeys.isEmpty
+        let cacheableMessages = restorationKeys.map {
+            SessionPresentationCache.removingPendingDecisionPresentation(
+                from: messages,
+                matching: $0
+            )
+        } ?? messages
+        let preservePendingDecisionCards = restorationKeys == nil
+            || !SessionPresentationCache.pendingDecisionKeys(in: cacheableMessages).isEmpty
         sessionPresentationCache.save(
-            messages,
+            cacheableMessages,
             profile: activeProfile,
             sessionIDs: ids,
             preservePendingDecisionCards: preservePendingDecisionCards
@@ -770,6 +778,15 @@ final class AppState: ObservableObject {
         pinnedSessionIDs.removeAll { ids.contains($0) }
         pinnedSessionIDsByProfile[activeProfile] = pinnedSessionIDs
         persistPinnedSessions()
+    }
+
+    private func pendingDecisionRestorationMessages(for sessionID: String) -> [ChatMessage] {
+        guard let restorationGuard = restoredPendingDecisionCardsAwaitingConfirmation,
+              restorationGuard.profile == activeProfile,
+              restorationGuard.sessionID == sessionID else {
+            return []
+        }
+        return restorationGuard.messages
     }
 
     private func clearPendingDecisionRestorationGuard() {
@@ -2426,6 +2443,7 @@ final class AppState: ObservableObject {
             automaticWorkToken,
             syncOperationID: automaticSyncOperationID
         ) else { return false }
+        let retainedRestoredMessages = pendingDecisionRestorationMessages(for: result.sessionId)
         markChatViewportReplacement()
         setActiveSessionState(id: result.sessionId, title: "New conversation")
         updateActiveSessionTitle(
@@ -2438,8 +2456,15 @@ final class AppState: ObservableObject {
         // pending decision cards.
         let restorePendingCards = Self.shouldRestorePendingCards(running: result.snapshot.running)
         let sessionIDs = [result.sessionId, reconciliation?.requestedSessionId].compactMap { $0 }
+        let gatewayDecisionKeys = Set(result.messages.compactMap(SessionPresentationCache.decisionKey(for:)))
+        let retainedMessages = restorePendingCards
+            ? retainedRestoredMessages.filter {
+                guard let key = SessionPresentationCache.decisionKey(for: $0) else { return false }
+                return !gatewayDecisionKeys.contains(key)
+            }
+            : []
         let restored = sessionPresentationCache.merge(
-            result.messages,
+            result.messages + retainedMessages,
             profile: activeProfile,
             sessionIDs: sessionIDs,
             includePendingClarifications: restorePendingCards,
@@ -2447,33 +2472,44 @@ final class AppState: ObservableObject {
         )
         messages = mergeCachedReviews(into: restored, sessionId: result.sessionId)
         noteChatViewportTranscriptReplacement()
-        let hasPendingDecision = Self.hasPendingDecision(in: messages)
         let gatewayPendingDecisionKeys = SessionPresentationCache.pendingDecisionKeys(in: result.messages)
         let restoredPendingDecisionKeys = SessionPresentationCache
             .pendingDecisionKeys(in: messages)
             .subtracting(gatewayPendingDecisionKeys)
         let gatewaySentPendingDecision = !gatewayPendingDecisionKeys.isEmpty
         if result.snapshot.running != true && !restoredPendingDecisionKeys.isEmpty {
+            Self.resetSubmittingRestoredDecisions(
+                in: &messages,
+                matching: restoredPendingDecisionKeys
+            )
+            let restoredMessages = messages.filter {
+                guard let key = SessionPresentationCache.decisionKey(for: $0),
+                      restoredPendingDecisionKeys.contains(key) else {
+                    return false
+                }
+                return SessionPresentationCache.pendingDecisionKey(for: $0) != nil
+            }
             restoredPendingDecisionCardsAwaitingConfirmation = PendingDecisionRestorationGuard(
                 profile: activeProfile,
                 sessionID: result.sessionId,
-                pendingDecisionKeys: restoredPendingDecisionKeys
+                pendingDecisionKeys: restoredPendingDecisionKeys,
+                messages: restoredMessages
             )
         } else {
             clearPendingDecisionRestorationGuard()
         }
+        let hasPendingDecision = Self.hasPendingDecision(in: messages)
         // Persist the gateway transcript on every resume so fresh rows are not
-        // lost. When liveness is nil, retain a locally restored pending card
-        // until Hermes provides an explicit settled signal; otherwise the
-        // first foreground cycle would consume the cache entry and the next
-        // foreground would lose the answerable card again.
-        let gatewayConfirmsActiveTurn = result.snapshot.running == true || gatewaySentPendingDecision
-        let shouldPersistMergedPresentation = gatewayConfirmsActiveTurn || !restoredPendingDecisionKeys.isEmpty
+        // lost. A locally restored card remains in the active AppState for the
+        // next foreground cycle, but is not written back until Hermes confirms
+        // the turn or the user interacts with it.
+        let gatewayConfirmsActiveTurn = result.snapshot.running == true
+            || (result.snapshot.running != false && gatewaySentPendingDecision)
         sessionPresentationCache.save(
-            shouldPersistMergedPresentation ? messages : result.messages,
+            result.snapshot.running == true ? messages : result.messages,
             profile: activeProfile,
             sessionIDs: sessionIDs,
-            preservePendingDecisionCards: gatewayConfirmsActiveTurn || !restoredPendingDecisionKeys.isEmpty
+            preservePendingDecisionCards: gatewayConfirmsActiveTurn
         )
         scheduleSecondaryProfileTitleRecovery(
             sessionId: result.sessionId,
@@ -2522,6 +2558,30 @@ final class AppState: ObservableObject {
             let clarifyPending = message.clarify?.status == .pending || message.clarify?.status == .submitting
             let approvalPending = message.approval?.status == .pending || message.approval?.status == .submitting
             return clarifyPending || approvalPending
+        }
+    }
+
+    private static func resetSubmittingRestoredDecisions(
+        in messages: inout [ChatMessage],
+        matching keys: Set<String>
+    ) {
+        for index in messages.indices {
+            if var clarify = messages[index].clarify,
+               clarify.status == .submitting,
+               keys.contains("clarify:\(clarify.requestId)") {
+                clarify.status = .pending
+                clarify.answer = nil
+                clarify.error = nil
+                messages[index].clarify = clarify
+            }
+            if var approval = messages[index].approval,
+               approval.status == .submitting,
+               keys.contains("approval:\(approval.sessionId)") {
+                approval.status = .pending
+                approval.choice = nil
+                approval.error = nil
+                messages[index].approval = approval
+            }
         }
     }
 

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -573,7 +573,8 @@ final class AppState: ObservableObject {
             cacheableMessages,
             profile: activeProfile,
             sessionIDs: ids,
-            preservePendingDecisionCards: preservePendingDecisionCards
+            preservePendingDecisionCards: preservePendingDecisionCards,
+            unconfirmedPendingDecisionKeys: restorationKeys ?? []
         )
     }
 
@@ -2505,11 +2506,17 @@ final class AppState: ObservableObject {
         // the turn or the user interacts with it.
         let gatewayConfirmsActiveTurn = result.snapshot.running == true
             || (result.snapshot.running != false && gatewaySentPendingDecision)
+        let unconfirmedPendingDecisionKeys = result.snapshot.running != true
+            ? restoredPendingDecisionKeys
+            : []
+        let shouldPersistMergedPresentation = gatewayConfirmsActiveTurn
+            || !unconfirmedPendingDecisionKeys.isEmpty
         sessionPresentationCache.save(
-            result.snapshot.running == true ? messages : result.messages,
+            shouldPersistMergedPresentation ? messages : result.messages,
             profile: activeProfile,
             sessionIDs: sessionIDs,
-            preservePendingDecisionCards: gatewayConfirmsActiveTurn
+            preservePendingDecisionCards: gatewayConfirmsActiveTurn || !unconfirmedPendingDecisionKeys.isEmpty,
+            unconfirmedPendingDecisionKeys: unconfirmedPendingDecisionKeys
         )
         scheduleSecondaryProfileTitleRecovery(
             sessionId: result.sessionId,

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2395,12 +2395,17 @@ final class AppState: ObservableObject {
             for: result.sessionId,
             fallbackSessionId: reconciliation?.requestedSessionId
         )
+        // Always restore pending clarifications and approvals from the
+        // presentation cache.  The gateway's `session.resume` response may
+        // omit `running: true` (returning nil) even while a turn is active,
+        // which previously caused user-visible clarify/approval cards to be
+        // silently dropped on foreground recovery.
         let restored = sessionPresentationCache.merge(
             result.messages,
             profile: activeProfile,
             sessionIDs: [result.sessionId, reconciliation?.requestedSessionId].compactMap { $0 },
-            includePendingClarifications: result.snapshot.running == true,
-            includePendingApprovals: result.snapshot.running == true
+            includePendingClarifications: true,
+            includePendingApprovals: true
         )
         messages = mergeCachedReviews(into: restored, sessionId: result.sessionId)
         noteChatViewportTranscriptReplacement()

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -498,13 +498,10 @@ final class AppState: ObservableObject {
     /// Coalesces presentation-cache flushes during streaming so we
     /// don't serialize and write UserDefaults on every WebSocket frame.
     private var presentationCacheFlushTask: Task<Void, Never>?
-    /// A nil resume can restore a decision card from local presentation data,
-    /// but that card is not authoritative until Hermes confirms the active
-    /// turn or the user interacts with it. Do not re-persist it on a scene
-    /// background in the meantime. Scope the guard to the session/profile that
-    /// produced the restored card so a session switch cannot prune another
-    /// session's pending presentation.
-    private struct PendingDecisionRestorationGuard: Equatable {
+    /// A nil resume can restore a decision card from local presentation data.
+    /// Keep the guard scoped to the session/profile that produced the restored
+    /// card so a session switch cannot affect another session's presentation.
+    private struct PendingDecisionRestorationGuard {
         let profile: String
         let sessionID: String
         let pendingDecisionKeys: Set<String>
@@ -553,7 +550,7 @@ final class AppState: ObservableObject {
             reconciliation?.requestedSessionId,
             reconciliation?.resolvedSessionId
         ].compactMap { $0 }
-        let unconfirmedKeys: Set<String>? = {
+        let restorationKeys: Set<String>? = {
             guard let restorationGuard = restoredPendingDecisionCardsAwaitingConfirmation,
                   restorationGuard.profile == activeProfile,
                   activeSessionId == restorationGuard.sessionID else {
@@ -561,16 +558,11 @@ final class AppState: ObservableObject {
             }
             return restorationGuard.pendingDecisionKeys
         }()
-        let cacheableMessages = unconfirmedKeys.map {
-            SessionPresentationCache.removingPendingDecisionPresentation(
-                from: messages,
-                matching: $0
-            )
-        } ?? messages
-        let preservePendingDecisionCards = unconfirmedKeys == nil
-            || !SessionPresentationCache.pendingDecisionKeys(in: cacheableMessages).isEmpty
+        let pendingDecisionKeys = SessionPresentationCache.pendingDecisionKeys(in: messages)
+        let hasScopedRestorationGuard = restorationKeys?.isEmpty == false
+        let preservePendingDecisionCards = !hasScopedRestorationGuard || !pendingDecisionKeys.isEmpty
         sessionPresentationCache.save(
-            cacheableMessages,
+            messages,
             profile: activeProfile,
             sessionIDs: ids,
             preservePendingDecisionCards: preservePendingDecisionCards
@@ -2470,18 +2462,18 @@ final class AppState: ObservableObject {
         } else {
             clearPendingDecisionRestorationGuard()
         }
-        // Persist the gateway transcript on every resume so fresh rows are
-        // not lost. When liveness is nil, do not write the locally restored
-        // decision cards back into the cache: the gateway has not confirmed
-        // that those cached cards are still pending. An explicitly running
-        // snapshot is the one case where persisting the merged presentation
-        // is safe and necessary for another foreground/background cycle.
+        // Persist the gateway transcript on every resume so fresh rows are not
+        // lost. When liveness is nil, retain a locally restored pending card
+        // until Hermes provides an explicit settled signal; otherwise the
+        // first foreground cycle would consume the cache entry and the next
+        // foreground would lose the answerable card again.
         let gatewayConfirmsActiveTurn = result.snapshot.running == true || gatewaySentPendingDecision
+        let shouldPersistMergedPresentation = gatewayConfirmsActiveTurn || !restoredPendingDecisionKeys.isEmpty
         sessionPresentationCache.save(
-            result.snapshot.running == true ? messages : result.messages,
+            shouldPersistMergedPresentation ? messages : result.messages,
             profile: activeProfile,
             sessionIDs: sessionIDs,
-            preservePendingDecisionCards: gatewayConfirmsActiveTurn
+            preservePendingDecisionCards: gatewayConfirmsActiveTurn || !restoredPendingDecisionKeys.isEmpty
         )
         scheduleSecondaryProfileTitleRecovery(
             sessionId: result.sessionId,

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2400,12 +2400,13 @@ final class AppState: ObservableObject {
         // omit `running: true` (returning nil) even while a turn is active,
         // which previously caused user-visible clarify/approval cards to be
         // silently dropped on foreground recovery.
+        let restorePendingCards = result.snapshot.running != false
         let restored = sessionPresentationCache.merge(
             result.messages,
             profile: activeProfile,
             sessionIDs: [result.sessionId, reconciliation?.requestedSessionId].compactMap { $0 },
-            includePendingClarifications: true,
-            includePendingApprovals: true
+            includePendingClarifications: restorePendingCards,
+            includePendingApprovals: restorePendingCards
         )
         messages = mergeCachedReviews(into: restored, sessionId: result.sessionId)
         noteChatViewportTranscriptReplacement()

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -501,8 +501,16 @@ final class AppState: ObservableObject {
     /// A nil resume can restore a decision card from local presentation data,
     /// but that card is not authoritative until Hermes confirms the active
     /// turn or the user interacts with it. Do not re-persist it on a scene
-    /// background in the meantime.
-    private var restoredPendingDecisionCardsAwaitingConfirmation = false
+    /// background in the meantime. Scope the guard to the session/profile that
+    /// produced the restored card so a session switch cannot prune another
+    /// session's pending presentation.
+    private struct PendingDecisionRestorationGuard: Equatable {
+        let profile: String
+        let sessionID: String
+        let pendingDecisionKeys: Set<String>
+    }
+
+    private var restoredPendingDecisionCardsAwaitingConfirmation: PendingDecisionRestorationGuard?
     /// Timestamp of the last successful coalesced cache flush; used to
     /// enforce a maximum 5-second interval even during continuous streaming.
     private var lastPresentationCacheFlushDate: Date?
@@ -517,7 +525,7 @@ final class AppState: ObservableObject {
     private var profileSessionCache: [String: [SessionSummary]] = [:]
     private var projectsRequestGeneration = 0
     private var loadedFullSessionHistory = Set<String>()
-    private let sessionPresentationCache = SessionPresentationCache.shared
+    private let sessionPresentationCache: SessionPresentationCache
 
     /// The dashboard's persisted transcript is richer than `session.resume`:
     /// it retains database timestamps, complete tool-call inputs, and other
@@ -545,30 +553,27 @@ final class AppState: ObservableObject {
             reconciliation?.requestedSessionId,
             reconciliation?.resolvedSessionId
         ].compactMap { $0 }
-        let cacheableMessages: [ChatMessage]
-        if restoredPendingDecisionCardsAwaitingConfirmation {
-            cacheableMessages = messages.compactMap { original in
-                var message = original
-                if let clarify = message.clarify,
-                   clarify.status == .pending || clarify.status == .submitting {
-                    message.clarify = nil
-                }
-                if let approval = message.approval,
-                   approval.status == .pending || approval.status == .submitting {
-                    message.approval = nil
-                }
-                if message.role == .clarify, message.clarify == nil { return nil }
-                if message.role == .approval, message.approval == nil { return nil }
-                return message
+        let unconfirmedKeys: Set<String>? = {
+            guard let restorationGuard = restoredPendingDecisionCardsAwaitingConfirmation,
+                  restorationGuard.profile == activeProfile,
+                  activeSessionId == restorationGuard.sessionID else {
+                return nil
             }
-        } else {
-            cacheableMessages = messages
-        }
+            return restorationGuard.pendingDecisionKeys
+        }()
+        let cacheableMessages = unconfirmedKeys.map {
+            SessionPresentationCache.removingPendingDecisionPresentation(
+                from: messages,
+                matching: $0
+            )
+        } ?? messages
+        let preservePendingDecisionCards = unconfirmedKeys == nil
+            || !SessionPresentationCache.pendingDecisionKeys(in: cacheableMessages).isEmpty
         sessionPresentationCache.save(
             cacheableMessages,
             profile: activeProfile,
             sessionIDs: ids,
-            preservePendingDecisionCards: !restoredPendingDecisionCardsAwaitingConfirmation
+            preservePendingDecisionCards: preservePendingDecisionCards
         )
     }
 
@@ -679,9 +684,11 @@ final class AppState: ObservableObject {
         sessionCatalogLoader: ((Bool) async throws -> [SessionSummary])? = nil,
         reconnectScheduler: ChatResumeReconnectScheduler? = nil,
         reconnectExecutor: ChatResumeReconnectExecutor? = nil,
-        chatResumeLifecycleOperations: ChatResumeLifecycleOperations = .live
+        chatResumeLifecycleOperations: ChatResumeLifecycleOperations = .live,
+        sessionPresentationCache: SessionPresentationCache = .shared
     ) {
         self.defaults = defaults
+        self.sessionPresentationCache = sessionPresentationCache
         self.chatResumeCoordinator = chatResumeCoordinator
             ?? ChatResumeCoordinator(store: ChatResumeStore(defaults: defaults))
         self.recoverySequence = recoverySequence
@@ -726,6 +733,7 @@ final class AppState: ObservableObject {
     }
 
     func restoreActiveSessionState(for profile: String) {
+        clearPendingDecisionRestorationGuard()
         activeSessionId = chatResumeCoordinator.lastSessionID(for: profile)
         activeSessionTitle = activeSessionTitlesByProfile[profile] ?? "New conversation"
     }
@@ -772,7 +780,14 @@ final class AppState: ObservableObject {
         persistPinnedSessions()
     }
 
+    private func clearPendingDecisionRestorationGuard() {
+        restoredPendingDecisionCardsAwaitingConfirmation = nil
+    }
+
     private func setActiveSessionState(id: String?, title: String? = nil) {
+        if activeSessionId != id {
+            clearPendingDecisionRestorationGuard()
+        }
         activeSessionId = id
         if let persistedID = ChatSessionPersistenceIdentity.canonicalID(
             for: id,
@@ -1204,6 +1219,7 @@ final class AppState: ObservableObject {
         supportsProjects = false
         projectsLoading = false
         profiles = []
+        clearPendingDecisionRestorationGuard()
         activeSessionId = nil
         activeSessionTitle = "New conversation"
         messages = []
@@ -2440,16 +2456,29 @@ final class AppState: ObservableObject {
         messages = mergeCachedReviews(into: restored, sessionId: result.sessionId)
         noteChatViewportTranscriptReplacement()
         let hasPendingDecision = Self.hasPendingDecision(in: messages)
-        restoredPendingDecisionCardsAwaitingConfirmation = result.snapshot.running != true && hasPendingDecision
+        let gatewayPendingDecisionKeys = SessionPresentationCache.pendingDecisionKeys(in: result.messages)
+        let restoredPendingDecisionKeys = SessionPresentationCache
+            .pendingDecisionKeys(in: messages)
+            .subtracting(gatewayPendingDecisionKeys)
+        let gatewaySentPendingDecision = !gatewayPendingDecisionKeys.isEmpty
+        if result.snapshot.running != true && !restoredPendingDecisionKeys.isEmpty {
+            restoredPendingDecisionCardsAwaitingConfirmation = PendingDecisionRestorationGuard(
+                profile: activeProfile,
+                sessionID: result.sessionId,
+                pendingDecisionKeys: restoredPendingDecisionKeys
+            )
+        } else {
+            clearPendingDecisionRestorationGuard()
+        }
         // Persist the gateway transcript on every resume so fresh rows are
         // not lost. When liveness is nil, do not write the locally restored
         // decision cards back into the cache: the gateway has not confirmed
         // that those cached cards are still pending. An explicitly running
         // snapshot is the one case where persisting the merged presentation
         // is safe and necessary for another foreground/background cycle.
-        let gatewayConfirmsActiveTurn = result.snapshot.running == true
+        let gatewayConfirmsActiveTurn = result.snapshot.running == true || gatewaySentPendingDecision
         sessionPresentationCache.save(
-            gatewayConfirmsActiveTurn ? messages : result.messages,
+            result.snapshot.running == true ? messages : result.messages,
             profile: activeProfile,
             sessionIDs: sessionIDs,
             preservePendingDecisionCards: gatewayConfirmsActiveTurn
@@ -4519,6 +4548,7 @@ final class AppState: ObservableObject {
             markChatViewportReplacement()
             connection = freshConnection
             client = nextClient
+            clearPendingDecisionRestorationGuard()
             activeProfile = target
             sessions = []
             cronSessions = []
@@ -4567,6 +4597,7 @@ final class AppState: ObservableObject {
                 return false
             }
             errorMessage = "Could not switch workspace: \(error.localizedDescription)"
+            clearPendingDecisionRestorationGuard()
             activeProfile = previousProfile
             sessions = previousSessions
             cronSessions = previousCronSessions
@@ -5991,7 +6022,7 @@ final class AppState: ObservableObject {
     private func setRunning(_ running: Bool) {
         guard turnState != .unsupportedGateway else { return }
         if running {
-            restoredPendingDecisionCardsAwaitingConfirmation = false
+            clearPendingDecisionRestorationGuard()
         }
         turnState = running ? .running : .idle
     }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -498,6 +498,11 @@ final class AppState: ObservableObject {
     /// Coalesces presentation-cache flushes during streaming so we
     /// don't serialize and write UserDefaults on every WebSocket frame.
     private var presentationCacheFlushTask: Task<Void, Never>?
+    /// A nil resume can restore a decision card from local presentation data,
+    /// but that card is not authoritative until Hermes confirms the active
+    /// turn or the user interacts with it. Do not re-persist it on a scene
+    /// background in the meantime.
+    private var restoredPendingDecisionCardsAwaitingConfirmation = false
     /// Timestamp of the last successful coalesced cache flush; used to
     /// enforce a maximum 5-second interval even during continuous streaming.
     private var lastPresentationCacheFlushDate: Date?
@@ -540,7 +545,31 @@ final class AppState: ObservableObject {
             reconciliation?.requestedSessionId,
             reconciliation?.resolvedSessionId
         ].compactMap { $0 }
-        sessionPresentationCache.save(messages, profile: activeProfile, sessionIDs: ids)
+        let cacheableMessages: [ChatMessage]
+        if restoredPendingDecisionCardsAwaitingConfirmation {
+            cacheableMessages = messages.compactMap { original in
+                var message = original
+                if let clarify = message.clarify,
+                   clarify.status == .pending || clarify.status == .submitting {
+                    message.clarify = nil
+                }
+                if let approval = message.approval,
+                   approval.status == .pending || approval.status == .submitting {
+                    message.approval = nil
+                }
+                if message.role == .clarify, message.clarify == nil { return nil }
+                if message.role == .approval, message.approval == nil { return nil }
+                return message
+            }
+        } else {
+            cacheableMessages = messages
+        }
+        sessionPresentationCache.save(
+            cacheableMessages,
+            profile: activeProfile,
+            sessionIDs: ids,
+            preservePendingDecisionCards: !restoredPendingDecisionCardsAwaitingConfirmation
+        )
     }
 
     /// Coalesces presentation-cache writes during streaming. Instead of
@@ -2395,13 +2424,11 @@ final class AppState: ObservableObject {
             for: result.sessionId,
             fallbackSessionId: reconciliation?.requestedSessionId
         )
-        // Only restore pending clarifications and approvals when the gateway
-        // explicitly confirms the turn is still active (`running == true`).
-        // When `running` is `nil` (omitted) the turn may have already
-        // completed while the app was backgrounded; restoring cached cards
-        // in that case risks displaying stale, answerable UI for an
-        // already-resolved request.
-        let restorePendingCards = result.snapshot.running == true
+        // Hermes can omit `running` on versions that still support paused
+        // clarify/approval turns. Only an explicit false means the turn is
+        // settled, so nil remains eligible for restoring locally observed
+        // pending decision cards.
+        let restorePendingCards = Self.shouldRestorePendingCards(running: result.snapshot.running)
         let sessionIDs = [result.sessionId, reconciliation?.requestedSessionId].compactMap { $0 }
         let restored = sessionPresentationCache.merge(
             result.messages,
@@ -2412,18 +2439,21 @@ final class AppState: ObservableObject {
         )
         messages = mergeCachedReviews(into: restored, sessionId: result.sessionId)
         noteChatViewportTranscriptReplacement()
-        // When `running == true`, save the merged messages (including any
-        // restored pending cards) so they survive in the cache if the user
-        // backgrounds again before the next flush.  When `running` is `nil`
-        // or `false`, skip the save to avoid dropping restored cards or
-        // overwriting the cache with a compact history that omits them.
-        if result.snapshot.running == true {
-            sessionPresentationCache.save(
-                messages,
-                profile: activeProfile,
-                sessionIDs: sessionIDs
-            )
-        }
+        let hasPendingDecision = Self.hasPendingDecision(in: messages)
+        restoredPendingDecisionCardsAwaitingConfirmation = result.snapshot.running != true && hasPendingDecision
+        // Persist the gateway transcript on every resume so fresh rows are
+        // not lost. When liveness is nil, do not write the locally restored
+        // decision cards back into the cache: the gateway has not confirmed
+        // that those cached cards are still pending. An explicitly running
+        // snapshot is the one case where persisting the merged presentation
+        // is safe and necessary for another foreground/background cycle.
+        let gatewayConfirmsActiveTurn = result.snapshot.running == true
+        sessionPresentationCache.save(
+            gatewayConfirmsActiveTurn ? messages : result.messages,
+            profile: activeProfile,
+            sessionIDs: sessionIDs,
+            preservePendingDecisionCards: gatewayConfirmsActiveTurn
+        )
         scheduleSecondaryProfileTitleRecovery(
             sessionId: result.sessionId,
             messages: messages
@@ -2442,11 +2472,11 @@ final class AppState: ObservableObject {
         receivedReasoningForCurrentTurn = false
         applyRuntime(result.snapshot)
 
-        // When `running` is `nil`, derive the turn state from the live
-        // projection alone.  A live projection is authoritative evidence
-        // that the gateway is actively streaming; mere cached card presence
-        // is not, because the turn may have completed while backgrounded.
-        if result.snapshot.running == nil && result.snapshot.hasLiveProjection {
+        // A paused clarification or approval can have neither a live text
+        // projection nor an explicit `running` field. The restored card is
+        // actionable evidence for this UI, so keep the composer enabled for
+        // it instead of treating the gateway as unsupported.
+        if result.snapshot.running == nil && (result.snapshot.hasLiveProjection || hasPendingDecision) {
             turnState = .running
         } else if TurnState.fromGatewayRunning(result.snapshot.running) == .unsupportedGateway {
             turnState = .unsupportedGateway
@@ -2459,12 +2489,19 @@ final class AppState: ObservableObject {
     }
 
     /// Testable helper: derives whether pending clarify/approval cards should
-    /// be restored from the presentation cache on resume.  Only `true` when
-    /// the gateway explicitly confirms the turn is still active; `nil`
-    /// (omitted) is treated as "don't restore" to avoid displaying stale
-    /// cards for a turn that may have completed while backgrounded.
+    /// be restored from the presentation cache on resume. An explicit false
+    /// is the only settled-turn signal; nil is still eligible because older
+    /// Hermes gateways omit `running` for paused decision turns.
     static func shouldRestorePendingCards(running: Bool?) -> Bool {
-        running == true
+        running != false
+    }
+
+    static func hasPendingDecision(in messages: [ChatMessage]) -> Bool {
+        messages.contains { message in
+            let clarifyPending = message.clarify?.status == .pending || message.clarify?.status == .submitting
+            let approvalPending = message.approval?.status == .pending || message.approval?.status == .submitting
+            return clarifyPending || approvalPending
+        }
     }
 
     /// `session.resume.inflight` is a cumulative projection on some gateways.
@@ -5953,6 +5990,9 @@ final class AppState: ObservableObject {
 
     private func setRunning(_ running: Bool) {
         guard turnState != .unsupportedGateway else { return }
+        if running {
+            restoredPendingDecisionCardsAwaitingConfirmation = false
+        }
         turnState = running ? .running : .idle
     }
 

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2410,13 +2410,14 @@ final class AppState: ObservableObject {
         )
         messages = mergeCachedReviews(into: restored, sessionId: result.sessionId)
         noteChatViewportTranscriptReplacement()
-        // Only re-save to cache when the gateway confirms the turn is still
-        // active.  When `running` is `nil` or `false`, restored pending cards
-        // may be stale (e.g. the turn completed while backgrounded). Skipping
-        // the save avoids perpetuating stale cards across launches.
-        if result.snapshot.running == true {
-            cacheMessagePresentation(for: [result.sessionId])
-        }
+        // Save only the gateway-provided messages to the cache, not restored
+        // cards.  This preserves timestamps and tool previews for server
+        // messages without re-persisting potentially stale pending cards.
+        sessionPresentationCache.save(
+            result.messages,
+            profile: activeProfile,
+            sessionIDs: [result.sessionId, reconciliation?.requestedSessionId].compactMap { $0 }
+        )
         scheduleSecondaryProfileTitleRecovery(
             sessionId: result.sessionId,
             messages: messages
@@ -2435,13 +2436,23 @@ final class AppState: ObservableObject {
         receivedReasoningForCurrentTurn = false
         applyRuntime(result.snapshot)
 
-        if TurnState.fromGatewayRunning(result.snapshot.running) == .unsupportedGateway {
+        // When `running` is `nil`, derive the turn state from the live
+        // projection or restored pending cards rather than declaring the
+        // gateway unsupported.  A nil value can mean the gateway omits the
+        // field while still being turn-state-capable.
+        let hasRestoredPendingCards = messages.contains {
+            ($0.clarify?.status == .pending || $0.clarify?.status == .submitting)
+                || ($0.approval?.status == .pending || $0.approval?.status == .submitting)
+        }
+        if result.snapshot.running == nil && (result.snapshot.hasLiveProjection || hasRestoredPendingCards) {
+            turnState = .running
+        } else if TurnState.fromGatewayRunning(result.snapshot.running) == .unsupportedGateway {
             turnState = .unsupportedGateway
             errorMessage = "This Hermes gateway must support session turn state. Update Hermes to enable message, stop, and steer controls."
             return true
+        } else {
+            turnState = TurnState.fromGatewayRunning(result.snapshot.running)
         }
-
-        turnState = TurnState.fromGatewayRunning(result.snapshot.running)
         return true
     }
 

--- a/Conduit/Services/SessionPresentationCache.swift
+++ b/Conduit/Services/SessionPresentationCache.swift
@@ -24,8 +24,19 @@ final class SessionPresentationCache {
         status == .pending || status == .submitting
     }
 
-    /// Stable identity for a pending decision card, used to distinguish a
-    /// gateway-authoritative card from one restored only from local cache.
+    /// Stable identity for a decision card, regardless of whether it is still
+    /// pending. This lets resume reconciliation recognize a resolved gateway
+    /// row and suppress a matching locally cached card.
+    static func decisionKey(for message: ChatMessage) -> String? {
+        if let clarify = message.clarify {
+            return "clarify:\(clarify.requestId)"
+        }
+        if let approval = message.approval {
+            return "approval:\(approval.sessionId)"
+        }
+        return nil
+    }
+
     static func pendingDecisionKey(for message: ChatMessage) -> String? {
         if let clarify = message.clarify, isPendingDecision(clarify.status) {
             return "clarify:\(clarify.requestId)"
@@ -38,6 +49,30 @@ final class SessionPresentationCache {
 
     static func pendingDecisionKeys(in messages: [ChatMessage]) -> Set<String> {
         Set(messages.compactMap(pendingDecisionKey(for:)))
+    }
+
+    /// Removes only the selected pending decision presentations. Completed
+    /// decision metadata and unrelated pending cards remain untouched.
+    static func removingPendingDecisionPresentation(
+        from messages: [ChatMessage],
+        matching keys: Set<String>
+    ) -> [ChatMessage] {
+        messages.compactMap { original in
+            var message = original
+            if let clarify = message.clarify,
+               isPendingDecision(clarify.status),
+               keys.contains("clarify:\(clarify.requestId)") {
+                message.clarify = nil
+            }
+            if let approval = message.approval,
+               isPendingDecision(approval.status),
+               keys.contains("approval:\(approval.sessionId)") {
+                message.approval = nil
+            }
+            if message.role == .clarify, message.clarify == nil { return nil }
+            if message.role == .approval, message.approval == nil { return nil }
+            return message
+        }
     }
 
     private struct CachedMessage: Codable, Equatable {

--- a/Conduit/Services/SessionPresentationCache.swift
+++ b/Conduit/Services/SessionPresentationCache.swift
@@ -40,27 +40,6 @@ final class SessionPresentationCache {
         Set(messages.compactMap(pendingDecisionKey(for:)))
     }
 
-    /// Removes only the pending decision presentations selected by `keys`.
-    /// Passing nil removes every pending decision while preserving the rest of
-    /// the transcript and any completed decision metadata.
-    static func removingPendingDecisionPresentation(
-        from messages: [ChatMessage],
-        matching keys: Set<String>? = nil
-    ) -> [ChatMessage] {
-        messages.compactMap { original in
-            guard let key = pendingDecisionKey(for: original),
-                  keys.map({ $0.contains(key) }) ?? true else {
-                return original
-            }
-            var message = original
-            if message.clarify != nil { message.clarify = nil }
-            if message.approval != nil { message.approval = nil }
-            if message.role == .clarify, message.clarify == nil { return nil }
-            if message.role == .approval, message.approval == nil { return nil }
-            return message
-        }
-    }
-
     private struct CachedMessage: Codable, Equatable {
         var id: String
         var role: MessageRole
@@ -165,11 +144,15 @@ final class SessionPresentationCache {
                 message.attachments = cachedAttachments
             }
 
-            if message.clarify == nil, let cachedClarify = presentation.clarify {
+            if message.clarify == nil,
+               let cachedClarify = presentation.clarify,
+               !Self.isPendingDecision(cachedClarify.status) || includePendingClarifications {
                 message.clarify = cachedClarify
             }
 
-            if message.approval == nil, let cachedApproval = presentation.approval {
+            if message.approval == nil,
+               let cachedApproval = presentation.approval,
+               !Self.isPendingDecision(cachedApproval.status) || includePendingApprovals {
                 message.approval = cachedApproval
             }
 
@@ -210,7 +193,6 @@ final class SessionPresentationCache {
             }
             for approval in pendingApprovals where !merged.contains(where: {
                 $0.approval?.sessionId == approval.sessionId
-                    && ($0.approval?.status == .pending || $0.approval?.status == .submitting)
             }) {
                 let cachedMessage = cached.last { $0.approval?.sessionId == approval.sessionId }
                 merged.append(ChatMessage(
@@ -254,7 +236,11 @@ final class SessionPresentationCache {
         let existingRecords = ids.lazy
             .compactMap { store[self.key(profile: profile, sessionID: $0)]?.messages }
             .first ?? []
-        var records = preservingPresentation(in: freshRecords, from: existingRecords)
+        var records = preservingPresentation(
+            in: freshRecords,
+            from: existingRecords,
+            preservePendingDecisionCards: preservePendingDecisionCards
+        )
         if !preservePendingDecisionCards {
             records = removingPendingDecisionPresentation(from: records)
         }
@@ -371,7 +357,8 @@ final class SessionPresentationCache {
     /// used when Hermes has re-rendered the response text.
     private func preservingPresentation(
         in fresh: [CachedMessage],
-        from existing: [CachedMessage]
+        from existing: [CachedMessage],
+        preservePendingDecisionCards: Bool
     ) -> [CachedMessage] {
         fresh.enumerated().map { position, record in
             var merged = record
@@ -398,10 +385,14 @@ final class SessionPresentationCache {
             if merged.attachments?.isEmpty != false {
                 merged.attachments = prior.attachments
             }
-            if merged.clarify == nil {
+            if merged.clarify == nil,
+               let priorClarify = prior.clarify,
+               !Self.isPendingDecision(priorClarify.status) || preservePendingDecisionCards {
                 merged.clarify = prior.clarify
             }
-            if merged.approval == nil {
+            if merged.approval == nil,
+               let priorApproval = prior.approval,
+               !Self.isPendingDecision(priorApproval.status) || preservePendingDecisionCards {
                 merged.approval = prior.approval
             }
             return merged

--- a/Conduit/Services/SessionPresentationCache.swift
+++ b/Conduit/Services/SessionPresentationCache.swift
@@ -14,6 +14,53 @@ import Foundation
 final class SessionPresentationCache {
     static let shared = SessionPresentationCache()
 
+    /// Returns whether a clarification or approval presentation still needs a
+    /// user decision. Keep this rule shared by resume pruning and cache saves.
+    static func isPendingDecision(_ status: ClarifyActivity.Status) -> Bool {
+        status == .pending || status == .submitting
+    }
+
+    static func isPendingDecision(_ status: ApprovalActivity.Status) -> Bool {
+        status == .pending || status == .submitting
+    }
+
+    /// Stable identity for a pending decision card, used to distinguish a
+    /// gateway-authoritative card from one restored only from local cache.
+    static func pendingDecisionKey(for message: ChatMessage) -> String? {
+        if let clarify = message.clarify, isPendingDecision(clarify.status) {
+            return "clarify:\(clarify.requestId)"
+        }
+        if let approval = message.approval, isPendingDecision(approval.status) {
+            return "approval:\(approval.sessionId)"
+        }
+        return nil
+    }
+
+    static func pendingDecisionKeys(in messages: [ChatMessage]) -> Set<String> {
+        Set(messages.compactMap(pendingDecisionKey(for:)))
+    }
+
+    /// Removes only the pending decision presentations selected by `keys`.
+    /// Passing nil removes every pending decision while preserving the rest of
+    /// the transcript and any completed decision metadata.
+    static func removingPendingDecisionPresentation(
+        from messages: [ChatMessage],
+        matching keys: Set<String>? = nil
+    ) -> [ChatMessage] {
+        messages.compactMap { original in
+            guard let key = pendingDecisionKey(for: original),
+                  keys.map({ $0.contains(key) }) ?? true else {
+                return original
+            }
+            var message = original
+            if message.clarify != nil { message.clarify = nil }
+            if message.approval != nil { message.approval = nil }
+            if message.role == .clarify, message.clarify == nil { return nil }
+            if message.role == .approval, message.approval == nil { return nil }
+            return message
+        }
+    }
+
     private struct CachedMessage: Codable, Equatable {
         var id: String
         var role: MessageRole
@@ -56,12 +103,14 @@ final class SessionPresentationCache {
         var messages: [CachedMessage]
     }
 
-    private let defaults = UserDefaults.standard
+    private let defaults: UserDefaults
     private let storageKey = "conduit.sessionPresentation.v1"
     private let maxSessions = 32
     private let maxMessagesPerSession = 320
 
-    private init() {}
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
 
     /// Restores only fields Hermes did not send in its persisted history.
     /// The transcript, message ordering, and any nonempty server value always
@@ -129,7 +178,7 @@ final class SessionPresentationCache {
 
         if includePendingClarifications {
             let pendingClarifications = cached.compactMap(\.clarify).filter {
-                $0.status == .pending || $0.status == .submitting
+                Self.isPendingDecision($0.status)
             }
 
             // A gateway resume can retain the running clarify tool call but omit
@@ -157,7 +206,7 @@ final class SessionPresentationCache {
 
         if includePendingApprovals {
             let pendingApprovals = cached.compactMap(\.approval).filter {
-                $0.status == .pending || $0.status == .submitting
+                Self.isPendingDecision($0.status)
             }
             for approval in pendingApprovals where !merged.contains(where: {
                 $0.approval?.sessionId == approval.sessionId
@@ -225,11 +274,11 @@ final class SessionPresentationCache {
         messages.compactMap { original in
             var message = original
             if let clarify = message.clarify,
-               clarify.status == .pending || clarify.status == .submitting {
+               Self.isPendingDecision(clarify.status) {
                 message.clarify = nil
             }
             if let approval = message.approval,
-               approval.status == .pending || approval.status == .submitting {
+               Self.isPendingDecision(approval.status) {
                 message.approval = nil
             }
             if message.role == .clarify, message.clarify == nil { return nil }

--- a/Conduit/Services/SessionPresentationCache.swift
+++ b/Conduit/Services/SessionPresentationCache.swift
@@ -115,15 +115,22 @@ final class SessionPresentationCache {
     private struct CachedSession: Codable {
         var updatedAt: Date
         var messages: [CachedMessage]
+        var unconfirmedPendingDecisionAt: Date?
     }
 
+    /// An omitted running state is inherently ambiguous. Keep an unconfirmed
+    /// decision across a cold launch for a bounded grace period, then prefer a
+    /// stale-card miss over making an old request answerable forever.
+    private let maxUnconfirmedPendingDecisionAge: TimeInterval = 24 * 60 * 60
     private let defaults: UserDefaults
+    private let now: () -> Date
     private let storageKey = "conduit.sessionPresentation.v1"
     private let maxSessions = 32
     private let maxMessagesPerSession = 320
 
-    init(defaults: UserDefaults = .standard) {
+    init(defaults: UserDefaults = .standard, now: @escaping () -> Date = { Date() }) {
         self.defaults = defaults
+        self.now = now
     }
 
     /// Restores only fields Hermes did not send in its persisted history.
@@ -136,9 +143,17 @@ final class SessionPresentationCache {
         includePendingClarifications: Bool = false,
         includePendingApprovals: Bool = false
     ) -> [ChatMessage] {
+        let stored = load()
         let cached = sessionIDs
-            .compactMap { load()[key(profile: profile, sessionID: $0)]?.messages }
-            .flatMap { $0 }
+            .compactMap { stored[key(profile: profile, sessionID: $0)] }
+            .flatMap { session in
+                let unconfirmedExpired = session.unconfirmedPendingDecisionAt.map {
+                    now().timeIntervalSince($0) > maxUnconfirmedPendingDecisionAge
+                } ?? false
+                return unconfirmedExpired
+                    ? removingPendingDecisionPresentation(from: session.messages)
+                    : session.messages
+            }
         guard !cached.isEmpty else { return messages }
 
         var remaining = Set(cached.indices)
@@ -246,7 +261,8 @@ final class SessionPresentationCache {
         _ messages: [ChatMessage],
         profile: String,
         sessionIDs: [String],
-        preservePendingDecisionCards: Bool = true
+        preservePendingDecisionCards: Bool = true,
+        unconfirmedPendingDecisionKeys: Set<String> = []
     ) {
         let ids = Set(sessionIDs.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty })
         guard !ids.isEmpty else { return }
@@ -254,14 +270,23 @@ final class SessionPresentationCache {
         var store = load()
         let freshRecords = messages.suffix(maxMessagesPerSession).map { CachedMessage($0) }
         guard !freshRecords.isEmpty else {
-            guard !preservePendingDecisionCards else { return }
+            guard !preservePendingDecisionCards || !unconfirmedPendingDecisionKeys.isEmpty else { return }
             var changed = false
             for id in ids {
                 let cacheKey = key(profile: profile, sessionID: id)
                 guard var session = store[cacheKey] else { continue }
-                let pruned = removingPendingDecisionPresentation(from: session.messages)
-                guard pruned != session.messages else { continue }
+                let pruned = removingPendingDecisionPresentation(
+                    from: session.messages,
+                    preserving: unconfirmedPendingDecisionKeys
+                )
+                let unconfirmedAt = unconfirmedPendingDecisionKeys.isEmpty
+                    ? nil
+                    : (session.unconfirmedPendingDecisionAt ?? now())
+                guard pruned != session.messages || unconfirmedAt != session.unconfirmedPendingDecisionAt else {
+                    continue
+                }
                 session.messages = pruned
+                session.unconfirmedPendingDecisionAt = unconfirmedAt
                 store[cacheKey] = session
                 changed = true
             }
@@ -276,10 +301,28 @@ final class SessionPresentationCache {
             from: existingRecords,
             preservePendingDecisionCards: preservePendingDecisionCards
         )
+        appendUnconfirmedPendingDecisionRecords(
+            to: &records,
+            from: existingRecords,
+            matching: unconfirmedPendingDecisionKeys
+        )
         if !preservePendingDecisionCards {
-            records = removingPendingDecisionPresentation(from: records)
+            records = removingPendingDecisionPresentation(
+                from: records,
+                preserving: unconfirmedPendingDecisionKeys
+            )
         }
-        let session = CachedSession(updatedAt: Date(), messages: records)
+        let existingUnconfirmedAt = ids.lazy
+            .compactMap { store[self.key(profile: profile, sessionID: $0)]?.unconfirmedPendingDecisionAt }
+            .first
+        let unconfirmedAt = unconfirmedPendingDecisionKeys.isEmpty
+            ? nil
+            : (existingUnconfirmedAt ?? now())
+        let session = CachedSession(
+            updatedAt: now(),
+            messages: records,
+            unconfirmedPendingDecisionAt: unconfirmedAt
+        )
         for id in ids {
             store[key(profile: profile, sessionID: id)] = session
         }
@@ -291,20 +334,64 @@ final class SessionPresentationCache {
     /// locally restored decision card, but that card is not authoritative
     /// enough to keep writing to disk. Strip only pending/submitting decision
     /// presentation while preserving normal transcript metadata.
-    private func removingPendingDecisionPresentation(from messages: [CachedMessage]) -> [CachedMessage] {
+    private func removingPendingDecisionPresentation(
+        from messages: [CachedMessage],
+        preserving keys: Set<String> = []
+    ) -> [CachedMessage] {
         messages.compactMap { original in
             var message = original
             if let clarify = message.clarify,
-               Self.isPendingDecision(clarify.status) {
+               Self.isPendingDecision(clarify.status),
+               !keys.contains("clarify:\(clarify.requestId)") {
                 message.clarify = nil
             }
             if let approval = message.approval,
-               Self.isPendingDecision(approval.status) {
+               Self.isPendingDecision(approval.status),
+               !keys.contains("approval:\(approval.sessionId)") {
                 message.approval = nil
             }
             if message.role == .clarify, message.clarify == nil { return nil }
             if message.role == .approval, message.approval == nil { return nil }
             return message
+        }
+    }
+
+    private func decisionKey(for message: CachedMessage) -> String? {
+        if let clarify = message.clarify {
+            return "clarify:\(clarify.requestId)"
+        }
+        if let approval = message.approval {
+            return "approval:\(approval.sessionId)"
+        }
+        return nil
+    }
+
+    private func pendingDecisionKey(for message: CachedMessage) -> String? {
+        if let clarify = message.clarify, Self.isPendingDecision(clarify.status) {
+            return "clarify:\(clarify.requestId)"
+        }
+        if let approval = message.approval, Self.isPendingDecision(approval.status) {
+            return "approval:\(approval.sessionId)"
+        }
+        return nil
+    }
+
+    private func appendUnconfirmedPendingDecisionRecords(
+        to records: inout [CachedMessage],
+        from existing: [CachedMessage],
+        matching keys: Set<String>
+    ) {
+        guard !keys.isEmpty else { return }
+        var existingRecordKeys = Set(records.compactMap(decisionKey(for:)))
+        for record in existing {
+            guard let pendingKey = pendingDecisionKey(for: record),
+                  keys.contains(pendingKey),
+                  let recordKey = decisionKey(for: record),
+                  !existingRecordKeys.contains(recordKey) else {
+                continue
+            }
+            records.append(record)
+            existingRecordKeys.insert(recordKey)
         }
     }
 

--- a/Conduit/Services/SessionPresentationCache.swift
+++ b/Conduit/Services/SessionPresentationCache.swift
@@ -306,6 +306,12 @@ final class SessionPresentationCache {
             if merged.attachments?.isEmpty != false {
                 merged.attachments = prior.attachments
             }
+            if merged.clarify == nil {
+                merged.clarify = prior.clarify
+            }
+            if merged.approval == nil {
+                merged.approval = prior.approval
+            }
             return merged
         }
     }

--- a/Conduit/Services/SessionPresentationCache.swift
+++ b/Conduit/Services/SessionPresentationCache.swift
@@ -14,7 +14,7 @@ import Foundation
 final class SessionPresentationCache {
     static let shared = SessionPresentationCache()
 
-    private struct CachedMessage: Codable {
+    private struct CachedMessage: Codable, Equatable {
         var id: String
         var role: MessageRole
         var signature: String
@@ -176,23 +176,66 @@ final class SessionPresentationCache {
         return merged
     }
 
-    func save(_ messages: [ChatMessage], profile: String, sessionIDs: [String]) {
+    func save(
+        _ messages: [ChatMessage],
+        profile: String,
+        sessionIDs: [String],
+        preservePendingDecisionCards: Bool = true
+    ) {
         let ids = Set(sessionIDs.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty })
         guard !ids.isEmpty else { return }
 
         var store = load()
         let freshRecords = messages.suffix(maxMessagesPerSession).map { CachedMessage($0) }
-        guard !freshRecords.isEmpty else { return }
+        guard !freshRecords.isEmpty else {
+            guard !preservePendingDecisionCards else { return }
+            var changed = false
+            for id in ids {
+                let cacheKey = key(profile: profile, sessionID: id)
+                guard var session = store[cacheKey] else { continue }
+                let pruned = removingPendingDecisionPresentation(from: session.messages)
+                guard pruned != session.messages else { continue }
+                session.messages = pruned
+                store[cacheKey] = session
+                changed = true
+            }
+            if changed { persist(store) }
+            return
+        }
         let existingRecords = ids.lazy
             .compactMap { store[self.key(profile: profile, sessionID: $0)]?.messages }
             .first ?? []
-        let records = preservingPresentation(in: freshRecords, from: existingRecords)
+        var records = preservingPresentation(in: freshRecords, from: existingRecords)
+        if !preservePendingDecisionCards {
+            records = removingPendingDecisionPresentation(from: records)
+        }
         let session = CachedSession(updatedAt: Date(), messages: records)
         for id in ids {
             store[key(profile: profile, sessionID: id)] = session
         }
         trim(&store)
         persist(store)
+    }
+
+    /// A resume without an explicit active-turn signal may temporarily show a
+    /// locally restored decision card, but that card is not authoritative
+    /// enough to keep writing to disk. Strip only pending/submitting decision
+    /// presentation while preserving normal transcript metadata.
+    private func removingPendingDecisionPresentation(from messages: [CachedMessage]) -> [CachedMessage] {
+        messages.compactMap { original in
+            var message = original
+            if let clarify = message.clarify,
+               clarify.status == .pending || clarify.status == .submitting {
+                message.clarify = nil
+            }
+            if let approval = message.approval,
+               approval.status == .pending || approval.status == .submitting {
+                message.approval = nil
+            }
+            if message.role == .clarify, message.clarify == nil { return nil }
+            if message.role == .approval, message.approval == nil { return nil }
+            return message
+        }
     }
 
     func clear(profile: String? = nil) {

--- a/Conduit/Services/SessionPresentationCache.swift
+++ b/Conduit/Services/SessionPresentationCache.swift
@@ -13,6 +13,7 @@ import Foundation
 
 final class SessionPresentationCache {
     static let shared = SessionPresentationCache()
+    static let maxUnconfirmedPendingDecisionAge: TimeInterval = 24 * 60 * 60
 
     /// Returns whether a clarification or approval presentation still needs a
     /// user decision. Keep this rule shared by resume pruning and cache saves.
@@ -121,7 +122,6 @@ final class SessionPresentationCache {
     /// An omitted running state is inherently ambiguous. Keep an unconfirmed
     /// decision across a cold launch for a bounded grace period, then prefer a
     /// stale-card miss over making an old request answerable forever.
-    private let maxUnconfirmedPendingDecisionAge: TimeInterval = 24 * 60 * 60
     private let defaults: UserDefaults
     private let now: () -> Date
     private let storageKey = "conduit.sessionPresentation.v1"
@@ -131,6 +131,21 @@ final class SessionPresentationCache {
     init(defaults: UserDefaults = .standard, now: @escaping () -> Date = { Date() }) {
         self.defaults = defaults
         self.now = now
+    }
+
+    func unconfirmedPendingDecisionDate(
+        profile: String,
+        sessionIDs: [String]
+    ) -> Date? {
+        let stored = load()
+        return sessionIDs
+            .compactMap { stored[key(profile: profile, sessionID: $0)]?.unconfirmedPendingDecisionAt }
+            .min()
+    }
+
+    func isUnconfirmedPendingDecisionExpired(since date: Date?) -> Bool {
+        guard let date else { return false }
+        return now().timeIntervalSince(date) > Self.maxUnconfirmedPendingDecisionAge
     }
 
     /// Restores only fields Hermes did not send in its persisted history.
@@ -147,9 +162,9 @@ final class SessionPresentationCache {
         let cached = sessionIDs
             .compactMap { stored[key(profile: profile, sessionID: $0)] }
             .flatMap { session in
-                let unconfirmedExpired = session.unconfirmedPendingDecisionAt.map {
-                    now().timeIntervalSince($0) > maxUnconfirmedPendingDecisionAge
-                } ?? false
+                let unconfirmedExpired = isUnconfirmedPendingDecisionExpired(
+                    since: session.unconfirmedPendingDecisionAt
+                )
                 return unconfirmedExpired
                     ? removingPendingDecisionPresentation(from: session.messages)
                     : session.messages

--- a/ConduitTests/SessionPresentationCacheTests.swift
+++ b/ConduitTests/SessionPresentationCacheTests.swift
@@ -327,4 +327,41 @@ final class SessionPresentationCacheTests: XCTestCase {
 
         cache.clear(profile: profile)
     }
+
+    func testMergeRestoresClarificationWhenRunningIsNil() {
+        let cache = SessionPresentationCache.shared
+        let sessionId = "test-merge-clarify-nil-\(UUID().uuidString)"
+        let profile = "test"
+
+        let clarify = ClarifyActivity(
+            requestId: "req-nil",
+            question: "Pick?",
+            choices: [ClarifyChoice(label: "X", value: "x")],
+            status: .pending
+        )
+        let savedMessages = [
+            ChatMessage(
+                id: "clarify-req-nil",
+                role: .clarify,
+                content: "Pick?",
+                timestamp: "2024-01-01",
+                clarify: clarify
+            ),
+        ]
+        cache.save(savedMessages, profile: profile, sessionIDs: [sessionId])
+
+        // running == nil (omitted by gateway) should still restore
+        let gatewayMessages: [ChatMessage] = []
+        let merged = cache.merge(
+            gatewayMessages,
+            profile: profile,
+            sessionIDs: [sessionId],
+            includePendingClarifications: true
+        )
+
+        XCTAssertTrue(merged.contains { $0.role == .clarify },
+                      "Clarification should be restored when running state is omitted")
+
+        cache.clear(profile: profile)
+    }
 }

--- a/ConduitTests/SessionPresentationCacheTests.swift
+++ b/ConduitTests/SessionPresentationCacheTests.swift
@@ -613,14 +613,24 @@ final class SessionPresentationCacheTests: XCTestCase {
         XCTAssertEqual(appState.messages.first?.clarify?.status, .pending)
         XCTAssertEqual(appState.turnState, TurnState.running,
                        "A restored pending clarification must keep the composer answerable")
-        XCTAssertTrue(
+        XCTAssertFalse(
             cache.merge(
                 [],
                 profile: profile,
                 sessionIDs: [sessionId],
                 includePendingClarifications: true
             ).contains { $0.clarify?.requestId == clarify.requestId },
-            "An omitted running state must retain an unconfirmed clarification card for the next foreground cycle"
+            "An unconfirmed clarification card must not be written back to the presentation cache"
+        )
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: sessionId,
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [:])
+        ))
+        XCTAssertEqual(
+            appState.messages.first?.clarify?.requestId,
+            clarify.requestId,
+            "The active AppState should retain the card for a subsequent foreground resume"
         )
     }
 
@@ -672,14 +682,24 @@ final class SessionPresentationCacheTests: XCTestCase {
         XCTAssertEqual(appState.messages.first?.approval?.status, .pending)
         XCTAssertEqual(appState.turnState, TurnState.running,
                        "A restored pending approval must keep the composer answerable")
-        XCTAssertTrue(
+        XCTAssertFalse(
             cache.merge(
                 [],
                 profile: profile,
                 sessionIDs: [sessionId],
                 includePendingApprovals: true
             ).contains { $0.approval?.sessionId == sessionId },
-            "An omitted running state must retain an unconfirmed approval card for the next foreground cycle"
+            "An unconfirmed approval card must not be written back to the presentation cache"
+        )
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: sessionId,
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [:])
+        ))
+        XCTAssertEqual(
+            appState.messages.first?.approval?.sessionId,
+            sessionId,
+            "The active AppState should retain the card for a subsequent foreground resume"
         )
     }
 
@@ -792,8 +812,12 @@ final class SessionPresentationCacheTests: XCTestCase {
             includePendingClarifications: true,
             includePendingApprovals: true
         )
-        XCTAssertTrue(persisted.contains { $0.approval?.sessionId == sessionId },
-                      "An omitted running state must retain a restored pending card")
+        XCTAssertFalse(persisted.contains { $0.approval?.sessionId == sessionId },
+                       "An unconfirmed restored card must not be written back to the presentation cache")
+        XCTAssertTrue(
+            appState.messages.contains { $0.approval?.sessionId == sessionId },
+            "The active AppState should retain the restored card while the gateway is inconclusive"
+        )
         XCTAssertEqual(
             cache.merge([gatewayMessage], profile: profile, sessionIDs: [sessionId]).first?.content,
             gatewayMessage.content
@@ -932,6 +956,224 @@ final class SessionPresentationCacheTests: XCTestCase {
                 sessionIDs: [sessionId],
                 includePendingApprovals: true
             ).contains { $0.approval?.status == .pending }
+        )
+    }
+
+    func testApplyChatResumeSuppressesCachedPendingClarificationWhenGatewayResolvedIt() {
+        let suiteName = "conduit.tests.session-presentation-resolved-clarify-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: defaults)
+        let sessionId = "test-apply-resume-resolved-clarify-\(UUID().uuidString)"
+        let appState = AppState(
+            defaults: defaults,
+            loadSavedConnection: false,
+            clearSessionPresentationCache: { cache.clear() },
+            sessionPresentationCache: cache
+        )
+        let profile = appState.activeProfile
+        let pendingClarify = ClarifyActivity(
+            requestId: "req-resolved-clarify",
+            question: "Which color?",
+            choices: [ClarifyChoice(label: "Red", value: "red")],
+            status: .pending
+        )
+        cache.save([
+            ChatMessage(
+                id: "clarify-\(pendingClarify.requestId)",
+                role: .clarify,
+                content: pendingClarify.question,
+                timestamp: "2024-01-01",
+                clarify: pendingClarify
+            )
+        ], profile: profile, sessionIDs: [sessionId])
+        let resolvedClarify = ClarifyActivity(
+            requestId: pendingClarify.requestId,
+            question: pendingClarify.question,
+            choices: pendingClarify.choices,
+            status: .answered,
+            answer: "red"
+        )
+        let gatewayMessage = ChatMessage(
+            id: "clarify-\(pendingClarify.requestId)",
+            role: .clarify,
+            content: resolvedClarify.question,
+            timestamp: "2024-01-02",
+            clarify: resolvedClarify
+        )
+        defer {
+            cache.clear()
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: sessionId,
+            messages: [gatewayMessage],
+            snapshot: SessionRuntimeSnapshot(object: [:])
+        ))
+
+        XCTAssertEqual(
+            appState.messages.filter { $0.clarify?.requestId == pendingClarify.requestId }.count,
+            1
+        )
+        XCTAssertEqual(appState.messages.first?.clarify?.status, ClarifyActivity.Status.answered)
+        XCTAssertFalse(AppState.hasPendingDecision(in: appState.messages))
+    }
+
+    func testApplyChatResumeMakesRestoredSubmittingApprovalRetryable() {
+        let suiteName = "conduit.tests.session-presentation-submitting-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: defaults)
+        let sessionId = "test-apply-resume-submitting-\(UUID().uuidString)"
+        let appState = AppState(
+            defaults: defaults,
+            loadSavedConnection: false,
+            clearSessionPresentationCache: { cache.clear() },
+            sessionPresentationCache: cache
+        )
+        let profile = appState.activeProfile
+        let approval = ApprovalActivity(
+            sessionId: sessionId,
+            command: "ls",
+            description: "List files",
+            choices: ["once", "deny"],
+            allowPermanent: false,
+            smartDenied: false,
+            status: .submitting,
+            choice: "once"
+        )
+        cache.save([
+            ChatMessage(
+                id: "approval-\(sessionId)",
+                role: .approval,
+                content: approval.description,
+                timestamp: "2024-01-01",
+                approval: approval
+            )
+        ], profile: profile, sessionIDs: [sessionId])
+        defer {
+            cache.clear()
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: sessionId,
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [:])
+        ))
+
+        XCTAssertEqual(
+            appState.messages.first?.approval?.status,
+            ApprovalActivity.Status.pending,
+            "A restored in-flight decision must be retryable after the app resumes"
+        )
+        XCTAssertNil(appState.messages.first?.approval?.choice)
+    }
+
+    func testApplyChatResumePersistsRestoredCardWhenRunningIsTrue() {
+        let suiteName = "conduit.tests.session-presentation-running-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: defaults)
+        let sessionId = "test-apply-resume-running-\(UUID().uuidString)"
+        let appState = AppState(
+            defaults: defaults,
+            loadSavedConnection: false,
+            clearSessionPresentationCache: { cache.clear() },
+            sessionPresentationCache: cache
+        )
+        let profile = appState.activeProfile
+        let clarify = ClarifyActivity(
+            requestId: "req-running",
+            question: "Which color?",
+            choices: [ClarifyChoice(label: "Red", value: "red")],
+            status: .pending
+        )
+        cache.save([
+            ChatMessage(
+                id: "clarify-running",
+                role: .clarify,
+                content: clarify.question,
+                timestamp: "2024-01-01",
+                clarify: clarify
+            )
+        ], profile: profile, sessionIDs: [sessionId])
+        defer {
+            cache.clear()
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: sessionId,
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: ["running": .bool(true)])
+        ))
+
+        XCTAssertTrue(
+            cache.merge(
+                [],
+                profile: profile,
+                sessionIDs: [sessionId],
+                includePendingClarifications: true
+            ).contains { $0.clarify?.requestId == clarify.requestId }
+        )
+    }
+
+    func testApplyChatResumePrunesGatewayPendingCardWhenRunningIsFalse() {
+        let suiteName = "conduit.tests.session-presentation-gateway-settled-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: defaults)
+        let sessionId = "test-apply-resume-gateway-settled-\(UUID().uuidString)"
+        let appState = AppState(
+            defaults: defaults,
+            loadSavedConnection: false,
+            clearSessionPresentationCache: { cache.clear() },
+            sessionPresentationCache: cache
+        )
+        let profile = appState.activeProfile
+        let clarify = ClarifyActivity(
+            requestId: "req-gateway-settled",
+            question: "Which color?",
+            choices: [ClarifyChoice(label: "Red", value: "red")],
+            status: .pending
+        )
+        let gatewayMessage = ChatMessage(
+            id: "clarify-gateway-settled",
+            role: .clarify,
+            content: clarify.question,
+            timestamp: "2024-01-01",
+            clarify: clarify
+        )
+        defer {
+            cache.clear()
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: sessionId,
+            messages: [gatewayMessage],
+            snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+        ))
+
+        XCTAssertEqual(appState.turnState, TurnState.idle)
+        XCTAssertFalse(
+            cache.merge(
+                [],
+                profile: profile,
+                sessionIDs: [sessionId],
+                includePendingClarifications: true
+            ).contains { $0.clarify?.requestId == clarify.requestId },
+            "An explicit settled signal must prune even an inconsistent pending gateway row"
         )
     }
 }

--- a/ConduitTests/SessionPresentationCacheTests.swift
+++ b/ConduitTests/SessionPresentationCacheTests.swift
@@ -568,10 +568,10 @@ final class SessionPresentationCacheTests: XCTestCase {
 
     // MARK: - AppState resume integration
 
-    func testApplyResumeRestoresPendingClarificationWhenRunningIsNil() {
+    func testApplyChatResumeRestoresPendingClarificationWhenRunningIsNil() {
         let cache = SessionPresentationCache.shared
         let sessionId = "test-apply-resume-clarify-\(UUID().uuidString)"
-        let appState = AppState(restoreSavedConnection: false)
+        let appState = AppState(loadSavedConnection: false)
         let profile = appState.activeProfile
         let clarify = ClarifyActivity(
             requestId: "req-apply-resume",
@@ -590,7 +590,7 @@ final class SessionPresentationCacheTests: XCTestCase {
         ], profile: profile, sessionIDs: [sessionId])
         defer { cache.clear(profile: profile) }
 
-        appState.applyResume(SessionResumeResult(
+        appState.applyChatResume(SessionResumeResult(
             sessionId: sessionId,
             messages: [],
             snapshot: SessionRuntimeSnapshot(object: [:])
@@ -598,7 +598,7 @@ final class SessionPresentationCacheTests: XCTestCase {
 
         XCTAssertEqual(appState.messages.first?.clarify?.requestId, clarify.requestId)
         XCTAssertEqual(appState.messages.first?.clarify?.status, .pending)
-        XCTAssertEqual(appState.turnState, .running,
+        XCTAssertEqual(appState.turnState, TurnState.running,
                        "A restored pending clarification must keep the composer answerable")
         XCTAssertFalse(
             cache.merge(
@@ -611,10 +611,10 @@ final class SessionPresentationCacheTests: XCTestCase {
         )
     }
 
-    func testApplyResumeRestoresPendingApprovalWhenRunningIsNil() {
+    func testApplyChatResumeRestoresPendingApprovalWhenRunningIsNil() {
         let cache = SessionPresentationCache.shared
         let sessionId = "test-apply-resume-approval-\(UUID().uuidString)"
-        let appState = AppState(restoreSavedConnection: false)
+        let appState = AppState(loadSavedConnection: false)
         let profile = appState.activeProfile
         let approval = ApprovalActivity(
             sessionId: sessionId,
@@ -636,7 +636,7 @@ final class SessionPresentationCacheTests: XCTestCase {
         ], profile: profile, sessionIDs: [sessionId])
         defer { cache.clear(profile: profile) }
 
-        appState.applyResume(SessionResumeResult(
+        appState.applyChatResume(SessionResumeResult(
             sessionId: sessionId,
             messages: [],
             snapshot: SessionRuntimeSnapshot(object: [:])
@@ -644,7 +644,7 @@ final class SessionPresentationCacheTests: XCTestCase {
 
         XCTAssertEqual(appState.messages.first?.approval?.sessionId, sessionId)
         XCTAssertEqual(appState.messages.first?.approval?.status, .pending)
-        XCTAssertEqual(appState.turnState, .running,
+        XCTAssertEqual(appState.turnState, TurnState.running,
                        "A restored pending approval must keep the composer answerable")
         XCTAssertFalse(
             cache.merge(
@@ -657,10 +657,10 @@ final class SessionPresentationCacheTests: XCTestCase {
         )
     }
 
-    func testApplyResumePersistsGatewayMessagesWithoutRecachingRestoredCardsWhenRunningIsNil() {
+    func testApplyChatResumePersistsGatewayMessagesWithoutRecachingRestoredCardsWhenRunningIsNil() {
         let cache = SessionPresentationCache.shared
         let sessionId = "test-apply-resume-cache-\(UUID().uuidString)"
-        let appState = AppState(restoreSavedConnection: false)
+        let appState = AppState(loadSavedConnection: false)
         let profile = appState.activeProfile
         let approval = ApprovalActivity(
             sessionId: sessionId,
@@ -688,7 +688,7 @@ final class SessionPresentationCacheTests: XCTestCase {
             content: "Fresh transcript row",
             timestamp: ""
         )
-        appState.applyResume(SessionResumeResult(
+        appState.applyChatResume(SessionResumeResult(
             sessionId: sessionId,
             messages: [gatewayMessage],
             snapshot: SessionRuntimeSnapshot(object: [:])

--- a/ConduitTests/SessionPresentationCacheTests.swift
+++ b/ConduitTests/SessionPresentationCacheTests.swift
@@ -236,6 +236,7 @@ final class SessionPresentationCacheTests: XCTestCase {
             ),
         ]
         cache.save(savedMessages, profile: profile, sessionIDs: [sessionId])
+        defer { cache.clear(profile: profile) }
 
         // Gateway resume omits the clarify card (compact history)
         let gatewayMessages: [ChatMessage] = []
@@ -251,8 +252,6 @@ final class SessionPresentationCacheTests: XCTestCase {
         XCTAssertEqual(restoredClarify?.clarify?.requestId, "req-123")
         XCTAssertEqual(restoredClarify?.clarify?.status, .pending)
         XCTAssertEqual(restoredClarify?.clarify?.choices.count, 2)
-
-        cache.clear(profile: profile)
     }
 
     func testMergeDoesNotRestoreClarificationWhenNotRequested() {
@@ -276,6 +275,7 @@ final class SessionPresentationCacheTests: XCTestCase {
             ),
         ]
         cache.save(savedMessages, profile: profile, sessionIDs: [sessionId])
+        defer { cache.clear(profile: profile) }
 
         let gatewayMessages: [ChatMessage] = []
         let merged = cache.merge(
@@ -287,8 +287,6 @@ final class SessionPresentationCacheTests: XCTestCase {
 
         XCTAssertFalse(merged.contains { $0.role == .clarify },
                        "Clarification should not be restored when includePendingClarifications is false")
-
-        cache.clear(profile: profile)
     }
 
     func testMergeDoesNotRestoreAnsweredClarification() {
@@ -313,6 +311,7 @@ final class SessionPresentationCacheTests: XCTestCase {
             ),
         ]
         cache.save(savedMessages, profile: profile, sessionIDs: [sessionId])
+        defer { cache.clear(profile: profile) }
 
         let gatewayMessages: [ChatMessage] = []
         let merged = cache.merge(
@@ -324,8 +323,6 @@ final class SessionPresentationCacheTests: XCTestCase {
 
         XCTAssertFalse(merged.contains { $0.role == .clarify },
                        "Answered clarification should not be restored as pending")
-
-        cache.clear(profile: profile)
     }
 
     func testMergeRestoresClarificationWhenRunningIsNil() {
@@ -349,6 +346,7 @@ final class SessionPresentationCacheTests: XCTestCase {
             ),
         ]
         cache.save(savedMessages, profile: profile, sessionIDs: [sessionId])
+        defer { cache.clear(profile: profile) }
 
         // running == nil (omitted by gateway) should still restore
         let gatewayMessages: [ChatMessage] = []
@@ -361,8 +359,6 @@ final class SessionPresentationCacheTests: XCTestCase {
 
         XCTAssertTrue(merged.contains { $0.role == .clarify },
                       "Clarification should be restored when running state is omitted")
-
-        cache.clear(profile: profile)
     }
 
     // MARK: - Merge: pending approval restoration
@@ -391,6 +387,7 @@ final class SessionPresentationCacheTests: XCTestCase {
             ),
         ]
         cache.save(savedMessages, profile: profile, sessionIDs: [sessionId])
+        defer { cache.clear(profile: profile) }
 
         // Gateway resume omits the approval card
         let gatewayMessages: [ChatMessage] = []
@@ -405,8 +402,6 @@ final class SessionPresentationCacheTests: XCTestCase {
         XCTAssertNotNil(restoredApproval, "Pending approval should be restored from cache")
         XCTAssertEqual(restoredApproval?.approval?.sessionId, sessionId)
         XCTAssertEqual(restoredApproval?.approval?.status, .pending)
-
-        cache.clear(profile: profile)
     }
 
     func testMergeDoesNotRestoreApprovalWhenNotRequested() {
@@ -433,6 +428,7 @@ final class SessionPresentationCacheTests: XCTestCase {
             ),
         ]
         cache.save(savedMessages, profile: profile, sessionIDs: [sessionId])
+        defer { cache.clear(profile: profile) }
 
         let gatewayMessages: [ChatMessage] = []
         let merged = cache.merge(
@@ -444,7 +440,5 @@ final class SessionPresentationCacheTests: XCTestCase {
 
         XCTAssertFalse(merged.contains { $0.role == .approval },
                        "Approval should not be restored when includePendingApprovals is false")
-
-        cache.clear(profile: profile)
     }
 }

--- a/ConduitTests/SessionPresentationCacheTests.swift
+++ b/ConduitTests/SessionPresentationCacheTests.swift
@@ -613,14 +613,14 @@ final class SessionPresentationCacheTests: XCTestCase {
         XCTAssertEqual(appState.messages.first?.clarify?.status, .pending)
         XCTAssertEqual(appState.turnState, TurnState.running,
                        "A restored pending clarification must keep the composer answerable")
-        XCTAssertFalse(
+        XCTAssertTrue(
             cache.merge(
                 [],
                 profile: profile,
                 sessionIDs: [sessionId],
                 includePendingClarifications: true
             ).contains { $0.clarify?.requestId == clarify.requestId },
-            "The nil resume must not re-persist an unconfirmed clarification card"
+            "An omitted running state must retain an unconfirmed clarification card for the next foreground cycle"
         )
     }
 
@@ -672,14 +672,14 @@ final class SessionPresentationCacheTests: XCTestCase {
         XCTAssertEqual(appState.messages.first?.approval?.status, .pending)
         XCTAssertEqual(appState.turnState, TurnState.running,
                        "A restored pending approval must keep the composer answerable")
-        XCTAssertFalse(
+        XCTAssertTrue(
             cache.merge(
                 [],
                 profile: profile,
                 sessionIDs: [sessionId],
                 includePendingApprovals: true
             ).contains { $0.approval?.sessionId == sessionId },
-            "The nil resume must not re-persist an unconfirmed approval card"
+            "An omitted running state must retain an unconfirmed approval card for the next foreground cycle"
         )
     }
 
@@ -735,7 +735,7 @@ final class SessionPresentationCacheTests: XCTestCase {
         XCTAssertEqual(appState.turnState, TurnState.running)
     }
 
-    func testApplyChatResumePersistsGatewayMessagesWithoutRecachingRestoredCardsWhenRunningIsNil() {
+    func testApplyChatResumePersistsGatewayMessagesAndRetainsRestoredCardsWhenRunningIsNil() {
         let suiteName = "conduit.tests.session-presentation-cache-\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
             XCTFail("Could not create isolated UserDefaults suite")
@@ -792,11 +792,146 @@ final class SessionPresentationCacheTests: XCTestCase {
             includePendingClarifications: true,
             includePendingApprovals: true
         )
-        XCTAssertFalse(persisted.contains { $0.approval?.sessionId == sessionId },
-                       "A nil running snapshot must not re-persist a restored pending card")
+        XCTAssertTrue(persisted.contains { $0.approval?.sessionId == sessionId },
+                      "An omitted running state must retain a restored pending card")
         XCTAssertEqual(
             cache.merge([gatewayMessage], profile: profile, sessionIDs: [sessionId]).first?.content,
             gatewayMessage.content
+        )
+    }
+
+    func testApplyChatResumeDoesNotRestorePendingCardsWhenRunningIsFalse() {
+        let suiteName = "conduit.tests.session-presentation-settled-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: defaults)
+        let sessionId = "test-apply-resume-settled-\(UUID().uuidString)"
+        let appState = AppState(
+            defaults: defaults,
+            loadSavedConnection: false,
+            clearSessionPresentationCache: { cache.clear() },
+            sessionPresentationCache: cache
+        )
+        let profile = appState.activeProfile
+        let clarify = ClarifyActivity(
+            requestId: "req-settled",
+            question: "Which color?",
+            choices: [ClarifyChoice(label: "Red", value: "red")],
+            status: .pending
+        )
+        cache.save([
+            ChatMessage(
+                id: "clarify-settled",
+                role: .clarify,
+                content: clarify.question,
+                timestamp: "2024-01-01",
+                clarify: clarify
+            )
+        ], profile: profile, sessionIDs: [sessionId])
+        defer {
+            cache.clear()
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: sessionId,
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+        ))
+
+        XCTAssertFalse(appState.messages.contains { $0.clarify?.requestId == clarify.requestId })
+        XCTAssertEqual(appState.turnState, TurnState.idle)
+        XCTAssertFalse(
+            cache.merge(
+                [],
+                profile: profile,
+                sessionIDs: [sessionId],
+                includePendingClarifications: true
+            ).contains { $0.clarify?.requestId == clarify.requestId },
+            "An explicitly settled resume must remove the cached pending card"
+        )
+    }
+
+    func testApplyChatResumeSuppressesCachedPendingApprovalWhenGatewayResolvedIt() {
+        let suiteName = "conduit.tests.session-presentation-resolved-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: defaults)
+        let sessionId = "test-apply-resume-resolved-\(UUID().uuidString)"
+        let appState = AppState(
+            defaults: defaults,
+            loadSavedConnection: false,
+            clearSessionPresentationCache: { cache.clear() },
+            sessionPresentationCache: cache
+        )
+        let profile = appState.activeProfile
+        let pendingApproval = ApprovalActivity(
+            sessionId: sessionId,
+            command: "ls",
+            description: "List files",
+            choices: ["once", "deny"],
+            allowPermanent: false,
+            smartDenied: false,
+            status: .pending
+        )
+        cache.save([
+            ChatMessage(
+                id: "approval-\(sessionId)",
+                role: .approval,
+                content: pendingApproval.description,
+                timestamp: "2024-01-01",
+                approval: pendingApproval
+            )
+        ], profile: profile, sessionIDs: [sessionId])
+        let resolvedApproval = ApprovalActivity(
+            sessionId: sessionId,
+            command: pendingApproval.command,
+            description: pendingApproval.description,
+            choices: pendingApproval.choices,
+            allowPermanent: pendingApproval.allowPermanent,
+            smartDenied: pendingApproval.smartDenied,
+            status: .approved,
+            choice: "once"
+        )
+        let gatewayMessage = ChatMessage(
+            id: "approval-\(sessionId)",
+            role: .approval,
+            content: resolvedApproval.description,
+            timestamp: "2024-01-02",
+            approval: resolvedApproval
+        )
+        defer {
+            cache.clear()
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: sessionId,
+            messages: [gatewayMessage],
+            snapshot: SessionRuntimeSnapshot(object: [:])
+        ))
+
+        XCTAssertEqual(
+            appState.messages.filter { $0.approval?.sessionId == sessionId }.count,
+            1,
+            "A resolved gateway approval must replace, not coexist with, the cached pending card"
+        )
+        XCTAssertEqual(
+            appState.messages.first?.approval?.status,
+            ApprovalActivity.Status.approved
+        )
+        XCTAssertFalse(AppState.hasPendingDecision(in: appState.messages))
+        XCTAssertFalse(
+            cache.merge(
+                [],
+                profile: profile,
+                sessionIDs: [sessionId],
+                includePendingApprovals: true
+            ).contains { $0.approval?.status == .pending }
         )
     }
 }

--- a/ConduitTests/SessionPresentationCacheTests.swift
+++ b/ConduitTests/SessionPresentationCacheTests.swift
@@ -325,7 +325,7 @@ final class SessionPresentationCacheTests: XCTestCase {
                        "Answered clarification should not be restored as pending")
     }
 
-    func testMergeRestoresClarificationWhenRunningIsNil() {
+    func testMergeDoesNotRestoreClarificationWhenRunningIsNil() {
         let cache = SessionPresentationCache.shared
         let sessionId = "test-merge-clarify-nil-\(UUID().uuidString)"
         let profile = "test"
@@ -348,17 +348,20 @@ final class SessionPresentationCacheTests: XCTestCase {
         cache.save(savedMessages, profile: profile, sessionIDs: [sessionId])
         defer { cache.clear(profile: profile) }
 
-        // running == nil (omitted by gateway) should still restore
+        // running == nil (omitted by gateway) should NOT restore because the
+        // turn may have completed while backgrounded — restoring would risk
+        // displaying a stale, answerable card for an already-resolved request.
+        let shouldRestore = AppState.shouldRestorePendingCards(running: nil)
         let gatewayMessages: [ChatMessage] = []
         let merged = cache.merge(
             gatewayMessages,
             profile: profile,
             sessionIDs: [sessionId],
-            includePendingClarifications: true
+            includePendingClarifications: shouldRestore
         )
 
-        XCTAssertTrue(merged.contains { $0.role == .clarify },
-                      "Clarification should be restored when running state is omitted")
+        XCTAssertFalse(merged.contains { $0.role == .clarify },
+                       "Clarification should not be restored when running state is omitted (nil)")
     }
 
     // MARK: - Merge: pending approval restoration
@@ -440,5 +443,127 @@ final class SessionPresentationCacheTests: XCTestCase {
 
         XCTAssertFalse(merged.contains { $0.role == .approval },
                        "Approval should not be restored when includePendingApprovals is false")
+    }
+
+    // MARK: - restorePendingCards derivation
+
+    func testShouldRestorePendingCardsWhenRunningIsTrue() {
+        XCTAssertTrue(AppState.shouldRestorePendingCards(running: true),
+                      "Must restore pending cards when gateway confirms turn is active")
+    }
+
+    func testShouldNotRestorePendingCardsWhenRunningIsFalse() {
+        XCTAssertFalse(AppState.shouldRestorePendingCards(running: false),
+                       "Must not restore pending cards when gateway reports turn is inactive")
+    }
+
+    func testShouldNotRestorePendingCardsWhenRunningIsNil() {
+        // The gateway may omit `running` (nil) even while a turn is active,
+        // but the turn may also have completed while the app was backgrounded.
+        // Restoring cached cards in the nil case risks displaying stale,
+        // answerable UI for an already-resolved request.
+        XCTAssertFalse(AppState.shouldRestorePendingCards(running: nil),
+                       "Must not restore pending cards when gateway omits running state")
+    }
+
+    // MARK: - Save preserves restored pending cards
+
+    func testSavePreservesRestoredClarificationCard() {
+        let cache = SessionPresentationCache.shared
+        let sessionId = "test-save-clarify-\(UUID().uuidString)"
+        let profile = "test"
+
+        let clarify = ClarifyActivity(
+            requestId: "req-save",
+            question: "Which?",
+            choices: [ClarifyChoice(label: "A", value: "a")],
+            status: .pending
+        )
+        let savedMessages = [
+            ChatMessage(
+                id: "clarify-req-save",
+                role: .clarify,
+                content: "Which?",
+                timestamp: "2024-01-01T10:00:00Z",
+                clarify: clarify
+            ),
+        ]
+        cache.save(savedMessages, profile: profile, sessionIDs: [sessionId])
+        defer { cache.clear(profile: profile) }
+
+        // Merge restores the pending card
+        let gatewayMessages: [ChatMessage] = []
+        let merged = cache.merge(
+            gatewayMessages,
+            profile: profile,
+            sessionIDs: [sessionId],
+            includePendingClarifications: true
+        )
+        XCTAssertTrue(merged.contains { $0.role == .clarify },
+                      "Card should be restored from cache")
+
+        // Save the merged result (as applyResume does when running == true)
+        cache.save(merged, profile: profile, sessionIDs: [sessionId])
+
+        // Re-merge: the card should survive because save persisted it
+        let remerged = cache.merge(
+            gatewayMessages,
+            profile: profile,
+            sessionIDs: [sessionId],
+            includePendingClarifications: true
+        )
+        XCTAssertTrue(remerged.contains { $0.role == .clarify },
+                      "Restored clarification card must survive a save-then-merge cycle")
+    }
+
+    func testSavePreservesRestoredApprovalCard() {
+        let cache = SessionPresentationCache.shared
+        let sessionId = "test-save-approval-\(UUID().uuidString)"
+        let profile = "test"
+
+        let approval = ApprovalActivity(
+            sessionId: sessionId,
+            command: "ls",
+            description: "List files",
+            choices: ["once", "session", "always", "deny"],
+            allowPermanent: true,
+            smartDenied: false,
+            status: .pending
+        )
+        let savedMessages = [
+            ChatMessage(
+                id: "approval-save",
+                role: .approval,
+                content: "List files",
+                timestamp: "2024-01-01T10:00:00Z",
+                approval: approval
+            ),
+        ]
+        cache.save(savedMessages, profile: profile, sessionIDs: [sessionId])
+        defer { cache.clear(profile: profile) }
+
+        // Merge restores the pending card
+        let gatewayMessages: [ChatMessage] = []
+        let merged = cache.merge(
+            gatewayMessages,
+            profile: profile,
+            sessionIDs: [sessionId],
+            includePendingApprovals: true
+        )
+        XCTAssertTrue(merged.contains { $0.role == .approval },
+                      "Card should be restored from cache")
+
+        // Save the merged result (as applyResume does when running == true)
+        cache.save(merged, profile: profile, sessionIDs: [sessionId])
+
+        // Re-merge: the card should survive
+        let remerged = cache.merge(
+            gatewayMessages,
+            profile: profile,
+            sessionIDs: [sessionId],
+            includePendingApprovals: true
+        )
+        XCTAssertTrue(remerged.contains { $0.role == .approval },
+                      "Restored approval card must survive a save-then-merge cycle")
     }
 }

--- a/ConduitTests/SessionPresentationCacheTests.swift
+++ b/ConduitTests/SessionPresentationCacheTests.swift
@@ -364,4 +364,87 @@ final class SessionPresentationCacheTests: XCTestCase {
 
         cache.clear(profile: profile)
     }
+
+    // MARK: - Merge: pending approval restoration
+
+    func testMergeRestoresPendingApprovalWhenRequested() {
+        let cache = SessionPresentationCache.shared
+        let sessionId = "test-merge-approval-\(UUID().uuidString)"
+        let profile = "test"
+
+        let approval = ApprovalActivity(
+            sessionId: sessionId,
+            command: "rm -rf /tmp",
+            description: "Delete temp files",
+            choices: ["once", "session", "always", "deny"],
+            allowPermanent: true,
+            smartDenied: false,
+            status: .pending
+        )
+        let savedMessages = [
+            ChatMessage(
+                id: "approval-\(sessionId)",
+                role: .approval,
+                content: "Delete temp files",
+                timestamp: "2024-01-01T10:00:00Z",
+                approval: approval
+            ),
+        ]
+        cache.save(savedMessages, profile: profile, sessionIDs: [sessionId])
+
+        // Gateway resume omits the approval card
+        let gatewayMessages: [ChatMessage] = []
+        let merged = cache.merge(
+            gatewayMessages,
+            profile: profile,
+            sessionIDs: [sessionId],
+            includePendingApprovals: true
+        )
+
+        let restoredApproval = merged.first { $0.role == .approval }
+        XCTAssertNotNil(restoredApproval, "Pending approval should be restored from cache")
+        XCTAssertEqual(restoredApproval?.approval?.sessionId, sessionId)
+        XCTAssertEqual(restoredApproval?.approval?.status, .pending)
+
+        cache.clear(profile: profile)
+    }
+
+    func testMergeDoesNotRestoreApprovalWhenNotRequested() {
+        let cache = SessionPresentationCache.shared
+        let sessionId = "test-merge-approval-off-\(UUID().uuidString)"
+        let profile = "test"
+
+        let approval = ApprovalActivity(
+            sessionId: sessionId,
+            command: "ls",
+            description: "List files",
+            choices: nil,
+            allowPermanent: false,
+            smartDenied: false,
+            status: .pending
+        )
+        let savedMessages = [
+            ChatMessage(
+                id: "approval-\(sessionId)",
+                role: .approval,
+                content: "List files",
+                timestamp: "2024-01-01",
+                approval: approval
+            ),
+        ]
+        cache.save(savedMessages, profile: profile, sessionIDs: [sessionId])
+
+        let gatewayMessages: [ChatMessage] = []
+        let merged = cache.merge(
+            gatewayMessages,
+            profile: profile,
+            sessionIDs: [sessionId],
+            includePendingApprovals: false
+        )
+
+        XCTAssertFalse(merged.contains { $0.role == .approval },
+                       "Approval should not be restored when includePendingApprovals is false")
+
+        cache.clear(profile: profile)
+    }
 }

--- a/ConduitTests/SessionPresentationCacheTests.swift
+++ b/ConduitTests/SessionPresentationCacheTests.swift
@@ -797,7 +797,7 @@ final class SessionPresentationCacheTests: XCTestCase {
             id: "gateway-user",
             role: .user,
             content: "Fresh transcript row",
-            timestamp: ""
+            timestamp: "2024-02-02"
         )
         appState.applyChatResume(SessionResumeResult(
             sessionId: sessionId,
@@ -818,9 +818,20 @@ final class SessionPresentationCacheTests: XCTestCase {
             appState.messages.contains { $0.approval?.sessionId == sessionId },
             "The active AppState should retain the restored card while the gateway is inconclusive"
         )
+        let compactGatewayMessage = ChatMessage(
+            id: gatewayMessage.id,
+            role: gatewayMessage.role,
+            content: gatewayMessage.content,
+            timestamp: ""
+        )
         XCTAssertEqual(
-            cache.merge([gatewayMessage], profile: profile, sessionIDs: [sessionId]).first?.content,
-            gatewayMessage.content
+            cache.merge(
+                [compactGatewayMessage],
+                profile: profile,
+                sessionIDs: [sessionId]
+            ).first?.timestamp,
+            gatewayMessage.timestamp,
+            "Fresh gateway transcript presentation must be persisted on resume"
         )
     }
 
@@ -868,7 +879,7 @@ final class SessionPresentationCacheTests: XCTestCase {
             ).contains { $0.clarify?.requestId == clarify.requestId }
         )
 
-        currentDate.addTimeInterval(24 * 60 * 60 + 1)
+        currentDate.addTimeInterval(SessionPresentationCache.maxUnconfirmedPendingDecisionAge + 1)
         XCTAssertFalse(
             cache.merge(
                 [],
@@ -877,6 +888,62 @@ final class SessionPresentationCacheTests: XCTestCase {
                 includePendingClarifications: true
             ).contains { $0.clarify?.requestId == clarify.requestId },
             "An unconfirmed card must not remain answerable forever without gateway confirmation"
+        )
+    }
+
+    func testApplyChatResumeExpiresWarmRestoredPendingDecision() {
+        let suiteName = "conduit.tests.session-presentation-warm-expiry-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        var currentDate = Date(timeIntervalSince1970: 2_000_000)
+        let cache = SessionPresentationCache(defaults: defaults, now: { currentDate })
+        let sessionId = "test-warm-presentation-expiry-\(UUID().uuidString)"
+        let appState = AppState(
+            defaults: defaults,
+            loadSavedConnection: false,
+            clearSessionPresentationCache: { cache.clear() },
+            sessionPresentationCache: cache
+        )
+        let profile = appState.activeProfile
+        let clarify = ClarifyActivity(
+            requestId: "req-warm-expiring",
+            question: "Which color?",
+            choices: [ClarifyChoice(label: "Red", value: "red")],
+            status: .pending
+        )
+        cache.save([
+            ChatMessage(
+                id: "clarify-warm-expiring",
+                role: .clarify,
+                content: clarify.question,
+                timestamp: "2024-01-01",
+                clarify: clarify
+            )
+        ], profile: profile, sessionIDs: [sessionId])
+        defer {
+            cache.clear()
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: sessionId,
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [:])
+        ))
+        XCTAssertTrue(appState.messages.contains { $0.clarify?.requestId == clarify.requestId })
+
+        currentDate.addTimeInterval(SessionPresentationCache.maxUnconfirmedPendingDecisionAge + 1)
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: sessionId,
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [:])
+        ))
+
+        XCTAssertFalse(
+            appState.messages.contains { $0.clarify?.requestId == clarify.requestId },
+            "Warm resumes must stop retaining an unconfirmed card after its grace period"
         )
     }
 
@@ -1076,6 +1143,15 @@ final class SessionPresentationCacheTests: XCTestCase {
         )
         XCTAssertEqual(appState.messages.first?.clarify?.status, ClarifyActivity.Status.answered)
         XCTAssertFalse(AppState.hasPendingDecision(in: appState.messages))
+        XCTAssertFalse(
+            cache.merge(
+                [],
+                profile: profile,
+                sessionIDs: [sessionId],
+                includePendingClarifications: true
+            ).contains { $0.clarify?.requestId == pendingClarify.requestId && $0.clarify?.status == .pending },
+            "A resolved gateway clarification must suppress the cached pending card"
+        )
     }
 
     func testApplyChatResumeMakesRestoredSubmittingApprovalRetryable() {
@@ -1222,6 +1298,10 @@ final class SessionPresentationCacheTests: XCTestCase {
         ))
 
         XCTAssertEqual(appState.turnState, TurnState.idle)
+        XCTAssertFalse(
+            AppState.hasPendingDecision(in: appState.messages),
+            "An explicitly settled resume must not leave an answerable gateway card in memory"
+        )
         XCTAssertFalse(
             cache.merge(
                 [],

--- a/ConduitTests/SessionPresentationCacheTests.swift
+++ b/ConduitTests/SessionPresentationCacheTests.swift
@@ -209,4 +209,122 @@ final class SessionPresentationCacheTests: XCTestCase {
 
         cache.clear(profile: profile)
     }
+
+    // MARK: - Merge: pending clarification restoration
+
+    func testMergeRestoresPendingClarificationWhenRequested() {
+        let cache = SessionPresentationCache.shared
+        let sessionId = "test-merge-clarify-\(UUID().uuidString)"
+        let profile = "test"
+
+        let clarify = ClarifyActivity(
+            requestId: "req-123",
+            question: "Which color?",
+            choices: [
+                ClarifyChoice(label: "Red", value: "red"),
+                ClarifyChoice(label: "Blue", value: "blue"),
+            ],
+            status: .pending
+        )
+        let savedMessages = [
+            ChatMessage(
+                id: "clarify-req-123",
+                role: .clarify,
+                content: "Which color?",
+                timestamp: "2024-01-01T10:00:00Z",
+                clarify: clarify
+            ),
+        ]
+        cache.save(savedMessages, profile: profile, sessionIDs: [sessionId])
+
+        // Gateway resume omits the clarify card (compact history)
+        let gatewayMessages: [ChatMessage] = []
+        let merged = cache.merge(
+            gatewayMessages,
+            profile: profile,
+            sessionIDs: [sessionId],
+            includePendingClarifications: true
+        )
+
+        let restoredClarify = merged.first { $0.role == .clarify }
+        XCTAssertNotNil(restoredClarify, "Pending clarification should be restored from cache")
+        XCTAssertEqual(restoredClarify?.clarify?.requestId, "req-123")
+        XCTAssertEqual(restoredClarify?.clarify?.status, .pending)
+        XCTAssertEqual(restoredClarify?.clarify?.choices.count, 2)
+
+        cache.clear(profile: profile)
+    }
+
+    func testMergeDoesNotRestoreClarificationWhenNotRequested() {
+        let cache = SessionPresentationCache.shared
+        let sessionId = "test-merge-clarify-off-\(UUID().uuidString)"
+        let profile = "test"
+
+        let clarify = ClarifyActivity(
+            requestId: "req-456",
+            question: "Pick one",
+            choices: [ClarifyChoice(label: "A", value: "a")],
+            status: .pending
+        )
+        let savedMessages = [
+            ChatMessage(
+                id: "clarify-req-456",
+                role: .clarify,
+                content: "Pick one",
+                timestamp: "2024-01-01",
+                clarify: clarify
+            ),
+        ]
+        cache.save(savedMessages, profile: profile, sessionIDs: [sessionId])
+
+        let gatewayMessages: [ChatMessage] = []
+        let merged = cache.merge(
+            gatewayMessages,
+            profile: profile,
+            sessionIDs: [sessionId],
+            includePendingClarifications: false
+        )
+
+        XCTAssertFalse(merged.contains { $0.role == .clarify },
+                       "Clarification should not be restored when includePendingClarifications is false")
+
+        cache.clear(profile: profile)
+    }
+
+    func testMergeDoesNotRestoreAnsweredClarification() {
+        let cache = SessionPresentationCache.shared
+        let sessionId = "test-merge-clarify-answered-\(UUID().uuidString)"
+        let profile = "test"
+
+        let clarify = ClarifyActivity(
+            requestId: "req-789",
+            question: "Done?",
+            choices: [ClarifyChoice(label: "Yes", value: "yes")],
+            status: .answered,
+            answer: "yes"
+        )
+        let savedMessages = [
+            ChatMessage(
+                id: "clarify-req-789",
+                role: .clarify,
+                content: "Done?",
+                timestamp: "2024-01-01",
+                clarify: clarify
+            ),
+        ]
+        cache.save(savedMessages, profile: profile, sessionIDs: [sessionId])
+
+        let gatewayMessages: [ChatMessage] = []
+        let merged = cache.merge(
+            gatewayMessages,
+            profile: profile,
+            sessionIDs: [sessionId],
+            includePendingClarifications: true
+        )
+
+        XCTAssertFalse(merged.contains { $0.role == .clarify },
+                       "Answered clarification should not be restored as pending")
+
+        cache.clear(profile: profile)
+    }
 }

--- a/ConduitTests/SessionPresentationCacheTests.swift
+++ b/ConduitTests/SessionPresentationCacheTests.swift
@@ -613,14 +613,14 @@ final class SessionPresentationCacheTests: XCTestCase {
         XCTAssertEqual(appState.messages.first?.clarify?.status, .pending)
         XCTAssertEqual(appState.turnState, TurnState.running,
                        "A restored pending clarification must keep the composer answerable")
-        XCTAssertFalse(
+        XCTAssertTrue(
             cache.merge(
                 [],
                 profile: profile,
                 sessionIDs: [sessionId],
                 includePendingClarifications: true
             ).contains { $0.clarify?.requestId == clarify.requestId },
-            "An unconfirmed clarification card must not be written back to the presentation cache"
+            "An unconfirmed clarification card should survive a cold launch during its grace period"
         )
         appState.applyChatResume(SessionResumeResult(
             sessionId: sessionId,
@@ -682,14 +682,14 @@ final class SessionPresentationCacheTests: XCTestCase {
         XCTAssertEqual(appState.messages.first?.approval?.status, .pending)
         XCTAssertEqual(appState.turnState, TurnState.running,
                        "A restored pending approval must keep the composer answerable")
-        XCTAssertFalse(
+        XCTAssertTrue(
             cache.merge(
                 [],
                 profile: profile,
                 sessionIDs: [sessionId],
                 includePendingApprovals: true
             ).contains { $0.approval?.sessionId == sessionId },
-            "An unconfirmed approval card must not be written back to the presentation cache"
+            "An unconfirmed approval card should survive a cold launch during its grace period"
         )
         appState.applyChatResume(SessionResumeResult(
             sessionId: sessionId,
@@ -812,8 +812,8 @@ final class SessionPresentationCacheTests: XCTestCase {
             includePendingClarifications: true,
             includePendingApprovals: true
         )
-        XCTAssertFalse(persisted.contains { $0.approval?.sessionId == sessionId },
-                       "An unconfirmed restored card must not be written back to the presentation cache")
+        XCTAssertTrue(persisted.contains { $0.approval?.sessionId == sessionId },
+                      "An unconfirmed restored card should survive a cold launch during its grace period")
         XCTAssertTrue(
             appState.messages.contains { $0.approval?.sessionId == sessionId },
             "The active AppState should retain the restored card while the gateway is inconclusive"
@@ -821,6 +821,62 @@ final class SessionPresentationCacheTests: XCTestCase {
         XCTAssertEqual(
             cache.merge([gatewayMessage], profile: profile, sessionIDs: [sessionId]).first?.content,
             gatewayMessage.content
+        )
+    }
+
+    func testUnconfirmedPendingDecisionExpiresFromPresentationCache() {
+        let suiteName = "conduit.tests.session-presentation-expiry-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        var currentDate = Date(timeIntervalSince1970: 1_000_000)
+        let cache = SessionPresentationCache(defaults: defaults, now: { currentDate })
+        let sessionId = "test-presentation-expiry-\(UUID().uuidString)"
+        let profile = "default"
+        let clarify = ClarifyActivity(
+            requestId: "req-expiring",
+            question: "Which color?",
+            choices: [ClarifyChoice(label: "Red", value: "red")],
+            status: .pending
+        )
+        let message = ChatMessage(
+            id: "clarify-expiring",
+            role: .clarify,
+            content: clarify.question,
+            timestamp: "2024-01-01",
+            clarify: clarify
+        )
+        defer {
+            cache.clear()
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        cache.save(
+            [message],
+            profile: profile,
+            sessionIDs: [sessionId],
+            preservePendingDecisionCards: true,
+            unconfirmedPendingDecisionKeys: ["clarify:\(clarify.requestId)"]
+        )
+        XCTAssertTrue(
+            cache.merge(
+                [],
+                profile: profile,
+                sessionIDs: [sessionId],
+                includePendingClarifications: true
+            ).contains { $0.clarify?.requestId == clarify.requestId }
+        )
+
+        currentDate.addTimeInterval(24 * 60 * 60 + 1)
+        XCTAssertFalse(
+            cache.merge(
+                [],
+                profile: profile,
+                sessionIDs: [sessionId],
+                includePendingClarifications: true
+            ).contains { $0.clarify?.requestId == clarify.requestId },
+            "An unconfirmed card must not remain answerable forever without gateway confirmation"
         )
     }
 

--- a/ConduitTests/SessionPresentationCacheTests.swift
+++ b/ConduitTests/SessionPresentationCacheTests.swift
@@ -6,6 +6,7 @@ import XCTest
 /// presentation metadata (timestamps, tool previews, attachments) survives
 /// a reconnect or session reopen. Getting this wrong means messages lose
 /// their timestamps or tool calls lose their input text.
+@MainActor
 final class SessionPresentationCacheTests: XCTestCase {
 
     // MARK: - Merge: timestamp restoration
@@ -325,7 +326,7 @@ final class SessionPresentationCacheTests: XCTestCase {
                        "Answered clarification should not be restored as pending")
     }
 
-    func testMergeDoesNotRestoreClarificationWhenRunningIsNil() {
+    func testMergeRestoresClarificationWhenRunningIsNil() {
         let cache = SessionPresentationCache.shared
         let sessionId = "test-merge-clarify-nil-\(UUID().uuidString)"
         let profile = "test"
@@ -348,9 +349,9 @@ final class SessionPresentationCacheTests: XCTestCase {
         cache.save(savedMessages, profile: profile, sessionIDs: [sessionId])
         defer { cache.clear(profile: profile) }
 
-        // running == nil (omitted by gateway) should NOT restore because the
-        // turn may have completed while backgrounded — restoring would risk
-        // displaying a stale, answerable card for an already-resolved request.
+        // Hermes versions that omit `running` can still be paused on this
+        // clarification request. Nil must remain eligible for restoration;
+        // explicit false is the only resolved/idle signal.
         let shouldRestore = AppState.shouldRestorePendingCards(running: nil)
         let gatewayMessages: [ChatMessage] = []
         let merged = cache.merge(
@@ -360,8 +361,8 @@ final class SessionPresentationCacheTests: XCTestCase {
             includePendingClarifications: shouldRestore
         )
 
-        XCTAssertFalse(merged.contains { $0.role == .clarify },
-                       "Clarification should not be restored when running state is omitted (nil)")
+        XCTAssertTrue(merged.contains { $0.role == .clarify },
+                      "Clarification should be restored when running state is omitted (nil)")
     }
 
     // MARK: - Merge: pending approval restoration
@@ -457,13 +458,11 @@ final class SessionPresentationCacheTests: XCTestCase {
                        "Must not restore pending cards when gateway reports turn is inactive")
     }
 
-    func testShouldNotRestorePendingCardsWhenRunningIsNil() {
-        // The gateway may omit `running` (nil) even while a turn is active,
-        // but the turn may also have completed while the app was backgrounded.
-        // Restoring cached cards in the nil case risks displaying stale,
-        // answerable UI for an already-resolved request.
-        XCTAssertFalse(AppState.shouldRestorePendingCards(running: nil),
-                       "Must not restore pending cards when gateway omits running state")
+    func testShouldRestorePendingCardsWhenRunningIsNil() {
+        // Hermes can omit `running` while a turn is paused on a user decision.
+        // Only an explicit false is proof that the turn is no longer active.
+        XCTAssertTrue(AppState.shouldRestorePendingCards(running: nil),
+                      "Must restore pending cards when gateway omits running state")
     }
 
     // MARK: - Save preserves restored pending cards
@@ -565,5 +564,148 @@ final class SessionPresentationCacheTests: XCTestCase {
         )
         XCTAssertTrue(remerged.contains { $0.role == .approval },
                       "Restored approval card must survive a save-then-merge cycle")
+    }
+
+    // MARK: - AppState resume integration
+
+    func testApplyResumeRestoresPendingClarificationWhenRunningIsNil() {
+        let cache = SessionPresentationCache.shared
+        let sessionId = "test-apply-resume-clarify-\(UUID().uuidString)"
+        let appState = AppState(restoreSavedConnection: false)
+        let profile = appState.activeProfile
+        let clarify = ClarifyActivity(
+            requestId: "req-apply-resume",
+            question: "Which color?",
+            choices: [ClarifyChoice(label: "Red", value: "red")],
+            status: .pending
+        )
+        cache.save([
+            ChatMessage(
+                id: "clarify-req-apply-resume",
+                role: .clarify,
+                content: clarify.question,
+                timestamp: "2024-01-01",
+                clarify: clarify
+            )
+        ], profile: profile, sessionIDs: [sessionId])
+        defer { cache.clear(profile: profile) }
+
+        appState.applyResume(SessionResumeResult(
+            sessionId: sessionId,
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [:])
+        ))
+
+        XCTAssertEqual(appState.messages.first?.clarify?.requestId, clarify.requestId)
+        XCTAssertEqual(appState.messages.first?.clarify?.status, .pending)
+        XCTAssertEqual(appState.turnState, .running,
+                       "A restored pending clarification must keep the composer answerable")
+        XCTAssertFalse(
+            cache.merge(
+                [],
+                profile: profile,
+                sessionIDs: [sessionId],
+                includePendingClarifications: true
+            ).contains { $0.clarify?.requestId == clarify.requestId },
+            "The nil resume must not re-persist an unconfirmed clarification card"
+        )
+    }
+
+    func testApplyResumeRestoresPendingApprovalWhenRunningIsNil() {
+        let cache = SessionPresentationCache.shared
+        let sessionId = "test-apply-resume-approval-\(UUID().uuidString)"
+        let appState = AppState(restoreSavedConnection: false)
+        let profile = appState.activeProfile
+        let approval = ApprovalActivity(
+            sessionId: sessionId,
+            command: "ls",
+            description: "List files",
+            choices: ["once", "deny"],
+            allowPermanent: false,
+            smartDenied: false,
+            status: .pending
+        )
+        cache.save([
+            ChatMessage(
+                id: "approval-\(sessionId)",
+                role: .approval,
+                content: approval.description,
+                timestamp: "2024-01-01",
+                approval: approval
+            )
+        ], profile: profile, sessionIDs: [sessionId])
+        defer { cache.clear(profile: profile) }
+
+        appState.applyResume(SessionResumeResult(
+            sessionId: sessionId,
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [:])
+        ))
+
+        XCTAssertEqual(appState.messages.first?.approval?.sessionId, sessionId)
+        XCTAssertEqual(appState.messages.first?.approval?.status, .pending)
+        XCTAssertEqual(appState.turnState, .running,
+                       "A restored pending approval must keep the composer answerable")
+        XCTAssertFalse(
+            cache.merge(
+                [],
+                profile: profile,
+                sessionIDs: [sessionId],
+                includePendingApprovals: true
+            ).contains { $0.approval?.sessionId == sessionId },
+            "The nil resume must not re-persist an unconfirmed approval card"
+        )
+    }
+
+    func testApplyResumePersistsGatewayMessagesWithoutRecachingRestoredCardsWhenRunningIsNil() {
+        let cache = SessionPresentationCache.shared
+        let sessionId = "test-apply-resume-cache-\(UUID().uuidString)"
+        let appState = AppState(restoreSavedConnection: false)
+        let profile = appState.activeProfile
+        let approval = ApprovalActivity(
+            sessionId: sessionId,
+            command: "ls",
+            description: "List files",
+            choices: ["once", "deny"],
+            allowPermanent: false,
+            smartDenied: false,
+            status: .pending
+        )
+        cache.save([
+            ChatMessage(
+                id: "approval-\(sessionId)",
+                role: .approval,
+                content: approval.description,
+                timestamp: "2024-01-01",
+                approval: approval
+            )
+        ], profile: profile, sessionIDs: [sessionId])
+        defer { cache.clear(profile: profile) }
+
+        let gatewayMessage = ChatMessage(
+            id: "gateway-user",
+            role: .user,
+            content: "Fresh transcript row",
+            timestamp: ""
+        )
+        appState.applyResume(SessionResumeResult(
+            sessionId: sessionId,
+            messages: [gatewayMessage],
+            snapshot: SessionRuntimeSnapshot(object: [:])
+        ))
+
+        let persisted = cache.merge(
+            [],
+            profile: profile,
+            sessionIDs: [sessionId],
+            includePendingClarifications: true,
+            includePendingApprovals: true
+        )
+        XCTAssertFalse(persisted.contains { $0.approval?.sessionId == sessionId },
+                       "A nil running snapshot must not re-persist a restored pending card")
+        XCTAssertEqual(
+            cache.merge([gatewayMessage], profile: profile, sessionIDs: [sessionId]).first?.content,
+            gatewayMessage.content
+        )
     }
 }

--- a/ConduitTests/SessionPresentationCacheTests.swift
+++ b/ConduitTests/SessionPresentationCacheTests.swift
@@ -569,9 +569,19 @@ final class SessionPresentationCacheTests: XCTestCase {
     // MARK: - AppState resume integration
 
     func testApplyChatResumeRestoresPendingClarificationWhenRunningIsNil() {
-        let cache = SessionPresentationCache.shared
+        let suiteName = "conduit.tests.session-presentation-clarify-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: defaults)
         let sessionId = "test-apply-resume-clarify-\(UUID().uuidString)"
-        let appState = AppState(loadSavedConnection: false)
+        let appState = AppState(
+            defaults: defaults,
+            loadSavedConnection: false,
+            clearSessionPresentationCache: { cache.clear() },
+            sessionPresentationCache: cache
+        )
         let profile = appState.activeProfile
         let clarify = ClarifyActivity(
             requestId: "req-apply-resume",
@@ -588,7 +598,10 @@ final class SessionPresentationCacheTests: XCTestCase {
                 clarify: clarify
             )
         ], profile: profile, sessionIDs: [sessionId])
-        defer { cache.clear(profile: profile) }
+        defer {
+            cache.clear()
+            defaults.removePersistentDomain(forName: suiteName)
+        }
 
         appState.applyChatResume(SessionResumeResult(
             sessionId: sessionId,
@@ -612,9 +625,19 @@ final class SessionPresentationCacheTests: XCTestCase {
     }
 
     func testApplyChatResumeRestoresPendingApprovalWhenRunningIsNil() {
-        let cache = SessionPresentationCache.shared
+        let suiteName = "conduit.tests.session-presentation-approval-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: defaults)
         let sessionId = "test-apply-resume-approval-\(UUID().uuidString)"
-        let appState = AppState(loadSavedConnection: false)
+        let appState = AppState(
+            defaults: defaults,
+            loadSavedConnection: false,
+            clearSessionPresentationCache: { cache.clear() },
+            sessionPresentationCache: cache
+        )
         let profile = appState.activeProfile
         let approval = ApprovalActivity(
             sessionId: sessionId,
@@ -634,7 +657,10 @@ final class SessionPresentationCacheTests: XCTestCase {
                 approval: approval
             )
         ], profile: profile, sessionIDs: [sessionId])
-        defer { cache.clear(profile: profile) }
+        defer {
+            cache.clear()
+            defaults.removePersistentDomain(forName: suiteName)
+        }
 
         appState.applyChatResume(SessionResumeResult(
             sessionId: sessionId,
@@ -657,10 +683,72 @@ final class SessionPresentationCacheTests: XCTestCase {
         )
     }
 
+    func testApplyChatResumePreservesGatewayPendingDecisionWhenRunningIsNil() {
+        let suiteName = "conduit.tests.session-presentation-gateway-pending-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: defaults)
+        let sessionId = "test-apply-resume-gateway-pending-\(UUID().uuidString)"
+        let appState = AppState(
+            defaults: defaults,
+            loadSavedConnection: false,
+            clearSessionPresentationCache: { cache.clear() },
+            sessionPresentationCache: cache
+        )
+        let profile = appState.activeProfile
+        let clarify = ClarifyActivity(
+            requestId: "req-gateway-pending",
+            question: "Which color?",
+            choices: [ClarifyChoice(label: "Red", value: "red")],
+            status: .pending
+        )
+        let gatewayMessage = ChatMessage(
+            id: "clarify-gateway-pending",
+            role: .clarify,
+            content: clarify.question,
+            timestamp: "2024-01-01",
+            clarify: clarify
+        )
+        defer {
+            cache.clear()
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: sessionId,
+            messages: [gatewayMessage],
+            snapshot: SessionRuntimeSnapshot(object: [:])
+        ))
+
+        let persisted = cache.merge(
+            [],
+            profile: profile,
+            sessionIDs: [sessionId],
+            includePendingClarifications: true
+        )
+        XCTAssertTrue(
+            persisted.contains { $0.clarify?.requestId == clarify.requestId },
+            "A pending decision sent by the gateway is authoritative and must remain cached"
+        )
+        XCTAssertEqual(appState.turnState, TurnState.running)
+    }
+
     func testApplyChatResumePersistsGatewayMessagesWithoutRecachingRestoredCardsWhenRunningIsNil() {
-        let cache = SessionPresentationCache.shared
+        let suiteName = "conduit.tests.session-presentation-cache-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: defaults)
         let sessionId = "test-apply-resume-cache-\(UUID().uuidString)"
-        let appState = AppState(loadSavedConnection: false)
+        let appState = AppState(
+            defaults: defaults,
+            loadSavedConnection: false,
+            clearSessionPresentationCache: { cache.clear() },
+            sessionPresentationCache: cache
+        )
         let profile = appState.activeProfile
         let approval = ApprovalActivity(
             sessionId: sessionId,
@@ -680,7 +768,10 @@ final class SessionPresentationCacheTests: XCTestCase {
                 approval: approval
             )
         ], profile: profile, sessionIDs: [sessionId])
-        defer { cache.clear(profile: profile) }
+        defer {
+            cache.clear()
+            defaults.removePersistentDomain(forName: suiteName)
+        }
 
         let gatewayMessage = ChatMessage(
             id: "gateway-user",


### PR DESCRIPTION
When the app resumes from background, session.resume may return running: nil even while a turn is active. The previous code conditioned includePendingClarifications on running == true, which silently dropped user-visible clarify and approval cards from the presentation cache.

Always restore pending clarifications and approvals from the cache during resume. The presentation cache only holds user-facing state (timestamps, tool previews, attachments, clarify/approval cards) and does not conflict with server-side message content.

The foreground recovery path already has a socket health check (healthCheck() with 8s timeout) that calls reconnect() on failure, so dead sockets are handled.

Regression tests added:
- Pending clarifications are restored when requested
- Clarifications are not restored when not requested
- Answered clarifications are not restored as pending

Closes #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Pending clarification and approval cards are now reliably restored when resuming a session, including when running status is unavailable.
  - Restored cards remain available until the turn becomes active or the user interacts with them.
  - Answered, expired, or disabled clarifications are no longer restored.
  - Pending decision cards are no longer incorrectly persisted after session restoration.
  - Gateway-provided decisions now correctly replace restored cards.

- **Tests**
  - Added coverage for restoration, cache merging, persistence, expiration, and resume behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->