### PR TITLE
Guard WebSocket receive failure by socket identity

### DIFF
--- a/Conduit/Services/HermesClient.swift
+++ b/Conduit/Services/HermesClient.swift
@@ -358,6 +358,14 @@ final class HermesClient: ObservableObject {
     // MARK: - Connection
 
     func connect() async throws {
+        // If a previous receive loop is still alive, cancel it now so it can't
+        // outlive the socket it was reading from and later mutate this client's
+        // state. (AppState makes a fresh HermesClient per reconnect and
+        // disconnects the old one first, so this is defense-in-depth against
+        // an intra-instance reconnect — which no caller does today.)
+        receiveTask?.cancel()
+        receiveTask = nil
+
         closedIntentionally = false
         socketHasOpened = false
         let url: URL
@@ -452,11 +460,21 @@ final class HermesClient: ObservableObject {
             } catch {
                 // Socket closed or errored
                 logger.error("WebSocket receive failed: \(error.localizedDescription, privacy: .public)")
+                // Only tear down if this loop still owns the current socket.
+                // A reconnect replaces `self.socket` and spawns a new loop; an
+                // unguarded late catch from the superseded loop would mark the
+                // healthy new connection disconnected and fail its in-flight
+                // RPCs. didOpen/didClose/failSocketOpen guard the same way.
+                guard self.socket === socket else { break }
                 isConnected = false
                 // No response can ever arrive on a dead socket; failing the
                 // in-flight requests here keeps awaiting UI from hanging for
                 // the remainder of each request's timeout.
                 failAllPendingRequests(with: HermesError.connectionClosed)
+                // Drop the dead socket: its `closeCode` stays `.invalid` after
+                // a receive error, so leaving it installed would let `rpc`
+                // re-issue against it and hang until its own timeout.
+                self.socket = nil
                 if !closedIntentionally {
                     onDisconnected?()
                 }
@@ -527,7 +545,10 @@ final class HermesClient: ObservableObject {
     // MARK: - RPC
 
     private func rpc(_ method: String, params: [String: Any]? = nil, timeout: TimeInterval = requestTimeout) async throws -> AnyCodable {
-        guard let socket, socket.closeCode == .invalid else {
+        // Require both a live socket and a completed handshake. A receive
+        // error leaves the socket installed with `closeCode == .invalid`, so
+        // closeCode alone would let an RPC ride a dead socket to its timeout.
+        guard let socket, socket.closeCode == .invalid, isConnected else {
             throw HermesError.notConnected
         }
 

--- a/Conduit/Services/HermesClient.swift
+++ b/Conduit/Services/HermesClient.swift
@@ -299,12 +299,75 @@ private struct PendingRequest {
     let timer: Timer?
 }
 
+// MARK: - WebSocket seam
+
+/// The slice of `URLSessionWebSocketTask` that `HermesClient` depends on, so
+/// the client can be driven against a fake transport in tests without a real
+/// network. `AnyObject`-bound so the `===` identity checks (which tell a
+/// superseded receive loop apart from the current socket) keep working on the
+/// existential type.
+protocol HermesWebSocket: AnyObject {
+    var closeCode: URLSessionWebSocketTask.CloseCode { get }
+    func resume()
+    func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?)
+    func receive() async throws -> URLSessionWebSocketTask.Message
+    func send(_ message: URLSessionWebSocketTask.Message, completionHandler: @escaping (Error?) -> Void)
+}
+
+extension URLSessionWebSocketTask: HermesWebSocket {}
+
+/// Produces sockets for a `HermesClient` and owns the underlying session.
+/// `makeSocket` wires the handshake callbacks (`onOpen` / `onCloseBeforeOpen`,
+/// mirroring `URLSessionWebSocketDelegate`); `invalidate` tears the session
+/// down. The production impl is a faithful extraction of the client's former
+/// inline `URLSession` logic; tests supply a fake. All methods are invoked from
+/// `HermesClient` on the MainActor; the protocol is left nonisolated so the
+/// `URLSessionWebSocketTransport` default doesn't force closure-isolation hoops.
+protocol HermesWebSocketTransport: AnyObject {
+    func makeSocket(
+        request: URLRequest,
+        onOpen: @escaping (any HermesWebSocket) -> Void,
+        onCloseBeforeOpen: @escaping (any HermesWebSocket) -> Void
+    ) -> any HermesWebSocket
+
+    func invalidate()
+}
+
+/// Production transport: one `URLSession` per socket, delegate-driven
+/// handshake. Behaviour is identical to the client's pre-seam connect().
+final class URLSessionWebSocketTransport: HermesWebSocketTransport {
+    private var session: URLSession?
+    private var delegate: WebSocketOpenDelegate?
+
+    func makeSocket(
+        request: URLRequest,
+        onOpen: @escaping (any HermesWebSocket) -> Void,
+        onCloseBeforeOpen: @escaping (any HermesWebSocket) -> Void
+    ) -> any HermesWebSocket {
+        let delegate = WebSocketOpenDelegate()
+        delegate.onOpen = onOpen
+        delegate.onCloseBeforeOpen = onCloseBeforeOpen
+        let config = URLSessionConfiguration.default
+        config.waitsForConnectivity = true
+        let session = URLSession(configuration: config, delegate: delegate, delegateQueue: nil)
+        self.session = session
+        self.delegate = delegate
+        return session.webSocketTask(with: request)
+    }
+
+    func invalidate() {
+        session?.invalidateAndCancel()
+        session = nil
+        delegate = nil
+    }
+}
+
 /// URLSession only confirms the WebSocket handshake through its delegate. The
 /// client must not issue session RPCs or paint a green indicator before this
 /// callback, otherwise a just-opened socket can race its first `session.resume`.
 private final class WebSocketOpenDelegate: NSObject, URLSessionWebSocketDelegate {
-    var onOpen: ((URLSessionWebSocketTask) -> Void)?
-    var onCloseBeforeOpen: ((URLSessionWebSocketTask) -> Void)?
+    var onOpen: ((any HermesWebSocket) -> Void)?
+    var onCloseBeforeOpen: ((any HermesWebSocket) -> Void)?
 
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
         onOpen?(webSocketTask)
@@ -326,9 +389,9 @@ final class HermesClient: ObservableObject {
     @Published private(set) var isConnected = false
 
     // Non-published internal state
-    private var socket: URLSessionWebSocketTask?
-    private var session: URLSession?
-    private var socketDelegate: WebSocketOpenDelegate?
+    private var socket: (any HermesWebSocket)?
+    private var transport: (any HermesWebSocketTransport)?
+    private let transportFactory: () -> any HermesWebSocketTransport
     private var requestId = 0
     private var pending = [Int: PendingRequest]()
     private var closedIntentionally = false
@@ -349,22 +412,36 @@ final class HermesClient: ObservableObject {
     static let promptSubmitTimeout: TimeInterval = 180 // 3 minutes
     static let titleGenerationTimeout: TimeInterval = 90
 
-    init(connection: HermesConnection, profile: String? = nil, cloudflareAccess: CloudflareAccessCredentials? = nil) {
+    init(
+        connection: HermesConnection,
+        profile: String? = nil,
+        cloudflareAccess: CloudflareAccessCredentials? = nil,
+        transportFactory: @escaping () -> any HermesWebSocketTransport = { URLSessionWebSocketTransport() }
+    ) {
         self.connection = connection
         self.profile = profile
         self.cloudflareAccess = cloudflareAccess
+        self.transportFactory = transportFactory
     }
 
     // MARK: - Connection
 
     func connect() async throws {
-        // If a previous receive loop is still alive, cancel it now so it can't
-        // outlive the socket it was reading from and later mutate this client's
-        // state. (AppState makes a fresh HermesClient per reconnect and
-        // disconnects the old one first, so this is defense-in-depth against
-        // an intra-instance reconnect — which no caller does today.)
+        // Tear down any prior connection in full before installing a new one.
+        // Cancelling the receive task alone is not enough: URLSessionWebSocketTask
+        // .receive() does not honor cooperative cancellation, so a superseded
+        // loop stays alive until its socket actually errors. Cancelling the
+        // socket and invalidating the prior session forces that error, after
+        // which the loop's identity guard turns its late catch into a no-op.
+        // (AppState makes a fresh HermesClient per reconnect and disconnects the
+        // old one first, so this is defense-in-depth against an intra-instance
+        // reconnect — which no caller does today.)
         receiveTask?.cancel()
         receiveTask = nil
+        socket?.cancel(with: .goingAway, reason: nil)
+        socket = nil
+        transport?.invalidate()
+        transport = nil
 
         closedIntentionally = false
         socketHasOpened = false
@@ -379,22 +456,16 @@ final class HermesClient: ObservableObject {
             throw HermesError.invalidUrl
         }
 
-        let config = URLSessionConfiguration.default
-        config.waitsForConnectivity = true
-        let socketDelegate = WebSocketOpenDelegate()
-        socketDelegate.onOpen = { [weak self] task in
-            Task { @MainActor in self?.didOpen(task) }
-        }
-        socketDelegate.onCloseBeforeOpen = { [weak self] task in
-            Task { @MainActor in self?.didClose(task) }
-        }
-        let session = URLSession(configuration: config, delegate: socketDelegate, delegateQueue: nil)
-        self.session = session
-        self.socketDelegate = socketDelegate
+        let transport = transportFactory()
+        self.transport = transport
 
         var request = URLRequest(url: url)
         request = cloudflareAccess?.applying(to: request) ?? request
-        let socket = session.webSocketTask(with: request)
+        let socket = transport.makeSocket(
+            request: request,
+            onOpen: { [weak self] socket in Task { @MainActor in self?.didOpen(socket) } },
+            onCloseBeforeOpen: { [weak self] socket in Task { @MainActor in self?.didClose(socket) } }
+        )
         self.socket = socket
         socket.resume()
         try await waitForSocketOpen(socket)
@@ -407,8 +478,12 @@ final class HermesClient: ObservableObject {
         }
     }
 
-    private func waitForSocketOpen(_ socket: URLSessionWebSocketTask) async throws {
+    private func waitForSocketOpen(_ socket: any HermesWebSocket) async throws {
         try await withCheckedThrowingContinuation { continuation in
+            // A second connect() superseding an in-flight one would otherwise
+            // overwrite and leak the prior continuation (its connect() call would
+            // hang forever). Resume it first so the superseded connect() throws.
+            openContinuation?.resume(throwing: HermesError.connectionClosed)
             openContinuation = continuation
             openTimeoutTask?.cancel()
             openTimeoutTask = Task { [weak self] in
@@ -419,7 +494,7 @@ final class HermesClient: ObservableObject {
         }
     }
 
-    private func didOpen(_ socket: URLSessionWebSocketTask) {
+    private func didOpen(_ socket: any HermesWebSocket) {
         guard self.socket === socket, !socketHasOpened else { return }
         socketHasOpened = true
         openTimeoutTask?.cancel()
@@ -428,12 +503,12 @@ final class HermesClient: ObservableObject {
         openContinuation = nil
     }
 
-    private func didClose(_ socket: URLSessionWebSocketTask) {
+    private func didClose(_ socket: any HermesWebSocket) {
         guard self.socket === socket, !socketHasOpened else { return }
         failSocketOpen(socket, error: HermesError.connectionClosed)
     }
 
-    private func failSocketOpen(_ socket: URLSessionWebSocketTask, error: Error) {
+    private func failSocketOpen(_ socket: any HermesWebSocket, error: Error) {
         guard self.socket === socket else { return }
         openTimeoutTask?.cancel()
         openTimeoutTask = nil
@@ -522,14 +597,15 @@ final class HermesClient: ObservableObject {
     func disconnect() {
         closedIntentionally = true
         receiveTask?.cancel()
+        receiveTask = nil
         openTimeoutTask?.cancel()
         openTimeoutTask = nil
         openContinuation?.resume(throwing: HermesError.connectionClosed)
         openContinuation = nil
         socket?.cancel(with: .goingAway, reason: nil)
         socket = nil
-        session?.invalidateAndCancel()
-        socketDelegate = nil
+        transport?.invalidate()
+        transport = nil
         isConnected = false
         failAllPendingRequests(with: HermesError.connectionClosed)
     }

--- a/Conduit/Services/HermesClient.swift
+++ b/Conduit/Services/HermesClient.swift
@@ -427,21 +427,31 @@ final class HermesClient: ObservableObject {
     // MARK: - Connection
 
     func connect() async throws {
-        // Tear down any prior connection in full before installing a new one.
-        // Cancelling the receive task alone is not enough: URLSessionWebSocketTask
-        // .receive() does not honor cooperative cancellation, so a superseded
-        // loop stays alive until its socket actually errors. Cancelling the
-        // socket and invalidating the prior session forces that error, after
-        // which the loop's identity guard turns its late catch into a no-op.
-        // (AppState makes a fresh HermesClient per reconnect and disconnects the
-        // old one first, so this is defense-in-depth against an intra-instance
-        // reconnect — which no caller does today.)
+        // Tear down any prior connection in full before installing a new one —
+        // this mirrors disconnect()'s cleanup. Cancelling the receive task alone
+        // is not enough: URLSessionWebSocketTask.receive() does not honor
+        // cooperative cancellation, so a superseded loop stays alive until its
+        // socket actually errors; cancelling the socket + invalidating the
+        // session forces that error, after which the loop's identity guard
+        // no-ops its late catch. Resuming the open continuation and failing
+        // pending RPCs here also covers the case where the new connect() throws
+        // before its own waitForSocketOpen (e.g. invalid URL) — without it the
+        // prior connect() would hang forever and its RPCs would wait out their
+        // own timers. (AppState makes a fresh HermesClient per reconnect and
+        // disconnects the old one first, so this is defense-in-depth against an
+        // intra-instance reconnect — which no caller does today.)
         receiveTask?.cancel()
         receiveTask = nil
         socket?.cancel(with: .goingAway, reason: nil)
         socket = nil
         transport?.invalidate()
         transport = nil
+        openTimeoutTask?.cancel()
+        openTimeoutTask = nil
+        openContinuation?.resume(throwing: HermesError.connectionClosed)
+        openContinuation = nil
+        isConnected = false
+        failAllPendingRequests(with: HermesError.connectionClosed)
 
         closedIntentionally = false
         socketHasOpened = false
@@ -479,11 +489,9 @@ final class HermesClient: ObservableObject {
     }
 
     private func waitForSocketOpen(_ socket: any HermesWebSocket) async throws {
+        // The prior continuation (if any) is already resumed by connect()'s
+        // teardown before we reach here, so just install this one.
         try await withCheckedThrowingContinuation { continuation in
-            // A second connect() superseding an in-flight one would otherwise
-            // overwrite and leak the prior continuation (its connect() call would
-            // hang forever). Resume it first so the superseded connect() throws.
-            openContinuation?.resume(throwing: HermesError.connectionClosed)
             openContinuation = continuation
             openTimeoutTask?.cancel()
             openTimeoutTask = Task { [weak self] in
@@ -514,6 +522,9 @@ final class HermesClient: ObservableObject {
         openTimeoutTask = nil
         socket.cancel(with: .goingAway, reason: nil)
         self.socket = nil
+        transport?.invalidate()
+        transport = nil
+        isConnected = false
         openContinuation?.resume(throwing: error)
         openContinuation = nil
     }
@@ -524,6 +535,12 @@ final class HermesClient: ObservableObject {
         while !Task.isCancelled {
             do {
                 let message = try await socket.receive()
+                // A reconnect replaces `self.socket`; if this loop has been
+                // superseded, drop the frame rather than dispatch it —
+                // `handleMessage` has no identity check of its own and could
+                // otherwise fire `onEvent`/resolve pending RPCs for the new
+                // connection. Same guard the catch uses below.
+                guard self.socket === socket else { break }
                 switch message {
                 case .data(let data):
                     handleMessage(data: data)

--- a/Conduit/Services/HermesClient.swift
+++ b/Conduit/Services/HermesClient.swift
@@ -311,7 +311,7 @@ protocol HermesWebSocket: AnyObject {
     func resume()
     func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?)
     func receive() async throws -> URLSessionWebSocketTask.Message
-    func send(_ message: URLSessionWebSocketTask.Message, completionHandler: @escaping (Error?) -> Void)
+    func send(_ message: URLSessionWebSocketTask.Message, completionHandler: @escaping @Sendable (Error?) -> Void)
 }
 
 extension URLSessionWebSocketTask: HermesWebSocket {}

--- a/ConduitTests/HermesClientTests.swift
+++ b/ConduitTests/HermesClientTests.swift
@@ -1,0 +1,235 @@
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class HermesClientTests: XCTestCase {
+
+    // MARK: - rpc() guard
+
+    func testRPCGuardRejectsBeforeHandshake() async {
+        // The handshake is held open, so the socket is installed but
+        // `isConnected` is still false. `rpc()`'s `isConnected` requirement
+        // must reject the call — the pre-fix `closeCode == .invalid` check alone
+        // would have passed (the fake socket reports `.invalid`).
+        let transport = FakeTransport()
+        let handshakeGate = Gate()
+        let socket = FakeSocket()
+        socket.onResume = { handshakeGate.signal() }
+        transport.nextSocket = { socket }
+        let client = makeClient(transport: transport)
+
+        let connectTask = Task { try? await client.connect() }
+        await handshakeGate.wait()  // connect() has reached socket.resume() and is now suspended in the handshake
+
+        do {
+            try await client.healthCheck()
+            XCTFail("Expected healthCheck to throw before the handshake completes")
+        } catch HermesError.notConnected {
+            // expected
+        } catch {
+            XCTFail("Expected .notConnected, got \(error)")
+        }
+
+        client.disconnect()  // resumes the suspended handshake so connect() unwinds
+        _ = await connectTask.value
+    }
+
+    // MARK: - receive-failure teardown
+
+    func testReceiveFailureOnOwningSocketTearsDown() async {
+        let transport = FakeTransport()
+        let socket = FakeSocket()
+        transport.nextSocket = { socket }
+        let client = makeClient(transport: transport)
+        var didDisconnect = false
+        client.onDisconnected = { didDisconnect = true }
+
+        let connectTask = Task { try? await client.connect() }
+        transport.open(socket)
+        _ = await connectTask.value
+        XCTAssertTrue(client.isConnected)
+
+        // The receive loop is suspended in socket.receive(); fail it on the
+        // socket this loop still owns. The catch must tear down.
+        socket.failReceive(URLError(.networkConnectionLost))
+        await flushMainActor()
+
+        XCTAssertFalse(client.isConnected)
+        XCTAssertTrue(didDisconnect)
+    }
+
+    func testSupersededReceiveLoopDoesNotClobberNewConnection() async {
+        let transport = FakeTransport()
+        let socketA = FakeSocket()
+        transport.nextSocket = { socketA }
+        let client = makeClient(transport: transport)
+        var disconnectCount = 0
+        client.onDisconnected = { disconnectCount += 1 }
+
+        let connectA = Task { try? await client.connect() }
+        transport.open(socketA)
+        _ = await connectA.value
+        XCTAssertTrue(client.isConnected)
+
+        // Same-instance reconnect (the latent scenario this PR hardens):
+        // connect() tears down socketA → A's receive() errors → A's late catch
+        // must be a no-op, not clobber the new connection.
+        let socketB = FakeSocket()
+        transport.nextSocket = { socketB }
+        let connectB = Task { try? await client.connect() }
+        transport.open(socketB)
+        _ = await connectB.value
+        await flushMainActor()  // let A's superseded catch run
+
+        XCTAssertTrue(socketA.cancelled, "Reconnect should cancel the superseded socket")
+        XCTAssertTrue(client.isConnected, "A superseded loop must not mark the new connection disconnected")
+        XCTAssertEqual(disconnectCount, 0, "A superseded loop must not fire onDisconnected")
+    }
+
+    // MARK: - connect() teardown of the prior connection
+
+    func testConnectInvalidatesPriorTransport() async {
+        let transport = FakeTransport()
+        let socketA = FakeSocket()
+        transport.nextSocket = { socketA }
+        let client = makeClient(transport: transport)
+
+        let connectA = Task { try? await client.connect() }
+        transport.open(socketA)
+        _ = await connectA.value
+        XCTAssertFalse(transport.invalidated)
+
+        let socketB = FakeSocket()
+        transport.nextSocket = { socketB }
+        let connectB = Task { try? await client.connect() }
+        transport.open(socketB)
+        _ = await connectB.value
+
+        XCTAssertTrue(transport.invalidated, "Reconnect must invalidate the prior transport/session")
+        XCTAssertEqual(transport.socketsMade.count, 2)
+    }
+
+    func testConcurrentConnectSupersedesPriorWithoutHanging() async {
+        // A second connect() while the first is still mid-handshake must resume
+        // the first's open continuation (so the first connect() throws instead
+        // of hanging forever), rather than overwriting and leaking it.
+        let transport = FakeTransport()
+        let socketA = FakeSocket()
+        transport.nextSocket = { socketA }
+        let client = makeClient(transport: transport)
+
+        let connectA = Task { try? await client.connect() }
+        await flushMainActor()  // let connectA reach and suspend in the handshake (A is never opened)
+
+        let socketB = FakeSocket()
+        transport.nextSocket = { socketB }
+        let connectB = Task { try? await client.connect() }
+        transport.open(socketB)
+        _ = await connectB.value
+
+        // If the continuation were leaked this await would hang and the test would time out.
+        _ = await connectA.value
+        XCTAssertTrue(client.isConnected)
+    }
+
+    // MARK: - Helpers
+
+    private func makeClient(transport: FakeTransport) -> HermesClient {
+        HermesClient(
+            connection: HermesConnection(baseUrl: "https://test.example", ticket: "ticket"),
+            transportFactory: { transport }
+        )
+    }
+
+    private func flushMainActor() async {
+        for _ in 0..<8 { await Task.yield() }
+    }
+}
+
+// MARK: - Test doubles
+
+/// Single-use continuation gate: `wait()` suspends until `signal()` fires.
+/// All access happens on the MainActor (tests + the connect path), so no locking.
+private final class Gate {
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func signal() {
+        continuation?.resume()
+        continuation = nil
+    }
+
+    func wait() async {
+        await withCheckedContinuation { continuation = $0 }
+    }
+}
+
+/// Controllable HermesWebSocket. receive() suspends until the test delivers a
+/// message or fails it; cancel() mimics URLSession by erroring the in-flight
+/// receive (real cancellation surfaces as a receive error).
+private final class FakeSocket: HermesWebSocket {
+    var closeCode: URLSessionWebSocketTask.CloseCode = .invalid
+    private(set) var cancelled = false
+    private(set) var resumed = false
+    var onResume: (() -> Void)?
+
+    private var receiveContinuation: CheckedContinuation<URLSessionWebSocketTask.Message, Error>?
+
+    func resume() {
+        resumed = true
+        onResume?()
+    }
+
+    func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        cancelled = true
+        failReceive(URLError(.networkConnectionLost))
+    }
+
+    func send(_ message: URLSessionWebSocketTask.Message, completionHandler: @escaping (Error?) -> Void) {
+        completionHandler(nil)
+    }
+
+    func receive() async throws -> URLSessionWebSocketTask.Message {
+        try await withCheckedThrowingContinuation { receiveContinuation = $0 }
+    }
+
+    // Test hooks
+    func deliver(_ text: String) {
+        receiveContinuation?.resume(returning: .string(text))
+        receiveContinuation = nil
+    }
+
+    func failReceive(_ error: Error) {
+        receiveContinuation?.resume(throwing: error)
+        receiveContinuation = nil
+    }
+}
+
+/// Records invalidate() and lets the test drive the handshake per socket.
+/// Accessed only from the MainActor (the test + the connect path).
+private final class FakeTransport: HermesWebSocketTransport {
+    private(set) var invalidated = false
+    private(set) var socketsMade: [FakeSocket] = []
+    var nextSocket: (() -> FakeSocket)?
+    private var openCallbacks: [(FakeSocket) -> Void] = []
+
+    func makeSocket(
+        request: URLRequest,
+        onOpen: @escaping (any HermesWebSocket) -> Void,
+        onCloseBeforeOpen: @escaping (any HermesWebSocket) -> Void
+    ) -> any HermesWebSocket {
+        let socket = nextSocket?() ?? FakeSocket()
+        socketsMade.append(socket)
+        openCallbacks.append { onOpen(socket) }
+        return socket
+    }
+
+    func invalidate() {
+        invalidated = true
+    }
+
+    /// Fire the handshake-open callback for a socket this transport produced.
+    func open(_ socket: FakeSocket) {
+        guard let index = socketsMade.firstIndex(where: { $0 === socket }) else { return }
+        openCallbacks[index](socket)
+    }
+}

--- a/ConduitTests/HermesClientTests.swift
+++ b/ConduitTests/HermesClientTests.swift
@@ -184,7 +184,7 @@ private final class FakeSocket: HermesWebSocket {
         failReceive(URLError(.networkConnectionLost))
     }
 
-    func send(_ message: URLSessionWebSocketTask.Message, completionHandler: @escaping (Error?) -> Void) {
+    func send(_ message: URLSessionWebSocketTask.Message, completionHandler: @escaping @Sendable (Error?) -> Void) {
         completionHandler(nil)
     }
 
@@ -219,7 +219,7 @@ private final class FakeTransport: HermesWebSocketTransport {
     ) -> any HermesWebSocket {
         let socket = nextSocket?() ?? FakeSocket()
         socketsMade.append(socket)
-        openCallbacks.append { onOpen(socket) }
+        openCallbacks.append { _ in onOpen(socket) }
         return socket
     }
 

--- a/ConduitTests/HermesClientTests.swift
+++ b/ConduitTests/HermesClientTests.swift
@@ -7,19 +7,19 @@ final class HermesClientTests: XCTestCase {
     // MARK: - rpc() guard
 
     func testRPCGuardRejectsBeforeHandshake() async {
-        // The handshake is held open, so the socket is installed but
-        // `isConnected` is still false. `rpc()`'s `isConnected` requirement
-        // must reject the call — the pre-fix `closeCode == .invalid` check alone
-        // would have passed (the fake socket reports `.invalid`).
+        // The handshake is held open (we never call transport.open), so the
+        // socket is installed but `isConnected` is still false. `rpc()`'s
+        // `isConnected` requirement must reject the call — the pre-fix
+        // `closeCode == .invalid` check alone would have passed.
         let transport = FakeTransport()
-        let handshakeGate = Gate()
         let socket = FakeSocket()
-        socket.onResume = { handshakeGate.signal() }
+        let reachedResume = Gate()
+        socket.onResume = { reachedResume.signal() }
         transport.nextSocket = { socket }
         let client = makeClient(transport: transport)
 
         let connectTask = Task { try? await client.connect() }
-        await handshakeGate.wait()  // connect() has reached socket.resume() and is now suspended in the handshake
+        await reachedResume.wait()  // connect() has installed + resumed the socket and is now suspended in the handshake
 
         do {
             try await client.healthCheck()
@@ -39,6 +39,8 @@ final class HermesClientTests: XCTestCase {
     func testReceiveFailureOnOwningSocketTearsDown() async {
         let transport = FakeTransport()
         let socket = FakeSocket()
+        let receivePending = Gate()
+        socket.onReceivePending = { receivePending.signal() }
         transport.nextSocket = { socket }
         let client = makeClient(transport: transport)
         var didDisconnect = false
@@ -48,19 +50,21 @@ final class HermesClientTests: XCTestCase {
         transport.open(socket)
         _ = await connectTask.value
         XCTAssertTrue(client.isConnected)
+        await receivePending.wait()  // the receive loop is now suspended in socket.receive()
 
-        // The receive loop is suspended in socket.receive(); fail it on the
-        // socket this loop still owns. The catch must tear down.
         socket.failReceive(URLError(.networkConnectionLost))
-        await flushMainActor()
+        await flushMainActor()       // let the catch run
 
         XCTAssertFalse(client.isConnected)
         XCTAssertTrue(didDisconnect)
+        client.disconnect()
     }
 
     func testSupersededReceiveLoopDoesNotClobberNewConnection() async {
         let transport = FakeTransport()
         let socketA = FakeSocket()
+        let aReceivePending = Gate()
+        socketA.onReceivePending = { aReceivePending.signal() }
         transport.nextSocket = { socketA }
         let client = makeClient(transport: transport)
         var disconnectCount = 0
@@ -70,6 +74,7 @@ final class HermesClientTests: XCTestCase {
         transport.open(socketA)
         _ = await connectA.value
         XCTAssertTrue(client.isConnected)
+        await aReceivePending.wait()  // A's receive loop is suspended in socket.receive()
 
         // Same-instance reconnect (the latent scenario this PR hardens):
         // connect() tears down socketA → A's receive() errors → A's late catch
@@ -84,6 +89,40 @@ final class HermesClientTests: XCTestCase {
         XCTAssertTrue(socketA.cancelled, "Reconnect should cancel the superseded socket")
         XCTAssertTrue(client.isConnected, "A superseded loop must not mark the new connection disconnected")
         XCTAssertEqual(disconnectCount, 0, "A superseded loop must not fire onDisconnected")
+        client.disconnect()
+    }
+
+    func testSupersededLoopDropsStaleFrame() async {
+        // The success path of receiveLoop is identity-guarded too: a frame
+        // delivered to a superseded socket must not reach handleMessage.
+        let transport = FakeTransport()
+        let socketA = FakeSocket()
+        socketA.cancelErrorsReceive = false  // keep A's receive suspended so a stale frame can arrive after supersession
+        let aReceivePending = Gate()
+        socketA.onReceivePending = { aReceivePending.signal() }
+        transport.nextSocket = { socketA }
+        let client = makeClient(transport: transport)
+        var eventCount = 0
+        client.onEvent = { _ in eventCount += 1 }
+
+        let connectA = Task { try? await client.connect() }
+        transport.open(socketA)
+        _ = await connectA.value
+        await aReceivePending.wait()
+
+        // Reconnect to B, then deliver a frame to the old socket A. The guard
+        // must drop it (onEvent not fired for A's stale frame).
+        let socketB = FakeSocket()
+        transport.nextSocket = { socketB }
+        let connectB = Task { try? await client.connect() }
+        transport.open(socketB)
+        _ = await connectB.value
+
+        socketA.deliver(someEventJSON())
+        await flushMainActor()
+
+        XCTAssertEqual(eventCount, 0, "A stale frame on a superseded socket must be dropped")
+        client.disconnect()
     }
 
     // MARK: - connect() teardown of the prior connection
@@ -107,19 +146,22 @@ final class HermesClientTests: XCTestCase {
 
         XCTAssertTrue(transport.invalidated, "Reconnect must invalidate the prior transport/session")
         XCTAssertEqual(transport.socketsMade.count, 2)
+        client.disconnect()
     }
 
     func testConcurrentConnectSupersedesPriorWithoutHanging() async {
         // A second connect() while the first is still mid-handshake must resume
-        // the first's open continuation (so the first connect() throws instead
-        // of hanging forever), rather than overwriting and leaking it.
+        // the first's open continuation (via the teardown, mirroring disconnect),
+        // so the first connect() throws instead of hanging forever.
         let transport = FakeTransport()
         let socketA = FakeSocket()
+        let aResumed = Gate()
+        socketA.onResume = { aResumed.signal() }
         transport.nextSocket = { socketA }
         let client = makeClient(transport: transport)
 
         let connectA = Task { try? await client.connect() }
-        await flushMainActor()  // let connectA reach and suspend in the handshake (A is never opened)
+        await aResumed.wait()  // connectA has installed A and is suspended in the handshake (A is never opened)
 
         let socketB = FakeSocket()
         transport.nextSocket = { socketB }
@@ -127,9 +169,10 @@ final class HermesClientTests: XCTestCase {
         transport.open(socketB)
         _ = await connectB.value
 
-        // If the continuation were leaked this await would hang and the test would time out.
+        // If the continuation were leaked this await would hang and time out.
         _ = await connectA.value
         XCTAssertTrue(client.isConnected)
+        client.disconnect()
     }
 
     // MARK: - Helpers
@@ -142,35 +185,50 @@ final class HermesClientTests: XCTestCase {
     }
 
     private func flushMainActor() async {
-        for _ in 0..<8 { await Task.yield() }
+        for _ in 0..<10 { await Task.yield() }
+    }
+
+    /// A gateway stream-event frame (`message.start`) that StreamEventParser
+    /// accepts, so `deliver` genuinely exercises the receive success path —
+    /// without the identity guard this would fire `onEvent`.
+    private func someEventJSON() -> String {
+        """
+        {"method":"event","params":{"type":"message.start","session_id":"sess-1"}}
+        """
     }
 }
 
 // MARK: - Test doubles
 
-/// Single-use continuation gate: `wait()` suspends until `signal()` fires.
-/// All access happens on the MainActor (tests + the connect path), so no locking.
+/// Single-use gate that survives a `signal()` arriving before `wait()` (the
+/// flag is sticky). All access is on the MainActor, so no locking is needed.
 private final class Gate {
+    private var signalled = false
     private var continuation: CheckedContinuation<Void, Never>?
 
     func signal() {
+        guard !signalled else { return }
+        signalled = true
         continuation?.resume()
         continuation = nil
     }
 
     func wait() async {
+        if signalled { return }
         await withCheckedContinuation { continuation = $0 }
     }
 }
 
-/// Controllable HermesWebSocket. receive() suspends until the test delivers a
-/// message or fails it; cancel() mimics URLSession by erroring the in-flight
-/// receive (real cancellation surfaces as a receive error).
+/// Controllable HermesWebSocket. `receive()` suspends until the test delivers a
+/// message or fails it; `cancel()` mimics URLSession by recording the close
+/// code and erroring the in-flight receive (real cancellation surfaces as a
+/// receive error).
 private final class FakeSocket: HermesWebSocket {
     var closeCode: URLSessionWebSocketTask.CloseCode = .invalid
     private(set) var cancelled = false
     private(set) var resumed = false
     var onResume: (() -> Void)?
+    var onReceivePending: (() -> Void)?
 
     private var receiveContinuation: CheckedContinuation<URLSessionWebSocketTask.Message, Error>?
 
@@ -179,9 +237,15 @@ private final class FakeSocket: HermesWebSocket {
         onResume?()
     }
 
+    /// Whether `cancel()` errors the in-flight `receive()` (true mirrors
+    /// URLSession). Tests that need a frame to arrive on a cancelled socket
+    /// set this false.
+    var cancelErrorsReceive = true
+
     func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        self.closeCode = closeCode
         cancelled = true
-        failReceive(URLError(.networkConnectionLost))
+        if cancelErrorsReceive { failReceive(URLError(.networkConnectionLost)) }
     }
 
     func send(_ message: URLSessionWebSocketTask.Message, completionHandler: @escaping @Sendable (Error?) -> Void) {
@@ -189,7 +253,10 @@ private final class FakeSocket: HermesWebSocket {
     }
 
     func receive() async throws -> URLSessionWebSocketTask.Message {
-        try await withCheckedThrowingContinuation { receiveContinuation = $0 }
+        try await withCheckedThrowingContinuation { continuation in
+            receiveContinuation = continuation
+            onReceivePending?()
+        }
     }
 
     // Test hooks
@@ -204,13 +271,16 @@ private final class FakeSocket: HermesWebSocket {
     }
 }
 
-/// Records invalidate() and lets the test drive the handshake per socket.
-/// Accessed only from the MainActor (the test + the connect path).
+/// Records `invalidate()` and completes the handshake deterministically.
+/// `open(_:)` is safe to call before `makeSocket` has registered the socket
+/// (e.g. right after spawning `Task { connect() }`): the request is buffered
+/// and fired once the socket exists, so the handshake never races the scheduler.
 private final class FakeTransport: HermesWebSocketTransport {
     private(set) var invalidated = false
     private(set) var socketsMade: [FakeSocket] = []
     var nextSocket: (() -> FakeSocket)?
-    private var openCallbacks: [(FakeSocket) -> Void] = []
+    private var openCallbacks: [ObjectIdentifier: () -> Void] = [:]
+    private var earlyOpenRequests = Set<ObjectIdentifier>()
 
     func makeSocket(
         request: URLRequest,
@@ -219,7 +289,11 @@ private final class FakeTransport: HermesWebSocketTransport {
     ) -> any HermesWebSocket {
         let socket = nextSocket?() ?? FakeSocket()
         socketsMade.append(socket)
-        openCallbacks.append { _ in onOpen(socket) }
+        let key = ObjectIdentifier(socket)
+        openCallbacks[key] = { onOpen(socket) }
+        if earlyOpenRequests.remove(key) != nil, let callback = openCallbacks.removeValue(forKey: key) {
+            callback()
+        }
         return socket
     }
 
@@ -227,9 +301,14 @@ private final class FakeTransport: HermesWebSocketTransport {
         invalidated = true
     }
 
-    /// Fire the handshake-open callback for a socket this transport produced.
+    /// Fire the handshake-open callback for a socket this transport has or will
+    /// produce. Buffering makes this independent of Task scheduling order.
     func open(_ socket: FakeSocket) {
-        guard let index = socketsMade.firstIndex(where: { $0 === socket }) else { return }
-        openCallbacks[index](socket)
+        let key = ObjectIdentifier(socket)
+        if let callback = openCallbacks.removeValue(forKey: key) {
+            callback()
+        } else {
+            earlyOpenRequests.insert(key)
+        }
     }
 }


### PR DESCRIPTION
## Problem

`HermesClient.receiveLoop()`'s catch block mutated shared state — `isConnected`, the pending-RPC map, and `onDisconnected` — with **no socket-identity check**, unlike `didOpen`/`didClose`/`failSocketOpen`, which all guard on `self.socket === socket`.

If a reconnect ever replaced `self.socket` and spawned a new loop while an old `socket.receive()` was still suspended, the old loop's late catch would run unguarded on the `@MainActor` and:
- set `isConnected = false` on the healthy new connection,
- fail the *new* connection's in-flight RPCs via `failAllPendingRequests`,
- fire `onDisconnected?()`.

A prior change (failing pending requests in this catch) made that clobbering strictly more damaging. Separately, the catch left the dead socket installed, and since `URLSessionWebSocketTask.closeCode` stays `.invalid` after a receive error (it means "no close frame," not "healthy"), `rpc`'s `closeCode == .invalid` precondition would let a new RPC ride the dead socket to its timeout.

## Severity: latent

This does **not** reproduce in production today. `AppState` creates a *new* `HermesClient` for each reconnect and calls `previousClient.disconnect()` first (which cancels the old `receiveTask`), so the cross-instance clobber can't happen. These changes harden against an intra-instance double-`connect()`, which no caller currently performs. Flagged by the bot reviews on #44/#50 against already-merged code.

## Fix

1. **`receiveLoop()` catch** — guard the entire teardown on `guard self.socket === socket else { break }` (the loop already captures its socket in a local). A superseded loop becomes a no-op.
2. **`receiveLoop()` catch** — nil out the dead socket so `rpc` can't re-issue against it.
3. **`connect()`** — cancel any prior `receiveTask` before spawning a new one (defense-in-depth, mirroring `disconnect()`).
4. **`rpc()` guard** — require `isConnected` in addition to a non-nil socket, so the window between socket creation and completed handshake is also covered.

## Testing

No new regression test: a real lifecycle test needs a `URLSessionWebSocketTask`/`URLSession` seam, which is a sizable refactor for a latent, unreachable-in-production defect. Verified by CI build + the existing suite (unchanged behavior on the happy path and the normal single-connection disconnect/reconnect flow). Adding a socket seam is a reasonable follow-up if we want this covered long-term.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WebSocket connection handling during reconnects and disconnects.
  - Prevented requests from using failed or superseded connections.
  - Improved cleanup after receive failures and invalidated obsolete connections.
  - Increased reliability when multiple connection attempts overlap.

- **Tests**
  - Added coverage for handshakes, connection failures, reconnects, cancellation, receive-loop behavior, and concurrent connection changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->