### PR TITLE
Clear dashboard web session cookies on Disconnect (#20 finding #3)

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -11,6 +11,7 @@ import SwiftUI
 import Combine
 import OSLog
 import UIKit
+import WebKit
 
 private let sessionCatalogLog = Logger(subsystem: "com.milim.conduit", category: "SessionCatalog")
 private let titleGenerationLog = Logger(subsystem: "com.milim.conduit", category: "TitleGeneration")
@@ -1642,6 +1643,13 @@ final class AppState: ObservableObject {
         KeychainHelper.clearConnection()
         KeychainHelper.clearCredentials()
         KeychainHelper.clearCloudflareAccess()
+        // The Keychain mirror of the dashboard cookies is cleared above, but
+        // the live session cookies live on in WebKit's persistent default data
+        // store and the shared Foundation cookie store. Without removing them,
+        // Disconnect is not equivalent to logging out: a still-valid server
+        // session could be silently resumed on the next authentication flow.
+        // Capture the origin before nulling `connection` and purge both stores.
+        let dashboardBaseURL = connection?.baseUrl
         connection = nil
         client = nil
         dashboardTicketBridge = nil
@@ -1664,6 +1672,24 @@ final class AppState: ObservableObject {
         activeSessionTitlesByProfile = [:]
         pinnedSessionIDsByProfile = [:]
         defaults.removeObject(forKey: activeProfileKey)
+        clearDashboardWebSession(for: dashboardBaseURL)
+    }
+
+    /// Removes the dashboard origin's cookies from the WebKit default data
+    /// store and the shared Foundation cookie store. The WebKit store can only
+    /// be mutated asynchronously, so this is dispatched as a background task;
+    /// the synchronous tear-down in `disconnect()` completes immediately.
+    private func clearDashboardWebSession(for dashboardBaseURL: String?) {
+        guard let dashboardBaseURL else { return }
+        Task { @MainActor in
+            if let url = URL(string: dashboardBaseURL) {
+                await DashboardCookiePersistence.clear(
+                    from: WKWebsiteDataStore.default().httpCookieStore,
+                    for: url
+                )
+            }
+            DashboardCookiePersistence.clearNativeCookies(for: dashboardBaseURL)
+        }
     }
 
     private func makeClient(connection: HermesConnection, profile: String) -> HermesClient {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -1676,11 +1676,13 @@ final class AppState: ObservableObject {
     }
 
     /// Removes the dashboard origin's cookies from the WebKit default data
-    /// store and the shared Foundation cookie store. The WebKit store can only
-    /// be mutated asynchronously, so this is dispatched as a background task;
-    /// the synchronous tear-down in `disconnect()` completes immediately.
+    /// store and the shared Foundation cookie store. The Foundation store is
+    /// cleared synchronously first so no rapid reconnect can reuse the native
+    /// session cookie; the WebKit store can only be mutated asynchronously, so
+    /// it is dispatched as a background task.
     private func clearDashboardWebSession(for dashboardBaseURL: String?) {
         guard let dashboardBaseURL else { return }
+        DashboardCookiePersistence.clearNativeCookies(for: dashboardBaseURL)
         Task { @MainActor in
             if let url = URL(string: dashboardBaseURL) {
                 await DashboardCookiePersistence.clear(
@@ -1688,7 +1690,6 @@ final class AppState: ObservableObject {
                     for: url
                 )
             }
-            DashboardCookiePersistence.clearNativeCookies(for: dashboardBaseURL)
         }
     }
 

--- a/Conduit/Services/DashboardTicketBridge.swift
+++ b/Conduit/Services/DashboardTicketBridge.swift
@@ -81,6 +81,28 @@ enum DashboardCookiePersistence {
         KeychainHelper.saveDashboardCookies(data)
     }
 
+    /// Removes dashboard-origin cookies from a WebKit cookie store. Disconnect
+    /// must not leave a reusable HttpOnly session behind in the persistent
+    /// default data store; clearing only the origin-matching cookies keeps any
+    /// unrelated cookies intact.
+    static func clear(from cookieStore: WKHTTPCookieStore, for url: URL?) async {
+        guard let host = url?.host?.lowercased() else { return }
+        for cookie in await cookieStore.allCookies() where cookieMatchesHost(cookie, host: host) {
+            await cookieStore.deleteCookie(cookie)
+        }
+    }
+
+    /// Removes dashboard-origin cookies from the shared Foundation cookie
+    /// store. The native password-login flow authenticates through
+    /// `HTTPCookieStorage.shared`; without this, its session cookie outlives
+    /// Disconnect and can satisfy a later silent resume.
+    static func clearNativeCookies(for baseURL: String) {
+        guard let host = URL(string: baseURL)?.host?.lowercased() else { return }
+        for cookie in HTTPCookieStorage.shared.cookies ?? [] where cookieMatchesHost(cookie, host: host) {
+            HTTPCookieStorage.shared.deleteCookie(cookie)
+        }
+    }
+
     private static func cookieMatchesHost(_ cookie: HTTPCookie, host: String) -> Bool {
         let domain = cookie.domain.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: "."))
         return host == domain || host.hasSuffix(".\(domain)")

--- a/Conduit/Services/DashboardTicketBridge.swift
+++ b/Conduit/Services/DashboardTicketBridge.swift
@@ -95,15 +95,17 @@ enum DashboardCookiePersistence {
     /// Removes dashboard-origin cookies from the shared Foundation cookie
     /// store. The native password-login flow authenticates through
     /// `HTTPCookieStorage.shared`; without this, its session cookie outlives
-    /// Disconnect and can satisfy a later silent resume.
-    static func clearNativeCookies(for baseURL: String) {
+    /// Disconnect and can satisfy a later silent resume. `HTTPCookieStorage`
+    /// is thread-safe, so this is `nonisolated` to stay callable from any
+    /// context (including tests) without requiring main-actor isolation.
+    nonisolated static func clearNativeCookies(for baseURL: String) {
         guard let host = URL(string: baseURL)?.host?.lowercased() else { return }
         for cookie in HTTPCookieStorage.shared.cookies ?? [] where cookieMatchesHost(cookie, host: host) {
             HTTPCookieStorage.shared.deleteCookie(cookie)
         }
     }
 
-    private static func cookieMatchesHost(_ cookie: HTTPCookie, host: String) -> Bool {
+    nonisolated private static func cookieMatchesHost(_ cookie: HTTPCookie, host: String) -> Bool {
         let domain = cookie.domain.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: "."))
         return host == domain || host.hasSuffix(".\(domain)")
     }

--- a/ConduitTests/DashboardCookieClearingTests.swift
+++ b/ConduitTests/DashboardCookieClearingTests.swift
@@ -23,8 +23,8 @@ final class DashboardCookieClearingTests: XCTestCase {
         let dashboardHost = "conduit-clear-dashboard.example"
         let otherHost = "conduit-clear-other.example"
 
-        let dashboardCookie = cookie(name: "session", value: "dash", domain: dashboardHost)!
-        let otherCookie = cookie(name: "session", value: "other", domain: otherHost)!
+        let dashboardCookie = try XCTUnwrap(cookie(name: "session", value: "dash", domain: dashboardHost))
+        let otherCookie = try XCTUnwrap(cookie(name: "session", value: "other", domain: otherHost))
         storage.setCookie(dashboardCookie)
         storage.setCookie(otherCookie)
         defer {
@@ -36,11 +36,11 @@ final class DashboardCookieClearingTests: XCTestCase {
 
         let remaining = storage.cookies ?? []
         XCTAssertFalse(
-            remaining.contains { $0.domain?.lowercased().contains(dashboardHost) ?? false },
+            remaining.contains { $0.domain.lowercased().contains(dashboardHost) },
             "Dashboard-origin cookie should have been removed by clearNativeCookies."
         )
         XCTAssertTrue(
-            remaining.contains { $0.domain?.lowercased().contains(otherHost) ?? false },
+            remaining.contains { $0.domain.lowercased().contains(otherHost) },
             "Unrelated origin's cookie must survive an origin-scoped clear."
         )
     }
@@ -54,8 +54,8 @@ final class DashboardCookieClearingTests: XCTestCase {
         let dashboardHost = "conduit-subdomain.example"
         let siblingHost = "evil-\(dashboardHost)" // shares suffix, not a subdomain
 
-        let dashboardCookie = cookie(name: "session", value: "dash", domain: dashboardHost)!
-        let siblingCookie = cookie(name: "session", value: "sibling", domain: siblingHost)!
+        let dashboardCookie = try XCTUnwrap(cookie(name: "session", value: "dash", domain: dashboardHost))
+        let siblingCookie = try XCTUnwrap(cookie(name: "session", value: "sibling", domain: siblingHost))
         storage.setCookie(dashboardCookie)
         storage.setCookie(siblingCookie)
         defer {
@@ -67,7 +67,7 @@ final class DashboardCookieClearingTests: XCTestCase {
 
         let remaining = storage.cookies ?? []
         XCTAssertTrue(
-            remaining.contains { $0.domain?.lowercased() == siblingHost },
+            remaining.contains { $0.domain.lowercased() == siblingHost },
             "A sibling host that shares only a textual suffix must survive clearing."
         )
     }
@@ -75,14 +75,14 @@ final class DashboardCookieClearingTests: XCTestCase {
     func testClearNativeCookiesNoopsForUnknownOrigin() throws {
         let storage = HTTPCookieStorage.shared
         let host = "conduit-noop.example"
-        let retained = cookie(name: "session", value: "keep", domain: host)!
+        let retained = try XCTUnwrap(cookie(name: "session", value: "keep", domain: host))
         storage.setCookie(retained)
         defer { storage.deleteCookie(retained) }
 
         DashboardCookiePersistence.clearNativeCookies(for: "https://unrelated-host.example")
 
         XCTAssertTrue(
-            (storage.cookies ?? []).contains { $0.domain?.lowercased() == host },
+            (storage.cookies ?? []).contains { $0.domain.lowercased() == host },
             "Clearing an unrelated origin must leave all other cookies intact."
         )
     }

--- a/ConduitTests/DashboardCookieClearingTests.swift
+++ b/ConduitTests/DashboardCookieClearingTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import XCTest
+@testable import Conduit
+
+/// Tests the cookie-clearing path wired into `AppState.disconnect()` for
+/// issue #20, finding #3: Disconnect must not leave a reusable dashboard
+/// session in the shared Foundation cookie store.
+///
+/// The origin-scoping logic (`cookieMatchesHost`) is the security-relevant
+/// part and is exercised here through the public `clearNativeCookies(for:)`
+/// surface. The WebKit `WKHTTPCookieStore` path mirrors the same matcher but
+/// requires a live WebKit process to test, so it is covered by the shared
+/// matcher coverage below rather than duplicated.
+final class DashboardCookieClearingTests: XCTestCase {
+
+    // MARK: - clearNativeCookies
+
+    /// Seeds cookies for two distinct hosts, clears only the dashboard origin,
+    /// and asserts the other origin's cookies survive. A blanket wipe would
+    /// fail this test.
+    func testClearNativeCookiesRemovesOnlyOriginMatching() throws {
+        let storage = HTTPCookieStorage.shared
+        let dashboardHost = "conduit-clear-dashboard.example"
+        let otherHost = "conduit-clear-other.example"
+
+        let dashboardCookie = cookie(name: "session", value: "dash", domain: dashboardHost)!
+        let otherCookie = cookie(name: "session", value: "other", domain: otherHost)!
+        storage.setCookie(dashboardCookie)
+        storage.setCookie(otherCookie)
+        defer {
+            storage.deleteCookie(dashboardCookie)
+            storage.deleteCookie(otherCookie)
+        }
+
+        DashboardCookiePersistence.clearNativeCookies(for: "https://\(dashboardHost)")
+
+        let remaining = storage.cookies ?? []
+        XCTAssertFalse(
+            remaining.contains { $0.domain?.lowercased().contains(dashboardHost) ?? false },
+            "Dashboard-origin cookie should have been removed by clearNativeCookies."
+        )
+        XCTAssertTrue(
+            remaining.contains { $0.domain?.lowercased().contains(otherHost) ?? false },
+            "Unrelated origin's cookie must survive an origin-scoped clear."
+        )
+    }
+
+    func testClearNativeCookiesDoesNotMatchSiblingSuffixHosts() throws {
+        // The matcher guards against bare-suffix confusion: a cookie whose
+        // domain merely contains the dashboard host as a textual substring
+        // (without the dot boundary that denotes a real subdomain) must not
+        // be cleared when the dashboard origin is disconnected.
+        let storage = HTTPCookieStorage.shared
+        let dashboardHost = "conduit-subdomain.example"
+        let siblingHost = "evil-\(dashboardHost)" // shares suffix, not a subdomain
+
+        let dashboardCookie = cookie(name: "session", value: "dash", domain: dashboardHost)!
+        let siblingCookie = cookie(name: "session", value: "sibling", domain: siblingHost)!
+        storage.setCookie(dashboardCookie)
+        storage.setCookie(siblingCookie)
+        defer {
+            storage.deleteCookie(dashboardCookie)
+            storage.deleteCookie(siblingCookie)
+        }
+
+        DashboardCookiePersistence.clearNativeCookies(for: "https://\(dashboardHost)")
+
+        let remaining = storage.cookies ?? []
+        XCTAssertTrue(
+            remaining.contains { $0.domain?.lowercased() == siblingHost },
+            "A sibling host that shares only a textual suffix must survive clearing."
+        )
+    }
+
+    func testClearNativeCookiesNoopsForUnknownOrigin() throws {
+        let storage = HTTPCookieStorage.shared
+        let host = "conduit-noop.example"
+        let retained = cookie(name: "session", value: "keep", domain: host)!
+        storage.setCookie(retained)
+        defer { storage.deleteCookie(retained) }
+
+        DashboardCookiePersistence.clearNativeCookies(for: "https://unrelated-host.example")
+
+        XCTAssertTrue(
+            (storage.cookies ?? []).contains { $0.domain?.lowercased() == host },
+            "Clearing an unrelated origin must leave all other cookies intact."
+        )
+    }
+
+    func testClearNativeCookiesNoopsForInvalidURL() {
+        // Must not trap when given an unparseable base URL.
+        DashboardCookiePersistence.clearNativeCookies(for: "not a url")
+        DashboardCookiePersistence.clearNativeCookies(for: "")
+    }
+
+    // MARK: - Helpers
+
+    private func cookie(name: String, value: String, domain: String) -> HTTPCookie? {
+        HTTPCookie(properties: [
+            .name: name,
+            .value: value,
+            .domain: domain,
+            .path: "/",
+            .secure: "TRUE"
+        ])
+    }
+}


### PR DESCRIPTION
## Summary

Addresses finding #3 of #20: **Disconnect clears application credentials but can leave the web session active** (Medium).

`AppState.disconnect()` cleared Conduit's own Keychain/UserDefaults state but left live dashboard session cookies in:
- `WKWebsiteDataStore.default().httpCookieStore` (persistent — used by `DashboardTicketBridge`'s WebView and the `LoginView` auth WebView)
- `HTTPCookieStorage.shared` (used by `NativeAuthClient`'s URLSession)

Because the WebKit default data store is persistent, **Disconnect was not equivalent to logging out** — a still-valid server session could be silently resumed on the next authentication flow.

## Changes

- **`DashboardTicketBridge.swift`** — two new origin-scoped helpers on `DashboardCookiePersistence`, reusing the existing private `cookieMatchesHost` matcher so unrelated cookies survive:
  - `clear(from:for:)` — removes origin-matching cookies from a `WKHTTPCookieStore`.
  - `clearNativeCookies(for:)` — removes them from `HTTPCookieStorage.shared`.
- **`AppState.swift`** — `disconnect()` now captures the dashboard origin and purges both stores via a new `clearDashboardWebSession(for:)`. The async WebKit clear runs in a detached `Task` because `disconnect()` is synchronous (called from a sync SwiftUI closure). The Keychain-backed cookie mirror was already cleared by `KeychainHelper.clearConnection()`.
- **`DashboardCookieClearingTests.swift`** — covers the origin-scoping logic (Foundation path + host matcher). The WebKit `WKHTTPCookieStore` path mirrors the same matcher but needs a live WebKit process, so it is covered indirectly rather than duplicated.

## Scope

- **Dashboard origin only** — clears cookies whose domain matches the connected dashboard origin, not a blanket wipe.
- **Local cookie clearing only** — no server logout endpoint is called. The Hermes dashboard does not expose one in this repo's scope; that layer is deferred.
- `requireSignIn()` (a separate server-rejected-session path) is intentionally left as-is: the server has already invalidated the session there, and the user may want the cookies for re-login.

## Out of scope

Findings #1, #2, #5, #6 of #20 (Cloudflare token origin guard, remote Markdown networking, presentation-cache lifetime, push-relay credential binding) are separate concerns.

## Verification

⚠️ **I could not run the iOS build or test suite from this Windows environment.** Verification is CI — the existing **Build & Test** GitHub Actions workflow. I will only consider this merged once CI is green.

`refs #20`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-out cleanup by clearing dashboard cookies from web and native storage.
  * Preserves cookies belonging to unrelated websites and sibling domains.
  * Safely handles invalid or unavailable dashboard URLs.

* **Tests**
  * Added coverage for dashboard-specific cookie removal, unrelated origins, sibling domains, and invalid URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->