### PR TITLE
docs: correct DashboardTicketBridge.deinit reachability comment

### DIFF
--- a/Conduit/Services/DashboardTicketBridge.swift
+++ b/Conduit/Services/DashboardTicketBridge.swift
@@ -189,14 +189,17 @@ final class DashboardTicketBridge: NSObject {
     }
 
     deinit {
-        // The retain-cycle fix is what makes deallocation reachable at all, so
-        // `deinit` can now run while requests are still pending. Removing the
-        // message handler alone leaves their continuations awaiting a JS reply
-        // that can never arrive: the proxy's weak delegate is already nil and
-        // silently drops the posted message. Resume them now so callers see
-        // `.notReady` instead of hanging for a response that will never come.
-        // (The dictionary is torn down with the bridge, so only the resumptions
-        // matter here — nothing else can resume them once the bridge is gone.)
+        // Defensive teardown. The retain-cycle fix is what makes bridge
+        // deallocation reachable at all. In practice this loop is a no-op
+        // today: a non-empty `pendingRequests` implies a `requestJSON`
+        // coroutine is suspended awaiting its continuation, and that
+        // suspended task retains `self`, so the bridge cannot deallocate
+        // until every request resolves and the dictionary drains. It is kept
+        // as a guard — if a future refactor breaks that invariant (e.g. the
+        // request task is detached, or continuations are stored somewhere
+        // `self` no longer keeps alive), resuming here is what stops callers
+        // from hanging on a reply the now-nil proxy would silently drop.
+        // Nothing else can resume these once the bridge is gone.
         for continuation in pendingRequests.values {
             continuation.resume(throwing: DashboardTicketBridgeError.notReady)
         }


### PR DESCRIPTION
Follow-up to #42 (merged). The `deinit` pending-request loop shipped with a comment claiming deallocation can happen "mid-request" and leave continuations hanging. A re-review correctly noted that premise is wrong: a non-empty `pendingRequests` implies a `requestJSON` coroutine is suspended awaiting its continuation, and that suspended task retains `self` — so the bridge cannot deallocate until all requests resolve and the dictionary drains. The loop is a no-op today.

This PR keeps the loop as a defensive guard (the retain-cycle fix did make deallocation reachable in general, and a hang is the worst-case failure if a future refactor breaks that invariant) but corrects the comment to state the real invariant and why the guard is worth keeping.

**Comment-only — no behavior change.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified teardown behavior for pending requests and defensive request completion.
  * No user-facing behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->