### PR TITLE
Persist session-scoped YOLO overrides across turns

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -55,6 +55,7 @@ struct ChatResumeLifecycleOperations {
         String
     ) async throws -> AnyCodable)?
     var setBusyInputMode: (@MainActor (HermesClient, BusyInputMode) async throws -> Void)?
+    var setSessionYolo: (@MainActor (HermesClient, String, Bool) async throws -> Void)?
     var loadProfiles: (@MainActor () async -> Void)?
     var loadBusyInputMode: (@MainActor (HermesClient) async -> Void)?
     var loadProfileDisplayPreferences: (@MainActor () async -> Void)?
@@ -90,6 +91,7 @@ struct ChatResumeLifecycleOperations {
             String
         ) async throws -> AnyCodable)? = nil,
         setBusyInputMode: (@MainActor (HermesClient, BusyInputMode) async throws -> Void)? = nil,
+        setSessionYolo: (@MainActor (HermesClient, String, Bool) async throws -> Void)? = nil,
         loadProfiles: (@MainActor () async -> Void)? = nil,
         loadBusyInputMode: (@MainActor (HermesClient) async -> Void)? = nil,
         loadProfileDisplayPreferences: (@MainActor () async -> Void)? = nil,
@@ -109,6 +111,7 @@ struct ChatResumeLifecycleOperations {
         self.executeSlash = executeSlash
         self.dispatchCommand = dispatchCommand
         self.setBusyInputMode = setBusyInputMode
+        self.setSessionYolo = setSessionYolo
         self.loadProfiles = loadProfiles
         self.loadBusyInputMode = loadBusyInputMode
         self.loadProfileDisplayPreferences = loadProfileDisplayPreferences
@@ -632,6 +635,7 @@ final class AppState: ObservableObject {
     private var sessionCatalogCache = SessionCatalogCache()
     private var projectsRequestGeneration = 0
     private let sessionPresentationCache: SessionPresentationCache
+    private let sessionYoloStore: SessionYoloStore
 
     /// The dashboard's persisted transcript is richer than `session.resume`:
     /// it retains database timestamps, complete tool-call inputs, and other
@@ -800,10 +804,12 @@ final class AppState: ObservableObject {
         reconnectScheduler: ChatResumeReconnectScheduler? = nil,
         reconnectExecutor: ChatResumeReconnectExecutor? = nil,
         chatResumeLifecycleOperations: ChatResumeLifecycleOperations = .live,
-        sessionPresentationCache: SessionPresentationCache = .shared
+        sessionPresentationCache: SessionPresentationCache = .shared,
+        sessionYoloStore: SessionYoloStore? = nil
     ) {
         self.defaults = defaults
         self.sessionPresentationCache = sessionPresentationCache
+        self.sessionYoloStore = sessionYoloStore ?? SessionYoloStore(defaults: defaults)
         self.chatResumeCoordinator = chatResumeCoordinator
             ?? ChatResumeCoordinator(store: ChatResumeStore(defaults: defaults))
         self.recoverySequence = recoverySequence
@@ -2777,7 +2783,7 @@ final class AppState: ObservableObject {
         activeAssistantMessageId = nil
         activeReasoningMessageId = nil
         receivedReasoningForCurrentTurn = false
-        applyRuntime(result.snapshot)
+        applyRuntime(result.snapshot, for: result.sessionId)
 
         // A paused clarification or approval can have neither a live text
         // projection nor an explicit `running` field. The restored card is
@@ -3137,7 +3143,19 @@ final class AppState: ObservableObject {
         return recovered
     }
 
-    private func applyRuntime(_ snapshot: SessionRuntimeSnapshot) {
+    private func canonicalSessionID(for sessionID: String?) -> String? {
+        ChatSessionPersistenceIdentity.canonicalID(
+            for: sessionID,
+            identity: activeChatScrollSessionIdentity,
+            catalog: sessions + cronSessions,
+            activeProfile: activeProfile
+        )
+    }
+
+    private func applyRuntime(
+        _ snapshot: SessionRuntimeSnapshot,
+        for sessionID: String? = nil
+    ) {
         if let model = snapshot.model { runtime.model = model }
         if let provider = snapshot.provider { runtime.provider = provider }
         if let cwd = snapshot.cwd { runtime.cwd = cwd }
@@ -3149,7 +3167,13 @@ final class AppState: ObservableObject {
             runtime.reasoningEffort = reasoningEffort.lowercased() == "none" ? "" : reasoningEffort
         }
         if let fast = snapshot.fast { runtime.fast = fast }
-        if let yolo = snapshot.yolo {
+        if let canonicalSessionID = canonicalSessionID(for: sessionID ?? activeSessionId),
+           let storedOverride = sessionYoloStore.storedOverride(
+               for: activeProfile,
+               sessionID: canonicalSessionID
+           ) {
+            runtime.yolo = storedOverride
+        } else if let yolo = snapshot.yolo {
             runtime.yolo = yolo
         } else if let approvalsMode = snapshot.approvalsMode {
             runtime.yolo = approvalsMode.lowercased() == "off"
@@ -4293,7 +4317,17 @@ final class AppState: ObservableObject {
     func setYoloMode(_ enabled: Bool) async -> Bool {
         guard let client, let sessionId = activeSessionId else { return false }
         do {
-            try await client.setSessionYolo(sessionId, enabled: enabled)
+            if let setSessionYolo = chatResumeLifecycleOperations.setSessionYolo {
+                try await setSessionYolo(client, sessionId, enabled)
+            } else {
+                try await client.setSessionYolo(sessionId, enabled: enabled)
+            }
+            let persistedSessionID = canonicalSessionID(for: sessionId) ?? sessionId
+            sessionYoloStore.setOverride(
+                enabled,
+                for: activeProfile,
+                sessionID: persistedSessionID
+            )
             runtime.yolo = enabled
             return true
         } catch {
@@ -6349,8 +6383,8 @@ final class AppState: ObservableObject {
                 scheduleResponseHapticConclusion(after: 180)
             }
 
-        case .sessionInfo(_, let snapshot):
-            applyRuntime(snapshot)
+        case .sessionInfo(let sessionID, let snapshot):
+            applyRuntime(snapshot, for: sessionID)
             if let running = snapshot.running {
                 setRunning(running)
             }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -3167,14 +3167,24 @@ final class AppState: ObservableObject {
             runtime.reasoningEffort = reasoningEffort.lowercased() == "none" ? "" : reasoningEffort
         }
         if let fast = snapshot.fast { runtime.fast = fast }
-        if let canonicalSessionID = canonicalSessionID(for: sessionID ?? activeSessionId),
-           let storedOverride = sessionYoloStore.storedOverride(
-               for: activeProfile,
-               sessionID: canonicalSessionID
-           ) {
-            runtime.yolo = storedOverride
-        } else if let yolo = snapshot.yolo {
+        let requestedSessionID = sessionID ?? activeSessionId
+        let resolvedCanonicalSessionID = canonicalSessionID(for: requestedSessionID)
+        let sessionIDsForOverride = [resolvedCanonicalSessionID, requestedSessionID]
+            .compactMap { $0 }
+        let storedOverride = sessionYoloStore.storedOverride(
+            for: activeProfile,
+            sessionIDs: sessionIDsForOverride
+        )
+        if let yolo = snapshot.yolo {
+            if let storedOverride, storedOverride != yolo {
+                sessionYoloStore.clearOverride(
+                    for: activeProfile,
+                    sessionIDs: sessionIDsForOverride
+                )
+            }
             runtime.yolo = yolo
+        } else if let storedOverride {
+            runtime.yolo = storedOverride
         } else if let approvalsMode = snapshot.approvalsMode {
             runtime.yolo = approvalsMode.lowercased() == "off"
         }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2783,7 +2783,11 @@ final class AppState: ObservableObject {
         activeAssistantMessageId = nil
         activeReasoningMessageId = nil
         receivedReasoningForCurrentTurn = false
-        applyRuntime(result.snapshot, for: result.sessionId)
+        applyRuntime(
+            result.snapshot,
+            for: result.sessionId,
+            reconcileExplicitYolo: true
+        )
 
         // A paused clarification or approval can have neither a live text
         // projection nor an explicit `running` field. The restored card is
@@ -3154,7 +3158,8 @@ final class AppState: ObservableObject {
 
     private func applyRuntime(
         _ snapshot: SessionRuntimeSnapshot,
-        for sessionID: String? = nil
+        for sessionID: String? = nil,
+        reconcileExplicitYolo: Bool = false
     ) {
         if let model = snapshot.model { runtime.model = model }
         if let provider = snapshot.provider { runtime.provider = provider }
@@ -3185,13 +3190,22 @@ final class AppState: ObservableObject {
             sessionIDs: sessionIDsForOverride
         )
         if let yolo = snapshot.yolo {
-            if let storedOverride, storedOverride != yolo {
-                sessionYoloStore.clearOverride(
-                    for: activeProfile,
-                    sessionIDs: sessionIDsForOverride
-                )
+            if let storedOverride {
+                if reconcileExplicitYolo, storedOverride != yolo {
+                    sessionYoloStore.clearOverride(
+                        for: activeProfile,
+                        sessionIDs: sessionIDsForOverride
+                    )
+                    runtime.yolo = yolo
+                } else {
+                    // Live session.info pushes can be older than a client
+                    // initiated config.set RPC. Keep the local choice until a
+                    // fresh resume snapshot can reconcile server authority.
+                    runtime.yolo = storedOverride
+                }
+            } else {
+                runtime.yolo = yolo
             }
-            runtime.yolo = yolo
         } else if let storedOverride {
             runtime.yolo = storedOverride
         } else if let approvalsMode = snapshot.approvalsMode {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2420,7 +2420,8 @@ final class AppState: ObservableObject {
                 presentationResult,
                 automaticWorkToken: automaticWorkToken,
                 automaticSyncOperationID: automaticSyncOperationID,
-                yoloWriteBaseline: yoloWriteBaseline
+                yoloWriteBaseline: yoloWriteBaseline,
+                reconcileExplicitYolo: reconcileExplicitYolo
             ) else {
                 settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
                 return false
@@ -2507,18 +2508,10 @@ final class AppState: ObservableObject {
                         .isEmpty == false
                 )
             }
-            if reconcileExplicitYolo {
-                // A session.info received while resume was in flight may be a
-                // pre-resume snapshot. Do not replay a contradictory YOLO
-                // value after fresh resume reconciliation clears an override;
-                // pushes received after reconciliation remain authoritative.
-                bufferedEvents = Self.filteringBufferedSessionInfo(
-                    bufferedEvents,
-                    against: result.snapshot,
-                    acceptedSessionIDs: reconciliation?.acceptedSessionIDs ?? Set([result.sessionId])
-                )
+            let bufferedYoloAuthority = reconcileExplicitYolo ? result.snapshot.yolo : nil
+            bufferedEvents.forEach { event in
+                applyStreamEvent(event, authoritativeYolo: bufferedYoloAuthority)
             }
-            bufferedEvents.forEach(applyStreamEvent)
             return settleReconciliationAndPublish(
                 token,
                 automaticWorkToken: automaticWorkToken,
@@ -2717,7 +2710,8 @@ final class AppState: ObservableObject {
         _ result: SessionResumeResult,
         automaticWorkToken: ChatResumeAutomaticWorkToken? = nil,
         automaticSyncOperationID: UUID? = nil,
-        yoloWriteBaseline: SessionYoloWriteBaseline?
+        yoloWriteBaseline: SessionYoloWriteBaseline?,
+        reconcileExplicitYolo: Bool? = nil
     ) -> Bool {
         guard automaticChatResumeWorkIsCurrent(
             automaticWorkToken,
@@ -2830,7 +2824,7 @@ final class AppState: ObservableObject {
         applyRuntime(
             result.snapshot,
             for: result.sessionId,
-            reconcileExplicitYolo: yoloWriteBaseline.map {
+            reconcileExplicitYolo: reconcileExplicitYolo ?? yoloWriteBaseline.map {
                 !hasNewerSessionYoloWrite(
                     since: $0,
                     sessionIDs: [result.sessionId, reconciliation?.requestedSessionId].compactMap { $0 }
@@ -3122,24 +3116,6 @@ final class AppState: ObservableObject {
         return deduplicated
     }
 
-    nonisolated static func filteringBufferedSessionInfo(
-        _ events: [StreamEvent],
-        against resumeSnapshot: SessionRuntimeSnapshot,
-        acceptedSessionIDs: Set<String>
-    ) -> [StreamEvent] {
-        guard let resumeYolo = resumeSnapshot.yolo else { return events }
-        return events.filter { event in
-            guard case .sessionInfo(let sessionID, let snapshot) = event,
-                  acceptedSessionIDs.contains(sessionID) else {
-                return true
-            }
-            let eventYolo = snapshot.yolo
-                ?? snapshot.approvalsMode.map { $0.lowercased() == "off" }
-            guard let eventYolo else { return true }
-            return eventYolo == resumeYolo
-        }
-    }
-
     /// Returns every non-empty prefix of `buffered` that is also a suffix of
     /// `covered`. The prefix-function scan stays linear in the cumulative
     /// projection size; callers can reject repeated-content ambiguity when
@@ -3257,7 +3233,8 @@ final class AppState: ObservableObject {
     private func applyRuntime(
         _ snapshot: SessionRuntimeSnapshot,
         for sessionID: String? = nil,
-        reconcileExplicitYolo: Bool = false
+        reconcileExplicitYolo: Bool = false,
+        authoritativeYolo: Bool? = nil
     ) {
         if let model = snapshot.model { runtime.model = model }
         if let provider = snapshot.provider { runtime.provider = provider }
@@ -3287,7 +3264,7 @@ final class AppState: ObservableObject {
             for: activeProfile,
             sessionIDs: sessionIDsForOverride
         )
-        if let yolo = snapshot.yolo {
+        if let yolo = authoritativeYolo ?? snapshot.yolo {
             if let storedOverride {
                 if reconcileExplicitYolo, storedOverride != yolo {
                     sessionYoloStore.clearOverride(
@@ -6462,7 +6439,7 @@ final class AppState: ObservableObject {
         return reconciliation.acceptedSessionIDs.contains(sessionId)
     }
 
-    private func applyStreamEvent(_ event: StreamEvent) {
+    private func applyStreamEvent(_ event: StreamEvent, authoritativeYolo: Bool? = nil) {
         let streamSessionId = sessionID(for: event)
         guard eventBelongsToActiveSession(streamSessionId) else { return }
         defer { schedulePresentationCacheFlush(for: streamSessionId) }
@@ -6524,7 +6501,7 @@ final class AppState: ObservableObject {
             }
 
         case .sessionInfo(let sessionID, let snapshot):
-            applyRuntime(snapshot, for: sessionID)
+            applyRuntime(snapshot, for: sessionID, authoritativeYolo: authoritativeYolo)
             if let running = snapshot.running {
                 setRunning(running)
             }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -620,6 +620,10 @@ final class AppState: ObservableObject {
         let messages: [ChatMessage]
     }
 
+    private struct SessionYoloWriteBaseline {
+        let revisions: [ChatScrollSessionKey: UInt64]
+    }
+
     private var restoredPendingDecisionCardsAwaitingConfirmation: PendingDecisionRestorationGuard?
     /// Timestamp of the last successful coalesced cache flush; used to
     /// enforce a maximum 5-second interval even during continuous streaming.
@@ -636,6 +640,8 @@ final class AppState: ObservableObject {
     private var projectsRequestGeneration = 0
     private let sessionPresentationCache: SessionPresentationCache
     private let sessionYoloStore: SessionYoloStore
+    private var sessionYoloWriteRevision: UInt64 = 0
+    private var sessionYoloWriteRevisions: [ChatScrollSessionKey: UInt64] = [:]
 
     /// The dashboard's persisted transcript is richer than `session.resume`:
     /// it retains database timestamps, complete tool-call inputs, and other
@@ -2325,6 +2331,10 @@ final class AppState: ObservableObject {
         refreshActiveChatScrollSessionIdentity(isReconciling: true)
         turnState = .synchronizing
         let profile = activeProfile
+        // The resume RPC can overlap a user-initiated config.set. Capture the
+        // local-write position before launching either request so a response
+        // from the older snapshot cannot clear the newer override.
+        let yoloWriteBaseline = sessionYoloWriteBaseline(for: sessionId)
 
         do {
             // Match Hermes Desktop: fetch the durable transcript and resume the
@@ -2402,7 +2412,8 @@ final class AppState: ObservableObject {
             guard applyChatResume(
                 presentationResult,
                 automaticWorkToken: automaticWorkToken,
-                automaticSyncOperationID: automaticSyncOperationID
+                automaticSyncOperationID: automaticSyncOperationID,
+                yoloWriteBaseline: yoloWriteBaseline
             ) else {
                 settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
                 return false
@@ -2675,6 +2686,21 @@ final class AppState: ObservableObject {
         automaticWorkToken: ChatResumeAutomaticWorkToken? = nil,
         automaticSyncOperationID: UUID? = nil
     ) -> Bool {
+        applyChatResume(
+            result,
+            automaticWorkToken: automaticWorkToken,
+            automaticSyncOperationID: automaticSyncOperationID,
+            yoloWriteBaseline: nil
+        )
+    }
+
+    @discardableResult
+    private func applyChatResume(
+        _ result: SessionResumeResult,
+        automaticWorkToken: ChatResumeAutomaticWorkToken? = nil,
+        automaticSyncOperationID: UUID? = nil,
+        yoloWriteBaseline: SessionYoloWriteBaseline?
+    ) -> Bool {
         guard automaticChatResumeWorkIsCurrent(
             automaticWorkToken,
             syncOperationID: automaticSyncOperationID
@@ -2786,7 +2812,12 @@ final class AppState: ObservableObject {
         applyRuntime(
             result.snapshot,
             for: result.sessionId,
-            reconcileExplicitYolo: true
+            reconcileExplicitYolo: yoloWriteBaseline.map {
+                !hasNewerSessionYoloWrite(
+                    since: $0,
+                    sessionIDs: [result.sessionId, reconciliation?.requestedSessionId].compactMap { $0 }
+                )
+            } ?? true
         )
 
         // A paused clarification or approval can have neither a live text
@@ -3154,6 +3185,37 @@ final class AppState: ObservableObject {
             catalog: sessions + cronSessions,
             activeProfile: activeProfile
         )
+    }
+
+    private func sessionYoloKeys(for sessionIDs: [String]) -> Set<ChatScrollSessionKey> {
+        Set(sessionIDs.map { ChatScrollSessionKey(profile: activeProfile, sessionID: $0) })
+            .filter(\.isValid)
+    }
+
+    private func sessionYoloWriteBaseline(for sessionID: String) -> SessionYoloWriteBaseline {
+        let sessionIDs = [sessionID, canonicalSessionID(for: sessionID)].compactMap { $0 }
+        let keys = sessionYoloKeys(for: sessionIDs)
+        return SessionYoloWriteBaseline(
+            revisions: Dictionary(uniqueKeysWithValues: keys.map { key in
+                (key, sessionYoloWriteRevisions[key] ?? 0)
+            })
+        )
+    }
+
+    private func hasNewerSessionYoloWrite(
+        since baseline: SessionYoloWriteBaseline,
+        sessionIDs: [String]
+    ) -> Bool {
+        sessionYoloKeys(for: sessionIDs).contains { key in
+            sessionYoloWriteRevisions[key, default: 0] > baseline.revisions[key, default: 0]
+        }
+    }
+
+    private func recordSessionYoloWrite(for sessionIDs: [String]) {
+        sessionYoloWriteRevision &+= 1
+        for key in sessionYoloKeys(for: sessionIDs) {
+            sessionYoloWriteRevisions[key] = sessionYoloWriteRevision
+        }
     }
 
     private func applyRuntime(
@@ -4369,6 +4431,7 @@ final class AppState: ObservableObject {
                 for: activeProfile,
                 sessionID: persistedSessionID
             )
+            recordSessionYoloWrite(for: [sessionId, persistedSessionID])
             runtime.yolo = enabled
             return true
         } catch {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2409,6 +2409,13 @@ final class AppState: ObservableObject {
                 presentationResult = result
             }
 
+            let resumeSessionIDs = [result.sessionId, reconciliation?.requestedSessionId]
+                .compactMap { $0 }
+            let reconcileExplicitYolo = !hasNewerSessionYoloWrite(
+                since: yoloWriteBaseline,
+                sessionIDs: resumeSessionIDs
+            )
+
             guard applyChatResume(
                 presentationResult,
                 automaticWorkToken: automaticWorkToken,
@@ -2498,6 +2505,17 @@ final class AppState: ObservableObject {
                     hasBoundaryAnchor: boundary?.streamTextAtBoundary?
                         .trimmingCharacters(in: .whitespacesAndNewlines)
                         .isEmpty == false
+                )
+            }
+            if reconcileExplicitYolo {
+                // A session.info received while resume was in flight may be a
+                // pre-resume snapshot. Do not replay a contradictory YOLO
+                // value after fresh resume reconciliation clears an override;
+                // pushes received after reconciliation remain authoritative.
+                bufferedEvents = Self.filteringBufferedSessionInfo(
+                    bufferedEvents,
+                    against: result.snapshot,
+                    acceptedSessionIDs: reconciliation?.acceptedSessionIDs ?? Set([result.sessionId])
                 )
             }
             bufferedEvents.forEach(applyStreamEvent)
@@ -3102,6 +3120,24 @@ final class AppState: ObservableObject {
             }
         }
         return deduplicated
+    }
+
+    nonisolated static func filteringBufferedSessionInfo(
+        _ events: [StreamEvent],
+        against resumeSnapshot: SessionRuntimeSnapshot,
+        acceptedSessionIDs: Set<String>
+    ) -> [StreamEvent] {
+        guard let resumeYolo = resumeSnapshot.yolo else { return events }
+        return events.filter { event in
+            guard case .sessionInfo(let sessionID, let snapshot) = event,
+                  acceptedSessionIDs.contains(sessionID) else {
+                return true
+            }
+            let eventYolo = snapshot.yolo
+                ?? snapshot.approvalsMode.map { $0.lowercased() == "off" }
+            guard let eventYolo else { return true }
+            return eventYolo == resumeYolo
+        }
     }
 
     /// Returns every non-empty prefix of `buffered` that is also a suffix of

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -3171,6 +3171,15 @@ final class AppState: ObservableObject {
         let resolvedCanonicalSessionID = canonicalSessionID(for: requestedSessionID)
         let sessionIDsForOverride = [resolvedCanonicalSessionID, requestedSessionID]
             .compactMap { $0 }
+        if let resolvedCanonicalSessionID,
+           let requestedSessionID,
+           resolvedCanonicalSessionID != requestedSessionID {
+            sessionYoloStore.canonicalizeOverride(
+                for: activeProfile,
+                canonicalSessionID: resolvedCanonicalSessionID,
+                aliases: [requestedSessionID]
+            )
+        }
         let storedOverride = sessionYoloStore.storedOverride(
             for: activeProfile,
             sessionIDs: sessionIDsForOverride
@@ -3692,6 +3701,10 @@ final class AppState: ObservableObject {
             var updated = session
             updated.isArchived = archived
             if archived {
+                sessionYoloStore.clearOverride(
+                    for: profile,
+                    sessionIDs: [updated.id] + updated.alternateIds
+                )
                 removeSessionFromLiveCatalog(updated)
                 archivedSessions = [updated] + archivedSessions.filter { !sessionMatches($0, updated) }
                 removePinnedState(for: updated)
@@ -3804,6 +3817,10 @@ final class AppState: ObservableObject {
                 method: "DELETE"
             )
             guard profile == activeProfile else { return false }
+            sessionYoloStore.clearOverride(
+                for: profile,
+                sessionIDs: [session.id] + session.alternateIds
+            )
             removeSessionFromLiveCatalog(session)
             archivedSessions.removeAll { sessionMatches($0, session) }
             removePinnedState(for: session)

--- a/Conduit/Services/SessionYoloStore.swift
+++ b/Conduit/Services/SessionYoloStore.swift
@@ -32,10 +32,19 @@ final class SessionYoloStore {
     }
 
     func storedOverride(for profile: String, sessionID: String) -> Bool? {
-        guard let key = normalizedKey(profile: profile, sessionID: sessionID) else {
-            return nil
+        storedOverride(for: profile, sessionIDs: [sessionID])
+    }
+
+    func storedOverride(for profile: String, sessionIDs: [String]) -> Bool? {
+        for sessionID in sessionIDs {
+            guard let key = normalizedKey(profile: profile, sessionID: sessionID) else {
+                continue
+            }
+            if let override = payload.overrides[key.profile]?[key.sessionID] {
+                return override
+            }
         }
-        return payload.overrides[key.profile]?[key.sessionID]
+        return nil
     }
 
     func setOverride(_ enabled: Bool, for profile: String, sessionID: String) {
@@ -46,6 +55,28 @@ final class SessionYoloStore {
         profileOverrides[key.sessionID] = enabled
         payload.overrides[key.profile] = profileOverrides
         persist()
+    }
+
+    func clearOverride(for profile: String, sessionID: String) {
+        clearOverride(for: profile, sessionIDs: [sessionID])
+    }
+
+    func clearOverride(for profile: String, sessionIDs: [String]) {
+        var changed = false
+        for sessionID in sessionIDs {
+            guard let key = normalizedKey(profile: profile, sessionID: sessionID),
+                  payload.overrides[key.profile]?[key.sessionID] != nil else {
+                continue
+            }
+            payload.overrides[key.profile]?.removeValue(forKey: key.sessionID)
+            if payload.overrides[key.profile]?.isEmpty == true {
+                payload.overrides.removeValue(forKey: key.profile)
+            }
+            changed = true
+        }
+        if changed {
+            persist()
+        }
     }
 
     private func normalizedKey(profile: String, sessionID: String) -> ChatScrollSessionKey? {

--- a/Conduit/Services/SessionYoloStore.swift
+++ b/Conduit/Services/SessionYoloStore.swift
@@ -1,4 +1,16 @@
 import Foundation
+import OSLog
+
+enum SessionYoloStoreDiagnostic: Equatable {
+    case decodeFailure
+    case unsupportedVersion(Int)
+    case encodeFailure
+}
+
+private let sessionYoloStoreLog = Logger(
+    subsystem: "com.milim.conduit",
+    category: "SessionYoloStore"
+)
 
 /// Stores explicit session-level YOLO choices independently from the
 /// profile-wide approval setting returned by Hermes.
@@ -14,20 +26,41 @@ final class SessionYoloStore {
     private static let schemaVersion = 1
     private let defaults: UserDefaults
     private let storageKey: String
+    private let diagnosticHandler: (@MainActor (SessionYoloStoreDiagnostic) -> Void)?
     private var payload: Payload
 
     init(
         defaults: UserDefaults = .standard,
-        storageKey: String = SessionYoloStore.defaultStorageKey
+        storageKey: String = SessionYoloStore.defaultStorageKey,
+        diagnosticHandler: (@MainActor (SessionYoloStoreDiagnostic) -> Void)? = nil
     ) {
         self.defaults = defaults
         self.storageKey = storageKey
-        if let data = defaults.data(forKey: storageKey),
-           let decoded = try? JSONDecoder().decode(Payload.self, from: data),
-           decoded.version == Self.schemaVersion {
-            payload = decoded
+        self.diagnosticHandler = diagnosticHandler
+
+        let loadedPayload: Payload
+        let diagnostic: SessionYoloStoreDiagnostic?
+        if let data = defaults.data(forKey: storageKey) {
+            do {
+                let decoded = try JSONDecoder().decode(Payload.self, from: data)
+                if decoded.version == Self.schemaVersion {
+                    loadedPayload = decoded
+                    diagnostic = nil
+                } else {
+                    loadedPayload = Payload(version: Self.schemaVersion, overrides: [:])
+                    diagnostic = .unsupportedVersion(decoded.version)
+                }
+            } catch {
+                loadedPayload = Payload(version: Self.schemaVersion, overrides: [:])
+                diagnostic = .decodeFailure
+            }
         } else {
-            payload = Payload(version: Self.schemaVersion, overrides: [:])
+            loadedPayload = Payload(version: Self.schemaVersion, overrides: [:])
+            diagnostic = nil
+        }
+        payload = loadedPayload
+        if let diagnostic {
+            report(diagnostic)
         }
     }
 
@@ -55,6 +88,45 @@ final class SessionYoloStore {
         profileOverrides[key.sessionID] = enabled
         payload.overrides[key.profile] = profileOverrides
         persist()
+    }
+
+    func canonicalizeOverride(
+        for profile: String,
+        canonicalSessionID: String,
+        aliases: [String]
+    ) {
+        guard let canonicalKey = normalizedKey(
+            profile: profile,
+            sessionID: canonicalSessionID
+        ) else {
+            return
+        }
+
+        var canonicalValue = payload.overrides[canonicalKey.profile]?[canonicalKey.sessionID]
+        var changed = false
+        for alias in aliases {
+            guard let aliasKey = normalizedKey(profile: profile, sessionID: alias),
+                  aliasKey != canonicalKey,
+                  let aliasValue = payload.overrides[aliasKey.profile]?[aliasKey.sessionID] else {
+                continue
+            }
+
+            if canonicalValue == nil {
+                var profileOverrides = payload.overrides[canonicalKey.profile] ?? [:]
+                profileOverrides[canonicalKey.sessionID] = aliasValue
+                payload.overrides[canonicalKey.profile] = profileOverrides
+                canonicalValue = aliasValue
+            }
+            payload.overrides[aliasKey.profile]?.removeValue(forKey: aliasKey.sessionID)
+            if payload.overrides[aliasKey.profile]?.isEmpty == true {
+                payload.overrides.removeValue(forKey: aliasKey.profile)
+            }
+            changed = true
+        }
+
+        if changed {
+            persist()
+        }
     }
 
     func clearOverride(for profile: String, sessionID: String) {
@@ -85,7 +157,23 @@ final class SessionYoloStore {
     }
 
     private func persist() {
-        guard let data = try? JSONEncoder().encode(payload) else { return }
-        defaults.set(data, forKey: storageKey)
+        do {
+            let data = try JSONEncoder().encode(payload)
+            defaults.set(data, forKey: storageKey)
+        } catch {
+            report(.encodeFailure)
+        }
+    }
+
+    private func report(_ diagnostic: SessionYoloStoreDiagnostic) {
+        switch diagnostic {
+        case .decodeFailure:
+            sessionYoloStoreLog.error("Unable to decode persisted session YOLO overrides; starting empty")
+        case .unsupportedVersion(let version):
+            sessionYoloStoreLog.error("Ignoring unsupported session YOLO override schema version \(version, privacy: .public)")
+        case .encodeFailure:
+            sessionYoloStoreLog.error("Unable to persist session YOLO overrides")
+        }
+        diagnosticHandler?(diagnostic)
     }
 }

--- a/Conduit/Services/SessionYoloStore.swift
+++ b/Conduit/Services/SessionYoloStore.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Stores explicit session-level YOLO choices independently from the
+/// profile-wide approval setting returned by Hermes.
+@MainActor
+final class SessionYoloStore {
+    nonisolated static let defaultStorageKey = "conduit.sessionYolo.v1"
+
+    private struct Payload: Codable {
+        var version: Int
+        var overrides: [String: [String: Bool]]
+    }
+
+    private static let schemaVersion = 1
+    private let defaults: UserDefaults
+    private let storageKey: String
+    private var payload: Payload
+
+    init(
+        defaults: UserDefaults = .standard,
+        storageKey: String = SessionYoloStore.defaultStorageKey
+    ) {
+        self.defaults = defaults
+        self.storageKey = storageKey
+        if let data = defaults.data(forKey: storageKey),
+           let decoded = try? JSONDecoder().decode(Payload.self, from: data),
+           decoded.version == Self.schemaVersion {
+            payload = decoded
+        } else {
+            payload = Payload(version: Self.schemaVersion, overrides: [:])
+        }
+    }
+
+    func storedOverride(for profile: String, sessionID: String) -> Bool? {
+        guard let key = normalizedKey(profile: profile, sessionID: sessionID) else {
+            return nil
+        }
+        return payload.overrides[key.profile]?[key.sessionID]
+    }
+
+    func setOverride(_ enabled: Bool, for profile: String, sessionID: String) {
+        guard let key = normalizedKey(profile: profile, sessionID: sessionID) else {
+            return
+        }
+        var profileOverrides = payload.overrides[key.profile] ?? [:]
+        profileOverrides[key.sessionID] = enabled
+        payload.overrides[key.profile] = profileOverrides
+        persist()
+    }
+
+    private func normalizedKey(profile: String, sessionID: String) -> ChatScrollSessionKey? {
+        let key = ChatScrollSessionKey(profile: profile, sessionID: sessionID)
+        return key.isValid ? key : nil
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(payload) else { return }
+        defaults.set(data, forKey: storageKey)
+    }
+}

--- a/Conduit/Views/ModelPickerView.swift
+++ b/Conduit/Views/ModelPickerView.swift
@@ -20,6 +20,11 @@ struct ModelPickerYoloDraft: Equatable {
         initial = runtimeYolo
         selected = runtimeYolo
     }
+
+    static func seededIfNeeded(initial: Bool?, runtimeYolo: Bool) -> ModelPickerYoloDraft? {
+        guard initial == nil else { return nil }
+        return ModelPickerYoloDraft(runtimeYolo: runtimeYolo)
+    }
 }
 
 struct ModelPickerView: View {
@@ -83,9 +88,13 @@ struct ModelPickerView: View {
         }
         .preferredColorScheme(appState.themePreference.colorScheme)
         .onAppear {
-            let draft = ModelPickerYoloDraft(runtimeYolo: appState.runtime.yolo)
-            yoloEnabled = draft.selected
-            initialYoloEnabled = draft.initial
+            if let draft = ModelPickerYoloDraft.seededIfNeeded(
+                initial: initialYoloEnabled,
+                runtimeYolo: appState.runtime.yolo
+            ) {
+                yoloEnabled = draft.selected
+                initialYoloEnabled = draft.initial
+            }
         }
         .task { await loadModels() }
     }

--- a/Conduit/Views/ModelPickerView.swift
+++ b/Conduit/Views/ModelPickerView.swift
@@ -7,6 +7,11 @@
 
 import SwiftUI
 
+func sessionYoloSelectionChanged(from initial: Bool?, to selected: Bool) -> Bool {
+    guard let initial else { return false }
+    return initial != selected
+}
+
 struct ModelPickerView: View {
     @EnvironmentObject var appState: AppState
     @Environment(\.colorScheme) private var colorScheme
@@ -16,6 +21,7 @@ struct ModelPickerView: View {
     @State private var reasoningEffort = "medium"
     @State private var fastEnabled = false
     @State private var yoloEnabled = false
+    @State private var initialYoloEnabled: Bool?
     @State private var providers: [ProviderInfo] = []
     @State private var expandedProvider: String?
     @State private var editingVisibility = false
@@ -384,6 +390,7 @@ struct ModelPickerView: View {
             }
             fastEnabled = appState.runtime.fast
             yoloEnabled = appState.runtime.yolo
+            initialYoloEnabled = appState.runtime.yolo
         } catch {
             // Model options are supplementary to the current session state.
         }
@@ -402,7 +409,9 @@ struct ModelPickerView: View {
             appState.runtime.reasoningEffort = reasoningEnabled ? reasoningEffort : ""
             try await client.setFast(sessionId, enabled: fastEnabled)
             appState.runtime.fast = fastEnabled
-            guard await appState.setYoloMode(yoloEnabled) else { return }
+            if sessionYoloSelectionChanged(from: initialYoloEnabled, to: yoloEnabled) {
+                guard await appState.setYoloMode(yoloEnabled) else { return }
+            }
             appState.showModelPicker = false
         } catch {
             appState.errorMessage = error.localizedDescription

--- a/Conduit/Views/ModelPickerView.swift
+++ b/Conduit/Views/ModelPickerView.swift
@@ -12,6 +12,16 @@ func sessionYoloSelectionChanged(from initial: Bool?, to selected: Bool) -> Bool
     return initial != selected
 }
 
+struct ModelPickerYoloDraft: Equatable {
+    let initial: Bool
+    let selected: Bool
+
+    init(runtimeYolo: Bool) {
+        initial = runtimeYolo
+        selected = runtimeYolo
+    }
+}
+
 struct ModelPickerView: View {
     @EnvironmentObject var appState: AppState
     @Environment(\.colorScheme) private var colorScheme
@@ -72,6 +82,11 @@ struct ModelPickerView: View {
             }
         }
         .preferredColorScheme(appState.themePreference.colorScheme)
+        .onAppear {
+            let draft = ModelPickerYoloDraft(runtimeYolo: appState.runtime.yolo)
+            yoloEnabled = draft.selected
+            initialYoloEnabled = draft.initial
+        }
         .task { await loadModels() }
     }
 
@@ -389,8 +404,11 @@ struct ModelPickerView: View {
                 reasoningEffort = appState.runtime.reasoningEffort
             }
             fastEnabled = appState.runtime.fast
-            yoloEnabled = appState.runtime.yolo
-            initialYoloEnabled = appState.runtime.yolo
+            if initialYoloEnabled == nil {
+                let draft = ModelPickerYoloDraft(runtimeYolo: appState.runtime.yolo)
+                yoloEnabled = draft.selected
+                initialYoloEnabled = draft.initial
+            }
         } catch {
             // Model options are supplementary to the current session state.
         }

--- a/Conduit/Views/ModelPickerView.swift
+++ b/Conduit/Views/ModelPickerView.swift
@@ -427,6 +427,13 @@ struct ModelPickerView: View {
         guard let client = appState.client, let sessionId = appState.activeSessionId else { return }
 
         do {
+            // Apply YOLO first. setYoloMode persists the session override only
+            // after the gateway accepts it, so a failure must bail before any of
+            // the other settings are mutated — otherwise the sheet hangs open
+            // showing a partially-applied configuration with no rollback.
+            if sessionYoloSelectionChanged(from: initialYoloEnabled, to: yoloEnabled) {
+                guard await appState.setYoloMode(yoloEnabled) else { return }
+            }
             if !selectedModel.isEmpty && !selectedProvider.isEmpty {
                 try await client.setModel(sessionId, model: selectedModel, provider: selectedProvider)
                 appState.runtime.model = selectedModel
@@ -436,9 +443,6 @@ struct ModelPickerView: View {
             appState.runtime.reasoningEffort = reasoningEnabled ? reasoningEffort : ""
             try await client.setFast(sessionId, enabled: fastEnabled)
             appState.runtime.fast = fastEnabled
-            if sessionYoloSelectionChanged(from: initialYoloEnabled, to: yoloEnabled) {
-                guard await appState.setYoloMode(yoloEnabled) else { return }
-            }
             appState.showModelPicker = false
         } catch {
             appState.errorMessage = error.localizedDescription

--- a/ConduitTests/ModelPickerTests.swift
+++ b/ConduitTests/ModelPickerTests.swift
@@ -2,6 +2,13 @@ import XCTest
 @testable import Conduit
 
 final class ModelPickerTests: XCTestCase {
+    func testModelPickerYoloDraftStartsFromCurrentRuntimeValue() {
+        let draft = ModelPickerYoloDraft(runtimeYolo: true)
+
+        XCTAssertTrue(draft.initial)
+        XCTAssertTrue(draft.selected)
+    }
+
     func testUnchangedYoloSelectionDoesNotPersistASessionOverride() {
         XCTAssertFalse(sessionYoloSelectionChanged(from: true, to: true))
     }

--- a/ConduitTests/ModelPickerTests.swift
+++ b/ConduitTests/ModelPickerTests.swift
@@ -9,6 +9,18 @@ final class ModelPickerTests: XCTestCase {
         XCTAssertTrue(draft.selected)
     }
 
+    func testModelPickerYoloDraftSeedsWhenInitialBaselineIsMissing() {
+        let draft = ModelPickerYoloDraft.seededIfNeeded(initial: nil, runtimeYolo: true)
+
+        XCTAssertEqual(draft, ModelPickerYoloDraft(runtimeYolo: true))
+    }
+
+    func testModelPickerYoloDraftDoesNotReseedAnExistingBaseline() {
+        let draft = ModelPickerYoloDraft.seededIfNeeded(initial: false, runtimeYolo: true)
+
+        XCTAssertNil(draft)
+    }
+
     func testUnchangedYoloSelectionDoesNotPersistASessionOverride() {
         XCTAssertFalse(sessionYoloSelectionChanged(from: true, to: true))
     }

--- a/ConduitTests/ModelPickerTests.swift
+++ b/ConduitTests/ModelPickerTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import Conduit
+
+final class ModelPickerTests: XCTestCase {
+    func testUnchangedYoloSelectionDoesNotPersistASessionOverride() {
+        XCTAssertFalse(sessionYoloSelectionChanged(from: true, to: true))
+    }
+
+    func testChangedYoloSelectionPersistsTheNewSessionOverride() {
+        XCTAssertTrue(sessionYoloSelectionChanged(from: false, to: true))
+        XCTAssertTrue(sessionYoloSelectionChanged(from: true, to: false))
+    }
+
+    func testSelectionBeforeInitialLoadDoesNotPersistAnOverride() {
+        XCTAssertFalse(sessionYoloSelectionChanged(from: nil, to: true))
+    }
+}

--- a/ConduitTests/SessionYoloPersistenceTests.swift
+++ b/ConduitTests/SessionYoloPersistenceTests.swift
@@ -216,6 +216,55 @@ final class SessionYoloPersistenceTests: XCTestCase {
         XCTAssertEqual(store.storedOverride(for: "default", sessionID: "session-a"), true)
     }
 
+    func testStaleResumeSnapshotCannotClearJustPersistedOverride() async {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let openGate = SessionYoloResumeGate()
+        let operations = ChatResumeLifecycleOperations(
+            loadCatalog: { _, _ in [self.session("session-a")] },
+            openSession: { _, sessionID in
+                await openGate.suspend()
+                return SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: [
+                        "running": .bool(false),
+                        "yolo": .bool(false),
+                        "approvals_mode": .string("on")
+                    ])
+                )
+            },
+            refreshContext: { _, _ in },
+            setSessionYolo: { _, _, _ in }
+        )
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        let appState = makeAppState(
+            defaults: defaults,
+            store: store,
+            lifecycleOperations: operations
+        )
+        appState.sessions = [session("session-a")]
+        appState.activeSessionId = "session-a"
+        appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+
+        let resume = Task { @MainActor in
+            await appState.syncSession()
+        }
+        await openGate.waitUntilSuspended()
+
+        let enabled = await appState.setYoloMode(true)
+        XCTAssertTrue(enabled)
+
+        openGate.resume()
+        await resume.value
+
+        XCTAssertTrue(appState.runtime.yolo)
+        XCTAssertEqual(store.storedOverride(for: "default", sessionID: "session-a"), true)
+    }
+
     func testFailedSessionYoloChangeDoesNotPersistOrChangeRuntime() async {
         let (suite, defaults) = makeDefaults()
         defer { defaults.removePersistentDomain(forName: suite) }
@@ -285,4 +334,30 @@ final class SessionYoloPersistenceTests: XCTestCase {
 
 private enum TestError: Error {
     case rejected
+}
+
+@MainActor
+private final class SessionYoloResumeGate {
+    private var suspension: CheckedContinuation<Void, Never>?
+    private var observer: CheckedContinuation<Void, Never>?
+
+    func suspend() async {
+        await withCheckedContinuation { continuation in
+            suspension = continuation
+            observer?.resume()
+            observer = nil
+        }
+    }
+
+    func waitUntilSuspended() async {
+        guard suspension == nil else { return }
+        await withCheckedContinuation { continuation in
+            observer = continuation
+        }
+    }
+
+    func resume() {
+        suspension?.resume()
+        suspension = nil
+    }
 }

--- a/ConduitTests/SessionYoloPersistenceTests.swift
+++ b/ConduitTests/SessionYoloPersistenceTests.swift
@@ -37,6 +37,48 @@ final class SessionYoloPersistenceTests: XCTestCase {
         XCTAssertTrue(relaunched.runtime.yolo)
     }
 
+    func testRuntimeIDOverrideRemainsVisibleAfterCatalogProvidesCanonicalID() {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        store.setOverride(true, for: "default", sessionID: "runtime-session")
+
+        let appState = makeAppState(defaults: defaults, store: store)
+        appState.sessions = [session("canonical-session", alternateIDs: ["runtime-session"])]
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: "runtime-session",
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false),
+                "approvals_mode": .string("on")
+            ])
+        ))
+
+        XCTAssertTrue(appState.runtime.yolo)
+    }
+
+    func testExplicitGatewayYoloReplacesConflictingLocalOverride() {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        store.setOverride(true, for: "default", sessionID: "session-a")
+
+        let appState = makeAppState(defaults: defaults, store: store)
+        appState.sessions = [session("session-a")]
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: "session-a",
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false),
+                "yolo": .bool(false),
+                "approvals_mode": .string("on")
+            ])
+        ))
+
+        XCTAssertFalse(appState.runtime.yolo)
+        XCTAssertNil(store.storedOverride(for: "default", sessionID: "session-a"))
+    }
+
     func testServerSessionYoloWinsOverProfileApprovalFallbackWhenNoOverrideExists() {
         let (suite, defaults) = makeDefaults()
         defer { defaults.removePersistentDomain(forName: suite) }

--- a/ConduitTests/SessionYoloPersistenceTests.swift
+++ b/ConduitTests/SessionYoloPersistenceTests.swift
@@ -265,6 +265,61 @@ final class SessionYoloPersistenceTests: XCTestCase {
         XCTAssertEqual(store.storedOverride(for: "default", sessionID: "session-a"), true)
     }
 
+    func testBufferedStaleSessionInfoCannotReapplyClearedOverride() async {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let openGate = SessionYoloResumeGate()
+        let operations = ChatResumeLifecycleOperations(
+            loadCatalog: { _, _ in [self.session("session-a")] },
+            openSession: { _, sessionID in
+                await openGate.suspend()
+                return SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: [
+                        "running": .bool(false),
+                        "yolo": .bool(false),
+                        "approvals_mode": .string("on")
+                    ])
+                )
+            },
+            refreshContext: { _, _ in }
+        )
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        store.setOverride(true, for: "default", sessionID: "session-a")
+        let appState = makeAppState(
+            defaults: defaults,
+            store: store,
+            lifecycleOperations: operations
+        )
+        appState.sessions = [session("session-a")]
+        appState.activeSessionId = "session-a"
+        appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+
+        let resume = Task { @MainActor in
+            await appState.syncSession()
+        }
+        await openGate.waitUntilSuspended()
+
+        appState.handleStreamEvent(.sessionInfo(
+            sessionId: "session-a",
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false),
+                "yolo": .bool(true),
+                "approvals_mode": .string("on")
+            ])
+        ))
+
+        openGate.resume()
+        await resume.value
+
+        XCTAssertFalse(appState.runtime.yolo)
+        XCTAssertNil(store.storedOverride(for: "default", sessionID: "session-a"))
+    }
+
     func testFailedSessionYoloChangeDoesNotPersistOrChangeRuntime() async {
         let (suite, defaults) = makeDefaults()
         defer { defaults.removePersistentDomain(forName: suite) }

--- a/ConduitTests/SessionYoloPersistenceTests.swift
+++ b/ConduitTests/SessionYoloPersistenceTests.swift
@@ -181,6 +181,41 @@ final class SessionYoloPersistenceTests: XCTestCase {
         XCTAssertFalse(appState.runtime.yolo)
     }
 
+    func testStaleLiveSessionInfoCannotClearJustPersistedOverride() async {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        let operations = ChatResumeLifecycleOperations(
+            setSessionYolo: { _, _, _ in }
+        )
+        let appState = makeAppState(
+            defaults: defaults,
+            store: store,
+            lifecycleOperations: operations
+        )
+        appState.sessions = [session("session-a")]
+        appState.activeSessionId = "session-a"
+        appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+
+        let enabled = await appState.setYoloMode(true)
+        XCTAssertTrue(enabled)
+
+        appState.handleStreamEvent(.sessionInfo(
+            sessionId: "session-a",
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false),
+                "yolo": .bool(false),
+                "approvals_mode": .string("on")
+            ])
+        ))
+
+        XCTAssertTrue(appState.runtime.yolo)
+        XCTAssertEqual(store.storedOverride(for: "default", sessionID: "session-a"), true)
+    }
+
     func testFailedSessionYoloChangeDoesNotPersistOrChangeRuntime() async {
         let (suite, defaults) = makeDefaults()
         defer { defaults.removePersistentDomain(forName: suite) }

--- a/ConduitTests/SessionYoloPersistenceTests.swift
+++ b/ConduitTests/SessionYoloPersistenceTests.swift
@@ -1,0 +1,209 @@
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class SessionYoloPersistenceTests: XCTestCase {
+    func testStoredOverrideWinsOverLaterProfileApprovalSnapshotAndSurvivesRelaunch() {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        store.setOverride(true, for: "default", sessionID: "canonical-session")
+
+        let first = makeAppState(defaults: defaults, store: store)
+        first.sessions = [session("canonical-session", alternateIDs: ["runtime-session"])]
+        first.applyChatResume(SessionResumeResult(
+            sessionId: "runtime-session",
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false),
+                "approvals_mode": .string("on")
+            ])
+        ))
+
+        XCTAssertTrue(first.runtime.yolo)
+
+        let recreatedStore = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        let relaunched = makeAppState(defaults: defaults, store: recreatedStore)
+        relaunched.sessions = [session("canonical-session", alternateIDs: ["runtime-session"])]
+        relaunched.applyChatResume(SessionResumeResult(
+            sessionId: "runtime-session",
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false),
+                "approvals_mode": .string("on")
+            ])
+        ))
+
+        XCTAssertTrue(relaunched.runtime.yolo)
+    }
+
+    func testServerSessionYoloWinsOverProfileApprovalFallbackWhenNoOverrideExists() {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        let appState = makeAppState(defaults: defaults, store: store)
+        appState.sessions = [session("session-a")]
+
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: "session-a",
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false),
+                "yolo": .bool(false),
+                "approvals_mode": .string("off")
+            ])
+        ))
+
+        XCTAssertFalse(appState.runtime.yolo)
+
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: "session-a",
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false),
+                "approvals_mode": .string("off")
+            ])
+        ))
+
+        XCTAssertTrue(appState.runtime.yolo)
+    }
+
+    func testSwitchingSessionsRecomputesTheSessionSpecificOverride() {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        store.setOverride(true, for: "default", sessionID: "session-a")
+        let appState = makeAppState(defaults: defaults, store: store)
+        appState.sessions = [session("session-a"), session("session-b")]
+
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: "session-a",
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false),
+                "approvals_mode": .string("on")
+            ])
+        ))
+        XCTAssertTrue(appState.runtime.yolo)
+
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: "session-b",
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false),
+                "approvals_mode": .string("on")
+            ])
+        ))
+        XCTAssertFalse(appState.runtime.yolo)
+
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: "session-a",
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false),
+                "approvals_mode": .string("on")
+            ])
+        ))
+        XCTAssertTrue(appState.runtime.yolo)
+    }
+
+    func testSuccessfulSessionYoloChangePersistsOnlyAfterGatewaySuccess() async {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        let operations = ChatResumeLifecycleOperations(
+            setSessionYolo: { _, _, _ in }
+        )
+        let appState = makeAppState(
+            defaults: defaults,
+            store: store,
+            lifecycleOperations: operations
+        )
+        appState.sessions = [session("session-a")]
+        appState.activeSessionId = "session-a"
+        appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+
+        let enabled = await appState.setYoloMode(true)
+        XCTAssertTrue(enabled)
+        XCTAssertEqual(store.storedOverride(for: "default", sessionID: "session-a"), true)
+        XCTAssertTrue(appState.runtime.yolo)
+
+        let disabled = await appState.setYoloMode(false)
+        XCTAssertTrue(disabled)
+        XCTAssertEqual(store.storedOverride(for: "default", sessionID: "session-a"), false)
+        XCTAssertFalse(appState.runtime.yolo)
+    }
+
+    func testFailedSessionYoloChangeDoesNotPersistOrChangeRuntime() async {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        let operations = ChatResumeLifecycleOperations(
+            setSessionYolo: { _, _, _ in throw TestError.rejected }
+        )
+        let appState = makeAppState(
+            defaults: defaults,
+            store: store,
+            lifecycleOperations: operations
+        )
+        appState.sessions = [session("session-a")]
+        appState.activeSessionId = "session-a"
+        appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+
+        let enabled = await appState.setYoloMode(true)
+        XCTAssertFalse(enabled)
+        XCTAssertNil(store.storedOverride(for: "default", sessionID: "session-a"))
+        XCTAssertFalse(appState.runtime.yolo)
+    }
+
+    private func makeAppState(
+        defaults: UserDefaults,
+        store: SessionYoloStore,
+        lifecycleOperations: ChatResumeLifecycleOperations = ChatResumeLifecycleOperations()
+    ) -> AppState {
+        AppState(
+            defaults: defaults,
+            loadSavedConnection: false,
+            chatResumeLifecycleOperations: lifecycleOperations,
+            sessionPresentationCache: SessionPresentationCache(defaults: defaults),
+            sessionYoloStore: store
+        )
+    }
+
+    private func session(
+        _ id: String,
+        alternateIDs: [String] = [],
+        profile: String = "default"
+    ) -> SessionSummary {
+        SessionSummary(
+            id: id,
+            alternateIds: alternateIDs,
+            title: id,
+            model: "Hermes",
+            updatedLabel: "now",
+            profile: profile,
+            source: .chat,
+            isActive: false,
+            isArchived: false,
+            lineageRootId: nil
+        )
+    }
+
+    private func makeDefaults() -> (String, UserDefaults) {
+        let suite = "SessionYoloPersistenceTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Could not create isolated UserDefaults suite")
+        }
+        return (suite, defaults)
+    }
+}
+
+private enum TestError: Error {
+    case rejected
+}

--- a/ConduitTests/SessionYoloPersistenceTests.swift
+++ b/ConduitTests/SessionYoloPersistenceTests.swift
@@ -320,6 +320,66 @@ final class SessionYoloPersistenceTests: XCTestCase {
         XCTAssertNil(store.storedOverride(for: "default", sessionID: "session-a"))
     }
 
+    func testBufferedConflictingSessionInfoPreservesNonYoloRuntimeFields() async {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let openGate = SessionYoloResumeGate()
+        let operations = ChatResumeLifecycleOperations(
+            loadCatalog: { _, _ in [self.session("session-a")] },
+            openSession: { _, sessionID in
+                await openGate.suspend()
+                return SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: [
+                        "running": .bool(false),
+                        "model": .string("resume-model"),
+                        "provider": .string("resume-provider"),
+                        "context_percent": .number(10),
+                        "yolo": .bool(false)
+                    ])
+                )
+            },
+            refreshContext: { _, _ in }
+        )
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        let appState = makeAppState(
+            defaults: defaults,
+            store: store,
+            lifecycleOperations: operations
+        )
+        appState.sessions = [session("session-a")]
+        appState.activeSessionId = "session-a"
+        appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+
+        let resume = Task { @MainActor in
+            await appState.syncSession()
+        }
+        await openGate.waitUntilSuspended()
+
+        appState.handleStreamEvent(.sessionInfo(
+            sessionId: "session-a",
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(true),
+                "model": .string("buffered-model"),
+                "provider": .string("buffered-provider"),
+                "context_percent": .number(42),
+                "yolo": .bool(true)
+            ])
+        ))
+
+        openGate.resume()
+        await resume.value
+
+        XCTAssertFalse(appState.runtime.yolo)
+        XCTAssertEqual(appState.runtime.model, "buffered-model")
+        XCTAssertEqual(appState.runtime.provider, "buffered-provider")
+        XCTAssertEqual(appState.runtime.contextPercent, 42)
+    }
+
     func testFailedSessionYoloChangeDoesNotPersistOrChangeRuntime() async {
         let (suite, defaults) = makeDefaults()
         defer { defaults.removePersistentDomain(forName: suite) }

--- a/ConduitTests/SessionYoloPersistenceTests.swift
+++ b/ConduitTests/SessionYoloPersistenceTests.swift
@@ -55,6 +55,8 @@ final class SessionYoloPersistenceTests: XCTestCase {
         ))
 
         XCTAssertTrue(appState.runtime.yolo)
+        XCTAssertEqual(store.storedOverride(for: "default", sessionID: "canonical-session"), true)
+        XCTAssertNil(store.storedOverride(for: "default", sessionID: "runtime-session"))
     }
 
     func testExplicitGatewayYoloReplacesConflictingLocalOverride() {

--- a/ConduitTests/SessionYoloStoreTests.swift
+++ b/ConduitTests/SessionYoloStoreTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class SessionYoloStoreTests: XCTestCase {
+    func testMissingOverrideIsDistinctFromExplicitFalse() {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+
+        XCTAssertNil(store.storedOverride(for: "default", sessionID: "session-a"))
+
+        store.setOverride(false, for: "default", sessionID: "session-a")
+
+        XCTAssertEqual(store.storedOverride(for: "default", sessionID: "session-a"), false)
+        XCTAssertNil(store.storedOverride(for: "default", sessionID: "session-b"))
+    }
+
+    func testTrueAndFalseOverridesRoundTripThroughDefaults() {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let key = "test.session-yolo"
+        let store = SessionYoloStore(defaults: defaults, storageKey: key)
+
+        store.setOverride(true, for: "Default", sessionID: "session-a")
+        store.setOverride(false, for: "default", sessionID: "session-b")
+
+        let recreated = SessionYoloStore(defaults: defaults, storageKey: key)
+        XCTAssertEqual(recreated.storedOverride(for: " default ", sessionID: "session-a"), true)
+        XCTAssertEqual(recreated.storedOverride(for: "DEFAULT", sessionID: "session-b"), false)
+    }
+
+    func testOverridesAreIsolatedByProfileAndSession() {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+
+        store.setOverride(true, for: "work", sessionID: "same-session")
+        store.setOverride(false, for: "personal", sessionID: "same-session")
+        store.setOverride(false, for: "work", sessionID: "other-session")
+
+        XCTAssertEqual(store.storedOverride(for: "work", sessionID: "same-session"), true)
+        XCTAssertEqual(store.storedOverride(for: "personal", sessionID: "same-session"), false)
+        XCTAssertEqual(store.storedOverride(for: "work", sessionID: "other-session"), false)
+        XCTAssertNil(store.storedOverride(for: "personal", sessionID: "other-session"))
+    }
+
+    func testInvalidKeysDoNotPersistAnOverride() {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+
+        store.setOverride(true, for: "   ", sessionID: "session-a")
+        store.setOverride(true, for: "default", sessionID: "   ")
+
+        XCTAssertNil(store.storedOverride(for: "default", sessionID: "session-a"))
+        XCTAssertNil(store.storedOverride(for: "default", sessionID: ""))
+    }
+
+    private func makeDefaults() -> (String, UserDefaults) {
+        let suite = "SessionYoloStoreTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Could not create isolated UserDefaults suite")
+        }
+        return (suite, defaults)
+    }
+}

