### PR TITLE
Keep pending decisions visible after background resume

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2680,33 +2680,46 @@ final class AppState: ObservableObject {
             for: result.sessionId,
             fallbackSessionId: reconciliation?.requestedSessionId
         )
-        // Hermes can omit `running` on versions that still support paused
-        // clarify/approval turns. Only an explicit false means the turn is
-        // settled, so nil remains eligible for restoring locally observed
-        // pending decision cards.
-        let restorePendingCards = Self.shouldRestorePendingCards(running: result.snapshot.running)
+        // A clarification request is a user-actionable event, not merely a
+        // projection of the gateway's current turn state. Hermes can omit the
+        // one-shot clarify event from a resume, and `running == false` can
+        // describe the preceding text even while that clarification remains
+        // unresolved. Keep clarification restoration independent of running;
+        // approvals retain the older explicit-running eligibility rule.
+        let restorePendingClarifications = true
+        let restorePendingApprovals = Self.shouldRestorePendingCards(running: result.snapshot.running)
         let sessionIDs = [result.sessionId, reconciliation?.requestedSessionId].compactMap { $0 }
         let gatewayDecisionKeys = Set(result.messages.compactMap(SessionPresentationCache.decisionKey(for:)))
-        let retainedMessages = restorePendingCards
-            ? retainedRestoredMessages.filter {
-                guard let key = SessionPresentationCache.decisionKey(for: $0) else { return false }
-                return !gatewayDecisionKeys.contains(key)
+        let retainedMessages = retainedRestoredMessages.filter { message in
+            guard let key = SessionPresentationCache.decisionKey(for: message),
+                  !gatewayDecisionKeys.contains(key) else {
+                return false
             }
-            : []
+            if message.clarify != nil { return restorePendingClarifications }
+            return restorePendingApprovals
+        }
         let restored = sessionPresentationCache.merge(
             result.messages + retainedMessages,
             profile: activeProfile,
             sessionIDs: sessionIDs,
-            includePendingClarifications: restorePendingCards,
-            includePendingApprovals: restorePendingCards
+            includePendingClarifications: restorePendingClarifications,
+            includePendingApprovals: restorePendingApprovals
         )
         messages = mergeCachedReviews(into: restored, sessionId: result.sessionId)
         noteChatViewportTranscriptReplacement()
         let gatewayPendingDecisionKeys = SessionPresentationCache.pendingDecisionKeys(in: result.messages)
-        if result.snapshot.running == false && !gatewayPendingDecisionKeys.isEmpty {
+        let gatewayPendingClarificationKeys = Set(result.messages.compactMap { message -> String? in
+            guard let clarify = message.clarify,
+                  SessionPresentationCache.isPendingDecision(clarify.status) else {
+                return nil
+            }
+            return "clarify:\(clarify.requestId)"
+        })
+        let gatewayPendingApprovalKeys = gatewayPendingDecisionKeys.subtracting(gatewayPendingClarificationKeys)
+        if result.snapshot.running == false && !gatewayPendingApprovalKeys.isEmpty {
             messages = SessionPresentationCache.removingPendingDecisionPresentation(
                 from: messages,
-                matching: gatewayPendingDecisionKeys
+                matching: gatewayPendingApprovalKeys
             )
         }
         let restoredPendingDecisionKeys = SessionPresentationCache
@@ -2736,6 +2749,7 @@ final class AppState: ObservableObject {
         // marker until Hermes confirms the turn or the user interacts with it.
         let gatewayConfirmsActiveTurn = result.snapshot.running == true
             || (result.snapshot.running != false && gatewaySentPendingDecision)
+            || !gatewayPendingClarificationKeys.isEmpty
         let unconfirmedPendingDecisionKeys = result.snapshot.running != true
             ? restoredPendingDecisionKeys
             : []
@@ -2779,11 +2793,15 @@ final class AppState: ObservableObject {
         receivedReasoningForCurrentTurn = false
         applyRuntime(result.snapshot)
 
-        // A paused clarification or approval can have neither a live text
-        // projection nor an explicit `running` field. The restored card is
-        // actionable evidence for this UI, so keep the composer enabled for
-        // it instead of treating the gateway as unsupported.
-        if result.snapshot.running == nil && (result.snapshot.hasLiveProjection || hasPendingDecision) {
+        // A pending clarification can survive a resume that reports the
+        // preceding turn as settled. Its answer controls remain actionable,
+        // so keep the composer enabled even when `running == false`.
+        let hasPendingClarification = messages.contains { message in
+            guard let clarify = message.clarify else { return false }
+            return SessionPresentationCache.isPendingDecision(clarify.status)
+        }
+        if hasPendingClarification
+            || (result.snapshot.running == nil && (result.snapshot.hasLiveProjection || hasPendingDecision)) {
             turnState = .running
         } else if TurnState.fromGatewayRunning(result.snapshot.running) == .unsupportedGateway {
             turnState = .unsupportedGateway
@@ -2795,10 +2813,10 @@ final class AppState: ObservableObject {
         return true
     }
 
-    /// Testable helper: derives whether pending clarify/approval cards should
-    /// be restored from the presentation cache on resume. An explicit false
-    /// is the only settled-turn signal; nil is still eligible because older
-    /// Hermes gateways omit `running` for paused decision turns.
+    /// Testable helper: derives whether pending approval cards should be
+    /// restored from the presentation cache on resume. Clarification cards
+    /// have independent eligibility because an unresolved request can survive
+    /// a resume that reports `running == false`.
     static func shouldRestorePendingCards(running: Bool?) -> Bool {
         running != false
     }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -604,11 +604,12 @@ final class AppState: ObservableObject {
     /// Coalesces presentation-cache flushes during streaming so we
     /// don't serialize and write UserDefaults on every WebSocket frame.
     private var presentationCacheFlushTask: Task<Void, Never>?
-    /// A nil resume can restore a decision card from local presentation data.
-    /// Keep the card in memory for this AppState so another foreground resume
-    /// can still show it, but strip it from cache writes until Hermes confirms
-    /// the turn. Scope the guard to the session/profile that produced it so a
-    /// session switch cannot affect another session's presentation.
+    /// A resume without explicit active-turn confirmation can restore a
+    /// decision card from local presentation data. Keep the card in memory for
+    /// this AppState so another foreground resume can still show it, but strip
+    /// it from cache writes until Hermes confirms the turn. Scope the guard to
+    /// the session/profile that produced it so a session switch cannot affect
+    /// another session's presentation.
     private struct PendingDecisionRestorationGuard {
         let profile: String
         let sessionID: String
@@ -2680,14 +2681,14 @@ final class AppState: ObservableObject {
             for: result.sessionId,
             fallbackSessionId: reconciliation?.requestedSessionId
         )
-        // A clarification request is a user-actionable event, not merely a
-        // projection of the gateway's current turn state. Hermes can omit the
-        // one-shot clarify event from a resume, and `running == false` can
-        // describe the preceding text even while that clarification remains
-        // unresolved. Keep clarification restoration independent of running;
-        // approvals retain the older explicit-running eligibility rule.
-        let restorePendingClarifications = true
-        let restorePendingApprovals = Self.shouldRestorePendingCards(running: result.snapshot.running)
+        // Pending clarifications and approvals are user-actionable decision
+        // events, not merely projections of the gateway's current turn state.
+        // Hermes can omit a one-shot decision event from a resume, and
+        // `running == false` can describe the preceding text even while the
+        // decision remains unresolved. Restore both card types independently
+        // of the turn snapshot; the gateway decision key remains authoritative
+        // when it includes a resolved record.
+        let restorePendingDecisionCards = true
         let sessionIDs = [result.sessionId, reconciliation?.requestedSessionId].compactMap { $0 }
         let gatewayDecisionKeys = Set(result.messages.compactMap(SessionPresentationCache.decisionKey(for:)))
         let retainedMessages = retainedRestoredMessages.filter { message in
@@ -2695,37 +2696,22 @@ final class AppState: ObservableObject {
                   !gatewayDecisionKeys.contains(key) else {
                 return false
             }
-            if message.clarify != nil { return restorePendingClarifications }
-            return restorePendingApprovals
+            return restorePendingDecisionCards
         }
         let restored = sessionPresentationCache.merge(
             result.messages + retainedMessages,
             profile: activeProfile,
             sessionIDs: sessionIDs,
-            includePendingClarifications: restorePendingClarifications,
-            includePendingApprovals: restorePendingApprovals
+            includePendingClarifications: restorePendingDecisionCards,
+            includePendingApprovals: restorePendingDecisionCards
         )
         messages = mergeCachedReviews(into: restored, sessionId: result.sessionId)
         noteChatViewportTranscriptReplacement()
         let gatewayPendingDecisionKeys = SessionPresentationCache.pendingDecisionKeys(in: result.messages)
-        let gatewayPendingClarificationKeys = Set(result.messages.compactMap { message -> String? in
-            guard let clarify = message.clarify,
-                  SessionPresentationCache.isPendingDecision(clarify.status) else {
-                return nil
-            }
-            return "clarify:\(clarify.requestId)"
-        })
-        let gatewayPendingApprovalKeys = gatewayPendingDecisionKeys.subtracting(gatewayPendingClarificationKeys)
-        if result.snapshot.running == false && !gatewayPendingApprovalKeys.isEmpty {
-            messages = SessionPresentationCache.removingPendingDecisionPresentation(
-                from: messages,
-                matching: gatewayPendingApprovalKeys
-            )
-        }
         let restoredPendingDecisionKeys = SessionPresentationCache
             .pendingDecisionKeys(in: messages)
             .subtracting(gatewayPendingDecisionKeys)
-        let gatewaySentPendingDecision = !gatewayPendingDecisionKeys.isEmpty
+        let gatewayHasPendingDecision = !gatewayPendingDecisionKeys.isEmpty
         var restoredMessagesAwaitingConfirmation: [ChatMessage] = []
         if result.snapshot.running != true && !restoredPendingDecisionKeys.isEmpty {
             Self.resetSubmittingRestoredDecisions(
@@ -2745,13 +2731,13 @@ final class AppState: ObservableObject {
         let hasPendingDecision = Self.hasPendingDecision(in: messages)
         // Persist the gateway transcript on every resume so fresh rows are not
         // lost. A locally restored card remains in the active AppState for the
-        // next foreground cycle and is persisted with a bounded unconfirmed
+        // next foreground cycle. Any pending decision observed without an
+        // explicit active-turn signal is persisted with a bounded unconfirmed
         // marker until Hermes confirms the turn or the user interacts with it.
         let gatewayConfirmsActiveTurn = result.snapshot.running == true
-            || (result.snapshot.running != false && gatewaySentPendingDecision)
-            || !gatewayPendingClarificationKeys.isEmpty
+            || (result.snapshot.running != false && gatewayHasPendingDecision)
         let unconfirmedPendingDecisionKeys = result.snapshot.running != true
-            ? restoredPendingDecisionKeys
+            ? SessionPresentationCache.pendingDecisionKeys(in: messages)
             : []
         let shouldPersistMergedPresentation = gatewayConfirmsActiveTurn
             || !unconfirmedPendingDecisionKeys.isEmpty
@@ -2793,15 +2779,10 @@ final class AppState: ObservableObject {
         receivedReasoningForCurrentTurn = false
         applyRuntime(result.snapshot)
 
-        // A pending clarification can survive a resume that reports the
-        // preceding turn as settled. Its answer controls remain actionable,
-        // so keep the composer enabled even when `running == false`.
-        let hasPendingClarification = messages.contains { message in
-            guard let clarify = message.clarify else { return false }
-            return SessionPresentationCache.isPendingDecision(clarify.status)
-        }
-        if hasPendingClarification
-            || (result.snapshot.running == nil && (result.snapshot.hasLiveProjection || hasPendingDecision)) {
+        // An omitted running state is ambiguous while a decision or live
+        // projection is present, but an explicit false is authoritative: the
+        // session is idle even when a pending card remains answerable.
+        if result.snapshot.running == nil && (result.snapshot.hasLiveProjection || hasPendingDecision) {
             turnState = .running
         } else if TurnState.fromGatewayRunning(result.snapshot.running) == .unsupportedGateway {
             turnState = .unsupportedGateway
@@ -2811,14 +2792,6 @@ final class AppState: ObservableObject {
             turnState = TurnState.fromGatewayRunning(result.snapshot.running)
         }
         return true
-    }
-
-    /// Testable helper: derives whether pending approval cards should be
-    /// restored from the presentation cache on resume. Clarification cards
-    /// have independent eligibility because an unresolved request can survive
-    /// a resume that reports `running == false`.
-    static func shouldRestorePendingCards(running: Bool?) -> Bool {
-        running != false
     }
 
     static func hasPendingDecision(in messages: [ChatMessage]) -> Bool {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -682,14 +682,19 @@ final class AppState: ObservableObject {
                 matching: $0
             )
         } ?? messages
+        let pendingDecisionKeys = SessionPresentationCache.pendingDecisionKeys(in: cacheableMessages)
+        // Gateway-provided cards do not create a restoration guard, so keep
+        // their bounded expiry marker across ordinary cache flushes as well.
+        let pendingDecisionKeysToPreserve = restorationKeys
+            ?? pendingDecisionKeys
         let preservePendingDecisionCards = restorationKeys == nil
-            || !SessionPresentationCache.pendingDecisionKeys(in: cacheableMessages).isEmpty
+            || !pendingDecisionKeys.isEmpty
         sessionPresentationCache.save(
             cacheableMessages,
             profile: activeProfile,
             sessionIDs: ids,
             preservePendingDecisionCards: preservePendingDecisionCards,
-            unconfirmedPendingDecisionKeys: restorationKeys ?? []
+            unconfirmedPendingDecisionKeys: pendingDecisionKeysToPreserve
         )
     }
 
@@ -2733,7 +2738,9 @@ final class AppState: ObservableObject {
         // lost. A locally restored card remains in the active AppState for the
         // next foreground cycle. Any pending decision observed without an
         // explicit active-turn signal is persisted with a bounded unconfirmed
-        // marker until Hermes confirms the turn or the user interacts with it.
+        // marker. The marker is intentionally independent from
+        // `gatewayConfirmsActiveTurn`: an ambiguous resume may contain a
+        // gateway-provided card that still needs the same stale-card guard.
         let gatewayConfirmsActiveTurn = result.snapshot.running == true
             || (result.snapshot.running != false && gatewayHasPendingDecision)
         let unconfirmedPendingDecisionKeys = result.snapshot.running != true
@@ -2809,7 +2816,8 @@ final class AppState: ObservableObject {
         for index in messages.indices {
             if var clarify = messages[index].clarify,
                clarify.status == .submitting,
-               keys.contains("clarify:\(clarify.requestId)") {
+               let key = SessionPresentationCache.decisionKey(for: messages[index]),
+               keys.contains(key) {
                 clarify.status = .pending
                 clarify.answer = nil
                 clarify.error = nil
@@ -2817,7 +2825,8 @@ final class AppState: ObservableObject {
             }
             if var approval = messages[index].approval,
                approval.status == .submitting,
-               keys.contains("approval:\(approval.sessionId)") {
+               let key = SessionPresentationCache.decisionKey(for: messages[index]),
+               keys.contains(key) {
                 approval.status = .pending
                 approval.choice = nil
                 approval.error = nil

--- a/Conduit/Services/SessionPresentationCache.swift
+++ b/Conduit/Services/SessionPresentationCache.swift
@@ -119,9 +119,10 @@ final class SessionPresentationCache {
         var unconfirmedPendingDecisionAt: Date?
     }
 
-    /// An omitted running state is inherently ambiguous. Keep an unconfirmed
-    /// decision across a cold launch for a bounded grace period, then prefer a
-    /// stale-card miss over making an old request answerable forever.
+    /// A resume without explicit active-turn confirmation is inherently
+    /// ambiguous for pending decisions. Keep an unconfirmed decision across a
+    /// cold launch for a bounded grace period, then prefer a stale-card miss
+    /// over making an old request answerable forever.
     private let defaults: UserDefaults
     private let now: () -> Date
     private let storageKey = "conduit.sessionPresentation.v1"

--- a/Conduit/Services/SessionPresentationCache.swift
+++ b/Conduit/Services/SessionPresentationCache.swift
@@ -229,10 +229,11 @@ final class SessionPresentationCache {
                 Self.isPendingDecision($0.status)
             }
 
-            // A gateway resume can retain the running clarify tool call but omit
-            // the one-shot clarify.request event. Restore the locally observed
-            // card only while the session is still running, and hide that duplicate
-            // generic tool row behind the answerable clarification UI.
+            // A gateway resume can retain the preceding transcript or generic
+            // clarify tool call but omit the one-shot clarify.request event.
+            // Restore the locally observed card while it remains unresolved,
+            // and hide that duplicate generic tool row behind the answerable
+            // clarification UI.
             if !pendingClarifications.isEmpty {
                 merged.removeAll { message in
                     message.role == .tool && message.tool?.name.lowercased() == "clarify"

--- a/ConduitTests/SessionPresentationCacheTests.swift
+++ b/ConduitTests/SessionPresentationCacheTests.swift
@@ -947,14 +947,14 @@ final class SessionPresentationCacheTests: XCTestCase {
         )
     }
 
-    func testApplyChatResumeDoesNotRestorePendingCardsWhenRunningIsFalse() {
-        let suiteName = "conduit.tests.session-presentation-settled-\(UUID().uuidString)"
+    func testApplyChatResumeRestoresPendingClarificationWhenRunningIsFalse() {
+        let suiteName = "conduit.tests.session-presentation-background-clarify-\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
             XCTFail("Could not create isolated UserDefaults suite")
             return
         }
         let cache = SessionPresentationCache(defaults: defaults)
-        let sessionId = "test-apply-resume-settled-\(UUID().uuidString)"
+        let sessionId = "test-apply-resume-background-clarify-\(UUID().uuidString)"
         let appState = AppState(
             defaults: defaults,
             loadSavedConnection: false,
@@ -970,7 +970,7 @@ final class SessionPresentationCacheTests: XCTestCase {
         )
         cache.save([
             ChatMessage(
-                id: "clarify-settled",
+                id: "clarify-background",
                 role: .clarify,
                 content: clarify.question,
                 timestamp: "2024-01-01",
@@ -984,20 +984,30 @@ final class SessionPresentationCacheTests: XCTestCase {
 
         appState.applyChatResume(SessionResumeResult(
             sessionId: sessionId,
-            messages: [],
+            messages: [ChatMessage(
+                id: "assistant-before-clarify",
+                role: .assistant,
+                content: "I need one more detail before I continue.",
+                timestamp: "2024-01-02"
+            )],
             snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
         ))
 
-        XCTAssertFalse(appState.messages.contains { $0.clarify?.requestId == clarify.requestId })
-        XCTAssertEqual(appState.turnState, TurnState.idle)
-        XCTAssertFalse(
+        XCTAssertTrue(appState.messages.contains { $0.content == "I need one more detail before I continue." })
+        XCTAssertEqual(
+            appState.messages.first(where: { $0.clarify?.requestId == clarify.requestId })?.clarify?.status,
+            ClarifyActivity.Status.pending
+        )
+        XCTAssertEqual(appState.turnState, TurnState.running)
+        XCTAssertTrue(appState.composerIsEnabled)
+        XCTAssertTrue(
             cache.merge(
                 [],
                 profile: profile,
                 sessionIDs: [sessionId],
                 includePendingClarifications: true
             ).contains { $0.clarify?.requestId == clarify.requestId },
-            "An explicitly settled resume must remove the cached pending card"
+            "An unresolved clarification must remain cached after a settled-looking background resume"
         )
     }
 
@@ -1258,14 +1268,14 @@ final class SessionPresentationCacheTests: XCTestCase {
         )
     }
 
-    func testApplyChatResumePrunesGatewayPendingCardWhenRunningIsFalse() {
-        let suiteName = "conduit.tests.session-presentation-gateway-settled-\(UUID().uuidString)"
+    func testApplyChatResumePreservesGatewayPendingClarificationWhenRunningIsFalse() {
+        let suiteName = "conduit.tests.session-presentation-gateway-pending-clarify-\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
             XCTFail("Could not create isolated UserDefaults suite")
             return
         }
         let cache = SessionPresentationCache(defaults: defaults)
-        let sessionId = "test-apply-resume-gateway-settled-\(UUID().uuidString)"
+        let sessionId = "test-apply-resume-gateway-pending-clarify-\(UUID().uuidString)"
         let appState = AppState(
             defaults: defaults,
             loadSavedConnection: false,
@@ -1274,13 +1284,13 @@ final class SessionPresentationCacheTests: XCTestCase {
         )
         let profile = appState.activeProfile
         let clarify = ClarifyActivity(
-            requestId: "req-gateway-settled",
+            requestId: "req-gateway-pending-false",
             question: "Which color?",
             choices: [ClarifyChoice(label: "Red", value: "red")],
             status: .pending
         )
         let gatewayMessage = ChatMessage(
-            id: "clarify-gateway-settled",
+            id: "clarify-gateway-pending-false",
             role: .clarify,
             content: clarify.question,
             timestamp: "2024-01-01",
@@ -1297,19 +1307,77 @@ final class SessionPresentationCacheTests: XCTestCase {
             snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
         ))
 
-        XCTAssertEqual(appState.turnState, TurnState.idle)
-        XCTAssertFalse(
+        XCTAssertEqual(appState.turnState, TurnState.running)
+        XCTAssertTrue(
             AppState.hasPendingDecision(in: appState.messages),
-            "An explicitly settled resume must not leave an answerable gateway card in memory"
+            "A gateway clarification without a resolved record must remain answerable"
         )
-        XCTAssertFalse(
+        XCTAssertTrue(
             cache.merge(
                 [],
                 profile: profile,
                 sessionIDs: [sessionId],
                 includePendingClarifications: true
             ).contains { $0.clarify?.requestId == clarify.requestId },
-            "An explicit settled signal must prune even an inconsistent pending gateway row"
+            "An unresolved gateway clarification must remain cached when running is false"
+        )
+    }
+
+    func testApplyChatResumePrunesGatewayPendingApprovalWhenRunningIsFalse() {
+        let suiteName = "conduit.tests.session-presentation-gateway-settled-approval-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: defaults)
+        let sessionId = "test-apply-resume-gateway-settled-approval-\(UUID().uuidString)"
+        let appState = AppState(
+            defaults: defaults,
+            loadSavedConnection: false,
+            clearSessionPresentationCache: { cache.clear() },
+            sessionPresentationCache: cache
+        )
+        let profile = appState.activeProfile
+        let approval = ApprovalActivity(
+            sessionId: sessionId,
+            command: "ls",
+            description: "List files",
+            choices: ["once", "deny"],
+            allowPermanent: false,
+            smartDenied: false,
+            status: .pending
+        )
+        let gatewayMessage = ChatMessage(
+            id: "approval-gateway-settled",
+            role: .approval,
+            content: approval.description,
+            timestamp: "2024-01-01",
+            approval: approval
+        )
+        defer {
+            cache.clear()
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: sessionId,
+            messages: [gatewayMessage],
+            snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+        ))
+
+        XCTAssertEqual(appState.turnState, TurnState.idle)
+        XCTAssertFalse(
+            AppState.hasPendingDecision(in: appState.messages),
+            "An explicitly settled approval must not leave an answerable card in memory"
+        )
+        XCTAssertFalse(
+            cache.merge(
+                [],
+                profile: profile,
+                sessionIDs: [sessionId],
+                includePendingApprovals: true
+            ).contains { $0.approval?.sessionId == sessionId },
+            "An explicit settled signal must still prune an inconsistent pending approval"
         )
     }
 }

--- a/ConduitTests/SessionPresentationCacheTests.swift
+++ b/ConduitTests/SessionPresentationCacheTests.swift
@@ -349,16 +349,12 @@ final class SessionPresentationCacheTests: XCTestCase {
         cache.save(savedMessages, profile: profile, sessionIDs: [sessionId])
         defer { cache.clear(profile: profile) }
 
-        // Hermes versions that omit `running` can still be paused on this
-        // clarification request. Nil must remain eligible for restoration;
-        // explicit false is the only resolved/idle signal.
-        let shouldRestore = AppState.shouldRestorePendingCards(running: nil)
         let gatewayMessages: [ChatMessage] = []
         let merged = cache.merge(
             gatewayMessages,
             profile: profile,
             sessionIDs: [sessionId],
-            includePendingClarifications: shouldRestore
+            includePendingClarifications: true
         )
 
         XCTAssertTrue(merged.contains { $0.role == .clarify },
@@ -444,25 +440,6 @@ final class SessionPresentationCacheTests: XCTestCase {
 
         XCTAssertFalse(merged.contains { $0.role == .approval },
                        "Approval should not be restored when includePendingApprovals is false")
-    }
-
-    // MARK: - restorePendingCards derivation
-
-    func testShouldRestorePendingCardsWhenRunningIsTrue() {
-        XCTAssertTrue(AppState.shouldRestorePendingCards(running: true),
-                      "Must restore pending cards when gateway confirms turn is active")
-    }
-
-    func testShouldNotRestorePendingCardsWhenRunningIsFalse() {
-        XCTAssertFalse(AppState.shouldRestorePendingCards(running: false),
-                       "Must not restore pending cards when gateway reports turn is inactive")
-    }
-
-    func testShouldRestorePendingCardsWhenRunningIsNil() {
-        // Hermes can omit `running` while a turn is paused on a user decision.
-        // Only an explicit false is proof that the turn is no longer active.
-        XCTAssertTrue(AppState.shouldRestorePendingCards(running: nil),
-                      "Must restore pending cards when gateway omits running state")
     }
 
     // MARK: - Save preserves restored pending cards
@@ -998,8 +975,12 @@ final class SessionPresentationCacheTests: XCTestCase {
             appState.messages.first(where: { $0.clarify?.requestId == clarify.requestId })?.clarify?.status,
             ClarifyActivity.Status.pending
         )
-        XCTAssertEqual(appState.turnState, TurnState.running)
+        XCTAssertEqual(appState.turnState, TurnState.idle)
         XCTAssertTrue(appState.composerIsEnabled)
+        XCTAssertEqual(
+            appState.composerAction(hasText: true, hasAttachments: false),
+            ComposerAction.send
+        )
         XCTAssertTrue(
             cache.merge(
                 [],
@@ -1008,6 +989,78 @@ final class SessionPresentationCacheTests: XCTestCase {
                 includePendingClarifications: true
             ).contains { $0.clarify?.requestId == clarify.requestId },
             "An unresolved clarification must remain cached after a settled-looking background resume"
+        )
+    }
+
+    func testApplyChatResumeRestoresPendingApprovalWhenRunningIsFalse() {
+        let suiteName = "conduit.tests.session-presentation-background-approval-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: defaults)
+        let sessionId = "test-apply-resume-background-approval-\(UUID().uuidString)"
+        let appState = AppState(
+            defaults: defaults,
+            loadSavedConnection: false,
+            clearSessionPresentationCache: { cache.clear() },
+            sessionPresentationCache: cache
+        )
+        let profile = appState.activeProfile
+        let approval = ApprovalActivity(
+            sessionId: sessionId,
+            command: "ls",
+            description: "List files",
+            choices: ["once", "deny"],
+            allowPermanent: false,
+            smartDenied: false,
+            status: .pending
+        )
+        cache.save([
+            ChatMessage(
+                id: "approval-background",
+                role: .approval,
+                content: approval.description,
+                timestamp: "2024-01-01",
+                approval: approval
+            )
+        ], profile: profile, sessionIDs: [sessionId])
+        defer {
+            cache.clear()
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: sessionId,
+            messages: [ChatMessage(
+                id: "assistant-before-approval",
+                role: .assistant,
+                content: "I need permission before I continue.",
+                timestamp: "2024-01-02"
+            )],
+            snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+        ))
+
+        XCTAssertTrue(appState.messages.contains { $0.content == "I need permission before I continue." })
+        XCTAssertEqual(
+            appState.messages.first(where: { $0.approval?.sessionId == sessionId })?.approval?.status,
+            ApprovalActivity.Status.pending
+        )
+        XCTAssertTrue(AppState.hasPendingDecision(in: appState.messages))
+        XCTAssertEqual(appState.turnState, TurnState.idle)
+        XCTAssertTrue(appState.composerIsEnabled)
+        XCTAssertEqual(
+            appState.composerAction(hasText: true, hasAttachments: false),
+            ComposerAction.send
+        )
+        XCTAssertTrue(
+            cache.merge(
+                [],
+                profile: profile,
+                sessionIDs: [sessionId],
+                includePendingApprovals: true
+            ).contains { $0.approval?.sessionId == sessionId },
+            "An unresolved approval must remain cached after a settled-looking background resume"
         )
     }
 
@@ -1307,10 +1360,15 @@ final class SessionPresentationCacheTests: XCTestCase {
             snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
         ))
 
-        XCTAssertEqual(appState.turnState, TurnState.running)
+        XCTAssertEqual(appState.turnState, TurnState.idle)
         XCTAssertTrue(
             AppState.hasPendingDecision(in: appState.messages),
             "A gateway clarification without a resolved record must remain answerable"
+        )
+        XCTAssertTrue(appState.composerIsEnabled)
+        XCTAssertEqual(
+            appState.composerAction(hasText: true, hasAttachments: false),
+            ComposerAction.send
         )
         XCTAssertTrue(
             cache.merge(
@@ -1323,7 +1381,7 @@ final class SessionPresentationCacheTests: XCTestCase {
         )
     }
 
-    func testApplyChatResumePrunesGatewayPendingApprovalWhenRunningIsFalse() {
+    func testApplyChatResumePreservesGatewayPendingApprovalWhenRunningIsFalse() {
         let suiteName = "conduit.tests.session-presentation-gateway-settled-approval-\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
             XCTFail("Could not create isolated UserDefaults suite")
@@ -1366,9 +1424,92 @@ final class SessionPresentationCacheTests: XCTestCase {
         ))
 
         XCTAssertEqual(appState.turnState, TurnState.idle)
-        XCTAssertFalse(
+        XCTAssertTrue(
             AppState.hasPendingDecision(in: appState.messages),
-            "An explicitly settled approval must not leave an answerable card in memory"
+            "A gateway approval without a resolved record must remain answerable"
+        )
+        XCTAssertEqual(
+            appState.messages.first(where: { $0.approval?.sessionId == sessionId })?.approval?.status,
+            ApprovalActivity.Status.pending
+        )
+        XCTAssertTrue(appState.composerIsEnabled)
+        XCTAssertEqual(
+            appState.composerAction(hasText: true, hasAttachments: false),
+            ComposerAction.send
+        )
+        XCTAssertTrue(
+            cache.merge(
+                [],
+                profile: profile,
+                sessionIDs: [sessionId],
+                includePendingApprovals: true
+            ).contains { $0.approval?.sessionId == sessionId },
+            "An unresolved gateway approval must remain cached when running is false"
+        )
+    }
+
+    func testApplyChatResumeExpiresGatewayPendingApprovalAfterGracePeriod() {
+        let suiteName = "conduit.tests.session-presentation-gateway-approval-expiry-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        var currentDate = Date(timeIntervalSince1970: 3_000_000)
+        let cache = SessionPresentationCache(defaults: defaults, now: { currentDate })
+        let sessionId = "test-apply-resume-gateway-approval-expiry-\(UUID().uuidString)"
+        let appState = AppState(
+            defaults: defaults,
+            loadSavedConnection: false,
+            clearSessionPresentationCache: { cache.clear() },
+            sessionPresentationCache: cache
+        )
+        let profile = appState.activeProfile
+        let approval = ApprovalActivity(
+            sessionId: sessionId,
+            command: "ls",
+            description: "List files",
+            choices: ["once", "deny"],
+            allowPermanent: false,
+            smartDenied: false,
+            status: .pending
+        )
+        let gatewayMessage = ChatMessage(
+            id: "approval-gateway-expiring",
+            role: .approval,
+            content: approval.description,
+            timestamp: "2024-01-01",
+            approval: approval
+        )
+        defer {
+            cache.clear()
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: sessionId,
+            messages: [gatewayMessage],
+            snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+        ))
+        XCTAssertTrue(
+            cache.merge(
+                [],
+                profile: profile,
+                sessionIDs: [sessionId],
+                includePendingApprovals: true
+            ).contains { $0.approval?.sessionId == sessionId },
+            "A gateway-provided pending approval should be cached during its grace period"
+        )
+
+        currentDate.addTimeInterval(SessionPresentationCache.maxUnconfirmedPendingDecisionAge + 1)
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: sessionId,
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+        ))
+
+        XCTAssertFalse(
+            appState.messages.contains { $0.approval?.sessionId == sessionId },
+            "An unconfirmed gateway approval must not remain answerable forever"
         )
         XCTAssertFalse(
             cache.merge(
@@ -1377,7 +1518,7 @@ final class SessionPresentationCacheTests: XCTestCase {
                 sessionIDs: [sessionId],
                 includePendingApprovals: true
             ).contains { $0.approval?.sessionId == sessionId },
-            "An explicit settled signal must still prune an inconsistent pending approval"
+            "An expired gateway approval must be removed from the presentation cache"
         )
     }
 }

--- a/ConduitTests/SessionPresentationCacheTests.swift
+++ b/ConduitTests/SessionPresentationCacheTests.swift
@@ -1448,6 +1448,64 @@ final class SessionPresentationCacheTests: XCTestCase {
         )
     }
 
+    func testBackgroundCacheFlushPreservesGatewayPendingDecisionExpiryMarker() {
+        let suiteName = "conduit.tests.session-presentation-gateway-flush-marker-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        var currentDate = Date(timeIntervalSince1970: 3_000_000)
+        let cache = SessionPresentationCache(defaults: defaults, now: { currentDate })
+        let sessionId = "test-apply-resume-gateway-flush-marker-\(UUID().uuidString)"
+        let appState = AppState(
+            defaults: defaults,
+            loadSavedConnection: false,
+            clearSessionPresentationCache: { cache.clear() },
+            sessionPresentationCache: cache
+        )
+        let profile = appState.activeProfile
+        let approval = ApprovalActivity(
+            sessionId: sessionId,
+            command: "ls",
+            description: "List files",
+            choices: ["once", "deny"],
+            allowPermanent: false,
+            smartDenied: false,
+            status: .pending
+        )
+        let gatewayMessage = ChatMessage(
+            id: "approval-gateway-flush-marker",
+            role: .approval,
+            content: approval.description,
+            timestamp: "2024-01-01",
+            approval: approval
+        )
+        defer {
+            cache.clear()
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: sessionId,
+            messages: [gatewayMessage],
+            snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+        ))
+        let initialMarker = cache.unconfirmedPendingDecisionDate(
+            profile: profile,
+            sessionIDs: [sessionId]
+        )
+        XCTAssertEqual(initialMarker, currentDate)
+
+        currentDate.addTimeInterval(60)
+        appState.handleScenePhase(.background)
+
+        XCTAssertEqual(
+            cache.unconfirmedPendingDecisionDate(profile: profile, sessionIDs: [sessionId]),
+            initialMarker,
+            "A guard-less cache flush must preserve the original pending-decision expiry marker"
+        )
+    }
+
     func testApplyChatResumeExpiresGatewayPendingApprovalAfterGracePeriod() {
         let suiteName = "conduit.tests.session-presentation-gateway-approval-expiry-\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {

--- a/docs/superpowers/plans/2026-08-13-clarify-background-resume.md
+++ b/docs/superpowers/plans/2026-08-13-clarify-background-resume.md
@@ -1,0 +1,41 @@
+# Implementation Plan: Restore Answerable Clarifications After Background Resume
+
+**Goal:** Keep an unresolved clarification visible and answerable after a background-to-foreground resume, even when the resume snapshot reports `running == false` and omits the one-shot clarification event.
+
+**Architecture:** Preserve the existing gateway-authoritative transcript and `SessionPresentationCache` merge. Split clarification restoration/actionability from the existing settled-turn approval behavior, and use the existing request-ID reconciliation plus bounded unconfirmed-card cache protection.
+
+**Tech Stack:** Swift, SwiftUI `AppState`, XCTest, XcodeGen, iOS Simulator.
+
+## Tasks
+
+- [ ] 1. Add the regression tests first (RED)
+  - Update `ConduitTests/SessionPresentationCacheTests.swift` so the explicit-settled clarification case models the reported background resume: seed a cached pending clarification, return preceding assistant text without a clarification event, and use `SessionRuntimeSnapshot(object: ["running": .bool(false)])`.
+  - Assert that the assistant text remains, the clarification with the same request ID is present and pending, the session is action-capable, and the presentation cache retains it.
+  - Update the existing gateway-pending clarification case so an unresolved gateway clarification also remains visible/actionable when `running == false`.
+  - Keep the answered/resolved same-request test asserting that the gateway representation replaces the cached pending card without a duplicate.
+  - Preserve the current approval-specific settled behavior tests.
+  - Refresh the generated project with `/Users/agrias/bin/bin/xcodegen generate`, then run the single new/updated test before changing production code:
+    `xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' -derivedDataPath /tmp/conduit-clarify-red CODE_SIGNING_ALLOWED=NO -only-testing:ConduitTests/SessionPresentationCacheTests/testApplyChatResumeRestoresPendingClarificationWhenRunningIsFalse`
+  - Confirm the test fails for the current implementation because `running == false` suppresses the cached card and leaves `turnState` idle.
+
+- [ ] 2. Implement clarification-specific resume reconciliation
+  - In `Conduit/Services/AppState.swift`, update `applyChatResume` so cached pending clarifications remain eligible independent of `snapshot.running`; retain the existing running-based eligibility for approvals unless a shared helper requires a narrowly scoped change.
+  - Keep locally retained clarification cards eligible when the gateway transcript omits the one-shot event, and continue filtering them by the authoritative gateway decision key so an answered/resolved same-request record wins.
+  - Narrow the explicit-`false` pruning path so it cannot remove a pending clarification. If approval pruning remains necessary, pass only approval keys through the existing presentation-pruning helper.
+  - Treat any unresolved pending clarification in the merged presentation as action-capable, including when `running == false`, so `respondToClarify` remains usable. Do not change unrelated turn-state behavior for sessions without a pending clarification.
+  - Ensure a gateway-supplied pending clarification is included in the existing bounded unconfirmed preservation set when the snapshot is otherwise settled, so the subsequent cache save does not strip it.
+  - Update stale comments/helper names in `AppState.swift` and `SessionPresentationCache.swift` so they describe clarification restoration accurately rather than saying it is only valid while a turn is running.
+  - Only change `Conduit/Services/SessionPresentationCache.swift` if a type-specific pending-key/pruning helper is needed; keep gateway transcript matching and resolved-card suppression intact.
+
+- [ ] 3. Run focused verification (GREEN)
+  - Run the complete clarification integration group:
+    `xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' -derivedDataPath /tmp/conduit-clarify-focused CODE_SIGNING_ALLOWED=NO -only-testing:ConduitTests/SessionPresentationCacheTests`
+  - Confirm the restored-card, explicit-settled, gateway-pending, resolved-gateway, approval, and expiry tests all pass.
+  - Review the diff for accidental changes to approval restoration, notification routing, or gateway protocol behavior.
+
+- [ ] 4. Verify the branch and prepare the PR
+  - Refresh `Conduit.xcodeproj` with `/Users/agrias/bin/bin/xcodegen generate` after the final source changes.
+  - Run the full XCTest suite in the iOS Simulator and record the final test count/result.
+  - Run `git diff --check`, inspect `git diff main...HEAD`, and confirm only the clarification resume implementation, tests, and plan/spec documentation are present.
+  - Commit the implementation as `fix: keep clarifications visible after background resume`.
+  - Push `codex/clarify-background-resume` and open its PR against `main` with a summary, root cause, test evidence, and explicit note that approval behavior is unchanged.

--- a/docs/superpowers/plans/2026-08-13-clarify-background-resume.md
+++ b/docs/superpowers/plans/2026-08-13-clarify-background-resume.md
@@ -1,41 +1,50 @@
-# Implementation Plan: Restore Answerable Clarifications After Background Resume
+# Restore Answerable Pending Decisions After Background Resume Implementation Plan
 
-**Goal:** Keep an unresolved clarification visible and answerable after a background-to-foreground resume, even when the resume snapshot reports `running == false` and omits the one-shot clarification event.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` or `superpowers:subagent-driven-development` to implement this plan task-by-task.
 
-**Architecture:** Preserve the existing gateway-authoritative transcript and `SessionPresentationCache` merge. Split clarification restoration/actionability from the existing settled-turn approval behavior, and use the existing request-ID reconciliation plus bounded unconfirmed-card cache protection.
+**Goal:** Keep unresolved clarification and approval cards visible and answerable after a background-to-foreground resume, even when the resume snapshot reports `running == false` and omits the one-shot decision event.
+
+**Architecture:** Preserve the existing gateway-authoritative transcript and `SessionPresentationCache` merge. Treat pending clarification and approval cards as one pending-decision presentation class during reconciliation, use canonical decision keys, and keep explicit settled turn state separate from card actionability. Use the existing bounded unconfirmed-card cache protection for gateway-provided and locally restored cards.
 
 **Tech Stack:** Swift, SwiftUI `AppState`, XCTest, XcodeGen, iOS Simulator.
 
+## Global Constraints
+
+- Do not change Hermes protocol messages or notification delivery.
+- Do not introduce a separate decision inbox or a new gateway query.
+- Do not change the existing clarification or approval response APIs.
+- Gateway-resolved decision records remain authoritative and suppress cached pending duplicates.
+- Explicit `running == false` maps to `.idle`; omitted `running` retains the existing conservative ambiguity handling.
+- Unconfirmed pending decision cards expire after `SessionPresentationCache.maxUnconfirmedPendingDecisionAge`.
+
+---
+
 ## Tasks
 
-- [ ] 1. Add the regression tests first (RED)
-  - Update `ConduitTests/SessionPresentationCacheTests.swift` so the explicit-settled clarification case models the reported background resume: seed a cached pending clarification, return preceding assistant text without a clarification event, and use `SessionRuntimeSnapshot(object: ["running": .bool(false)])`.
-  - Assert that the assistant text remains, the clarification with the same request ID is present and pending, the session is action-capable, and the presentation cache retains it.
-  - Update the existing gateway-pending clarification case so an unresolved gateway clarification also remains visible/actionable when `running == false`.
-  - Keep the answered/resolved same-request test asserting that the gateway representation replaces the cached pending card without a duplicate.
-  - Preserve the current approval-specific settled behavior tests.
-  - Refresh the generated project with `/Users/agrias/bin/bin/xcodegen generate`, then run the single new/updated test before changing production code:
-    `xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' -derivedDataPath /tmp/conduit-clarify-red CODE_SIGNING_ALLOWED=NO -only-testing:ConduitTests/SessionPresentationCacheTests/testApplyChatResumeRestoresPendingClarificationWhenRunningIsFalse`
-  - Confirm the test fails for the current implementation because `running == false` suppresses the cached card and leaves `turnState` idle.
+- [ ] 1. Add the failing regression tests (RED)
+  - In `ConduitTests/SessionPresentationCacheTests.swift`, change the cached clarification test for an explicit `running == false` snapshot to expect `turnState == .idle` while retaining assertions that the card is pending, present, composer-enabled, and cached.
+  - Replace the settled gateway approval-pruning test with a pending-approval restoration test: supply a gateway approval with `running == false`, assert the pending card remains in `AppState`, assert `turnState == .idle`, and assert it is cached for the grace period.
+  - Add a cached pending approval test parallel to the cached clarification test: seed the presentation cache, resume with transcript text but no approval event and `running == false`, then assert the approval card remains pending and answerable.
+  - Add an expiry assertion for a gateway-provided pending decision using an injected clock, so preserving gateway cards cannot create an unbounded stale-card path.
+  - Refresh the generated project with `/Users/agrias/bin/bin/xcodegen generate`, then run the updated focused tests before changing production code. The approval tests must fail because the current implementation rejects approvals when `running == false`; the clarification test must fail because the current implementation reports `.running`.
 
-- [ ] 2. Implement clarification-specific resume reconciliation
-  - In `Conduit/Services/AppState.swift`, update `applyChatResume` so cached pending clarifications remain eligible independent of `snapshot.running`; retain the existing running-based eligibility for approvals unless a shared helper requires a narrowly scoped change.
-  - Keep locally retained clarification cards eligible when the gateway transcript omits the one-shot event, and continue filtering them by the authoritative gateway decision key so an answered/resolved same-request record wins.
-  - Narrow the explicit-`false` pruning path so it cannot remove a pending clarification. If approval pruning remains necessary, pass only approval keys through the existing presentation-pruning helper.
-  - Treat any unresolved pending clarification in the merged presentation as action-capable, including when `running == false`, so `respondToClarify` remains usable. Do not change unrelated turn-state behavior for sessions without a pending clarification.
-  - Ensure a gateway-supplied pending clarification is included in the existing bounded unconfirmed preservation set when the snapshot is otherwise settled, so the subsequent cache save does not strip it.
-  - Update stale comments/helper names in `AppState.swift` and `SessionPresentationCache.swift` so they describe clarification restoration accurately rather than saying it is only valid while a turn is running.
-  - Only change `Conduit/Services/SessionPresentationCache.swift` if a type-specific pending-key/pruning helper is needed; keep gateway transcript matching and resolved-card suppression intact.
+- [ ] 2. Implement shared pending-decision resume reconciliation
+  - In `Conduit/Services/AppState.swift`, set both pending clarification and approval restoration eligibility independently of `snapshot.running`; retain gateway decision-key matching so resolved records replace cached pending cards without duplicates.
+  - Remove the explicit-`false` approval pruning branch and the manually rebuilt clarification-key set. Use `SessionPresentationCache.pendingDecisionKey(for:)`/`pendingDecisionKeys(in:)` for all pending decision identity comparisons.
+  - Include gateway-provided pending decision keys in the unconfirmed preservation set whenever the snapshot is not explicitly active, so `SessionPresentationCache.save` keeps them with its existing bounded timestamp.
+  - Keep the local restored-card confirmation guard for cards absent from the gateway result, while allowing both decision types to remain retryable after resume.
+  - Resolve `turnState` from the gateway snapshot after applying the merged presentation: explicit `running == false` must remain `.idle`; only the existing ambiguous `running == nil` live-projection/pending-decision path may force `.running`.
+  - Update comments/helper names in `AppState.swift` and `SessionPresentationCache.swift` to describe shared pending-decision behavior and the bounded unconfirmed safeguard.
 
 - [ ] 3. Run focused verification (GREEN)
-  - Run the complete clarification integration group:
-    `xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' -derivedDataPath /tmp/conduit-clarify-focused CODE_SIGNING_ALLOWED=NO -only-testing:ConduitTests/SessionPresentationCacheTests`
-  - Confirm the restored-card, explicit-settled, gateway-pending, resolved-gateway, approval, and expiry tests all pass.
-  - Review the diff for accidental changes to approval restoration, notification routing, or gateway protocol behavior.
+  - Run the complete integration group:
+    `xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' -derivedDataPath /tmp/conduit-pending-decision-focused CODE_SIGNING_ALLOWED=NO -only-testing:ConduitTests/SessionPresentationCacheTests`
+  - Confirm cached and gateway-provided clarification and approval tests pass, including explicit settled idle state, resolved gateway suppression, retryable submitting cards, and expiry.
+  - Review the diff for accidental changes to response APIs, notification routing, or Hermes protocol behavior.
 
-- [ ] 4. Verify the branch and prepare the PR
-  - Refresh `Conduit.xcodeproj` with `/Users/agrias/bin/bin/xcodegen generate` after the final source changes.
+- [ ] 4. Verify and publish the updated PR
+  - Refresh `Conduit.xcodeproj` with `/Users/agrias/bin/bin/xcodegen generate` after final source changes.
   - Run the full XCTest suite in the iOS Simulator and record the final test count/result.
-  - Run `git diff --check`, inspect `git diff main...HEAD`, and confirm only the clarification resume implementation, tests, and plan/spec documentation are present.
-  - Commit the implementation as `fix: keep clarifications visible after background resume`.
-  - Push `codex/clarify-background-resume` and open its PR against `main` with a summary, root cause, test evidence, and explicit note that approval behavior is unchanged.
+  - Run `git diff --check`, inspect `git diff origin/main...HEAD`, and confirm only pending-decision resume implementation, tests, and spec/plan documentation are present.
+  - Commit the implementation with a message describing pending decision cards after background resume.
+  - Push `codex/clarify-background-resume` and update PR #54’s title/body to cover both clarifications and approvals, without replying to or resolving review threads unless explicitly requested.

--- a/docs/superpowers/plans/2026-08-13-clarify-background-resume.md
+++ b/docs/superpowers/plans/2026-08-13-clarify-background-resume.md
@@ -21,14 +21,14 @@
 
 ## Tasks
 
-- [ ] 1. Add the failing regression tests (RED)
+- [x] 1. Add the failing regression tests (RED)
   - In `ConduitTests/SessionPresentationCacheTests.swift`, change the cached clarification test for an explicit `running == false` snapshot to expect `turnState == .idle` while retaining assertions that the card is pending, present, composer-enabled, and cached.
   - Replace the settled gateway approval-pruning test with a pending-approval restoration test: supply a gateway approval with `running == false`, assert the pending card remains in `AppState`, assert `turnState == .idle`, and assert it is cached for the grace period.
   - Add a cached pending approval test parallel to the cached clarification test: seed the presentation cache, resume with transcript text but no approval event and `running == false`, then assert the approval card remains pending and answerable.
   - Add an expiry assertion for a gateway-provided pending decision using an injected clock, so preserving gateway cards cannot create an unbounded stale-card path.
   - Refresh the generated project with `/Users/agrias/bin/bin/xcodegen generate`, then run the updated focused tests before changing production code. The approval tests must fail because the current implementation rejects approvals when `running == false`; the clarification test must fail because the current implementation reports `.running`.
 
-- [ ] 2. Implement shared pending-decision resume reconciliation
+- [x] 2. Implement shared pending-decision resume reconciliation
   - In `Conduit/Services/AppState.swift`, set both pending clarification and approval restoration eligibility independently of `snapshot.running`; retain gateway decision-key matching so resolved records replace cached pending cards without duplicates.
   - Remove the explicit-`false` approval pruning branch and the manually rebuilt clarification-key set. Use `SessionPresentationCache.pendingDecisionKey(for:)`/`pendingDecisionKeys(in:)` for all pending decision identity comparisons.
   - Include gateway-provided pending decision keys in the unconfirmed preservation set whenever the snapshot is not explicitly active, so `SessionPresentationCache.save` keeps them with its existing bounded timestamp.
@@ -36,15 +36,15 @@
   - Resolve `turnState` from the gateway snapshot after applying the merged presentation: explicit `running == false` must remain `.idle`; only the existing ambiguous `running == nil` live-projection/pending-decision path may force `.running`.
   - Update comments/helper names in `AppState.swift` and `SessionPresentationCache.swift` to describe shared pending-decision behavior and the bounded unconfirmed safeguard.
 
-- [ ] 3. Run focused verification (GREEN)
+- [x] 3. Run focused verification (GREEN)
   - Run the complete integration group:
     `xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' -derivedDataPath /tmp/conduit-pending-decision-focused CODE_SIGNING_ALLOWED=NO -only-testing:ConduitTests/SessionPresentationCacheTests`
   - Confirm cached and gateway-provided clarification and approval tests pass, including explicit settled idle state, resolved gateway suppression, retryable submitting cards, and expiry.
   - Review the diff for accidental changes to response APIs, notification routing, or Hermes protocol behavior.
 
-- [ ] 4. Verify and publish the updated PR
+- [x] 4. Verify and publish the updated PR
   - Refresh `Conduit.xcodeproj` with `/Users/agrias/bin/bin/xcodegen generate` after final source changes.
-  - Run the full XCTest suite in the iOS Simulator and record the final test count/result.
+  - Run the full XCTest suite in the iOS Simulator and record the final result: 509 tests, 0 failures.
   - Run `git diff --check`, inspect `git diff origin/main...HEAD`, and confirm only pending-decision resume implementation, tests, and spec/plan documentation are present.
   - Commit the implementation with a message describing pending decision cards after background resume.
   - Push `codex/clarify-background-resume` and update PR #54’s title/body to cover both clarifications and approvals, without replying to or resolving review threads unless explicitly requested.

--- a/docs/superpowers/specs/2026-08-13-clarify-background-resume-design.md
+++ b/docs/superpowers/specs/2026-08-13-clarify-background-resume-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-13
 **Branch:** `codex/clarify-background-resume`
-**Status:** Approved design; implementation in progress
+**Status:** Implemented and verified
 
 ## Problem
 

--- a/docs/superpowers/specs/2026-08-13-clarify-background-resume-design.md
+++ b/docs/superpowers/specs/2026-08-13-clarify-background-resume-design.md
@@ -1,7 +1,7 @@
 # Design Spec: Restore Answerable Clarifications After Background Resume
 
-**Date:** 2026-08-13  
-**Branch:** `codex/clarify-background-resume`  
+**Date:** 2026-08-13
+**Branch:** `codex/clarify-background-resume`
 **Status:** Approved design; implementation pending
 
 ## Problem

--- a/docs/superpowers/specs/2026-08-13-clarify-background-resume-design.md
+++ b/docs/superpowers/specs/2026-08-13-clarify-background-resume-design.md
@@ -1,0 +1,87 @@
+# Design Spec: Restore Answerable Clarifications After Background Resume
+
+**Date:** 2026-08-13  
+**Branch:** `codex/clarify-background-resume`  
+**Status:** Approved design; implementation pending
+
+## Problem
+
+When Conduit receives a clarification request while the app is backgrounded,
+the push notification arrives and the preceding assistant text is present after
+the app returns to the foreground, but the clarification card can be missing.
+The resume path merges the server transcript with the locally persisted
+`SessionPresentationCache`. A resume snapshot with `running == false` currently
+acts as a settled-turn signal and removes or refuses to restore locally cached
+pending decision presentation. Hermes can report the preceding transcript
+without replaying the one-shot clarification event, so this loses the only
+answerable representation of the request.
+
+## Goal
+
+After a background-to-foreground resume, a pending clarification remains
+visible and answerable whenever Conduit has not received a gateway record that
+resolves that exact clarification request.
+
+The behavior must hold when the resume snapshot explicitly reports
+`running == false`, and it must preserve the current notification, transcript,
+and cache lifecycle behavior.
+
+## Non-goals
+
+- Do not change Hermes protocol messages or notification delivery.
+- Do not introduce a separate clarification inbox or a new gateway query.
+- Do not broaden approval-card restoration semantics beyond what is required by
+  shared reconciliation code; existing approval behavior remains covered by
+  its current tests.
+- Do not keep a clarification that the gateway has already answered, rejected,
+  or otherwise resolved.
+
+## Design
+
+1. Treat a locally cached pending clarification as eligible for resume whenever
+   the clarification is still unresolved. The value of `snapshot.running` must
+   not by itself disable cached clarification restoration.
+2. Reconcile by the clarification request identity already used by
+   `SessionPresentationCache`. A gateway message for the same request ID is
+   authoritative: an answered/resolved gateway activity replaces the cached
+   pending presentation, and no duplicate pending card is appended.
+3. An explicit `running == false` with no resolved record must not remove a
+   cached pending clarification. The existing generic pending-decision pruning
+   must be narrowed so it cannot discard this unresolved clarification.
+4. When the restored clarification is pending, keep the session action-capable
+   so the existing clarification response path can submit an answer. The
+   restored card must not be downgraded to an inert historical row merely
+   because the resume snapshot says the turn is no longer running.
+5. Continue persisting the merged transcript through the existing presentation
+   cache. Existing expiry and confirmation safeguards remain in force; user
+   interaction continues through `respondToClarify`.
+
+## Expected implementation surface
+
+- `Conduit/Services/AppState.swift`: separate unresolved-clarification resume
+  eligibility from the settled-turn pruning path and preserve actionability.
+- `Conduit/Services/SessionPresentationCache.swift`: adjust only if the
+  shared merge helper needs a narrow clarification-specific distinction.
+- `ConduitTests/SessionPresentationCacheTests.swift`: add regression coverage
+  for a background-style resume with preceding assistant text and
+  `running == false`, plus the resolved-request suppression case.
+
+## Acceptance tests
+
+- A cached pending clarification is restored when the resumed gateway response
+  contains preceding assistant text, omits the clarification event, and reports
+  `running == false`.
+- The restored clarification remains pending and its existing answer path is
+  available to the session.
+- A gateway activity with the same request ID and an answered/resolved status
+  suppresses the cached pending clarification and leaves only the authoritative
+  gateway representation.
+- The existing full test suite remains green, including current pending
+  approval and clarification cache tests.
+
+## Verification
+
+Run the focused clarification resume tests first, then run the complete
+`Conduit` XCTest suite in the iOS Simulator. Review the final diff to confirm
+that the change is limited to clarification resume reconciliation and its
+tests.

--- a/docs/superpowers/specs/2026-08-13-clarify-background-resume-design.md
+++ b/docs/superpowers/specs/2026-08-13-clarify-background-resume-design.md
@@ -1,87 +1,98 @@
-# Design Spec: Restore Answerable Clarifications After Background Resume
+# Design Spec: Restore Answerable Pending Decisions After Background Resume
 
 **Date:** 2026-08-13
 **Branch:** `codex/clarify-background-resume`
-**Status:** Approved design; implementation pending
+**Status:** Approved design; implementation in progress
 
 ## Problem
 
-When Conduit receives a clarification request while the app is backgrounded,
-the push notification arrives and the preceding assistant text is present after
-the app returns to the foreground, but the clarification card can be missing.
-The resume path merges the server transcript with the locally persisted
-`SessionPresentationCache`. A resume snapshot with `running == false` currently
-acts as a settled-turn signal and removes or refuses to restore locally cached
-pending decision presentation. Hermes can report the preceding transcript
-without replaying the one-shot clarification event, so this loses the only
+When Conduit receives a clarification request or approval request while the app
+is backgrounded, the notification arrives and the surrounding transcript is
+present after the app returns to the foreground, but the answerable card can be
+missing. The resume path merges the server transcript with the locally
+persisted `SessionPresentationCache`. A resume snapshot with `running == false`
+currently acts as a settled-turn signal and removes or refuses to restore
+locally cached pending decision presentation. Hermes can report the transcript
+without replaying the one-shot decision event, so this loses the only
 answerable representation of the request.
 
 ## Goal
 
-After a background-to-foreground resume, a pending clarification remains
-visible and answerable whenever Conduit has not received a gateway record that
-resolves that exact clarification request.
+After a background-to-foreground resume, a pending clarification or approval
+remains visible and answerable whenever Conduit has not received a gateway
+record that resolves that exact decision.
 
 The behavior must hold when the resume snapshot explicitly reports
 `running == false`, and it must preserve the current notification, transcript,
-and cache lifecycle behavior.
+cache, and response lifecycle behavior. An explicit settled gateway state must
+still map to an idle session state; card visibility and session turn state are
+separate concerns.
 
 ## Non-goals
 
 - Do not change Hermes protocol messages or notification delivery.
-- Do not introduce a separate clarification inbox or a new gateway query.
-- Do not broaden approval-card restoration semantics beyond what is required by
-  shared reconciliation code; existing approval behavior remains covered by
-  its current tests.
-- Do not keep a clarification that the gateway has already answered, rejected,
-  or otherwise resolved.
+- Do not introduce a separate decision inbox or a new gateway query.
+- Do not change the existing clarification or approval response APIs.
+- Do not keep a decision that the gateway has already answered, rejected, or
+  otherwise resolved.
 
 ## Design
 
-1. Treat a locally cached pending clarification as eligible for resume whenever
-   the clarification is still unresolved. The value of `snapshot.running` must
-   not by itself disable cached clarification restoration.
-2. Reconcile by the clarification request identity already used by
-   `SessionPresentationCache`. A gateway message for the same request ID is
+1. Treat a locally cached pending clarification or approval as eligible for
+   resume whenever that decision is still unresolved. The value of
+   `snapshot.running` must not by itself disable pending decision restoration.
+2. Reconcile by the decision identity already used by
+   `SessionPresentationCache`. A gateway message for the same decision key is
    authoritative: an answered/resolved gateway activity replaces the cached
    pending presentation, and no duplicate pending card is appended.
 3. An explicit `running == false` with no resolved record must not remove a
-   cached pending clarification. The existing generic pending-decision pruning
-   must be narrowed so it cannot discard this unresolved clarification.
-4. When the restored clarification is pending, keep the session action-capable
-   so the existing clarification response path can submit an answer. The
-   restored card must not be downgraded to an inert historical row merely
-   because the resume snapshot says the turn is no longer running.
+   pending clarification or approval. The old approval-specific pruning path is
+   removed because both cards have the same resume semantics.
+4. Resolve turn state from the gateway snapshot. Explicit `running == false`
+   remains `.idle`, which keeps the composer and decision controls usable while
+   avoiding a false typing indicator or stop/steer action. An omitted running
+   state may still use the existing conservative `.running` path when live
+   projection or a pending decision makes the gateway state ambiguous.
 5. Continue persisting the merged transcript through the existing presentation
-   cache. Existing expiry and confirmation safeguards remain in force; user
-   interaction continues through `respondToClarify`.
+   cache. Gateway-provided pending decisions observed without active-turn
+   confirmation receive the same bounded unconfirmed marker as locally restored
+   cards, so they expire rather than remaining answerable forever. User
+   interaction continues through the existing clarification and approval
+   response paths.
 
 ## Expected implementation surface
 
-- `Conduit/Services/AppState.swift`: separate unresolved-clarification resume
-  eligibility from the settled-turn pruning path and preserve actionability.
-- `Conduit/Services/SessionPresentationCache.swift`: adjust only if the
-  shared merge helper needs a narrow clarification-specific distinction.
-- `ConduitTests/SessionPresentationCacheTests.swift`: add regression coverage
-  for a background-style resume with preceding assistant text and
-  `running == false`, plus the resolved-request suppression case.
+- `Conduit/Services/AppState.swift`: unify pending-decision resume eligibility,
+  remove settled approval pruning, preserve idle turn state for explicit false,
+  and apply bounded persistence to gateway-provided pending decisions.
+- `Conduit/Services/SessionPresentationCache.swift`: use the shared pending-key
+  helpers for reconciliation and keep expiry behavior type-independent.
+- `ConduitTests/SessionPresentationCacheTests.swift`: cover cached and
+  gateway-provided clarification and approval cards, explicit settled state,
+  expiry, and resolved-decision suppression.
 
 ## Acceptance tests
 
 - A cached pending clarification is restored when the resumed gateway response
   contains preceding assistant text, omits the clarification event, and reports
   `running == false`.
-- The restored clarification remains pending and its existing answer path is
-  available to the session.
+- A cached pending approval is restored when the resumed gateway response omits
+  the approval event and reports `running == false`.
+- Both restored cards remain pending and their existing answer paths are
+  available while `turnState == .idle` for an explicit settled snapshot.
+- A gateway-provided pending clarification or approval remains visible when
+  `running == false` and is stored with the bounded unconfirmed marker.
 - A gateway activity with the same request ID and an answered/resolved status
-  suppresses the cached pending clarification and leaves only the authoritative
-  gateway representation.
+  (or the equivalent approval key) suppresses the cached pending card and
+  leaves only the authoritative gateway representation.
+- An unconfirmed gateway-provided card expires after
+  `SessionPresentationCache.maxUnconfirmedPendingDecisionAge`.
 - The existing full test suite remains green, including current pending
   approval and clarification cache tests.
 
 ## Verification
 
-Run the focused clarification resume tests first, then run the complete
+Run the focused pending-decision resume tests first, then run the complete
 `Conduit` XCTest suite in the iOS Simulator. Review the final diff to confirm
-that the change is limited to clarification resume reconciliation and its
+that the change is limited to pending-decision resume reconciliation and its
 tests.


### PR DESCRIPTION
## Summary

- keep unresolved clarification and approval cards visible and answerable after a background resume, including when the gateway omits the one-shot decision event
- keep an explicit `running == false` session idle so the composer remains a normal send action instead of showing false busy/stop/steer state
- use shared pending-decision keys and reconciliation so gateway-resolved records replace cached pending cards without duplicates
- persist gateway-provided pending cards with the existing bounded unconfirmed expiry safeguard, including across subsequent cache flushes
- add regression coverage for cached and gateway-provided clarification and approval cards

## Root cause

The resume path treated pending approvals as restorable only while the gateway reported an active turn, and explicitly pruned gateway approvals when `running == false`. Clarifications were restored by forcing `turnState` to `.running`, which made the UI report a false busy state and route composer input through steer/interrupt behavior. A background resume can omit the one-shot decision event while still reporting the preceding turn as settled, so both decision types need independent presentation restoration and the settled turn state must remain separate from card actionability.

Gateway-provided pending cards also had no restoration guard. A later background or streaming cache flush passed an empty unconfirmed-key set to the cache, clearing the 24-hour expiry marker and allowing a stale card to persist indefinitely. Ordinary cache writes now derive the pending decision keys directly from the current presentation so the original marker survives until the card is resolved or expires.

## Validation

- Focused `SessionPresentationCacheTests`: 33 passed, 0 failed
- Full iOS Simulator XCTest suite: 510 passed, 0 failed
- New regression confirms a background cache flush preserves the original pending-decision expiry marker
- `git diff --check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pending clarification and approval cards now persist when resuming from the background, even if the session appears inactive.
  * Resolved decisions are correctly removed when authoritative updates are available.
  * Pending cards remain available during background cache updates and can expire safely when no longer confirmed.
  * Restored cards now retain composer availability and decision context more reliably.

* **Documentation**
  * Added design and implementation guidance for background session resume behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->