### PR TITLE
Deduplicate buffered stream deltas against the resume inflight snapshot

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2324,6 +2324,11 @@ final class AppState: ObservableObject {
                     acceptedSessionIDs = boundary.acceptedSessionIDs.intersection(
                         knownSessionIDs(for: boundarySessionID)
                     )
+                    if !acceptedSessionIDs.contains(result.sessionId) {
+                        sessionCatalogLog.debug(
+                            "Skipping buffered delta dedup because resumed session \(result.sessionId, privacy: .public) is not a catalog-confirmed alias of the reconciliation boundary"
+                        )
+                    }
                 } else {
                     acceptedSessionIDs = [result.sessionId]
                 }
@@ -2852,18 +2857,17 @@ final class AppState: ObservableObject {
             )
         } else if normalizedCoveredText.hasPrefix(normalizedBufferedDeltaText) {
             coveredRawCharacters = bufferedDeltaText.count
-        } else if normalizedCoveredText.hasSuffix(normalizedBufferedDeltaText) {
-            // A reconnect can leave the local boundary behind a persisted
-            // portion of the turn. In that case the buffered window may begin
-            // in the middle of the covered span; consume it only when the
-            // entire buffered text is the covered span's suffix.
-            coveredRawCharacters = bufferedDeltaText.count
         } else {
-            let overlap = Self.longestSuffixPrefixOverlapLength(
+            let overlaps = Self.suffixPrefixOverlapLengths(
                 covered: normalizedCoveredText,
                 buffered: normalizedBufferedDeltaText
             )
-            guard overlap > 0 else { return events }
+            guard overlaps.count == 1, let overlap = overlaps.first else {
+                // Repeated content can produce multiple valid alignments. A
+                // content-only guess could consume genuinely new text, so
+                // preserve the events when the offset is ambiguous.
+                return events
+            }
             let leadingWhitespaceCount = bufferedDeltaText.prefix { $0.isWhitespace }.count
             coveredRawCharacters = leadingWhitespaceCount + overlap
         }
@@ -2895,15 +2899,16 @@ final class AppState: ObservableObject {
         return deduplicated
     }
 
-    /// Returns the longest prefix of `buffered` that is also a suffix of
+    /// Returns every non-empty prefix of `buffered` that is also a suffix of
     /// `covered`. The prefix-function scan stays linear in the cumulative
-    /// projection size while preserving the boundary-derived alignment rule.
-    nonisolated static func longestSuffixPrefixOverlapLength(
+    /// projection size; callers can reject repeated-content ambiguity when
+    /// more than one alignment is possible.
+    nonisolated static func suffixPrefixOverlapLengths(
         covered: String,
         buffered: String
-    ) -> Int {
+    ) -> [Int] {
         let pattern = Array(buffered)
-        guard !pattern.isEmpty, !covered.isEmpty else { return 0 }
+        guard !pattern.isEmpty, !covered.isEmpty else { return [] }
 
         var prefixLengths = Array(repeating: 0, count: pattern.count)
         var prefixLength = 0
@@ -2917,8 +2922,10 @@ final class AppState: ObservableObject {
             prefixLengths[index] = prefixLength
         }
 
+        let text = Array(covered)
         var matched = 0
-        for character in covered {
+        var overlaps: [Int] = []
+        for (index, character) in text.enumerated() {
             while matched > 0, pattern[matched] != character {
                 matched = prefixLengths[matched - 1]
             }
@@ -2926,10 +2933,18 @@ final class AppState: ObservableObject {
                 matched += 1
             }
             if matched == pattern.count {
+                if index == text.count - 1 {
+                    overlaps.append(pattern.count)
+                }
                 matched = prefixLengths[matched - 1]
             }
         }
-        return matched
+
+        while matched > 0 {
+            overlaps.append(matched)
+            matched = prefixLengths[matched - 1]
+        }
+        return overlaps
     }
 
     /// `session.resume.inflight` is a cumulative projection on some gateways.

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2311,16 +2311,37 @@ final class AppState: ObservableObject {
                 : []
             if result.snapshot.hasLiveProjection {
                 let resumedInflightText = streamingBuffer
+                let boundary = reconciliation?.token == token ? reconciliation : nil
+                let acceptedSessionIDs: Set<String>
+                if let boundary,
+                   let boundarySessionID = boundary.streamSessionIDAtBoundary {
+                    acceptedSessionIDs = boundary.acceptedSessionIDs.intersection(
+                        knownSessionIDs(for: boundarySessionID)
+                    )
+                } else {
+                    acceptedSessionIDs = [result.sessionId]
+                }
                 let knownPrefix: String?
-                if let boundary = reconciliation, boundary.token == token {
+                let coveredText: String?
+                if let boundary {
                     knownPrefix = Self.normalizedReconciliationBoundaryPrefix(
                         boundaryText: boundary.streamTextAtBoundary,
                         boundarySessionID: boundary.streamSessionIDAtBoundary,
                         resumedSessionID: result.sessionId,
+                        acceptedSessionIDs: acceptedSessionIDs,
+                        after: messages
+                    )
+                    coveredText = Self.reconciliationBoundaryCoverageText(
+                        boundaryText: boundary.streamTextAtBoundary,
+                        boundarySessionID: boundary.streamSessionIDAtBoundary,
+                        resumedSessionID: result.sessionId,
+                        acceptedSessionIDs: acceptedSessionIDs,
+                        snapshotInflightText: result.snapshot.inflightAssistantText,
                         after: messages
                     )
                 } else {
                     knownPrefix = nil
+                    coveredText = nil
                 }
 
                 // The live bubble was just seeded from the cumulative inflight
@@ -2331,7 +2352,9 @@ final class AppState: ObservableObject {
                     bufferedEvents,
                     againstInflight: resumedInflightText,
                     knownPrefix: knownPrefix,
-                    sessionID: result.sessionId
+                    sessionID: result.sessionId,
+                    acceptedSessionIDs: acceptedSessionIDs,
+                    coveredText: coveredText
                 )
             }
             bufferedEvents.forEach(applyStreamEvent)
@@ -2698,34 +2721,85 @@ final class AppState: ObservableObject {
         boundaryText: String?,
         boundarySessionID: String?,
         resumedSessionID: String,
+        acceptedSessionIDs: Set<String>,
         after messages: [ChatMessage]
     ) -> String? {
         guard let boundaryText,
               let boundarySessionID,
               !boundarySessionID.isEmpty,
-              boundarySessionID == resumedSessionID else {
+              acceptedSessionIDs.contains(boundarySessionID),
+              acceptedSessionIDs.contains(resumedSessionID) else {
             return nil
         }
         return unpersistedInflightAssistantText(boundaryText, after: messages)
+    }
+
+    nonisolated static func reconciliationBoundaryCoverageText(
+        boundaryText: String?,
+        boundarySessionID: String?,
+        resumedSessionID: String,
+        acceptedSessionIDs: Set<String>,
+        snapshotInflightText: String,
+        after messages: [ChatMessage]
+    ) -> String? {
+        guard let boundaryText,
+              let boundarySessionID,
+              !boundarySessionID.isEmpty,
+              acceptedSessionIDs.contains(boundarySessionID),
+              acceptedSessionIDs.contains(resumedSessionID) else {
+            return nil
+        }
+
+        let normalizedBoundaryText = boundaryText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedSnapshotText = snapshotInflightText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalizedSnapshotText.hasPrefix(normalizedBoundaryText) {
+            return String(normalizedSnapshotText.dropFirst(normalizedBoundaryText.count))
+        }
+
+        let normalizedUnpersistedBoundary = unpersistedInflightAssistantText(
+            boundaryText,
+            after: messages
+        )
+        let normalizedUnpersistedSnapshot = unpersistedInflightAssistantText(
+            snapshotInflightText,
+            after: messages
+        )
+        guard normalizedUnpersistedSnapshot.hasPrefix(normalizedUnpersistedBoundary) else {
+            return nil
+        }
+        return String(
+            normalizedUnpersistedSnapshot.dropFirst(normalizedUnpersistedBoundary.count)
+        )
     }
 
     nonisolated static func deduplicatingBufferedEvents(
         _ events: [StreamEvent],
         againstInflight inflight: String,
         knownPrefix: String?,
-        sessionID: String
+        sessionID: String,
+        acceptedSessionIDs: Set<String> = [],
+        coveredText explicitCoveredText: String? = nil
     ) -> [StreamEvent] {
-        let normalizedInflight = inflight.trimmingCharacters(in: .whitespacesAndNewlines)
-        let normalizedKnownPrefix = knownPrefix?.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let normalizedKnownPrefix,
-              normalizedInflight.hasPrefix(normalizedKnownPrefix) else {
-            return events
+        let coveredText: String
+        if let explicitCoveredText {
+            coveredText = explicitCoveredText
+        } else {
+            guard let knownPrefix else { return events }
+            if inflight.hasPrefix(knownPrefix) {
+                coveredText = String(inflight.dropFirst(knownPrefix.count))
+            } else {
+                let normalizedInflight = inflight.trimmingCharacters(in: .whitespacesAndNewlines)
+                let normalizedKnownPrefix = knownPrefix.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard normalizedInflight.hasPrefix(normalizedKnownPrefix) else {
+                    return events
+                }
+                coveredText = String(
+                    normalizedInflight.dropFirst(normalizedKnownPrefix.count)
+                )
+            }
         }
-
-        let coveredText = String(
-            normalizedInflight.dropFirst(normalizedKnownPrefix.count)
-        ).trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !coveredText.isEmpty else { return events }
+        let normalizedCoveredText = coveredText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedCoveredText.isEmpty else { return events }
 
         let bufferedDeltaTexts = events.compactMap { event in
             if case .messageDelta(_, let text) = event {
@@ -2741,8 +2815,12 @@ final class AppState: ObservableObject {
             }
             return nil
         })
+        let allowedSessionIDs = acceptedSessionIDs.isEmpty
+            ? Set([sessionID])
+            : acceptedSessionIDs
         guard deltaSessionIDs.count == 1,
-              deltaSessionIDs.first == sessionID else {
+              let deltaSessionID = deltaSessionIDs.first,
+              allowedSessionIDs.contains(deltaSessionID) else {
             return events
         }
 
@@ -2751,12 +2829,20 @@ final class AppState: ObservableObject {
         guard !normalizedBufferedDeltaText.isEmpty else { return events }
 
         let coveredRawCharacters: Int
-        if normalizedBufferedDeltaText == coveredText {
+        if normalizedBufferedDeltaText == normalizedCoveredText {
             coveredRawCharacters = bufferedDeltaText.count
-        } else if normalizedBufferedDeltaText.hasPrefix(coveredText) {
+        } else if normalizedBufferedDeltaText.hasPrefix(normalizedCoveredText) {
             let leadingWhitespaceCount = bufferedDeltaText.prefix { $0.isWhitespace }.count
-            coveredRawCharacters = leadingWhitespaceCount + coveredText.count
-        } else if coveredText.hasPrefix(normalizedBufferedDeltaText) {
+            let coveredEnd = leadingWhitespaceCount + normalizedCoveredText.count
+            let coveredTrailingWhitespaceCount = coveredText.reversed().prefix { $0.isWhitespace }.count
+            let bufferedTrailingWhitespaceCount = bufferedDeltaText.dropFirst(coveredEnd)
+                .prefix { $0.isWhitespace }
+                .count
+            coveredRawCharacters = coveredEnd + min(
+                coveredTrailingWhitespaceCount,
+                bufferedTrailingWhitespaceCount
+            )
+        } else if normalizedCoveredText.hasPrefix(normalizedBufferedDeltaText) {
             coveredRawCharacters = bufferedDeltaText.count
         } else {
             return events

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2795,6 +2795,25 @@ final class AppState: ObservableObject {
     ) -> [StreamEvent] {
         let coveredText: String
         if let explicitCoveredText {
+            guard let knownPrefix else { return events }
+            let normalizedInflight = inflight.trimmingCharacters(in: .whitespacesAndNewlines)
+            let normalizedKnownPrefix = knownPrefix.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard normalizedInflight.hasPrefix(normalizedKnownPrefix) else {
+                return events
+            }
+            let expectedCoveredText = String(
+                normalizedInflight.dropFirst(normalizedKnownPrefix.count)
+            )
+            let normalizedExplicitCoveredText = explicitCoveredText
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let explicitCoverageOverlapsSeededText = Self.suffixPrefixOverlapLengths(
+                covered: normalizedExplicitCoveredText,
+                buffered: expectedCoveredText
+            )
+            guard !expectedCoveredText.isEmpty,
+                  explicitCoverageOverlapsSeededText.count == 1 else {
+                return events
+            }
             coveredText = explicitCoveredText
         } else {
             guard let knownPrefix else { return events }
@@ -2835,6 +2854,26 @@ final class AppState: ObservableObject {
               let deltaSessionID = deltaSessionIDs.first,
               allowedSessionIDs.contains(deltaSessionID) else {
             return events
+        }
+
+        if let newTurnIndex = events.firstIndex(where: { event in
+            guard case .messageStart(let startSessionID) = event else { return false }
+            return allowedSessionIDs.contains(startSessionID)
+        }) {
+            // A message start observed after the reconciliation boundary is
+            // an explicit new-turn marker. Deduplicate any older buffered
+            // events, but preserve the marker and everything after it because
+            // the same text can be fresh content from the new turn.
+            let eventsBeforeNewTurn = Array(events[..<newTurnIndex])
+            let eventsAfterNewTurn = Array(events[newTurnIndex...])
+            return deduplicatingBufferedEvents(
+                eventsBeforeNewTurn,
+                againstInflight: inflight,
+                knownPrefix: knownPrefix,
+                sessionID: sessionID,
+                acceptedSessionIDs: acceptedSessionIDs,
+                coveredText: explicitCoveredText
+            ) + eventsAfterNewTurn
         }
 
         let bufferedDeltaText = bufferedDeltaTexts.joined()

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2315,6 +2315,12 @@ final class AppState: ObservableObject {
                 let acceptedSessionIDs: Set<String>
                 if let boundary,
                    let boundarySessionID = boundary.streamSessionIDAtBoundary {
+                    // Do not infer that a newly returned runtime ID belongs
+                    // to this boundary solely because the resume RPC returned
+                    // it. Keep only IDs already accepted for the boundary and
+                    // known as aliases of that catalog session; an empty
+                    // result intentionally disables deduplication rather than
+                    // risking text from a different session.
                     acceptedSessionIDs = boundary.acceptedSessionIDs.intersection(
                         knownSessionIDs(for: boundarySessionID)
                     )
@@ -2713,10 +2719,12 @@ final class AppState: ObservableObject {
     /// in the resume snapshot's cumulative `inflight` projection — replaying
     /// them on top of the seeded live bubble repeats that text. When the exact
     /// stream text at the matching session boundary is known, consume only the
-    /// corresponding prefix of the buffered deltas. Edge whitespace is ignored
+    /// corresponding span of the buffered deltas. Edge whitespace is ignored
     /// consistently with resume seeding, and the raw covered count preserves
-    /// event order when deltas carry that whitespace. Without a matching
-    /// boundary or session, repeated text is ambiguous, so leave events intact.
+    /// event order when deltas carry that whitespace. Interior whitespace is
+    /// not rewritten: a mismatch may be real content, so leave it intact.
+    /// Without a matching boundary or session, repeated text is ambiguous, so
+    /// leave events intact.
     nonisolated static func normalizedReconciliationBoundaryPrefix(
         boundaryText: String?,
         boundarySessionID: String?,
@@ -2843,6 +2851,12 @@ final class AppState: ObservableObject {
                 bufferedTrailingWhitespaceCount
             )
         } else if normalizedCoveredText.hasPrefix(normalizedBufferedDeltaText) {
+            coveredRawCharacters = bufferedDeltaText.count
+        } else if normalizedCoveredText.hasSuffix(normalizedBufferedDeltaText) {
+            // A reconnect can leave the local boundary behind a persisted
+            // portion of the turn. In that case the buffered window may begin
+            // in the middle of the covered span; consume it only when the
+            // entire buffered text is the covered span's suffix.
             coveredRawCharacters = bufferedDeltaText.count
         } else {
             return events

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2859,7 +2859,13 @@ final class AppState: ObservableObject {
             // entire buffered text is the covered span's suffix.
             coveredRawCharacters = bufferedDeltaText.count
         } else {
-            return events
+            let overlap = Self.longestSuffixPrefixOverlapLength(
+                covered: normalizedCoveredText,
+                buffered: normalizedBufferedDeltaText
+            )
+            guard overlap > 0 else { return events }
+            let leadingWhitespaceCount = bufferedDeltaText.prefix { $0.isWhitespace }.count
+            coveredRawCharacters = leadingWhitespaceCount + overlap
         }
 
         var remainingCoverage = coveredRawCharacters
@@ -2887,6 +2893,43 @@ final class AppState: ObservableObject {
             }
         }
         return deduplicated
+    }
+
+    /// Returns the longest prefix of `buffered` that is also a suffix of
+    /// `covered`. The prefix-function scan stays linear in the cumulative
+    /// projection size while preserving the boundary-derived alignment rule.
+    nonisolated static func longestSuffixPrefixOverlapLength(
+        covered: String,
+        buffered: String
+    ) -> Int {
+        let pattern = Array(buffered)
+        guard !pattern.isEmpty, !covered.isEmpty else { return 0 }
+
+        var prefixLengths = Array(repeating: 0, count: pattern.count)
+        var prefixLength = 0
+        for index in 1..<pattern.count {
+            while prefixLength > 0, pattern[index] != pattern[prefixLength] {
+                prefixLength = prefixLengths[prefixLength - 1]
+            }
+            if pattern[index] == pattern[prefixLength] {
+                prefixLength += 1
+            }
+            prefixLengths[index] = prefixLength
+        }
+
+        var matched = 0
+        for character in covered {
+            while matched > 0, pattern[matched] != character {
+                matched = prefixLengths[matched - 1]
+            }
+            if pattern[matched] == character {
+                matched += 1
+            }
+            if matched == pattern.count {
+                matched = prefixLengths[matched - 1]
+            }
+        }
+        return matched
     }
 
     /// `session.resume.inflight` is a cumulative projection on some gateways.

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2286,11 +2286,21 @@ final class AppState: ObservableObject {
                 return false
             }
 
-            let bufferedEvents = reconciliation?.token == token
+            var bufferedEvents = reconciliation?.token == token
                 ? (reconciliation?.bufferedEvents ?? []).filter {
                     reconciliation?.accepts(sessionID(for: $0)) == true
                 }
                 : []
+            if result.snapshot.hasLiveProjection {
+                // The live bubble was just seeded from the cumulative inflight
+                // projection, which already includes deltas emitted while this
+                // reconciliation was in flight. Replaying them verbatim repeats
+                // that text in the bubble.
+                bufferedEvents = Self.deduplicatingBufferedEvents(
+                    bufferedEvents,
+                    againstInflight: result.snapshot.inflightAssistantText
+                )
+            }
             bufferedEvents.forEach(applyStreamEvent)
             return settleReconciliationAndPublish(
                 token,
@@ -2641,6 +2651,61 @@ final class AppState: ObservableObject {
                 messages[index].approval = approval
             }
         }
+    }
+
+    /// Deltas buffered while reconciliation ran are usually already contained
+    /// in the resume snapshot's cumulative `inflight` projection — replaying
+    /// them on top of the seeded live bubble repeats that text. Collapse the
+    /// buffered deltas to the suffix the snapshot has not covered yet (their
+    /// concatenation overlaps the snapshot's tail), emitted as a single delta
+    /// in place of the last buffered one. Non-delta events pass through.
+    nonisolated static func deduplicatingBufferedEvents(
+        _ events: [StreamEvent],
+        againstInflight inflight: String
+    ) -> [StreamEvent] {
+        guard !inflight.isEmpty else { return events }
+        let deltaTexts: [String] = events.compactMap {
+            if case .messageDelta(_, let text) = $0 { return text }
+            return nil
+        }
+        guard !deltaTexts.isEmpty else { return events }
+
+        let combined = deltaTexts.joined()
+        let covered = overlapLength(betweenSuffixOf: inflight, andPrefixOf: combined)
+        let remainder = String(combined.dropFirst(covered))
+        guard remainder.count < combined.count else { return events }
+
+        let lastDeltaIndex = events.lastIndex {
+            if case .messageDelta = $0 { return true }
+            return false
+        }
+        var deduplicated: [StreamEvent] = []
+        for (index, event) in events.enumerated() {
+            guard case .messageDelta(let sessionId, _) = event else {
+                deduplicated.append(event)
+                continue
+            }
+            if index == lastDeltaIndex, !remainder.isEmpty {
+                deduplicated.append(.messageDelta(sessionId: sessionId, text: remainder))
+            }
+        }
+        return deduplicated
+    }
+
+    /// Longest `k` where the last `k` characters of `text` equal the first
+    /// `k` characters of `candidate`. The buffered stream is contiguous, so
+    /// the snapshot's tail and the buffer's head meet at exactly one offset.
+    nonisolated static func overlapLength(betweenSuffixOf text: String, andPrefixOf candidate: String) -> Int {
+        let textChars = Array(text)
+        let candidateChars = Array(candidate)
+        var k = min(textChars.count, candidateChars.count)
+        while k > 0 {
+            if textChars.suffix(k).elementsEqual(candidateChars.prefix(k)) {
+                return k
+            }
+            k -= 1
+        }
+        return 0
     }
 
     /// `session.resume.inflight` is a cumulative projection on some gateways.

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2707,6 +2707,14 @@ final class AppState: ObservableObject {
         let covered = inflight.count - knownPrefix.count
         guard covered > 0 else { return events }
 
+        let bufferedDeltaTexts = events.compactMap { event in
+            if case .messageDelta(_, let text) = event {
+                return text
+            }
+            return nil
+        }
+        guard !bufferedDeltaTexts.isEmpty else { return events }
+
         let deltaSessionIDs = Set(events.compactMap { event in
             if case .messageDelta(let sessionId, _) = event {
                 return sessionId
@@ -2714,6 +2722,13 @@ final class AppState: ObservableObject {
             return nil
         })
         guard deltaSessionIDs.count == 1 else {
+            return events
+        }
+
+        let bufferedDeltaText = bufferedDeltaTexts.joined()
+        let inflightSuffix = String(inflight.dropFirst(knownPrefix.count))
+        guard bufferedDeltaText.hasPrefix(inflightSuffix)
+                || inflightSuffix.hasPrefix(bufferedDeltaText) else {
             return events
         }
 

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2289,9 +2289,6 @@ final class AppState: ObservableObject {
                 settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
                 return false
             }
-            let resumedInflightText = result.snapshot.hasLiveProjection
-                ? streamingBuffer
-                : nil
             await refreshChatResumeContext(sessionId: result.sessionId, using: client)
 
             guard automaticChatResumeWorkIsCurrent(
@@ -2313,15 +2310,15 @@ final class AppState: ObservableObject {
                 }
                 : []
             if result.snapshot.hasLiveProjection {
+                let resumedInflightText = streamingBuffer
                 let knownPrefix: String?
-                if let boundary = reconciliation,
-                   boundary.token == token,
-                   let boundarySessionID = boundary.streamSessionIDAtBoundary,
-                   !boundarySessionID.isEmpty,
-                   (boundarySessionID == result.sessionId
-                    || boundarySessionID == boundary.requestedSessionId
-                    || boundary.acceptedSessionIDs.contains(boundarySessionID)) {
-                    knownPrefix = boundary.streamTextAtBoundary
+                if let boundary = reconciliation, boundary.token == token {
+                    knownPrefix = Self.normalizedReconciliationBoundaryPrefix(
+                        boundaryText: boundary.streamTextAtBoundary,
+                        boundarySessionID: boundary.streamSessionIDAtBoundary,
+                        resumedSessionID: result.sessionId,
+                        after: messages
+                    )
                 } else {
                     knownPrefix = nil
                 }
@@ -2329,11 +2326,12 @@ final class AppState: ObservableObject {
                 // The live bubble was just seeded from the cumulative inflight
                 // projection, which already includes deltas emitted while this
                 // reconciliation was in flight. Replay only the portion beyond
-                // the exact text captured at the reconciliation boundary.
+                // the normalized text captured at the same session boundary.
                 bufferedEvents = Self.deduplicatingBufferedEvents(
                     bufferedEvents,
-                    againstInflight: resumedInflightText ?? "",
-                    knownPrefix: knownPrefix
+                    againstInflight: resumedInflightText,
+                    knownPrefix: knownPrefix,
+                    sessionID: result.sessionId
                 )
             }
             bufferedEvents.forEach(applyStreamEvent)
@@ -2691,21 +2689,43 @@ final class AppState: ObservableObject {
     /// Deltas buffered while reconciliation ran are usually already contained
     /// in the resume snapshot's cumulative `inflight` projection — replaying
     /// them on top of the seeded live bubble repeats that text. When the exact
-    /// stream text at the reconciliation boundary is known, consume only the
-    /// corresponding prefix of the buffered deltas. Without that boundary,
-    /// repeated text is ambiguous, so leave the events untouched.
+    /// stream text at the matching session boundary is known, consume only the
+    /// corresponding prefix of the buffered deltas. Edge whitespace is ignored
+    /// consistently with resume seeding, and the raw covered count preserves
+    /// event order when deltas carry that whitespace. Without a matching
+    /// boundary or session, repeated text is ambiguous, so leave events intact.
+    nonisolated static func normalizedReconciliationBoundaryPrefix(
+        boundaryText: String?,
+        boundarySessionID: String?,
+        resumedSessionID: String,
+        after messages: [ChatMessage]
+    ) -> String? {
+        guard let boundaryText,
+              let boundarySessionID,
+              !boundarySessionID.isEmpty,
+              boundarySessionID == resumedSessionID else {
+            return nil
+        }
+        return unpersistedInflightAssistantText(boundaryText, after: messages)
+    }
+
     nonisolated static func deduplicatingBufferedEvents(
         _ events: [StreamEvent],
         againstInflight inflight: String,
-        knownPrefix: String?
+        knownPrefix: String?,
+        sessionID: String
     ) -> [StreamEvent] {
-        guard let knownPrefix,
-              inflight.hasPrefix(knownPrefix) else {
+        let normalizedInflight = inflight.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedKnownPrefix = knownPrefix?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let normalizedKnownPrefix,
+              normalizedInflight.hasPrefix(normalizedKnownPrefix) else {
             return events
         }
 
-        let covered = inflight.count - knownPrefix.count
-        guard covered > 0 else { return events }
+        let coveredText = String(
+            normalizedInflight.dropFirst(normalizedKnownPrefix.count)
+        ).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !coveredText.isEmpty else { return events }
 
         let bufferedDeltaTexts = events.compactMap { event in
             if case .messageDelta(_, let text) = event {
@@ -2721,18 +2741,28 @@ final class AppState: ObservableObject {
             }
             return nil
         })
-        guard deltaSessionIDs.count == 1 else {
+        guard deltaSessionIDs.count == 1,
+              deltaSessionIDs.first == sessionID else {
             return events
         }
 
         let bufferedDeltaText = bufferedDeltaTexts.joined()
-        let inflightSuffix = String(inflight.dropFirst(knownPrefix.count))
-        guard bufferedDeltaText.hasPrefix(inflightSuffix)
-                || inflightSuffix.hasPrefix(bufferedDeltaText) else {
+        let normalizedBufferedDeltaText = bufferedDeltaText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedBufferedDeltaText.isEmpty else { return events }
+
+        let coveredRawCharacters: Int
+        if normalizedBufferedDeltaText == coveredText {
+            coveredRawCharacters = bufferedDeltaText.count
+        } else if normalizedBufferedDeltaText.hasPrefix(coveredText) {
+            let leadingWhitespaceCount = bufferedDeltaText.prefix { $0.isWhitespace }.count
+            coveredRawCharacters = leadingWhitespaceCount + coveredText.count
+        } else if coveredText.hasPrefix(normalizedBufferedDeltaText) {
+            coveredRawCharacters = bufferedDeltaText.count
+        } else {
             return events
         }
 
-        var remainingCoverage = covered
+        var remainingCoverage = coveredRawCharacters
         var deduplicated: [StreamEvent] = []
         deduplicated.reserveCapacity(events.count)
         for event in events {
@@ -2763,7 +2793,7 @@ final class AppState: ObservableObject {
     /// When its already-persisted prefix is also present in the recovered
     /// transcript, rendering it as the live bubble repeats the last reply.
     /// Keep only the unpersisted suffix so the next delta continues naturally.
-    static func unpersistedInflightAssistantText(
+    nonisolated static func unpersistedInflightAssistantText(
         _ inflight: String,
         after messages: [ChatMessage]
     ) -> String {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2365,7 +2365,10 @@ final class AppState: ObservableObject {
                     knownPrefix: knownPrefix,
                     sessionID: result.sessionId,
                     acceptedSessionIDs: acceptedSessionIDs,
-                    coveredText: coveredText
+                    coveredText: coveredText,
+                    hasBoundaryAnchor: boundary?.streamTextAtBoundary?
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                        .isEmpty == false
                 )
             }
             bufferedEvents.forEach(applyStreamEvent)
@@ -2791,7 +2794,8 @@ final class AppState: ObservableObject {
         knownPrefix: String?,
         sessionID: String,
         acceptedSessionIDs: Set<String> = [],
-        coveredText explicitCoveredText: String? = nil
+        coveredText explicitCoveredText: String? = nil,
+        hasBoundaryAnchor: Bool = false
     ) -> [StreamEvent] {
         let coveredText: String
         if let explicitCoveredText {
@@ -2872,8 +2876,17 @@ final class AppState: ObservableObject {
                 knownPrefix: knownPrefix,
                 sessionID: sessionID,
                 acceptedSessionIDs: acceptedSessionIDs,
-                coveredText: explicitCoveredText
+                coveredText: explicitCoveredText,
+                hasBoundaryAnchor: hasBoundaryAnchor
             ) + eventsAfterNewTurn
+        }
+
+        guard hasBoundaryAnchor else {
+            // Content equality cannot distinguish a fresh turn that happens
+            // to repeat the snapshot. Without a non-empty stream boundary (or
+            // the explicit message-start marker above), preserve the events
+            // rather than risking loss of genuinely new text.
+            return events
         }
 
         let bufferedDeltaText = bufferedDeltaTexts.joined()

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -407,6 +407,8 @@ final class AppState: ObservableObject {
         var resolvedSessionId: String?
         var acceptedSessionIDs: Set<String>
         let acceptsAnySession: Bool
+        let streamTextAtBoundary: String?
+        let streamSessionIDAtBoundary: String?
         var bufferedEvents: [StreamEvent] = []
 
         init(
@@ -415,6 +417,8 @@ final class AppState: ObservableObject {
             automaticSyncOperationID: UUID? = nil,
             acceptedSessionIDs: Set<String> = [],
             acceptsAnySession: Bool = false,
+            streamTextAtBoundary: String? = nil,
+            streamSessionIDAtBoundary: String? = nil,
             bufferedEvents: [StreamEvent] = []
         ) {
             self.token = token
@@ -422,6 +426,8 @@ final class AppState: ObservableObject {
             self.automaticSyncOperationID = automaticSyncOperationID
             self.acceptedSessionIDs = acceptedSessionIDs
             self.acceptsAnySession = acceptsAnySession
+            self.streamTextAtBoundary = streamTextAtBoundary
+            self.streamSessionIDAtBoundary = streamSessionIDAtBoundary
             self.bufferedEvents = bufferedEvents
         }
 
@@ -2010,11 +2016,22 @@ final class AppState: ObservableObject {
     func beginReconciliation() -> UUID {
         let token = UUID()
         let bufferedEvents = reconciliation?.bufferedEvents ?? []
+        let streamTextAtBoundary: String?
+        let streamSessionIDAtBoundary: String?
+        if let existingReconciliation = reconciliation {
+            streamTextAtBoundary = existingReconciliation.streamTextAtBoundary
+            streamSessionIDAtBoundary = existingReconciliation.streamSessionIDAtBoundary
+        } else {
+            streamTextAtBoundary = activeSessionId.map { _ in streamingBuffer }
+            streamSessionIDAtBoundary = activeSessionId
+        }
         reconciliationToken = token
         reconciliation = Reconciliation(
             token: token,
             requestedSessionId: activeSessionId ?? "",
             acceptsAnySession: true,
+            streamTextAtBoundary: streamTextAtBoundary,
+            streamSessionIDAtBoundary: streamSessionIDAtBoundary,
             bufferedEvents: bufferedEvents
         )
         refreshActiveChatScrollSessionIdentity(isReconciling: true)
@@ -2176,14 +2193,15 @@ final class AppState: ObservableObject {
         ), chatViewportTransitionIsCurrent(requiredViewportTransitionGeneration) else {
             return false
         }
-        let bufferedEvents = reconciliation?.token == token
-            ? reconciliation?.bufferedEvents ?? []
-            : []
+        let priorReconciliation = reconciliation?.token == token ? reconciliation : nil
+        let bufferedEvents = priorReconciliation?.bufferedEvents ?? []
         reconciliation = Reconciliation(
             token: token,
             requestedSessionId: sessionId,
             automaticSyncOperationID: automaticSyncOperationID,
             acceptedSessionIDs: acceptedSessionIDs.union([sessionId]),
+            streamTextAtBoundary: priorReconciliation?.streamTextAtBoundary,
+            streamSessionIDAtBoundary: priorReconciliation?.streamSessionIDAtBoundary,
             bufferedEvents: bufferedEvents
         )
         refreshActiveChatScrollSessionIdentity(isReconciling: true)
@@ -2271,6 +2289,9 @@ final class AppState: ObservableObject {
                 settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
                 return false
             }
+            let resumedInflightText = result.snapshot.hasLiveProjection
+                ? streamingBuffer
+                : nil
             await refreshChatResumeContext(sessionId: result.sessionId, using: client)
 
             guard automaticChatResumeWorkIsCurrent(
@@ -2292,13 +2313,27 @@ final class AppState: ObservableObject {
                 }
                 : []
             if result.snapshot.hasLiveProjection {
+                let knownPrefix: String?
+                if let boundary = reconciliation,
+                   boundary.token == token,
+                   let boundarySessionID = boundary.streamSessionIDAtBoundary,
+                   !boundarySessionID.isEmpty,
+                   (boundarySessionID == result.sessionId
+                    || boundarySessionID == boundary.requestedSessionId
+                    || boundary.acceptedSessionIDs.contains(boundarySessionID)) {
+                    knownPrefix = boundary.streamTextAtBoundary
+                } else {
+                    knownPrefix = nil
+                }
+
                 // The live bubble was just seeded from the cumulative inflight
                 // projection, which already includes deltas emitted while this
-                // reconciliation was in flight. Replaying them verbatim repeats
-                // that text in the bubble.
+                // reconciliation was in flight. Replay only the portion beyond
+                // the exact text captured at the reconciliation boundary.
                 bufferedEvents = Self.deduplicatingBufferedEvents(
                     bufferedEvents,
-                    againstInflight: result.snapshot.inflightAssistantText
+                    againstInflight: resumedInflightText ?? "",
+                    knownPrefix: knownPrefix
                 )
             }
             bufferedEvents.forEach(applyStreamEvent)
@@ -2655,57 +2690,58 @@ final class AppState: ObservableObject {
 
     /// Deltas buffered while reconciliation ran are usually already contained
     /// in the resume snapshot's cumulative `inflight` projection — replaying
-    /// them on top of the seeded live bubble repeats that text. Collapse the
-    /// buffered deltas to the suffix the snapshot has not covered yet (their
-    /// concatenation overlaps the snapshot's tail), emitted as a single delta
-    /// in place of the last buffered one. Non-delta events pass through.
+    /// them on top of the seeded live bubble repeats that text. When the exact
+    /// stream text at the reconciliation boundary is known, consume only the
+    /// corresponding prefix of the buffered deltas. Without that boundary,
+    /// repeated text is ambiguous, so leave the events untouched.
     nonisolated static func deduplicatingBufferedEvents(
         _ events: [StreamEvent],
-        againstInflight inflight: String
+        againstInflight inflight: String,
+        knownPrefix: String?
     ) -> [StreamEvent] {
-        guard !inflight.isEmpty else { return events }
-        let deltaTexts: [String] = events.compactMap {
-            if case .messageDelta(_, let text) = $0 { return text }
+        guard let knownPrefix,
+              inflight.hasPrefix(knownPrefix) else {
+            return events
+        }
+
+        let covered = inflight.count - knownPrefix.count
+        guard covered > 0 else { return events }
+
+        let deltaSessionIDs = Set(events.compactMap { event in
+            if case .messageDelta(let sessionId, _) = event {
+                return sessionId
+            }
             return nil
+        })
+        guard deltaSessionIDs.count == 1 else {
+            return events
         }
-        guard !deltaTexts.isEmpty else { return events }
 
-        let combined = deltaTexts.joined()
-        let covered = overlapLength(betweenSuffixOf: inflight, andPrefixOf: combined)
-        let remainder = String(combined.dropFirst(covered))
-        guard remainder.count < combined.count else { return events }
-
-        let lastDeltaIndex = events.lastIndex {
-            if case .messageDelta = $0 { return true }
-            return false
-        }
+        var remainingCoverage = covered
         var deduplicated: [StreamEvent] = []
-        for (index, event) in events.enumerated() {
-            guard case .messageDelta(let sessionId, _) = event else {
+        deduplicated.reserveCapacity(events.count)
+        for event in events {
+            guard case .messageDelta(let sessionId, let text) = event else {
                 deduplicated.append(event)
                 continue
             }
-            if index == lastDeltaIndex, !remainder.isEmpty {
+            guard remainingCoverage > 0 else {
+                deduplicated.append(event)
+                continue
+            }
+
+            let consumed = min(remainingCoverage, text.count)
+            guard consumed > 0 else {
+                deduplicated.append(event)
+                continue
+            }
+            remainingCoverage -= consumed
+            let remainder = String(text.dropFirst(consumed))
+            if !remainder.isEmpty {
                 deduplicated.append(.messageDelta(sessionId: sessionId, text: remainder))
             }
         }
         return deduplicated
-    }
-
-    /// Longest `k` where the last `k` characters of `text` equal the first
-    /// `k` characters of `candidate`. The buffered stream is contiguous, so
-    /// the snapshot's tail and the buffer's head meet at exactly one offset.
-    nonisolated static func overlapLength(betweenSuffixOf text: String, andPrefixOf candidate: String) -> Int {
-        let textChars = Array(text)
-        let candidateChars = Array(candidate)
-        var k = min(textChars.count, candidateChars.count)
-        while k > 0 {
-            if textChars.suffix(k).elementsEqual(candidateChars.prefix(k)) {
-                return k
-            }
-            k -= 1
-        }
-        return 0
     }
 
     /// `session.resume.inflight` is a cumulative projection on some gateways.

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -304,6 +304,64 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertEqual(harness.appState.streamingText, "C")
     }
 
+    func testResumeDedupKeepsOnlyNewTextWhenBufferedWindowStraddlesCoverage() async {
+        let openGate = ControlledSuspension()
+        let active = session("stored-a")
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID in
+                    await openGate.suspend()
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [
+                            ChatMessage(
+                                id: "persisted-assistant",
+                                role: .assistant,
+                                content: "AB",
+                                timestamp: "1"
+                            )
+                        ],
+                        snapshot: SessionRuntimeSnapshot(
+                            object: [:],
+                            inflight: .object([
+                                "assistant": .string("ABCD")
+                            ])
+                        )
+                    )
+                },
+                refreshContext: { _, _ in }
+            )
+        )
+        installComposerClient(in: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        harness.appState.handleStreamEvent(
+            .messageDelta(sessionId: active.id, text: "A")
+        )
+
+        let refresh = Task { @MainActor in
+            await harness.appState.refreshActiveSession()
+        }
+        await openGate.waitUntilSuspended()
+        harness.appState.handleStreamEvent(
+            .messageDelta(sessionId: active.id, text: "CDE")
+        )
+        harness.appState.handleStreamEvent(
+            .toolStart(sessionId: active.id, toolName: "Bash", toolInput: "ls")
+        )
+        openGate.resume()
+        await refresh.value
+
+        harness.appState.showSidebar = true
+        harness.appState.showSidebar = false
+        let partials = harness.appState.messages.filter { $0.role == .partial }
+        let toolIndex = harness.appState.messages.firstIndex { $0.role == .tool }
+        let partialIndex = harness.appState.messages.firstIndex { $0.role == .partial }
+        XCTAssertEqual(partials.map(\.content), ["CDE"])
+        XCTAssertEqual(toolIndex, partialIndex.map { $0 + 1 })
+    }
+
     func testResumeDedupAcceptsAlternateSessionIDForBufferedDelta() async {
         let openGate = ControlledSuspension()
         let active = session("stored-a", alternateIDs: ["runtime-a"])

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -182,6 +182,47 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertEqual(harness.appState.streamingText, "I found it.")
     }
 
+    func testResumeDedupPreservesNoMarkerCollisionWithoutBoundaryText() async {
+        let openGate = ControlledSuspension()
+        let active = session("stored-a")
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID in
+                    await openGate.suspend()
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(
+                            object: [:],
+                            inflight: .object([
+                                "assistant": .string("xyz")
+                            ])
+                        )
+                    )
+                },
+                refreshContext: { _, _ in }
+            )
+        )
+        installComposerClient(in: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+
+        let refresh = Task { @MainActor in
+            await harness.appState.refreshActiveSession()
+        }
+        await openGate.waitUntilSuspended()
+        harness.appState.handleStreamEvent(
+            .messageDelta(sessionId: active.id, text: "xyz more")
+        )
+        openGate.resume()
+        await refresh.value
+
+        harness.appState.showSidebar = true
+        harness.appState.showSidebar = false
+        XCTAssertEqual(harness.appState.streamingText, "xyzxyz more")
+    }
+
     func testResumeDedupHandlesBoundaryLagWithInterleavedToolEvent() async {
         let openGate = ControlledSuspension()
         let active = session("stored-a")

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -120,6 +120,112 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertFalse(harness.appState.activeChatScrollSessionIdentity.isReconciling)
     }
 
+    func testResumeDedupNormalizesPersistedBoundaryBeforeReplayingBufferedDelta() async {
+        let openGate = ControlledSuspension()
+        let active = session("stored-a")
+        let persistedText = "Let me find the transcript."
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID in
+                    await openGate.suspend()
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [
+                            ChatMessage(
+                                id: "persisted-assistant",
+                                role: .assistant,
+                                content: persistedText,
+                                timestamp: "1"
+                            )
+                        ],
+                        snapshot: SessionRuntimeSnapshot(
+                            object: [:],
+                            inflight: .object([
+                                "assistant": .string("\(persistedText) I found it.")
+                            ])
+                        )
+                    )
+                },
+                refreshContext: { _, _ in }
+            )
+        )
+        installComposerClient(in: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        harness.appState.messages = [
+            ChatMessage(
+                id: "persisted-assistant",
+                role: .assistant,
+                content: persistedText,
+                timestamp: "1"
+            )
+        ]
+        harness.appState.handleStreamEvent(
+            .messageDelta(sessionId: active.id, text: persistedText)
+        )
+
+        let refresh = Task { @MainActor in
+            await harness.appState.refreshActiveSession()
+        }
+        await openGate.waitUntilSuspended()
+        harness.appState.handleStreamEvent(
+            .messageDelta(sessionId: active.id, text: " I found it.")
+        )
+        openGate.resume()
+        await refresh.value
+
+        // Force the authoritative streaming buffer into the published test
+        // projection so a wrongly replayed buffered delta is observable.
+        harness.appState.showSidebar = true
+        harness.appState.showSidebar = false
+        XCTAssertEqual(harness.appState.streamingText, "I found it.")
+    }
+
+    func testResumeDoesNotUsePreviousSessionBoundaryForNewSessionDelta() async {
+        let contextGate = ControlledSuspension()
+        let previous = session("stored-old")
+        let resumedSessionID = "runtime-new"
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [previous] },
+                openSession: { _, _ in
+                    return SessionResumeResult(
+                        sessionId: resumedSessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(
+                            object: [:],
+                            inflight: .object([
+                                "assistant": .string("Okay next")
+                            ])
+                        )
+                    )
+                },
+                refreshContext: { _, _ in await contextGate.suspend() }
+            )
+        )
+        installComposerClient(in: harness)
+        harness.appState.sessions = [previous]
+        harness.appState.activeSessionId = previous.id
+        harness.appState.handleStreamEvent(
+            .messageDelta(sessionId: previous.id, text: "Okay")
+        )
+
+        let refresh = Task { @MainActor in
+            await harness.appState.refreshActiveSession()
+        }
+        await contextGate.waitUntilSuspended()
+        harness.appState.handleStreamEvent(
+            .messageDelta(sessionId: resumedSessionID, text: " next")
+        )
+        contextGate.resume()
+        await refresh.value
+
+        harness.appState.showSidebar = true
+        harness.appState.showSidebar = false
+        XCTAssertEqual(harness.appState.streamingText, "Okay next next")
+    }
+
     func testCancelledExplicitSessionSwitchDoesNotLeaveSynchronizationStuck() async {
         let openGate = ControlledSuspension()
         let harness = makeHarness(

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -253,6 +253,57 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertEqual(harness.appState.streamingText, " now")
     }
 
+    func testResumeDedupDropsSuffixAlignedGapAfterTranscriptAdvances() async {
+        let openGate = ControlledSuspension()
+        let active = session("stored-a")
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID in
+                    await openGate.suspend()
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [
+                            ChatMessage(
+                                id: "persisted-assistant",
+                                role: .assistant,
+                                content: "AB",
+                                timestamp: "1"
+                            )
+                        ],
+                        snapshot: SessionRuntimeSnapshot(
+                            object: [:],
+                            inflight: .object([
+                                "assistant": .string("ABC")
+                            ])
+                        )
+                    )
+                },
+                refreshContext: { _, _ in }
+            )
+        )
+        installComposerClient(in: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        harness.appState.handleStreamEvent(
+            .messageDelta(sessionId: active.id, text: "A")
+        )
+
+        let refresh = Task { @MainActor in
+            await harness.appState.refreshActiveSession()
+        }
+        await openGate.waitUntilSuspended()
+        harness.appState.handleStreamEvent(
+            .messageDelta(sessionId: active.id, text: "C")
+        )
+        openGate.resume()
+        await refresh.value
+
+        harness.appState.showSidebar = true
+        harness.appState.showSidebar = false
+        XCTAssertEqual(harness.appState.streamingText, "C")
+    }
+
     func testResumeDedupAcceptsAlternateSessionIDForBufferedDelta() async {
         let openGate = ControlledSuspension()
         let active = session("stored-a", alternateIDs: ["runtime-a"])

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -182,6 +182,137 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertEqual(harness.appState.streamingText, "I found it.")
     }
 
+    func testResumeDedupHandlesBoundaryLagWithInterleavedToolEvent() async {
+        let openGate = ControlledSuspension()
+        let active = session("stored-a")
+        let persistedText = "The quick brown"
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID in
+                    await openGate.suspend()
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [
+                            ChatMessage(
+                                id: "persisted-assistant",
+                                role: .assistant,
+                                content: persistedText,
+                                timestamp: "1"
+                            )
+                        ],
+                        snapshot: SessionRuntimeSnapshot(
+                            object: [:],
+                            inflight: .object([
+                                "assistant": .string("The quick brown fox")
+                            ])
+                        )
+                    )
+                },
+                refreshContext: { _, _ in }
+            )
+        )
+        installComposerClient(in: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        harness.appState.messages = [
+            ChatMessage(
+                id: "persisted-assistant",
+                role: .assistant,
+                content: persistedText,
+                timestamp: "1"
+            )
+        ]
+        harness.appState.handleStreamEvent(
+            .messageDelta(sessionId: active.id, text: "The quick")
+        )
+
+        let refresh = Task { @MainActor in
+            await harness.appState.refreshActiveSession()
+        }
+        await openGate.waitUntilSuspended()
+        harness.appState.handleStreamEvent(
+            .messageDelta(sessionId: active.id, text: " brown fox jumps")
+        )
+        harness.appState.handleStreamEvent(
+            .toolStart(sessionId: active.id, toolName: "Bash", toolInput: "ls")
+        )
+        harness.appState.handleStreamEvent(
+            .messageDelta(sessionId: active.id, text: " now")
+        )
+        openGate.resume()
+        await refresh.value
+
+        harness.appState.showSidebar = true
+        harness.appState.showSidebar = false
+        let partials = harness.appState.messages.filter { $0.role == .partial }
+        let toolIndex = harness.appState.messages.firstIndex { $0.role == .tool }
+        let partialIndex = harness.appState.messages.firstIndex { $0.role == .partial }
+        XCTAssertEqual(partials.map(\.content), ["fox jumps"])
+        XCTAssertEqual(toolIndex, partialIndex.map { $0 + 1 })
+        XCTAssertEqual(harness.appState.streamingText, " now")
+    }
+
+    func testResumeDedupAcceptsAlternateSessionIDForBufferedDelta() async {
+        let openGate = ControlledSuspension()
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let persistedText = "Let me find the transcript."
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, _ in
+                    await openGate.suspend()
+                    return SessionResumeResult(
+                        sessionId: "runtime-a",
+                        messages: [
+                            ChatMessage(
+                                id: "persisted-assistant",
+                                role: .assistant,
+                                content: persistedText,
+                                timestamp: "1"
+                            )
+                        ],
+                        snapshot: SessionRuntimeSnapshot(
+                            object: [:],
+                            inflight: .object([
+                                "assistant": .string("\(persistedText) I found it.")
+                            ])
+                        )
+                    )
+                },
+                refreshContext: { _, _ in }
+            )
+        )
+        installComposerClient(in: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        harness.appState.messages = [
+            ChatMessage(
+                id: "persisted-assistant",
+                role: .assistant,
+                content: persistedText,
+                timestamp: "1"
+            )
+        ]
+        harness.appState.handleStreamEvent(
+            .messageDelta(sessionId: active.id, text: persistedText)
+        )
+
+        let refresh = Task { @MainActor in
+            await harness.appState.refreshActiveSession()
+        }
+        await openGate.waitUntilSuspended()
+        harness.appState.handleStreamEvent(
+            .messageDelta(sessionId: "runtime-a", text: " I found it.")
+        )
+        openGate.resume()
+        await refresh.value
+
+        harness.appState.showSidebar = true
+        harness.appState.showSidebar = false
+        XCTAssertEqual(harness.appState.streamingText, "I found it.")
+    }
+
     func testResumeDoesNotUsePreviousSessionBoundaryForNewSessionDelta() async {
         let contextGate = ControlledSuspension()
         let previous = session("stored-old")

--- a/ConduitTests/BufferedEventDeduplicationTests.swift
+++ b/ConduitTests/BufferedEventDeduplicationTests.swift
@@ -35,7 +35,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         let result = AppState.deduplicatingBufferedEvents(
             events,
             againstInflight: "The fox jumps over the lazy dog.",
-            knownPrefix: "The fox jumps "
+            knownPrefix: "The fox jumps ",
+            sessionID: "s1"
         )
         XCTAssertTrue(result.isEmpty)
     }
@@ -50,7 +51,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         let result = AppState.deduplicatingBufferedEvents(
             events,
             againstInflight: "The fox jumps over the lazy",
-            knownPrefix: "The fox jumps "
+            knownPrefix: "The fox jumps ",
+            sessionID: "s1"
         )
         XCTAssertEqual(deltaTexts(in: result), [" dog."])
     }
@@ -64,7 +66,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         let result = AppState.deduplicatingBufferedEvents(
             events,
             againstInflight: "unrelated snapshot",
-            knownPrefix: "The fox jumps "
+            knownPrefix: "The fox jumps ",
+            sessionID: "s1"
         )
         XCTAssertEqual(deltaTexts(in: result), ["fresh text"])
     }
@@ -78,7 +81,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         let result = AppState.deduplicatingBufferedEvents(
             events,
             againstInflight: "Everything is done.",
-            knownPrefix: "Everything is "
+            knownPrefix: "Everything is ",
+            sessionID: "s1"
         )
         XCTAssertEqual(result.count, 2)
         if case .toolStart = result[0] {} else {
@@ -98,7 +102,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         let result = AppState.deduplicatingBufferedEvents(
             events,
             againstInflight: "abc",
-            knownPrefix: ""
+            knownPrefix: "",
+            sessionID: "s1"
         )
 
         XCTAssertEqual(result.count, 3)
@@ -124,7 +129,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         let result = AppState.deduplicatingBufferedEvents(
             events,
             againstInflight: "aaaa",
-            knownPrefix: "aaaa"
+            knownPrefix: "aaaa",
+            sessionID: "s1"
         )
 
         XCTAssertEqual(deltaTexts(in: result), ["aaa"])
@@ -137,7 +143,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         let result = AppState.deduplicatingBufferedEvents(
             events,
             againstInflight: "aaaaaa",
-            knownPrefix: "aaaa"
+            knownPrefix: "aaaa",
+            sessionID: "s1"
         )
 
         XCTAssertEqual(deltaTexts(in: result), ["a"])
@@ -150,10 +157,25 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         let result = AppState.deduplicatingBufferedEvents(
             events,
             againstInflight: "AB",
-            knownPrefix: "A"
+            knownPrefix: "A",
+            sessionID: "s1"
         )
 
         XCTAssertEqual(deltaTexts(in: result), ["C"])
+    }
+
+    func testWhitespaceAroundCoveredDeltaIsNotReplayed() {
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "s1", text: " I found it. "),
+        ]
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "I found it.",
+            knownPrefix: "",
+            sessionID: "s1"
+        )
+
+        XCTAssertTrue(result.isEmpty)
     }
 
     func testMissingBoundaryDoesNotGuessFromText() {
@@ -163,7 +185,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         let result = AppState.deduplicatingBufferedEvents(
             events,
             againstInflight: "aaaa",
-            knownPrefix: nil
+            knownPrefix: nil,
+            sessionID: "s1"
         )
 
         XCTAssertEqual(deltaTexts(in: result), ["aaa"])
@@ -177,7 +200,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         let result = AppState.deduplicatingBufferedEvents(
             events,
             againstInflight: "abc",
-            knownPrefix: ""
+            knownPrefix: "",
+            sessionID: "s1"
         )
 
         XCTAssertEqual(deltaSessionIDs(in: result), ["s1", "s2"])
@@ -191,7 +215,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         let result = AppState.deduplicatingBufferedEvents(
             events,
             againstInflight: "",
-            knownPrefix: "prefix"
+            knownPrefix: "prefix",
+            sessionID: "s1"
         )
         XCTAssertEqual(deltaTexts(in: result), ["hello"])
     }
@@ -203,7 +228,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         let result = AppState.deduplicatingBufferedEvents(
             events,
             againstInflight: "xyz abc",
-            knownPrefix: "xyz "
+            knownPrefix: "xyz ",
+            sessionID: "runtime-42"
         )
         guard case .messageDelta(let sessionId, let text)? = result.first else {
             return XCTFail("Expected a merged delta")

--- a/ConduitTests/BufferedEventDeduplicationTests.swift
+++ b/ConduitTests/BufferedEventDeduplicationTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import XCTest
+@testable import Conduit
+
+/// Foreground reconciliation buffers stream events while `session.resume`
+/// runs, then replays them after the live bubble is seeded from the resume
+/// snapshot's cumulative inflight projection. These tests cover the dedupe
+/// that keeps replayed deltas from repeating text the snapshot already
+/// contains.
+final class BufferedEventDeduplicationTests: XCTestCase {
+
+    private func deltaTexts(in events: [StreamEvent]) -> [String] {
+        events.compactMap {
+            if case .messageDelta(_, let text) = $0 { return text }
+            return nil
+        }
+    }
+
+    // MARK: - overlapLength
+
+    func testOverlapFullCoverage() {
+        XCTAssertEqual(AppState.overlapLength(betweenSuffixOf: "Hello world", andPrefixOf: "world"), 5)
+    }
+
+    func testOverlapPartialCoverage() {
+        // Snapshot ends mid-way through the buffered run.
+        XCTAssertEqual(AppState.overlapLength(betweenSuffixOf: "The quick bro", andPrefixOf: "brown fox"), 3)
+    }
+
+    func testOverlapNone() {
+        XCTAssertEqual(AppState.overlapLength(betweenSuffixOf: "alpha", andPrefixOf: "beta"), 0)
+    }
+
+    func testOverlapPrefersLongestMatch() {
+        // "aba" occurs twice; the longest suffix/prefix meeting point wins.
+        XCTAssertEqual(AppState.overlapLength(betweenSuffixOf: "ababa", andPrefixOf: "ababa"), 5)
+    }
+
+    func testOverlapEmptyInputs() {
+        XCTAssertEqual(AppState.overlapLength(betweenSuffixOf: "", andPrefixOf: "x"), 0)
+        XCTAssertEqual(AppState.overlapLength(betweenSuffixOf: "x", andPrefixOf: ""), 0)
+    }
+
+    // MARK: - deduplicatingBufferedEvents
+
+    func testDeltasFullyCoveredBySnapshotAreDropped() {
+        // User foregrounds mid-turn; deltas D1+D2 arrive while resume runs,
+        // and the snapshot's cumulative inflight already ends with them.
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "s1", text: "over the "),
+            .messageDelta(sessionId: "s1", text: "lazy dog."),
+        ]
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "The fox jumps over the lazy dog."
+        )
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testUncoveredSuffixSurvivesAsSingleDelta() {
+        // The snapshot was generated between the two buffered deltas: only
+        // the portion beyond the snapshot tail may be replayed.
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "s1", text: "over the "),
+            .messageDelta(sessionId: "s1", text: "lazy dog."),
+        ]
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "The fox jumps over the lazy"
+        )
+        XCTAssertEqual(deltaTexts(in: result), [" dog."])
+    }
+
+    func testNoOverlapKeepsEventsUntouched() {
+        // A gateway whose inflight projection is not cumulative (or a turn
+        // that started after the snapshot) must keep its deltas.
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "s1", text: "fresh text"),
+        ]
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "unrelated snapshot"
+        )
+        XCTAssertEqual(deltaTexts(in: result), ["fresh text"])
+    }
+
+    func testNonDeltaEventsPassThroughInOrder() {
+        let events: [StreamEvent] = [
+            .toolStart(sessionId: "s1", toolName: "Bash", toolInput: "ls"),
+            .messageDelta(sessionId: "s1", text: "done."),
+            .messageComplete(sessionId: "s1", messageId: nil, content: "All done.", reasoning: nil),
+        ]
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "Everything is done."
+        )
+        XCTAssertEqual(result.count, 2)
+        if case .toolStart = result[0] {} else {
+            XCTFail("Expected toolStart to pass through first")
+        }
+        if case .messageComplete = result[1] {} else {
+            XCTFail("Expected messageComplete to pass through last")
+        }
+    }
+
+    func testEmptyInflightKeepsEvents() {
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "s1", text: "hello"),
+        ]
+        let result = AppState.deduplicatingBufferedEvents(events, againstInflight: "")
+        XCTAssertEqual(deltaTexts(in: result), ["hello"])
+    }
+
+    func testRemainderKeepsSessionIdOfBufferedDeltas() {
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "runtime-42", text: "abc def"),
+        ]
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "xyz abc"
+        )
+        guard case .messageDelta(let sessionId, let text)? = result.first else {
+            return XCTFail("Expected a merged delta")
+        }
+        XCTAssertEqual(sessionId, "runtime-42")
+        XCTAssertEqual(text, " def")
+    }
+}

--- a/ConduitTests/BufferedEventDeduplicationTests.swift
+++ b/ConduitTests/BufferedEventDeduplicationTests.swift
@@ -178,6 +178,21 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         XCTAssertTrue(result.isEmpty)
     }
 
+    func testCoveredTrailingWhitespaceIsNotReplayedBeforeNewText() {
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "s1", text: "foo bar"),
+        ]
+
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "foo ",
+            knownPrefix: "",
+            sessionID: "s1"
+        )
+
+        XCTAssertEqual(deltaTexts(in: result), ["bar"])
+    }
+
     func testMissingBoundaryDoesNotGuessFromText() {
         let events: [StreamEvent] = [
             .messageDelta(sessionId: "s1", text: "aaa"),

--- a/ConduitTests/BufferedEventDeduplicationTests.swift
+++ b/ConduitTests/BufferedEventDeduplicationTests.swift
@@ -36,7 +36,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
             events,
             againstInflight: "The fox jumps over the lazy dog.",
             knownPrefix: "The fox jumps ",
-            sessionID: "s1"
+            sessionID: "s1",
+            hasBoundaryAnchor: true
         )
         XCTAssertTrue(result.isEmpty)
     }
