### PR TITLE
Offer Paste in composer edit menu for image pasteboards

### DIFF
--- a/Conduit/Views/Components/ComposerPasteTextView.swift
+++ b/Conduit/Views/Components/ComposerPasteTextView.swift
@@ -146,6 +146,45 @@ final class ImagePasteTextView: UITextView {
         return super.canPaste(itemProviders)
     }
 
+    /// Surfaces the standard "Paste" edit-menu item when an image is on the
+    /// pasteboard. UITextView drops "Paste" for image-only content (it cannot
+    /// paste an image as text), leaving system items such as "Autofill" as the
+    /// only options. `canPaste`/`paste(itemProviders:)` route external paste
+    /// triggers but never gate the long-press menu, so without this override
+    /// the image paste code is unreachable from the edit menu.
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        if action == #selector(paste(_:)), shouldOfferImagePaste() {
+            return true
+        }
+        return super.canPerformAction(action, withSender: sender)
+    }
+
+    /// Whether the edit menu should offer "Paste" for an image. Extracted as a
+    /// pure function over `isEditable` and `pasteboardContainsImage()` so the
+    /// gate is unit-testable in isolation, without depending on `super` or the
+    /// view's first-responder/window state.
+    func shouldOfferImagePaste() -> Bool {
+        isEditable && pasteboardContainsImage()
+    }
+
+    /// Reports whether the general pasteboard advertises image content using
+    /// only banner-safe metadata access: `hasImages` (Apple's conformance-aware
+    /// detector) plus a conformance scan over `pasteboard.types` as a
+    /// belt-and-suspenders fallback. Both read type metadata rather than
+    /// contents, so they do NOT raise the iOS "Paste from Other App" prompt —
+    /// important because `canPerformAction` runs before the user consents to a
+    /// paste and is called repeatedly while the edit menu is displayed. This
+    /// deliberately avoids `pb.image`/`pb.data(...)`, `pb.url`, and
+    /// materializing `pb.itemProviders`, all of which can trigger the banner.
+    /// Note: an image *URL* without image data (e.g. copied from Safari) is not
+    /// detected here, so "Paste" is not offered for that case; the legacy
+    /// `pb.url` path in `paste(_:)` stays reachable only via external triggers.
+    func pasteboardContainsImage() -> Bool {
+        let pasteboard = UIPasteboard.general
+        if pasteboard.hasImages { return true }
+        return pasteboard.types.contains { UTType($0)?.conforms(to: .image) ?? false }
+    }
+
     override func layoutSubviews() {
         super.layoutSubviews()
         let contentHeight = bounds.width > 0 && contentSize.height.isFinite
@@ -234,6 +273,10 @@ final class ImagePasteTextView: UITextView {
         }
     }
 
