### PR TITLE
Cache markdown parsing, syntax highlighting, and attachment previews

### DIFF
--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -777,9 +777,22 @@ private struct UserImageAttachmentPreview: View {
     @State private var gatewayImage: UIImage?
     @State private var gatewayLoadFailed = false
 
+    /// Body re-evaluates at streaming frame rate, and re-reading the file
+    /// from disk each time hitches scrolling. Decoded previews are shared
+    /// across rows; NSCache evicts them under memory pressure.
+    private static let localImageCache: NSCache<NSString, UIImage> = {
+        let cache = NSCache<NSString, UIImage>()
+        cache.countLimit = 64
+        return cache
+    }()
+
     private var localImage: UIImage? {
         guard let url = localFileURL else { return nil }
-        return UIImage(contentsOfFile: url.path)
+        let key = url.path as NSString
+        if let cached = Self.localImageCache.object(forKey: key) { return cached }
+        guard let image = UIImage(contentsOfFile: url.path) else { return nil }
+        Self.localImageCache.setObject(image, forKey: key)
+        return image
     }
 
     private var localFileURL: URL? {

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import UIKit
+import ImageIO
 
 struct ChatView: View {
     @EnvironmentObject var appState: AppState
@@ -777,12 +778,15 @@ private struct UserImageAttachmentPreview: View {
     @State private var gatewayImage: UIImage?
     @State private var gatewayLoadFailed = false
 
-    /// Body re-evaluates at streaming frame rate, and re-reading the file
-    /// from disk each time hitches scrolling. Decoded previews are shared
-    /// across rows; NSCache evicts them under memory pressure.
+    /// Body re-evaluates at streaming frame rate, and re-reading + fully
+    /// decoding the file each time hitches scrolling. Previews are downsampled
+    /// to the display size and shared across rows; NSCache evicts them under
+    /// memory pressure. Cost-bounded so a handful of large photos can't
+    /// exhaust it before then.
     private static let localImageCache: NSCache<NSString, UIImage> = {
         let cache = NSCache<NSString, UIImage>()
         cache.countLimit = 64
+        cache.totalCostLimit = 64 * 1024 * 1024
         return cache
     }()
 
@@ -790,9 +794,29 @@ private struct UserImageAttachmentPreview: View {
         guard let url = localFileURL else { return nil }
         let key = url.path as NSString
         if let cached = Self.localImageCache.object(forKey: key) { return cached }
-        guard let image = UIImage(contentsOfFile: url.path) else { return nil }
-        Self.localImageCache.setObject(image, forKey: key)
+        // Decode at the preview's retina resolution instead of caching the
+        // full-resolution bitmap — a library photo can decode to tens of MB.
+        guard let image = Self.downsampledPreview(url: url) else { return nil }
+        let pixelWidth = image.cgImage?.width ?? Int(image.size.width * image.scale)
+        let pixelHeight = image.cgImage?.height ?? Int(image.size.height * image.scale)
+        Self.localImageCache.setObject(image, forKey: key, cost: pixelWidth * pixelHeight * 4)
         return image
+    }
+
+    /// Decodes `url` as a thumbnail sized for the 224pt attachment preview
+    /// (~3× retina on the long edge). ImageIO decodes straight to the smaller
+    /// bitmap, so the full-resolution pixels never need to be resident.
+    private static func downsampledPreview(url: URL) -> UIImage? {
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceShouldCache: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: CGFloat(800)
+        ]
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+              let thumbnail = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
+        else { return nil }
+        return UIImage(cgImage: thumbnail)
     }
 
     private var localFileURL: URL? {

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -778,7 +778,8 @@ private struct UserImageAttachmentPreview: View {
     @State private var gatewayImage: UIImage?
     @State private var gatewayLoadFailed = false
     @State private var localPreview: UIImage?
-    @State private var localPreviewFailed = false
+    @State private var localPreviewPath: String?
+    @State private var localPreviewFailedPath: String?
 
     /// Body re-evaluates at streaming frame rate, and re-reading + fully
     /// decoding the file each time hitches scrolling. Previews are downsampled
@@ -799,6 +800,21 @@ private struct UserImageAttachmentPreview: View {
         return Self.localImageCache.object(forKey: url.path as NSString)
     }
 
+    /// The decoded preview, gated on the path it was decoded for so a stale
+    /// value can't leak in if SwiftUI ever reuses this view identity for a
+    /// different `attachment.uri`. Today that can't happen — `Attachment` is
+    /// `Identifiable` so each id gets fresh `@State`, and uris are immutable —
+    /// but this makes the invariant non-load-bearing rather than relying on it.
+    private var currentLocalPreview: UIImage? {
+        guard localPreviewPath == localFileURL?.path else { return nil }
+        return localPreview
+    }
+
+    /// True only for a decode failure of the *current* path.
+    private var localPreviewFailed: Bool {
+        localPreviewFailedPath == localFileURL?.path
+    }
+
     /// Estimated decoded byte cost for NSCache. `bytesPerRow * height` accounts
     /// for the row-alignment padding that a naive `width * height * 4` misses.
     private static func bitmapCost(of image: UIImage) -> Int {
@@ -809,12 +825,16 @@ private struct UserImageAttachmentPreview: View {
     }
 
     /// Decodes `url` as a thumbnail sized for the 224pt attachment preview
-    /// (~3× retina on the long edge). Pure CoreGraphics, so it is safe to call
-    /// off the MainActor — which is how the `.task` below uses it, so a large
-    /// photo can't hitch scrolling on a cache miss. `ShouldCache` is false
-    /// because the resulting `UIImage` is already retained by our cache; the
-    /// default `true` would double-buffer the decoded bitmap inside ImageIO.
-    private static func downsampledPreview(url: URL) -> UIImage? {
+    /// (~3× retina on the long edge). `nonisolated` makes explicit that this is
+    /// pure CoreGraphics and safe to call off the MainActor — which is how the
+    /// `.task` below invokes it, so a large photo can't hitch scrolling on a
+    /// cache miss. `ShouldCache` is false because the resulting `UIImage` is
+    /// already retained by our cache; the default `true` would double-buffer
+    /// the decoded bitmap inside ImageIO. Note: the detached caller returns a
+    /// non-Sendable `UIImage` across the task boundary — fine under the
+    /// project's Swift 5 mode, but it would need a Sendable box if strict
+    /// concurrency is ever enabled.
+    private nonisolated static func downsampledPreview(url: URL) -> UIImage? {
         let options: [CFString: Any] = [
             kCGImageSourceCreateThumbnailFromImageAlways: true,
             kCGImageSourceShouldCache: false,
@@ -835,9 +855,9 @@ private struct UserImageAttachmentPreview: View {
 
     var body: some View {
         Group {
-            if let image = cachedLocalImage ?? localPreview ?? gatewayImage {
+            if let image = cachedLocalImage ?? currentLocalPreview ?? gatewayImage {
                 imagePreview(image)
-            } else if isGatewayImage && !gatewayLoadFailed {
+            } else if isGatewayImage && localFileURL == nil && !gatewayLoadFailed {
                 loadingPlaceholder
             } else if localFileURL != nil && !localPreviewFailed {
                 // Local file decoding off-main on a cache miss.
@@ -859,17 +879,18 @@ private struct UserImageAttachmentPreview: View {
             // frame via `cachedLocalImage`, so only misses reach here. Decode
             // off the MainActor so a large photo can't hitch scrolling.
             if let url = localFileURL {
-                guard localPreview == nil, cachedLocalImage == nil else { return }
+                guard currentLocalPreview == nil, cachedLocalImage == nil else { return }
                 let image = await Task.detached(priority: .userInitiated) { () -> UIImage? in
                     Self.downsampledPreview(url: url)
                 }.value
                 guard !Task.isCancelled else { return }
                 guard let image else {
-                    localPreviewFailed = true
+                    localPreviewFailedPath = url.path
                     return
                 }
                 Self.localImageCache.setObject(image, forKey: url.path as NSString, cost: Self.bitmapCost(of: image))
                 localPreview = image
+                localPreviewPath = url.path
                 // Gateway image, fetched through Hermes. The local-file branch
                 // returns above, so a local URI never reaches here — which also
                 // removes the old `localImage == nil` check that decoded local

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -777,6 +777,8 @@ private struct UserImageAttachmentPreview: View {
     @EnvironmentObject private var appState: AppState
     @State private var gatewayImage: UIImage?
     @State private var gatewayLoadFailed = false
+    @State private var localPreview: UIImage?
+    @State private var localPreviewFailed = false
 
     /// Body re-evaluates at streaming frame rate, and re-reading + fully
     /// decoding the file each time hitches scrolling. Previews are downsampled
@@ -790,26 +792,32 @@ private struct UserImageAttachmentPreview: View {
         return cache
     }()
 
-    private var localImage: UIImage? {
+    /// Cache-only lookup (no decode) so a hit renders on the first frame.
+    /// Misses are filled asynchronously — see the `.task` in `body`.
+    private var cachedLocalImage: UIImage? {
         guard let url = localFileURL else { return nil }
-        let key = url.path as NSString
-        if let cached = Self.localImageCache.object(forKey: key) { return cached }
-        // Decode at the preview's retina resolution instead of caching the
-        // full-resolution bitmap — a library photo can decode to tens of MB.
-        guard let image = Self.downsampledPreview(url: url) else { return nil }
-        let pixelWidth = image.cgImage?.width ?? Int(image.size.width * image.scale)
-        let pixelHeight = image.cgImage?.height ?? Int(image.size.height * image.scale)
-        Self.localImageCache.setObject(image, forKey: key, cost: pixelWidth * pixelHeight * 4)
-        return image
+        return Self.localImageCache.object(forKey: url.path as NSString)
+    }
+
+    /// Estimated decoded byte cost for NSCache. `bytesPerRow * height` accounts
+    /// for the row-alignment padding that a naive `width * height * 4` misses.
+    private static func bitmapCost(of image: UIImage) -> Int {
+        if let cg = image.cgImage {
+            return cg.bytesPerRow * cg.height
+        }
+        return Int(image.size.width * image.scale * image.size.height * image.scale) * 4
     }
 
     /// Decodes `url` as a thumbnail sized for the 224pt attachment preview
-    /// (~3× retina on the long edge). ImageIO decodes straight to the smaller
-    /// bitmap, so the full-resolution pixels never need to be resident.
+    /// (~3× retina on the long edge). Pure CoreGraphics, so it is safe to call
+    /// off the MainActor — which is how the `.task` below uses it, so a large
+    /// photo can't hitch scrolling on a cache miss. `ShouldCache` is false
+    /// because the resulting `UIImage` is already retained by our cache; the
+    /// default `true` would double-buffer the decoded bitmap inside ImageIO.
     private static func downsampledPreview(url: URL) -> UIImage? {
         let options: [CFString: Any] = [
             kCGImageSourceCreateThumbnailFromImageAlways: true,
-            kCGImageSourceShouldCache: true,
+            kCGImageSourceShouldCache: false,
             kCGImageSourceCreateThumbnailWithTransform: true,
             kCGImageSourceThumbnailMaxPixelSize: CGFloat(800)
         ]
@@ -827,23 +835,17 @@ private struct UserImageAttachmentPreview: View {
 
     var body: some View {
         Group {
-            if let image = localImage ?? gatewayImage {
+            if let image = cachedLocalImage ?? localPreview ?? gatewayImage {
                 imagePreview(image)
             } else if isGatewayImage && !gatewayLoadFailed {
-                HStack(spacing: 8) {
-                    ProgressView()
-                        .tint(.white)
-                    Text("Loading image...")
-                }
-                .font(.caption.weight(.medium))
-                .foregroundStyle(.white)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 7)
-                .background(Color.white.opacity(0.13), in: Capsule())
+                loadingPlaceholder
+            } else if localFileURL != nil && !localPreviewFailed {
+                // Local file decoding off-main on a cache miss.
+                loadingPlaceholder
             } else {
                 Label(
-                    gatewayLoadFailed ? "Image unavailable" : "Image attached",
-                    systemImage: gatewayLoadFailed ? "photo.badge.exclamationmark" : "photo"
+                    (gatewayLoadFailed || localPreviewFailed) ? "Image unavailable" : "Image attached",
+                    systemImage: (gatewayLoadFailed || localPreviewFailed) ? "photo.badge.exclamationmark" : "photo"
                 )
                 .font(.caption.weight(.medium))
                 .foregroundStyle(.white)
@@ -853,21 +855,54 @@ private struct UserImageAttachmentPreview: View {
             }
         }
         .task(id: "\(attachment.uri)|\(appState.activeProfile)") {
-            guard localImage == nil, isGatewayImage else { return }
-            gatewayImage = nil
-            gatewayLoadFailed = false
-            guard let dataURL = await appState.gatewayMediaDataURL(
-                for: attachment.uri,
-                profile: appState.activeProfile
-            ),
-            !Task.isCancelled,
-            let image = image(fromDataURL: dataURL) else {
+            // Local file: cache hits are already shown by `body` on the first
+            // frame via `cachedLocalImage`, so only misses reach here. Decode
+            // off the MainActor so a large photo can't hitch scrolling.
+            if let url = localFileURL {
+                guard localPreview == nil, cachedLocalImage == nil else { return }
+                let image = await Task.detached(priority: .userInitiated) { () -> UIImage? in
+                    Self.downsampledPreview(url: url)
+                }.value
                 guard !Task.isCancelled else { return }
-                gatewayLoadFailed = true
-                return
+                guard let image else {
+                    localPreviewFailed = true
+                    return
+                }
+                Self.localImageCache.setObject(image, forKey: url.path as NSString, cost: Self.bitmapCost(of: image))
+                localPreview = image
+                // Gateway image, fetched through Hermes. The local-file branch
+                // returns above, so a local URI never reaches here — which also
+                // removes the old `localImage == nil` check that decoded local
+                // files on the MainActor before short-circuiting.
+            } else if isGatewayImage {
+                gatewayImage = nil
+                gatewayLoadFailed = false
+                guard let dataURL = await appState.gatewayMediaDataURL(
+                    for: attachment.uri,
+                    profile: appState.activeProfile
+                ),
+                !Task.isCancelled,
+                let image = image(fromDataURL: dataURL) else {
+                    guard !Task.isCancelled else { return }
+                    gatewayLoadFailed = true
+                    return
+                }
+                gatewayImage = image
             }
-            gatewayImage = image
         }
+    }
+
+    private var loadingPlaceholder: some View {
+        HStack(spacing: 8) {
+            ProgressView()
+                .tint(.white)
+            Text("Loading image...")
+        }
+        .font(.caption.weight(.medium))
+        .foregroundStyle(.white)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(Color.white.opacity(0.13), in: Capsule())
     }
 
     private var isGatewayImage: Bool {

--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -27,18 +27,21 @@ struct MarkdownText: View {
     var newestCharacterOpacities: [Double] = []
 
     var body: some View {
-        let blocks = MarkdownParser.parse(source, recognizesGatewayMedia: gatewayMediaDataURL != nil)
-        let selectableText = MarkdownSelectionFormatter.attributedText(
-            for: blocks,
+        let rendering = MarkdownRenderCache.rendering(
+            source: source,
+            recognizesGatewayMedia: gatewayMediaDataURL != nil,
             foregroundStyle: foregroundStyle,
-            usesAccentSurface: usesAccentSurface,
-            newestCharacterOpacities: newestCharacterOpacities
+            usesAccentSurface: usesAccentSurface
         )
 
         Group {
-            if let selectableText {
+            if let baseText = rendering.selectableText {
                 SelectableTextView(
-                    attributedText: selectableText,
+                    attributedText: MarkdownSelectionFormatter.applyingTrailingCharacterOpacities(
+                        newestCharacterOpacities,
+                        to: baseText,
+                        baseColor: usesAccentSurface ? .white : UIColor(foregroundStyle)
+                    ),
                     font: .preferredFont(forTextStyle: .body),
                     textColor: usesAccentSurface ? .white : UIColor(foregroundStyle),
                     lineSpacing: 4,
@@ -47,13 +50,13 @@ struct MarkdownText: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             } else {
                 VStack(alignment: .leading, spacing: 10) {
-                    ForEach(Array(blocks.enumerated()), id: \.offset) { index, block in
+                    ForEach(Array(rendering.blocks.enumerated()), id: \.offset) { index, block in
                         MarkdownBlockView(
                             block: block,
                             foregroundStyle: foregroundStyle,
                             usesAccentSurface: usesAccentSurface,
                             gatewayMediaDataURL: gatewayMediaDataURL,
-                            newestCharacterOpacities: index == blocks.count - 1
+                            newestCharacterOpacities: index == rendering.blocks.count - 1
                                 ? newestCharacterOpacities
                                 : []
                         )
@@ -62,6 +65,64 @@ struct MarkdownText: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+/// One render's parsed blocks plus the prebuilt selectable string (nil when
+/// the blocks need the full block-view path). A class so NSCache can hold it.
+private final class MarkdownRendering {
+    let blocks: [MarkdownBlock]
+    let selectableText: NSAttributedString?
+
+    init(blocks: [MarkdownBlock], selectableText: NSAttributedString?) {
+        self.blocks = blocks
+        self.selectableText = selectableText
+    }
+}
+
+/// Every visible MarkdownText body re-evaluates ~30x/s while a reply streams
+/// (each delta publishes an AppState change), and each evaluation used to
+/// re-parse the source and rebuild the attributed string from scratch —
+/// O(visible transcript) main-thread work per frame. Memoize per source and
+/// style so settled messages render from cache and only genuinely new content
+/// pays for parsing. Streaming-tail fades stay per-frame but are applied to a
+/// copy of the cached base rather than triggering a rebuild.
+private enum MarkdownRenderCache {
+    private static let cache: NSCache<NSString, MarkdownRendering> = {
+        let cache = NSCache<NSString, MarkdownRendering>()
+        cache.countLimit = 256
+        return cache
+    }()
+
+    static func rendering(
+        source: String,
+        recognizesGatewayMedia: Bool,
+        foregroundStyle: Color,
+        usesAccentSurface: Bool
+    ) -> MarkdownRendering {
+        // Fonts resolve against the current Dynamic Type size, so a size
+        // change must miss the cache rather than serve stale metrics.
+        let key = [
+            recognizesGatewayMedia ? "1" : "0",
+            usesAccentSurface ? "1" : "0",
+            String(describing: foregroundStyle),
+            UIApplication.shared.preferredContentSizeCategory.rawValue,
+            source
+        ].joined(separator: "|") as NSString
+
+        if let cached = cache.object(forKey: key) { return cached }
+        let blocks = MarkdownParser.parse(source, recognizesGatewayMedia: recognizesGatewayMedia)
+        let rendering = MarkdownRendering(
+            blocks: blocks,
+            selectableText: MarkdownSelectionFormatter.attributedText(
+                for: blocks,
+                foregroundStyle: foregroundStyle,
+                usesAccentSurface: usesAccentSurface,
+                newestCharacterOpacities: []
+            )
+        )
+        cache.setObject(rendering, forKey: key)
+        return rendering
     }
 }
 
@@ -250,6 +311,19 @@ enum MarkdownSelectionFormatter {
 
     private static func headingFont(_ level: Int) -> UIFont {
         MarkdownHeading.font(for: level)
+    }
+
+    /// Applies the streaming-tail fade to a copy, leaving the shared cached
+    /// base untouched for reuse on the next frame.
+    static func applyingTrailingCharacterOpacities(
+        _ opacities: [Double],
+        to base: NSAttributedString,
+        baseColor: UIColor
+    ) -> NSAttributedString {
+        guard !opacities.isEmpty, base.length > 0 else { return base }
+        let copy = NSMutableAttributedString(attributedString: base)
+        applyTrailingCharacterOpacities(opacities, to: copy, baseColor: baseColor)
+        return copy
     }
 
     private static func applyTrailingCharacterOpacities(
@@ -1276,8 +1350,31 @@ private enum MarkdownLanguage {
     }
 }
 
+/// Box for NSCache, which stores class instances only.
+private final class HighlightedCode {
+    let value: AttributedString
+    init(_ value: AttributedString) { self.value = value }
+}
+
 private enum SyntaxHighlighter {
+    /// Settled code blocks across the transcript re-render at streaming frame
+    /// rate; tokenizing is linear but allocation-heavy, so memoize by content.
+    /// Only the still-growing streaming block misses per frame.
+    private static let cache: NSCache<NSString, HighlightedCode> = {
+        let cache = NSCache<NSString, HighlightedCode>()
+        cache.countLimit = 128
+        return cache
+    }()
+
     static func highlight(_ source: String, language: String) -> AttributedString {
+        let key = "\(language)|\(source)" as NSString
+        if let cached = cache.object(forKey: key) { return cached.value }
+        let highlighted = tokenize(source, language: language)
+        cache.setObject(HighlightedCode(highlighted), forKey: key)
+        return highlighted
+    }
+
+    private static func tokenize(_ source: String, language: String) -> AttributedString {
         let keywords: Set<String> = ["as", "async", "await", "break", "case", "catch", "class", "const", "continue", "def", "else", "enum", "false", "final", "for", "func", "guard", "if", "import", "in", "init", "let", "nil", "null", "private", "public", "return", "self", "static", "struct", "switch", "throw", "true", "try", "var", "while"]
         // String-literal alternatives must be disjoint (`\\.` vs `[^"\\]`):
         // if both branches can match a backslash, an unterminated literal with

--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -98,9 +98,11 @@ private enum MarkdownRenderCache {
     private static let cache: NSCache<NSString, MarkdownRendering> = {
         let cache = NSCache<NSString, MarkdownRendering>()
         cache.countLimit = 256
+        cache.totalCostLimit = 32 * 1024 * 1024
         return cache
     }()
 
+    @MainActor
     static func rendering(
         source: String,
         recognizesGatewayMedia: Bool,
@@ -108,16 +110,22 @@ private enum MarkdownRenderCache {
         usesAccentSurface: Bool,
         isStreaming: Bool
     ) -> MarkdownRendering {
-        // Fonts resolve against the current Dynamic Type size, so a size
-        // change must miss the cache rather than serve stale metrics.
-        //
         // `foregroundStyle` is deliberately absent from the key: only two
         // values are ever passed (.primary / .white), each uniquely tied to
         // `usesAccentSurface` (false / true), so keying on that is stable —
         // whereas `String(describing:)` of a SwiftUI Color is not (its
-        // description is undocumented and can drift for adaptive colors).
-        // If a third foreground style is ever introduced, give it an explicit
-        // token here instead of re-adding `String(describing:)`.
+        // description is undocumented and can drift for adaptive colors). The
+        // assert fails loudly in debug if a third style is ever introduced;
+        // promote it to an explicit key token then.
+        assert(
+            usesAccentSurface ? foregroundStyle == .white : foregroundStyle == .primary,
+            "MarkdownRenderCache keys on usesAccentSurface, not foregroundStyle; a new style needs an explicit key token."
+        )
+
+        // Fonts resolve against the current Dynamic Type size, so a size change
+        // must miss the cache rather than serve stale metrics. Reading
+        // preferredContentSizeCategory touches UIApplication.shared, hence the
+        // @MainActor isolation on this function.
         let key = [
             recognizesGatewayMedia ? "1" : "0",
             usesAccentSurface ? "1" : "0",
@@ -142,7 +150,11 @@ private enum MarkdownRenderCache {
         // The message is cached on its first settled render via the
         // non-streaming call sites (isStreaming == false).
         if !isStreaming {
-            cache.setObject(rendering, forKey: key)
+            // Approximate byte cost: source bytes + attributed-string storage
+            // (each char carries attribute runs), so a few large messages can't
+            // crowd out many small ones within totalCostLimit.
+            let cost = source.utf8.count + (rendering.selectableText?.length ?? 0) * 4
+            cache.setObject(rendering, forKey: key, cost: cost)
         }
         return rendering
     }
@@ -1393,6 +1405,7 @@ private enum SyntaxHighlighter {
     private static let cache: NSCache<NSString, HighlightedCode> = {
         let cache = NSCache<NSString, HighlightedCode>()
         cache.countLimit = 128
+        cache.totalCostLimit = 16 * 1024 * 1024
         return cache
     }()
 
@@ -1400,7 +1413,7 @@ private enum SyntaxHighlighter {
         let key = "\(language)|\(source)" as NSString
         if let cached = cache.object(forKey: key) { return cached.value }
         let highlighted = tokenize(source, language: language)
-        cache.setObject(HighlightedCode(highlighted), forKey: key)
+        cache.setObject(HighlightedCode(highlighted), forKey: key, cost: source.utf8.count)
         return highlighted
     }
 

--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -26,12 +26,19 @@ struct MarkdownText: View {
     /// while already-read text remains fully stable.
     var newestCharacterOpacities: [Double] = []
 
+    /// True only for the actively streaming reply, whose `source` changes
+    /// every frame. Settled messages (the default) populate the render cache;
+    /// the streaming instance still parses each frame but skips inserting a
+    /// snapshot that would be dead the moment the next delta arrives.
+    var isStreaming: Bool = false
+
     var body: some View {
         let rendering = MarkdownRenderCache.rendering(
             source: source,
             recognizesGatewayMedia: gatewayMediaDataURL != nil,
             foregroundStyle: foregroundStyle,
-            usesAccentSurface: usesAccentSurface
+            usesAccentSurface: usesAccentSurface,
+            isStreaming: isStreaming
         )
 
         Group {
@@ -98,14 +105,22 @@ private enum MarkdownRenderCache {
         source: String,
         recognizesGatewayMedia: Bool,
         foregroundStyle: Color,
-        usesAccentSurface: Bool
+        usesAccentSurface: Bool,
+        isStreaming: Bool
     ) -> MarkdownRendering {
         // Fonts resolve against the current Dynamic Type size, so a size
         // change must miss the cache rather than serve stale metrics.
+        //
+        // `foregroundStyle` is deliberately absent from the key: only two
+        // values are ever passed (.primary / .white), each uniquely tied to
+        // `usesAccentSurface` (false / true), so keying on that is stable —
+        // whereas `String(describing:)` of a SwiftUI Color is not (its
+        // description is undocumented and can drift for adaptive colors).
+        // If a third foreground style is ever introduced, give it an explicit
+        // token here instead of re-adding `String(describing:)`.
         let key = [
             recognizesGatewayMedia ? "1" : "0",
             usesAccentSurface ? "1" : "0",
-            String(describing: foregroundStyle),
             UIApplication.shared.preferredContentSizeCategory.rawValue,
             source
         ].joined(separator: "|") as NSString
@@ -121,7 +136,14 @@ private enum MarkdownRenderCache {
                 newestCharacterOpacities: []
             )
         )
-        cache.setObject(rendering, forKey: key)
+        // While streaming, `source` changes every frame, so a cached entry is
+        // dead on insertion and would only evict reusable settled entries.
+        // Parse anyway (unavoidable — the content is new), but skip the write.
+        // The message is cached on its first settled render via the
+        // non-streaming call sites (isStreaming == false).
+        if !isStreaming {
+            cache.setObject(rendering, forKey: key)
+        }
         return rendering
     }
 }
@@ -1359,7 +1381,15 @@ private final class HighlightedCode {
 private enum SyntaxHighlighter {
     /// Settled code blocks across the transcript re-render at streaming frame
     /// rate; tokenizing is linear but allocation-heavy, so memoize by content.
-    /// Only the still-growing streaming block misses per frame.
+    ///
+    /// Unlike `MarkdownRenderCache` (keyed on whole-message source, which is
+    /// transient every frame while streaming and therefore skips writes), this
+    /// cache is keyed per code block by (language, source). Only the single
+    /// still-growing block produces a throwaway entry each frame; stable blocks
+    /// — both earlier in the streaming message and across the settled
+    /// transcript — have a constant key and hit on every subsequent frame, so
+    /// writes here are worth keeping. The one transient entry per frame is
+    /// bounded and self-evicting under NSCache's LRU/memory policy.
     private static let cache: NSCache<NSString, HighlightedCode> = {
         let cache = NSCache<NSString, HighlightedCode>()
         cache.countLimit = 128

--- a/Conduit/Views/Components/StreamingText.swift
+++ b/Conduit/Views/Components/StreamingText.swift
@@ -39,7 +39,8 @@ struct StreamingText: View {
             MarkdownText(
                 source: String(visibleCharacters),
                 gatewayMediaDataURL: gatewayMediaDataURL,
-                newestCharacterOpacities: characterOpacities(at: timeline.date)
+                newestCharacterOpacities: characterOpacities(at: timeline.date),
+                isStreaming: true
             )
         }
         .onAppear {


### PR DESCRIPTION
## Origin

Supersedes the net-new portion of #44 by @angel12. #44 bundled three commits that were already merged to `main` (regex backtracking fix, RPC-fail-on-socket-death, WebKit weak-handler proxy) plus one genuinely new caching commit; that duplication left it conflicting and not up to date. This PR cherry-picks **only** the new caching commit (`473eee3a`, attribution preserved — @angel12 + Claude) onto current `main`, then folds in the review findings in a second commit.

## What it does

Eliminates the per-frame O(visible transcript) re-parse/rebuild that pegged the CPU while a reply streamed. Three `NSCache` layers, all evicted under memory pressure:

- **`MarkdownRenderCache`** — parsed blocks + prebuilt selectable `NSAttributedString`, keyed by (source, style, gateway-media flag, Dynamic Type size). Settled messages render from cache; only genuinely new content pays for parsing. Streaming-tail fade opacities are applied to a *copy* of the cached base each frame instead of forcing a rebuild.
- **`SyntaxHighlighter`** — tokenized code memoized by (language, source). Settled code blocks across the transcript stop re-tokenizing at frame rate.
- **`UserImageAttachmentPreview`** — decoded local attachment previews cached by path instead of re-reading the file every render.

## Review fixes applied (second commit)

1. **Unstable cache key.** Dropped `String(describing: foregroundStyle)` from the render-cache key. Only `.primary` / `.white` are ever passed, each uniquely identified by `usesAccentSurface`, so keying on that is stable — whereas a SwiftUI `Color`'s `description` is undocumented and can drift for adaptive colors.
2. **Transient streaming snapshots.** Added `MarkdownText.isStreaming` (set only by `StreamingText`) and skip the render-cache write while streaming: a streaming message's whole-message `source` changes every frame, so a cached entry is dead on insertion and only evicts reusable settled entries. The message is cached on its first settled render instead.
   - **Deliberate non-change:** the per-block `SyntaxHighlighter` cache still writes while streaming. Only its *single growing block* is transient; stable blocks (earlier in the message and across the transcript) have a constant key and hit every frame, so skipping writes there would discard that benefit. The distinction (whole-message key = transient; per-block key = mostly stable) is documented in a comment.
3. **Unbounded decoded-image memory.** `localImageCache` is now cost-bounded (`totalCostLimit = 64 MB`) and attachments are decoded to the preview's retina size via an ImageIO thumbnail (`CGImageSourceCreateThumbnailAtIndex`) instead of caching full-resolution bitmaps; pixel cost is passed to `setObject(_:forKey:cost:)`.

## Note on the HermesClient socket finding

Both bot reviews on #44 flagged a stale-receive-loop / dead-socket issue in `HermesClient.swift` as blocking. That code is **already on `main`** (from an earlier PR) and is not touched here. It's a real but **latent** defect — `AppState` creates a new `HermesClient` per reconnect and calls `previousClient.disconnect()` first, so the cross-instance clobber can't occur in production today; it only bites on intra-instance double-`connect()`. It will be addressed in a separate PR.

## Testing

Existing `ChatTextSelectionTests` (parser/formatter) are unaffected — caching wraps the same pure functions with identical outputs. Parser/formatter/highlighter behavior is unchanged; only caching, the streaming skip-write, and image downsampling are new. Verifying via CI (macos-26).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved image attachment loading with faster, appropriately sized previews and smoother loading states.
  * Added caching for image previews, Markdown rendering, and syntax highlighting to improve display speed.
  * Improved streaming text updates while preserving visual effects during generation.
  * Reduced unnecessary rendering during streamed content updates.

* **Bug Fixes**
  * Improved error reporting by distinguishing local image preview failures from gateway loading failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->