### PR TITLE
Fix iOS voice capture audio-session startup

### DIFF
--- a/Conduit/Services/Haptics.swift
+++ b/Conduit/Services/Haptics.swift
@@ -21,6 +21,17 @@ struct HapticsEnginePolicy: Equatable {
     )
 }
 
+enum HapticsEngineStopPolicy {
+    static func shouldDiscardEngine(for reason: CHHapticEngine.StoppedReason) -> Bool {
+        switch reason {
+        case .audioSessionInterrupt, .systemError:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
 struct ResponseHapticState {
     enum Effect: Equatable {
         case responseStarted
@@ -370,11 +381,13 @@ enum Haptics {
                 coreHapticsEngine = nil
             }
         }
-        engine.stoppedHandler = { [weak engine] _ in
+        engine.stoppedHandler = { [weak engine] reason in
             Task { @MainActor in
                 guard let engine, coreHapticsEngine === engine else { return }
                 clearLifecyclePatternState()
-                coreHapticsEngine = nil
+                if HapticsEngineStopPolicy.shouldDiscardEngine(for: reason) {
+                    coreHapticsEngine = nil
+                }
             }
         }
         return engine

--- a/Conduit/Services/Haptics.swift
+++ b/Conduit/Services/Haptics.swift
@@ -6,9 +6,20 @@
 //  calibrated response lifecycle patterns and subordinate tool activity.
 //
 
+import AVFAudio
 import CoreHaptics
 import SwiftUI
 import UIKit
+
+struct HapticsEnginePolicy: Equatable {
+    let usesSharedAudioSession: Bool
+    let playsHapticsOnly: Bool
+
+    static let response = Self(
+        usesSharedAudioSession: true,
+        playsHapticsOnly: true
+    )
+}
 
 struct ResponseHapticState {
     enum Effect: Equatable {
@@ -163,6 +174,7 @@ enum Haptics {
 #endif
 
     static let preferenceKey = "conduit.haptics"
+    static let enginePolicy = HapticsEnginePolicy.response
 
 
     private static let softGenerator = UIImpactFeedbackGenerator(style: .soft)
@@ -343,7 +355,13 @@ enum Haptics {
         ]
     }
     private static func makeCoreHapticsEngine() throws -> CHHapticEngine {
-        let engine = try CHHapticEngine()
+        let engine: CHHapticEngine
+        if enginePolicy.usesSharedAudioSession {
+            engine = try CHHapticEngine(audioSession: AVAudioSession.sharedInstance())
+        } else {
+            engine = try CHHapticEngine()
+        }
+        engine.playsHapticsOnly = enginePolicy.playsHapticsOnly
         engine.isAutoShutdownEnabled = true
         engine.resetHandler = { [weak engine] in
             Task { @MainActor in
@@ -356,6 +374,7 @@ enum Haptics {
             Task { @MainActor in
                 guard let engine, coreHapticsEngine === engine else { return }
                 clearLifecyclePatternState()
+                coreHapticsEngine = nil
             }
         }
         return engine

--- a/Conduit/Voice/AVAudioCaptureService.swift
+++ b/Conduit/Voice/AVAudioCaptureService.swift
@@ -11,18 +11,24 @@ private let voiceAudioLogger = Logger(subsystem: "com.milim.relay", category: "V
 
 @MainActor
 final class AVAudioCaptureService: NSObject, AudioCaptureService {
+    private static let outputSampleRate = VoiceAudioSessionConfiguration.capture.outputSampleRate
+    private static let outputChannelCount = VoiceAudioSessionConfiguration.capture.outputChannelCount
+    private static let outputBytesPerSample = MemoryLayout<Int16>.size
+    private static let outputBytesPerFrame = outputBytesPerSample * Int(outputChannelCount)
+    private static let preRollDuration: TimeInterval = 5
+
     private let engine = AVAudioEngine()
     private let session = AVAudioSession.sharedInstance()
     /// AVAudioEngine and AVAudioConverter use deinterleaved Float32 as their
     /// canonical PCM representation. Quantize to PCM16 only after resampling.
     private let outputFormat = AVAudioFormat(
-        standardFormatWithSampleRate: VoiceAudioSessionConfiguration.capture.outputSampleRate,
-        channels: VoiceAudioSessionConfiguration.capture.outputChannelCount
+        standardFormatWithSampleRate: AVAudioCaptureService.outputSampleRate,
+        channels: AVAudioCaptureService.outputChannelCount
     )!
     private var converter: AVAudioConverter?
     private var capturedPCM = Data()
     private var preRollPCM = Data()
-    private let maximumPreRollBytes = 16_000 * 2 * 5
+    private let maximumPreRollBytes = Int(AVAudioCaptureService.outputSampleRate * AVAudioCaptureService.preRollDuration) * AVAudioCaptureService.outputBytesPerFrame
     private var activelyRecording = false
     private var paused = false
     private var shouldKeepEngineRunning = false
@@ -114,11 +120,11 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
             if let lastCaptureFailure { throw VoiceAudioError.unavailable(lastCaptureFailure) }
             throw VoiceAudioError.noAudioCaptured
         }
-        let duration = Double(pcm.count) / (16_000 * 2)
+        let duration = Double(pcm.count) / (Self.outputSampleRate * Double(Self.outputBytesPerFrame))
         return VoiceCapturedAudio(
-            wavData: Self.wavWrapping(pcm16: pcm, sampleRate: 16_000),
+            wavData: Self.wavWrapping(pcm16: pcm, sampleRate: Int(Self.outputSampleRate)),
             pcm16Data: pcm,
-            sampleRate: 16_000,
+            sampleRate: Self.outputSampleRate,
             duration: duration
         )
     }
@@ -274,6 +280,7 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
             } catch {
                 handleStartupFailure(error, stage: "routeChange")
                 continuation?.yield(.interrupted)
+                return
             }
         }
         continuation?.yield(.routeChanged)
@@ -288,7 +295,7 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
     }
 
     private static func wavWrapping(pcm16: Data, sampleRate: Int) -> Data {
-        let byteRate = sampleRate * 2
+        let byteRate = sampleRate * outputBytesPerFrame
         let fileSize = 36 + pcm16.count
         var header = Data()
         header.append("RIFF".data(using: .ascii)!)
@@ -296,10 +303,10 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
         header.append("WAVEfmt ".data(using: .ascii)!)
         header.append(UInt32(16).littleEndianData)
         header.append(UInt16(1).littleEndianData)
-        header.append(UInt16(1).littleEndianData)
+        header.append(UInt16(outputChannelCount).littleEndianData)
         header.append(UInt32(sampleRate).littleEndianData)
         header.append(UInt32(byteRate).littleEndianData)
-        header.append(UInt16(2).littleEndianData)
+        header.append(UInt16(outputBytesPerFrame).littleEndianData)
         header.append(UInt16(16).littleEndianData)
         header.append("data".data(using: .ascii)!)
         header.append(UInt32(pcm16.count).littleEndianData)

--- a/Conduit/Voice/AVAudioCaptureService.swift
+++ b/Conduit/Voice/AVAudioCaptureService.swift
@@ -5,6 +5,9 @@
 
 import AVFAudio
 import Foundation
+import OSLog
+
+private let voiceAudioLogger = Logger(subsystem: "com.milim.relay", category: "VoiceAudio")
 
 @MainActor
 final class AVAudioCaptureService: NSObject, AudioCaptureService {
@@ -12,7 +15,10 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
     private let session = AVAudioSession.sharedInstance()
     /// AVAudioEngine and AVAudioConverter use deinterleaved Float32 as their
     /// canonical PCM representation. Quantize to PCM16 only after resampling.
-    private let outputFormat = AVAudioFormat(standardFormatWithSampleRate: 16_000, channels: 1)!
+    private let outputFormat = AVAudioFormat(
+        standardFormatWithSampleRate: VoiceAudioSessionConfiguration.capture.outputSampleRate,
+        channels: VoiceAudioSessionConfiguration.capture.outputChannelCount
+    )!
     private var converter: AVAudioConverter?
     private var capturedPCM = Data()
     private var preRollPCM = Data()
@@ -61,8 +67,12 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
     }
 
     func startListening(includePreRoll: Bool = false) throws {
-        try configureSession()
-        if !engine.isRunning { try startEngine() }
+        do {
+            try startCaptureIfNeeded()
+        } catch {
+            handleStartupFailure(error, stage: "startListening")
+            throw error
+        }
         capturedPCM = includePreRoll ? preRollPCM : Data()
         lastCaptureFailure = nil
         activelyRecording = true
@@ -71,8 +81,12 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
     }
 
     func beginBargeInMonitoring() throws {
-        try configureSession()
-        if !engine.isRunning { try startEngine() }
+        do {
+            try startCaptureIfNeeded()
+        } catch {
+            handleStartupFailure(error, stage: "beginBargeInMonitoring")
+            throw error
+        }
         activelyRecording = false
         paused = false
         shouldKeepEngineRunning = true
@@ -81,8 +95,12 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
     func pause() { paused = true }
 
     func resume() throws {
-        try configureSession()
-        if !engine.isRunning { try startEngine() }
+        do {
+            try startCaptureIfNeeded()
+        } catch {
+            handleStartupFailure(error, stage: "resume")
+            throw error
+        }
         paused = false
         shouldKeepEngineRunning = true
     }
@@ -116,14 +134,35 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
         try? session.setActive(false, options: .notifyOthersOnDeactivation)
     }
 
+    private func startCaptureIfNeeded() throws {
+        try configureSession()
+        if !engine.isRunning { try startEngine() }
+    }
+
     private func configureSession() throws {
+        let configuration = VoiceAudioSessionConfiguration.capture
         try session.setCategory(
-            .playAndRecord,
-            mode: .voiceChat,
-            options: [.allowBluetooth, .allowBluetoothA2DP, .defaultToSpeaker]
+            configuration.category,
+            mode: configuration.mode,
+            options: configuration.options
         )
-        try session.setPreferredSampleRate(16_000)
         try session.setActive(true)
+    }
+
+    private func handleStartupFailure(_ error: Error, stage: String) {
+        logStartupFailure(error, stage: stage)
+        stop()
+    }
+
+    private func logStartupFailure(_ error: Error, stage: String) {
+        let nsError = error as NSError
+        let inputFormat = engine.inputNode.inputFormat(forBus: 0)
+        let inputPorts = session.currentRoute.inputs
+            .map { $0.portType.rawValue }
+            .joined(separator: ",")
+        voiceAudioLogger.error(
+            "Capture startup failed stage=\(stage, privacy: .public) domain=\(nsError.domain, privacy: .public) code=\(nsError.code, privacy: .public) ports=\(inputPorts, privacy: .public) sessionRate=\(self.session.sampleRate, privacy: .public) sessionChannels=\(self.session.inputNumberOfChannels, privacy: .public) inputRate=\(inputFormat.sampleRate, privacy: .public) inputChannels=\(inputFormat.channelCount, privacy: .public)"
+        )
     }
 
     private func startEngine() throws {
@@ -229,8 +268,13 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
         // the converter lazily without churning an already-running engine.
         converter = nil
         if shouldKeepEngineRunning, !engine.isRunning {
-            do { try startEngine() }
-            catch { continuation?.yield(.interrupted) }
+            do {
+                try configureSession()
+                try startEngine()
+            } catch {
+                handleStartupFailure(error, stage: "routeChange")
+                continuation?.yield(.interrupted)
+            }
         }
         continuation?.yield(.routeChanged)
     }

--- a/Conduit/Voice/VoiceAudioSessionConfiguration.swift
+++ b/Conduit/Voice/VoiceAudioSessionConfiguration.swift
@@ -10,7 +10,7 @@ struct VoiceAudioSessionConfiguration: Equatable {
     static let capture = Self(
         category: .playAndRecord,
         mode: .voiceChat,
-        options: [.allowBluetooth, .defaultToSpeaker],
+        options: [.allowBluetoothHFP, .defaultToSpeaker],
         outputSampleRate: 16_000,
         outputChannelCount: 1
     )

--- a/Conduit/Voice/VoiceAudioSessionConfiguration.swift
+++ b/Conduit/Voice/VoiceAudioSessionConfiguration.swift
@@ -1,0 +1,17 @@
+import AVFAudio
+
+struct VoiceAudioSessionConfiguration: Equatable {
+    let category: AVAudioSession.Category
+    let mode: AVAudioSession.Mode
+    let options: AVAudioSession.CategoryOptions
+    let outputSampleRate: Double
+    let outputChannelCount: AVAudioChannelCount
+
+    static let capture = Self(
+        category: .playAndRecord,
+        mode: .voiceChat,
+        options: [.allowBluetooth, .defaultToSpeaker],
+        outputSampleRate: 16_000,
+        outputChannelCount: 1
+    )
+}

--- a/ConduitTests/HapticsTests.swift
+++ b/ConduitTests/HapticsTests.swift
@@ -1,3 +1,4 @@
+import CoreHaptics
 import XCTest
 @testable import Conduit
 
@@ -6,6 +7,12 @@ final class HapticsTests: XCTestCase {
     func testResponseEngineUsesSharedHapticsOnlyPolicy() {
         XCTAssertTrue(Haptics.enginePolicy.usesSharedAudioSession)
         XCTAssertTrue(Haptics.enginePolicy.playsHapticsOnly)
+    }
+
+    func testEngineStopPolicyDiscardsOnlyRecoveryCriticalStops() {
+        XCTAssertFalse(HapticsEngineStopPolicy.shouldDiscardEngine(for: .idleTimeout))
+        XCTAssertTrue(HapticsEngineStopPolicy.shouldDiscardEngine(for: .audioSessionInterrupt))
+        XCTAssertTrue(HapticsEngineStopPolicy.shouldDiscardEngine(for: .systemError))
     }
 
     func testEnabledUsesDevicePreference() {

--- a/ConduitTests/HapticsTests.swift
+++ b/ConduitTests/HapticsTests.swift
@@ -3,6 +3,11 @@ import XCTest
 
 @MainActor
 final class HapticsTests: XCTestCase {
+    func testResponseEngineUsesSharedHapticsOnlyPolicy() {
+        XCTAssertTrue(Haptics.enginePolicy.usesSharedAudioSession)
+        XCTAssertTrue(Haptics.enginePolicy.playsHapticsOnly)
+    }
+
     func testEnabledUsesDevicePreference() {
         let defaults = UserDefaults.standard
         let previousValue = defaults.object(forKey: Haptics.preferenceKey)

--- a/ConduitTests/VoiceAudioSessionConfigurationTests.swift
+++ b/ConduitTests/VoiceAudioSessionConfigurationTests.swift
@@ -8,7 +8,7 @@ final class VoiceAudioSessionConfigurationTests: XCTestCase {
 
         XCTAssertEqual(configuration.category.rawValue, AVAudioSession.Category.playAndRecord.rawValue)
         XCTAssertEqual(configuration.mode.rawValue, AVAudioSession.Mode.voiceChat.rawValue)
-        XCTAssertTrue(configuration.options.contains(.allowBluetooth))
+        XCTAssertTrue(configuration.options.contains(.allowBluetoothHFP))
         XCTAssertTrue(configuration.options.contains(.defaultToSpeaker))
         XCTAssertFalse(configuration.options.contains(.allowBluetoothA2DP))
     }

--- a/ConduitTests/VoiceAudioSessionConfigurationTests.swift
+++ b/ConduitTests/VoiceAudioSessionConfigurationTests.swift
@@ -1,0 +1,22 @@
+import AVFAudio
+import XCTest
+@testable import Conduit
+
+final class VoiceAudioSessionConfigurationTests: XCTestCase {
+    func testCaptureUsesInputCapableVoiceChatBluetoothPolicy() {
+        let configuration = VoiceAudioSessionConfiguration.capture
+
+        XCTAssertEqual(configuration.category.rawValue, AVAudioSession.Category.playAndRecord.rawValue)
+        XCTAssertEqual(configuration.mode.rawValue, AVAudioSession.Mode.voiceChat.rawValue)
+        XCTAssertTrue(configuration.options.contains(.allowBluetooth))
+        XCTAssertTrue(configuration.options.contains(.defaultToSpeaker))
+        XCTAssertFalse(configuration.options.contains(.allowBluetoothA2DP))
+    }
+
+    func testCapturePreservesCanonicalProviderFormat() {
+        let configuration = VoiceAudioSessionConfiguration.capture
+
+        XCTAssertEqual(configuration.outputSampleRate, 16_000)
+        XCTAssertEqual(configuration.outputChannelCount, 1)
+    }
+}

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -86,6 +86,27 @@ final class VoiceConversationControllerTests: XCTestCase {
         XCTAssertEqual(result.message, "Microphone access is required for voice conversations.")
     }
 
+    func testTranscriptionTestReportsCaptureStartFailureBeforeProviderCall() async {
+        let capture = MockCapture(
+            permissionGranted: true,
+            startError: VoiceAudioError.unavailable("Microphone capture could not start.")
+        )
+        let gateway = MockGateway()
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            submit: { _ in true },
+            interrupt: {}
+        )
+
+        let result = await controller.runTranscriptionTest(duration: 0)
+
+        XCTAssertFalse(result.passed)
+        XCTAssertEqual(result.message, "Microphone capture could not start.")
+        XCTAssertEqual(gateway.transcriptionCount, 0)
+    }
+
     func testTranscriptionTestReturnsCapturedTranscript() async {
         let controller = VoiceConversationController(
             capture: MockCapture(permissionGranted: true),
@@ -590,20 +611,26 @@ private final class MockCapture: AudioCaptureService {
     let events: AsyncStream<VoiceCaptureEvent>
     private var continuation: AsyncStream<VoiceCaptureEvent>.Continuation?
     let permissionGranted: Bool
+    let startError: Error?
     var didStart = false
     var startCount = 0
     var didBeginMonitoring = false
     var didPause = false
     var resumeCount = 0
 
-    init(permissionGranted: Bool) {
+    init(permissionGranted: Bool, startError: Error? = nil) {
         self.permissionGranted = permissionGranted
+        self.startError = startError
         var captured: AsyncStream<VoiceCaptureEvent>.Continuation?
         events = AsyncStream { captured = $0 }
         continuation = captured
     }
     func requestPermission() async -> Bool { permissionGranted }
-    func startListening(includePreRoll: Bool) throws { didStart = true; startCount += 1 }
+    func startListening(includePreRoll: Bool) throws {
+        didStart = true
+        startCount += 1
+        if let startError { throw startError }
+    }
     func beginBargeInMonitoring() throws { didBeginMonitoring = true }
     func pause() { didPause = true }
     func resume() throws { resumeCount += 1 }

--- a/docs/superpowers/plans/2026-08-12-voice-capture-session-recovery.md
+++ b/docs/superpowers/plans/2026-08-12-voice-capture-session-recovery.md
@@ -1,0 +1,352 @@
+# Voice Capture Session Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the shared iOS microphone capture path start reliably after Core Haptics activity or route changes while preserving the existing 16 kHz mono PCM16 transcription contract.
+
+**Architecture:** Keep `AVAudioCaptureService` as the sole owner of microphone-session activation and route-native input capture. Move its category/options/output-format choices into a value-oriented policy tested without hardware. Configure Core Haptics as a haptics-only engine bound to the shared `AVAudioSession`, discard stale engines after stops/resets, and add safe startup diagnostics for the physical-device failure path.
+
+**Tech Stack:** Swift 5.9, SwiftUI, AVFAudio, CoreHaptics, OSLog, XCTest, XcodeGen, iOS deployment target 17.0.
+
+## Global Constraints
+
+- Keep the canonical transcription output at 16,000 Hz, one channel, PCM16.
+- Do not change Hermes or Apple speech-recognition provider APIs.
+- Keep `.playAndRecord` with `.voiceChat`, Bluetooth HFP input support, and speaker fallback.
+- Do not request a preferred hardware sample rate; convert the active route's actual input format after capture.
+- Do not include audio contents, transcripts, credentials, or session secrets in diagnostics.
+- Do not claim physical iOS 27 validation from the available iOS 26.5 simulator.
+- The PR targets `main`; after merge, cherry-pick the merge commit into `release/0.1.3`; do not package a build in this change.
+
+---
+
+### Task 1: Add the route-native audio-session policy
+
+**Files:**
+- Create: `Conduit/Voice/VoiceAudioSessionConfiguration.swift`
+- Create: `ConduitTests/VoiceAudioSessionConfigurationTests.swift`
+
+**Interfaces:**
+- Produces `VoiceAudioSessionConfiguration.capture` with `category`, `mode`, `options`, `outputSampleRate`, and `outputChannelCount` properties.
+- Later tasks consume the policy from `AVAudioCaptureService` and the tests consume it without activating real audio hardware.
+
+- [ ] **Step 1: Write the failing policy tests**
+
+Create `ConduitTests/VoiceAudioSessionConfigurationTests.swift` with tests that assert the exact capture policy:
+
+```swift
+import AVFAudio
+import XCTest
+@testable import Conduit
+
+final class VoiceAudioSessionConfigurationTests: XCTestCase {
+    func testCaptureUsesInputCapableVoiceChatBluetoothPolicy() {
+        let configuration = VoiceAudioSessionConfiguration.capture
+
+        XCTAssertEqual(configuration.category.rawValue, AVAudioSession.Category.playAndRecord.rawValue)
+        XCTAssertEqual(configuration.mode.rawValue, AVAudioSession.Mode.voiceChat.rawValue)
+        XCTAssertTrue(configuration.options.contains(.allowBluetooth))
+        XCTAssertTrue(configuration.options.contains(.defaultToSpeaker))
+        XCTAssertFalse(configuration.options.contains(.allowBluetoothA2DP))
+    }
+
+    func testCapturePreservesCanonicalProviderFormat() {
+        let configuration = VoiceAudioSessionConfiguration.capture
+
+        XCTAssertEqual(configuration.outputSampleRate, 16_000)
+        XCTAssertEqual(configuration.outputChannelCount, 1)
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run:
+
+```bash
+xcodegen generate
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit \
+  -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' \
+  -derivedDataPath /tmp/conduit-voice-capture-policy \
+  CODE_SIGNING_ALLOWED=NO \
+  -only-testing:ConduitTests/VoiceAudioSessionConfigurationTests
+```
+
+Expected: compilation fails because `VoiceAudioSessionConfiguration` does not yet exist.
+
+- [ ] **Step 3: Implement the policy value**
+
+Create `Conduit/Voice/VoiceAudioSessionConfiguration.swift`:
+
+```swift
+import AVFAudio
+
+struct VoiceAudioSessionConfiguration: Equatable {
+    let category: AVAudioSession.Category
+    let mode: AVAudioSession.Mode
+    let options: AVAudioSession.CategoryOptions
+    let outputSampleRate: Double
+    let outputChannelCount: AVAudioChannelCount
+
+    static let capture = Self(
+        category: .playAndRecord,
+        mode: .voiceChat,
+        options: [.allowBluetooth, .defaultToSpeaker],
+        outputSampleRate: 16_000,
+        outputChannelCount: 1
+    )
+}
+```
+
+- [ ] **Step 4: Run the policy tests to verify they pass**
+
+Run the command from Step 2. Expected: both tests pass.
+
+- [ ] **Step 5: Commit the policy unit**
+
+```bash
+git add Conduit/Voice/VoiceAudioSessionConfiguration.swift ConduitTests/VoiceAudioSessionConfigurationTests.swift
+git commit -m "test: define voice audio session policy"
+```
+
+### Task 2: Bind Core Haptics to the shared session
+
+**Files:**
+- Modify: `Conduit/Services/Haptics.swift:144-370`
+- Modify: `ConduitTests/HapticsTests.swift`
+
+**Interfaces:**
+- Produces `HapticsEnginePolicy.response` with `usesSharedAudioSession == true` and `playsHapticsOnly == true`.
+- `Haptics.makeCoreHapticsEngine()` consumes that policy and creates `CHHapticEngine(audioSession: AVAudioSession.sharedInstance())`.
+
+- [ ] **Step 1: Write the failing haptics policy test**
+
+Add this test to the existing `@MainActor` `HapticsTests` class:
+
+```swift
+func testResponseEngineUsesSharedHapticsOnlyPolicy() {
+    XCTAssertTrue(Haptics.enginePolicy.usesSharedAudioSession)
+    XCTAssertTrue(Haptics.enginePolicy.playsHapticsOnly)
+}
+```
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```bash
+xcodegen generate
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit \
+  -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' \
+  -derivedDataPath /tmp/conduit-haptics-policy \
+  CODE_SIGNING_ALLOWED=NO \
+  -only-testing:ConduitTests/HapticsTests/testResponseEngineUsesSharedHapticsOnlyPolicy
+```
+
+Expected: compilation fails because `Haptics.enginePolicy` does not yet exist.
+
+- [ ] **Step 3: Implement the shared-session haptic policy and lifecycle reset**
+
+In `Conduit/Services/Haptics.swift`, add the value type before `Haptics`:
+
+```swift
+struct HapticsEnginePolicy: Equatable {
+    let usesSharedAudioSession: Bool
+    let playsHapticsOnly: Bool
+
+    static let response = Self(
+        usesSharedAudioSession: true,
+        playsHapticsOnly: true
+    )
+}
+```
+
+Inside `Haptics`, add:
+
+```swift
+static let enginePolicy = HapticsEnginePolicy.response
+```
+
+Update `makeCoreHapticsEngine()` so it selects the shared-session initializer from `enginePolicy`, sets `engine.playsHapticsOnly` before starting the engine, and retains the existing auto-shutdown behavior. The stopped handler must clear the pattern/player state and set `coreHapticsEngine = nil` for the stopped engine; the reset handler must continue to clear the engine and player state. This makes audio-session interruptions and stale auto-shutdown engines recreate cleanly.
+
+- [ ] **Step 4: Run the focused haptics tests to verify they pass**
+
+Run the command from Step 2. Expected: the policy test and the existing haptics tests pass without requiring hardware haptic output.
+
+- [ ] **Step 5: Commit the haptics change**
+
+```bash
+git add Conduit/Services/Haptics.swift ConduitTests/HapticsTests.swift
+git commit -m "fix: bind response haptics to shared audio session"
+```
+
+### Task 3: Make capture route-native and diagnose startup failures
+
+**Files:**
+- Modify: `Conduit/Voice/AVAudioCaptureService.swift:6-159,218-235`
+- Modify: `ConduitTests/VoiceConversationControllerTests.swift:74-102,589-615`
+
+**Interfaces:**
+- `AVAudioCaptureService` consumes `VoiceAudioSessionConfiguration.capture` for session category/options and canonical output format.
+- `VoiceConversationController` continues to receive the same `AudioCaptureService` errors; no provider-specific behavior changes.
+
+- [ ] **Step 1: Add the controller regression test**
+
+Extend `MockCapture` with an optional `startError: Error? = nil`, make `startListening(includePreRoll:)` throw that error after recording the attempted start, and add this test to `VoiceConversationControllerTests`:
+
+```swift
+func testTranscriptionTestReportsCaptureStartFailureBeforeProviderCall() async {
+    let capture = MockCapture(
+        permissionGranted: true,
+        startError: VoiceAudioError.unavailable("Microphone capture could not start.")
+    )
+    let gateway = MockGateway()
+    let controller = VoiceConversationController(
+        capture: capture,
+        playback: MockPlayback(),
+        gateway: gateway,
+        submit: { _ in true },
+        interrupt: {}
+    )
+
+    let result = await controller.runTranscriptionTest(duration: 0)
+
+    XCTAssertFalse(result.passed)
+    XCTAssertEqual(result.message, "Microphone capture could not start.")
+    XCTAssertEqual(gateway.transcriptionCount, 0)
+}
+```
+
+- [ ] **Step 2: Run the new controller test to verify it fails**
+
+Run:
+
+```bash
+xcodegen generate
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit \
+  -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' \
+  -derivedDataPath /tmp/conduit-capture-failure \
+  CODE_SIGNING_ALLOWED=NO \
+  -only-testing:ConduitTests/VoiceConversationControllerTests/testTranscriptionTestReportsCaptureStartFailureBeforeProviderCall
+```
+
+Expected: compilation fails because `MockCapture` has no `startError` initializer parameter.
+
+- [ ] **Step 3: Implement the minimal capture policy and cleanup path**
+
+In `AVAudioCaptureService.swift`:
+
+1. Import `OSLog` and define a private voice-audio logger with subsystem `com.milim.conduit` and category `VoiceAudio`.
+2. Build `outputFormat` from `VoiceAudioSessionConfiguration.capture.outputSampleRate` and `.outputChannelCount`.
+3. Replace the existing `setCategory` options with `VoiceAudioSessionConfiguration.capture.options`, remove `.allowBluetoothA2DP`, and remove `setPreferredSampleRate(16_000)`.
+4. Keep `setActive(true)` as the final session-configuration call before engine startup.
+5. Route `startListening`, `beginBargeInMonitoring`, and `resume` through one private activation helper that configures the session, starts the engine if needed, and on failure logs diagnostics, calls `stop()` to remove any partially installed tap/deactivate the session, then rethrows the original error.
+6. Keep the nil-format tap and `AVAudioConverter` conversion unchanged so the route's actual input format is converted to the same 16 kHz mono PCM16 output.
+7. When startup fails, log only stage, error domain/code, current input port types, session sample rate, session input-channel count, input-node sample rate, and input-node channel count. Use OSLog privacy `.public` for those diagnostic values and do not log buffers, transcripts, URLs, cookies, or credentials.
+8. On a route-change restart failure, perform the same cleanup before yielding `.interrupted`.
+
+The diagnostic helper should have this shape so the fields remain explicit and bounded:
+
+```swift
+private func logStartupFailure(_ error: Error) {
+    let nsError = error as NSError
+    let inputFormat = engine.inputNode.inputFormat(forBus: 0)
+    let inputPorts = session.currentRoute.inputs
+        .map { $0.portType.rawValue }
+        .joined(separator: ",")
+    audioCaptureLog.error(
+        "Capture start failed domain=\(nsError.domain, privacy: .public) code=\(nsError.code, privacy: .public) ports=\(inputPorts, privacy: .public) sessionRate=\(session.sampleRate, privacy: .public) sessionChannels=\(session.inputNumberOfChannels, privacy: .public) inputRate=\(inputFormat.sampleRate, privacy: .public) inputChannels=\(inputFormat.channelCount, privacy: .public)"
+    )
+}
+```
+
+- [ ] **Step 4: Run the controller regression test to verify it passes**
+
+Run the command from Step 2. Expected: the new test passes, existing transcription tests remain green, and the provider is not called when capture startup throws.
+
+- [ ] **Step 5: Run all voice and haptics tests**
+
+Run:
+
+```bash
+xcodegen generate
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit \
+  -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' \
+  -derivedDataPath /tmp/conduit-voice-capture-focused \
+  CODE_SIGNING_ALLOWED=NO \
+  -only-testing:ConduitTests/VoiceConversationControllerTests \
+  -only-testing:ConduitTests/VoiceAudioSessionConfigurationTests \
+  -only-testing:ConduitTests/HapticsTests \
+  -only-testing:ConduitTests/InteractionHapticsTests \
+  -only-testing:ConduitTests/ResponseHapticStateTests
+```
+
+Expected: all selected tests pass. The simulator may still report its existing Audio Unit diagnostic because it has no physical microphone route; that does not substitute for device acceptance.
+
+- [ ] **Step 6: Commit the capture change**
+
+```bash
+git add Conduit/Voice/AVAudioCaptureService.swift ConduitTests/VoiceConversationControllerTests.swift
+git commit -m "fix: use route-native voice capture startup"
+```
+
+### Task 4: Verify the complete change and prepare the integration handoff
+
+**Files:**
+- Verify: `Conduit/Voice/VoiceAudioSessionConfiguration.swift`
+- Verify: `Conduit/Voice/AVAudioCaptureService.swift`
+- Verify: `Conduit/Services/Haptics.swift`
+- Verify: `ConduitTests/VoiceAudioSessionConfigurationTests.swift`
+- Verify: `ConduitTests/VoiceConversationControllerTests.swift`
+- Verify: `ConduitTests/HapticsTests.swift`
+
+**Interfaces:**
+- No new public API or provider contract is introduced.
+- The feature branch remains based on current `main` and contains only the design, tests, and audio-session implementation.
+
+- [ ] **Step 1: Regenerate the ignored Xcode project**
+
+Run:
+
+```bash
+/Users/agrias/bin/bin/xcodegen generate
+```
+
+Expected: `Conduit.xcodeproj` regenerates successfully and remains ignored by Git.
+
+- [ ] **Step 2: Run the complete unit suite**
+
+Run:
+
+```bash
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit \
+  -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' \
+  -derivedDataPath /tmp/conduit-voice-capture-final \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: the full suite succeeds with zero test failures.
+
+- [ ] **Step 3: Perform static and worktree checks**
+
+Run:
+
+```bash
+git diff --check
+git status --short --branch
+git log --oneline --decorate -4
+```
+
+Expected: no whitespace errors, no unrelated files, and the original checkout at `/Users/agrias/Documents/Conduit` remains untouched.
+
+- [ ] **Step 4: Push the feature branch and open the PR against `main`**
+
+Push `codex/voice-capture-session-fix`, create the PR against `main`, and describe the physical-device acceptance requirement. Do not create a release build or TestFlight artifact.
+
+- [ ] **Step 5: After CI/review approval, merge and cherry-pick the merge commit**
+
+Merge the PR into `main`, fetch the resulting merge commit, check out `release/0.1.3`, cherry-pick that merge commit, and push the release branch. Verify both branches contain the same fix; leave build/TestFlight packaging for a later request.
+
+- [ ] **Step 6: Run the physical-device acceptance checklist**
+
+On the iPhone 16 Pro Max running iOS 27, test build 126 or the PR build after a normal response haptic, after notification launch, after background/foreground, and with both Hermes and **On this iPhone** selected. Confirm Record ASR starts, captures, reaches transcription, and that TTS and response haptics still work afterward. Capture the new route/format diagnostics if `-10868` remains.

--- a/docs/superpowers/plans/2026-08-12-voice-capture-session-recovery.md
+++ b/docs/superpowers/plans/2026-08-12-voice-capture-session-recovery.md
@@ -45,7 +45,7 @@ final class VoiceAudioSessionConfigurationTests: XCTestCase {
 
         XCTAssertEqual(configuration.category.rawValue, AVAudioSession.Category.playAndRecord.rawValue)
         XCTAssertEqual(configuration.mode.rawValue, AVAudioSession.Mode.voiceChat.rawValue)
-        XCTAssertTrue(configuration.options.contains(.allowBluetooth))
+        XCTAssertTrue(configuration.options.contains(.allowBluetoothHFP))
         XCTAssertTrue(configuration.options.contains(.defaultToSpeaker))
         XCTAssertFalse(configuration.options.contains(.allowBluetoothA2DP))
     }
@@ -91,7 +91,7 @@ struct VoiceAudioSessionConfiguration: Equatable {
     static let capture = Self(
         category: .playAndRecord,
         mode: .voiceChat,
-        options: [.allowBluetooth, .defaultToSpeaker],
+        options: [.allowBluetoothHFP, .defaultToSpeaker],
         outputSampleRate: 16_000,
         outputChannelCount: 1
     )

--- a/docs/superpowers/specs/2026-08-12-voice-capture-session-design.md
+++ b/docs/superpowers/specs/2026-08-12-voice-capture-session-design.md
@@ -49,7 +49,7 @@ Introduce a small value-oriented `VoiceAudioSessionConfiguration` used by `AVAud
 
 - category: `.playAndRecord`;
 - mode: `.voiceChat`;
-- options: `.allowBluetooth` and `.defaultToSpeaker`;
+- options: `.allowBluetoothHFP` and `.defaultToSpeaker`;
 - no preferred hardware sample rate;
 - canonical conversion output: 16,000 Hz, one channel, PCM16.
 

--- a/docs/superpowers/specs/2026-08-12-voice-capture-session-design.md
+++ b/docs/superpowers/specs/2026-08-12-voice-capture-session-design.md
@@ -1,0 +1,103 @@
+# Voice Capture Session Recovery Design
+
+## Context
+
+On an iPhone 16 Pro Max running iOS 27, the Voice settings action **Record ASR** fails before transcription with:
+
+> The operation couldn't be completed. (com.apple.coreaudio.avfaudio error -10868.)
+
+The same failure occurs when the selected transcription provider is Hermes or **On this iPhone**, which places the failure in the shared microphone-capture path rather than in either speech-to-text provider. The user reports that the same device and OS worked before build 120.
+
+The build history narrows what this repository can explain. There is no retained build-113 snapshot; the earliest source snapshot is build 114. `AVAudioCaptureService`, `AVSpeechPlaybackService`, `VoiceConversationController`, the microphone permission description, and the audio-session setup are byte-for-byte unchanged from build 114 through the current build 126 source. Build 120 itself changes the local-network URL policy and build number, not voice or audio code. The first audio-adjacent source change after build 119 is the custom `CHHapticEngine` added to the build-126 train after build 125. The current haptic engine is created with `CHHapticEngine()`; Apple documents that this form creates its own audio session when no session is supplied. A separate haptic audio session can contend with the voice capture session during `AVAudioEngine` startup. The capture path also asks the hardware for a preferred 16 kHz rate and enables both Bluetooth HFP and A2DP even though it converts the route's actual input format to 16 kHz after capture.
+
+## Goals
+
+- Make voice capture start reliably after response haptics have run or been interrupted.
+- Keep ASR output at the existing canonical 16 kHz mono PCM16 format for both Hermes and Apple on-device transcription.
+- Let `AVAudioEngine` use the active route's actual hardware input format and perform conversion after capture.
+- Keep bidirectional Bluetooth microphone routing available while avoiding an output-only A2DP preference in the voice session.
+- Preserve the existing UIKit haptic fallback and response lifecycle behavior.
+- Add deterministic tests for the audio-session and haptic-session policies.
+- Provide route/format diagnostics when the device audio engine still rejects startup.
+
+## Non-goals
+
+- Changing Hermes or Apple speech-recognition APIs.
+- Changing the 16 kHz WAV/PCM contract sent to transcription providers.
+- Rewriting the voice conversation state machine.
+- Adding a separate recording implementation just for the settings test.
+- Supporting audio capture from a Bluetooth A2DP-only input; A2DP is output-only and cannot provide the microphone path required by voice capture.
+- Claiming physical iOS 27 validation from the available iOS 26.5 simulator.
+
+## Root-cause hypothesis
+
+The leading hypothesis for the current build is the custom Core Haptics engine owning a separate audio session; this does not prove that the regression began exactly at build 120. Apple’s Core Haptics API explicitly distinguishes an engine associated with an existing `AVAudioSession` from an engine that creates its own session, and documents audio-session interruption as a haptic-engine stop reason. When the voice capture service later changes category, activates the session, and starts its input audio unit, the independent haptic session can leave the audio graph in a format or interruption state that produces `-10868`. If build 125 can be reproduced on the same device and succeeds while build 126 fails, that makes this hypothesis strong; if build 125 also fails, the route-native capture hardening becomes the primary path and haptics is not the release-boundary explanation.
+
+The capture code has a second fragility: it requests 16 kHz as the hardware preferred rate even though the code already supports conversion from the route’s native format. Device hardware may select a different actual rate, and voice-chat input routes are not required to accept the requested preference. Removing that unnecessary hardware constraint makes the capture path tolerant of the actual iPhone route without changing the provider format.
+
+## Architecture
+
+### Shared haptic audio-session ownership
+
+Update `Haptics` so its custom engine is created with `AVAudioSession.sharedInstance()` and is explicitly configured as haptics-only. The existing stopped/reset handlers remain responsible for clearing the active pattern and will discard an engine stopped by an audio-session interruption so the next response creates a clean engine. The UIKit fallback continues to handle unsupported hardware or engine-start failures.
+
+This keeps Conduit’s haptic and voice features on one audio-session boundary instead of allowing Core Haptics to create an independent session. It does not make the haptic engine responsible for configuring the voice category; `AVAudioCaptureService` remains the owner of microphone activation.
+
+### Route-native microphone capture
+
+Introduce a small value-oriented `VoiceAudioSessionConfiguration` used by `AVAudioCaptureService` and unit tests. Its capture policy is:
+
+- category: `.playAndRecord`;
+- mode: `.voiceChat`;
+- options: `.allowBluetooth` and `.defaultToSpeaker`;
+- no preferred hardware sample rate;
+- canonical conversion output: 16,000 Hz, one channel, PCM16.
+
+`configureSession()` applies the category and activates the shared session without forcing the hardware rate. `startEngine()` verifies that input is available, queries the active input node’s actual format, and installs the existing nil-format tap. `AVAudioConverter` continues to resample that route-native Float32 input into the canonical 16 kHz PCM16 buffer.
+
+If the session or input format is unavailable, or `AVAudioEngine.start()` throws, the service records a concise user-facing failure and logs the route name, session sample rate, input sample rate, channel count, and error code for device diagnostics. Logs must not include audio contents, credentials, or transcript text.
+
+### Provider boundary
+
+No provider-specific branching is added to capture. `VoiceConversationController.runTranscriptionTest()` remains responsible for recording, finishing the WAV, and then choosing Hermes or Apple transcription. A failure before `finishUtterance()` therefore remains a capture failure visible in the settings status, and both provider choices exercise the same repaired path.
+
+## Error handling and lifecycle
+
+- Starting capture after a haptic response uses the shared session and route-native format.
+- A haptic engine interrupted by microphone activation is discarded; future haptics fall back or recreate cleanly.
+- `AVAudioCaptureService.stop()` continues to remove the input tap, stop the engine, reset conversion state, and deactivate the shared audio session.
+- Route changes continue to invalidate the converter and lazily rebuild the nil-format tap if capture should remain active.
+- Existing microphone and speech permission messages are unchanged.
+- The raw Core Audio error is not presented as the only diagnostic path in logs; the settings UI receives the existing localized failure message.
+
+## Testing
+
+### Policy tests
+
+- The haptic engine policy uses the shared `AVAudioSession` and haptics-only playback.
+- The voice capture policy does not request a hardware sample rate.
+- The voice capture policy preserves Bluetooth microphone support and excludes A2DP from the capture options.
+- The canonical output policy remains 16 kHz, mono, PCM16.
+
+### Controller regression tests
+
+- A capture-start failure is returned before either Hermes or Apple transcription is invoked.
+- Hermes and Apple provider modes both continue to consume the same `VoiceCapturedAudio` contract after capture succeeds.
+
+### Device acceptance
+
+On the reported iPhone 16 Pro Max running iOS 27:
+
+1. If available, run build 125 and build 126 on the same device and OS; record whether the failure follows the build boundary.
+2. Launch the candidate build after a normal chat response has produced response haptics.
+3. Open Voice settings and press **Record ASR** with Hermes selected.
+4. Repeat with **On this iPhone** selected.
+5. Repeat after backgrounding and returning to the app.
+6. Confirm that both tests record and reach provider transcription instead of showing `-10868`.
+7. Confirm that TTS and response haptics still work after the ASR test.
+
+The available local simulator is iOS 26.5 and cannot prove the reported iOS 27 physical-device case. Local unit tests and any simulator test suite remain useful for compile and policy coverage, but the iPhone acceptance steps are required before treating the device regression as closed.
+
+## Integration boundary
+
+The feature branch is based on current `main`. The PR targets `main`. After the PR is merged, its merge commit will be cherry-picked into `release/0.1.3`; no release build or TestFlight packaging is part of this change.


### PR DESCRIPTION
## Summary
- Bind Core Haptics to the shared AVAudioSession and mark response haptics as haptics-only.
- Use a route-native voice capture policy with Bluetooth HFP and speaker fallback; stop forcing the hardware to 16 kHz and remove A2DP from capture setup.
- Clean up and log capture startup/route-restart failures, and cover the transcription test's capture-start failure path.

## Validation
- Full iOS Simulator suite: 438 tests passed, 0 failures.
- Physical iPhone 16 Pro Max on iOS 27/TestFlight validation remains pending.
- No archive or TestFlight build was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved voice capture across Bluetooth and audio-route changes.
  * Added consistent 16 kHz mono voice recording with configured audio-session handling.
  * Improved coordination between haptics and voice audio for more reliable playback and recording.

* **Bug Fixes**
  * Improved cleanup and diagnostics when microphone startup or route recovery fails.
  * Prevented transcription requests when recording cannot start.

* **Documentation**
  * Added design and implementation guidance for reliable voice-capture recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->