### PR TITLE
Invalidate the profile session cache on delete, archive, and sign-out

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -175,8 +175,7 @@ struct SessionCatalogCache {
         liveKey: String,
         cronSessions: [SessionSummary]?,
         cronKey: String,
-        loadedFullHistoryKey: String,
-        recordFullHistoryAt: Date?,
+        historyMarkers: [String: Date],
         at generation: UInt64
     ) -> Bool {
         guard generation == mutationGeneration else { return false }
@@ -184,9 +183,9 @@ struct SessionCatalogCache {
         if let cronSessions {
             sessionsByKey[cronKey] = cronSessions
         }
-        if let recordFullHistoryAt {
-            loadedFullHistoryKeys.insert(loadedFullHistoryKey)
-            fullHistoryLoadedAt[loadedFullHistoryKey] = recordFullHistoryAt
+        for (key, loadedAt) in historyMarkers {
+            loadedFullHistoryKeys.insert(key)
+            fullHistoryLoadedAt[key] = loadedAt
         }
         return true
     }
@@ -4871,14 +4870,19 @@ final class AppState: ObservableObject {
                     let merged = uniqueSessions(scoped + cached)
 
                     // Fetch cron sessions separately -- the main query excludes them.
+                    let shouldLoadCron = sessionCatalogCache.shouldLoadFullHistory(
+                        forKey: cronKey,
+                        forceRefresh: forceRefresh
+                    )
                     let cachedCronSessions = sessionCatalogCache.cachedSessions(forKey: cronKey)?.filter {
                         sessionBelongsToProfile($0, profile: profile)
                     }
                     let publishedCronSnapshot = self.cronSessions.filter {
                         sessionBelongsToProfile($0, profile: profile)
                     }
+                    var didFetchCronSessions = false
                     let cronSessions: [SessionSummary]?
-                    if !forceRefresh, let cachedCronSessions {
+                    if !shouldLoadCron, let cachedCronSessions {
                         cronSessions = cachedCronSessions
                     } else {
                         do {
@@ -4888,6 +4892,7 @@ final class AppState: ObservableObject {
                             ).filter {
                                 sessionBelongsToProfile($0, profile: profile)
                             }
+                            didFetchCronSessions = true
                         } catch {
                             // Keep a previous cron snapshot if one exists, but
                             // do not cache an empty result for a failed request.
@@ -4908,13 +4913,19 @@ final class AppState: ObservableObject {
                         merged + (cronSessions ?? cachedCronSessions ?? publishedCronSnapshot)
                     )
                     if !combined.isEmpty || shouldLoadHistory == false {
+                        var historyMarkers: [String: Date] = [:]
+                        if scopedResult.isAuthoritative && !scoped.isEmpty {
+                            historyMarkers[cacheKey] = Date()
+                        }
+                        if didFetchCronSessions {
+                            historyMarkers[cronKey] = Date()
+                        }
                         guard sessionCatalogCache.commit(
                             liveSessions: combined,
                             liveKey: cacheKey,
                             cronSessions: cronSessions,
                             cronKey: cronKey,
-                            loadedFullHistoryKey: cacheKey,
-                            recordFullHistoryAt: scopedResult.isAuthoritative && !scoped.isEmpty ? Date() : nil,
+                            historyMarkers: historyMarkers,
                             at: generation
                         ) else {
                             catalogRetryCount += 1

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -118,6 +118,65 @@ struct ChatResumeLifecycleOperations {
     static let live = ChatResumeLifecycleOperations()
 }
 
+/// Owns the profile-scoped session catalog cache and rejects writes from a
+/// load that started before a destructive cache mutation. AppState is
+/// main-actor isolated, but every dashboard request can re-enter the actor
+/// while it awaits WebKit, so a request must not overwrite a newer purge when
+/// it resumes.
+struct SessionCatalogCache {
+    private(set) var sessionsByKey: [String: [SessionSummary]] = [:]
+    private(set) var loadedFullHistoryKeys = Set<String>()
+    private(set) var mutationGeneration: UInt64 = 0
+
+    func sessions(forKey key: String) -> [SessionSummary] {
+        sessionsByKey[key] ?? []
+    }
+
+    func cachedSessions(forKey key: String) -> [SessionSummary]? {
+        sessionsByKey[key]
+    }
+
+    /// Commits a live and cron snapshot only when no cache mutation occurred
+    /// during the load that produced it.
+    @discardableResult
+    mutating func commit(
+        liveSessions: [SessionSummary],
+        liveKey: String,
+        cronSessions: [SessionSummary],
+        cronKey: String,
+        loadedFullHistoryKey: String,
+        at generation: UInt64
+    ) -> Bool {
+        guard generation == mutationGeneration else { return false }
+        sessionsByKey[liveKey] = liveSessions
+        sessionsByKey[cronKey] = cronSessions
+        loadedFullHistoryKeys.insert(loadedFullHistoryKey)
+        return true
+    }
+
+    mutating func removeAll() {
+        mutationGeneration &+= 1
+        sessionsByKey.removeAll()
+        loadedFullHistoryKeys.removeAll()
+    }
+
+    mutating func removeValue(forKey key: String) {
+        mutationGeneration &+= 1
+        sessionsByKey.removeValue(forKey: key)
+        loadedFullHistoryKeys.remove(key)
+    }
+
+    mutating func removeSession(withIDs sessionIDs: Set<String>) {
+        mutationGeneration &+= 1
+        for key in sessionsByKey.keys {
+            sessionsByKey[key]?.removeAll { cachedSession in
+                let cachedIDs = Set([cachedSession.id] + cachedSession.alternateIds)
+                return !cachedIDs.isDisjoint(with: sessionIDs)
+            }
+        }
+    }
+}
+
 @MainActor
 private func scheduleChatResumeReconnectTask(
     after delay: TimeInterval,
@@ -532,9 +591,8 @@ final class AppState: ObservableObject {
     private let sessionCatalogLoaderOverride: ((Bool) async throws -> [SessionSummary])?
     private var reconnectAttempts = 0
     private var connectedAt: Date?
-    private var profileSessionCache: [String: [SessionSummary]] = [:]
+    private var sessionCatalogCache = SessionCatalogCache()
     private var projectsRequestGeneration = 0
-    private var loadedFullSessionHistory = Set<String>()
     private let sessionPresentationCache: SessionPresentationCache
 
     /// The dashboard's persisted transcript is richer than `session.resume`:
@@ -1237,8 +1295,7 @@ final class AppState: ObservableObject {
         recoverySequence.cancel()
         chatResumeRestorationRequest = nil
         invalidateReconciliation()
-        profileSessionCache.removeAll()
-        loadedFullSessionHistory.removeAll()
+        sessionCatalogCache.removeAll()
         sessions = []
         cronSessions = []
         archivedSessions = []
@@ -1675,10 +1732,9 @@ final class AppState: ObservableObject {
         cronSessions = []
         // Sessions can be deleted from another client while signed out; a
         // stale catalog cache would show those rows again after re-sign-in
-        // (and `loadedFullSessionHistory` would suppress the reload that
-        // could correct them).
-        profileSessionCache.removeAll()
-        loadedFullSessionHistory.removeAll()
+        // (and the full-history marker would suppress the reload that could
+        // correct them).
+        sessionCatalogCache.removeAll()
         pinnedSessionIDs = []
         messages = []
         setActiveSessionState(id: nil, title: "New conversation")
@@ -3504,9 +3560,8 @@ final class AppState: ObservableObject {
 
         let sessionKey = "\(activeProfile):exclude"
         let cronKey = "\(activeProfile):cron"
-        profileSessionCache.removeValue(forKey: sessionKey)
-        profileSessionCache.removeValue(forKey: cronKey)
-        loadedFullSessionHistory.remove(sessionKey)
+        sessionCatalogCache.removeValue(forKey: sessionKey)
+        sessionCatalogCache.removeValue(forKey: cronKey)
         await loadSessions(forceRefresh: true)
     }
 
@@ -3716,9 +3771,9 @@ final class AppState: ObservableObject {
         // the published arrays and re-saves the union. A row left in the
         // cache therefore resurrects a deleted or archived conversation on
         // the next foreground or send, until a pull-to-refresh purges it.
-        for key in profileSessionCache.keys {
-            profileSessionCache[key]?.removeAll { sessionMatches($0, session) }
-        }
+        sessionCatalogCache.removeSession(
+            withIDs: Set([session.id] + session.alternateIds)
+        )
     }
 
     func clearActiveSessionIfNeeded(
@@ -4741,34 +4796,55 @@ final class AppState: ObservableObject {
         if let dashboardTicketBridge {
             do {
                 let cacheKey = "\(profile):exclude"
-                let shouldLoadHistory = forceRefresh || !loadedFullSessionHistory.contains(cacheKey)
-                let scoped = try await dashboardSessions(
-                    profile: profile,
-                    loadFullHistory: shouldLoadHistory,
-                    using: dashboardTicketBridge
-                ).filter { sessionBelongsToProfile($0, profile: profile) }
-
-                let cached = forceRefresh ? [] : (profileSessionCache[cacheKey] ?? []).filter {
-                    sessionBelongsToProfile($0, profile: profile)
-                }
-                let merged = uniqueSessions(scoped + cached)
-                // Fetch cron sessions separately -- the main query excludes them.
                 let cronKey = "\(profile):cron"
-                let cronSessions: [SessionSummary]
-                if !forceRefresh, let cached = profileSessionCache[cronKey] {
-                    cronSessions = cached.filter { sessionBelongsToProfile($0, profile: profile) }
-                } else {
-                    cronSessions = ((try? await dashboardCronSessions(profile: profile, using: dashboardTicketBridge)) ?? []).filter {
+                while true {
+                    let generation = sessionCatalogCache.mutationGeneration
+                    let shouldLoadHistory = forceRefresh
+                        || !sessionCatalogCache.loadedFullHistoryKeys.contains(cacheKey)
+                    let scoped = try await dashboardSessions(
+                        profile: profile,
+                        loadFullHistory: shouldLoadHistory,
+                        using: dashboardTicketBridge
+                    ).filter { sessionBelongsToProfile($0, profile: profile) }
+
+                    let cached = forceRefresh ? [] : sessionCatalogCache.sessions(forKey: cacheKey).filter {
                         sessionBelongsToProfile($0, profile: profile)
                     }
-                    profileSessionCache[cronKey] = cronSessions
-                }
-                let combined = uniqueSessions(merged + cronSessions)
-                if !combined.isEmpty || shouldLoadHistory == false {
-                    loadedFullSessionHistory.insert(cacheKey)
-                    sessionCatalogLog.notice("Dashboard catalog for \(profile, privacy: .public): \(combined.count, privacy: .public) sessions; \(self.sourceSummary(combined), privacy: .public)")
-                    profileSessionCache[cacheKey] = combined
-                    return combined
+                    let merged = uniqueSessions(scoped + cached)
+
+                    // Fetch cron sessions separately -- the main query excludes them.
+                    let cronSessions: [SessionSummary]
+                    if !forceRefresh, let cached = sessionCatalogCache.cachedSessions(forKey: cronKey) {
+                        cronSessions = cached.filter { sessionBelongsToProfile($0, profile: profile) }
+                    } else {
+                        cronSessions = ((try? await dashboardCronSessions(profile: profile, using: dashboardTicketBridge)) ?? []).filter {
+                            sessionBelongsToProfile($0, profile: profile)
+                        }
+                    }
+
+                    // A delete/archive/disconnect can run while either request
+                    // is suspended. Never let this attempt overwrite the
+                    // newer cache state; retry from the authoritative source.
+                    guard sessionCatalogCache.mutationGeneration == generation else {
+                        continue
+                    }
+
+                    let combined = uniqueSessions(merged + cronSessions)
+                    if !combined.isEmpty || shouldLoadHistory == false {
+                        guard sessionCatalogCache.commit(
+                            liveSessions: combined,
+                            liveKey: cacheKey,
+                            cronSessions: cronSessions,
+                            cronKey: cronKey,
+                            loadedFullHistoryKey: cacheKey,
+                            at: generation
+                        ) else {
+                            continue
+                        }
+                        sessionCatalogLog.notice("Dashboard catalog for \(profile, privacy: .public): \(combined.count, privacy: .public) sessions; \(self.sourceSummary(combined), privacy: .public)")
+                        return combined
+                    }
+                    break
                 }
             } catch {
                 sessionCatalogLog.error("Dashboard history failed; using gateway fallback: \(error.localizedDescription, privacy: .public)")

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -139,6 +139,19 @@ struct SessionCatalogCache {
         sessionsByKey[key]
     }
 
+    /// Preserve the previous live snapshot when the dashboard returns no
+    /// usable rows. An empty response is not safe evidence that a populated
+    /// catalog was deleted: it can also represent a transient, malformed, or
+    /// profile-mismatched response.
+    func cachedSessionsForLiveMerge(
+        remoteSessions: [SessionSummary],
+        isAuthoritative: Bool,
+        forKey key: String
+    ) -> [SessionSummary] {
+        guard !isAuthoritative || remoteSessions.isEmpty else { return [] }
+        return sessions(forKey: key)
+    }
+
     func shouldLoadFullHistory(
         forKey key: String,
         forceRefresh: Bool,
@@ -625,6 +638,9 @@ final class AppState: ObservableObject {
     /// state and any in-flight projection.
     private struct DashboardSessionCatalog {
         let sessions: [SessionSummary]
+        /// True only when the dashboard returned a meaningful, terminal
+        /// catalog. Empty or unusable responses must remain mergeable with
+        /// the previous snapshot instead of evicting it.
         let isAuthoritative: Bool
     }
 
@@ -4843,15 +4859,25 @@ final class AppState: ObservableObject {
                         sessionBelongsToProfile($0, profile: profile)
                     }
 
-                    let cached = !scopedResult.isAuthoritative ? sessionCatalogCache.sessions(forKey: cacheKey).filter {
+                    let cached = sessionCatalogCache.cachedSessionsForLiveMerge(
+                        remoteSessions: scoped,
+                        isAuthoritative: scopedResult.isAuthoritative,
+                        forKey: cacheKey
+                    ).filter {
                         sessionBelongsToProfile($0, profile: profile)
-                    } : []
+                    }
                     let merged = uniqueSessions(scoped + cached)
 
                     // Fetch cron sessions separately -- the main query excludes them.
+                    let cachedCronSessions = sessionCatalogCache.cachedSessions(forKey: cronKey)?.filter {
+                        sessionBelongsToProfile($0, profile: profile)
+                    }
+                    let publishedCronSnapshot = self.cronSessions.filter {
+                        sessionBelongsToProfile($0, profile: profile)
+                    }
                     let cronSessions: [SessionSummary]?
-                    if !forceRefresh, let cached = sessionCatalogCache.cachedSessions(forKey: cronKey) {
-                        cronSessions = cached.filter { sessionBelongsToProfile($0, profile: profile) }
+                    if !forceRefresh, let cachedCronSessions {
+                        cronSessions = cachedCronSessions
                     } else {
                         do {
                             cronSessions = try await dashboardCronSessions(
@@ -4875,25 +4901,29 @@ final class AppState: ObservableObject {
                           self.client === client else {
                         throw DashboardTicketBridgeError.notReady
                     }
-                    guard sessionCatalogCache.mutationGeneration == generation else {
-                        catalogRetryCount += 1
-                        guard catalogRetryCount < maximumCatalogRetries else {
-                            break
-                        }
-                        continue
-                    }
 
-                    let combined = uniqueSessions(merged + (cronSessions ?? sessionCatalogCache.sessions(forKey: cronKey)))
+                    let combined = uniqueSessions(
+                        merged + (cronSessions ?? cachedCronSessions ?? publishedCronSnapshot)
+                    )
                     if !combined.isEmpty || shouldLoadHistory == false {
-                        _ = sessionCatalogCache.commit(
+                        guard sessionCatalogCache.commit(
                             liveSessions: combined,
                             liveKey: cacheKey,
                             cronSessions: cronSessions,
                             cronKey: cronKey,
                             loadedFullHistoryKey: cacheKey,
-                            recordFullHistoryAt: scopedResult.isAuthoritative ? Date() : nil,
+                            recordFullHistoryAt: scopedResult.isAuthoritative && !scoped.isEmpty ? Date() : nil,
                             at: generation
-                        )
+                        ) else {
+                            catalogRetryCount += 1
+                            guard catalogRetryCount < maximumCatalogRetries else {
+                                sessionCatalogLog.warning(
+                                    "Dashboard catalog mutation retry budget exhausted for \(profile, privacy: .public); using gateway fallback."
+                                )
+                                break
+                            }
+                            continue
+                        }
                         sessionCatalogLog.notice("Dashboard catalog for \(profile, privacy: .public): \(combined.count, privacy: .public) sessions; \(self.sourceSummary(combined), privacy: .public)")
                         return combined
                     }
@@ -5016,7 +5046,7 @@ final class AppState: ObservableObject {
                 || (total.map { offset + batch.count < $0 } ?? false)
                 || batch.count == 200
             if !hasMore || batch.isEmpty {
-                isAuthoritative = true
+                isAuthoritative = !sessions.isEmpty
                 break
             }
         }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -5042,12 +5042,19 @@ final class AppState: ObservableObject {
             let normalizedBatch = dashboardOwnedSessions(batch, profile: profile)
             sessions += normalizedBatch
 
+            let rawHasMore = response["has_more"] ?? response["hasMore"]
+            let explicitHasMore = rawHasMore.map { booleanValue($0) }
             let nextOffset = integerValue(response["next_offset"] ?? response["nextOffset"])
             let total = integerValue(response["total"])
-            let hasMore = booleanValue(response["has_more"] ?? response["hasMore"])
-                || (nextOffset ?? 0) > offset
-                || (total.map { offset + batch.count < $0 } ?? false)
-                || batch.count == 200
+            let hasExplicitTerminalSignal = explicitHasMore == false
+                || (nextOffset.map { $0 <= offset } ?? false)
+                || (total.map { offset + batch.count >= $0 } ?? false)
+            let hasMore = !hasExplicitTerminalSignal && (
+                explicitHasMore == true
+                    || (nextOffset ?? 0) > offset
+                    || (total.map { offset + batch.count < $0 } ?? false)
+                    || batch.count == 200
+            )
             if batch.isEmpty {
                 // An empty page after a non-empty prefix is not proof that
                 // the full catalog was read. Preserve older rows and retry a
@@ -5055,7 +5062,7 @@ final class AppState: ObservableObject {
                 break
             }
             if !hasMore {
-                isAuthoritative = !normalizedBatch.isEmpty
+                isAuthoritative = hasExplicitTerminalSignal && !normalizedBatch.isEmpty
                 break
             }
         }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -1665,6 +1665,13 @@ final class AppState: ObservableObject {
         showLogin = true
         sessions = []
         archivedSessions = []
+        cronSessions = []
+        // Sessions can be deleted from another client while signed out; a
+        // stale catalog cache would show those rows again after re-sign-in
+        // (and `loadedFullSessionHistory` would suppress the reload that
+        // could correct them).
+        profileSessionCache.removeAll()
+        loadedFullSessionHistory.removeAll()
         pinnedSessionIDs = []
         messages = []
         setActiveSessionState(id: nil, title: "New conversation")
@@ -3411,6 +3418,13 @@ final class AppState: ObservableObject {
     private func removeSessionFromLiveCatalog(_ session: SessionSummary) {
         sessions.removeAll { sessionMatches($0, session) }
         cronSessions.removeAll { sessionMatches($0, session) }
+        // Every non-forced catalog load merges the profile cache back into
+        // the published arrays and re-saves the union. A row left in the
+        // cache therefore resurrects a deleted or archived conversation on
+        // the next foreground or send, until a pull-to-refresh purges it.
+        for key in profileSessionCache.keys {
+            profileSessionCache[key]?.removeAll { sessionMatches($0, session) }
+        }
     }
 
     func clearActiveSessionIfNeeded(

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -124,8 +124,11 @@ struct ChatResumeLifecycleOperations {
 /// while it awaits WebKit, so a request must not overwrite a newer purge when
 /// it resumes.
 struct SessionCatalogCache {
+    static let fullHistoryRefreshInterval: TimeInterval = 5 * 60
+
     private(set) var sessionsByKey: [String: [SessionSummary]] = [:]
     private(set) var loadedFullHistoryKeys = Set<String>()
+    private(set) var fullHistoryLoadedAt: [String: Date] = [:]
     private(set) var mutationGeneration: UInt64 = 0
 
     func sessions(forKey key: String) -> [SessionSummary] {
@@ -136,21 +139,40 @@ struct SessionCatalogCache {
         sessionsByKey[key]
     }
 
+    func shouldLoadFullHistory(
+        forKey key: String,
+        forceRefresh: Bool,
+        now: Date = Date()
+    ) -> Bool {
+        guard !forceRefresh,
+              loadedFullHistoryKeys.contains(key),
+              let loadedAt = fullHistoryLoadedAt[key] else {
+            return true
+        }
+        return now.timeIntervalSince(loadedAt) >= Self.fullHistoryRefreshInterval
+    }
+
     /// Commits a live and cron snapshot only when no cache mutation occurred
     /// during the load that produced it.
     @discardableResult
     mutating func commit(
         liveSessions: [SessionSummary],
         liveKey: String,
-        cronSessions: [SessionSummary],
+        cronSessions: [SessionSummary]?,
         cronKey: String,
         loadedFullHistoryKey: String,
+        recordFullHistoryAt: Date?,
         at generation: UInt64
     ) -> Bool {
         guard generation == mutationGeneration else { return false }
         sessionsByKey[liveKey] = liveSessions
-        sessionsByKey[cronKey] = cronSessions
-        loadedFullHistoryKeys.insert(loadedFullHistoryKey)
+        if let cronSessions {
+            sessionsByKey[cronKey] = cronSessions
+        }
+        if let recordFullHistoryAt {
+            loadedFullHistoryKeys.insert(loadedFullHistoryKey)
+            fullHistoryLoadedAt[loadedFullHistoryKey] = recordFullHistoryAt
+        }
         return true
     }
 
@@ -158,12 +180,14 @@ struct SessionCatalogCache {
         mutationGeneration &+= 1
         sessionsByKey.removeAll()
         loadedFullHistoryKeys.removeAll()
+        fullHistoryLoadedAt.removeAll()
     }
 
     mutating func removeValue(forKey key: String) {
         mutationGeneration &+= 1
         sessionsByKey.removeValue(forKey: key)
         loadedFullHistoryKeys.remove(key)
+        fullHistoryLoadedAt.removeValue(forKey: key)
     }
 
     mutating func removeSession(withIDs sessionIDs: Set<String>) {
@@ -599,6 +623,11 @@ final class AppState: ObservableObject {
     /// it retains database timestamps, complete tool-call inputs, and other
     /// presentation fields. The resume RPC remains authoritative for live turn
     /// state and any in-flight projection.
+    private struct DashboardSessionCatalog {
+        let sessions: [SessionSummary]
+        let isAuthoritative: Bool
+    }
+
     private struct PersistedSessionTranscript {
         let resolvedSessionId: String?
         let messages: [ChatMessage]
@@ -4797,56 +4826,85 @@ final class AppState: ObservableObject {
             do {
                 let cacheKey = "\(profile):exclude"
                 let cronKey = "\(profile):cron"
+                let maximumCatalogRetries = 3
+                var catalogRetryCount = 0
                 while true {
                     let generation = sessionCatalogCache.mutationGeneration
-                    let shouldLoadHistory = forceRefresh
-                        || !sessionCatalogCache.loadedFullHistoryKeys.contains(cacheKey)
-                    let scoped = try await dashboardSessions(
+                    let shouldLoadHistory = sessionCatalogCache.shouldLoadFullHistory(
+                        forKey: cacheKey,
+                        forceRefresh: forceRefresh
+                    )
+                    let scopedResult = try await dashboardSessions(
                         profile: profile,
                         loadFullHistory: shouldLoadHistory,
                         using: dashboardTicketBridge
-                    ).filter { sessionBelongsToProfile($0, profile: profile) }
-
-                    let cached = forceRefresh ? [] : sessionCatalogCache.sessions(forKey: cacheKey).filter {
+                    )
+                    let scoped = scopedResult.sessions.filter {
                         sessionBelongsToProfile($0, profile: profile)
                     }
+
+                    let cached = !scopedResult.isAuthoritative ? sessionCatalogCache.sessions(forKey: cacheKey).filter {
+                        sessionBelongsToProfile($0, profile: profile)
+                    } : []
                     let merged = uniqueSessions(scoped + cached)
 
                     // Fetch cron sessions separately -- the main query excludes them.
-                    let cronSessions: [SessionSummary]
+                    let cronSessions: [SessionSummary]?
                     if !forceRefresh, let cached = sessionCatalogCache.cachedSessions(forKey: cronKey) {
                         cronSessions = cached.filter { sessionBelongsToProfile($0, profile: profile) }
                     } else {
-                        cronSessions = ((try? await dashboardCronSessions(profile: profile, using: dashboardTicketBridge)) ?? []).filter {
-                            sessionBelongsToProfile($0, profile: profile)
+                        do {
+                            cronSessions = try await dashboardCronSessions(
+                                profile: profile,
+                                using: dashboardTicketBridge
+                            ).filter {
+                                sessionBelongsToProfile($0, profile: profile)
+                            }
+                        } catch {
+                            // Keep a previous cron snapshot if one exists, but
+                            // do not cache an empty result for a failed request.
+                            cronSessions = nil
                         }
                     }
 
                     // A delete/archive/disconnect can run while either request
                     // is suspended. Never let this attempt overwrite the
                     // newer cache state; retry from the authoritative source.
+                    guard profile == activeProfile,
+                          self.dashboardTicketBridge === dashboardTicketBridge,
+                          self.client === client else {
+                        throw DashboardTicketBridgeError.notReady
+                    }
                     guard sessionCatalogCache.mutationGeneration == generation else {
+                        catalogRetryCount += 1
+                        guard catalogRetryCount < maximumCatalogRetries else {
+                            break
+                        }
                         continue
                     }
 
-                    let combined = uniqueSessions(merged + cronSessions)
+                    let combined = uniqueSessions(merged + (cronSessions ?? sessionCatalogCache.sessions(forKey: cronKey)))
                     if !combined.isEmpty || shouldLoadHistory == false {
-                        guard sessionCatalogCache.commit(
+                        _ = sessionCatalogCache.commit(
                             liveSessions: combined,
                             liveKey: cacheKey,
                             cronSessions: cronSessions,
                             cronKey: cronKey,
                             loadedFullHistoryKey: cacheKey,
+                            recordFullHistoryAt: scopedResult.isAuthoritative ? Date() : nil,
                             at: generation
-                        ) else {
-                            continue
-                        }
+                        )
                         sessionCatalogLog.notice("Dashboard catalog for \(profile, privacy: .public): \(combined.count, privacy: .public) sessions; \(self.sourceSummary(combined), privacy: .public)")
                         return combined
                     }
                     break
                 }
             } catch {
+                guard profile == activeProfile,
+                      self.dashboardTicketBridge === dashboardTicketBridge,
+                      self.client === client else {
+                    throw DashboardTicketBridgeError.notReady
+                }
                 sessionCatalogLog.error("Dashboard history failed; using gateway fallback: \(error.localizedDescription, privacy: .public)")
                 // Keep older dashboard installations usable; the gateway is
                 // still an authoritative fallback when the history endpoint is
@@ -4940,9 +4998,10 @@ final class AppState: ObservableObject {
         profile: String,
         loadFullHistory: Bool,
         using bridge: DashboardTicketBridge
-    ) async throws -> [SessionSummary] {
+    ) async throws -> DashboardSessionCatalog {
         let maximumPages = loadFullHistory ? 25 : 1
         var sessions: [SessionSummary] = []
+        var isAuthoritative = false
 
         for page in 0..<maximumPages {
             let offset = page * 200
@@ -4956,10 +5015,16 @@ final class AppState: ObservableObject {
                 || (nextOffset ?? 0) > offset
                 || (total.map { offset + batch.count < $0 } ?? false)
                 || batch.count == 200
-            if !hasMore || batch.isEmpty { break }
+            if !hasMore || batch.isEmpty {
+                isAuthoritative = true
+                break
+            }
         }
 
-        return sessions
+        return DashboardSessionCatalog(
+            sessions: sessions,
+            isAuthoritative: isAuthoritative
+        )
     }
 
     private func dashboardArchivedSessions(

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -139,16 +139,18 @@ struct SessionCatalogCache {
         sessionsByKey[key]
     }
 
-    /// Preserve the previous live snapshot when the dashboard returns no
-    /// usable rows. An empty response is not safe evidence that a populated
-    /// catalog was deleted: it can also represent a transient, malformed, or
-    /// profile-mismatched response.
-    func cachedSessionsForLiveMerge(
+    /// Returns cached rows to merge unless the dashboard supplied a meaningful
+    /// authoritative replacement. An empty response is not safe evidence that
+    /// a populated catalog was deleted: it can also represent a transient,
+    /// malformed, or profile-mismatched response.
+    func cachedSessionsToMerge(
         remoteSessions: [SessionSummary],
         isAuthoritative: Bool,
         forKey key: String
     ) -> [SessionSummary] {
-        guard !isAuthoritative || remoteSessions.isEmpty else { return [] }
+        if isAuthoritative && !remoteSessions.isEmpty {
+            return []
+        }
         return sessions(forKey: key)
     }
 
@@ -4859,7 +4861,7 @@ final class AppState: ObservableObject {
                         sessionBelongsToProfile($0, profile: profile)
                     }
 
-                    let cached = sessionCatalogCache.cachedSessionsForLiveMerge(
+                    let cached = sessionCatalogCache.cachedSessionsToMerge(
                         remoteSessions: scoped,
                         isAuthoritative: scopedResult.isAuthoritative,
                         forKey: cacheKey
@@ -5037,7 +5039,8 @@ final class AppState: ObservableObject {
             let offset = page * 200
             let response = try await bridge.requestJSON(path: profileSessionsPath(profile, offset: offset))
             let batch = response["sessions"] as? [Any] ?? []
-            sessions += dashboardOwnedSessions(batch, profile: profile)
+            let normalizedBatch = dashboardOwnedSessions(batch, profile: profile)
+            sessions += normalizedBatch
 
             let nextOffset = integerValue(response["next_offset"] ?? response["nextOffset"])
             let total = integerValue(response["total"])
@@ -5045,8 +5048,14 @@ final class AppState: ObservableObject {
                 || (nextOffset ?? 0) > offset
                 || (total.map { offset + batch.count < $0 } ?? false)
                 || batch.count == 200
-            if !hasMore || batch.isEmpty {
-                isAuthoritative = !sessions.isEmpty
+            if batch.isEmpty {
+                // An empty page after a non-empty prefix is not proof that
+                // the full catalog was read. Preserve older rows and retry a
+                // complete load later instead of evicting the cached suffix.
+                break
+            }
+            if !hasMore {
+                isAuthoritative = !normalizedBatch.isEmpty
                 break
             }
         }

--- a/ConduitTests/SessionCatalogCacheTests.swift
+++ b/ConduitTests/SessionCatalogCacheTests.swift
@@ -132,7 +132,7 @@ final class SessionCatalogCacheTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            cache.cachedSessionsForLiveMerge(
+            cache.cachedSessionsToMerge(
                 remoteSessions: [],
                 isAuthoritative: true,
                 forKey: "default:exclude"

--- a/ConduitTests/SessionCatalogCacheTests.swift
+++ b/ConduitTests/SessionCatalogCacheTests.swift
@@ -4,18 +4,7 @@ import XCTest
 final class SessionCatalogCacheTests: XCTestCase {
     func testRejectsStaleCommitAfterSessionRemoval() {
         var cache = SessionCatalogCache()
-        let deleted = SessionSummary(
-            id: "deleted-session",
-            alternateIds: [],
-            title: "Deleted",
-            model: "Hermes",
-            updatedLabel: "now",
-            profile: "default",
-            source: .chat,
-            isActive: false,
-            isArchived: false,
-            lineageRootId: nil
-        )
+        let deleted = session(id: "deleted-session", title: "Deleted")
         let loadGeneration = cache.mutationGeneration
 
         XCTAssertTrue(
@@ -25,6 +14,7 @@ final class SessionCatalogCacheTests: XCTestCase {
                 cronSessions: [],
                 cronKey: "default:cron",
                 loadedFullHistoryKey: "default:exclude",
+                recordFullHistoryAt: Date(timeIntervalSince1970: 100),
                 at: loadGeneration
             )
         )
@@ -38,9 +28,161 @@ final class SessionCatalogCacheTests: XCTestCase {
                 cronSessions: [],
                 cronKey: "default:cron",
                 loadedFullHistoryKey: "default:exclude",
+                recordFullHistoryAt: Date(timeIntervalSince1970: 100),
                 at: loadGeneration
             )
         )
         XCTAssertTrue(cache.sessions(forKey: "default:exclude").isEmpty)
+    }
+
+    func testRemoveSessionPurgesMatchingAlternateID() {
+        var cache = SessionCatalogCache()
+        let session = session(
+            id: "runtime-id",
+            alternateIds: ["stored-id"],
+            title: "Conversation"
+        )
+        let generation = cache.mutationGeneration
+
+        XCTAssertTrue(
+            cache.commit(
+                liveSessions: [session],
+                liveKey: "default:exclude",
+                cronSessions: [],
+                cronKey: "default:cron",
+                loadedFullHistoryKey: "default:exclude",
+                recordFullHistoryAt: Date(timeIntervalSince1970: 100),
+                at: generation
+            )
+        )
+
+        cache.removeSession(withIDs: ["stored-id"])
+
+        XCTAssertTrue(cache.sessions(forKey: "default:exclude").isEmpty)
+    }
+
+    func testRemoveAllClearsCatalogAndHistoryMarker() {
+        var cache = SessionCatalogCache()
+        let session = session(id: "stored-id", title: "Conversation")
+
+        XCTAssertTrue(
+            cache.commit(
+                liveSessions: [session],
+                liveKey: "default:exclude",
+                cronSessions: [],
+                cronKey: "default:cron",
+                loadedFullHistoryKey: "default:exclude",
+                recordFullHistoryAt: Date(timeIntervalSince1970: 100),
+                at: cache.mutationGeneration
+            )
+        )
+
+        cache.removeAll()
+
+        XCTAssertTrue(cache.sessions(forKey: "default:exclude").isEmpty)
+        XCTAssertTrue(cache.loadedFullHistoryKeys.isEmpty)
+        XCTAssertTrue(cache.fullHistoryLoadedAt.isEmpty)
+    }
+
+    func testAuthoritativeCommitEvictsSessionOmittedByRemoteCatalog() {
+        var cache = SessionCatalogCache()
+        let retained = session(id: "retained-id", title: "Retained")
+        let deletedRemotely = session(id: "deleted-id", title: "Deleted remotely")
+
+        XCTAssertTrue(
+            cache.commit(
+                liveSessions: [retained, deletedRemotely],
+                liveKey: "default:exclude",
+                cronSessions: [],
+                cronKey: "default:cron",
+                loadedFullHistoryKey: "default:exclude",
+                recordFullHistoryAt: Date(timeIntervalSince1970: 100),
+                at: cache.mutationGeneration
+            )
+        )
+        XCTAssertTrue(
+            cache.commit(
+                liveSessions: [retained],
+                liveKey: "default:exclude",
+                cronSessions: [],
+                cronKey: "default:cron",
+                loadedFullHistoryKey: "default:exclude",
+                recordFullHistoryAt: Date(timeIntervalSince1970: 200),
+                at: cache.mutationGeneration
+            )
+        )
+
+        XCTAssertEqual(cache.sessions(forKey: "default:exclude"), [retained])
+    }
+
+    func testFailedCronFetchDoesNotPoisonTheCronCache() {
+        var cache = SessionCatalogCache()
+        let live = session(id: "live-id", title: "Live")
+
+        XCTAssertTrue(
+            cache.commit(
+                liveSessions: [live],
+                liveKey: "default:exclude",
+                cronSessions: nil,
+                cronKey: "default:cron",
+                loadedFullHistoryKey: "default:exclude",
+                recordFullHistoryAt: Date(timeIntervalSince1970: 100),
+                at: cache.mutationGeneration
+            )
+        )
+
+        XCTAssertNil(cache.cachedSessions(forKey: "default:cron"))
+        XCTAssertEqual(cache.sessions(forKey: "default:exclude"), [live])
+    }
+
+    func testFullHistoryRefreshesAfterCacheLifetime() {
+        var cache = SessionCatalogCache()
+        let loadedAt = Date(timeIntervalSince1970: 100)
+
+        XCTAssertTrue(
+            cache.commit(
+                liveSessions: [session(id: "stored-id", title: "Conversation")],
+                liveKey: "default:exclude",
+                cronSessions: [],
+                cronKey: "default:cron",
+                loadedFullHistoryKey: "default:exclude",
+                recordFullHistoryAt: loadedAt,
+                at: cache.mutationGeneration
+            )
+        )
+
+        XCTAssertFalse(
+            cache.shouldLoadFullHistory(
+                forKey: "default:exclude",
+                forceRefresh: false,
+                now: loadedAt.addingTimeInterval(1)
+            )
+        )
+        XCTAssertTrue(
+            cache.shouldLoadFullHistory(
+                forKey: "default:exclude",
+                forceRefresh: false,
+                now: loadedAt.addingTimeInterval(SessionCatalogCache.fullHistoryRefreshInterval + 1)
+            )
+        )
+    }
+
+    private func session(
+        id: String,
+        alternateIds: [String] = [],
+        title: String
+    ) -> SessionSummary {
+        SessionSummary(
+            id: id,
+            alternateIds: alternateIds,
+            title: title,
+            model: "Hermes",
+            updatedLabel: "now",
+            profile: "default",
+            source: .chat,
+            isActive: false,
+            isArchived: false,
+            lineageRootId: nil
+        )
     }
 }

--- a/ConduitTests/SessionCatalogCacheTests.swift
+++ b/ConduitTests/SessionCatalogCacheTests.swift
@@ -115,6 +115,32 @@ final class SessionCatalogCacheTests: XCTestCase {
         XCTAssertEqual(cache.sessions(forKey: "default:exclude"), [retained])
     }
 
+    func testEmptyRemoteCatalogPreservesCachedRowsForLiveMerge() {
+        var cache = SessionCatalogCache()
+        let cached = session(id: "cached-id", title: "Cached")
+
+        XCTAssertTrue(
+            cache.commit(
+                liveSessions: [cached],
+                liveKey: "default:exclude",
+                cronSessions: [],
+                cronKey: "default:cron",
+                loadedFullHistoryKey: "default:exclude",
+                recordFullHistoryAt: Date(timeIntervalSince1970: 100),
+                at: cache.mutationGeneration
+            )
+        )
+
+        XCTAssertEqual(
+            cache.cachedSessionsForLiveMerge(
+                remoteSessions: [],
+                isAuthoritative: true,
+                forKey: "default:exclude"
+            ),
+            [cached]
+        )
+    }
+
     func testFailedCronFetchDoesNotPoisonTheCronCache() {
         var cache = SessionCatalogCache()
         let live = session(id: "live-id", title: "Live")

--- a/ConduitTests/SessionCatalogCacheTests.swift
+++ b/ConduitTests/SessionCatalogCacheTests.swift
@@ -13,8 +13,7 @@ final class SessionCatalogCacheTests: XCTestCase {
                 liveKey: "default:exclude",
                 cronSessions: [],
                 cronKey: "default:cron",
-                loadedFullHistoryKey: "default:exclude",
-                recordFullHistoryAt: Date(timeIntervalSince1970: 100),
+                historyMarkers: ["default:exclude": Date(timeIntervalSince1970: 100)],
                 at: loadGeneration
             )
         )
@@ -27,8 +26,7 @@ final class SessionCatalogCacheTests: XCTestCase {
                 liveKey: "default:exclude",
                 cronSessions: [],
                 cronKey: "default:cron",
-                loadedFullHistoryKey: "default:exclude",
-                recordFullHistoryAt: Date(timeIntervalSince1970: 100),
+                historyMarkers: ["default:exclude": Date(timeIntervalSince1970: 100)],
                 at: loadGeneration
             )
         )
@@ -50,8 +48,7 @@ final class SessionCatalogCacheTests: XCTestCase {
                 liveKey: "default:exclude",
                 cronSessions: [],
                 cronKey: "default:cron",
-                loadedFullHistoryKey: "default:exclude",
-                recordFullHistoryAt: Date(timeIntervalSince1970: 100),
+                historyMarkers: ["default:exclude": Date(timeIntervalSince1970: 100)],
                 at: generation
             )
         )
@@ -71,8 +68,7 @@ final class SessionCatalogCacheTests: XCTestCase {
                 liveKey: "default:exclude",
                 cronSessions: [],
                 cronKey: "default:cron",
-                loadedFullHistoryKey: "default:exclude",
-                recordFullHistoryAt: Date(timeIntervalSince1970: 100),
+                historyMarkers: ["default:exclude": Date(timeIntervalSince1970: 100)],
                 at: cache.mutationGeneration
             )
         )
@@ -95,8 +91,7 @@ final class SessionCatalogCacheTests: XCTestCase {
                 liveKey: "default:exclude",
                 cronSessions: [],
                 cronKey: "default:cron",
-                loadedFullHistoryKey: "default:exclude",
-                recordFullHistoryAt: Date(timeIntervalSince1970: 100),
+                historyMarkers: ["default:exclude": Date(timeIntervalSince1970: 100)],
                 at: cache.mutationGeneration
             )
         )
@@ -106,8 +101,7 @@ final class SessionCatalogCacheTests: XCTestCase {
                 liveKey: "default:exclude",
                 cronSessions: [],
                 cronKey: "default:cron",
-                loadedFullHistoryKey: "default:exclude",
-                recordFullHistoryAt: Date(timeIntervalSince1970: 200),
+                historyMarkers: ["default:exclude": Date(timeIntervalSince1970: 200)],
                 at: cache.mutationGeneration
             )
         )
@@ -125,8 +119,7 @@ final class SessionCatalogCacheTests: XCTestCase {
                 liveKey: "default:exclude",
                 cronSessions: [],
                 cronKey: "default:cron",
-                loadedFullHistoryKey: "default:exclude",
-                recordFullHistoryAt: Date(timeIntervalSince1970: 100),
+                historyMarkers: ["default:exclude": Date(timeIntervalSince1970: 100)],
                 at: cache.mutationGeneration
             )
         )
@@ -151,8 +144,7 @@ final class SessionCatalogCacheTests: XCTestCase {
                 liveKey: "default:exclude",
                 cronSessions: nil,
                 cronKey: "default:cron",
-                loadedFullHistoryKey: "default:exclude",
-                recordFullHistoryAt: Date(timeIntervalSince1970: 100),
+                historyMarkers: ["default:exclude": Date(timeIntervalSince1970: 100)],
                 at: cache.mutationGeneration
             )
         )
@@ -171,8 +163,7 @@ final class SessionCatalogCacheTests: XCTestCase {
                 liveKey: "default:exclude",
                 cronSessions: [],
                 cronKey: "default:cron",
-                loadedFullHistoryKey: "default:exclude",
-                recordFullHistoryAt: loadedAt,
+                historyMarkers: ["default:exclude": loadedAt],
                 at: cache.mutationGeneration
             )
         )
@@ -187,6 +178,37 @@ final class SessionCatalogCacheTests: XCTestCase {
         XCTAssertTrue(
             cache.shouldLoadFullHistory(
                 forKey: "default:exclude",
+                forceRefresh: false,
+                now: loadedAt.addingTimeInterval(SessionCatalogCache.fullHistoryRefreshInterval + 1)
+            )
+        )
+    }
+
+    func testCronHistoryRefreshesAfterCacheLifetime() {
+        var cache = SessionCatalogCache()
+        let loadedAt = Date(timeIntervalSince1970: 100)
+
+        XCTAssertTrue(
+            cache.commit(
+                liveSessions: [],
+                liveKey: "default:exclude",
+                cronSessions: [session(id: "cron-id", title: "Cron")],
+                cronKey: "default:cron",
+                historyMarkers: ["default:cron": loadedAt],
+                at: cache.mutationGeneration
+            )
+        )
+
+        XCTAssertFalse(
+            cache.shouldLoadFullHistory(
+                forKey: "default:cron",
+                forceRefresh: false,
+                now: loadedAt.addingTimeInterval(1)
+            )
+        )
+        XCTAssertTrue(
+            cache.shouldLoadFullHistory(
+                forKey: "default:cron",
                 forceRefresh: false,
                 now: loadedAt.addingTimeInterval(SessionCatalogCache.fullHistoryRefreshInterval + 1)
             )

--- a/ConduitTests/SessionCatalogCacheTests.swift
+++ b/ConduitTests/SessionCatalogCacheTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import Conduit
+
+final class SessionCatalogCacheTests: XCTestCase {
+    func testRejectsStaleCommitAfterSessionRemoval() {
+        var cache = SessionCatalogCache()
+        let deleted = SessionSummary(
+            id: "deleted-session",
+            alternateIds: [],
+            title: "Deleted",
+            model: "Hermes",
+            updatedLabel: "now",
+            profile: "default",
+            source: .chat,
+            isActive: false,
+            isArchived: false,
+            lineageRootId: nil
+        )
+        let loadGeneration = cache.mutationGeneration
+
+        XCTAssertTrue(
+            cache.commit(
+                liveSessions: [deleted],
+                liveKey: "default:exclude",
+                cronSessions: [],
+                cronKey: "default:cron",
+                loadedFullHistoryKey: "default:exclude",
+                at: loadGeneration
+            )
+        )
+
+        cache.removeSession(withIDs: [deleted.id])
+
+        XCTAssertFalse(
+            cache.commit(
+                liveSessions: [deleted],
+                liveKey: "default:exclude",
+                cronSessions: [],
+                cronKey: "default:cron",
+                loadedFullHistoryKey: "default:exclude",
+                at: loadGeneration
+            )
+        )
+        XCTAssertTrue(cache.sessions(forKey: "default:exclude").isEmpty)
+    }
+}

--- a/docs/superpowers/plans/2026-08-12-pr46-session-cache-salvage.md
+++ b/docs/superpowers/plans/2026-08-12-pr46-session-cache-salvage.md
@@ -4,7 +4,7 @@
 
 **Goal:** Update PR #46 onto current `main` while retaining only its session-catalog cache invalidation behavior.
 
-**Architecture:** Use a non-rewriting merge of current `origin/main` into the contributor-owned PR branch. Current `main` remains authoritative for the already-merged stream, WebSocket, WebKit, rendering-cache, and image-fallback code; PR #46 contributes its AppState cache invalidation, bounded generation-checked retry, authoritative-catalog replacement, and cache expiry logic. The cache remains private to `AppState`; the standalone cache value type provides focused coverage for stale writes, alias-aware purges, failed cron loads, authoritative omissions, and expiry without adding a test-only production hook.
+**Architecture:** Use a non-rewriting merge of current `origin/main` into the contributor-owned PR branch. Current `main` remains authoritative for the already-merged stream, WebSocket, WebKit, rendering-cache, and image-fallback code; PR #46 contributes its AppState cache invalidation, bounded generation-checked retry, authoritative-catalog replacement, and cache expiry logic. Empty or unusable dashboard responses are non-authoritative and preserve a prior live snapshot. The cache remains private to `AppState`; the standalone cache value type provides focused coverage for stale writes, alias-aware purges, failed cron loads, empty responses, authoritative omissions, and expiry without adding a test-only production hook.
 
 **Tech Stack:** Swift 5.9, SwiftUI, XCTest, XcodeGen, Xcode 26.5, iOS Simulator.
 
@@ -15,7 +15,7 @@
 - Keep the session cache purge attached to successful delete/archive paths and explicit disconnect.
 - Abort catalog publication when the profile, client, or dashboard bridge changes while a request is suspended.
 - Preserve the previous cron cache when its refresh fails, and bound mutation retries.
-- Replace cached live rows after a complete dashboard catalog response; retain older rows only for explicitly partial responses, which are refreshed after a bounded cache lifetime.
+- Replace cached live rows after a meaningful complete dashboard catalog response; treat empty or unusable responses as non-authoritative so they cannot wipe a prior snapshot or refresh its full-history marker. Retain older rows for explicitly partial responses, which are refreshed after a bounded cache lifetime.
 - Do not add a production-only test hook solely to expose private AppState caches.
 - Run the generated-project full test suite before publishing the branch.
 
@@ -110,7 +110,8 @@ needed.
 **Interfaces:**
 - Consumes: The reduced effective diff from Task 1.
 - Produces: Focused coverage for stale commit rejection, alias-aware purges,
-  cache reset, failed cron refreshes, authoritative remote omissions, and
+  cache reset, failed cron refreshes, empty-response preservation,
+  authoritative remote omissions, and
   bounded full-history expiry. The WebKit-backed delete/archive integration
   boundary remains outside the unit-test harness.
 

--- a/docs/superpowers/plans/2026-08-12-pr46-session-cache-salvage.md
+++ b/docs/superpowers/plans/2026-08-12-pr46-session-cache-salvage.md
@@ -1,0 +1,209 @@
+# PR #46 Session-Cache Salvage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update PR #46 onto current `main` while retaining only its session-catalog cache invalidation behavior.
+
+**Architecture:** Use a non-rewriting merge of current `origin/main` into the contributor-owned PR branch. Current `main` remains authoritative for the already-merged stream, WebSocket, WebKit, rendering-cache, and image-fallback code; PR #46 contributes only its AppState cache purge logic. The existing AppState caches are private and have no suitable integration seam, so verification will rely on the effective diff plus the full iOS test suite rather than adding test-only production hooks.
+
+**Tech Stack:** Swift 5.9, SwiftUI, XCTest, XcodeGen, Xcode 26.5, iOS Simulator.
+
+## Global Constraints
+
+- Do not rewrite or force-push the contributor-owned PR branch.
+- Preserve current `main` implementations for all behavior already merged through PR #45.
+- Keep the session cache purge attached to successful delete/archive paths and explicit disconnect.
+- Do not add a production-only test hook solely to expose private AppState caches.
+- Run the generated-project full test suite before publishing the branch.
+
+---
+
+### Task 1: Merge current main into the PR branch
+
+**Files:**
+- Modify: Git history on `codex/pr46-session-cache-invalidation`.
+- Preserve: `Conduit/Services/AppState.swift` cache invalidation from commit `313a26d`.
+
+**Interfaces:**
+- Consumes: `origin/main` at the current PR #45 merge commit.
+- Produces: A merge commit whose first parent is current `origin/main` and whose effective PR diff contains the cache invalidation plus the approved design/plan documents.
+
+- [ ] **Step 1: Confirm the worktree is clean and the source refs are current**
+
+Run:
+
+```bash
+git status --short --branch
+git rev-parse origin/main
+git rev-parse HEAD
+```
+
+Expected: only committed salvage documentation is present; `origin/main` is
+`725610341c75bab7acf84e2de7f4dcc9549aa24d` or a newer fetched `main` commit.
+
+- [ ] **Step 2: Merge current main without rewriting history**
+
+Run:
+
+```bash
+git merge origin/main --no-edit
+```
+
+If a conflict occurs, keep current `origin/main` for the already-merged
+stability code and reapply only these PR #46 behaviors in `AppState.swift`:
+
+```swift
+cronSessions = []
+profileSessionCache.removeAll()
+loadedFullSessionHistory.removeAll()
+```
+
+and the cache-row removal in `removeSessionFromLiveCatalog`:
+
+```swift
+for key in profileSessionCache.keys {
+    profileSessionCache[key]?.removeAll { sessionMatches($0, session) }
+}
+```
+
+- [ ] **Step 3: Confirm the effective diff is reduced to the intended scope**
+
+Run:
+
+```bash
+git diff --name-status origin/main...HEAD
+git diff origin/main...HEAD -- Conduit/Services/AppState.swift
+```
+
+Expected: no stale PR #46 replacements of the current deduplication, bridge,
+WebSocket, cache, or image-fallback implementations; only the cache purge and
+the committed salvage documentation remain different from `main`.
+
+- [ ] **Step 4: Commit any conflict resolution**
+
+Run:
+
+```bash
+git status --short
+git commit -m "Merge current main into PR46 salvage"
+```
+
+Skip the commit command when `git merge` already created the merge commit.
+
+### Task 2: Verify the cache behavior without adding test-only hooks
+
+**Files:**
+- Inspect: `Conduit/Services/AppState.swift` around `disconnect()` and `removeSessionFromLiveCatalog()`.
+- Inspect: `ConduitTests/` existing AppState and session-catalog tests.
+
+**Interfaces:**
+- Consumes: The reduced effective diff from Task 1.
+- Produces: A verified decision that the private cache behavior is covered by existing integration paths, or a narrowly scoped test only if an existing seam can exercise it without exposing private state.
+
+- [ ] **Step 1: Check existing test seams before adding coverage**
+
+Run:
+
+```bash
+rg -n -C 8 "profileSessionCache|loadedFullSessionHistory|removeSessionFromLiveCatalog|disconnect\(" ConduitTests Conduit/Services/AppState.swift
+```
+
+Expected: do not change production visibility merely to inspect private cache
+storage. If no existing seam can observe cache reuse after delete/archive or
+disconnect/re-sign-in, record that no focused test is added and rely on the
+full suite for regression protection.
+
+- [ ] **Step 2: Check the reduced diff for accidental behavior changes**
+
+Run:
+
+```bash
+git diff --check
+git diff --stat origin/main...HEAD
+```
+
+Expected: no whitespace errors and no files outside the approved AppState and
+salvage-document scope.
+
+### Task 3: Run full verification
+
+**Files:**
+- Generate: ignored `Conduit.xcodeproj` from `project.yml`.
+- Test: all targets in the `Conduit` scheme.
+
+**Interfaces:**
+- Consumes: The merged, reduced PR branch.
+- Produces: A result bundle showing zero failed or skipped tests.
+
+- [ ] **Step 1: Generate the Xcode project and run the full suite**
+
+Run:
+
+```bash
+xcodegen generate
+xcodebuild test \
+  -project Conduit.xcodeproj \
+  -scheme Conduit \
+  -destination "platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355" \
+  -configuration Debug \
+  -resultBundlePath /tmp/conduit-pr46-salvage.xcresult \
+  CODE_SIGN_IDENTITY="" \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  DEVELOPMENT_TEAM="" \
+  PROVISIONING_PROFILE_SPECIFIER=""
+```
+
+- [ ] **Step 2: Read the result summary**
+
+Run:
+
+```bash
+xcrun xcresulttool get test-results summary --path /tmp/conduit-pr46-salvage.xcresult
+```
+
+Expected: `result` is `Passed`, `failedTests` is `0`, and `skippedTests` is
+`0`.
+
+### Task 4: Publish and wait for fresh PR validation
+
+**Files:**
+- Push: contributor fork branch `angel12/hermes-conduit:fix/session-cache-invalidation`.
+- Review: GitHub PR #46.
+
+**Interfaces:**
+- Consumes: Verified merge commit and clean worktree.
+- Produces: Fresh Build & Test, OpenCode review, and CodeRabbit results against
+  the reduced PR diff.
+
+- [ ] **Step 1: Confirm the branch and worktree state**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline --decorate -4
+```
+
+Expected: clean worktree, branch `codex/pr46-session-cache-invalidation`, and
+the salvage merge commit at `HEAD`.
+
+- [ ] **Step 2: Push without force**
+
+Run:
+
+```bash
+git push https://github.com/angel12/hermes-conduit.git HEAD:fix/session-cache-invalidation
+```
+
+- [ ] **Step 3: Wait for the fresh checks and inspect new review threads**
+
+Run:
+
+```bash
+gh pr checks 46 --repo kaishi00/hermes-conduit --watch --interval 30
+gh pr view 46 --repo kaishi00/hermes-conduit --json state,headRefOid,statusCheckRollup,reviews
+```
+
+Expected: the checks complete successfully and any new comments are evaluated
+against the reduced cache-only diff, not the historical bundled commits.

--- a/docs/superpowers/plans/2026-08-12-pr46-session-cache-salvage.md
+++ b/docs/superpowers/plans/2026-08-12-pr46-session-cache-salvage.md
@@ -4,7 +4,7 @@
 
 **Goal:** Update PR #46 onto current `main` while retaining only its session-catalog cache invalidation behavior.
 
-**Architecture:** Use a non-rewriting merge of current `origin/main` into the contributor-owned PR branch. Current `main` remains authoritative for the already-merged stream, WebSocket, WebKit, rendering-cache, and image-fallback code; PR #46 contributes its AppState cache invalidation, bounded generation-checked retry, authoritative-catalog replacement, and cache expiry logic. Empty, unusable, or ambiguous dashboard responses without trustworthy terminal metadata are non-authoritative and preserve a prior live snapshot. The cache remains private to `AppState`; the standalone cache value type provides focused coverage for stale writes, alias-aware purges, failed cron loads, empty responses, authoritative omissions, and expiry without adding a test-only production hook.
+**Architecture:** Use a non-rewriting merge of current `origin/main` into the contributor-owned PR branch. Current `main` remains authoritative for the already-merged stream, WebSocket, WebKit, rendering-cache, and image-fallback code; PR #46 contributes its AppState cache invalidation, bounded generation-checked retry, authoritative-catalog replacement, and cache expiry logic. Empty, unusable, or ambiguous dashboard responses without trustworthy terminal metadata are non-authoritative and preserve a prior live snapshot. Live and cron history markers are tracked per cache key so cron rows also receive bounded normal-load refreshes. The cache remains private to `AppState`; the standalone cache value type provides focused coverage for stale writes, alias-aware purges, failed cron loads, empty responses, authoritative omissions, and expiry without adding a test-only production hook.
 
 **Tech Stack:** Swift 5.9, SwiftUI, XCTest, XcodeGen, Xcode 26.5, iOS Simulator.
 
@@ -14,7 +14,7 @@
 - Preserve current `main` implementations for all behavior already merged through PR #45.
 - Keep the session cache purge attached to successful delete/archive paths and explicit disconnect.
 - Abort catalog publication when the profile, client, or dashboard bridge changes while a request is suspended.
-- Preserve the previous cron cache when its refresh fails, and bound mutation retries.
+- Preserve the previous cron cache when its refresh fails, refresh cron after the same bounded cache lifetime, and bound mutation retries.
 - Replace cached live rows after a meaningful complete dashboard catalog response with trustworthy terminal metadata; treat empty, unusable, or ambiguous responses as non-authoritative so they cannot wipe a prior snapshot or refresh its full-history marker. Retain older rows for explicitly partial responses, which are refreshed after a bounded cache lifetime.
 - Do not add a production-only test hook solely to expose private AppState caches.
 - Run the generated-project full test suite before publishing the branch.
@@ -110,7 +110,7 @@ needed.
 **Interfaces:**
 - Consumes: The reduced effective diff from Task 1.
 - Produces: Focused coverage for stale commit rejection, alias-aware purges,
-  cache reset, failed cron refreshes, empty-response preservation,
+  cache reset, failed cron refreshes, cron expiry, empty-response preservation,
   authoritative remote omissions, and
   bounded full-history expiry. The WebKit-backed delete/archive integration
   boundary remains outside the unit-test harness.

--- a/docs/superpowers/plans/2026-08-12-pr46-session-cache-salvage.md
+++ b/docs/superpowers/plans/2026-08-12-pr46-session-cache-salvage.md
@@ -4,7 +4,7 @@
 
 **Goal:** Update PR #46 onto current `main` while retaining only its session-catalog cache invalidation behavior.
 
-**Architecture:** Use a non-rewriting merge of current `origin/main` into the contributor-owned PR branch. Current `main` remains authoritative for the already-merged stream, WebSocket, WebKit, rendering-cache, and image-fallback code; PR #46 contributes its AppState cache invalidation and generation-checked commit logic. The cache remains private to `AppState`; the standalone cache value type provides focused coverage for stale write rejection without adding a test-only production hook, while the end-to-end WebKit-backed delete/archive flow remains an integration boundary outside the unit-test seam.
+**Architecture:** Use a non-rewriting merge of current `origin/main` into the contributor-owned PR branch. Current `main` remains authoritative for the already-merged stream, WebSocket, WebKit, rendering-cache, and image-fallback code; PR #46 contributes its AppState cache invalidation, bounded generation-checked retry, authoritative-catalog replacement, and cache expiry logic. The cache remains private to `AppState`; the standalone cache value type provides focused coverage for stale writes, alias-aware purges, failed cron loads, authoritative omissions, and expiry without adding a test-only production hook.
 
 **Tech Stack:** Swift 5.9, SwiftUI, XCTest, XcodeGen, Xcode 26.5, iOS Simulator.
 
@@ -13,6 +13,9 @@
 - Do not rewrite or force-push the contributor-owned PR branch.
 - Preserve current `main` implementations for all behavior already merged through PR #45.
 - Keep the session cache purge attached to successful delete/archive paths and explicit disconnect.
+- Abort catalog publication when the profile, client, or dashboard bridge changes while a request is suspended.
+- Preserve the previous cron cache when its refresh fails, and bound mutation retries.
+- Replace cached live rows after a complete dashboard catalog response; retain older rows only for explicitly partial responses, which are refreshed after a bounded cache lifetime.
 - Do not add a production-only test hook solely to expose private AppState caches.
 - Run the generated-project full test suite before publishing the branch.
 
@@ -49,7 +52,8 @@ freshness guarantee.
 Run:
 
 ```bash
-git merge origin/main --no-edit
+git merge --no-ff origin/main --no-edit
+test "$(git rev-parse HEAD^2)" = "$(git rev-parse origin/main)"
 ```
 
 If a conflict occurs, keep current `origin/main` for the already-merged
@@ -88,10 +92,14 @@ Run:
 
 ```bash
 git status --short
+git add -A
+test -z "$(git diff --name-only --diff-filter=U)"
 git commit -m "Merge current main into PR46 salvage"
 ```
 
-Skip the commit command when `git merge` already created the merge commit.
+Skip the commit command when `git merge` already created the merge commit. The
+staging and unmerged-path checks apply only when conflict resolution was
+needed.
 
 ### Task 2: Verify the cache behavior without adding test-only hooks
 
@@ -101,9 +109,10 @@ Skip the commit command when `git merge` already created the merge commit.
 
 **Interfaces:**
 - Consumes: The reduced effective diff from Task 1.
-- Produces: Focused coverage for rejecting a stale cache commit after a
-  destructive mutation, with the WebKit-backed delete/archive integration
-  boundary explicitly recorded as unverified by unit tests.
+- Produces: Focused coverage for stale commit rejection, alias-aware purges,
+  cache reset, failed cron refreshes, authoritative remote omissions, and
+  bounded full-history expiry. The WebKit-backed delete/archive integration
+  boundary remains outside the unit-test harness.
 
 - [ ] **Step 1: Check existing test seams before adding coverage**
 
@@ -114,7 +123,7 @@ rg -n -C 8 "sessionCatalogCache|SessionCatalogCache|removeSessionFromLiveCatalog
 ```
 
 Expected: do not change `AppState` production visibility merely to inspect
-private cache storage. Keep the focused test at the cache commit boundary and
+private cache storage. Keep focused tests at the cache policy boundary and
 record that the WebKit-backed delete/archive and disconnect/re-sign-in flows
 remain integration boundaries not exercised by the unit-test harness.
 

--- a/docs/superpowers/plans/2026-08-12-pr46-session-cache-salvage.md
+++ b/docs/superpowers/plans/2026-08-12-pr46-session-cache-salvage.md
@@ -4,7 +4,7 @@
 
 **Goal:** Update PR #46 onto current `main` while retaining only its session-catalog cache invalidation behavior.
 
-**Architecture:** Use a non-rewriting merge of current `origin/main` into the contributor-owned PR branch. Current `main` remains authoritative for the already-merged stream, WebSocket, WebKit, rendering-cache, and image-fallback code; PR #46 contributes only its AppState cache purge logic. The existing AppState caches are private and have no suitable integration seam, so verification will rely on the effective diff plus the full iOS test suite rather than adding test-only production hooks.
+**Architecture:** Use a non-rewriting merge of current `origin/main` into the contributor-owned PR branch. Current `main` remains authoritative for the already-merged stream, WebSocket, WebKit, rendering-cache, and image-fallback code; PR #46 contributes its AppState cache invalidation and generation-checked commit logic. The cache remains private to `AppState`; the standalone cache value type provides focused coverage for stale write rejection without adding a test-only production hook, while the end-to-end WebKit-backed delete/archive flow remains an integration boundary outside the unit-test seam.
 
 **Tech Stack:** Swift 5.9, SwiftUI, XCTest, XcodeGen, Xcode 26.5, iOS Simulator.
 
@@ -26,20 +26,23 @@
 
 **Interfaces:**
 - Consumes: `origin/main` at the current PR #45 merge commit.
-- Produces: A merge commit whose first parent is current `origin/main` and whose effective PR diff contains the cache invalidation plus the approved design/plan documents.
+- Produces: A merge commit whose second parent is current `origin/main` and whose effective PR diff contains the cache invalidation, generation guard, focused test, and approved design/plan documents.
 
 - [ ] **Step 1: Confirm the worktree is clean and the source refs are current**
 
 Run:
 
 ```bash
+git fetch origin main --prune
 git status --short --branch
 git rev-parse origin/main
 git rev-parse HEAD
 ```
 
 Expected: only committed salvage documentation is present; `origin/main` is
-`725610341c75bab7acf84e2de7f4dcc9549aa24d` or a newer fetched `main` commit.
+the current fetched `main` commit. The original checkpoint
+`725610341c75bab7acf84e2de7f4dcc9549aa24d` is historical context, not a
+freshness guarantee.
 
 - [ ] **Step 2: Merge current main without rewriting history**
 
@@ -54,16 +57,15 @@ stability code and reapply only these PR #46 behaviors in `AppState.swift`:
 
 ```swift
 cronSessions = []
-profileSessionCache.removeAll()
-loadedFullSessionHistory.removeAll()
+sessionCatalogCache.removeAll()
 ```
 
 and the cache-row removal in `removeSessionFromLiveCatalog`:
 
 ```swift
-for key in profileSessionCache.keys {
-    profileSessionCache[key]?.removeAll { sessionMatches($0, session) }
-}
+sessionCatalogCache.removeSession(
+    withIDs: Set([session.id] + session.alternateIds)
+)
 ```
 
 - [ ] **Step 3: Confirm the effective diff is reduced to the intended scope**
@@ -76,8 +78,9 @@ git diff origin/main...HEAD -- Conduit/Services/AppState.swift
 ```
 
 Expected: no stale PR #46 replacements of the current deduplication, bridge,
-WebSocket, cache, or image-fallback implementations; only the cache purge and
-the committed salvage documentation remain different from `main`.
+WebSocket, rendering-cache, or image-fallback implementations; only the cache
+invalidation, generation guard, focused test, and committed salvage
+documentation remain different from `main`.
 
 - [ ] **Step 4: Commit any conflict resolution**
 
@@ -98,20 +101,22 @@ Skip the commit command when `git merge` already created the merge commit.
 
 **Interfaces:**
 - Consumes: The reduced effective diff from Task 1.
-- Produces: A verified decision that the private cache behavior is covered by existing integration paths, or a narrowly scoped test only if an existing seam can exercise it without exposing private state.
+- Produces: Focused coverage for rejecting a stale cache commit after a
+  destructive mutation, with the WebKit-backed delete/archive integration
+  boundary explicitly recorded as unverified by unit tests.
 
 - [ ] **Step 1: Check existing test seams before adding coverage**
 
 Run:
 
 ```bash
-rg -n -C 8 "profileSessionCache|loadedFullSessionHistory|removeSessionFromLiveCatalog|disconnect\(" ConduitTests Conduit/Services/AppState.swift
+rg -n -C 8 "sessionCatalogCache|SessionCatalogCache|removeSessionFromLiveCatalog|disconnect\(" ConduitTests Conduit/Services/AppState.swift
 ```
 
-Expected: do not change production visibility merely to inspect private cache
-storage. If no existing seam can observe cache reuse after delete/archive or
-disconnect/re-sign-in, record that no focused test is added and rely on the
-full suite for regression protection.
+Expected: do not change `AppState` production visibility merely to inspect
+private cache storage. Keep the focused test at the cache commit boundary and
+record that the WebKit-backed delete/archive and disconnect/re-sign-in flows
+remain integration boundaries not exercised by the unit-test harness.
 
 - [ ] **Step 2: Check the reduced diff for accidental behavior changes**
 
@@ -119,11 +124,12 @@ Run:
 
 ```bash
 git diff --check
+git diff --check origin/main...HEAD
 git diff --stat origin/main...HEAD
 ```
 
-Expected: no whitespace errors and no files outside the approved AppState and
-salvage-document scope.
+Expected: no whitespace errors and no files outside the approved AppState,
+focused-test, and salvage-document scope.
 
 ### Task 3: Run full verification
 
@@ -140,11 +146,12 @@ salvage-document scope.
 Run:
 
 ```bash
+DESTINATION="${DESTINATION:-platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5}"
 xcodegen generate
 xcodebuild test \
   -project Conduit.xcodeproj \
   -scheme Conduit \
-  -destination "platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355" \
+  -destination "$DESTINATION" \
   -configuration Debug \
   -resultBundlePath /tmp/conduit-pr46-salvage.xcresult \
   CODE_SIGN_IDENTITY="" \
@@ -153,6 +160,8 @@ xcodebuild test \
   DEVELOPMENT_TEAM="" \
   PROVISIONING_PROFILE_SPECIFIER=""
 ```
+
+Set `DESTINATION` to another available simulator name and runtime when needed.
 
 - [ ] **Step 2: Read the result summary**
 

--- a/docs/superpowers/plans/2026-08-12-pr46-session-cache-salvage.md
+++ b/docs/superpowers/plans/2026-08-12-pr46-session-cache-salvage.md
@@ -4,7 +4,7 @@
 
 **Goal:** Update PR #46 onto current `main` while retaining only its session-catalog cache invalidation behavior.
 
-**Architecture:** Use a non-rewriting merge of current `origin/main` into the contributor-owned PR branch. Current `main` remains authoritative for the already-merged stream, WebSocket, WebKit, rendering-cache, and image-fallback code; PR #46 contributes its AppState cache invalidation, bounded generation-checked retry, authoritative-catalog replacement, and cache expiry logic. Empty or unusable dashboard responses are non-authoritative and preserve a prior live snapshot. The cache remains private to `AppState`; the standalone cache value type provides focused coverage for stale writes, alias-aware purges, failed cron loads, empty responses, authoritative omissions, and expiry without adding a test-only production hook.
+**Architecture:** Use a non-rewriting merge of current `origin/main` into the contributor-owned PR branch. Current `main` remains authoritative for the already-merged stream, WebSocket, WebKit, rendering-cache, and image-fallback code; PR #46 contributes its AppState cache invalidation, bounded generation-checked retry, authoritative-catalog replacement, and cache expiry logic. Empty, unusable, or ambiguous dashboard responses without trustworthy terminal metadata are non-authoritative and preserve a prior live snapshot. The cache remains private to `AppState`; the standalone cache value type provides focused coverage for stale writes, alias-aware purges, failed cron loads, empty responses, authoritative omissions, and expiry without adding a test-only production hook.
 
 **Tech Stack:** Swift 5.9, SwiftUI, XCTest, XcodeGen, Xcode 26.5, iOS Simulator.
 
@@ -15,7 +15,7 @@
 - Keep the session cache purge attached to successful delete/archive paths and explicit disconnect.
 - Abort catalog publication when the profile, client, or dashboard bridge changes while a request is suspended.
 - Preserve the previous cron cache when its refresh fails, and bound mutation retries.
-- Replace cached live rows after a meaningful complete dashboard catalog response; treat empty or unusable responses as non-authoritative so they cannot wipe a prior snapshot or refresh its full-history marker. Retain older rows for explicitly partial responses, which are refreshed after a bounded cache lifetime.
+- Replace cached live rows after a meaningful complete dashboard catalog response with trustworthy terminal metadata; treat empty, unusable, or ambiguous responses as non-authoritative so they cannot wipe a prior snapshot or refresh its full-history marker. Retain older rows for explicitly partial responses, which are refreshed after a bounded cache lifetime.
 - Do not add a production-only test hook solely to expose private AppState caches.
 - Run the generated-project full test suite before publishing the branch.
 

--- a/docs/superpowers/specs/2026-08-12-pr46-session-cache-salvage-design.md
+++ b/docs/superpowers/specs/2026-08-12-pr46-session-cache-salvage-design.md
@@ -18,10 +18,15 @@ owned by the contributor fork.
    - remove deleted or archived sessions from every profile catalog cache;
    - clear profile catalog caches and full-history markers on disconnect so a
      later sign-in performs an authoritative reload.
+   - reject stale catalog commits after an interleaved mutation, abort when
+     the profile/client/bridge context changes, and bound retries;
+   - preserve cron cache entries when refresh requests fail;
+   - replace cached live rows after complete catalog responses and periodically
+     refresh partial catalogs so remote deletions do not remain indefinitely.
 3. Do not reimplement or alter the already-merged stream, WebSocket, WebKit,
    rendering-cache, or image-fallback changes.
-4. Add focused regression coverage only if the existing AppState test seams can
-   verify the cache contract without exposing production-only test hooks.
+4. Add focused regression coverage at the cache policy boundary without
+   exposing production-only test hooks.
 
 ## Integration and behavior
 
@@ -31,6 +36,12 @@ existing successful delete/archive paths and the explicit disconnect path.
 
 The resulting PR should have a small effective diff against `main`, making the
 review target the cache behavior rather than stale historical commits.
+
+Catalog responses that include all pages are authoritative and replace the
+cached live catalog. Responses capped at the available page limit are treated
+as partial and may merge older cached rows; the full catalog is refreshed after
+a bounded cache lifetime. A failed cron refresh leaves its prior cache entry
+untouched and is retried by the next load.
 
 ## Verification
 

--- a/docs/superpowers/specs/2026-08-12-pr46-session-cache-salvage-design.md
+++ b/docs/superpowers/specs/2026-08-12-pr46-session-cache-salvage-design.md
@@ -1,0 +1,41 @@
+# PR #46 Salvage Design
+
+## Context
+
+PR #46 was opened from an older `main` revision and bundled several stability
+changes. Those changes are now already present on current `main`, including the
+later stream-reconciliation hardening from PR #43 and the image-fallback and
+dashboard lifecycle work from PR #45. The only behavior unique to PR #46 is
+session-catalog cache invalidation.
+
+The PR must be updated without rewriting its remote history because its head is
+owned by the contributor fork.
+
+## Scope
+
+1. Merge the current `origin/main` into the PR branch.
+2. Preserve the PR #46 cache invalidation behavior:
+   - remove deleted or archived sessions from every profile catalog cache;
+   - clear profile catalog caches and full-history markers on disconnect so a
+     later sign-in performs an authoritative reload.
+3. Do not reimplement or alter the already-merged stream, WebSocket, WebKit,
+   rendering-cache, or image-fallback changes.
+4. Add focused regression coverage only if the existing AppState test seams can
+   verify the cache contract without exposing production-only test hooks.
+
+## Integration and behavior
+
+The merge should retain current `main` as the source of truth for files that
+changed after PR #46 branched. The cache invalidation remains attached to the
+existing successful delete/archive paths and the explicit disconnect path.
+
+The resulting PR should have a small effective diff against `main`, making the
+review target the cache behavior rather than stale historical commits.
+
+## Verification
+
+- Confirm the merge has no unresolved conflicts.
+- Run the focused cache-related tests, if added.
+- Run the full Xcode-generated iOS test suite on the available simulator.
+- Push the non-rewritten PR head and wait for Build & Test, OpenCode, and
+  CodeRabbit to evaluate the reduced diff.

--- a/docs/superpowers/specs/2026-08-12-pr46-session-cache-salvage-design.md
+++ b/docs/superpowers/specs/2026-08-12-pr46-session-cache-salvage-design.md
@@ -20,7 +20,8 @@ owned by the contributor fork.
      later sign-in performs an authoritative reload.
    - reject stale catalog commits after an interleaved mutation, abort when
      the profile/client/bridge context changes, and bound retries;
-   - preserve cron cache entries when refresh requests fail;
+   - preserve cron cache entries when refresh requests fail and refresh them
+     after a bounded per-key cache lifetime;
    - replace cached live rows after meaningful complete catalog responses with
      trustworthy terminal metadata and periodically refresh partial catalogs
      so remote deletions do not remain indefinitely; empty, unusable, or
@@ -46,8 +47,10 @@ or ambiguous responses without terminal metadata are non-authoritative and may
 merge older cached rows; they do not record a fresh full-history marker.
 Responses capped at the available page limit are treated as partial and may
 merge older cached rows; the full catalog is refreshed after a bounded cache
-lifetime. A failed cron refresh leaves its prior cache entry untouched and is
-retried by the next load.
+lifetime. Cron uses its own marker, so a normal load eventually revalidates
+remotely deleted cron rows without forcing the whole session list. A failed
+cron refresh leaves its prior cache entry untouched and is retried by the next
+load.
 
 ## Verification
 

--- a/docs/superpowers/specs/2026-08-12-pr46-session-cache-salvage-design.md
+++ b/docs/superpowers/specs/2026-08-12-pr46-session-cache-salvage-design.md
@@ -21,10 +21,11 @@ owned by the contributor fork.
    - reject stale catalog commits after an interleaved mutation, abort when
      the profile/client/bridge context changes, and bound retries;
    - preserve cron cache entries when refresh requests fail;
-   - replace cached live rows after meaningful complete catalog responses and
-     periodically refresh partial catalogs so remote deletions do not remain
-     indefinitely; empty or unusable responses remain non-authoritative and
-     preserve the previous live snapshot.
+   - replace cached live rows after meaningful complete catalog responses with
+     trustworthy terminal metadata and periodically refresh partial catalogs
+     so remote deletions do not remain indefinitely; empty, unusable, or
+     ambiguous responses remain non-authoritative and preserve the previous
+     live snapshot.
 3. Do not reimplement or alter the already-merged stream, WebSocket, WebKit,
    rendering-cache, or image-fallback changes.
 4. Add focused regression coverage at the cache policy boundary without
@@ -39,13 +40,14 @@ existing successful delete/archive paths and the explicit disconnect path.
 The resulting PR should have a small effective diff against `main`, making the
 review target the cache behavior rather than stale historical commits.
 
-Meaningful catalog responses that include all pages are authoritative and
-replace the cached live catalog. Empty or unusable responses are non-
-authoritative and may merge older cached rows; they do not record a fresh
-full-history marker. Responses capped at the available page limit are treated
-as partial and may merge older cached rows; the full catalog is refreshed after
-a bounded cache lifetime. A failed cron refresh leaves its prior cache entry
-untouched and is retried by the next load.
+Meaningful catalog responses that include all pages and a trustworthy terminal
+signal are authoritative and replace the cached live catalog. Empty, unusable,
+or ambiguous responses without terminal metadata are non-authoritative and may
+merge older cached rows; they do not record a fresh full-history marker.
+Responses capped at the available page limit are treated as partial and may
+merge older cached rows; the full catalog is refreshed after a bounded cache
+lifetime. A failed cron refresh leaves its prior cache entry untouched and is
+retried by the next load.
 
 ## Verification
 

--- a/docs/superpowers/specs/2026-08-12-pr46-session-cache-salvage-design.md
+++ b/docs/superpowers/specs/2026-08-12-pr46-session-cache-salvage-design.md
@@ -21,8 +21,10 @@ owned by the contributor fork.
    - reject stale catalog commits after an interleaved mutation, abort when
      the profile/client/bridge context changes, and bound retries;
    - preserve cron cache entries when refresh requests fail;
-   - replace cached live rows after complete catalog responses and periodically
-     refresh partial catalogs so remote deletions do not remain indefinitely.
+   - replace cached live rows after meaningful complete catalog responses and
+     periodically refresh partial catalogs so remote deletions do not remain
+     indefinitely; empty or unusable responses remain non-authoritative and
+     preserve the previous live snapshot.
 3. Do not reimplement or alter the already-merged stream, WebSocket, WebKit,
    rendering-cache, or image-fallback changes.
 4. Add focused regression coverage at the cache policy boundary without
@@ -37,8 +39,10 @@ existing successful delete/archive paths and the explicit disconnect path.
 The resulting PR should have a small effective diff against `main`, making the
 review target the cache behavior rather than stale historical commits.
 
-Catalog responses that include all pages are authoritative and replace the
-cached live catalog. Responses capped at the available page limit are treated
+Meaningful catalog responses that include all pages are authoritative and
+replace the cached live catalog. Empty or unusable responses are non-
+authoritative and may merge older cached rows; they do not record a fresh
+full-history marker. Responses capped at the available page limit are treated
 as partial and may merge older cached rows; the full catalog is refreshed after
 a bounded cache lifetime. A failed cron refresh leaves its prior cache entry
 untouched and is retried by the next load.


### PR DESCRIPTION
`deleteSession` and `setSessionArchived` remove the row from the published arrays but leave it in `profileSessionCache`, and every non-forced catalog load merges that cache back in and re-saves the union — so a deleted or archived conversation resurrects in Recents on the next foreground or send, until a pull-to-refresh clears the exact keys involved.

- `removeSessionFromLiveCatalog` now purges matching rows from the cache (covers both delete and archive; matching is alias-aware via `sessionMatches`).
- `disconnect()` now clears `cronSessions`, `profileSessionCache`, and `loadedFullSessionHistory`, so re-signing-in cannot show sessions deleted from another client while signed out.

Full suite passes (438 tests, 0 failures). Full write-up: [angel12/hermes-conduit#6](https://github.com/angel12/hermes-conduit/issues/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Disconnecting now clears related session history and cached session data.
  - Deleted or archived sessions are removed from all session views, preventing stale entries from reappearing.
  - Improved session and cron loading to prevent outdated results from overwriting newer changes.
  - Refreshes better preserve accurate catalog data during concurrent updates or failed requests.
  - Session cache cleanup remains consistent during refresh and reconciliation.

- **Documentation**
  - Added documentation covering session-cache behavior, cleanup scenarios, and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->