### PR TITLE
Handle Cloudflare auth redirects during provider discovery

### DIFF
--- a/Conduit/Services/NativeAuthClient.swift
+++ b/Conduit/Services/NativeAuthClient.swift
@@ -65,8 +65,11 @@ struct NativeAuthClient {
         guard let http = response as? HTTPURLResponse else {
             throw AuthClientError.providerDiscoveryFailed("No response")
         }
-        if (300...399).contains(http.statusCode) {
+        switch http.statusCode {
+        case 301, 302, 303, 307, 308:
             return []
+        default:
+            break
         }
         guard (200...299).contains(http.statusCode) else {
             throw AuthClientError.providerDiscoveryFailed(parseError(data) ?? "HTTP \(http.statusCode)")

--- a/Conduit/Services/NativeAuthClient.swift
+++ b/Conduit/Services/NativeAuthClient.swift
@@ -44,15 +44,19 @@ struct NativeAuthClient {
     let cloudflareAccess: CloudflareAccessCredentials?
     private let session: URLSession
 
-    init(baseURL: String, cloudflareAccess: CloudflareAccessCredentials? = nil) {
+    init(
+        baseURL: String,
+        cloudflareAccess: CloudflareAccessCredentials? = nil,
+        sessionConfiguration: URLSessionConfiguration? = nil
+    ) {
         self.baseURL = (try? ConnectionURLPolicy.normalizedBaseURL(baseURL))
             ?? baseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         self.cloudflareAccess = cloudflareAccess
-        let configuration = URLSessionConfiguration.default
+        let configuration = sessionConfiguration ?? URLSessionConfiguration.default
         configuration.httpCookieAcceptPolicy = .always
         configuration.httpCookieStorage = HTTPCookieStorage.shared
         configuration.httpShouldSetCookies = true
-        session = URLSession(configuration: configuration, delegate: SecureRedirectDelegate(), delegateQueue: nil)
+        self.session = URLSession(configuration: configuration, delegate: SecureRedirectDelegate(), delegateQueue: nil)
     }
 
     func authProviders() async throws -> [[String: Any]] {
@@ -60,6 +64,9 @@ struct NativeAuthClient {
         let (data, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse else {
             throw AuthClientError.providerDiscoveryFailed("No response")
+        }
+        if (300...399).contains(http.statusCode) {
+            return []
         }
         guard (200...299).contains(http.statusCode) else {
             throw AuthClientError.providerDiscoveryFailed(parseError(data) ?? "HTTP \(http.statusCode)")

--- a/ConduitTests/NativeAuthClientTests.swift
+++ b/ConduitTests/NativeAuthClientTests.swift
@@ -12,6 +12,30 @@ final class NativeAuthClientTests: XCTestCase {
         let providers = try await client.authProviders()
 
         XCTAssertTrue(providers.isEmpty)
+        XCTAssertEqual(NativeAuthURLProtocol.responseStatusCode(for: "redirect.example"), 302)
+        XCTAssertEqual(
+            NativeAuthURLProtocol.responseHeader(for: "redirect.example", name: "Location"),
+            "https://tenant.cloudflareaccess.com/cdn-cgi/access/login"
+        )
+        XCTAssertEqual(NativeAuthURLProtocol.requestCount(for: "redirect.example"), 1)
+        XCTAssertEqual(NativeAuthURLProtocol.requestCount(for: "tenant.cloudflareaccess.com"), 0)
+    }
+
+    func testProviderDiscoveryPreservesNonRedirect3xxResponses() async throws {
+        let client = NativeAuthClient(
+            baseURL: "https://multiple.example",
+            sessionConfiguration: makeSessionConfiguration()
+        )
+
+        do {
+            _ = try await client.authProviders()
+            XCTFail("Expected provider discovery to fail for a non-redirect 3xx response")
+        } catch let error as AuthClientError {
+            guard case .providerDiscoveryFailed(let detail) = error else {
+                return XCTFail("Expected provider discovery failure, got \(error)")
+            }
+            XCTAssertEqual(detail, "HTTP 300")
+        }
     }
 
     func testProviderDiscoveryParsesPasswordProvider() async throws {
@@ -69,8 +93,25 @@ final class NativeAuthClientTests: XCTestCase {
 }
 
 private final class NativeAuthURLProtocol: URLProtocol {
+    private struct ResponseRecord {
+        let host: String
+        let statusCode: Int?
+        let headers: [String: String]
+    }
+
+    private static let recordLock = NSLock()
+    private static var responseRecords: [ResponseRecord] = []
+
     override class func canInit(with request: URLRequest) -> Bool {
-        request.url?.host?.hasSuffix(".example") == true
+        guard let host = request.url?.host else { return false }
+        return [
+            "redirect.example",
+            "providers.example",
+            "server-error.example",
+            "headers.example",
+            "multiple.example",
+            "tenant.cloudflareaccess.com"
+        ].contains(host)
     }
 
     override class func canonicalRequest(for request: URLRequest) -> URLRequest {
@@ -78,8 +119,17 @@ private final class NativeAuthURLProtocol: URLProtocol {
     }
 
     override func startLoading() {
-        guard let url = request.url,
-              let fixture = fixture(for: request),
+        guard let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+        let fixture = fixture(for: request)
+        Self.record(
+            host: url.host ?? "",
+            statusCode: fixture?.statusCode,
+            headers: fixture?.headers ?? [:]
+        )
+        guard let fixture,
               let response = HTTPURLResponse(
                   url: url,
                   statusCode: fixture.statusCode,
@@ -96,6 +146,30 @@ private final class NativeAuthURLProtocol: URLProtocol {
     }
 
     override func stopLoading() {}
+
+    static func responseStatusCode(for host: String) -> Int? {
+        recordLock.lock()
+        defer { recordLock.unlock() }
+        return responseRecords.last(where: { $0.host == host })?.statusCode
+    }
+
+    static func responseHeader(for host: String, name: String) -> String? {
+        recordLock.lock()
+        defer { recordLock.unlock() }
+        return responseRecords.last(where: { $0.host == host })?.headers[name]
+    }
+
+    static func requestCount(for host: String) -> Int {
+        recordLock.lock()
+        defer { recordLock.unlock() }
+        return responseRecords.filter { $0.host == host }.count
+    }
+
+    private static func record(host: String, statusCode: Int?, headers: [String: String]) {
+        recordLock.lock()
+        responseRecords.append(ResponseRecord(host: host, statusCode: statusCode, headers: headers))
+        recordLock.unlock()
+    }
 
     private struct Fixture {
         let statusCode: Int
@@ -119,6 +193,8 @@ private final class NativeAuthURLProtocol: URLProtocol {
             return Fixture(statusCode: 200, headers: [:], body: providerBody())
         case "server-error.example":
             return Fixture(statusCode: 500, headers: [:], body: Data(#"{"error":"origin unavailable"}"#.utf8))
+        case "multiple.example":
+            return Fixture(statusCode: 300, headers: [:], body: Data())
         case "headers.example":
             let hasExpectedHeaders = request.value(forHTTPHeaderField: "CF-Access-Client-Id") == "test-client-id"
                 && request.value(forHTTPHeaderField: "CF-Access-Client-Secret") == "test-client-secret"

--- a/ConduitTests/NativeAuthClientTests.swift
+++ b/ConduitTests/NativeAuthClientTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import XCTest
+@testable import Conduit
+
+final class NativeAuthClientTests: XCTestCase {
+    func testProviderDiscoveryRedirectFallsBackToWebView() async throws {
+        let client = NativeAuthClient(
+            baseURL: "https://redirect.example",
+            sessionConfiguration: makeSessionConfiguration()
+        )
+
+        let providers = try await client.authProviders()
+
+        XCTAssertTrue(providers.isEmpty)
+    }
+
+    func testProviderDiscoveryParsesPasswordProvider() async throws {
+        let client = NativeAuthClient(
+            baseURL: "https://providers.example",
+            sessionConfiguration: makeSessionConfiguration()
+        )
+
+        let providers = try await client.authProviders()
+
+        XCTAssertEqual(providers.count, 1)
+        XCTAssertEqual(providers[0]["name"] as? String, "basic")
+        XCTAssertEqual(providers[0]["supports_password"] as? Bool, true)
+    }
+
+    func testProviderDiscoveryPreservesServerErrors() async throws {
+        let client = NativeAuthClient(
+            baseURL: "https://server-error.example",
+            sessionConfiguration: makeSessionConfiguration()
+        )
+
+        do {
+            _ = try await client.authProviders()
+            XCTFail("Expected provider discovery to fail for a server error")
+        } catch let error as AuthClientError {
+            guard case .providerDiscoveryFailed(let detail) = error else {
+                return XCTFail("Expected provider discovery failure, got \(error)")
+            }
+            XCTAssertEqual(detail, "origin unavailable")
+        }
+    }
+
+    func testProviderDiscoverySendsCloudflareAccessHeaders() async throws {
+        let credentials = CloudflareAccessCredentials(
+            clientID: "test-client-id",
+            clientSecret: "test-client-secret"
+        )
+        let client = NativeAuthClient(
+            baseURL: "https://headers.example",
+            cloudflareAccess: credentials,
+            sessionConfiguration: makeSessionConfiguration()
+        )
+
+        let providers = try await client.authProviders()
+
+        XCTAssertEqual(providers.count, 1)
+        XCTAssertEqual(providers[0]["name"] as? String, "basic")
+    }
+
+    private func makeSessionConfiguration() -> URLSessionConfiguration {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [NativeAuthURLProtocol.self]
+        return configuration
+    }
+}
+
+private final class NativeAuthURLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host?.hasSuffix(".example") == true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let url = request.url,
+              let fixture = fixture(for: request),
+              let response = HTTPURLResponse(
+                  url: url,
+                  statusCode: fixture.statusCode,
+                  httpVersion: "HTTP/1.1",
+                  headerFields: fixture.headers
+              ) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: fixture.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private struct Fixture {
+        let statusCode: Int
+        let headers: [String: String]
+        let body: Data
+    }
+
+    private func fixture(for request: URLRequest) -> Fixture? {
+        guard let host = request.url?.host else { return nil }
+
+        switch host {
+        case "redirect.example":
+            return Fixture(
+                statusCode: 302,
+                headers: [
+                    "Location": "https://tenant.cloudflareaccess.com/cdn-cgi/access/login"
+                ],
+                body: Data()
+            )
+        case "providers.example":
+            return Fixture(statusCode: 200, headers: [:], body: providerBody())
+        case "server-error.example":
+            return Fixture(statusCode: 500, headers: [:], body: Data(#"{"error":"origin unavailable"}"#.utf8))
+        case "headers.example":
+            let hasExpectedHeaders = request.value(forHTTPHeaderField: "CF-Access-Client-Id") == "test-client-id"
+                && request.value(forHTTPHeaderField: "CF-Access-Client-Secret") == "test-client-secret"
+            return hasExpectedHeaders
+                ? Fixture(statusCode: 200, headers: [:], body: providerBody())
+                : Fixture(statusCode: 403, headers: [:], body: Data(#"{"error":"missing Cloudflare service token"}"#.utf8))
+        default:
+            return nil
+        }
+    }
+
+    private func providerBody() -> Data {
+        Data(#"{"providers":[{"name":"basic","supports_password":true}]}"#.utf8)
+    }
+}

--- a/docs/superpowers/plans/2026-08-11-cloudflare-provider-redirect.md
+++ b/docs/superpowers/plans/2026-08-11-cloudflare-provider-redirect.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make Conduit fall through to its existing WebView authentication flow when Hermes provider discovery returns a redirect, including the Cloudflare Access `302` reported in issue #37.
 
-**Architecture:** Keep `LoginView` unchanged and reuse its existing empty-provider fallback. Add a small injectable `URLSessionConfiguration` seam to `NativeAuthClient` so tests can exercise real response classification with the production redirect delegate, then classify `3xx` provider responses as an empty provider list while retaining errors for `4xx`/`5xx` responses. No Cloudflare-only mode or Hermes Desktop changes.
+**Architecture:** Keep `LoginView` unchanged and reuse its existing empty-provider fallback. Add a small injectable `URLSessionConfiguration` seam to `NativeAuthClient` so tests can exercise real response classification with the production redirect delegate, then classify actual HTTP redirect responses (`301`, `302`, `303`, `307`, and `308`) as an empty provider list while retaining errors for other non-2xx responses. No Cloudflare-only mode or Hermes Desktop changes.
 
 **Tech Stack:** Swift 5.9, Foundation `URLSession`, XCTest, XcodeGen, Xcodebuild.
 
@@ -57,7 +57,7 @@ Expected result before production changes: the test fails because `authProviders
 
 **Interfaces:**
 - Consumes: The failing test's registered protocol and the existing production session construction.
-- Produces: `NativeAuthClient.init(baseURL:cloudflareAccess:sessionConfiguration:)` with a default `nil` configuration for production, and `authProviders()` returning `[]` for `300...399` responses.
+- Produces: `NativeAuthClient.init(baseURL:cloudflareAccess:sessionConfiguration:)` with a default `nil` configuration for production, and `authProviders()` returning `[]` for known HTTP redirect responses.
 
 - [ ] **Step 1: Add the optional session injection without changing production defaults**
 
@@ -78,8 +78,11 @@ Use the supplied configuration when non-`nil`, apply the existing cookie setting
 Immediately after the `HTTPURLResponse` guard in `authProviders()`, add:
 
 ```swift
-if (300...399).contains(http.statusCode) {
+switch http.statusCode {
+case 301, 302, 303, 307, 308:
     return []
+default:
+    break
 }
 ```
 

--- a/docs/superpowers/plans/2026-08-11-cloudflare-provider-redirect.md
+++ b/docs/superpowers/plans/2026-08-11-cloudflare-provider-redirect.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make Conduit fall through to its existing WebView authentication flow when Hermes provider discovery returns a redirect, including the Cloudflare Access `302` reported in issue #37.
 
-**Architecture:** Keep `LoginView` unchanged and reuse its existing empty-provider fallback. Add a small injectable `URLSession` seam to `NativeAuthClient` so tests can exercise real response classification, then classify `3xx` provider responses as an empty provider list while retaining errors for `4xx`/`5xx` responses. No Cloudflare-only mode or Hermes Desktop changes.
+**Architecture:** Keep `LoginView` unchanged and reuse its existing empty-provider fallback. Add a small injectable `URLSessionConfiguration` seam to `NativeAuthClient` so tests can exercise real response classification with the production redirect delegate, then classify `3xx` provider responses as an empty provider list while retaining errors for `4xx`/`5xx` responses. No Cloudflare-only mode or Hermes Desktop changes.
 
 **Tech Stack:** Swift 5.9, Foundation `URLSession`, XCTest, XcodeGen, Xcodebuild.
 
@@ -24,12 +24,12 @@
 - Create: `ConduitTests/NativeAuthClientTests.swift`
 
 **Interfaces:**
-- Consumes: `NativeAuthClient.authProviders()` and its injectable `URLSession` initializer parameter, which will be added in Task 2.
+- Consumes: `NativeAuthClient.authProviders()` and its injectable `URLSessionConfiguration` initializer parameter, which will be added in Task 2.
 - Produces: A regression test proving that a `302` response from `/api/auth/providers` must resolve as an empty provider list rather than throw `AuthClientError.providerDiscoveryFailed`.
 
 - [ ] **Step 1: Create the test fixture and failing test**
 
-Create a `URLProtocol` test double that returns a `302` response with a Cloudflare Access login `Location` header for the `redirect.example` host. Register the protocol for the test, construct `NativeAuthClient` with the existing production initializer, and assert that `try await client.authProviders()` returns `[]`. Register and unregister the protocol in the test class lifecycle so the first red run exercises the current production session without requiring a production-only test seam.
+Create a `URLProtocol` test double that returns a `302` response with a Cloudflare Access login `Location` header for the `redirect.example` host. Construct `NativeAuthClient` with a test `URLSessionConfiguration` containing that protocol and assert that `try await client.authProviders()` returns `[]`. The test configuration must still use `SecureRedirectDelegate` through the production initializer so the regression covers the actual redirect policy.
 
 The test must include `@testable import Conduit`, use XCTest async assertions, and keep the response body empty because the behavior depends on the HTTP status and redirect location, not JSON parsing.
 
@@ -57,7 +57,7 @@ Expected result before production changes: the test fails because `authProviders
 
 **Interfaces:**
 - Consumes: The failing test's registered protocol and the existing production session construction.
-- Produces: `NativeAuthClient.init(baseURL:cloudflareAccess:session:)` with a default `nil` session for production, and `authProviders()` returning `[]` for `300...399` responses.
+- Produces: `NativeAuthClient.init(baseURL:cloudflareAccess:sessionConfiguration:)` with a default `nil` configuration for production, and `authProviders()` returning `[]` for `300...399` responses.
 
 - [ ] **Step 1: Add the optional session injection without changing production defaults**
 
@@ -67,11 +67,11 @@ Change the initializer signature to:
 init(
     baseURL: String,
     cloudflareAccess: CloudflareAccessCredentials? = nil,
-    session: URLSession? = nil
+    sessionConfiguration: URLSessionConfiguration? = nil
 )
 ```
 
-Use the supplied session when non-`nil`; otherwise construct the existing cookie-enabled session with `SecureRedirectDelegate`. Update the final test to use the injected session so tests no longer rely on global protocol registration. Do not alter the default production configuration.
+Use the supplied configuration when non-`nil`, apply the existing cookie settings, and construct the session with `SecureRedirectDelegate`. Update the tests to use the injected configuration so they do not rely on global protocol registration. Do not alter the default production configuration.
 
 - [ ] **Step 2: Classify provider redirects as the existing empty-provider signal**
 

--- a/docs/superpowers/plans/2026-08-11-cloudflare-provider-redirect.md
+++ b/docs/superpowers/plans/2026-08-11-cloudflare-provider-redirect.md
@@ -1,0 +1,167 @@
+# Cloudflare Provider Redirect Handling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Conduit fall through to its existing WebView authentication flow when Hermes provider discovery returns a redirect, including the Cloudflare Access `302` reported in issue #37.
+
+**Architecture:** Keep `LoginView` unchanged and reuse its existing empty-provider fallback. Add a small injectable `URLSession` seam to `NativeAuthClient` so tests can exercise real response classification, then classify `3xx` provider responses as an empty provider list while retaining errors for `4xx`/`5xx` responses. No Cloudflare-only mode or Hermes Desktop changes.
+
+**Tech Stack:** Swift 5.9, Foundation `URLSession`, XCTest, XcodeGen, Xcodebuild.
+
+## Global Constraints
+
+- Preserve the existing native password-login and WebSocket-ticket flow.
+- Preserve the existing Cloudflare service-token request headers.
+- Treat only provider-discovery redirects as WebView fallback signals.
+- Keep ordinary client/server errors visible to the user.
+- Do not change Hermes server behavior or Hermes Desktop.
+
+---
+
+### Task 1: Add a failing provider-discovery redirect test
+
+**Files:**
+- Create: `ConduitTests/NativeAuthClientTests.swift`
+
+**Interfaces:**
+- Consumes: `NativeAuthClient.authProviders()` and its injectable `URLSession` initializer parameter, which will be added in Task 2.
+- Produces: A regression test proving that a `302` response from `/api/auth/providers` must resolve as an empty provider list rather than throw `AuthClientError.providerDiscoveryFailed`.
+
+- [ ] **Step 1: Create the test fixture and failing test**
+
+Create a `URLProtocol` test double that returns a `302` response with a Cloudflare Access login `Location` header for the `redirect.example` host. Register the protocol for the test, construct `NativeAuthClient` with the existing production initializer, and assert that `try await client.authProviders()` returns `[]`. Register and unregister the protocol in the test class lifecycle so the first red run exercises the current production session without requiring a production-only test seam.
+
+The test must include `@testable import Conduit`, use XCTest async assertions, and keep the response body empty because the behavior depends on the HTTP status and redirect location, not JSON parsing.
+
+- [ ] **Step 2: Generate the project and run only the new test**
+
+Run:
+
+```bash
+xcodegen generate
+xcodebuild test \
+  -project Conduit.xcodeproj \
+  -scheme Conduit \
+  -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
+  -only-testing:ConduitTests/NativeAuthClientTests/testProviderDiscoveryRedirectFallsBackToWebView \
+  CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
+  DEVELOPMENT_TEAM='' PROVISIONING_PROFILE_SPECIFIER=''
+```
+
+Expected result before production changes: the test fails because `authProviders()` throws `providerDiscoveryFailed("HTTP 302")`.
+
+### Task 2: Implement the minimal redirect classification
+
+**Files:**
+- Modify: `Conduit/Services/NativeAuthClient.swift:42-66`
+
+**Interfaces:**
+- Consumes: The failing test's registered protocol and the existing production session construction.
+- Produces: `NativeAuthClient.init(baseURL:cloudflareAccess:session:)` with a default `nil` session for production, and `authProviders()` returning `[]` for `300...399` responses.
+
+- [ ] **Step 1: Add the optional session injection without changing production defaults**
+
+Change the initializer signature to:
+
+```swift
+init(
+    baseURL: String,
+    cloudflareAccess: CloudflareAccessCredentials? = nil,
+    session: URLSession? = nil
+)
+```
+
+Use the supplied session when non-`nil`; otherwise construct the existing cookie-enabled session with `SecureRedirectDelegate`. Update the final test to use the injected session so tests no longer rely on global protocol registration. Do not alter the default production configuration.
+
+- [ ] **Step 2: Classify provider redirects as the existing empty-provider signal**
+
+Immediately after the `HTTPURLResponse` guard in `authProviders()`, add:
+
+```swift
+if (300...399).contains(http.statusCode) {
+    return []
+}
+```
+
+Leave the existing `200...299` success parsing and non-2xx error path intact for all other statuses.
+
+- [ ] **Step 3: Re-run the focused test**
+
+Run the Task 1 command again. Expected result: `NativeAuthClientTests/testProviderDiscoveryRedirectFallsBackToWebView` passes.
+
+### Task 3: Add preservation and header-coverage tests
+
+**Files:**
+- Modify: `ConduitTests/NativeAuthClientTests.swift`
+
+**Interfaces:**
+- Consumes: The real `NativeAuthClient.authProviders()` response classification and request construction.
+- Produces: Coverage for successful provider discovery, server-error preservation, and Cloudflare headers on the discovery probe.
+
+- [ ] **Step 1: Add successful-provider and server-error fixtures**
+
+Extend the URLProtocol fixture with deterministic responses keyed by host:
+
+- `providers.example`: `200` with `{"providers":[{"name":"basic","supports_password":true}]}`.
+- `server-error.example`: `500` with `{"error":"origin unavailable"}`.
+
+Add tests asserting that the successful response returns one password-capable provider and the `500` response throws `AuthClientError.providerDiscoveryFailed` containing `HTTP 500` or the parsed error detail.
+
+- [ ] **Step 2: Add a Cloudflare-header request assertion**
+
+For a `200` response on `headers.example`, configure the test protocol to record the incoming request and assert that `CF-Access-Client-Id` is `test-client-id` and `CF-Access-Client-Secret` is `test-client-secret` when the client is initialized with matching `CloudflareAccessCredentials`.
+
+- [ ] **Step 3: Run the focused test class**
+
+Run:
+
+```bash
+xcodebuild test \
+  -project Conduit.xcodeproj \
+  -scheme Conduit \
+  -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
+  -only-testing:ConduitTests/NativeAuthClientTests \
+  CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
+  DEVELOPMENT_TEAM='' PROVISIONING_PROFILE_SPECIFIER=''
+```
+
+Expected result: all `NativeAuthClientTests` pass, including redirect fallback, successful provider parsing, server-error preservation, and Cloudflare header coverage.
+
+### Task 4: Run full verification and prepare the PR
+
+**Files:**
+- Verify: `Conduit/Services/NativeAuthClient.swift`
+- Verify: `ConduitTests/NativeAuthClientTests.swift`
+- Verify: `docs/superpowers/specs/2026-08-11-cloudflare-provider-redirect-design.md`
+- Verify: `docs/superpowers/plans/2026-08-11-cloudflare-provider-redirect.md`
+
+**Interfaces:**
+- Consumes: The completed implementation and regression suite.
+- Produces: A clean, reviewable branch for Conduit issue #37.
+
+- [ ] **Step 1: Run the complete repository test command**
+
+Generate the project and run the same simulator-selection and `xcodebuild test` command used by `.github/workflows/ci.yml`, with code signing disabled.
+
+- [ ] **Step 2: Inspect the final diff and repository state**
+
+Run:
+
+```bash
+git diff --check
+git diff --stat origin/main...HEAD
+git status --short --branch
+```
+
+Confirm the diff contains only the design/plan records, `NativeAuthClient.swift`, and `NativeAuthClientTests.swift`; confirm the original checkout's unrelated dirty files are not present in this worktree.
+
+- [ ] **Step 3: Commit the implementation and tests**
+
+```bash
+git add Conduit/Services/NativeAuthClient.swift ConduitTests/NativeAuthClientTests.swift
+git commit -m "Handle Cloudflare auth redirects during provider discovery"
+```
+
+- [ ] **Step 4: Push and open a draft PR against `main`**
+
+Push `agent/conduit-issue-37-cloudflare-redirect`, then open a draft PR in `kaishi00/hermes-conduit` with `Fixes #37`. The PR body must explain that redirects now enter the existing WebView path, ordinary errors remain fatal, and Cloudflare-only mode is intentionally excluded.

--- a/docs/superpowers/specs/2026-08-11-cloudflare-provider-redirect-design.md
+++ b/docs/superpowers/specs/2026-08-11-cloudflare-provider-redirect-design.md
@@ -10,7 +10,7 @@ This change covers only the provider-discovery redirect fallback and regression 
 
 ## Current behavior
 
-`LoginView.connect()` calls `NativeAuthClient.authProviders()` before deciding whether to use native password login or the WebView. `NativeAuthClient` rejects every response outside `200...299`, so a Cloudflare Access `3xx` response becomes `providerDiscoveryFailed` and prevents the WebView fallback from opening.
+`LoginView.connect()` calls `NativeAuthClient.authProviders()` before deciding whether to use native password login or the WebView. `NativeAuthClient` rejects every response outside `200...299`, so a Cloudflare Access redirect such as `302` becomes `providerDiscoveryFailed` and prevents the WebView fallback from opening.
 
 ## Design
 
@@ -20,7 +20,7 @@ The redirect handling will be covered by focused tests for provider discovery, a
 
 ## Acceptance criteria
 
-1. A `3xx` response from `/api/auth/providers` does not produce `Could not check dashboard sign-in options: HTTP 302`.
+1. A Cloudflare Access `302` from `/api/auth/providers` does not produce `Could not check dashboard sign-in options: HTTP 302`.
 2. The caller receives the existing empty-provider signal and opens the WebView path.
 3. `4xx` and `5xx` provider responses still produce `providerDiscoveryFailed`.
 4. A successful provider response still exposes its providers, including password-capable providers.

--- a/docs/superpowers/specs/2026-08-11-cloudflare-provider-redirect-design.md
+++ b/docs/superpowers/specs/2026-08-11-cloudflare-provider-redirect-design.md
@@ -1,0 +1,31 @@
+# Cloudflare Provider Discovery Redirect Design
+
+## Goal
+
+Fix Conduit issue #37 so a Cloudflare Access redirect during dashboard auth-provider discovery does not appear as a fatal provider-probe error. Conduit should fall through to its existing dashboard WebView sign-in path, which already carries configured Cloudflare service-token headers.
+
+## Scope
+
+This change covers only the provider-discovery redirect fallback and regression tests. It preserves the existing native username/password flow, native Cloudflare header injection, and origin-scoped WebView injection. It does not add a Cloudflare-Access-only mode or modify Hermes Desktop.
+
+## Current behavior
+
+`LoginView.connect()` calls `NativeAuthClient.authProviders()` before deciding whether to use native password login or the WebView. `NativeAuthClient` rejects every response outside `200...299`, so a Cloudflare Access `3xx` response becomes `providerDiscoveryFailed` and prevents the WebView fallback from opening.
+
+## Design
+
+`NativeAuthClient.authProviders()` will return an empty provider list for a redirect response. An empty provider list already selects `AuthWebView` in `LoginView`, preserving the existing edge-authenticated browser flow. Ordinary client and server errors remain failures, so this does not hide authentication or connectivity errors. Successful provider responses and the password-login/ticket sequence are unchanged.
+
+The redirect handling will be covered by focused tests for provider discovery, alongside the existing successful response behavior. The tests will use a URL loading protocol or equivalent injectable session boundary so they exercise the real response classification without depending on a live Cloudflare tenant.
+
+## Acceptance criteria
+
+1. A `3xx` response from `/api/auth/providers` does not produce `Could not check dashboard sign-in options: HTTP 302`.
+2. The caller receives the existing empty-provider signal and opens the WebView path.
+3. `4xx` and `5xx` provider responses still produce `providerDiscoveryFailed`.
+4. A successful provider response still exposes its providers, including password-capable providers.
+5. No Cloudflare-only authentication mode, Hermes server change, or Hermes Desktop change is included.
+
+## Verification
+
+Run the focused provider-discovery tests, the full Conduit test suite, and the repository’s generated Xcode project build/test command where the local Xcode toolchain permits.


### PR DESCRIPTION
## Summary

- Treat HTTP redirect responses from `/api/auth/providers` (`301`, `302`, `303`, `307`, and `308`), including Cloudflare Access `302`, as a signal to use Conduit's existing WebView authentication flow.
- Preserve native password-provider discovery, Cloudflare service-token headers, and fatal handling for non-redirect 3xx plus 4xx/5xx responses.
- Add regression coverage for redirect fallback, response status and `Location` validation, cross-origin redirect blocking, provider parsing, server errors, and Cloudflare headers.

## Scope

This fixes the provider-discovery failure described in #37. Cloudflare-only mode is intentionally not included because it would require an explicit server-side/auth-flow decision and is separate from making the existing WebView fallback work. No Hermes Desktop changes are required.

Fixes #37

## Verification

- Focused `NativeAuthClientTests`: 5 passed
- Full iPhone 17 simulator suite: 427 passed, 0 failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in handling when authentication-provider discovery encounters redirects, allowing the existing web-based login flow to continue.
  * Preserved failure handling for other server errors and maintained support for successful provider discovery and required security headers.

* **Documentation**
  * Added design and implementation documentation describing redirect handling, fallback behavior, acceptance criteria, and verification coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->