@@ -52,7 +53,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
             events,
             againstInflight: "The fox jumps over the lazy",
             knownPrefix: "The fox jumps ",
-            sessionID: "s1"
+            sessionID: "s1",
+            hasBoundaryAnchor: true
         )
         XCTAssertEqual(deltaTexts(in: result), [" dog."])
     }
@@ -82,7 +84,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
             events,
             againstInflight: "Everything is done.",
             knownPrefix: "Everything is ",
-            sessionID: "s1"
+            sessionID: "s1",
+            hasBoundaryAnchor: true
         )
         XCTAssertEqual(result.count, 2)
         if case .toolStart = result[0] {} else {
@@ -103,7 +106,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
             events,
             againstInflight: "abc",
             knownPrefix: "",
-            sessionID: "s1"
+            sessionID: "s1",
+            hasBoundaryAnchor: true
         )
 
         XCTAssertEqual(result.count, 3)
@@ -130,7 +134,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
             events,
             againstInflight: "aaaa",
             knownPrefix: "aaaa",
-            sessionID: "s1"
+            sessionID: "s1",
+            hasBoundaryAnchor: true
         )
 
         XCTAssertEqual(deltaTexts(in: result), ["aaa"])
@@ -144,7 +149,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
             events,
             againstInflight: "aaaaaa",
             knownPrefix: "aaaa",
