### PR TITLE
Stop re-latching follow-latest while the user is dragging the transcript

### DIFF
--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -107,6 +107,10 @@ enum ChatFollowLatestRelatchPolicy {
             && !isDragging
     }
 
+    static func shouldFollowLatestAfterTransition(isDragging: Bool) -> Bool {
+        !isDragging
+    }
+
     static func isCompletionCurrent(
         completed: ChatDragCompletionToken,
         current: ChatDragCompletionToken,
@@ -115,7 +119,11 @@ enum ChatFollowLatestRelatchPolicy {
         hasPendingRestoration: Bool,
         hasNotificationHandoff: Bool
     ) -> Bool {
-        let sameSession = completed.sessionKey == current.sessionKey
+        // A new chat can acquire its first server session ID without replacing
+        // the viewport. The transition generation distinguishes that identity
+        // resolution from an actual transcript transition.
+        let sameSession = completed.sessionKey == nil
+            || completed.sessionKey == current.sessionKey
             || identity.areEquivalent(completed.sessionKey, current.sessionKey)
         return completed.dragGeneration == current.dragGeneration
             && completed.viewportTransitionGeneration == current.viewportTransitionGeneration

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -39,19 +39,28 @@ enum ChatFollowLatestRelatchPolicy {
     static func shouldRelatch(
         isNearBottom: Bool,
         hasPendingRestoration: Bool,
+        hasNotificationHandoff: Bool,
         isDragging: Bool
     ) -> Bool {
-        isNearBottom && !hasPendingRestoration && !isDragging
+        isNearBottom
+            && !hasPendingRestoration
+            && !hasNotificationHandoff
+            && !isDragging
     }
 
+    /// Defers completion until gesture state from the current actor turn has
+    /// settled. A newer drag or transcript transition invalidates the work via
+    /// `isCurrent`; otherwise persistence runs after the relatch decision.
     @MainActor
-    static func relatchAfterDragEnds(
-        isDragging: () -> Bool,
-        relatch: () -> Void
+    static func completeDragAfterYield(
+        isCurrent: () -> Bool,
+        relatch: () -> Void,
+        persist: () -> Void
     ) async {
         await Task.yield()
-        guard !isDragging() else { return }
+        guard isCurrent() else { return }
         relatch()
+        persist()
     }
 }
 

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -35,6 +35,26 @@ enum ChatMessageScrollUpdatePolicy {
     }
 }
 
+enum ChatFollowLatestRelatchPolicy {
+    static func shouldRelatch(
+        isNearBottom: Bool,
+        hasPendingRestoration: Bool,
+        isDragging: Bool
+    ) -> Bool {
+        isNearBottom && !hasPendingRestoration && !isDragging
+    }
+
+    @MainActor
+    static func relatchAfterDragEnds(
+        isDragging: () -> Bool,
+        relatch: () -> Void
+    ) async {
+        await Task.yield()
+        guard !isDragging() else { return }
+        relatch()
+    }
+}
+
 struct ChatMessageScrollTargetCache: Equatable {
     private(set) var targets: [ChatMessageScrollTarget] = []
     private(set) var renderingRevision: UInt64 = 0

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -35,6 +35,65 @@ enum ChatMessageScrollUpdatePolicy {
     }
 }
 
+struct ChatDragCompletionToken: Hashable {
+    let dragGeneration: UInt64
+    let sessionKey: ChatScrollSessionKey?
+    let viewportTransitionGeneration: UInt64
+}
+
+struct ChatDragLifecycleState: Equatable {
+    private(set) var generation: UInt64 = 0
+    private var activeCompletion: ChatDragCompletionToken?
+    private var activeGestureInvalidated = false
+
+    mutating func begin(
+        sessionKey: ChatScrollSessionKey?,
+        viewportTransitionGeneration: UInt64
+    ) -> Bool {
+        guard activeCompletion == nil, !activeGestureInvalidated else { return false }
+        generation &+= 1
+        activeCompletion = ChatDragCompletionToken(
+            dragGeneration: generation,
+            sessionKey: sessionKey,
+            viewportTransitionGeneration: viewportTransitionGeneration
+        )
+        return true
+    }
+
+    mutating func invalidate(hasActiveGesture: Bool) {
+        generation &+= 1
+        if hasActiveGesture || activeCompletion != nil {
+            activeGestureInvalidated = true
+        }
+    }
+
+    mutating func abandon() {
+        generation &+= 1
+        activeCompletion = nil
+        activeGestureInvalidated = false
+    }
+
+    mutating func finish() -> ChatDragCompletionToken? {
+        defer {
+            activeCompletion = nil
+            activeGestureInvalidated = false
+        }
+        guard !activeGestureInvalidated else { return nil }
+        return activeCompletion
+    }
+
+    func currentToken(
+        sessionKey: ChatScrollSessionKey?,
+        viewportTransitionGeneration: UInt64
+    ) -> ChatDragCompletionToken {
+        ChatDragCompletionToken(
+            dragGeneration: generation,
+            sessionKey: sessionKey,
+            viewportTransitionGeneration: viewportTransitionGeneration
+        )
+    }
+}
+
 enum ChatFollowLatestRelatchPolicy {
     static func shouldRelatch(
         isNearBottom: Bool,
@@ -48,17 +107,58 @@ enum ChatFollowLatestRelatchPolicy {
             && !isDragging
     }
 
-    /// Defers completion until gesture state from the current actor turn has
-    /// settled. A newer drag or transcript transition invalidates the work via
-    /// `isCurrent`; otherwise persistence runs after the relatch decision.
+    static func isCompletionCurrent(
+        completed: ChatDragCompletionToken,
+        current: ChatDragCompletionToken,
+        identity: ChatScrollSessionIdentity,
+        isDragging: Bool,
+        hasPendingRestoration: Bool,
+        hasNotificationHandoff: Bool
+    ) -> Bool {
+        let sameSession = completed.sessionKey == current.sessionKey
+            || identity.areEquivalent(completed.sessionKey, current.sessionKey)
+        return completed.dragGeneration == current.dragGeneration
+            && completed.viewportTransitionGeneration == current.viewportTransitionGeneration
+            && sameSession
+            && !isDragging
+            && !hasPendingRestoration
+            && !hasNotificationHandoff
+    }
+
+    static func persistenceSessionKey(
+        currentKey: ChatScrollSessionKey?,
+        identity: ChatScrollSessionIdentity
+    ) -> ChatScrollSessionKey? {
+        guard let currentKey else { return nil }
+        if identity.areEquivalent(currentKey, identity.canonicalSessionKey) {
+            return identity.canonicalSessionKey
+        }
+        return currentKey
+    }
+
     @MainActor
-    static func completeDragAfterYield(
-        isCurrent: () -> Bool,
-        relatch: () -> Void,
-        persist: () -> Void
+    static func waitForNextMainActorTurn() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                continuation.resume()
+            }
+        }
+    }
+
+    /// Defers completion until the next main-actor turn. A newer drag or
+    /// transcript transition invalidates the work via `isCurrent`; otherwise
+    /// persistence runs after the relatch decision.
+    @MainActor
+    static func completeDragAfterNextTurn(
+        suspend: @MainActor () async -> Void = {
+            await ChatFollowLatestRelatchPolicy.waitForNextMainActorTurn()
+        },
+        isCurrent: @MainActor () -> Bool,
+        relatch: @MainActor () -> Void,
+        persist: @MainActor () -> Void
     ) async {
-        await Task.yield()
-        guard isCurrent() else { return }
+        await suspend()
+        guard !Task.isCancelled, isCurrent() else { return }
         relatch()
         persist()
     }

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -634,12 +634,23 @@ struct ChatView: View {
 
     private func updateBottomMarker(_ value: CGFloat?) {
         bottomMarkerMaxY = value
-        if isNearBottom && !hasPendingRestoration { followsLatest = true }
+        relatchFollowsLatestIfSettled()
     }
 
     private func updateViewportBottom(_ value: CGFloat?) {
         scrollViewportMaxY = value
-        if isNearBottom && !hasPendingRestoration { followsLatest = true }
+        relatchFollowsLatestIfSettled()
+    }
+
+    /// Geometry callbacks fire on every content-growth and scroll tick, so
+    /// they must not re-latch while the user's finger is still down: the drag
+    /// sets `followsLatest = false`, but until the finger travels past the
+    /// near-bottom window each streamed delta would yank the scroll back to
+    /// the bottom, fighting the drag.
+    private func relatchFollowsLatestIfSettled() {
+        if isNearBottom && !hasPendingRestoration && !isDraggingChat {
+            followsLatest = true
+        }
     }
 }
 

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -22,8 +22,9 @@ struct ChatView: View {
     @State private var renderedTranscriptRevision: UInt64 = 0
     @State private var renderedViewportTransitionGeneration: UInt64 = 0
     @State private var viewportSnapshotProviderID = UUID()
-    @State private var isDraggingChat = false
-    @State private var chatDragGeneration: UInt64 = 0
+    @GestureState private var isDraggingChat = false
+    @State private var chatDragLifecycle = ChatDragLifecycleState()
+    @State private var chatDragCompletionToken: ChatDragCompletionToken?
     @State private var notificationHandoffPending = false
     @State private var notificationHandoffSessionKey: ChatScrollSessionKey?
     @State private var notificationHandoffHasMeasuredLayout = false
@@ -204,11 +205,17 @@ struct ChatView: View {
                     )
                 }
                 .onDisappear {
+                    abandonChatDrag()
                     appState.removeChatViewportSnapshotProvider(id: viewportSnapshotProviderID)
                 }
                 .task(id: appState.chatResumeRestorationRequest?.generation) {
                     guard let request = appState.chatResumeRestorationRequest else { return }
+                    invalidateChatDrag()
                     await applyChatResumeRestoration(request, using: proxy)
+                }
+                .task(id: chatDragCompletionToken) {
+                    guard let completed = chatDragCompletionToken else { return }
+                    await completeChatDrag(completed)
                 }
                 .onPreferenceChange(ChatBottomMarkerPreferenceKey.self) { value in
                     updateBottomMarker(value)
@@ -233,6 +240,10 @@ struct ChatView: View {
                 }
                 .onPreferenceChange(ChatRenderedScrollTargetsPreferenceKey.self) { value in
                     renderedScrollTargets = value
+                }
+                .onChange(of: isDraggingChat) { wasDragging, isDragging in
+                    guard wasDragging, !isDragging else { return }
+                    chatDragCompletionToken = chatDragLifecycle.finish()
                 }
                 .onChange(of: appState.messages) { _, newMessages in
                     let cacheUpdate = chatMessageScrollTargetCache.update(for: newMessages)
@@ -277,12 +288,14 @@ struct ChatView: View {
                     saveChatScrollPosition(for: renderedScrollSessionKey)
                 }
                 .onChange(of: appState.chatScrollRequest) { _, _ in
+                    invalidateChatDrag()
                     cancelAutomaticRestoration()
                     followsLatest = true
                     scrollToLatest(using: proxy)
                 }
                 .onChange(of: appState.activeSessionId) { oldSessionID, newSessionID in
                     guard !appState.isOpeningNotificationSession else {
+                        invalidateChatDrag()
                         cancelAutomaticRestoration()
                         notificationHandoffPending = true
                         notificationHandoffSessionKey = activeScrollSessionKey
@@ -301,6 +314,9 @@ struct ChatView: View {
                         cancelAutomaticRestoration()
                     }
                     let keysAreEquivalent = identity.areEquivalent(oldKey, newKey)
+                    if !keysAreEquivalent {
+                        invalidateChatDrag()
+                    }
                     renderedScrollSessionKey = newKey
                     if followsLatest {
                         renderedViewportTransitionGeneration = appState.chatViewportTransitionGeneration
@@ -311,6 +327,7 @@ struct ChatView: View {
                     scrollToLatest(using: proxy)
                 }
                 .onChange(of: appState.activeProfile) { _, _ in
+                    invalidateChatDrag()
                     let oldKey = renderedScrollSessionKey
                     let newKey = activeScrollSessionKey
                     if let request = appState.chatResumeRestorationRequest,
@@ -348,6 +365,7 @@ struct ChatView: View {
                 }
                 .onChange(of: appState.isOpeningNotificationSession) { _, isOpening in
                     if isOpening {
+                        invalidateChatDrag()
                         cancelAutomaticRestoration()
                         notificationHandoffPending = true
                         notificationHandoffSessionKey = nil
@@ -371,40 +389,7 @@ struct ChatView: View {
                         scrollToLatest(using: proxy)
                     }
                 }
-                .simultaneousGesture(
-                    DragGesture(minimumDistance: 3)
-                        .onChanged { _ in
-                            // Only a deliberate user drag opts out of the
-                            // stream-following behavior. Content growth alone
-                            // must not make a live conversation appear stale.
-                            guard !isDraggingChat else { return }
-                            chatDragGeneration &+= 1
-                            isDraggingChat = true
-                            cancelAutomaticRestoration()
-                            followsLatest = false
-                        }
-                        .onEnded { _ in
-                            isDraggingChat = false
-                            let completedGeneration = chatDragGeneration
-                            let completedSessionKey = renderedScrollSessionKey ?? activeScrollSessionKey
-                            Task { @MainActor in
-                                await ChatFollowLatestRelatchPolicy.completeDragAfterYield(
-                                    isCurrent: {
-                                        !isDraggingChat
-                                            && chatDragGeneration == completedGeneration
-                                            && (renderedScrollSessionKey ?? activeScrollSessionKey) == completedSessionKey
-                                            && !notificationHandoffPending
-                                            && !appState.isOpeningNotificationSession
-                                    },
-                                    relatch: { relatchFollowsLatestIfSettled() },
-                                    persist: {
-                                        saveChatScrollPosition(for: completedSessionKey)
-                                        appState.flushChatResumeViewport()
-                                    }
-                                )
-                            }
-                        }
-                )
+                .simultaneousGesture(chatDragGesture)
                 .overlay(alignment: .bottomTrailing) {
                     if !followsLatest && !isNearBottom {
                         Button {
@@ -444,7 +429,11 @@ struct ChatView: View {
     }
 
     private func saveChatScrollPosition(for preferredKey: ChatScrollSessionKey? = nil) {
-        guard let sessionKey = preferredKey ?? renderedScrollSessionKey ?? activeScrollSessionKey else { return }
+        let currentKey = preferredKey ?? renderedScrollSessionKey ?? activeScrollSessionKey
+        guard let sessionKey = ChatFollowLatestRelatchPolicy.persistenceSessionKey(
+            currentKey: currentKey,
+            identity: appState.activeChatScrollSessionIdentity
+        ) else { return }
         guard let snapshot = currentChatViewportSnapshot() else { return }
         appState.recordChatViewport(snapshot, for: sessionKey)
     }
@@ -464,6 +453,70 @@ struct ChatView: View {
 
     private func cancelAutomaticRestoration() {
         appState.cancelChatResumeRestoration()
+    }
+
+    private var chatDragGesture: some Gesture {
+        DragGesture(minimumDistance: 3)
+            .updating($isDraggingChat) { _, isDragging, _ in
+                isDragging = true
+            }
+            .onChanged { _ in
+                beginChatDragIfNeeded()
+            }
+    }
+
+    private func beginChatDragIfNeeded() {
+        // Only a deliberate user drag opts out of stream following. Capturing
+        // here preserves the session and transition that owned the gesture.
+        guard chatDragLifecycle.begin(
+            sessionKey: renderedScrollSessionKey ?? activeScrollSessionKey,
+            viewportTransitionGeneration: appState.chatViewportTransitionGeneration
+        ) else { return }
+        chatDragCompletionToken = nil
+        cancelAutomaticRestoration()
+        followsLatest = false
+    }
+
+    @MainActor
+    private func completeChatDrag(_ completed: ChatDragCompletionToken) async {
+        await ChatFollowLatestRelatchPolicy.completeDragAfterNextTurn(
+            isCurrent: {
+                ChatFollowLatestRelatchPolicy.isCompletionCurrent(
+                    completed: completed,
+                    current: currentChatDragCompletionToken,
+                    identity: appState.activeChatScrollSessionIdentity,
+                    isDragging: isDraggingChat,
+                    hasPendingRestoration: hasPendingRestoration,
+                    hasNotificationHandoff: appState.isOpeningNotificationSession
+                        || notificationHandoffPending
+                )
+            },
+            relatch: { relatchFollowsLatestIfSettled() },
+            persist: {
+                saveChatScrollPosition(for: currentChatDragCompletionToken.sessionKey)
+                appState.flushChatResumeViewport()
+            }
+        )
+        guard !Task.isCancelled,
+              chatDragCompletionToken == completed else { return }
+        chatDragCompletionToken = nil
+    }
+
+    private var currentChatDragCompletionToken: ChatDragCompletionToken {
+        chatDragLifecycle.currentToken(
+            sessionKey: renderedScrollSessionKey ?? activeScrollSessionKey,
+            viewportTransitionGeneration: appState.chatViewportTransitionGeneration
+        )
+    }
+
+    private func invalidateChatDrag() {
+        chatDragLifecycle.invalidate(hasActiveGesture: isDraggingChat)
+        chatDragCompletionToken = nil
+    }
+
+    private func abandonChatDrag() {
+        chatDragLifecycle.abandon()
+        chatDragCompletionToken = nil
     }
 
     @MainActor

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -323,7 +323,8 @@ struct ChatView: View {
                     }
                     guard !keysAreEquivalent else { return }
                     topVisibleChatID = nil
-                    followsLatest = true
+                    followsLatest = ChatFollowLatestRelatchPolicy
+                        .shouldFollowLatestAfterTransition(isDragging: isDraggingChat)
                     scrollToLatest(using: proxy)
                 }
                 .onChange(of: appState.activeProfile) { _, _ in
@@ -350,7 +351,8 @@ struct ChatView: View {
                         return
                     }
                     guard oldKey != newKey else { return }
-                    followsLatest = true
+                    followsLatest = ChatFollowLatestRelatchPolicy
+                        .shouldFollowLatestAfterTransition(isDragging: isDraggingChat)
                     scrollToLatest(using: proxy)
                 }
                 .onChange(of: appState.activeChatScrollSessionIdentity) { _, _ in
@@ -696,7 +698,8 @@ struct ChatView: View {
         notificationHandoffPending = false
         notificationHandoffSessionKey = nil
         cancelAutomaticRestoration()
-        followsLatest = true
+        followsLatest = ChatFollowLatestRelatchPolicy
+            .shouldFollowLatestAfterTransition(isDragging: isDraggingChat)
         var transaction = Transaction()
         transaction.animation = nil
         withTransaction(transaction) {

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -383,6 +383,12 @@ struct ChatView: View {
                         }
                         .onEnded { _ in
                             isDraggingChat = false
+                            Task { @MainActor in
+                                await ChatFollowLatestRelatchPolicy.relatchAfterDragEnds(
+                                    isDragging: { isDraggingChat },
+                                    relatch: { relatchFollowsLatestIfSettled() }
+                                )
+                            }
                             saveChatScrollPosition(for: renderedScrollSessionKey)
                             appState.flushChatResumeViewport()
                         }
@@ -649,7 +655,11 @@ struct ChatView: View {
     /// near-bottom window each streamed delta would yank the scroll back to
     /// the bottom, fighting the drag.
     private func relatchFollowsLatestIfSettled() {
-        if isNearBottom && !hasPendingRestoration && !isDraggingChat {
+        if ChatFollowLatestRelatchPolicy.shouldRelatch(
+            isNearBottom: isNearBottom,
+            hasPendingRestoration: hasPendingRestoration,
+            isDragging: isDraggingChat
+        ) {
             followsLatest = true
         }
     }

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -323,9 +323,12 @@ struct ChatView: View {
                     }
                     guard !keysAreEquivalent else { return }
                     topVisibleChatID = nil
-                    followsLatest = ChatFollowLatestRelatchPolicy
+                    let shouldFollowLatest = ChatFollowLatestRelatchPolicy
                         .shouldFollowLatestAfterTransition(isDragging: isDraggingChat)
-                    scrollToLatest(using: proxy)
+                    followsLatest = shouldFollowLatest
+                    if shouldFollowLatest {
+                        scrollToLatest(using: proxy)
+                    }
                 }
                 .onChange(of: appState.activeProfile) { _, _ in
                     invalidateChatDrag()
@@ -351,9 +354,12 @@ struct ChatView: View {
                         return
                     }
                     guard oldKey != newKey else { return }
-                    followsLatest = ChatFollowLatestRelatchPolicy
+                    let shouldFollowLatest = ChatFollowLatestRelatchPolicy
                         .shouldFollowLatestAfterTransition(isDragging: isDraggingChat)
-                    scrollToLatest(using: proxy)
+                    followsLatest = shouldFollowLatest
+                    if shouldFollowLatest {
+                        scrollToLatest(using: proxy)
+                    }
                 }
                 .onChange(of: appState.activeChatScrollSessionIdentity) { _, _ in
                     guard !appState.isOpeningNotificationSession else { return }
@@ -698,8 +704,10 @@ struct ChatView: View {
         notificationHandoffPending = false
         notificationHandoffSessionKey = nil
         cancelAutomaticRestoration()
-        followsLatest = ChatFollowLatestRelatchPolicy
+        let shouldFollowLatest = ChatFollowLatestRelatchPolicy
             .shouldFollowLatestAfterTransition(isDragging: isDraggingChat)
+        followsLatest = shouldFollowLatest
+        guard shouldFollowLatest else { return }
         var transaction = Transaction()
         transaction.animation = nil
         withTransaction(transaction) {

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -23,6 +23,7 @@ struct ChatView: View {
     @State private var renderedViewportTransitionGeneration: UInt64 = 0
     @State private var viewportSnapshotProviderID = UUID()
     @State private var isDraggingChat = false
+    @State private var chatDragGeneration: UInt64 = 0
     @State private var notificationHandoffPending = false
     @State private var notificationHandoffSessionKey: ChatScrollSessionKey?
     @State private var notificationHandoffHasMeasuredLayout = false
@@ -377,20 +378,31 @@ struct ChatView: View {
                             // stream-following behavior. Content growth alone
                             // must not make a live conversation appear stale.
                             guard !isDraggingChat else { return }
+                            chatDragGeneration &+= 1
                             isDraggingChat = true
                             cancelAutomaticRestoration()
                             followsLatest = false
                         }
                         .onEnded { _ in
                             isDraggingChat = false
+                            let completedGeneration = chatDragGeneration
+                            let completedSessionKey = renderedScrollSessionKey ?? activeScrollSessionKey
                             Task { @MainActor in
-                                await ChatFollowLatestRelatchPolicy.relatchAfterDragEnds(
-                                    isDragging: { isDraggingChat },
-                                    relatch: { relatchFollowsLatestIfSettled() }
+                                await ChatFollowLatestRelatchPolicy.completeDragAfterYield(
+                                    isCurrent: {
+                                        !isDraggingChat
+                                            && chatDragGeneration == completedGeneration
+                                            && (renderedScrollSessionKey ?? activeScrollSessionKey) == completedSessionKey
+                                            && !notificationHandoffPending
+                                            && !appState.isOpeningNotificationSession
+                                    },
+                                    relatch: { relatchFollowsLatestIfSettled() },
+                                    persist: {
+                                        saveChatScrollPosition(for: completedSessionKey)
+                                        appState.flushChatResumeViewport()
+                                    }
                                 )
                             }
-                            saveChatScrollPosition(for: renderedScrollSessionKey)
-                            appState.flushChatResumeViewport()
                         }
                 )
                 .overlay(alignment: .bottomTrailing) {
@@ -658,6 +670,8 @@ struct ChatView: View {
         if ChatFollowLatestRelatchPolicy.shouldRelatch(
             isNearBottom: isNearBottom,
             hasPendingRestoration: hasPendingRestoration,
+            hasNotificationHandoff: appState.isOpeningNotificationSession
+                || notificationHandoffPending,
             isDragging: isDraggingChat
         ) {
             followsLatest = true

--- a/ConduitTests/ChatScrollStateTests.swift
+++ b/ConduitTests/ChatScrollStateTests.swift
@@ -1,6 +1,29 @@
 import XCTest
 @testable import Conduit
 
+private actor ChatScrollTestGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            if isOpen {
+                continuation.resume()
+            } else {
+                waiters.append(continuation)
+            }
+        }
+    }
+
+    func open() {
+        isOpen = true
+        let pending = waiters
+        waiters.removeAll()
+        pending.forEach { $0.resume() }
+    }
+}
+
 final class ChatScrollStateTests: XCTestCase {
     func testFollowLatestRelatchRequiresSettledNearBottomViewport() {
         let cases: [(
@@ -30,29 +53,360 @@ final class ChatScrollStateTests: XCTestCase {
         }
     }
 
-    @MainActor
-    func testDragCompletionRechecksGestureAfterYield() async {
-        var dragGeneration = 1
-        var completionEvents: [String] = []
-        let nextDrag = Task { @MainActor in
-            dragGeneration = 2
+    func testDragCompletionRequiresCurrentGestureViewportAndSession() {
+        let runtimeKey = ChatScrollSessionKey(profile: "default", sessionID: "runtime-id")
+        let canonicalKey = ChatScrollSessionKey(profile: "default", sessionID: "canonical-id")
+        let unrelatedKey = ChatScrollSessionKey(profile: "default", sessionID: "other-id")
+        let identity = ChatScrollSessionIdentity(
+            profile: "default",
+            canonicalSessionID: "canonical-id",
+            equivalentSessionIDs: ["runtime-id"],
+            isReconciling: false,
+            settledRevision: 1
+        )
+        let completed = ChatDragCompletionToken(
+            dragGeneration: 7,
+            sessionKey: runtimeKey,
+            viewportTransitionGeneration: 11
+        )
+        let equivalentCurrent = ChatDragCompletionToken(
+            dragGeneration: 7,
+            sessionKey: canonicalKey,
+            viewportTransitionGeneration: 11
+        )
+        let cases: [(
+            current: ChatDragCompletionToken,
+            isDragging: Bool,
+            hasPendingRestoration: Bool,
+            hasNotificationHandoff: Bool,
+            expected: Bool
+        )] = [
+            (equivalentCurrent, false, false, false, true),
+            (
+                ChatDragCompletionToken(
+                    dragGeneration: 8,
+                    sessionKey: canonicalKey,
+                    viewportTransitionGeneration: 11
+                ),
+                false,
+                false,
+                false,
+                false
+            ),
+            (
+                ChatDragCompletionToken(
+                    dragGeneration: 7,
+                    sessionKey: canonicalKey,
+                    viewportTransitionGeneration: 12
+                ),
+                false,
+                false,
+                false,
+                false
+            ),
+            (
+                ChatDragCompletionToken(
+                    dragGeneration: 7,
+                    sessionKey: unrelatedKey,
+                    viewportTransitionGeneration: 11
+                ),
+                false,
+                false,
+                false,
+                false
+            ),
+            (equivalentCurrent, true, false, false, false),
+            (equivalentCurrent, false, true, false, false),
+            (equivalentCurrent, false, false, true, false),
+        ]
+
+        for testCase in cases {
+            XCTAssertEqual(
+                ChatFollowLatestRelatchPolicy.isCompletionCurrent(
+                    completed: completed,
+                    current: testCase.current,
+                    identity: identity,
+                    isDragging: testCase.isDragging,
+                    hasPendingRestoration: testCase.hasPendingRestoration,
+                    hasNotificationHandoff: testCase.hasNotificationHandoff
+                ),
+                testCase.expected
+            )
         }
 
-        await ChatFollowLatestRelatchPolicy.completeDragAfterYield(
-            isCurrent: { dragGeneration == 1 },
+        let noSession = ChatDragCompletionToken(
+            dragGeneration: 7,
+            sessionKey: nil,
+            viewportTransitionGeneration: 11
+        )
+        XCTAssertTrue(
+            ChatFollowLatestRelatchPolicy.isCompletionCurrent(
+                completed: noSession,
+                current: noSession,
+                identity: .none,
+                isDragging: false,
+                hasPendingRestoration: false,
+                hasNotificationHandoff: false
+            )
+        )
+    }
+
+    func testDragLifecycleCapturesStartAndSuppressesInvalidatedGestureUntilFinish() {
+        let originalKey = ChatScrollSessionKey(profile: "default", sessionID: "original")
+        let replacementKey = ChatScrollSessionKey(profile: "default", sessionID: "replacement")
+        var lifecycle = ChatDragLifecycleState()
+
+        XCTAssertTrue(
+            lifecycle.begin(
+                sessionKey: originalKey,
+                viewportTransitionGeneration: 4
+            )
+        )
+        lifecycle.invalidate(hasActiveGesture: true)
+        XCTAssertFalse(
+            lifecycle.begin(
+                sessionKey: replacementKey,
+                viewportTransitionGeneration: 5
+            )
+        )
+        XCTAssertNil(lifecycle.finish())
+
+        XCTAssertTrue(
+            lifecycle.begin(
+                sessionKey: replacementKey,
+                viewportTransitionGeneration: 5
+            )
+        )
+        XCTAssertEqual(
+            lifecycle.finish(),
+            ChatDragCompletionToken(
+                dragGeneration: 3,
+                sessionKey: replacementKey,
+                viewportTransitionGeneration: 5
+            )
+        )
+    }
+
+    func testDragLifecycleIgnoresDuplicateChangedCallbacks() {
+        let originalKey = ChatScrollSessionKey(profile: "default", sessionID: "original")
+        let replacementKey = ChatScrollSessionKey(profile: "default", sessionID: "replacement")
+        var lifecycle = ChatDragLifecycleState()
+
+        XCTAssertTrue(
+            lifecycle.begin(
+                sessionKey: originalKey,
+                viewportTransitionGeneration: 4
+            )
+        )
+        XCTAssertFalse(
+            lifecycle.begin(
+                sessionKey: replacementKey,
+                viewportTransitionGeneration: 5
+            )
+        )
+        XCTAssertEqual(
+            lifecycle.currentToken(
+                sessionKey: replacementKey,
+                viewportTransitionGeneration: 5
+            ),
+            ChatDragCompletionToken(
+                dragGeneration: 1,
+                sessionKey: replacementKey,
+                viewportTransitionGeneration: 5
+            )
+        )
+        XCTAssertEqual(
+            lifecycle.finish()?.sessionKey,
+            originalKey
+        )
+    }
+
+    func testDragLifecycleInvalidatesPendingCompletionAfterGestureStateReset() {
+        let sessionKey = ChatScrollSessionKey(profile: "default", sessionID: "session")
+        var lifecycle = ChatDragLifecycleState()
+
+        XCTAssertTrue(
+            lifecycle.begin(
+                sessionKey: sessionKey,
+                viewportTransitionGeneration: 1
+            )
+        )
+        lifecycle.invalidate(hasActiveGesture: false)
+
+        XCTAssertNil(lifecycle.finish())
+    }
+
+    func testIdleDragInvalidationDoesNotBlockNextGesture() {
+        let sessionKey = ChatScrollSessionKey(profile: "default", sessionID: "session")
+        var lifecycle = ChatDragLifecycleState()
+
+        lifecycle.invalidate(hasActiveGesture: false)
+
+        XCTAssertTrue(
+            lifecycle.begin(
+                sessionKey: sessionKey,
+                viewportTransitionGeneration: 1
+            )
+        )
+        XCTAssertEqual(lifecycle.finish()?.dragGeneration, 2)
+    }
+
+    func testDragLifecycleSuppressesInvalidationBeforeFirstChangedCallback() {
+        let sessionKey = ChatScrollSessionKey(profile: "default", sessionID: "session")
+        var lifecycle = ChatDragLifecycleState()
+
+        lifecycle.invalidate(hasActiveGesture: true)
+        XCTAssertFalse(
+            lifecycle.begin(
+                sessionKey: sessionKey,
+                viewportTransitionGeneration: 1
+            )
+        )
+        XCTAssertNil(lifecycle.finish())
+        XCTAssertTrue(
+            lifecycle.begin(
+                sessionKey: sessionKey,
+                viewportTransitionGeneration: 1
+            )
+        )
+    }
+
+    func testDragLifecycleAbandonAllowsFreshGestureAfterViewReappears() {
+        let sessionKey = ChatScrollSessionKey(profile: "default", sessionID: "session")
+        var lifecycle = ChatDragLifecycleState()
+
+        XCTAssertTrue(
+            lifecycle.begin(
+                sessionKey: sessionKey,
+                viewportTransitionGeneration: 1
+            )
+        )
+        lifecycle.invalidate(hasActiveGesture: true)
+        lifecycle.abandon()
+
+        XCTAssertTrue(
+            lifecycle.begin(
+                sessionKey: sessionKey,
+                viewportTransitionGeneration: 1
+            )
+        )
+        XCTAssertEqual(
+            lifecycle.finish()?.dragGeneration,
+            4
+        )
+    }
+
+    func testDragCompletionPersistsUsingCanonicalSessionIdentity() {
+        let runtimeKey = ChatScrollSessionKey(profile: "default", sessionID: "runtime-id")
+        let canonicalKey = ChatScrollSessionKey(profile: "default", sessionID: "canonical-id")
+        let unrelatedKey = ChatScrollSessionKey(profile: "default", sessionID: "other-id")
+        let identity = ChatScrollSessionIdentity(
+            profile: "default",
+            canonicalSessionID: "canonical-id",
+            equivalentSessionIDs: ["runtime-id"],
+            isReconciling: false,
+            settledRevision: 1
+        )
+
+        XCTAssertEqual(
+            ChatFollowLatestRelatchPolicy.persistenceSessionKey(
+                currentKey: runtimeKey,
+                identity: identity
+            ),
+            canonicalKey
+        )
+        XCTAssertEqual(
+            ChatFollowLatestRelatchPolicy.persistenceSessionKey(
+                currentKey: unrelatedKey,
+                identity: identity
+            ),
+            unrelatedKey
+        )
+        XCTAssertNil(
+            ChatFollowLatestRelatchPolicy.persistenceSessionKey(
+                currentKey: nil,
+                identity: identity
+            )
+        )
+    }
+
+    @MainActor
+    func testDragCompletionRechecksStateAfterControlledSuspension() async {
+        var dragGeneration = 1
+        var completionEvents: [String] = []
+        let suspensionReached = expectation(description: "completion reached suspension")
+        let gate = ChatScrollTestGate()
+
+        let completion = Task { @MainActor in
+            await ChatFollowLatestRelatchPolicy.completeDragAfterNextTurn(
+                suspend: {
+                    suspensionReached.fulfill()
+                    await gate.wait()
+                },
+                isCurrent: { dragGeneration == 1 },
+                relatch: { completionEvents.append("relatch") },
+                persist: { completionEvents.append("persist") }
+            )
+        }
+
+        await fulfillment(of: [suspensionReached], timeout: 1)
+        dragGeneration = 2
+        await gate.open()
+        await completion.value
+
+        XCTAssertEqual(completionEvents, [])
+    }
+
+    @MainActor
+    func testCancelledDragCompletionDoesNotRelatchOrPersist() async {
+        var completionEvents: [String] = []
+        let suspensionReached = expectation(description: "completion reached suspension")
+        let gate = ChatScrollTestGate()
+
+        let completion = Task { @MainActor in
+            await ChatFollowLatestRelatchPolicy.completeDragAfterNextTurn(
+                suspend: {
+                    suspensionReached.fulfill()
+                    await gate.wait()
+                },
+                isCurrent: { true },
+                relatch: { completionEvents.append("relatch") },
+                persist: { completionEvents.append("persist") }
+            )
+        }
+
+        await fulfillment(of: [suspensionReached], timeout: 1)
+        completion.cancel()
+        await gate.open()
+        await completion.value
+
+        XCTAssertEqual(completionEvents, [])
+    }
+
+    @MainActor
+    func testDragCompletionWaitsForNextMainActorTurn() async {
+        var completionEvents: [String] = []
+        DispatchQueue.main.async {
+            completionEvents.append("queued")
+        }
+
+        await ChatFollowLatestRelatchPolicy.completeDragAfterNextTurn(
+            isCurrent: {
+                completionEvents.append("validate")
+                return true
+            },
             relatch: { completionEvents.append("relatch") },
             persist: { completionEvents.append("persist") }
         )
-        await nextDrag.value
 
-        XCTAssertEqual(completionEvents, [])
+        XCTAssertEqual(completionEvents, ["queued", "validate", "relatch", "persist"])
     }
 
     @MainActor
     func testDragCompletionPersistsAfterRelatchDecision() async {
         var completionEvents: [String] = []
 
-        await ChatFollowLatestRelatchPolicy.completeDragAfterYield(
+        await ChatFollowLatestRelatchPolicy.completeDragAfterNextTurn(
             isCurrent: { true },
             relatch: { completionEvents.append("relatch") },
             persist: { completionEvents.append("persist") }

--- a/ConduitTests/ChatScrollStateTests.swift
+++ b/ConduitTests/ChatScrollStateTests.swift
@@ -2,6 +2,56 @@ import XCTest
 @testable import Conduit
 
 final class ChatScrollStateTests: XCTestCase {
+    func testFollowLatestRelatchIsBlockedWhileDraggingNearBottom() {
+        XCTAssertFalse(
+            ChatFollowLatestRelatchPolicy.shouldRelatch(
+                isNearBottom: true,
+                hasPendingRestoration: false,
+                isDragging: true
+            )
+        )
+    }
+
+    func testFollowLatestRelatchIsAllowedAfterSettledDragEnds() {
+        XCTAssertTrue(
+            ChatFollowLatestRelatchPolicy.shouldRelatch(
+                isNearBottom: true,
+                hasPendingRestoration: false,
+                isDragging: false
+            )
+        )
+    }
+
+    @MainActor
+    func testDragEndRelatchIsCancelledWhenAnotherDragStarts() async {
+        var isDragging = false
+        var relatchCount = 0
+
+        let scheduledRelatch = Task { @MainActor in
+            await ChatFollowLatestRelatchPolicy.relatchAfterDragEnds(
+                isDragging: { isDragging },
+                relatch: { relatchCount += 1 }
+            )
+        }
+        isDragging = true
+
+        await scheduledRelatch.value
+
+        XCTAssertEqual(relatchCount, 0)
+    }
+
+    @MainActor
+    func testDragEndRelatchRunsAfterSettledDragEnds() async {
+        var relatchCount = 0
+
+        await ChatFollowLatestRelatchPolicy.relatchAfterDragEnds(
+            isDragging: { false },
+            relatch: { relatchCount += 1 }
+        )
+
+        XCTAssertEqual(relatchCount, 1)
+    }
+
     func testRestorationWaitsForMatchingRenderedTargetAndGeometryConfirmation() {
         let sessionA = ChatScrollSessionKey(profile: "default", sessionID: "session-a")
         let sessionB = ChatScrollSessionKey(profile: "default", sessionID: "session-b")

--- a/ConduitTests/ChatScrollStateTests.swift
+++ b/ConduitTests/ChatScrollStateTests.swift
@@ -2,54 +2,63 @@ import XCTest
 @testable import Conduit
 
 final class ChatScrollStateTests: XCTestCase {
-    func testFollowLatestRelatchIsBlockedWhileDraggingNearBottom() {
-        XCTAssertFalse(
-            ChatFollowLatestRelatchPolicy.shouldRelatch(
-                isNearBottom: true,
-                hasPendingRestoration: false,
-                isDragging: true
-            )
-        )
-    }
+    func testFollowLatestRelatchRequiresSettledNearBottomViewport() {
+        let cases: [(
+            isNearBottom: Bool,
+            hasPendingRestoration: Bool,
+            hasNotificationHandoff: Bool,
+            isDragging: Bool,
+            expected: Bool
+        )] = [
+            (true, false, false, false, true),
+            (false, false, false, false, false),
+            (true, true, false, false, false),
+            (true, false, true, false, false),
+            (true, false, false, true, false),
+        ]
 
-    func testFollowLatestRelatchIsAllowedAfterSettledDragEnds() {
-        XCTAssertTrue(
-            ChatFollowLatestRelatchPolicy.shouldRelatch(
-                isNearBottom: true,
-                hasPendingRestoration: false,
-                isDragging: false
-            )
-        )
-    }
-
-    @MainActor
-    func testDragEndRelatchIsCancelledWhenAnotherDragStarts() async {
-        var isDragging = false
-        var relatchCount = 0
-
-        let scheduledRelatch = Task { @MainActor in
-            await ChatFollowLatestRelatchPolicy.relatchAfterDragEnds(
-                isDragging: { isDragging },
-                relatch: { relatchCount += 1 }
+        for testCase in cases {
+            XCTAssertEqual(
+                ChatFollowLatestRelatchPolicy.shouldRelatch(
+                    isNearBottom: testCase.isNearBottom,
+                    hasPendingRestoration: testCase.hasPendingRestoration,
+                    hasNotificationHandoff: testCase.hasNotificationHandoff,
+                    isDragging: testCase.isDragging
+                ),
+                testCase.expected
             )
         }
-        isDragging = true
-
-        await scheduledRelatch.value
-
-        XCTAssertEqual(relatchCount, 0)
     }
 
     @MainActor
-    func testDragEndRelatchRunsAfterSettledDragEnds() async {
-        var relatchCount = 0
+    func testDragCompletionRechecksGestureAfterYield() async {
+        var dragGeneration = 1
+        var completionEvents: [String] = []
+        let nextDrag = Task { @MainActor in
+            dragGeneration = 2
+        }
 
-        await ChatFollowLatestRelatchPolicy.relatchAfterDragEnds(
-            isDragging: { false },
-            relatch: { relatchCount += 1 }
+        await ChatFollowLatestRelatchPolicy.completeDragAfterYield(
+            isCurrent: { dragGeneration == 1 },
+            relatch: { completionEvents.append("relatch") },
+            persist: { completionEvents.append("persist") }
+        )
+        await nextDrag.value
+
+        XCTAssertEqual(completionEvents, [])
+    }
+
+    @MainActor
+    func testDragCompletionPersistsAfterRelatchDecision() async {
+        var completionEvents: [String] = []
+
+        await ChatFollowLatestRelatchPolicy.completeDragAfterYield(
+            isCurrent: { true },
+            relatch: { completionEvents.append("relatch") },
+            persist: { completionEvents.append("persist") }
         )
 
-        XCTAssertEqual(relatchCount, 1)
+        XCTAssertEqual(completionEvents, ["relatch", "persist"])
     }
 
     func testRestorationWaitsForMatchingRenderedTargetAndGeometryConfirmation() {

--- a/ConduitTests/ChatScrollStateTests.swift
+++ b/ConduitTests/ChatScrollStateTests.swift
@@ -149,6 +149,39 @@ final class ChatScrollStateTests: XCTestCase {
                 hasNotificationHandoff: false
             )
         )
+        XCTAssertTrue(
+            ChatFollowLatestRelatchPolicy.isCompletionCurrent(
+                completed: noSession,
+                current: equivalentCurrent,
+                identity: identity,
+                isDragging: false,
+                hasPendingRestoration: false,
+                hasNotificationHandoff: false
+            )
+        )
+        XCTAssertFalse(
+            ChatFollowLatestRelatchPolicy.isCompletionCurrent(
+                completed: equivalentCurrent,
+                current: noSession,
+                identity: identity,
+                isDragging: false,
+                hasPendingRestoration: false,
+                hasNotificationHandoff: false
+            )
+        )
+    }
+
+    func testTranscriptTransitionKeepsFollowDisabledForActiveDrag() {
+        XCTAssertFalse(
+            ChatFollowLatestRelatchPolicy.shouldFollowLatestAfterTransition(
+                isDragging: true
+            )
+        )
+        XCTAssertTrue(
+            ChatFollowLatestRelatchPolicy.shouldFollowLatestAfterTransition(
+                isDragging: false
+            )
+        )
     }
 
     func testDragLifecycleCapturesStartAndSuppressesInvalidatedGestureUntilFinish() {


### PR DESCRIPTION
## Summary

- Prevents geometry callbacks from re-latching `followsLatest` while the user is actively dragging the transcript.
- Defers the drag-end decision to the next main-actor turn so ending near the bottom re-enables following even when no geometry preference changes.
- Captures gesture ownership at drag start and rejects stale completion after a newer drag, viewport transition, restoration, session change, notification handoff, cancellation, or view disappearance.
- Persists only after the relatch decision and resolves equivalent runtime IDs to the current canonical session key.

## Background

A slow upward drag during streaming set `followsLatest = false`, but content-growth and scroll geometry callbacks could immediately set it back to `true` while the finger was still inside the 40 pt near-bottom window. The next streamed delta then pulled the transcript back to the bottom.

The original branch also contained stacked fixes that had since landed on `main`. This branch has been updated with current `main`, so the PR now contains only the scroll interaction repair and its focused tests.

## Verification

- Added regression coverage for:
  - mid-drag relatch suppression;
  - near-bottom, restoration, and notification-handoff guards;
  - deterministic next-main-actor-turn completion;
  - drag-start session and viewport-transition ownership;
  - normal, cancelled, invalidated, and disappeared gesture lifecycles;
  - equivalent-ID canonical persistence;
  - relatch-before-persist ordering.
- Mutation checks:
  - removing the next-turn suspension fails `testDragCompletionWaitsForNextMainActorTurn`;
  - allowing an invalidated gesture to finish fails `testDragLifecycleCapturesStartAndSuppressesInvalidatedGestureUntilFinish`.
- Local full suite on iPhone 17 Pro / iOS 26.5 Simulator: **501 tests passed, 0 failed, 0 skipped**.

Original report: [angel12/hermes-conduit#7](https://github.com/angel12/hermes-conduit/issues/7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat scrolling during and after drag gestures.
  * Prevented outdated or cancelled drag events from unexpectedly repositioning the conversation.
  * Preserved the latest-message position more reliably during restoration, conversation changes, and notification transitions.
  * Improved viewport persistence when returning to an equivalent conversation.

* **Tests**
  * Added comprehensive coverage for scroll eligibility, drag completion, cancellation, restoration, and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->