+    /// When the pasteboard holds an image it is delivered as an attachment via
+    /// `onPastedImage`; any accompanying text is not inserted, since this
+    /// attachment composer treats the image as the payload. Non-image
+    /// pasteboards fall through to the standard text behavior.
     override func paste(_ sender: Any?) {
         let pb = UIPasteboard.general
 

--- a/ConduitTests/ComposerPasteTextViewTests.swift
+++ b/ConduitTests/ComposerPasteTextViewTests.swift
@@ -7,6 +7,95 @@ import XCTest
 
 @MainActor
 final class ComposerPasteTextViewTests: XCTestCase {
+    private var savedPasteboardItems: [[String: Any]] = []
+
+    override func setUp() {
+        super.setUp()
+        // Snapshot the system pasteboard so tearDown can restore it instead of
+        // clobbering a real clipboard (relevant when the suite runs on a device).
+        savedPasteboardItems = UIPasteboard.general.items
+    }
+
+    override func tearDown() {
+        UIPasteboard.general.items = savedPasteboardItems
+        super.tearDown()
+    }
+
+    func testPasteboardContainsImageTrueForImagePasteboard() {
+        let view = ImagePasteTextView()
+        UIPasteboard.general.image = Self.fixtureImage()
+
+        XCTAssertTrue(view.pasteboardContainsImage())
+    }
+
+    func testPasteboardContainsImageFalseForTextPasteboard() {
+        let view = ImagePasteTextView()
+        UIPasteboard.general.string = "just text"
+
+        XCTAssertFalse(view.pasteboardContainsImage())
+    }
+
+    func testCanPerformActionOffersPasteForImagePasteboard() {
+        let view = ImagePasteTextView()
+        view.isEditable = true
+        UIPasteboard.general.image = Self.fixtureImage()
+
+        // Regression: UITextView drops "Paste" for an image-only pasteboard, so
+        // the long-press edit menu only offered system items like "Autofill".
+        // canPerformAction must surface paste: so the existing paste(_:) path
+        // becomes reachable from the menu.
+        XCTAssertTrue(view.canPerformAction(#selector(UIResponder.paste(_:)), withSender: nil))
+    }
+
+    func testShouldOfferImagePasteTrueForImagePasteboard() {
+        let view = ImagePasteTextView()
+        view.isEditable = true
+        UIPasteboard.general.image = Self.fixtureImage()
+
+        XCTAssertTrue(view.shouldOfferImagePaste())
+    }
+
+    func testShouldOfferImagePasteFalseWhenNotEditable() {
+        let view = ImagePasteTextView()
+        view.isEditable = false
+        UIPasteboard.general.image = Self.fixtureImage()
+
+        // A disabled composer must not offer image paste even with an image on
+        // the pasteboard.
+        XCTAssertFalse(view.shouldOfferImagePaste())
+    }
+
+    func testShouldOfferImagePasteFalseForTextOnlyPasteboard() {
+        let view = ImagePasteTextView()
+        view.isEditable = true
+        UIPasteboard.general.string = "just text"
+
+        // Text-only content must not be treated as an image paste.
+        XCTAssertFalse(view.shouldOfferImagePaste())
+    }
+
+    func testPasteSelectorDeliversImageFromPasteboard() async {
+        // End-to-end check of the exact path a menu tap now dispatches: the
+        // legacy paste(_:) selector reads UIPasteboard.general and fires
+        // onPastedImage. This is independent of the canPerformAction gate.
+        let view = ImagePasteTextView()
+        UIPasteboard.general.image = Self.fixtureImage()
+
+        let callback = expectation(description: "paste(_:) delivered image")
+        view.onPastedImage = { pastedImage in
+            XCTAssertFalse(pastedImage.data.isEmpty)
+            XCTAssertEqual(pastedImage.typeIdentifier, UTType.png.identifier)
+            callback.fulfill()
+        }
+        view.onPastedImageError = { message in
+            XCTFail("paste(_:) should deliver the image, got: \(message)")
+        }
+
+        view.paste(nil as Any?)
+
+        await fulfillment(of: [callback], timeout: 5.0)
+    }
+
     func testPasteItemProvidersDeliversImageData() async {
         let view = ImagePasteTextView()
         let expectedData = Data([0x89, 0x50, 0x4E, 0x47])
@@ -253,6 +342,13 @@ final class ComposerPasteTextViewTests: XCTestCase {
             ComposerBar.pastedImageErrorMessage("The image provider failed."),
             "Could not paste image: The image provider failed."
         )
+    }
+
+    private static func fixtureImage() -> UIImage {
+        UIGraphicsImageRenderer(size: CGSize(width: 2, height: 2)).image { context in
+            UIColor.systemOrange.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 2, height: 2))
+        }
     }
 
     private func encodedImageData(_ image: UIImage, type: UTType) -> Data? {


### PR DESCRIPTION
## Summary

Follow-up to #27 / refs #26. Pasting an image into the composer still did not work: long-pressing the composer showed only "Autofill", with no "Paste" item, so the existing image-paste code was unreachable from the edit menu.

- Override `canPerformAction(_:withSender:)` on `ImagePasteTextView` to surface the standard "Paste" edit-menu item whenever the general pasteboard advertises image content.
- Add a privacy-safe `pasteboardContainsImage()` helper that uses metadata-only checks (`contains(pasteboardTypes:)` + `NSItemProvider` conformance) so it does **not** raise the iOS "Paste from Other App" banner.
- Add regression coverage and a `tearDown` that clears `UIPasteboard.general`.

## Root cause

Image paste in `ComposerPasteTextView.swift` is implemented through three paths — `canPaste(_:)`/`paste(itemProviders:)` (the responder paste system, for external triggers like iOS 27's keyboard "Photo to paste") and the legacy `paste(_:)` selector. **None of those gate the long-press edit menu**, whose items are controlled by `canPerformAction(_:withSender:)`. That was never overridden (no `UIEditMenuInteraction`, no `UIPasteControl` anywhere in the app).

For an image-only pasteboard, UITextView's default `canPerformAction(paste:)` returns false — it cannot paste an image as text — so "Paste" is dropped, and iOS surfaces system items like "Autofill" instead. PR #27 fixed the item-provider code path but never addressed edit-menu gating, so the menu never offered Paste.

With this change, tapping "Paste" dispatches the existing `paste(_:)` selector, which reads `UIPasteboard.general` and delivers the image through the existing `onPastedImage` → `addAttachment` path. No backend, model, or UX-layout changes.

## Validation

- Regression test mirrors the failing behavior: `UITextView` drops "Paste" for an image-only pasteboard; the new test asserts `canPerformAction(#selector(paste(_:)))` is `true`.
- Focused composer tests cover pasteboard detection (image vs. text-only) and the `canPerformAction` regression.
- ⚠️ **Not yet built/run from this Windows dev environment.** Needs `xcodegen` + `ComposerPasteTextViewTests` on a Mac or the macos-26 CI runner before merge.
- On-device check: copy a screenshot → long-press the composer → "Paste" should now appear and add the image attachment.

## Considered alternative

A dedicated `UIPasteControl` button would guarantee availability without the edit menu, but it changes the composer's UX (new visible control). The `canPerformAction` override is the minimal root-cause fix that preserves the existing long-press → Paste gesture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for pasting images into editable text areas using the standard Paste action.

- **Bug Fixes**
  - Improved paste detection so image content is recognized even when text is unavailable, making image pasting more reliable.

- **Tests**
  - Added coverage for image and text paste behavior, including a regression test confirming image pasting remains available through the standard menu action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->