-            sessionID: "s1"
+            sessionID: "s1",
+            hasBoundaryAnchor: true
         )
 
         XCTAssertEqual(deltaTexts(in: result), ["a"])
@@ -158,7 +164,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
             events,
             againstInflight: "AB",
             knownPrefix: "A",
-            sessionID: "s1"
+            sessionID: "s1",
+            hasBoundaryAnchor: true
         )
 
         XCTAssertEqual(deltaTexts(in: result), ["C"])
@@ -172,7 +179,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
             events,
             againstInflight: "I found it.",
             knownPrefix: "",
-            sessionID: "s1"
+            sessionID: "s1",
+            hasBoundaryAnchor: true
         )
 
         XCTAssertTrue(result.isEmpty)
@@ -187,7 +195,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
             events,
             againstInflight: "foo ",
             knownPrefix: "",
-            sessionID: "s1"
+            sessionID: "s1",
+            hasBoundaryAnchor: true
         )
 
         XCTAssertEqual(deltaTexts(in: result), ["bar"])
@@ -203,7 +212,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
             againstInflight: "C",
             knownPrefix: "",
             sessionID: "s1",
-            coveredText: "BC"
+            coveredText: "BC",
+            hasBoundaryAnchor: true
         )
 
         XCTAssertTrue(result.isEmpty)