--- a/ConduitTests/SessionYoloStoreTests.swift
+++ b/ConduitTests/SessionYoloStoreTests.swift
@@ -57,6 +57,44 @@ final class SessionYoloStoreTests: XCTestCase {
         XCTAssertNil(store.storedOverride(for: "default", sessionID: ""))
     }
 
+    func testCorruptPersistedPayloadReportsDiagnostic() {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let key = "test.session-yolo"
+        defaults.set(Data("not-json".utf8), forKey: key)
+        var diagnostics: [SessionYoloStoreDiagnostic] = []
+
+        let store = SessionYoloStore(
+            defaults: defaults,
+            storageKey: key,
+            diagnosticHandler: { diagnostics.append($0) }
+        )
+
+        XCTAssertNil(store.storedOverride(for: "default", sessionID: "session-a"))
+        XCTAssertEqual(diagnostics, [.decodeFailure])
+    }
+
+    func testUnsupportedPersistedPayloadVersionReportsDiagnostic() throws {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let key = "test.session-yolo"
+        let data = try JSONSerialization.data(withJSONObject: [
+            "version": 99,
+            "overrides": [:]
+        ])
+        defaults.set(data, forKey: key)
+        var diagnostics: [SessionYoloStoreDiagnostic] = []
+
+        let store = SessionYoloStore(
+            defaults: defaults,
+            storageKey: key,
+            diagnosticHandler: { diagnostics.append($0) }
+        )
+
+        XCTAssertNil(store.storedOverride(for: "default", sessionID: "session-a"))
+        XCTAssertEqual(diagnostics, [.unsupportedVersion(99)])
+    }
+
     private func makeDefaults() -> (String, UserDefaults) {
         let suite = "SessionYoloStoreTests.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suite) else {

--- a/docs/superpowers/plans/2026-08-13-session-yolo-persistence.md
+++ b/docs/superpowers/plans/2026-08-13-session-yolo-persistence.md
@@ -1,0 +1,50 @@
+# Implementation Plan: Persist Session YOLO Overrides
+
+**Goal:** Persist an explicit YOLO choice per normalized profile and canonical conversation, restore it across turns/backgrounding/relaunch, and prevent it from leaking between sessions.
+
+**Architecture:** Add an injectable `UserDefaults`-backed `SessionYoloStore` with three states (`true`, `false`, absent). Resolve the active canonical session through the existing chat identity/catalog seam, then apply local override > explicit session snapshot `yolo` > profile `approvalsMode`.
+
+**Tech Stack:** Swift, SwiftUI `AppState`, UserDefaults/JSON Codable storage, XCTest, XcodeGen, iOS Simulator.
+
+## Tasks
+
+- [ ] 1. Add store and AppState regression tests first (RED)
+  - Add `ConduitTests/SessionYoloStoreTests.swift` with isolated UserDefaults coverage for absent, `true`, and `false` values, plus profile/session isolation and round-trip persistence.
+  - Add focused AppState coverage in a dedicated `ConduitTests/SessionYoloPersistenceTests.swift` for:
+    - a stored session override winning over a later snapshot containing only `approvals_mode`;
+    - no override using explicit `snapshot.yolo`, then `approvals_mode` when session YOLO is omitted;
+    - switching from overridden session A to unoverridden session B and back without leaking A's value;
+    - canonicalizing an alternate runtime/session ID to the catalog's canonical session ID;
+    - a failed YOLO gateway operation leaving both the store and visible runtime unchanged.
+  - Use the existing `AppState` test constructor seams and an isolated defaults suite; add the `setSessionYolo` lifecycle operation seam before wiring the failure test rather than opening a real socket.
+  - Refresh the generated project with `/Users/agrias/bin/bin/xcodegen generate`, then run both new test classes before adding production types:
+    `xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination 'platform=iOS Simulator,id=E174DE05-4FA3-43F6-8135-38F8835E2313' -derivedDataPath /tmp/conduit-yolo-red CODE_SIGNING_ALLOWED=NO -only-testing:ConduitTests/SessionYoloStoreTests -only-testing:ConduitTests/SessionYoloPersistenceTests`
+  - Confirm the tests fail to compile or fail assertions because `SessionYoloStore` and the persistence path do not yet exist.
+
+- [ ] 2. Implement the injectable persistence store
+  - Add `Conduit/Services/SessionYoloStore.swift`.
+  - Inject `UserDefaults` and a storage key; encode a profile/session-keyed `[String: Bool]` payload so explicit `false` is preserved and an absent key remains distinguishable from false.
+  - Normalize profile and session components using the existing `ChatScrollSessionKey` identity normalization, reject invalid/empty keys, and expose read/write operations suitable for isolated tests.
+  - Keep the store limited to session YOLO overrides; do not mutate or reuse the profile-wide approval settings.
+
+- [ ] 3. Wire AppState lifecycle, canonical identity, and precedence
+  - In `Conduit/Services/AppState.swift`, inject a `SessionYoloStore` (defaulting to one backed by the AppState defaults) without breaking existing test constructors.
+  - Add a helper that resolves the active canonical session ID with `ChatSessionPersistenceIdentity.canonicalID`, `activeChatScrollSessionIdentity`, the session/cron catalog, and `activeProfile`.
+  - Apply the local override when resuming a session and whenever runtime snapshots arrive, while preserving the existing `snapshot.yolo` over `approvalsMode` fallback when no local override exists. Pass the resumed session ID explicitly where that avoids resolving a stale active ID.
+  - Recompute/clear the session-local visible state on profile/session transitions so switching sessions cannot retain the previous session's override; a session without an override must use its own snapshot/global fallback.
+  - Extend `ChatResumeLifecycleOperations` with an injectable session-YOLO setter if required by the failure test, and have `setYoloMode(_:)` call it or the real `HermesClient` method first.
+  - Persist the boolean and update `runtime.yolo` only after the gateway call succeeds. Preserve existing error handling and leave persistence/runtime unchanged on failure.
+  - Cover relaunch by constructing a new AppState/store against the same defaults suite and restoring the same conversation.
+
+- [ ] 4. Run focused verification (GREEN)
+  - Run the store and AppState-focused tests, then the Hermes/client tests if the lifecycle seam changes:
+    `xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination 'platform=iOS Simulator,id=E174DE05-4FA3-43F6-8135-38F8835E2313' -derivedDataPath /tmp/conduit-yolo-focused CODE_SIGNING_ALLOWED=NO -only-testing:ConduitTests/SessionYoloStoreTests -only-testing:ConduitTests/AppStateChatResumeTests -only-testing:ConduitTests/HermesClientTests`
+  - Confirm true/false/absent semantics, profile/session isolation, canonical IDs, precedence, session switching, relaunch, and failure behavior.
+  - Review the diff for accidental changes to global approval settings or unrelated runtime fields.
+
+- [ ] 5. Verify the branch and prepare the PR
+  - Refresh `Conduit.xcodeproj` with `/Users/agrias/bin/bin/xcodegen generate` after the final source changes.
+  - Run the full XCTest suite in the iOS Simulator and record the final test count/result.
+  - Run `git diff --check`, inspect `git diff main...HEAD`, and confirm only the YOLO persistence implementation, tests, and plan/spec documentation are present.
+  - Commit the implementation as `fix: persist session YOLO overrides`.
+  - Push `codex/session-yolo-persistence` and open its PR against `main` with a summary, precedence rule, failure behavior, and test evidence.

--- a/docs/superpowers/plans/2026-08-13-session-yolo-persistence.md
+++ b/docs/superpowers/plans/2026-08-13-session-yolo-persistence.md
@@ -32,7 +32,7 @@
 - [x] 3. Wire AppState lifecycle, canonical identity, and precedence
   - In `Conduit/Services/AppState.swift`, inject a `SessionYoloStore` (defaulting to one backed by the AppState defaults) without breaking existing test constructors.
   - Add a helper that resolves the active canonical session ID with `ChatSessionPersistenceIdentity.canonicalID`, `activeChatScrollSessionIdentity`, the session/cron catalog, and `activeProfile`.
-  - Apply the local override when resuming a session and whenever runtime snapshots arrive, while treating explicit `snapshot.yolo` as authoritative, clearing conflicting local aliases, and falling back to the local override only when session YOLO is omitted. Pass the resumed session ID explicitly where that avoids resolving a stale active ID.
+  - Apply the local override when resuming a session and whenever runtime snapshots arrive. Treat explicit `snapshot.yolo` as authoritative for fresh resume snapshots, but do not clear a local override from a potentially stale live `session.info` push; fall back to the local override when session YOLO is omitted. Pass the resumed session ID explicitly where that avoids resolving a stale active ID.
   - Recompute/clear the session-local visible state on profile/session transitions so switching sessions cannot retain the previous session's override; a session without an override must use its own snapshot/global fallback.
   - Clear the canonical session ID and known alternate IDs after successful archive and delete mutations.
   - Extend `ChatResumeLifecycleOperations` with an injectable session-YOLO setter if required by the failure test, and have `setYoloMode(_:)` call it or the real `HermesClient` method first.

--- a/docs/superpowers/plans/2026-08-13-session-yolo-persistence.md
+++ b/docs/superpowers/plans/2026-08-13-session-yolo-persistence.md
@@ -32,11 +32,12 @@
 - [x] 3. Wire AppState lifecycle, canonical identity, and precedence
   - In `Conduit/Services/AppState.swift`, inject a `SessionYoloStore` (defaulting to one backed by the AppState defaults) without breaking existing test constructors.
   - Add a helper that resolves the active canonical session ID with `ChatSessionPersistenceIdentity.canonicalID`, `activeChatScrollSessionIdentity`, the session/cron catalog, and `activeProfile`.
-  - Apply the local override when resuming a session and whenever runtime snapshots arrive. Treat explicit `snapshot.yolo` as authoritative for fresh resume snapshots, but do not clear a local override from a potentially stale live `session.info` push; fall back to the local override when session YOLO is omitted. Pass the resumed session ID explicitly where that avoids resolving a stale active ID.
+  - Apply the local override when resuming a session and whenever runtime snapshots arrive. Treat explicit `snapshot.yolo` as authoritative for fresh resume snapshots when no newer local write occurred after that resume began; capture a per-session local-write baseline so a stale resume response cannot clear a newer override. Do not clear a local override from a potentially stale live `session.info` push; fall back to the local override when session YOLO is omitted. Pass the resumed session ID explicitly where that avoids resolving a stale active ID.
   - Recompute/clear the session-local visible state on profile/session transitions so switching sessions cannot retain the previous session's override; a session without an override must use its own snapshot/global fallback.
   - Clear the canonical session ID and known alternate IDs after successful archive and delete mutations.
   - Extend `ChatResumeLifecycleOperations` with an injectable session-YOLO setter if required by the failure test, and have `setYoloMode(_:)` call it or the real `HermesClient` method first.
   - Persist the boolean and update `runtime.yolo` only after the gateway call succeeds. Preserve existing error handling and leave persistence/runtime unchanged on failure.
+  - Record each successful local write in the in-memory per-session revision map used to reject stale resume reconciliation.
   - Cover relaunch by constructing a new AppState/store against the same defaults suite and restoring the same conversation.
 
 - [x] 4. Run focused verification (GREEN)

--- a/docs/superpowers/plans/2026-08-13-session-yolo-persistence.md
+++ b/docs/superpowers/plans/2026-08-13-session-yolo-persistence.md
@@ -2,13 +2,13 @@
 
 **Goal:** Persist an explicit YOLO choice per normalized profile and canonical conversation, restore it across turns/backgrounding/relaunch, and prevent it from leaking between sessions.
 
-**Architecture:** Add an injectable `UserDefaults`-backed `SessionYoloStore` with three states (`true`, `false`, absent). Resolve the active canonical session through the existing chat identity/catalog seam, then apply local override > explicit session snapshot `yolo` > profile `approvalsMode`.
+**Architecture:** Add an injectable `UserDefaults`-backed `SessionYoloStore` with three states (`true`, `false`, absent). Resolve the active canonical session through the existing chat identity/catalog seam, then apply explicit session snapshot `yolo` > local override when omitted > profile `approvalsMode`.
 
 **Tech Stack:** Swift, SwiftUI `AppState`, UserDefaults/JSON Codable storage, XCTest, XcodeGen, iOS Simulator.
 
 ## Tasks
 
-- [ ] 1. Add store and AppState regression tests first (RED)
+- [x] 1. Add store and AppState regression tests first (RED)
   - Add `ConduitTests/SessionYoloStoreTests.swift` with isolated UserDefaults coverage for absent, `true`, and `false` values, plus profile/session isolation and round-trip persistence.
   - Add focused AppState coverage in a dedicated `ConduitTests/SessionYoloPersistenceTests.swift` for:
     - a stored session override winning over a later snapshot containing only `approvals_mode`;
@@ -21,28 +21,28 @@
     `xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination 'platform=iOS Simulator,id=E174DE05-4FA3-43F6-8135-38F8835E2313' -derivedDataPath /tmp/conduit-yolo-red CODE_SIGNING_ALLOWED=NO -only-testing:ConduitTests/SessionYoloStoreTests -only-testing:ConduitTests/SessionYoloPersistenceTests`
   - Confirm the tests fail to compile or fail assertions because `SessionYoloStore` and the persistence path do not yet exist.
 
-- [ ] 2. Implement the injectable persistence store
+- [x] 2. Implement the injectable persistence store
   - Add `Conduit/Services/SessionYoloStore.swift`.
   - Inject `UserDefaults` and a storage key; encode a profile/session-keyed `[String: Bool]` payload so explicit `false` is preserved and an absent key remains distinguishable from false.
   - Normalize profile and session components using the existing `ChatScrollSessionKey` identity normalization, reject invalid/empty keys, and expose read/write operations suitable for isolated tests.
   - Keep the store limited to session YOLO overrides; do not mutate or reuse the profile-wide approval settings.
 
-- [ ] 3. Wire AppState lifecycle, canonical identity, and precedence
+- [x] 3. Wire AppState lifecycle, canonical identity, and precedence
   - In `Conduit/Services/AppState.swift`, inject a `SessionYoloStore` (defaulting to one backed by the AppState defaults) without breaking existing test constructors.
   - Add a helper that resolves the active canonical session ID with `ChatSessionPersistenceIdentity.canonicalID`, `activeChatScrollSessionIdentity`, the session/cron catalog, and `activeProfile`.
-  - Apply the local override when resuming a session and whenever runtime snapshots arrive, while preserving the existing `snapshot.yolo` over `approvalsMode` fallback when no local override exists. Pass the resumed session ID explicitly where that avoids resolving a stale active ID.
+  - Apply the local override when resuming a session and whenever runtime snapshots arrive, while treating explicit `snapshot.yolo` as authoritative, clearing conflicting local aliases, and falling back to the local override only when session YOLO is omitted. Pass the resumed session ID explicitly where that avoids resolving a stale active ID.
   - Recompute/clear the session-local visible state on profile/session transitions so switching sessions cannot retain the previous session's override; a session without an override must use its own snapshot/global fallback.
   - Extend `ChatResumeLifecycleOperations` with an injectable session-YOLO setter if required by the failure test, and have `setYoloMode(_:)` call it or the real `HermesClient` method first.
   - Persist the boolean and update `runtime.yolo` only after the gateway call succeeds. Preserve existing error handling and leave persistence/runtime unchanged on failure.
   - Cover relaunch by constructing a new AppState/store against the same defaults suite and restoring the same conversation.
 
-- [ ] 4. Run focused verification (GREEN)
+- [x] 4. Run focused verification (GREEN)
   - Run the store and AppState-focused tests, then the Hermes/client tests if the lifecycle seam changes:
     `xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination 'platform=iOS Simulator,id=E174DE05-4FA3-43F6-8135-38F8835E2313' -derivedDataPath /tmp/conduit-yolo-focused CODE_SIGNING_ALLOWED=NO -only-testing:ConduitTests/SessionYoloStoreTests -only-testing:ConduitTests/AppStateChatResumeTests -only-testing:ConduitTests/HermesClientTests`
   - Confirm true/false/absent semantics, profile/session isolation, canonical IDs, precedence, session switching, relaunch, and failure behavior.
   - Review the diff for accidental changes to global approval settings or unrelated runtime fields.
 
-- [ ] 5. Verify the branch and prepare the PR
+- [x] 5. Verify the branch and prepare the PR
   - Refresh `Conduit.xcodeproj` with `/Users/agrias/bin/bin/xcodegen generate` after the final source changes.
   - Run the full XCTest suite in the iOS Simulator and record the final test count/result.
   - Run `git diff --check`, inspect `git diff main...HEAD`, and confirm only the YOLO persistence implementation, tests, and plan/spec documentation are present.

--- a/docs/superpowers/plans/2026-08-13-session-yolo-persistence.md
+++ b/docs/superpowers/plans/2026-08-13-session-yolo-persistence.md
@@ -2,7 +2,7 @@
 
 **Goal:** Persist an explicit YOLO choice per normalized profile and canonical conversation, restore it across turns/backgrounding/relaunch, and prevent it from leaking between sessions.
 
-**Architecture:** Add an injectable `UserDefaults`-backed `SessionYoloStore` with three states (`true`, `false`, absent). Resolve the active canonical session through the existing chat identity/catalog seam, then apply explicit session snapshot `yolo` > local override when omitted > profile `approvalsMode`.
+**Architecture:** Add an injectable `UserDefaults`-backed `SessionYoloStore` with three states (`true`, `false`, absent). Resolve the active canonical session through the existing chat identity/catalog seam, then apply explicit session snapshot `yolo` > local override when omitted > profile `approvalsMode`. Migrate runtime aliases to canonical keys, evict overrides when sessions are archived or deleted, and report persistence failures through OSLog diagnostics.
 
 **Tech Stack:** Swift, SwiftUI `AppState`, UserDefaults/JSON Codable storage, XCTest, XcodeGen, iOS Simulator.
 
@@ -25,6 +25,8 @@
   - Add `Conduit/Services/SessionYoloStore.swift`.
   - Inject `UserDefaults` and a storage key; encode a profile/session-keyed `[String: Bool]` payload so explicit `false` is preserved and an absent key remains distinguishable from false.
   - Normalize profile and session components using the existing `ChatScrollSessionKey` identity normalization, reject invalid/empty keys, and expose read/write operations suitable for isolated tests.
+  - Migrate a stored runtime alias to its canonical session key when catalog identity becomes available, removing the stale alias.
+  - Report decode, unsupported-version, and encode failures through OSLog and an injectable diagnostic handler.
   - Keep the store limited to session YOLO overrides; do not mutate or reuse the profile-wide approval settings.
 
 - [x] 3. Wire AppState lifecycle, canonical identity, and precedence
@@ -32,6 +34,7 @@
   - Add a helper that resolves the active canonical session ID with `ChatSessionPersistenceIdentity.canonicalID`, `activeChatScrollSessionIdentity`, the session/cron catalog, and `activeProfile`.
   - Apply the local override when resuming a session and whenever runtime snapshots arrive, while treating explicit `snapshot.yolo` as authoritative, clearing conflicting local aliases, and falling back to the local override only when session YOLO is omitted. Pass the resumed session ID explicitly where that avoids resolving a stale active ID.
   - Recompute/clear the session-local visible state on profile/session transitions so switching sessions cannot retain the previous session's override; a session without an override must use its own snapshot/global fallback.
+  - Clear the canonical session ID and known alternate IDs after successful archive and delete mutations.
   - Extend `ChatResumeLifecycleOperations` with an injectable session-YOLO setter if required by the failure test, and have `setYoloMode(_:)` call it or the real `HermesClient` method first.
   - Persist the boolean and update `runtime.yolo` only after the gateway call succeeds. Preserve existing error handling and leave persistence/runtime unchanged on failure.
   - Cover relaunch by constructing a new AppState/store against the same defaults suite and restoring the same conversation.

--- a/docs/superpowers/plans/2026-08-13-yolo-review-followups.md
+++ b/docs/superpowers/plans/2026-08-13-yolo-review-followups.md
@@ -1,0 +1,134 @@
+# Session YOLO Review Follow-ups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve non-YOLO state from buffered `session.info` events during resume reconciliation and prevent Model Picker `onAppear` from resetting an in-progress YOLO draft.
+
+**Architecture:** Resume reconciliation computes one explicit-YOLO authority decision and passes the resulting authoritative YOLO value only while replaying buffered `session.info` events. `applyRuntime` uses that value for YOLO while continuing to apply every other snapshot field normally. Model Picker draft seeding moves behind a small pure factory that returns a draft only when no initial baseline exists.
+
+**Tech Stack:** Swift, SwiftUI, XCTest, Xcode Simulator.
+
+## Global Constraints
+
+- Do not change the Hermes protocol or profile-wide approval settings.
+- A fresh resume with no newer local write remains authoritative for session YOLO.
+- Buffered event replay must preserve running state, model, provider, context usage, and other non-YOLO fields.
+- Repeated Model Picker appearances must not overwrite an existing YOLO draft or comparison baseline.
+- Use simulator `6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355` with `CODE_SIGNING_ALLOWED=NO`.
+
+---
+
+### Task 1: Add the buffered-event regression (RED)
+
+**Files:** `ConduitTests/SessionYoloPersistenceTests.swift`
+
+Add `testBufferedConflictingSessionInfoPreservesNonYoloRuntimeFields`. Use the existing `SessionYoloResumeGate` and `makeAppState` seams. Return a resume snapshot with `model = "resume-model"`, `provider = "resume-provider"`, `context_percent = 10`, and `yolo = false`. While `openSession` is suspended, buffer a `.sessionInfo` snapshot with `model = "buffered-model"`, `provider = "buffered-provider"`, `context_percent = 42`, `running = true`, and `yolo = true`. After releasing the gate and awaiting `syncSession()`, assert `runtime.yolo == false`, `runtime.model == "buffered-model"`, `runtime.provider == "buffered-provider"`, and `runtime.contextPercent == 42`.
+
+- [ ] **Step 1: Write the test before production changes.**
+- [ ] **Step 2: Run the focused test and confirm the current whole-event filter fails because `runtime.model` remains `resume-model`.**
+
+```bash
+xcodebuild test -quiet -project Conduit.xcodeproj -scheme Conduit \
+  -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' \
+  -derivedDataPath /tmp/conduit-yolo-followup-red CODE_SIGNING_ALLOWED=NO \
+  -only-testing:ConduitTests/SessionYoloPersistenceTests/testBufferedConflictingSessionInfoPreservesNonYoloRuntimeFields
+```
+
+### Task 2: Preserve buffered fields while anchoring YOLO authority (GREEN)
+
+**Files:** `Conduit/Services/AppState.swift`
+
+1. Extend the private `applyChatResume` overload with optional `reconcileExplicitYolo: Bool?`. Pass the already-computed reconciliation decision from `reconcile`; direct callers retain the existing baseline-derived default.
+2. Extend `applyRuntime` with `authoritativeYolo: Bool? = nil` and use `authoritativeYolo ?? snapshot.yolo` only for the YOLO branch. Leave all other runtime field handling unchanged.
+3. Extend `applyStreamEvent` with `authoritativeYolo: Bool? = nil`. In `.sessionInfo`, pass it through to `applyRuntime`; normal live callers use the default.
+4. During buffered replay, pass `result.snapshot.yolo` only when the single `reconcileExplicitYolo` decision is true. Remove `filteringBufferedSessionInfo`; no buffered event is dropped merely because its YOLO value is stale.
+
+- [ ] **Step 1: Implement the smallest production change described above.**
+- [ ] **Step 2: Run the new regression plus the existing stale-ordering tests.**
+
+```bash
+xcodebuild test -quiet -project Conduit.xcodeproj -scheme Conduit \
+  -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' \
+  -derivedDataPath /tmp/conduit-yolo-followup-buffered-green CODE_SIGNING_ALLOWED=NO \
+  -only-testing:ConduitTests/SessionYoloPersistenceTests/testBufferedConflictingSessionInfoPreservesNonYoloRuntimeFields \
+  -only-testing:ConduitTests/SessionYoloPersistenceTests/testBufferedStaleSessionInfoCannotReapplyClearedOverride \
+  -only-testing:ConduitTests/SessionYoloPersistenceTests/testStaleResumeSnapshotCannotClearJustPersistedOverride
+```
+
+- [ ] **Step 3: Commit the buffered replay fix.**
+
+```bash
+git add Conduit/Services/AppState.swift ConduitTests/SessionYoloPersistenceTests.swift
+git commit -m "fix: preserve buffered session info fields"
+```
+
+### Task 3: Add the Model Picker draft regression (RED)
+
+**Files:** `ConduitTests/ModelPickerTests.swift`
+
+Add tests for a new pure factory on `ModelPickerYoloDraft`:
+
+```swift
+func testModelPickerYoloDraftSeedsWhenInitialBaselineIsMissing() {
+    let draft = ModelPickerYoloDraft.seededIfNeeded(initial: nil, runtimeYolo: true)
+    XCTAssertEqual(draft, ModelPickerYoloDraft(runtimeYolo: true))
+}
+
+func testModelPickerYoloDraftDoesNotReseedAnExistingBaseline() {
+    let draft = ModelPickerYoloDraft.seededIfNeeded(initial: false, runtimeYolo: true)
+    XCTAssertNil(draft)
+}
+```
+
+- [ ] **Step 1: Add the tests before adding the factory.**
+- [ ] **Step 2: Run `ModelPickerTests`; the current source must fail to compile because `seededIfNeeded` is missing.**
+
+```bash
+xcodebuild test -quiet -project Conduit.xcodeproj -scheme Conduit \
+  -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' \
+  -derivedDataPath /tmp/conduit-yolo-followup-picker-red CODE_SIGNING_ALLOWED=NO \
+  -only-testing:ConduitTests/ModelPickerTests
+```
+
+### Task 4: Guard Model Picker draft initialization (GREEN)
+
+**Files:** `Conduit/Views/ModelPickerView.swift`, `ConduitTests/ModelPickerTests.swift`
+
+Add:
+
+```swift
+static func seededIfNeeded(initial: Bool?, runtimeYolo: Bool) -> ModelPickerYoloDraft? {
+    guard initial == nil else { return nil }
+    return ModelPickerYoloDraft(runtimeYolo: runtimeYolo)
+}
+```
+
+Replace the unconditional `.onAppear` assignments with an `if let` call to this factory. When `initialYoloEnabled` already has a value, do nothing; when it is nil, assign both `yoloEnabled` and `initialYoloEnabled` from the returned draft. Keep the existing `loadModels` nil-baseline guard unchanged.
+
+- [ ] **Step 1: Implement the factory and guarded `onAppear`.**
+- [ ] **Step 2: Run all `ModelPickerTests`; the new and existing tests must pass.**
+- [ ] **Step 3: Commit the picker fix.**
+
+```bash
+git add Conduit/Views/ModelPickerView.swift ConduitTests/ModelPickerTests.swift
+git commit -m "fix: preserve Model Picker YOLO drafts"
+```
+
+### Task 5: Verify and hand off PR #55
+
+**Files:** PR #55 description; the approved spec only if implementation wording needs correction.
+
+- [ ] **Step 1: Run focused coverage for `SessionYoloPersistenceTests` and `ModelPickerTests`.**
+
+```bash
+xcodebuild test -quiet -project Conduit.xcodeproj -scheme Conduit \
+  -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' \
+  -derivedDataPath /tmp/conduit-yolo-followup-focused CODE_SIGNING_ALLOWED=NO \
+  -only-testing:ConduitTests/SessionYoloPersistenceTests \
+  -only-testing:ConduitTests/ModelPickerTests
+```
+
+- [ ] **Step 2: Run the complete XCTest suite and inspect `xcresulttool get test-results summary` for actual passed/failed counts.**
+- [ ] **Step 3: Run `git diff --check`, inspect the final diff, and confirm the worktree is clean after commits.**
+- [ ] **Step 4: Update PR #55 validation notes with the new behavior and final counts.**
+- [ ] **Step 5: Push `codex/session-yolo-persistence` and verify the new CI/review checks; do not reply to or resolve comments unless explicitly requested.**

--- a/docs/superpowers/specs/2026-08-13-session-yolo-persistence-design.md
+++ b/docs/superpowers/specs/2026-08-13-session-yolo-persistence-design.md
@@ -1,0 +1,112 @@
+# Design Spec: Persist Session YOLO Overrides
+
+**Date:** 2026-08-13  
+**Branch:** `codex/session-yolo-persistence`  
+**Status:** Approved design; implementation pending
+
+## Problem
+
+Conduit sends a session-scoped `config.set` request when the user changes YOLO
+mode and updates `runtime.yolo` in memory. A later resume or turn snapshot can
+omit the session-level `yolo` field while including the profile-level
+`approvalsMode`; `applyRuntime` then derives `runtime.yolo` from that global
+fallback and overwrites the user's session choice. The choice is also lost
+when the app is relaunched because no local session override is stored.
+
+## Goal
+
+Remember the user's explicit YOLO choice for the current conversation across
+turns, backgrounding, and app relaunch, while keeping the choice isolated to
+that conversation and profile. Switching to a different session must reload
+that session's own override or its current global fallback rather than leaking
+the previous session's value.
+
+## Non-goals
+
+- Do not change the Hermes `config.set` protocol or profile-wide approval
+  settings.
+- Do not persist a value when the gateway rejects the setting request.
+- Do not make one session's override affect another session, profile, or
+  gateway identity.
+- Do not add a migration for unrelated preference stores.
+
+## Design
+
+### Injectable session override store
+
+Add a small `SessionYoloStore` backed by injectable `UserDefaults`. It stores an
+optional override keyed by the normalized active profile and canonical session
+ID. The optional state is important: `true`, `false`, and no local override are
+three distinct states. The store should expose read and write operations that
+are straightforward to exercise with an isolated defaults suite.
+
+Canonicalization must use the existing session identity rules, including
+catalog alternate IDs, so a runtime/session ID and the persisted conversation
+ID address the same entry. Profile and session keys must remain independent.
+
+### Runtime precedence
+
+When deriving `runtime.yolo` for a session, use this precedence:
+
+1. A locally persisted override for the active normalized profile/session.
+2. An explicit session-level `snapshot.yolo` from Hermes.
+3. The profile-level `snapshot.approvalsMode` fallback.
+
+The local override takes precedence because it records the user's explicit
+choice in this app and prevents a later snapshot that omitted session-level
+YOLO from silently replacing it. If the session has no local override, the
+existing server-provided precedence remains intact.
+
+When the active session changes, recompute this value for the new canonical
+session. A session with no override must not retain the previous session's
+local value; it should use that session's snapshot/global fallback. Returning
+to an overridden session must reload its saved choice.
+
+### Write and lifecycle behavior
+
+- `setYoloMode(_:)` calls the existing gateway method first. Only after success
+  does it write the explicit boolean to `SessionYoloStore` and update
+  `runtime.yolo`.
+- On failure, the persisted value and visible runtime value remain unchanged,
+  and the existing error reporting remains in place.
+- Resume, foreground synchronization, session selection, and app relaunch
+  paths must resolve the canonical active session and apply the store before or
+  alongside runtime snapshot reconciliation.
+- A new conversation without a canonical session ID has no session override;
+  it must not reuse the last session's value.
+
+## Expected implementation surface
+
+- `Conduit/Services/SessionYoloStore.swift`: injectable profile/session-keyed
+  persistence with explicit optional override semantics.
+- `Conduit/Services/AppState.swift`: inject/use the store, persist successful
+  changes, apply precedence, and refresh on session/profile transitions.
+- `Conduit/Services/ChatScrollState.swift` or the existing identity seam only
+  if a small reusable canonical-ID helper is needed; avoid duplicating
+  normalization rules.
+- `ConduitTests/SessionYoloStoreTests.swift` and/or
+  `ConduitTests/AppStateChatResumeTests.swift`: store round trips, true/false
+  distinction, profile/session isolation, runtime precedence, failure
+  behavior, and session switching.
+
+## Acceptance tests
+
+- `true` and `false` overrides round-trip through an isolated `UserDefaults`
+  suite, while an absent key returns no override.
+- Overrides for two sessions or two profiles do not collide.
+- A stored session override wins over a later snapshot containing only the
+  profile/global approval mode.
+- With no stored override, explicit `snapshot.yolo` still wins over
+  `approvalsMode`, and `approvalsMode` remains the fallback when session YOLO
+  is omitted.
+- Switching from an overridden session to an unoverridden session clears the
+  previous local value from the visible runtime; switching back restores it.
+- A failed `config.set` does not write the override.
+- The complete existing test suite remains green.
+
+## Verification
+
+Run the store and AppState-focused tests first, then run the complete `Conduit`
+XCTest suite in the iOS Simulator. Review the final diff to confirm that the
+store is scoped only to profile/session YOLO state and that no profile-wide
+setting is mutated.

--- a/docs/superpowers/specs/2026-08-13-session-yolo-persistence-design.md
+++ b/docs/superpowers/specs/2026-08-13-session-yolo-persistence-design.md
@@ -65,10 +65,29 @@ response, so an explicit conflicting value in a live push does not clear a
 local override. A later resume with no newer local write performs the
 server-authority reconciliation.
 
+### Buffered resume events
+
+While a fresh resume is in flight, buffered `session.info` events may describe
+the state that preceded the resume snapshot. If a buffered event conflicts with
+an authoritative fresh-resume YOLO value, replay it with that YOLO value
+anchored to the resume snapshot while preserving the event's other runtime
+fields, including running state, model, provider, and context usage. Do not
+drop the entire event merely because its YOLO field is stale. Compute the
+authority decision once for the reconciliation and use that same decision for
+both resume application and buffered-event replay. Events received after
+reconciliation remain normal live pushes.
+
 When the active session changes, recompute this value for the new canonical
 session. A session with no override must not retain the previous session's
 local value; it should use that session's snapshot/global fallback. Returning
 to an overridden session must reload its saved choice.
+
+### Model Picker draft state
+
+The Model Picker seeds its YOLO draft and comparison baseline only on the first
+appearance of a presentation. Repeated `onAppear` calls must not overwrite a
+toggle the user has already changed; asynchronous model loading uses the same
+nil-baseline guard.
 
 ### Write and lifecycle behavior
 
@@ -124,6 +143,8 @@ to an overridden session must reload its saved choice.
   that newer override when the response arrives afterward.
 - A stale live `session.info` snapshot cannot clear a just-persisted local
   override or revert the visible runtime value.
+- A contradictory buffered `session.info` event preserves its non-YOLO fields
+  while the fresh-resume YOLO authority remains visible after replay.
 - Switching from an overridden session to an unoverridden session clears the
   previous local value from the visible runtime; switching back restores it.
 - A failed `config.set` does not write the override.
@@ -131,6 +152,8 @@ to an overridden session must reload its saved choice.
   and removes the raw alias.
 - Archiving or deleting a session removes its canonical and alternate-ID
   overrides after the server mutation succeeds.
+- Repeated Model Picker appearances do not reset an in-progress YOLO toggle or
+  its change baseline.
 - Corrupt or unsupported persisted data is ignored and produces a diagnostic.
 - The complete existing test suite remains green.
 

--- a/docs/superpowers/specs/2026-08-13-session-yolo-persistence-design.md
+++ b/docs/superpowers/specs/2026-08-13-session-yolo-persistence-design.md
@@ -54,9 +54,12 @@ When deriving `runtime.yolo` for a session, use this precedence:
 3. The profile-level `snapshot.approvalsMode` fallback.
 
 The local override preserves the user's explicit choice when a later snapshot
-omits session-level YOLO. When Hermes explicitly reports session YOLO, that
-gateway state is authoritative; a conflicting local override is cleared so the
-visible runtime and the server cannot diverge.
+omits session-level YOLO. A fresh resume snapshot is authoritative when Hermes
+explicitly reports session YOLO; a conflicting local override is cleared so the
+visible runtime and the server can reconcile. Live `session.info` pushes may be
+older than a client-initiated `config.set` response, so an explicit conflicting
+value in a live push does not clear a local override. The next fresh resume
+snapshot performs that server-authority reconciliation.
 
 When the active session changes, recompute this value for the new canonical
 session. A session with no override must not retain the previous session's
@@ -72,7 +75,9 @@ to an overridden session must reload its saved choice.
   and the existing error reporting remains in place.
 - Resume, foreground synchronization, session selection, and app relaunch
   paths must resolve the canonical active session and apply the store before or
-  alongside runtime snapshot reconciliation.
+  alongside runtime snapshot reconciliation. Fresh resume snapshots may clear
+  a conflicting local override; live session-info pushes must not invalidate a
+  local write because their ordering relative to config.set is not guaranteed.
 - A new conversation without a canonical session ID has no session override;
   it must not reuse the last session's value.
 - When a runtime/session alias is resolved to a catalog session ID, migrate the
@@ -108,7 +113,9 @@ to an overridden session must reload its saved choice.
   `approvalsMode`, and `approvalsMode` remains the fallback when session YOLO
   is omitted.
 - An explicit `snapshot.yolo` replaces a conflicting local override and clears
-  the stale persisted value.
+  the stale persisted value on a fresh resume.
+- A stale live `session.info` snapshot cannot clear a just-persisted local
+  override or revert the visible runtime value.
 - Switching from an overridden session to an unoverridden session clears the
   previous local value from the visible runtime; switching back restores it.
 - A failed `config.set` does not write the override.

--- a/docs/superpowers/specs/2026-08-13-session-yolo-persistence-design.md
+++ b/docs/superpowers/specs/2026-08-13-session-yolo-persistence-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-13
 **Branch:** `codex/session-yolo-persistence`
-**Status:** Approved design; implementation pending
+**Status:** Implemented
 
 ## Problem
 
@@ -48,14 +48,15 @@ ID address the same entry. Profile and session keys must remain independent.
 
 When deriving `runtime.yolo` for a session, use this precedence:
 
-1. A locally persisted override for the active normalized profile/session.
-2. An explicit session-level `snapshot.yolo` from Hermes.
+1. An explicit session-level `snapshot.yolo` from Hermes.
+2. A locally persisted override for the active normalized profile/session when
+   the snapshot omits session YOLO.
 3. The profile-level `snapshot.approvalsMode` fallback.
 
-The local override takes precedence because it records the user's explicit
-choice in this app and prevents a later snapshot that omitted session-level
-YOLO from silently replacing it. If the session has no local override, the
-existing server-provided precedence remains intact.
+The local override preserves the user's explicit choice when a later snapshot
+omits session-level YOLO. When Hermes explicitly reports session YOLO, that
+gateway state is authoritative; a conflicting local override is cleared so the
+visible runtime and the server cannot diverge.
 
 When the active session changes, recompute this value for the new canonical
 session. A session with no override must not retain the previous session's
@@ -99,6 +100,8 @@ to an overridden session must reload its saved choice.
 - With no stored override, explicit `snapshot.yolo` still wins over
   `approvalsMode`, and `approvalsMode` remains the fallback when session YOLO
   is omitted.
+- An explicit `snapshot.yolo` replaces a conflicting local override and clears
+  the stale persisted value.
 - Switching from an overridden session to an unoverridden session clears the
   previous local value from the visible runtime; switching back restores it.
 - A failed `config.set` does not write the override.

--- a/docs/superpowers/specs/2026-08-13-session-yolo-persistence-design.md
+++ b/docs/superpowers/specs/2026-08-13-session-yolo-persistence-design.md
@@ -75,11 +75,18 @@ to an overridden session must reload its saved choice.
   alongside runtime snapshot reconciliation.
 - A new conversation without a canonical session ID has no session override;
   it must not reuse the last session's value.
+- When a runtime/session alias is resolved to a catalog session ID, migrate the
+  stored override to the canonical key and remove the raw alias.
+- On successful archive or delete, clear overrides for the session's canonical
+  and known alternate IDs so retired conversations do not retain stale state.
+- Invalid or unsupported persisted payloads are ignored and reported through
+  the session-store diagnostics logger.
 
 ## Expected implementation surface
 
 - `Conduit/Services/SessionYoloStore.swift`: injectable profile/session-keyed
-  persistence with explicit optional override semantics.
+  persistence with explicit optional override semantics, alias migration, and
+  diagnostics for unreadable payloads.
 - `Conduit/Services/AppState.swift`: inject/use the store, persist successful
   changes, apply precedence, and refresh on session/profile transitions.
 - `Conduit/Services/ChatScrollState.swift` or the existing identity seam only
@@ -105,6 +112,11 @@ to an overridden session must reload its saved choice.
 - Switching from an overridden session to an unoverridden session clears the
   previous local value from the visible runtime; switching back restores it.
 - A failed `config.set` does not write the override.
+- A runtime alias migration leaves the override under the canonical session ID
+  and removes the raw alias.
+- Archiving or deleting a session removes its canonical and alternate-ID
+  overrides after the server mutation succeeds.
+- Corrupt or unsupported persisted data is ignored and produces a diagnostic.
 - The complete existing test suite remains green.
 
 ## Verification

--- a/docs/superpowers/specs/2026-08-13-session-yolo-persistence-design.md
+++ b/docs/superpowers/specs/2026-08-13-session-yolo-persistence-design.md
@@ -1,7 +1,7 @@
 # Design Spec: Persist Session YOLO Overrides
 
-**Date:** 2026-08-13  
-**Branch:** `codex/session-yolo-persistence`  
+**Date:** 2026-08-13
+**Branch:** `codex/session-yolo-persistence`
 **Status:** Approved design; implementation pending
 
 ## Problem

--- a/docs/superpowers/specs/2026-08-13-session-yolo-persistence-design.md
+++ b/docs/superpowers/specs/2026-08-13-session-yolo-persistence-design.md
@@ -55,11 +55,15 @@ When deriving `runtime.yolo` for a session, use this precedence:
 
 The local override preserves the user's explicit choice when a later snapshot
 omits session-level YOLO. A fresh resume snapshot is authoritative when Hermes
-explicitly reports session YOLO; a conflicting local override is cleared so the
-visible runtime and the server can reconcile. Live `session.info` pushes may be
-older than a client-initiated `config.set` response, so an explicit conflicting
-value in a live push does not clear a local override. The next fresh resume
-snapshot performs that server-authority reconciliation.
+explicitly reports session YOLO, and a conflicting local override is cleared so
+the visible runtime and the server can reconcile. A resume can, however, have
+started before a client-initiated `config.set` completes. AppState captures the
+per-session local-write revision when the resume starts and skips conflict
+clearing if a newer successful write exists when the response arrives. Live
+`session.info` pushes may also be older than a client-initiated `config.set`
+response, so an explicit conflicting value in a live push does not clear a
+local override. A later resume with no newer local write performs the
+server-authority reconciliation.
 
 When the active session changes, recompute this value for the new canonical
 session. A session with no override must not retain the previous session's
@@ -76,8 +80,10 @@ to an overridden session must reload its saved choice.
 - Resume, foreground synchronization, session selection, and app relaunch
   paths must resolve the canonical active session and apply the store before or
   alongside runtime snapshot reconciliation. Fresh resume snapshots may clear
-  a conflicting local override; live session-info pushes must not invalidate a
-  local write because their ordering relative to config.set is not guaranteed.
+  a conflicting local override when no newer local write occurred after that
+  resume began; a stale resume response must not invalidate the newer write.
+  Live session-info pushes must also not invalidate a local write because their
+  ordering relative to config.set is not guaranteed.
 - A new conversation without a canonical session ID has no session override;
   it must not reuse the last session's value.
 - When a runtime/session alias is resolved to a catalog session ID, migrate the
@@ -114,6 +120,8 @@ to an overridden session must reload its saved choice.
   is omitted.
 - An explicit `snapshot.yolo` replaces a conflicting local override and clears
   the stale persisted value on a fresh resume.
+- A resume snapshot captured before a successful local YOLO write cannot clear
+  that newer override when the response arrives afterward.
 - A stale live `session.info` snapshot cannot clear a just-persisted local
   override or revert the visible runtime value.
 - Switching from an overridden session to an unoverridden session clears the


### PR DESCRIPTION
## Summary
- persist explicit session YOLO choices as normalized profile/session overrides with distinct true, false, and absent states
- treat an explicit session snapshot `yolo` from Hermes as authoritative during fresh resume reconciliation when no newer local write occurred after that resume began
- preserve the local override when live pushes or an older in-flight resume response may be stale
- replay buffered `session.info` fields while anchoring only their YOLO value to fresh resume authority
- avoid writing a session YOLO override when Model Picker Apply leaves the YOLO selection unchanged
- seed Model Picker YOLO draft state synchronously before asynchronous model loading, without reseeding an existing draft on repeated appearances
- resolve both canonical and runtime session IDs across resume and catalog updates, migrating raw runtime aliases to canonical keys
- evict session YOLO overrides for canonical and alternate IDs after successful archive or delete mutations
- write the override and update visible runtime only after the gateway accepts the setting
- log and surface corrupt, unsupported-version, and encode persistence failures
- add isolated store, relaunch, session-switching, precedence, success, failure, model-picker, alias, server-authority, stale-ordering, and buffered-replay coverage

## Root cause
`setYoloMode` waits for the gateway RPC before persisting the local override, while WebSocket `session.info` pushes and `session.resume` responses can be delivered independently and out of order. A snapshot captured before the toggle could arrive after the RPC succeeded; the conflict handler treated that stale `yolo` value as authoritative, cleared the new override, and flipped the UI back. During foreground reconciliation, buffered `session.info` events were then replayed after the fresh resume snapshot; a contradictory buffered snapshot could reapply the old YOLO value, and the old whole-event filter also discarded newer non-YOLO runtime fields.

## Review follow-ups addressed
- model-only Apply no longer creates a spurious persisted YOLO override
- early Model Picker YOLO changes survive asynchronous model loading
- repeated Model Picker appearances no longer overwrite an in-progress YOLO draft or its comparison baseline
- explicit gateway session YOLO state can replace a stale local override during a fresh resume
- stale live session-info pushes cannot erase a newer local write
- stale resume responses are compared with a per-session local-write baseline and cannot erase a newer successful write
- buffered session-info replay preserves model, provider, running, context, and other runtime fields while fresh resume authority controls YOLO
- overrides written under a runtime session ID migrate to the canonical catalog ID
- archived and deleted sessions no longer retain local YOLO overrides
- persistence decode/version/encode failures produce OSLog diagnostics

## Validation
- Focused `SessionYoloPersistenceTests`: 11 passed, 0 failed
- Focused `ModelPickerTests`: 6 passed, 0 failed
- Full iOS Simulator XCTest suite: 532 passed, 0 failed
- `git diff --check` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - YOLO settings now persist independently for each chat session, including across app relaunches and session switches.
  - Session-specific settings are restored consistently and support canonical session identity changes.
- **Bug Fixes**
  - Prevented stale resume data or live updates from overwriting newer local YOLO changes.
  - Model Picker preserves existing YOLO selections instead of unexpectedly resetting them.
  - Failed YOLO updates no longer leave the interface or saved state inconsistent.
- **Documentation**
  - Added design and implementation documentation for session-level YOLO persistence and reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->