### PR TITLE
Fix notification session reload loop

### DIFF
--- a/Conduit/ConduitApp.swift
+++ b/Conduit/ConduitApp.swift
@@ -74,8 +74,8 @@ struct ConduitApp: App {
                     guard appState.isConnected, let target = notifications.pendingTarget else { return }
                     if await appState.openNotificationTarget(target) {
                         notifications.clearPendingTarget(target)
-                    } else if !notifications.retryPendingTarget(target) {
-                        notifications.clearPendingTarget(target)
+                    } else {
+                        notifications.handleFailedNotificationRoute(target)
                     }
                 }
                 .task(id: voiceIntentRouteKey) {

--- a/Conduit/ConduitApp.swift
+++ b/Conduit/ConduitApp.swift
@@ -74,8 +74,8 @@ struct ConduitApp: App {
                     guard appState.isConnected, let target = notifications.pendingTarget else { return }
                     if await appState.openNotificationTarget(target) {
                         notifications.clearPendingTarget(target)
-                    } else {
-                        notifications.discardPendingTarget(target)
+                    } else if !notifications.retryPendingTarget(target) {
+                        notifications.clearPendingTarget(target)
                     }
                 }
                 .task(id: voiceIntentRouteKey) {

--- a/Conduit/ConduitApp.swift
+++ b/Conduit/ConduitApp.swift
@@ -75,7 +75,7 @@ struct ConduitApp: App {
                     if await appState.openNotificationTarget(target) {
                         notifications.clearPendingTarget(target)
                     } else {
-                        notifications.retryPendingTarget()
+                        notifications.discardPendingTarget(target)
                     }
                 }
                 .task(id: voiceIntentRouteKey) {

--- a/Conduit/Models/Models.swift
+++ b/Conduit/Models/Models.swift
@@ -274,6 +274,9 @@ struct DelegateAgentActivity: Identifiable, Equatable {
 
 struct SessionSummary: Identifiable, Equatable {
     let id: String
+    /// The durable database identity used by `session.resume`. Hermes stream
+    /// events and notifications may carry the live runtime identity instead.
+    var storedSessionId: String? = nil
     var alternateIds: [String]
     var title: String
     var model: String

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -3511,11 +3511,12 @@ final class AppState: ObservableObject {
             return false
         }
         let requestedID = target.sessionId
-        let matchingSession = (sessions + cronSessions).first { session in
-            session.id == requestedID || session.alternateIds.contains(requestedID)
-        }
+        let resumableID = NotificationSessionResolver.resumableSessionID(
+            for: requestedID,
+            in: sessions + cronSessions
+        )
         let opened = await openSession(
-            matchingSession?.id ?? requestedID,
+            resumableID,
             reusing: transitionGeneration
         )
         guard notificationOpenAttemptIsCurrent(

--- a/Conduit/Services/HermesClient.swift
+++ b/Conduit/Services/HermesClient.swift
@@ -1156,6 +1156,9 @@ enum MessageNormalizer {
         return records.enumerated().map { index, item in
             let obj = item.objectValue ?? [:]
             let id = obj["session_id"]?.stringValue ?? obj["id"]?.stringValue ?? String(index)
+            let storedSessionId = ["stored_session_id", "storedSessionId", "id"]
+                .compactMap { obj[$0]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .first { !$0.isEmpty }
 
             // Collect alternate IDs
             let altKeys = ["session_id", "id", "stored_session_id", "runtime_session_id", "session_key"]
@@ -1178,6 +1181,7 @@ enum MessageNormalizer {
 
             return SessionSummary(
                 id: id,
+                storedSessionId: storedSessionId,
                 alternateIds: Array(altIds),
                 title: obj["title"]?.stringValue ?? obj["preview"]?.stringValue ?? "Untitled conversation",
                 model: obj["model"]?.stringValue ?? "Hermes",

--- a/Conduit/Services/HermesClient.swift
+++ b/Conduit/Services/HermesClient.swift
@@ -1155,10 +1155,18 @@ enum MessageNormalizer {
 
         return records.enumerated().map { index, item in
             let obj = item.objectValue ?? [:]
-            let id = obj["session_id"]?.stringValue ?? obj["id"]?.stringValue ?? String(index)
-            let storedSessionId = ["stored_session_id", "storedSessionId", "id"]
+            let runtimeSessionId = obj["session_id"]?.stringValue
+            let id = runtimeSessionId ?? obj["id"]?.stringValue ?? String(index)
+            let explicitStoredSessionId = ["stored_session_id", "storedSessionId"]
                 .compactMap { obj[$0]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines) }
                 .first { !$0.isEmpty }
+            let storedSessionId = explicitStoredSessionId ?? {
+                // The legacy catalog shape exposes the durable ID as `id`
+                // alongside a separate runtime `session_id`. A lone `id` is
+                // ambiguous, so do not label it as a verified stored ID.
+                guard runtimeSessionId != nil else { return nil }
+                return obj["id"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
+            }()
 
             // Collect alternate IDs
             let altKeys = ["session_id", "id", "stored_session_id", "runtime_session_id", "session_key"]

--- a/Conduit/Services/PushNotificationService.swift
+++ b/Conduit/Services/PushNotificationService.swift
@@ -9,6 +9,26 @@ struct ConduitNotificationTarget: Equatable, Identifiable {
     var id: String { "\(profile ?? "default"):\(sessionId):\(type ?? "")" }
 }
 
+enum NotificationSessionResolver {
+    /// Hermes notifications identify a live runtime session, while
+    /// `session.resume` is keyed by the durable stored session. Catalog rows
+    /// retain both identities so a notification can be routed without asking
+    /// the gateway to resume a runtime-only key.
+    static func resumableSessionID(
+        for notificationSessionID: String,
+        in sessions: [SessionSummary]
+    ) -> String {
+        let normalizedID = notificationSessionID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedID.isEmpty else { return notificationSessionID }
+        guard let session = sessions.first(where: { session in
+            session.id == normalizedID || session.alternateIds.contains(normalizedID)
+        }) else {
+            return notificationSessionID
+        }
+        return session.storedSessionId ?? session.id
+    }
+}
+
 struct ConduitNotificationPreferences: Codable, Equatable {
     var enabled = true
     var approvalNeeded = true
@@ -55,7 +75,6 @@ final class PushNotificationService: ObservableObject {
     private var registration: StoredRegistration?
     private var deviceToken: String?
     private var tokenContinuation: CheckedContinuation<String, Error>?
-    private var navigationRetryTask: Task<Void, Never>?
 
     var isEnabled: Bool { registration != nil && preferences.enabled }
     var statusText: String {
@@ -167,26 +186,17 @@ final class PushNotificationService: ObservableObject {
 
     func receiveNotificationPayload(_ userInfo: [AnyHashable: Any]) {
         guard let target = notificationTarget(from: userInfo) else { return }
-        navigationRetryTask?.cancel()
         pendingTarget = target
         navigationAttempt += 1
     }
 
     func clearPendingTarget(_ target: ConduitNotificationTarget) {
         guard pendingTarget == target else { return }
-        navigationRetryTask?.cancel()
-        navigationRetryTask = nil
         pendingTarget = nil
     }
 
-    func retryPendingTarget() {
-        guard pendingTarget != nil else { return }
-        navigationRetryTask?.cancel()
-        navigationRetryTask = Task { [weak self] in
-            try? await Task.sleep(for: .seconds(1.5))
-            guard !Task.isCancelled else { return }
-            self?.navigationAttempt += 1
-        }
+    func discardPendingTarget(_ target: ConduitNotificationTarget) {
+        clearPendingTarget(target)
     }
 
     private func notificationTarget(from userInfo: [AnyHashable: Any]) -> ConduitNotificationTarget? {

--- a/Conduit/Services/PushNotificationService.swift
+++ b/Conduit/Services/PushNotificationService.swift
@@ -19,11 +19,11 @@ enum NotificationSessionResolver {
         in sessions: [SessionSummary]
     ) -> String {
         let normalizedID = notificationSessionID.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !normalizedID.isEmpty else { return notificationSessionID }
+        guard !normalizedID.isEmpty else { return normalizedID }
         guard let session = sessions.first(where: { session in
             session.id == normalizedID || session.alternateIds.contains(normalizedID)
         }) else {
-            return notificationSessionID
+            return normalizedID
         }
         return session.storedSessionId ?? session.id
     }
@@ -75,6 +75,9 @@ final class PushNotificationService: ObservableObject {
     private var registration: StoredRegistration?
     private var deviceToken: String?
     private var tokenContinuation: CheckedContinuation<String, Error>?
+    private var navigationRetryTask: Task<Void, Never>?
+    private var pendingRetryCount = 0
+    private let maxNotificationRetriesPerTarget = 1
 
     var isEnabled: Bool { registration != nil && preferences.enabled }
     var statusText: String {
@@ -186,17 +189,32 @@ final class PushNotificationService: ObservableObject {
 
     func receiveNotificationPayload(_ userInfo: [AnyHashable: Any]) {
         guard let target = notificationTarget(from: userInfo) else { return }
+        navigationRetryTask?.cancel()
         pendingTarget = target
+        pendingRetryCount = 0
         navigationAttempt += 1
     }
 
     func clearPendingTarget(_ target: ConduitNotificationTarget) {
         guard pendingTarget == target else { return }
+        navigationRetryTask?.cancel()
+        navigationRetryTask = nil
         pendingTarget = nil
+        pendingRetryCount = 0
     }
 
-    func discardPendingTarget(_ target: ConduitNotificationTarget) {
-        clearPendingTarget(target)
+    @discardableResult
+    func retryPendingTarget(_ target: ConduitNotificationTarget) -> Bool {
+        guard pendingTarget == target,
+              pendingRetryCount < maxNotificationRetriesPerTarget else { return false }
+        pendingRetryCount += 1
+        navigationRetryTask?.cancel()
+        navigationRetryTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(1.5))
+            guard !Task.isCancelled else { return }
+            self?.navigationAttempt += 1
+        }
+        return true
     }
 
     private func notificationTarget(from userInfo: [AnyHashable: Any]) -> ConduitNotificationTarget? {

--- a/Conduit/Services/PushNotificationService.swift
+++ b/Conduit/Services/PushNotificationService.swift
@@ -78,6 +78,7 @@ final class PushNotificationService: ObservableObject {
     private var navigationRetryTask: Task<Void, Never>?
     private var pendingRetryCount = 0
     private let maxNotificationRetriesPerTarget = 1
+    private let retryDelay: Duration
 
     var isEnabled: Bool { registration != nil && preferences.enabled }
     var statusText: String {
@@ -87,7 +88,8 @@ final class PushNotificationService: ObservableObject {
         return "Off"
     }
 
-    private init() {
+    init(retryDelay: Duration = .seconds(1.5)) {
+        self.retryDelay = retryDelay
         if let data = KeychainHelper.loadPushRegistration(),
            let saved = try? JSONDecoder().decode(StoredRegistration.self, from: data) {
             registration = saved
@@ -190,6 +192,7 @@ final class PushNotificationService: ObservableObject {
     func receiveNotificationPayload(_ userInfo: [AnyHashable: Any]) {
         guard let target = notificationTarget(from: userInfo) else { return }
         navigationRetryTask?.cancel()
+        navigationRetryTask = nil
         pendingTarget = target
         pendingRetryCount = 0
         navigationAttempt += 1
@@ -204,15 +207,21 @@ final class PushNotificationService: ObservableObject {
     }
 
     @discardableResult
-    func retryPendingTarget(_ target: ConduitNotificationTarget) -> Bool {
+    func handleFailedNotificationRoute(_ target: ConduitNotificationTarget) -> Bool {
         guard pendingTarget == target,
-              pendingRetryCount < maxNotificationRetriesPerTarget else { return false }
+              pendingRetryCount < maxNotificationRetriesPerTarget else {
+            clearPendingTarget(target)
+            return false
+        }
         pendingRetryCount += 1
         navigationRetryTask?.cancel()
+        let retryDelay = self.retryDelay
         navigationRetryTask = Task { [weak self] in
-            try? await Task.sleep(for: .seconds(1.5))
+            try? await Task.sleep(for: retryDelay)
             guard !Task.isCancelled else { return }
-            self?.navigationAttempt += 1
+            guard let self else { return }
+            self.navigationRetryTask = nil
+            self.navigationAttempt += 1
         }
         return true
     }

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -260,6 +260,24 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertEqual(harness.appState.messages, secondMessages)
     }
 
+    func testFailedNotificationOpenReleasesNotificationBusyState() async {
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in throw ControlledLifecycleError.failed }
+            )
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.connection = connection
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+
+        let opened = await harness.appState.openNotificationTarget(
+            ConduitNotificationTarget(profile: nil, sessionId: "stored-a", type: "response_ready")
+        )
+
+        XCTAssertFalse(opened)
+        XCTAssertFalse(harness.appState.isOpeningNotificationSession)
+    }
+
     func testStaleSameTokenSyncCannotSettleNewerOpeningReconciliation() async {
         let staleCatalogGate = ControlledSuspension()
         let newerOpenGate = ControlledSuspension()

--- a/ConduitTests/MessageNormalizerTests.swift
+++ b/ConduitTests/MessageNormalizerTests.swift
@@ -89,6 +89,62 @@ final class MessageNormalizerTests: XCTestCase {
         XCTAssertEqual(sessions.compactMap(\.profile), ["work", "personal"])
     }
 
+    func testSessionNormalizationKeepsStoredIDSeparateFromRuntimeID() {
+        let sessions = MessageNormalizer.normalizeSessions(
+            .object([
+                "sessions": .array([
+                    .object([
+                        "session_id": .string("runtime-123"),
+                        "id": .string("stored-123"),
+                        "profile": .string("default")
+                    ])
+                ])
+            ]),
+            profile: "default"
+        )
+
+        XCTAssertEqual(sessions.first?.storedSessionId, "stored-123")
+        XCTAssertTrue(sessions.first?.alternateIds.contains("stored-123") == true)
+    }
+
+    func testNotificationRuntimeIDResolvesToStoredSessionID() {
+        let session = SessionSummary(
+            id: "runtime-123",
+            storedSessionId: "stored-123",
+            alternateIds: ["stored-123"],
+            title: "A session",
+            model: "Hermes",
+            updatedLabel: "now",
+            profile: "default",
+            source: .chat,
+            isActive: false,
+            isArchived: false
+        )
+
+        XCTAssertEqual(
+            NotificationSessionResolver.resumableSessionID(for: "runtime-123", in: [session]),
+            "stored-123"
+        )
+    }
+
+    func testFailedNotificationRouteDiscardsPendingTarget() {
+        let service = PushNotificationService.shared
+        service.receiveNotificationPayload([
+            "conduit": [
+                "session_id": "runtime-123",
+                "type": "response_ready"
+            ] as [String: Any]
+        ])
+
+        guard let target = service.pendingTarget else {
+            return XCTFail("Expected the notification target to be pending")
+        }
+
+        service.discardPendingTarget(target)
+
+        XCTAssertNil(service.pendingTarget)
+    }
+
     func testSessionNormalizationDoesNotInventOwnershipWithoutFallback() {
         let sessions = MessageNormalizer.normalizeSessions(
             .object([

--- a/ConduitTests/MessageNormalizerTests.swift
+++ b/ConduitTests/MessageNormalizerTests.swift
@@ -184,14 +184,22 @@ final class MessageNormalizerTests: XCTestCase {
 
         let initialAttempt = service.navigationAttempt
         XCTAssertTrue(service.handleFailedNotificationRoute(target))
-        try? await Task.sleep(for: .milliseconds(10))
+        let retryDeadline = ContinuousClock.now.advanced(by: .seconds(1))
+        while service.navigationAttempt == initialAttempt,
+              ContinuousClock.now < retryDeadline {
+            await Task.yield()
+        }
         XCTAssertEqual(service.navigationAttempt, initialAttempt + 1)
         XCTAssertEqual(service.pendingTarget, target)
 
         XCTAssertFalse(service.handleFailedNotificationRoute(target))
         XCTAssertNil(service.pendingTarget)
         let terminalAttempt = service.navigationAttempt
-        try? await Task.sleep(for: .milliseconds(10))
+        let terminalDeadline = ContinuousClock.now.advanced(by: .milliseconds(100))
+        while service.navigationAttempt == terminalAttempt,
+              ContinuousClock.now < terminalDeadline {
+            await Task.yield()
+        }
         XCTAssertEqual(service.navigationAttempt, terminalAttempt)
     }
 

--- a/ConduitTests/MessageNormalizerTests.swift
+++ b/ConduitTests/MessageNormalizerTests.swift
@@ -127,8 +127,20 @@ final class MessageNormalizerTests: XCTestCase {
         )
     }
 
-    func testFailedNotificationRouteDiscardsPendingTarget() {
+    func testNotificationResolverTrimsUnknownRuntimeID() {
+        XCTAssertEqual(
+            NotificationSessionResolver.resumableSessionID(for: "  runtime-123  ", in: []),
+            "runtime-123"
+        )
+    }
+
+    func testFailedNotificationRouteClearsPendingTarget() {
         let service = PushNotificationService.shared
+        defer {
+            if let pendingTarget = service.pendingTarget {
+                service.clearPendingTarget(pendingTarget)
+            }
+        }
         service.receiveNotificationPayload([
             "conduit": [
                 "session_id": "runtime-123",
@@ -140,9 +152,26 @@ final class MessageNormalizerTests: XCTestCase {
             return XCTFail("Expected the notification target to be pending")
         }
 
-        service.discardPendingTarget(target)
+        service.clearPendingTarget(target)
 
         XCTAssertNil(service.pendingTarget)
+    }
+
+    func testNotificationRetryIsBoundedPerPendingTarget() {
+        let service = PushNotificationService.shared
+        service.receiveNotificationPayload([
+            "conduit": [
+                "session_id": "runtime-123",
+                "type": "response_ready"
+            ] as [String: Any]
+        ])
+        guard let target = service.pendingTarget else {
+            return XCTFail("Expected the notification target to be pending")
+        }
+        defer { service.clearPendingTarget(target) }
+
+        XCTAssertTrue(service.retryPendingTarget(target))
+        XCTAssertFalse(service.retryPendingTarget(target))
     }
 
     func testSessionNormalizationDoesNotInventOwnershipWithoutFallback() {

--- a/ConduitTests/MessageNormalizerTests.swift
+++ b/ConduitTests/MessageNormalizerTests.swift
@@ -107,6 +107,19 @@ final class MessageNormalizerTests: XCTestCase {
         XCTAssertTrue(sessions.first?.alternateIds.contains("stored-123") == true)
     }
 
+    func testSessionNormalizationDoesNotTreatLoneIDAsVerifiedStoredID() {
+        let sessions = MessageNormalizer.normalizeSessions(
+            .object([
+                "sessions": .array([
+                    .object(["id": .string("ambiguous-123")])
+                ])
+            ]),
+            profile: "default"
+        )
+
+        XCTAssertNil(sessions.first?.storedSessionId)
+    }
+
     func testNotificationRuntimeIDResolvesToStoredSessionID() {
         let session = SessionSummary(
             id: "runtime-123",
@@ -157,8 +170,8 @@ final class MessageNormalizerTests: XCTestCase {
         XCTAssertNil(service.pendingTarget)
     }
 
-    func testNotificationRetryIsBoundedPerPendingTarget() {
-        let service = PushNotificationService.shared
+    func testFailedNotificationRouteRetriesOnceThenClearsTarget() async {
+        let service = PushNotificationService(retryDelay: .zero)
         service.receiveNotificationPayload([
             "conduit": [
                 "session_id": "runtime-123",
@@ -168,10 +181,18 @@ final class MessageNormalizerTests: XCTestCase {
         guard let target = service.pendingTarget else {
             return XCTFail("Expected the notification target to be pending")
         }
-        defer { service.clearPendingTarget(target) }
 
-        XCTAssertTrue(service.retryPendingTarget(target))
-        XCTAssertFalse(service.retryPendingTarget(target))
+        let initialAttempt = service.navigationAttempt
+        XCTAssertTrue(service.handleFailedNotificationRoute(target))
+        try? await Task.sleep(for: .milliseconds(10))
+        XCTAssertEqual(service.navigationAttempt, initialAttempt + 1)
+        XCTAssertEqual(service.pendingTarget, target)
+
+        XCTAssertFalse(service.handleFailedNotificationRoute(target))
+        XCTAssertNil(service.pendingTarget)
+        let terminalAttempt = service.navigationAttempt
+        try? await Task.sleep(for: .milliseconds(10))
+        XCTAssertEqual(service.navigationAttempt, terminalAttempt)
     }
 
     func testSessionNormalizationDoesNotInventOwnershipWithoutFallback() {


### PR DESCRIPTION
## Summary

Fix notification taps so they reopen the intended Hermes conversation without repeatedly reloading a failed session.

## Root cause

Hermes notifications carry the live runtime session ID, while `session.resume` requires the durable stored session ID. The app treated the runtime ID as the resume key, received a session-not-found failure, and retained the pending target. Its delayed retry task then incremented the navigation attempt indefinitely, causing the constant reload loop seen in TestFlight.

Hermes Desktop documents the same runtime-to-stored identity distinction in its notification/session routing: [session-ids.ts](https://raw.githubusercontent.com/NousResearch/hermes-agent/main/apps/desktop/src/lib/session-ids.ts).

## Changes

- Preserve `storedSessionId` separately on `SessionSummary` while retaining runtime IDs as alternates.
- Resolve notification runtime IDs to stored IDs before calling `session.resume`.
- Bound a failed notification route to one delayed retry for the same target, then clear it if the retry also fails.
- Inject retry timing and test the complete retry-fire → second-failure → clear sequence on an isolated service instance.
- Prefer explicit stored-ID fields; do not treat a lone ambiguous `id` field as a verified stored ID.
- Remove the redundant `discardPendingTarget` alias and normalize resolver fallback IDs.
- Add regression coverage for normalization, runtime-to-stored resolution, bounded retries, and AppState failure cleanup.

## Verification

- Focused notification/session tests: 31 passed.
- Full iOS simulator suite on iPhone 17 Pro: 434 passed, 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification navigation by reliably matching sessions using their durable identities and alternate IDs.
  * Failed notification opens now retry in a controlled manner and clear the pending target after repeated failures.
  * Improved handling of session identity differences when resuming conversations.
* **Tests**
  * Added coverage for notification routing, session identity resolution, retry behavior, and clearing failed navigation state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->