@@ -219,7 +229,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
             againstInflight: "CD",
             knownPrefix: "",
             sessionID: "s1",
-            coveredText: "BCD"
+            coveredText: "BCD",
+            hasBoundaryAnchor: true
         )
 
         XCTAssertTrue(result.isEmpty)
@@ -235,7 +246,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
             againstInflight: "CDE",
             knownPrefix: "",
             sessionID: "s1",
-            coveredText: "BCD"
+            coveredText: "BCD",
+            hasBoundaryAnchor: true
         )
 
         XCTAssertEqual(deltaTexts(in: result), ["E"])
@@ -253,7 +265,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
             againstInflight: "CDEF",
             knownPrefix: "",
             sessionID: "s1",
-            coveredText: "BCD"
+            coveredText: "BCD",
+            hasBoundaryAnchor: true
         )
 
         XCTAssertEqual(result.count, 3)
@@ -282,7 +295,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
             againstInflight: "bcabc",
             knownPrefix: "",
             sessionID: "s1",
-            coveredText: "abcabc"
+            coveredText: "abcabc",
+            hasBoundaryAnchor: true
         )
 
         XCTAssertEqual(deltaTexts(in: result), ["bcabc"])
@@ -317,7 +331,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
             againstInflight: "old",
             knownPrefix: "",
             sessionID: "s1",
-            coveredText: "old"
+            coveredText: "old",
+            hasBoundaryAnchor: true
         )
 
         XCTAssertEqual(deltaTexts(in: result), ["xyz more"])
@@ -325,6 +340,38 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         if case .messageStart = result[0] {} else {
             XCTFail("Expected the new-turn marker to remain before its delta")
         }
+    }
+
+    func testNoMarkerPrefixCollisionPreservesBufferedTextWithoutBoundaryProof() {
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "s1", text: "xyz more"),
+        ]
+
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "xyz",
+            knownPrefix: "",
+            sessionID: "s1",
+            coveredText: "xyz"
+        )
+
+        XCTAssertEqual(deltaTexts(in: result), ["xyz more"])
+    }
+
+    func testNoMarkerExactCollisionPreservesBufferedTextWithoutBoundaryProof() {
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "s1", text: "xyz"),
+        ]
+
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "xyz",
+            knownPrefix: "",
+            sessionID: "s1",
+            coveredText: "xyz"
+        )
+
+        XCTAssertEqual(deltaTexts(in: result), ["xyz"])
     }
 
     func testExplicitCoverageMustMatchSeededInflightBeforeDeduplicating() {
@@ -410,7 +457,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
             events,
             againstInflight: "xyz abc",
             knownPrefix: "xyz ",
-            sessionID: "runtime-42"
+            sessionID: "runtime-42",
+            hasBoundaryAnchor: true
         )
         guard case .messageDelta(let sessionId, let text)? = result.first else {
             return XCTFail("Expected a merged delta")

--- a/ConduitTests/BufferedEventDeduplicationTests.swift
+++ b/ConduitTests/BufferedEventDeduplicationTests.swift
@@ -225,6 +225,53 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         XCTAssertTrue(result.isEmpty)
     }
 
+    func testStraddledCoveredDeltaKeepsOnlyNewSuffix() {
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "s1", text: "CDE"),
+        ]
+
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "CDE",
+            knownPrefix: "",
+            sessionID: "s1",
+            coveredText: "BCD"
+        )
+
+        XCTAssertEqual(deltaTexts(in: result), ["E"])
+    }
+
+    func testStraddledCoveragePreservesInterleavedEventOrder() {
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "s1", text: "CDE"),
+            .toolStart(sessionId: "s1", toolName: "Bash", toolInput: "ls"),
+            .messageDelta(sessionId: "s1", text: "F"),
+        ]
+
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "CDEF",
+            knownPrefix: "",
+            sessionID: "s1",
+            coveredText: "BCD"
+        )
+
+        XCTAssertEqual(result.count, 3)
+        if case .messageDelta(_, let text) = result[0] {
+            XCTAssertEqual(text, "E")
+        } else {
+            XCTFail("Expected the uncovered suffix before toolStart")
+        }
+        if case .toolStart = result[1] {} else {
+            XCTFail("Expected toolStart to remain between the deltas")
+        }
+        if case .messageDelta(_, let text) = result[2] {
+            XCTAssertEqual(text, "F")
+        } else {
+            XCTFail("Expected the later delta after toolStart")
+        }
+    }
+
     func testMissingBoundaryDoesNotGuessFromText() {
         let events: [StreamEvent] = [
             .messageDelta(sessionId: "s1", text: "aaa"),

--- a/ConduitTests/BufferedEventDeduplicationTests.swift
+++ b/ConduitTests/BufferedEventDeduplicationTests.swift
@@ -288,6 +288,77 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         XCTAssertEqual(deltaTexts(in: result), ["bcabc"])
     }
 
+    func testNewTurnMarkerPreservesCoincidentallyRepeatedText() {
+        let events: [StreamEvent] = [
+            .messageStart(sessionId: "s1"),
+            .messageDelta(sessionId: "s1", text: "xyz more"),
+        ]
+
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "xyz",
+            knownPrefix: "",
+            sessionID: "s1",
+            coveredText: "xyz"
+        )
+
+        XCTAssertEqual(deltaTexts(in: result), ["xyz more"])
+    }
+
+    func testNewTurnMarkerOnlyPreservesEventsAfterTheMarker() {
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "s1", text: "old"),
+            .messageStart(sessionId: "s1"),
+            .messageDelta(sessionId: "s1", text: "xyz more"),
+        ]
+
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "old",
+            knownPrefix: "",
+            sessionID: "s1",
+            coveredText: "old"
+        )
+
+        XCTAssertEqual(deltaTexts(in: result), ["xyz more"])
+        XCTAssertEqual(result.count, 2)
+        if case .messageStart = result[0] {} else {
+            XCTFail("Expected the new-turn marker to remain before its delta")
+        }
+    }
+
+    func testExplicitCoverageMustMatchSeededInflightBeforeDeduplicating() {
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "s1", text: "covered"),
+        ]
+
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "unrelated",
+            knownPrefix: "boundary",
+            sessionID: "s1",
+            coveredText: "covered"
+        )
+
+        XCTAssertEqual(deltaTexts(in: result), ["covered"])
+    }
+
+    func testExplicitCoverageMustOverlapSeededInflightBeforeDeduplicating() {
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "s1", text: "coincidental"),
+        ]
+
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "seeded",
+            knownPrefix: "",
+            sessionID: "s1",
+            coveredText: "coincidental"
+        )
+
+        XCTAssertEqual(deltaTexts(in: result), ["coincidental"])
+    }
+
     func testMissingBoundaryDoesNotGuessFromText() {
         let events: [StreamEvent] = [
             .messageDelta(sessionId: "s1", text: "aaa"),

--- a/ConduitTests/BufferedEventDeduplicationTests.swift
+++ b/ConduitTests/BufferedEventDeduplicationTests.swift
@@ -143,6 +143,19 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         XCTAssertEqual(deltaTexts(in: result), ["a"])
     }
 
+    func testMismatchedInflightSuffixDoesNotDropNewText() {
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "s1", text: "C"),
+        ]
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "AB",
+            knownPrefix: "A"
+        )
+
+        XCTAssertEqual(deltaTexts(in: result), ["C"])
+    }
+
     func testMissingBoundaryDoesNotGuessFromText() {
         let events: [StreamEvent] = [
             .messageDelta(sessionId: "s1", text: "aaa"),

--- a/ConduitTests/BufferedEventDeduplicationTests.swift
+++ b/ConduitTests/BufferedEventDeduplicationTests.swift
@@ -193,6 +193,38 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         XCTAssertEqual(deltaTexts(in: result), ["bar"])
     }
 
+    func testSuffixAlignedCoveredDeltaIsNotReplayed() {
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "s1", text: "C"),
+        ]
+
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "C",
+            knownPrefix: "",
+            sessionID: "s1",
+            coveredText: "BC"
+        )
+
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testMidWindowGapDropsSuffixAlignedBufferedDeltas() {
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "s1", text: "CD"),
+        ]
+
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "CD",
+            knownPrefix: "",
+            sessionID: "s1",
+            coveredText: "BCD"
+        )
+
+        XCTAssertTrue(result.isEmpty)
+    }
+
     func testMissingBoundaryDoesNotGuessFromText() {
         let events: [StreamEvent] = [
             .messageDelta(sessionId: "s1", text: "aaa"),

--- a/ConduitTests/BufferedEventDeduplicationTests.swift
+++ b/ConduitTests/BufferedEventDeduplicationTests.swift
@@ -16,29 +16,11 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         }
     }
 
-    // MARK: - overlapLength
-
-    func testOverlapFullCoverage() {
-        XCTAssertEqual(AppState.overlapLength(betweenSuffixOf: "Hello world", andPrefixOf: "world"), 5)
-    }
-
-    func testOverlapPartialCoverage() {
-        // Snapshot ends mid-way through the buffered run.
-        XCTAssertEqual(AppState.overlapLength(betweenSuffixOf: "The quick bro", andPrefixOf: "brown fox"), 3)
-    }
-
-    func testOverlapNone() {
-        XCTAssertEqual(AppState.overlapLength(betweenSuffixOf: "alpha", andPrefixOf: "beta"), 0)
-    }
-
-    func testOverlapPrefersLongestMatch() {
-        // "aba" occurs twice; the longest suffix/prefix meeting point wins.
-        XCTAssertEqual(AppState.overlapLength(betweenSuffixOf: "ababa", andPrefixOf: "ababa"), 5)
-    }
-
-    func testOverlapEmptyInputs() {
-        XCTAssertEqual(AppState.overlapLength(betweenSuffixOf: "", andPrefixOf: "x"), 0)
-        XCTAssertEqual(AppState.overlapLength(betweenSuffixOf: "x", andPrefixOf: ""), 0)
+    private func deltaSessionIDs(in events: [StreamEvent]) -> [String] {
+        events.compactMap {
+            if case .messageDelta(let sessionId, _) = $0 { return sessionId }
+            return nil
+        }
     }
 
     // MARK: - deduplicatingBufferedEvents
@@ -52,7 +34,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         ]
         let result = AppState.deduplicatingBufferedEvents(
             events,
-            againstInflight: "The fox jumps over the lazy dog."
+            againstInflight: "The fox jumps over the lazy dog.",
+            knownPrefix: "The fox jumps "
         )
         XCTAssertTrue(result.isEmpty)
     }
@@ -66,7 +49,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         ]
         let result = AppState.deduplicatingBufferedEvents(
             events,
-            againstInflight: "The fox jumps over the lazy"
+            againstInflight: "The fox jumps over the lazy",
+            knownPrefix: "The fox jumps "
         )
         XCTAssertEqual(deltaTexts(in: result), [" dog."])
     }
@@ -79,7 +63,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         ]
         let result = AppState.deduplicatingBufferedEvents(
             events,
-            againstInflight: "unrelated snapshot"
+            againstInflight: "unrelated snapshot",
+            knownPrefix: "The fox jumps "
         )
         XCTAssertEqual(deltaTexts(in: result), ["fresh text"])
     }
@@ -92,7 +77,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         ]
         let result = AppState.deduplicatingBufferedEvents(
             events,
-            againstInflight: "Everything is done."
+            againstInflight: "Everything is done.",
+            knownPrefix: "Everything is "
         )
         XCTAssertEqual(result.count, 2)
         if case .toolStart = result[0] {} else {
@@ -103,11 +89,97 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         }
     }
 
+    func testPartialCoveragePreservesInterleavedEventOrder() {
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "s1", text: "abcd"),
+            .toolStart(sessionId: "s1", toolName: "Bash", toolInput: "ls"),
+            .messageDelta(sessionId: "s1", text: "ef"),
+        ]
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "abc",
+            knownPrefix: ""
+        )
+
+        XCTAssertEqual(result.count, 3)
+        if case .messageDelta(_, let text) = result[0] {
+            XCTAssertEqual(text, "d")
+        } else {
+            XCTFail("Expected the uncovered first delta before toolStart")
+        }
+        if case .toolStart = result[1] {} else {
+            XCTFail("Expected toolStart to remain between the deltas")
+        }
+        if case .messageDelta(_, let text) = result[2] {
+            XCTAssertEqual(text, "ef")
+        } else {
+            XCTFail("Expected the second delta after toolStart")
+        }
+    }
+
+    func testAmbiguousRepeatedTextIsNotDeduplicated() {
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "s1", text: "aaa"),
+        ]
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "aaaa",
+            knownPrefix: "aaaa"
+        )
+
+        XCTAssertEqual(deltaTexts(in: result), ["aaa"])
+    }
+
+    func testExactBoundaryConsumesOnlyNewRepeatedText() {
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "s1", text: "aaa"),
+        ]
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "aaaaaa",
+            knownPrefix: "aaaa"
+        )
+
+        XCTAssertEqual(deltaTexts(in: result), ["a"])
+    }
+
+    func testMissingBoundaryDoesNotGuessFromText() {
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "s1", text: "aaa"),
+        ]
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "aaaa",
+            knownPrefix: nil
+        )
+
+        XCTAssertEqual(deltaTexts(in: result), ["aaa"])
+    }
+
+    func testMultipleSessionDeltasAreNotMerged() {
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "s1", text: "abc"),
+            .messageDelta(sessionId: "s2", text: "def"),
+        ]
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "abc",
+            knownPrefix: ""
+        )
+
+        XCTAssertEqual(deltaSessionIDs(in: result), ["s1", "s2"])
+        XCTAssertEqual(deltaTexts(in: result), ["abc", "def"])
+    }
+
     func testEmptyInflightKeepsEvents() {
         let events: [StreamEvent] = [
             .messageDelta(sessionId: "s1", text: "hello"),
         ]
-        let result = AppState.deduplicatingBufferedEvents(events, againstInflight: "")
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "",
+            knownPrefix: "prefix"
+        )
         XCTAssertEqual(deltaTexts(in: result), ["hello"])
     }
 
@@ -117,7 +189,8 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         ]
         let result = AppState.deduplicatingBufferedEvents(
             events,
-            againstInflight: "xyz abc"
+            againstInflight: "xyz abc",
+            knownPrefix: "xyz "
         )
         guard case .messageDelta(let sessionId, let text)? = result.first else {
             return XCTFail("Expected a merged delta")

--- a/ConduitTests/BufferedEventDeduplicationTests.swift
+++ b/ConduitTests/BufferedEventDeduplicationTests.swift
@@ -272,6 +272,22 @@ final class BufferedEventDeduplicationTests: XCTestCase {
         }
     }
 
+    func testAmbiguousRepeatedStraddleKeepsBufferedText() {
+        let events: [StreamEvent] = [
+            .messageDelta(sessionId: "s1", text: "bcabc"),
+        ]
+
+        let result = AppState.deduplicatingBufferedEvents(
+            events,
+            againstInflight: "bcabc",
+            knownPrefix: "",
+            sessionID: "s1",
+            coveredText: "abcabc"
+        )
+
+        XCTAssertEqual(deltaTexts(in: result), ["bcabc"])
+    }
+
     func testMissingBoundaryDoesNotGuessFromText() {
         let events: [StreamEvent] = [
             .messageDelta(sessionId: "s1", text: "aaa"),


### PR DESCRIPTION
## Problem
Foreground reconciliation buffers stream events while `session.list` + `session.resume` run, seeds the live bubble from the resume snapshot's **cumulative** `inflight` projection, then replays the buffered events on top. The inflight text already contains the deltas that arrived during the buffer window, so foregrounding the app mid-turn visibly repeated a chunk of the streaming reply.

## Fix
Before replay, collapse the buffered `.messageDelta` events to the suffix the snapshot has not covered. The delta stream is contiguous, so the snapshot's tail and the buffered concatenation meet at exactly one offset — computed as the longest overlap between the inflight's suffix and the buffer's prefix. Fully covered deltas are dropped; a partial overlap replays only the remainder (as a single delta, in the last delta's position); zero overlap (non-cumulative gateways, or a turn that started after the snapshot) leaves the events untouched. Non-delta events always pass through in order.

Applied only when `snapshot.hasLiveProjection` — the case where the bubble was seeded from inflight.

## Testing
- 11 new unit tests (`BufferedEventDeduplicationTests`) covering full/partial/zero overlap, longest-match selection, non-delta pass-through, empty inflight, and session-id preservation.
- Full suite passes on the iPhone 17 Pro simulator.

Full write-up: [angel12/hermes-conduit#19](https://github.com/angel12/hermes-conduit/issues/19)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when resuming interrupted streaming sessions.
  * Prevented already-displayed text from appearing again after a resume, including partial and whitespace variations.
  * Preserved the correct session context while replaying buffered updates.
  * Maintained event order and retained updates that cannot be safely matched, improving reliability in edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->