### PR TITLE
Fix cross-block Markdown selection and composer session races

### DIFF
--- a/.superpowers/sdd/2026-08-13-composer-session-isolation/task-2-report.md
+++ b/.superpowers/sdd/2026-08-13-composer-session-isolation/task-2-report.md
@@ -1,0 +1,78 @@
+# Task 2 Report — Composer UIKit bridge guarded updates and teardown
+
+Date: 2026-08-13
+
+Base commit: `5f3eff2`
+
+Scope completed:
+- Guarded programmatic composer text updates in `ComposerPasteTextView`
+- Coordinator active/applying flags and helper methods
+- Deterministic `dismantleUIView` teardown
+- Focused bridge tests for guarded callbacks
+
+Out of scope by design:
+- No ComposerBar session handoff integration beyond passing the new required `editorIdentity`
+- No `AppState` changes
+
+## Files changed
+
+- `Conduit/Views/Components/ComposerPasteTextView.swift`
+- `Conduit/Views/Components/ComposerBar.swift`
+- `ConduitTests/ComposerPasteTextViewTests.swift`
+
+## Implementation summary
+
+- Added `editorIdentity: UUID` to `ComposerPasteTextView`
+- Replaced direct `uiView.text` assignment with `Coordinator.apply(text:editorIdentity:to:)`
+- Added `Coordinator.isApplyingProgrammaticState` and `Coordinator.isActive`
+- Guarded `textViewDidChange`, `textViewDidBeginEditing`, `textViewDidEndEditing`, and `updateMeasuredHeight`
+- Added `Coordinator.deactivate(textView:)` and wired it through `dismantleUIView`
+- Cleared delegate and paste/height callbacks during teardown and resigned first responder
+- Preserved selection during programmatic text application with clamping
+- Added focused tests covering programmatic-update suppression and inactive-coordinator suppression
+
+## TDD / verification log
+
+1. Added new failing tests in `ConduitTests/ComposerPasteTextViewTests.swift`
+
+2. First focused red run:
+
+```bash
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination 'id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' -only-testing:ConduitTests/ComposerPasteTextViewTests
+```
+
+Result:
+- Failed at compile time
+- Initial failure included missing `SwiftUI` import for `Binding`
+- After fixing the test import, the remaining intended red failure was:
+  - `Extra argument 'editorIdentity' in call`
+
+3. Implemented the minimal bridge changes
+
+4. Focused green run:
+
+```bash
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination 'id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' -only-testing:ConduitTests/ComposerPasteTextViewTests
+```
+
+Result:
+- `** TEST SUCCEEDED **`
+- `Executed 12 tests, with 0 failures (0 unexpected)`
+
+## Self-review notes
+
+- The bridge changes are narrowly scoped to the UIKit representable and its existing call site
+- `editorIdentity` is currently held as stable local `@State` in `ComposerBar` only to satisfy the new bridge contract without prematurely implementing session handoff
+- Teardown explicitly clears delegate and callback closures before release, matching the task brief
+- Existing image paste metadata/error tests remained unchanged
+
+## Concerns / follow-up
+
+- Session-generation rotation is intentionally not implemented here; `editorIdentity` is stable but not yet tied to session handoff
+- The focused test run still emits unrelated pre-existing build warnings in other files (`ChatResumeStore`, `HermesClient`, `PendingVoiceIntentStore`)
+- The focused test run also logs existing runtime noise from image-provider fallback/HEIC normalization paths, but all tests pass
+
+## Commit
+
+- Implementation commit: `6fe5799`
+- Implementation message: `fix: isolate composer UIKit callbacks during handoff`

--- a/.superpowers/sdd/2026-08-13-composer-session-isolation/task-3-report.md
+++ b/.superpowers/sdd/2026-08-13-composer-session-isolation/task-3-report.md
@@ -1,0 +1,131 @@
+### Task 3 report — ComposerBar session/profile draft handoff
+
+Base commit before Task 3: `956eca4 docs: record task 2 implementation report`.
+
+Implementation commit: created from this report's work with message `fix: restore composer drafts per active session`; final hash is reported by the implementer after commit.
+
+#### Files changed
+
+- `Conduit/Views/Components/ComposerBar.swift`
+  - Added ComposerBar-owned `ComposerDraftStore`, `loadedDraftKey`, and `composerDraftKey` helpers.
+  - Loaded the active profile/session draft on first appearance.
+  - Observed the combined `ComposerDraftKey(profile: appState.activeProfile, sessionID: appState.activeSessionId ?? "new-conversation")` so profile and session changes use the same handoff path.
+  - Saved the previous loaded draft before local teardown, dismissed focus/suggestions, remounted the editor by changing `editorIdentity`, restored destination text/attachments, reset measured height, and left the destination unfocused.
+  - Cleared the submitted draft bucket on successful submit and restored/saved the submitted draft on failure without mutating a different currently loaded key.
+  - Captured the session ID before delayed context refresh and guarded before calling `refreshContextUsage()`.
+  - Captured editor identity in paste image/error closures and ignored stale callbacks.
+
+- `Conduit/Views/Components/ComposerPasteTextView.swift`
+  - Propagated `editorIdentity` into the UIKit `ImagePasteTextView`.
+  - Captured editor identity at paste start for item-provider, URL, direct-image, raw-data, normalization, and failure paths.
+  - Dropped delayed paste callbacks when the text view's identity no longer matches the captured identity.
+  - Cleared identity during UIKit dismantle.
+
+- `ConduitTests/ComposerDraftStoreTests.swift`
+  - Added a red-first handoff/key test that saves `"draft A"` under session A, verifies session B starts empty, saves `"draft B"`, and asserts both text and attachment arrays restore independently.
+  - Added profile/session key coverage for same session ID across different profiles.
+
+#### Commands and results
+
+1. Red test:
+
+```bash
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:ConduitTests/ComposerDraftStoreTests CODE_SIGNING_ALLOWED=NO
+```
+
+Result: failed as expected before implementation with `Type 'ComposerBar' has no member 'composerDraftKey'` in `ComposerDraftStoreTests.swift`; exit code 65.
+
+2. Focused composer tests after implementation:
+
+```bash
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:ConduitTests/ComposerDraftStoreTests -only-testing:ConduitTests/ComposerPasteTextViewTests CODE_SIGNING_ALLOWED=NO
+```
+
+Result: `** TEST SUCCEEDED **`; selected tests executed 17 tests with 0 failures.
+
+3. Diff whitespace check:
+
+```bash
+git diff --check
+```
+
+Result: exit code 0, no output.
+
+#### Self-review notes
+
+- AppState was not changed.
+- Title scroll and markdown selection code were not touched.
+- The draft store remains in-memory only; no `UserDefaults`, server, or persistence writes were added.
+- Handoff does not await network work and does not focus the destination editor.
+- The pure handoff tests cover key/store restoration and profile isolation. The SwiftUI `ComposerBar` runtime handoff remains primarily covered by the implementation and focused compile/runtime tests because the existing test harness does not expose private `@State` values directly.
+
+#### Concerns
+
+- The focused xcodebuild run still emits pre-existing warnings/noise unrelated to this task: AppIcon unassigned-child asset warnings, existing Swift 6 isolation warnings, and expected NSItemProvider/image encoding logs from paste tests.
+- No AppState ownership defect was proven, so AppState was intentionally left untouched.
+
+### Fix round 1 report — slash restore and failed-submit draft preservation
+
+Base commit before fix round 1: `1bb85d8 fix: restore composer drafts per active session`.
+
+Implementation commit: created from this fix round's work; final hash is reported by the implementer after commit.
+
+#### Review findings addressed
+
+1. Programmatic handoff could restore slash-prefixed text and then let the global text `onChange` reopen slash suggestions. Fix: `ComposerBar` now marks draft text assignments as programmatic, clears that one-shot marker inside the text-change handler, and routes slash visibility through `shouldShowSlashSuggestions(for:isProgrammaticDraftRestore:)`, which returns false for programmatic draft restores.
+
+2. A failed inactive submission could overwrite a newer saved draft for the original session key. Fix: inactive failure restoration now calls `ComposerDraftStore.saveIfMissing`, preserving an existing bucket instead of replacing it.
+
+#### Files changed in fix round 1
+
+- `Conduit/Views/Components/ComposerBar.swift`
+  - Added one-shot `suppressNextTextChangeSuggestions`.
+  - Reused a static slash-prefix helper for user-edit suggestions.
+  - Suppressed slash suggestions for programmatic draft restoration.
+  - Changed inactive failed-submit restoration from unconditional save to save-if-missing.
+
+- `Conduit/Views/Components/ComposerDraftStore.swift`
+  - Added `saveIfMissing(_:for:)` for failed inactive submissions that should preserve any newer saved draft.
+
+- `ConduitTests/ComposerDraftStoreTests.swift`
+  - Added regression coverage for programmatic restored slash text keeping suggestions hidden.
+  - Added regression coverage that an old failed submission cannot clobber a newer saved draft for its original key.
+
+#### Commands and results
+
+1. Red tests:
+
+```bash
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:ConduitTests/ComposerDraftStoreTests CODE_SIGNING_ALLOWED=NO
+```
+
+Result: failed as expected before implementation; exit code 65. Errors were `Type 'ComposerBar' has no member 'shouldShowSlashSuggestions'` and `Value of type 'ComposerDraftStore' has no member 'saveIfMissing'`.
+
+2. Draft-store regressions after implementation:
+
+```bash
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:ConduitTests/ComposerDraftStoreTests CODE_SIGNING_ALLOWED=NO
+```
+
+Result: `** TEST SUCCEEDED **`; `ComposerDraftStoreTests` executed 7 tests with 0 failures.
+
+3. Focused composer/session tests:
+
+```bash
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:ConduitTests/ComposerDraftStoreTests -only-testing:ConduitTests/ComposerPasteTextViewTests -only-testing:ConduitTests/AppStateChatResumeTests CODE_SIGNING_ALLOWED=NO
+```
+
+Result: `** TEST SUCCEEDED **`; selected tests executed 82 tests with 0 failures.
+
+4. Diff whitespace check:
+
+```bash
+git diff --check
+```
+
+Result: exit code 0, no output.
+
+#### Concerns
+
+- AppState was not changed; no AppState ownership defect was proven.
+- The focused composer/session test run still emits pre-existing simulator/framework log noise unrelated to this fix, including audio/haptic/WebKit logs and paste-provider NSItemProvider messages.

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -121,6 +121,14 @@ struct ChatResumeLifecycleOperations {
     static let live = ChatResumeLifecycleOperations()
 }
 
+struct ComposerSubmissionContext: Equatable {
+    let profile: String
+    let sessionID: String?
+    let clientIdentity: ObjectIdentifier?
+    let clientEpoch: UUID
+    let viewportTransitionGeneration: UInt64
+}
+
 /// Owns the profile-scoped session catalog cache and rejects writes from a
 /// load that started before a destructive cache mutation. AppState is
 /// main-actor isolated, but every dashboard request can re-enter the actor
@@ -376,6 +384,7 @@ final class AppState: ObservableObject {
     /// An explicit user-send request lets ChatView scroll after SwiftUI has
     /// inserted the outgoing bubble, even if the user previously browsed up.
     @Published private(set) var chatScrollRequest = 0
+    @Published private(set) var chatScrollToTopRequest = 0
 
     /// Profile changes and network refreshes are asynchronous. Keep a final
     /// ownership boundary at the published catalog so a stale row can never
@@ -4339,7 +4348,92 @@ final class AppState: ObservableObject {
 
     // MARK: - Composer actions
 
-    func submitComposer(text: String, attachments: [Attachment] = []) async -> Bool {
+    func composerSubmissionContext() -> ComposerSubmissionContext {
+        ComposerSubmissionContext(
+            profile: activeProfile,
+            sessionID: activeSessionId,
+            clientIdentity: client.map(ObjectIdentifier.init),
+            clientEpoch: activeClientEpoch,
+            viewportTransitionGeneration: chatViewportTransitionGeneration
+        )
+    }
+
+    private func isCurrentComposerSubmission(_ context: ComposerSubmissionContext) -> Bool {
+        context.profile == activeProfile
+            && context.sessionID == activeSessionId
+            && context.clientIdentity == client.map(ObjectIdentifier.init)
+            && context.clientEpoch == activeClientEpoch
+            && context.viewportTransitionGeneration == chatViewportTransitionGeneration
+    }
+
+    private func composerSubmissionOwnershipIsCurrent(
+        _ context: ComposerSubmissionContext
+    ) -> Bool {
+        context.profile == activeProfile
+            && context.clientIdentity == client.map(ObjectIdentifier.init)
+            && context.clientEpoch == activeClientEpoch
+            && context.viewportTransitionGeneration == chatViewportTransitionGeneration
+    }
+
+    private func composerSessionIDsAreEquivalent(
+        _ lhs: String?,
+        _ rhs: String?
+    ) -> Bool {
+        guard let lhs, let rhs, !lhs.isEmpty, !rhs.isEmpty else { return false }
+        if lhs == rhs || activeChatScrollSessionIdentity.areEquivalent(lhs, rhs) {
+            return true
+        }
+        guard let session = (sessions + cronSessions).first(where: { session in
+            let ids = Set([session.id] + session.alternateIds)
+            return ids.contains(lhs) || ids.contains(rhs)
+        }) else {
+            return false
+        }
+        let ids = Set([session.id] + session.alternateIds)
+        return ids.contains(lhs) && ids.contains(rhs)
+    }
+
+    private func isCurrentOrAliasedComposerSubmission(
+        _ context: ComposerSubmissionContext
+    ) -> Bool {
+        currentComposerSubmissionContextIfOwnedAndAliased(context) != nil
+    }
+
+    private func currentComposerSubmissionContextIfOwnedAndAliased(
+        _ context: ComposerSubmissionContext
+    ) -> ComposerSubmissionContext? {
+        guard composerSubmissionOwnershipIsCurrent(context),
+              let activeSessionId,
+              composerSessionIDsAreEquivalent(context.sessionID, activeSessionId) else {
+            return nil
+        }
+        return ComposerSubmissionContext(
+            profile: context.profile,
+            sessionID: activeSessionId,
+            clientIdentity: context.clientIdentity,
+            clientEpoch: context.clientEpoch,
+            viewportTransitionGeneration: context.viewportTransitionGeneration
+        )
+    }
+
+    private func recoverComposerSubmission(
+        using context: ComposerSubmissionContext
+    ) async -> ComposerSubmissionContext? {
+        // Keep recovery owned by the submission that produced the error. The
+        // active actor may have moved to another session while the RPC waited.
+        guard isCurrentOrAliasedComposerSubmission(context) else { return nil }
+        await syncSession()
+        return currentComposerSubmissionContextIfOwnedAndAliased(context)
+    }
+
+    func submitComposer(
+        text: String,
+        attachments: [Attachment] = [],
+        context: ComposerSubmissionContext? = nil
+    ) async -> Bool {
+        let submissionContext = context ?? composerSubmissionContext()
+        guard isCurrentComposerSubmission(submissionContext) else { return false }
+
         // The gateway is already idle while the final visual tail drains.
         // If the user acts first, commit that response synchronously so the
         // new outgoing message retains correct transcript order.
@@ -4348,7 +4442,7 @@ final class AppState: ObservableObject {
 
         // Slash command intercept — handle before normal message/steer logic
         if attachments.isEmpty && Self.parseSlashCommand(text) != nil {
-            await executeSlashCommand(text)
+            await executeSlashCommand(text, context: submissionContext)
             return true
         }
 
@@ -4360,16 +4454,26 @@ final class AppState: ObservableObject {
 
             switch busyInputMode {
             case .steer:
-                return await steer(text)
+                return await steer(text, context: submissionContext)
             case .interrupt:
-                return await redirectOrInterruptAndSend(text)
+                return await redirectOrInterruptAndSend(text, context: submissionContext)
             }
         }
 
-        return await sendMessage(text, attachments: attachments)
+        return await sendMessage(
+            text,
+            attachments: attachments,
+            context: submissionContext
+        )
     }
 
-    func sendMessage(_ text: String, attachments: [Attachment] = []) async -> Bool {
+    func sendMessage(
+        _ text: String,
+        attachments: [Attachment] = [],
+        context: ComposerSubmissionContext? = nil
+    ) async -> Bool {
+        let submissionContext = context ?? composerSubmissionContext()
+        guard isCurrentComposerSubmission(submissionContext) else { return false }
         guard let client, let sessionId = activeSessionId else { return false }
         cancelChatResumeRestoration()
         resetResponseHapticTurn()
@@ -4393,20 +4497,25 @@ final class AppState: ObservableObject {
             do {
                 if attachment.kind == .image {
                     let base64 = await AttachmentHelper.toBase64(attachment)
+                    guard isCurrentComposerSubmission(submissionContext) else { return false }
                     guard !base64.isEmpty else { throw AttachmentError.unreadableFile(attachment.name) }
                     _ = try await client.attachImage(sessionId, base64: base64, filename: attachment.name)
                 } else if attachment.name.lowercased().hasSuffix(".pdf") {
                     let base64 = await AttachmentHelper.toBase64(attachment)
+                    guard isCurrentComposerSubmission(submissionContext) else { return false }
                     guard !base64.isEmpty else { throw AttachmentError.unreadableFile(attachment.name) }
                     try await client.attachPdf(sessionId, base64: base64, filename: attachment.name)
                 } else {
                     let dataUrl = await AttachmentHelper.toDataUrl(attachment)
+                    guard isCurrentComposerSubmission(submissionContext) else { return false }
                     guard !dataUrl.isEmpty else { throw AttachmentError.unreadableFile(attachment.name) }
                     try await client.attachFile(sessionId, dataUrl: dataUrl, name: attachment.name)
                 }
+                guard isCurrentComposerSubmission(submissionContext) else { return false }
             } catch {
+                guard isCurrentComposerSubmission(submissionContext) else { return false }
                 errorMessage = "Attachment failed: \(error.localizedDescription)"
-                await syncSession()
+                await recoverComposerSubmission(using: submissionContext)
                 return false
             }
         }
@@ -4417,20 +4526,31 @@ final class AppState: ObservableObject {
             } else {
                 try await client.sendPrompt(sessionId, text: text)
             }
+            // The gateway accepted the prompt. A session handoff may have
+            // happened while the RPC was suspended, but that does not turn a
+            // remotely successful send into a local draft failure. There are
+            // no current-session mutations after this point.
             return true
         } catch {
+            guard isCurrentComposerSubmission(submissionContext) else { return false }
             errorMessage = "Failed to send: \(error.localizedDescription)"
-            await syncSession()
+            await recoverComposerSubmission(using: submissionContext)
             return false
         }
     }
 
-    func toggleYolo() async {
-        _ = await setYoloMode(!runtime.yolo)
+    func toggleYolo(context: ComposerSubmissionContext? = nil) async {
+        let submissionContext = context ?? composerSubmissionContext()
+        _ = await setYoloMode(!runtime.yolo, context: submissionContext)
     }
 
     @discardableResult
-    func setYoloMode(_ enabled: Bool) async -> Bool {
+    func setYoloMode(
+        _ enabled: Bool,
+        context: ComposerSubmissionContext? = nil
+    ) async -> Bool {
+        let submissionContext = context ?? composerSubmissionContext()
+        guard isCurrentComposerSubmission(submissionContext) else { return false }
         guard let client, let sessionId = activeSessionId else { return false }
         do {
             if let setSessionYolo = chatResumeLifecycleOperations.setSessionYolo {
@@ -4438,6 +4558,9 @@ final class AppState: ObservableObject {
             } else {
                 try await client.setSessionYolo(sessionId, enabled: enabled)
             }
+            // Hermes accepted the setting. Avoid publishing it into a new
+            // session if the composer origin was handed off while awaiting.
+            guard isCurrentComposerSubmission(submissionContext) else { return true }
             let persistedSessionID = canonicalSessionID(for: sessionId) ?? sessionId
             sessionYoloStore.setOverride(
                 enabled,
@@ -4448,6 +4571,7 @@ final class AppState: ObservableObject {
             runtime.yolo = enabled
             return true
         } catch {
+            guard isCurrentComposerSubmission(submissionContext) else { return false }
             errorMessage = "Unable to change YOLO mode: \(error.localizedDescription)"
             return false
         }
@@ -4641,7 +4765,12 @@ final class AppState: ObservableObject {
         return nil
     }
 
-    func executeSlashCommand(_ text: String) async {
+    func executeSlashCommand(
+        _ text: String,
+        context: ComposerSubmissionContext? = nil
+    ) async {
+        let submissionContext = context ?? composerSubmissionContext()
+        guard isCurrentComposerSubmission(submissionContext) else { return }
         guard let client,
               let sessionId = activeSessionId,
               let command = Self.parseSlashCommand(text) else { return }
@@ -4692,12 +4821,12 @@ final class AppState: ObservableObject {
         case "yolo":
             if command.argument.isEmpty {
                 cancelChatResumeRestoration()
-                await toggleYolo()
+                await toggleYolo(context: submissionContext)
                 return
             }
         case "help":
             cancelChatResumeRestoration()
-            appendSlashOutput(Self.formatSlashHelp())
+            appendSlashOutput(Self.formatSlashHelp(), context: submissionContext)
             return
         default:
             break
@@ -4706,17 +4835,35 @@ final class AppState: ObservableObject {
         // Server-side execution
         cancelChatResumeRestoration()
         do {
-            let result = try await executeGatewaySlash(client: client, sessionID: sessionId, command: command.cleaned)
-            await handleSlashResult(result, depth: 0, aliasArgument: command.argument)
+            let result = try await executeGatewaySlash(
+                client: client,
+                sessionID: sessionId,
+                command: command.cleaned,
+                context: submissionContext
+            )
+            guard isCurrentComposerSubmission(submissionContext) else { return }
+            await handleSlashResult(
+                result,
+                depth: 0,
+                aliasArgument: command.argument,
+                client: client,
+                sessionID: sessionId,
+                context: submissionContext
+            )
         } catch {
-            appendSlashOutput("⚠️ Command failed: \(error.localizedDescription)")
+            guard isCurrentComposerSubmission(submissionContext) else { return }
+            appendSlashOutput(
+                "⚠️ Command failed: \(error.localizedDescription)",
+                context: submissionContext
+            )
         }
     }
 
     private func executeGatewaySlash(
         client: HermesClient,
         sessionID: String,
-        command: String
+        command: String,
+        context: ComposerSubmissionContext? = nil
     ) async throws -> AnyCodable {
         do {
             if let executeSlash = chatResumeLifecycleOperations.executeSlash {
@@ -4724,6 +4871,9 @@ final class AppState: ObservableObject {
             }
             return try await client.executeSlash(sessionId: sessionID, command: command)
         } catch {
+            if let context {
+                guard isCurrentComposerSubmission(context) else { throw error }
+            }
             guard let parsed = Self.parseSlashCommand(command) else { throw error }
             if let dispatchCommand = chatResumeLifecycleOperations.dispatchCommand {
                 return try await dispatchCommand(
@@ -4737,9 +4887,17 @@ final class AppState: ObservableObject {
         }
     }
 
-    private func handleSlashResult(_ result: AnyCodable, depth: Int, aliasArgument: String) async {
+    private func handleSlashResult(
+        _ result: AnyCodable,
+        depth: Int,
+        aliasArgument: String,
+        client: HermesClient,
+        sessionID: String,
+        context: ComposerSubmissionContext
+    ) async {
+        guard isCurrentComposerSubmission(context) else { return }
         guard depth < 4 else {
-            appendSlashOutput("⚠️ Too many command aliases.")
+            appendSlashOutput("⚠️ Too many command aliases.", context: context)
             return
         }
 
@@ -4751,20 +4909,20 @@ final class AppState: ObservableObject {
         case "exec", "plugin":
             // Command executed server-side; show any output
             if !output.isEmpty {
-                appendSlashOutput(output)
+                appendSlashOutput(output, context: context)
             }
         case "send", "skill":
             // These send a prompt — extract the message and send it
             let message = obj["message"]?.stringValue ?? output
             if !message.isEmpty {
-                await sendMessage(message, attachments: [])
+                _ = await sendMessage(message, attachments: [], context: context)
             }
         case "prefill":
             if let notice = obj["notice"]?.stringValue, !notice.isEmpty {
-                appendSlashOutput(notice)
+                appendSlashOutput(notice, context: context)
             }
             let message = obj["message"]?.stringValue ?? output
-            if !message.isEmpty {
+            if !message.isEmpty, isCurrentComposerSubmission(context) {
                 composerPrefillText = message
                 composerPrefillToken = UUID()
             }
@@ -4773,25 +4931,48 @@ final class AppState: ObservableObject {
             let target = obj["target"]?.stringValue ?? obj["command"]?.stringValue ?? obj["name"]?.stringValue ?? ""
             if !target.isEmpty {
                 do {
-                    guard let client, let sessionId = activeSessionId else { return }
+                    guard isCurrentComposerSubmission(context) else { return }
                     let nestedCommand = aliasArgument.isEmpty ? target : "\(target) \(aliasArgument)"
-                    let nested = try await executeGatewaySlash(client: client, sessionID: sessionId, command: nestedCommand)
-                    await handleSlashResult(nested, depth: depth + 1, aliasArgument: aliasArgument)
+                    let nested = try await executeGatewaySlash(
+                        client: client,
+                        sessionID: sessionID,
+                        command: nestedCommand,
+                        context: context
+                    )
+                    guard isCurrentComposerSubmission(context) else { return }
+                    await handleSlashResult(
+                        nested,
+                        depth: depth + 1,
+                        aliasArgument: aliasArgument,
+                        client: client,
+                        sessionID: sessionID,
+                        context: context
+                    )
                 } catch {
-                    appendSlashOutput("⚠️ Alias target failed: \(error.localizedDescription)")
+                    guard isCurrentComposerSubmission(context) else { return }
+                    appendSlashOutput(
+                        "⚠️ Alias target failed: \(error.localizedDescription)",
+                        context: context
+                    )
                 }
             } else if !output.isEmpty {
-                appendSlashOutput(output)
+                appendSlashOutput(output, context: context)
             }
         default:
             // Unknown type — show output if present
             if !output.isEmpty {
-                appendSlashOutput(output)
+                appendSlashOutput(output, context: context)
             }
         }
     }
 
-    private func appendSlashOutput(_ text: String) {
+    private func appendSlashOutput(
+        _ text: String,
+        context: ComposerSubmissionContext? = nil
+    ) {
+        if let context {
+            guard isCurrentComposerSubmission(context) else { return }
+        }
         messages.append(ChatMessage(
             id: "slash-\(Date().timeIntervalSince1970)",
             role: .system,
@@ -4807,7 +4988,12 @@ final class AppState: ObservableObject {
         return "**Slash Commands**\n\nType `/` followed by a command name.\n\n**Built-in:**\n• `/new` — Start a new conversation\n• `/model` — Open the model picker\n• `/yolo` — Toggle auto-approve mode\n• `/help` — Show this help\n\nUse the suggestions list to discover gateway commands."
     }
 
-    private func steer(_ text: String) async -> Bool {
+    private func steer(
+        _ text: String,
+        context: ComposerSubmissionContext? = nil
+    ) async -> Bool {
+        let submissionContext = context ?? composerSubmissionContext()
+        guard isCurrentComposerSubmission(submissionContext) else { return false }
         guard let client, let sessionId = activeSessionId else { return false }
         cancelChatResumeRestoration()
         do {
@@ -4816,10 +5002,14 @@ final class AppState: ObservableObject {
             } else {
                 try await client.steer(sessionId, text: text)
             }
+            // A successful steer is accepted by Hermes even if the user
+            // switched sessions while the RPC was suspended. It has no local
+            // post-await mutation, so preserve success for draft handling.
             return true
         } catch {
+            guard isCurrentOrAliasedComposerSubmission(submissionContext) else { return false }
             errorMessage = error.localizedDescription
-            await syncSession()
+            await recoverComposerSubmission(using: submissionContext)
             return false
         }
     }
@@ -4828,7 +5018,13 @@ final class AppState: ObservableObject {
     /// request while retaining completed work; gateways can also acknowledge a
     /// correction as queued during their agent-build window. Older gateways
     /// retain the established `session.interrupt` then `prompt.submit` flow.
-    private func redirectOrInterruptAndSend(_ text: String, retriedAfterResume: Bool = false) async -> Bool {
+    private func redirectOrInterruptAndSend(
+        _ text: String,
+        retriedAfterResume: Bool = false,
+        context: ComposerSubmissionContext? = nil
+    ) async -> Bool {
+        let submissionContext = context ?? composerSubmissionContext()
+        guard isCurrentComposerSubmission(submissionContext) else { return false }
         guard let client, let sessionId = activeSessionId else { return false }
         cancelChatResumeRestoration()
 
@@ -4841,50 +5037,82 @@ final class AppState: ObservableObject {
             }
             switch outcome {
             case .redirected, .queued:
-                appendLocalUserMessage(text)
+                if isCurrentOrAliasedComposerSubmission(submissionContext) {
+                    appendLocalUserMessage(text)
+                }
                 return true
             case .rejected:
                 // A reject commonly means the turn won the race to completion.
                 // Reconcile first so we submit directly when it is already idle
                 // instead of surfacing a misleading interrupt failure.
-                await syncSession()
+                guard isCurrentOrAliasedComposerSubmission(submissionContext) else { return false }
+                guard let recoveredContext = await recoverComposerSubmission(using: submissionContext) else {
+                    return false
+                }
+                guard isCurrentComposerSubmission(recoveredContext) else { return false }
                 if turnState == .idle {
-                    return await sendMessage(text, attachments: [])
+                    return await sendMessage(
+                        text,
+                        attachments: [],
+                        context: recoveredContext
+                    )
                 }
                 guard turnState == .running else { return false }
-                return await interruptAndSendLegacy(text)
+                return await interruptAndSendLegacy(text, context: recoveredContext)
             }
         } catch let error as RpcError {
+            guard isCurrentOrAliasedComposerSubmission(submissionContext) else { return false }
             if isUnsupportedRedirect(error) {
-                return await interruptAndSendLegacy(text)
+                guard let currentContext = currentComposerSubmissionContextIfOwnedAndAliased(submissionContext) else {
+                    return false
+                }
+                return await interruptAndSendLegacy(text, context: currentContext)
             }
 
             // A runtime session can be rotated while the app was backgrounded.
             // Reconcile once, then retry against the recovered runtime id.
             if !retriedAfterResume, isSessionNotFound(error) {
-                await syncSession()
+                guard let recoveredContext = await recoverComposerSubmission(using: submissionContext) else {
+                    return false
+                }
+                guard isCurrentComposerSubmission(recoveredContext) else { return false }
                 if turnState == .running {
-                    return await redirectOrInterruptAndSend(text, retriedAfterResume: true)
+                    return await redirectOrInterruptAndSend(
+                        text,
+                        retriedAfterResume: true,
+                        context: recoveredContext
+                    )
                 }
                 if turnState == .idle {
-                    return await sendMessage(text, attachments: [])
+                    return await sendMessage(
+                        text,
+                        attachments: [],
+                        context: recoveredContext
+                    )
                 }
                 return false
             }
 
             errorMessage = "Could not redirect the active response: \(error.localizedDescription)"
-            await syncSession()
+            await recoverComposerSubmission(using: submissionContext)
             return false
         } catch {
+            guard isCurrentOrAliasedComposerSubmission(submissionContext) else { return false }
             errorMessage = "Could not redirect the active response: \(error.localizedDescription)"
-            await syncSession()
+            await recoverComposerSubmission(using: submissionContext)
             return false
         }
     }
 
-    private func interruptAndSendLegacy(_ text: String) async -> Bool {
-        guard await interruptForReplacement() else { return false }
-        return await sendMessage(text, attachments: [])
+    private func interruptAndSendLegacy(
+        _ text: String,
+        context: ComposerSubmissionContext
+    ) async -> Bool {
+        guard await interruptForReplacement(context: context) else { return false }
+        guard let currentContext = currentComposerSubmissionContextIfOwnedAndAliased(context) else {
+            return false
+        }
+        return await sendMessage(text, attachments: [], context: currentContext)
     }
 
     private func appendLocalUserMessage(_ text: String) {
@@ -4921,8 +5149,14 @@ final class AppState: ObservableObject {
         error.message.lowercased().contains("session not found")
     }
 
-    private func interruptForReplacement() async -> Bool {
-        guard let client, let sessionId = activeSessionId else { return false }
+    private func interruptForReplacement(
+        context: ComposerSubmissionContext? = nil
+    ) async -> Bool {
+        let submissionContext = context ?? composerSubmissionContext()
+        guard let currentContext = currentComposerSubmissionContextIfOwnedAndAliased(submissionContext) else {
+            return false
+        }
+        guard let client, let sessionId = currentContext.sessionID else { return false }
         cancelChatResumeRestoration()
         turnState = .synchronizing
         do {
@@ -4931,18 +5165,22 @@ final class AppState: ObservableObject {
             } else {
                 try await client.cancel(sessionId)
             }
+            guard isCurrentOrAliasedComposerSubmission(currentContext) else { return false }
             return true
         } catch {
+            guard isCurrentOrAliasedComposerSubmission(currentContext) else { return false }
             errorMessage = "Could not interrupt the active response: \(error.localizedDescription)"
-            await syncSession()
+            await recoverComposerSubmission(using: currentContext)
             return false
         }
     }
 
     func cancelCurrent() async {
         guard isBusy else { return }
-        guard await interruptForReplacement() else { return }
-        await syncSession()
+        let submissionContext = composerSubmissionContext()
+        guard await interruptForReplacement(context: submissionContext) else { return }
+        guard let currentContext = currentComposerSubmissionContextIfOwnedAndAliased(submissionContext) else { return }
+        await recoverComposerSubmission(using: currentContext)
     }
 
     func respondToClarify(requestId: String, answer: String) async {
@@ -6693,6 +6931,10 @@ final class AppState: ObservableObject {
 
     func requestChatScrollToLatest() {
         chatScrollRequest &+= 1
+    }
+
+    func requestChatScrollToTop() {
+        chatScrollToTopRequest &+= 1
     }
 
     private func updateActiveSessionTitle(for sessionId: String, fallbackSessionId: String? = nil) {

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -22,6 +22,7 @@ struct ChatView: View {
     @State private var renderedTranscriptRevision: UInt64 = 0
     @State private var renderedViewportTransitionGeneration: UInt64 = 0
     @State private var viewportSnapshotProviderID = UUID()
+    @State private var scrollOwnerState = ChatScrollOwnerState()
     @GestureState private var isDraggingChat = false
     @State private var chatDragLifecycle = ChatDragLifecycleState()
     @State private var chatDragCompletionToken: ChatDragCompletionToken?
@@ -41,11 +42,25 @@ struct ChatView: View {
         return fallback.isValid ? fallback : nil
     }
 
-    private var bottomAnchor: String {
-        let scope = activeScrollSessionKey ?? ChatScrollSessionKey(
+    private var activeOrFallbackScrollSessionKey: ChatScrollSessionKey {
+        activeScrollSessionKey ?? ChatScrollSessionKey(
             profile: appState.activeProfile,
             sessionID: "new"
         )
+    }
+
+    private var topAnchor: String {
+        ChatTitleScrollAnchor.id(for: activeOrFallbackScrollSessionKey)
+    }
+
+    private var renderedTopAnchor: String {
+        ChatTitleScrollAnchor.id(
+            for: renderedScrollSessionKey ?? activeOrFallbackScrollSessionKey
+        )
+    }
+
+    private var bottomAnchor: String {
+        let scope = activeOrFallbackScrollSessionKey
         return "chat-latest-\(scope.profile)-\(scope.sessionID)"
     }
 
@@ -76,6 +91,10 @@ struct ChatView: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     LazyVStack(spacing: 18) {
+                        Color.clear
+                            .frame(height: 1)
+                            .id(topAnchor)
+
                         if appState.messages.isEmpty {
                             EmptyChatState().padding(.top, 60)
                         }
@@ -187,16 +206,14 @@ struct ChatView: View {
                                 return nil
                             }
                             let followsLatest = followsLatestState.wrappedValue
-                            let target = targetCacheState.wrappedValue.targets.first {
-                                $0.id == topVisibleChatIDState.wrappedValue
-                            }
-                            guard followsLatest || target != nil else { return nil }
-                            let snapshot = ChatScrollSnapshot(
-                                anchorMessageID: followsLatest ? nil : target?.semanticID,
+                            guard let snapshot = ChatTitleScrollViewportSnapshot.make(
                                 followsLatest: followsLatest,
-                                anchorMetadata: followsLatest ? nil : target?.restorationMetadata,
-                                anchorSourceMessageID: followsLatest ? nil : target?.id
-                            )
+                                topVisibleID: topVisibleChatIDState.wrappedValue,
+                                topAnchorID: ChatTitleScrollAnchor.id(for: sessionKey),
+                                targets: targetCacheState.wrappedValue.targets
+                            ) else {
+                                return nil
+                            }
                             return ChatRenderedViewportSnapshot(
                                 sessionKey: sessionKey,
                                 snapshot: snapshot
@@ -293,9 +310,16 @@ struct ChatView: View {
                     followsLatest = true
                     scrollToLatest(using: proxy)
                 }
+                .onChange(of: appState.chatScrollToTopRequest) { _, request in
+                    invalidateChatDrag()
+                    cancelAutomaticRestoration()
+                    followsLatest = false
+                    scrollToTop(using: proxy, request: request)
+                }
                 .onChange(of: appState.activeSessionId) { oldSessionID, newSessionID in
                     guard !appState.isOpeningNotificationSession else {
                         invalidateChatDrag()
+                        scrollOwnerState.invalidateForSessionTransition()
                         cancelAutomaticRestoration()
                         notificationHandoffPending = true
                         notificationHandoffSessionKey = activeScrollSessionKey
@@ -316,6 +340,7 @@ struct ChatView: View {
                     let keysAreEquivalent = identity.areEquivalent(oldKey, newKey)
                     if !keysAreEquivalent {
                         invalidateChatDrag()
+                        scrollOwnerState.invalidateForSessionTransition()
                     }
                     renderedScrollSessionKey = newKey
                     if followsLatest {
@@ -332,6 +357,7 @@ struct ChatView: View {
                 }
                 .onChange(of: appState.activeProfile) { _, _ in
                     invalidateChatDrag()
+                    scrollOwnerState.invalidateForSessionTransition()
                     let oldKey = renderedScrollSessionKey
                     let newKey = activeScrollSessionKey
                     if let request = appState.chatResumeRestorationRequest,
@@ -374,6 +400,7 @@ struct ChatView: View {
                 .onChange(of: appState.isOpeningNotificationSession) { _, isOpening in
                     if isOpening {
                         invalidateChatDrag()
+                        scrollOwnerState.invalidateForSessionTransition()
                         cancelAutomaticRestoration()
                         notificationHandoffPending = true
                         notificationHandoffSessionKey = nil
@@ -447,15 +474,11 @@ struct ChatView: View {
     }
 
     private func currentChatViewportSnapshot() -> ChatScrollSnapshot? {
-        let anchorTarget = chatMessageScrollTargetCache.targets.first {
-            $0.id == topVisibleChatID
-        }
-        guard followsLatest || anchorTarget != nil else { return nil }
-        return ChatScrollSnapshot(
-            anchorMessageID: followsLatest ? nil : anchorTarget?.semanticID,
+        ChatTitleScrollViewportSnapshot.make(
             followsLatest: followsLatest,
-            anchorMetadata: followsLatest ? nil : anchorTarget?.restorationMetadata,
-            anchorSourceMessageID: followsLatest ? nil : anchorTarget?.id
+            topVisibleID: topVisibleChatID,
+            topAnchorID: renderedTopAnchor,
+            targets: chatMessageScrollTargetCache.targets
         )
     }
 
@@ -480,6 +503,7 @@ struct ChatView: View {
             sessionKey: renderedScrollSessionKey ?? activeScrollSessionKey,
             viewportTransitionGeneration: appState.chatViewportTransitionGeneration
         ) else { return }
+        scrollOwnerState.invalidateForUserDrag()
         chatDragCompletionToken = nil
         cancelAutomaticRestoration()
         followsLatest = false
@@ -663,8 +687,10 @@ struct ChatView: View {
 
     private func scrollToLatest(using proxy: ScrollViewProxy) {
         guard !hasPendingRestoration else { return }
+        let ownerToken = scrollOwnerState.claimLatest()
+        let anchorID = bottomAnchor
         withAnimation(ConduitMotion.response) {
-            proxy.scrollTo(bottomAnchor, anchor: .bottom)
+            proxy.scrollTo(anchorID, anchor: .bottom)
         }
         // Retry after a short delay: proxy.scrollTo is a silent no-op if the
         // bottom anchor row isn't materialized yet (LazyVStack on a long
@@ -672,9 +698,39 @@ struct ChatView: View {
         // messages arrive on the same main-actor turn.
         Task { @MainActor in
             try? await Task.sleep(for: .milliseconds(150))
-            guard !Task.isCancelled, !hasPendingRestoration else { return }
+            guard let retryAnchor = scrollOwnerState.latestRetryAnchor(
+                for: ownerToken,
+                currentAnchor: bottomAnchor,
+                followsLatest: followsLatest,
+                hasPendingRestoration: hasPendingRestoration,
+                isCancelled: Task.isCancelled
+            ) else { return }
             withAnimation(ConduitMotion.response) {
-                proxy.scrollTo(bottomAnchor, anchor: .bottom)
+                proxy.scrollTo(retryAnchor, anchor: .bottom)
+            }
+        }
+    }
+
+    private func scrollToTop(using proxy: ScrollViewProxy, request: Int) {
+        let ownerToken = scrollOwnerState.claimTop(request: request)
+        let anchorID = topAnchor
+        var transaction = Transaction()
+        transaction.animation = nil
+        withTransaction(transaction) {
+            proxy.scrollTo(anchorID, anchor: .top)
+        }
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(150))
+            guard let retryAnchor = scrollOwnerState.topRetryAnchor(
+                for: ownerToken,
+                currentRequest: appState.chatScrollToTopRequest,
+                currentAnchor: topAnchor,
+                isCancelled: Task.isCancelled
+            ) else { return }
+            var transaction = Transaction()
+            transaction.animation = nil
+            withTransaction(transaction) {
+                proxy.scrollTo(retryAnchor, anchor: .top)
             }
         }
     }
@@ -706,12 +762,28 @@ struct ChatView: View {
         cancelAutomaticRestoration()
         let shouldFollowLatest = ChatFollowLatestRelatchPolicy
             .shouldFollowLatestAfterTransition(isDragging: isDraggingChat)
-        followsLatest = shouldFollowLatest
-        guard shouldFollowLatest else { return }
-        var transaction = Transaction()
-        transaction.animation = nil
-        withTransaction(transaction) {
-            proxy.scrollTo(bottomAnchor, anchor: .bottom)
+        switch scrollOwnerState.handoffCompletionAction(
+            currentTopRequest: appState.chatScrollToTopRequest,
+            currentTopAnchor: topAnchor,
+            shouldFollowLatest: shouldFollowLatest
+        ) {
+        case .top:
+            followsLatest = false
+            // The handoff completes once the destination's bottom-marker
+            // geometry arrives, but the lazy top anchor may not be laid out
+            // yet. Use the retry-capable path so the viewport still lands at
+            // the top once the anchor materializes.
+            scrollToTop(using: proxy, request: appState.chatScrollToTopRequest)
+        case .latest:
+            followsLatest = true
+            _ = scrollOwnerState.claimLatest()
+            var transaction = Transaction()
+            transaction.animation = nil
+            withTransaction(transaction) {
+                proxy.scrollTo(bottomAnchor, anchor: .bottom)
+            }
+        case .none:
+            followsLatest = false
         }
     }
 
@@ -731,6 +803,19 @@ struct ChatView: View {
     /// near-bottom window each streamed delta would yank the scroll back to
     /// the bottom, fighting the drag.
     private func relatchFollowsLatestIfSettled() {
+        if scrollOwnerState.hasActiveTopOwner(
+            currentRequest: appState.chatScrollToTopRequest
+        ) {
+            // A title tap pins the viewport near the top so the user can read
+            // back up the thread without streamed deltas yanking them to the
+            // bottom. Once they return near the bottom, hand ownership back to
+            // "latest" so auto-follow of new messages resumes instead of staying
+            // suppressed for the rest of the session. (A finger drag already
+            // clears this owner via beginChatDragIfNeeded; this covers the
+            // non-drag paths, e.g. short conversations where top ≈ bottom.)
+            guard isNearBottom else { return }
+            scrollOwnerState.claimLatest()
+        }
         if ChatFollowLatestRelatchPolicy.shouldRelatch(
             isNearBottom: isNearBottom,
             hasPendingRestoration: hasPendingRestoration,
@@ -740,6 +825,151 @@ struct ChatView: View {
         ) {
             followsLatest = true
         }
+    }
+}
+
+enum ChatTitleScrollAnchor {
+    static func id(for sessionKey: ChatScrollSessionKey) -> String {
+        "chat-top-\(sessionKey.profile)-\(sessionKey.sessionID)"
+    }
+}
+
+enum ChatScrollOwner: Equatable {
+    case latest
+    case explicitTop(request: Int)
+    case userDrag
+    case sessionTransition
+}
+
+struct ChatScrollOwnerToken: Equatable {
+    let generation: UInt64
+    let owner: ChatScrollOwner
+}
+
+enum ChatHandoffCompletionAction: Equatable {
+    case top(anchorID: String)
+    case latest
+    case none
+}
+
+struct ChatScrollOwnerState: Equatable {
+    private(set) var generation: UInt64 = 0
+    private(set) var owner: ChatScrollOwner = .latest
+
+    @discardableResult
+    mutating func claimLatest() -> ChatScrollOwnerToken {
+        advance(to: .latest)
+    }
+
+    @discardableResult
+    mutating func claimTop(request: Int) -> ChatScrollOwnerToken {
+        advance(to: .explicitTop(request: request))
+    }
+
+    mutating func invalidateForUserDrag() {
+        advance(to: .userDrag)
+    }
+
+    mutating func invalidateForSessionTransition() {
+        advance(to: .sessionTransition)
+    }
+
+    func hasActiveTopOwner(currentRequest: Int) -> Bool {
+        guard case .explicitTop(let request) = owner else { return false }
+        return request == currentRequest
+    }
+
+    func topRetryAnchor(
+        for token: ChatScrollOwnerToken,
+        currentRequest: Int,
+        currentAnchor: String,
+        isCancelled: Bool
+    ) -> String? {
+        guard !isCancelled,
+              token == currentToken,
+              hasActiveTopOwner(currentRequest: currentRequest) else {
+            return nil
+        }
+        return currentAnchor
+    }
+
+    func latestRetryAnchor(
+        for token: ChatScrollOwnerToken,
+        currentAnchor: String,
+        followsLatest: Bool,
+        hasPendingRestoration: Bool,
+        isCancelled: Bool
+    ) -> String? {
+        guard !isCancelled,
+              token == currentToken,
+              owner == .latest,
+              followsLatest,
+              !hasPendingRestoration else {
+            return nil
+        }
+        return currentAnchor
+    }
+
+    func handoffCompletionAction(
+        currentTopRequest: Int,
+        currentTopAnchor: String,
+        shouldFollowLatest: Bool
+    ) -> ChatHandoffCompletionAction {
+        if hasActiveTopOwner(currentRequest: currentTopRequest) {
+            return .top(anchorID: currentTopAnchor)
+        }
+        return shouldFollowLatest ? .latest : .none
+    }
+
+    private var currentToken: ChatScrollOwnerToken {
+        ChatScrollOwnerToken(generation: generation, owner: owner)
+    }
+
+    @discardableResult
+    private mutating func advance(to nextOwner: ChatScrollOwner) -> ChatScrollOwnerToken {
+        generation &+= 1
+        owner = nextOwner
+        return currentToken
+    }
+}
+
+enum ChatTitleScrollViewportSnapshot {
+    static func make(
+        followsLatest: Bool,
+        topVisibleID: String?,
+        topAnchorID: String,
+        targets: [ChatMessageScrollTarget]
+    ) -> ChatScrollSnapshot? {
+        if followsLatest {
+            return ChatScrollSnapshot(
+                anchorMessageID: nil,
+                followsLatest: true
+            )
+        }
+        guard let target = visibleTarget(
+            topVisibleID: topVisibleID,
+            topAnchorID: topAnchorID,
+            targets: targets
+        ) else {
+            return nil
+        }
+        return ChatScrollSnapshot(
+            anchorMessageID: target.semanticID,
+            followsLatest: false,
+            anchorMetadata: target.restorationMetadata,
+            anchorSourceMessageID: target.id
+        )
+    }
+
+    private static func visibleTarget(
+        topVisibleID: String?,
+        topAnchorID: String,
+        targets: [ChatMessageScrollTarget]
+    ) -> ChatMessageScrollTarget? {
+        if topVisibleID == topAnchorID {
+            return targets.first
+        }
+        return targets.first { $0.id == topVisibleID }
     }
 }
 

--- a/Conduit/Views/Components/ComposerBar.swift
+++ b/Conduit/Views/Components/ComposerBar.swift
@@ -24,7 +24,102 @@ struct ComposerBar: View {
     @State private var isFocused = false
     @State private var isShowingSlashSuggestions = false
     @State private var composerErrorMessage: String?
+    @State private var draftStore = ComposerDraftStore()
+    @State private var editorIdentity = UUID()
+    @State private var loadedDraftKey: ComposerDraftKey?
+    @State private var photoImportContext: AsyncAttachmentContext?
+    @State private var photoImportGeneration: UInt64 = 0
+    @State private var documentImportContext: AsyncAttachmentContext?
+    @State private var attachmentGeneration: UInt64 = 0
+    @State private var suppressNextTextChangeSuggestions = false
     @Namespace private var glassNamespace
+
+    struct AsyncAttachmentContext: Equatable {
+        let editorIdentity: UUID
+        let draftKey: ComposerDraftKey
+        let attachmentGeneration: UInt64
+    }
+
+    static func composerDraftKey(for sessionID: String?, profile: String) -> ComposerDraftKey {
+        ComposerDraftKey(
+            profile: profile,
+            sessionID: sessionID ?? ComposerDraftKey.newConversationSessionID
+        )
+    }
+
+    static func draftKeysAreEquivalent(
+        _ lhs: ComposerDraftKey,
+        _ rhs: ComposerDraftKey,
+        identity: ChatScrollSessionIdentity
+    ) -> Bool {
+        guard lhs.profile == rhs.profile else { return false }
+        if lhs == rhs { return true }
+        guard !lhs.isNewConversation, !rhs.isNewConversation else { return false }
+        return identity.areEquivalent(lhs.sessionID, rhs.sessionID)
+    }
+
+    static func shouldAcceptAsyncAttachmentCompletion(
+        startedIn origin: AsyncAttachmentContext,
+        currentEditorIdentity: UUID,
+        currentDraftKey: ComposerDraftKey,
+        currentAttachmentGeneration: UInt64
+    ) -> Bool {
+        origin.editorIdentity == currentEditorIdentity
+            && origin.draftKey == currentDraftKey
+            && origin.attachmentGeneration == currentAttachmentGeneration
+    }
+
+    static func photoImportContext(
+        editorIdentity: UUID,
+        draftKey: ComposerDraftKey,
+        attachmentGeneration: UInt64
+    ) -> AsyncAttachmentContext {
+        AsyncAttachmentContext(
+            editorIdentity: editorIdentity,
+            draftKey: draftKey,
+            attachmentGeneration: attachmentGeneration
+        )
+    }
+
+    static func shouldAcceptPhotoPickerCompletion(
+        openedIn origin: AsyncAttachmentContext?,
+        currentEditorIdentity: UUID,
+        currentDraftKey: ComposerDraftKey,
+        currentAttachmentGeneration: UInt64
+    ) -> Bool {
+        guard let origin else { return false }
+        return shouldAcceptAsyncAttachmentCompletion(
+            startedIn: origin,
+            currentEditorIdentity: currentEditorIdentity,
+            currentDraftKey: currentDraftKey,
+            currentAttachmentGeneration: currentAttachmentGeneration
+        )
+    }
+
+    static func shouldClearPhotoImportContext(
+        completingGeneration: UInt64,
+        completingContext: AsyncAttachmentContext,
+        currentGeneration: UInt64,
+        currentContext: AsyncAttachmentContext?
+    ) -> Bool {
+        completingGeneration == currentGeneration && completingContext == currentContext
+    }
+
+    static func shouldShowSlashSuggestions(
+        for text: String,
+        isProgrammaticDraftRestore: Bool
+    ) -> Bool {
+        guard !isProgrammaticDraftRestore else { return false }
+        return slashPrefix(in: text) != nil
+    }
+
+    private static func slashPrefix(in text: String) -> String? {
+        let trimmed = text.replacingOccurrences(of: "^\\s+", with: "", options: .regularExpression)
+        guard trimmed.hasPrefix("/") else { return nil }
+        let prefix = String(trimmed.dropFirst())
+        guard !prefix.contains(where: { $0.isWhitespace || $0.isNewline }) else { return nil }
+        return prefix.lowercased()
+    }
 
     static func pastedImageAttachmentMetadata(for typeIdentifier: String) -> (name: String, mimeType: String) {
         guard let type = UTType(typeIdentifier),
@@ -48,11 +143,7 @@ struct ComposerBar: View {
     /// Returns the slash prefix being typed, or nil if the cursor has moved
     /// beyond the command name. Leading whitespace is accepted on purpose.
     private var slashPrefix: String? {
-        let trimmed = text.replacingOccurrences(of: "^\\s+", with: "", options: .regularExpression)
-        guard trimmed.hasPrefix("/") else { return nil }
-        let prefix = String(trimmed.dropFirst())
-        guard !prefix.contains(where: { $0.isWhitespace || $0.isNewline }) else { return nil }
-        return prefix.lowercased()
+        Self.slashPrefix(in: text)
     }
 
     private var filteredSlashCommands: [SlashCommand] {
@@ -68,6 +159,10 @@ struct ComposerBar: View {
 
     private var action: ComposerAction {
         appState.composerAction(hasText: hasText, hasAttachments: !attachments.isEmpty)
+    }
+
+    private var activeDraftKey: ComposerDraftKey {
+        composerDraftKey(for: appState.activeSessionId)
     }
 
     private var stopOnly: Bool {
@@ -134,13 +229,18 @@ struct ComposerBar: View {
         .padding(.top, 8)
         .padding(.bottom, 10)
         .onChange(of: text) { _, newValue in
+            let isProgrammaticDraftRestore = suppressNextTextChangeSuggestions
+            suppressNextTextChangeSuggestions = false
             composerErrorMessage = nil
             if newValue.isEmpty {
                 composerTextHeight = ComposerPasteTextView.minimumHeight
             }
             // Show suggestions when actively typing a slash command prefix
             withAnimation(ConduitMotion.response) {
-                isShowingSlashSuggestions = slashPrefix != nil
+                isShowingSlashSuggestions = Self.shouldShowSlashSuggestions(
+                    for: newValue,
+                    isProgrammaticDraftRestore: isProgrammaticDraftRestore
+                )
             }
         }
         .onChange(of: appState.composerPrefillToken) { _, _ in
@@ -151,20 +251,32 @@ struct ComposerBar: View {
         .onChange(of: photoItem) { _, _ in
             handlePhotoSelection()
         }
+        .onAppear {
+            guard loadedDraftKey == nil else { return }
+            loadDraft(for: activeDraftKey)
+        }
+        .onChange(of: activeDraftKey) { _, newKey in
+            handoffComposer(to: newKey)
+        }
         // A session resume can complete before the gateway has refreshed its
         // context accounting. Recheck once the active composer is on screen,
         // rather than making the user open the context sheet to populate it.
         .task(id: appState.activeSessionId) {
-            guard appState.activeSessionId != nil else { return }
+            let sessionID = appState.activeSessionId
+            guard sessionID != nil else { return }
             try? await Task.sleep(for: .milliseconds(350))
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled, appState.activeSessionId == sessionID else { return }
             await appState.refreshContextUsage()
         }
         .fileImporter(
             isPresented: $showDocumentPicker,
             allowedContentTypes: [.data],
             allowsMultipleSelection: true,
-            onCompletion: handleDocumentSelection
+            onCompletion: { result in
+                let origin = documentImportContext
+                handleDocumentSelection(result, startedIn: origin)
+                clearDocumentImportContextIfCurrent(origin)
+            }
         )
     }
 
@@ -202,6 +314,7 @@ struct ComposerBar: View {
                 voiceButton
 
                 ZStack(alignment: .topLeading) {
+                    let currentEditorIdentity = editorIdentity
                     if text.isEmpty {
                         Text(appState.composerPlaceholder)
                             .foregroundStyle(.secondary)
@@ -214,22 +327,14 @@ struct ComposerBar: View {
                         measuredHeight: $composerTextHeight,
                         enabled: appState.composerIsEnabled,
                         onPastedImage: { pastedImage in
-                            composerErrorMessage = nil
-                            let metadata = Self.pastedImageAttachmentMetadata(
-                                for: pastedImage.typeIdentifier
-                            )
-                            addAttachment(
-                                data: pastedImage.data,
-                                name: metadata.name,
-                                mimeType: metadata.mimeType,
-                                kind: .image
-                            )
+                            handlePastedImage(pastedImage, editorIdentity: currentEditorIdentity)
                         },
                         onPastedImageError: { message in
-                            composerErrorMessage = Self.pastedImageErrorMessage(message)
-                            Haptics.error()
-                        }
+                            handlePastedImageError(message, editorIdentity: currentEditorIdentity)
+                        },
+                        editorIdentity: editorIdentity
                     )
+                    .id(editorIdentity)
                     .padding(.horizontal, 5)
                     .frame(height: composerTextHeight)
                 }
@@ -334,11 +439,12 @@ struct ComposerBar: View {
     private var attachmentButton: some View {
         Menu {
             Button {
-                showAttachmentMenu = true
+                openPhotoLibraryPicker()
             } label: {
                 Label("Photo Library", systemImage: "photo")
             }
             Button {
+                documentImportContext = asyncAttachmentContext
                 showDocumentPicker = true
             } label: {
                 Label("Document", systemImage: "doc")
@@ -483,6 +589,10 @@ struct ComposerBar: View {
         let submittedAttachments = attachments
         let submittedAction = action
         let prefillToken = appState.composerPrefillToken
+        let submittedDraftKey = loadedDraftKey ?? activeDraftKey
+        let submittedDraftBucket = draftStore.submissionBucket(for: submittedDraftKey)
+        let submissionContext = appState.composerSubmissionContext()
+        rotateAttachmentGeneration()
         collapseSubmittedDraft()
 
         switch submittedAction {
@@ -495,16 +605,20 @@ struct ComposerBar: View {
         Task {
             let didSubmit = await appState.submitComposer(
                 text: trimmed,
-                attachments: submittedAttachments
+                attachments: submittedAttachments,
+                context: submissionContext
             )
             guard didSubmit else {
                 restoreSubmittedDraftIfNeeded(
                     text: submittedText,
-                    attachments: submittedAttachments
+                    attachments: submittedAttachments,
+                    for: submittedDraftKey
                 )
                 Haptics.error()
                 return
             }
+            draftStore.removeDraft(for: submittedDraftBucket)
+            guard loadedDraftKey == submittedDraftKey else { return }
             if appState.composerPrefillToken != prefillToken {
                 text = appState.composerPrefillText
                 isFocused = !text.isEmpty
@@ -562,8 +676,27 @@ struct ComposerBar: View {
 
     private func restoreSubmittedDraftIfNeeded(
         text submittedText: String,
-        attachments submittedAttachments: [Attachment]
+        attachments submittedAttachments: [Attachment],
+        for key: ComposerDraftKey
     ) {
+        let restorationKey: ComposerDraftKey
+        if Self.draftKeysAreEquivalent(
+            key,
+            activeDraftKey,
+            identity: appState.activeChatScrollSessionIdentity
+        ) {
+            restorationKey = activeDraftKey
+        } else {
+            restorationKey = key
+        }
+
+        guard loadedDraftKey == restorationKey else {
+            draftStore.saveIfMissing(
+                ComposerDraft(text: submittedText, attachments: submittedAttachments),
+                for: restorationKey
+            )
+            return
+        }
         // Do not overwrite a new draft if the user already returned to the
         // composer while the failed request was in flight.
         guard text.isEmpty, attachments.isEmpty else { return }
@@ -579,17 +712,149 @@ struct ComposerBar: View {
         isShowingSlashSuggestions = false
     }
 
+    private func composerDraftKey(for sessionID: String?) -> ComposerDraftKey {
+        Self.composerDraftKey(for: sessionID, profile: appState.activeProfile)
+    }
+
+    private var asyncAttachmentContext: AsyncAttachmentContext {
+        Self.photoImportContext(
+            editorIdentity: editorIdentity,
+            draftKey: activeDraftKey,
+            attachmentGeneration: attachmentGeneration
+        )
+    }
+
+    private func shouldAcceptAsyncAttachmentCompletion(startedIn origin: AsyncAttachmentContext) -> Bool {
+        Self.shouldAcceptAsyncAttachmentCompletion(
+            startedIn: origin,
+            currentEditorIdentity: editorIdentity,
+            currentDraftKey: activeDraftKey,
+            currentAttachmentGeneration: attachmentGeneration
+        )
+    }
+
+    private func shouldAcceptPhotoPickerCompletion(openedIn origin: AsyncAttachmentContext?) -> Bool {
+        Self.shouldAcceptPhotoPickerCompletion(
+            openedIn: origin,
+            currentEditorIdentity: editorIdentity,
+            currentDraftKey: activeDraftKey,
+            currentAttachmentGeneration: attachmentGeneration
+        )
+    }
+
+    private func openPhotoLibraryPicker() {
+        photoImportContext = asyncAttachmentContext
+        photoImportGeneration &+= 1
+        showAttachmentMenu = true
+    }
+
+    private func saveDraft(for key: ComposerDraftKey) {
+        draftStore.save(ComposerDraft(text: text, attachments: attachments), for: key)
+    }
+
+    private func loadDraft(for key: ComposerDraftKey) {
+        let draft = draftStore.draft(for: key)
+        if text != draft.text {
+            suppressNextTextChangeSuggestions = true
+        }
+        text = draft.text
+        attachments = draft.attachments
+        loadedDraftKey = key
+        composerTextHeight = ComposerPasteTextView.minimumHeight
+        isFocused = false
+        isShowingSlashSuggestions = false
+    }
+
+    private func handoffComposer(to destinationKey: ComposerDraftKey) {
+        guard loadedDraftKey != destinationKey else { return }
+        if let loadedDraftKey {
+            saveDraft(for: loadedDraftKey)
+            if Self.draftKeysAreEquivalent(
+                loadedDraftKey,
+                destinationKey,
+                identity: appState.activeChatScrollSessionIdentity
+            ) {
+                draftStore.migrateDraft(from: loadedDraftKey, to: destinationKey)
+            }
+        }
+        composerErrorMessage = nil
+        isFocused = false
+        isShowingSlashSuggestions = false
+        rotateAttachmentGeneration()
+        editorIdentity = UUID()
+        loadDraft(for: destinationKey)
+        composerTextHeight = ComposerPasteTextView.minimumHeight
+        isFocused = false
+    }
+
+    private func rotateAttachmentGeneration() {
+        attachmentGeneration &+= 1
+        photoImportGeneration &+= 1
+        photoItem = nil
+        photoImportContext = nil
+        documentImportContext = nil
+        editorIdentity = UUID()
+    }
+
+    private func handlePastedImage(_ pastedImage: PastedImage, editorIdentity callbackEditorIdentity: UUID) {
+        guard callbackEditorIdentity == editorIdentity else { return }
+        composerErrorMessage = nil
+        let metadata = Self.pastedImageAttachmentMetadata(
+            for: pastedImage.typeIdentifier
+        )
+        addAttachment(
+            data: pastedImage.data,
+            name: metadata.name,
+            mimeType: metadata.mimeType,
+            kind: .image
+        )
+    }
+
+    private func handlePastedImageError(_ message: String, editorIdentity callbackEditorIdentity: UUID) {
+        guard callbackEditorIdentity == editorIdentity else { return }
+        composerErrorMessage = Self.pastedImageErrorMessage(message)
+        Haptics.error()
+    }
+
     private func handlePhotoSelection() {
         guard let item = photoItem else { return }
+        guard let origin = photoImportContext else {
+            photoItem = nil
+            return
+        }
+        let completionGeneration = photoImportGeneration
         Task {
-            if let data = try? await item.loadTransferable(type: Data.self) {
+            if let data = try? await item.loadTransferable(type: Data.self),
+               shouldAcceptPhotoPickerCompletion(openedIn: origin) {
                 addAttachment(data: data, name: "photo.jpg", mimeType: "image/jpeg", kind: .image)
             }
-            photoItem = nil
+            clearPhotoImportContextIfCurrent(
+                completingGeneration: completionGeneration,
+                completingContext: origin
+            )
         }
     }
 
-    private func handleDocumentSelection(_ result: Result<[URL], Error>) {
+    private func clearPhotoImportContextIfCurrent(
+        completingGeneration: UInt64,
+        completingContext: AsyncAttachmentContext
+    ) {
+        guard Self.shouldClearPhotoImportContext(
+            completingGeneration: completingGeneration,
+            completingContext: completingContext,
+            currentGeneration: photoImportGeneration,
+            currentContext: photoImportContext
+        ) else { return }
+        photoItem = nil
+        photoImportContext = nil
+    }
+
+    private func handleDocumentSelection(
+        _ result: Result<[URL], Error>,
+        startedIn origin: AsyncAttachmentContext?
+    ) {
+        guard let origin,
+              shouldAcceptAsyncAttachmentCompletion(startedIn: origin) else { return }
         guard case .success(let urls) = result else { return }
         for url in urls {
             let didAccess = url.startAccessingSecurityScopedResource()
@@ -603,6 +868,11 @@ struct ComposerBar: View {
                 kind: type?.conforms(to: .image) == true ? .image : .document
             )
         }
+    }
+
+    private func clearDocumentImportContextIfCurrent(_ completingContext: AsyncAttachmentContext?) {
+        guard documentImportContext == completingContext else { return }
+        documentImportContext = nil
     }
 
     private func addAttachment(data: Data, name: String, mimeType: String, kind: Attachment.Kind) {

--- a/Conduit/Views/Components/ComposerDraftStore.swift
+++ b/Conduit/Views/Components/ComposerDraftStore.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+struct ComposerDraft: Equatable {
+    var text: String
+    var attachments: [Attachment]
+
+    static let empty = ComposerDraft(text: "", attachments: [])
+
+    var isEmpty: Bool {
+        text.isEmpty && attachments.isEmpty
+    }
+}
+
+struct ComposerDraftKey: Hashable {
+    static let newConversationSessionID = "new-conversation"
+
+    var profile: String
+    var sessionID: String
+
+    var isNewConversation: Bool {
+        sessionID == Self.newConversationSessionID
+    }
+}
+
+struct ComposerDraftSubmissionBucket: Equatable {
+    let key: ComposerDraftKey
+    fileprivate let generation: UUID?
+}
+
+@MainActor
+final class ComposerDraftStore {
+    private let capacity: Int
+    private var drafts: [ComposerDraftKey: ComposerDraft] = [:]
+    private var order: [ComposerDraftKey] = []
+    private var generations: [ComposerDraftKey: UUID] = [:]
+
+    init(capacity: Int = 12) {
+        self.capacity = max(0, capacity)
+    }
+
+    func draft(for key: ComposerDraftKey) -> ComposerDraft {
+        guard let draft = drafts[key] else { return .empty }
+        touch(key)
+        return draft
+    }
+
+    func save(_ draft: ComposerDraft, for key: ComposerDraftKey) {
+        if draft.isEmpty {
+            removeDraft(for: key)
+            return
+        }
+
+        guard capacity > 0 else {
+            removeDraft(for: key)
+            return
+        }
+
+        drafts[key] = draft
+        refreshGeneration(for: key)
+        touch(key)
+        evictIfNeeded()
+    }
+
+    func saveIfMissing(_ draft: ComposerDraft, for key: ComposerDraftKey) {
+        guard drafts[key] == nil else { return }
+        save(draft, for: key)
+    }
+
+    func migrateDraft(from source: ComposerDraftKey, to destination: ComposerDraftKey) {
+        guard source != destination, let draft = drafts[source] else { return }
+        removeDraft(for: source)
+        save(draft, for: destination)
+    }
+
+    func submissionBucket(for key: ComposerDraftKey) -> ComposerDraftSubmissionBucket {
+        ComposerDraftSubmissionBucket(key: key, generation: generations[key])
+    }
+
+    func removeDraft(for key: ComposerDraftKey) {
+        drafts.removeValue(forKey: key)
+        generations.removeValue(forKey: key)
+        order.removeAll { $0 == key }
+    }
+
+    func removeDraft(for bucket: ComposerDraftSubmissionBucket) {
+        guard let generation = bucket.generation,
+              generations[bucket.key] == generation else { return }
+        removeDraft(for: bucket.key)
+    }
+
+    func removeAll() {
+        drafts.removeAll()
+        generations.removeAll()
+        order.removeAll()
+    }
+
+    private func touch(_ key: ComposerDraftKey) {
+        order.removeAll { $0 == key }
+        order.append(key)
+    }
+
+    private func evictIfNeeded() {
+        while order.count > capacity {
+            let oldest = order.removeFirst()
+            drafts.removeValue(forKey: oldest)
+            generations.removeValue(forKey: oldest)
+        }
+    }
+
+    private func refreshGeneration(for key: ComposerDraftKey) {
+        generations[key] = UUID()
+    }
+}

--- a/Conduit/Views/Components/ComposerPasteTextView.swift
+++ b/Conduit/Views/Components/ComposerPasteTextView.swift
@@ -26,6 +26,7 @@ struct ComposerPasteTextView: UIViewRepresentable {
     let enabled: Bool
     let onPastedImage: (PastedImage) -> Void
     let onPastedImageError: (String) -> Void
+    let editorIdentity: UUID
 
     func makeCoordinator() -> Coordinator { Coordinator(self) }
 
@@ -46,6 +47,7 @@ struct ComposerPasteTextView: UIViewRepresentable {
         view.keyboardDismissMode = .interactive
         view.minimumReportedHeight = Self.minimumHeight
         view.maximumReportedHeight = Self.maximumHeight
+        view.editorIdentity = editorIdentity
         view.onContentHeightChange = { height in
             context.coordinator.updateMeasuredHeight(height)
         }
@@ -54,10 +56,16 @@ struct ComposerPasteTextView: UIViewRepresentable {
         return view
     }
 
+    static func dismantleUIView(_ uiView: ImagePasteTextView, coordinator: Coordinator) {
+        coordinator.deactivate(textView: uiView)
+    }
+
     func updateUIView(_ uiView: ImagePasteTextView, context: Context) {
         context.coordinator.parent = self
-        if uiView.text != text { uiView.text = text }
+        context.coordinator.isActive = true
+        context.coordinator.apply(text: text, editorIdentity: editorIdentity, to: uiView)
         uiView.isEditable = enabled
+        uiView.editorIdentity = editorIdentity
         uiView.onContentHeightChange = { height in
             context.coordinator.updateMeasuredHeight(height)
         }
@@ -70,20 +78,75 @@ struct ComposerPasteTextView: UIViewRepresentable {
 
     final class Coordinator: NSObject, UITextViewDelegate {
         var parent: ComposerPasteTextView
+        var isApplyingProgrammaticState = false
+        var isActive = true
+        private var editorIdentity: UUID?
 
         init(_ parent: ComposerPasteTextView) { self.parent = parent }
 
         func textViewDidChange(_ textView: UITextView) {
+            guard isActive, !isApplyingProgrammaticState else { return }
             parent.text = textView.text
             textView.scrollRangeToVisible(textView.selectedRange)
             textView.setNeedsLayout()
         }
-        func textViewDidBeginEditing(_ textView: UITextView) { parent.isFocused = true }
-        func textViewDidEndEditing(_ textView: UITextView) { parent.isFocused = false }
+        func textViewDidBeginEditing(_ textView: UITextView) {
+            guard isActive, !isApplyingProgrammaticState else { return }
+            parent.isFocused = true
+        }
+        func textViewDidEndEditing(_ textView: UITextView) {
+            guard isActive, !isApplyingProgrammaticState else { return }
+            parent.isFocused = false
+        }
 
         func updateMeasuredHeight(_ height: CGFloat) {
+            guard isActive else { return }
             guard abs(parent.measuredHeight - height) > 0.5 else { return }
             parent.measuredHeight = height
+        }
+
+        func apply(text: String, editorIdentity: UUID, to textView: UITextView) {
+            let needsTextUpdate = textView.text != text
+            let needsIdentityUpdate = self.editorIdentity != editorIdentity
+            guard needsTextUpdate || needsIdentityUpdate else { return }
+
+            let clampedSelection = clampedSelectionRange(
+                textView.selectedRange,
+                maxLength: (text as NSString).length
+            )
+
+            isApplyingProgrammaticState = true
+            defer {
+                isApplyingProgrammaticState = false
+                self.editorIdentity = editorIdentity
+            }
+
+            textView.text = text
+            textView.selectedRange = clampedSelection
+            textView.setNeedsLayout()
+        }
+
+        func deactivate(textView: UITextView) {
+            isActive = false
+            isApplyingProgrammaticState = false
+            editorIdentity = nil
+            textView.delegate = nil
+            if let textView = textView as? ImagePasteTextView {
+                textView.editorIdentity = nil
+                textView.onContentHeightChange = nil
+                textView.onPastedImage = nil
+                textView.onPastedImageError = nil
+            }
+            if textView.isFirstResponder {
+                textView.resignFirstResponder()
+            }
+        }
+
+        private func clampedSelectionRange(_ range: NSRange, maxLength: Int) -> NSRange {
+            let location = min(max(range.location, 0), maxLength)
+            let remaining = max(0, maxLength - location)
+            let length = min(max(range.length, 0), remaining)
+            return NSRange(location: location, length: length)
         }
     }
 }
@@ -92,6 +155,7 @@ final class ImagePasteTextView: UITextView {
     var onPastedImage: ((PastedImage) -> Void)?
     var onPastedImageError: ((String) -> Void)?
     var onContentHeightChange: ((CGFloat) -> Void)?
+    var editorIdentity: UUID?
     var minimumReportedHeight: CGFloat = 44
     var maximumReportedHeight: CGFloat = 160
     private var lastReportedHeight: CGFloat = 0
@@ -204,25 +268,39 @@ final class ImagePasteTextView: UITextView {
             return
         }
 
+        let pasteEditorIdentity = editorIdentity
         if let imageType = imageTypeIdentifier(for: provider) {
             provider.loadDataRepresentation(forTypeIdentifier: imageType) { [weak self] data, error in
                 guard let data, !data.isEmpty else {
                     if provider.canLoadObject(ofClass: UIImage.self) {
-                        self?.loadImageObject(from: provider, fallbackError: error)
+                        self?.loadImageObject(
+                            from: provider,
+                            fallbackError: error,
+                            editorIdentity: pasteEditorIdentity
+                        )
                     } else {
-                        self?.reportImageLoadFailure(error)
+                        self?.reportImageLoadFailure(error, editorIdentity: pasteEditorIdentity)
                     }
                     return
                 }
-                self?.deliverImageData(data, typeIdentifier: imageType)
+                self?.deliverImageData(
+                    data,
+                    typeIdentifier: imageType,
+                    editorIdentity: pasteEditorIdentity
+                )
             }
             return
         }
 
-        loadImageObject(from: provider)
+        loadImageObject(from: provider, editorIdentity: pasteEditorIdentity)
     }
 
-    private func loadImageObject(from provider: NSItemProvider, fallbackError: Error? = nil) {
+    private func loadImageObject(
+        from provider: NSItemProvider,
+        fallbackError: Error? = nil,
+        editorIdentity pasteEditorIdentity: UUID? = nil
+    ) {
+        let pasteEditorIdentity = pasteEditorIdentity ?? editorIdentity
         // Spell out the protocol existential so Swift selects the
         // NSItemProviderReading overload. The inferred generic overload on
         // newer SDKs expects UIImage to be _ObjectiveCBridgeable and fails
@@ -231,20 +309,32 @@ final class ImagePasteTextView: UITextView {
             guard let image = object as? UIImage,
                   let data = image.pngData(),
                   !data.isEmpty else {
-                self?.reportImageLoadFailure(error ?? fallbackError)
+                self?.reportImageLoadFailure(
+                    error ?? fallbackError,
+                    editorIdentity: pasteEditorIdentity
+                )
                 return
             }
-            self?.deliverImageData(data, typeIdentifier: UTType.png.identifier)
+            self?.deliverImageData(
+                data,
+                typeIdentifier: UTType.png.identifier,
+                editorIdentity: pasteEditorIdentity
+            )
         }
     }
 
-    private func deliverImageData(_ data: Data, typeIdentifier: String) {
+    private func deliverImageData(
+        _ data: Data,
+        typeIdentifier: String,
+        editorIdentity pasteEditorIdentity: UUID? = nil
+    ) {
+        let pasteEditorIdentity = pasteEditorIdentity ?? editorIdentity
         let pastedImage: PastedImage
         if typeIdentifier == UTType.image.identifier {
             guard let image = UIImage(data: data),
                   let normalizedData = image.pngData(),
                   !normalizedData.isEmpty else {
-                reportImageNormalizationFailure()
+                reportImageNormalizationFailure(editorIdentity: pasteEditorIdentity)
                 return
             }
             pastedImage = PastedImage(
@@ -256,20 +346,28 @@ final class ImagePasteTextView: UITextView {
         }
 
         DispatchQueue.main.async { [weak self] in
-            self?.onPastedImage?(pastedImage)
+            guard let self, self.editorIdentity == pasteEditorIdentity else { return }
+            self.onPastedImage?(pastedImage)
         }
     }
 
-    private func reportImageNormalizationFailure() {
+    private func reportImageNormalizationFailure(editorIdentity pasteEditorIdentity: UUID? = nil) {
+        let pasteEditorIdentity = pasteEditorIdentity ?? editorIdentity
         DispatchQueue.main.async { [weak self] in
-            self?.onPastedImageError?("The image provider returned invalid image data.")
+            guard let self, self.editorIdentity == pasteEditorIdentity else { return }
+            self.onPastedImageError?("The image provider returned invalid image data.")
         }
     }
 
-    private func reportImageLoadFailure(_ error: Error?) {
+    private func reportImageLoadFailure(
+        _ error: Error?,
+        editorIdentity pasteEditorIdentity: UUID? = nil
+    ) {
+        let pasteEditorIdentity = pasteEditorIdentity ?? editorIdentity
         let message = error?.localizedDescription ?? "The image provider returned no data."
         DispatchQueue.main.async { [weak self] in
-            self?.onPastedImageError?(message)
+            guard let self, self.editorIdentity == pasteEditorIdentity else { return }
+            self.onPastedImageError?(message)
         }
     }
 
@@ -279,10 +377,15 @@ final class ImagePasteTextView: UITextView {
     /// pasteboards fall through to the standard text behavior.
     override func paste(_ sender: Any?) {
         let pb = UIPasteboard.general
+        let pasteEditorIdentity = editorIdentity
 
         // Direct image in pasteboard
         if let image = pb.image, let data = image.pngData() {
-            onPastedImage?(PastedImage(data: data, typeIdentifier: UTType.png.identifier))
+            deliverImageData(
+                data,
+                typeIdentifier: UTType.png.identifier,
+                editorIdentity: pasteEditorIdentity
+            )
             return
         }
 
@@ -294,7 +397,11 @@ final class ImagePasteTextView: UITextView {
                 URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
                     guard let data = data else { return }
                     let typeIdentifier = UTType(filenameExtension: ext)?.identifier ?? UTType.image.identifier
-                    self?.deliverImageData(data, typeIdentifier: typeIdentifier)
+                    self?.deliverImageData(
+                        data,
+                        typeIdentifier: typeIdentifier,
+                        editorIdentity: pasteEditorIdentity
+                    )
                 }.resume()
                 return
             }
@@ -302,7 +409,11 @@ final class ImagePasteTextView: UITextView {
 
         // Raw image data without .image property
         if let data = pb.data(forPasteboardType: "public.image"), !data.isEmpty {
-            deliverImageData(data, typeIdentifier: UTType.image.identifier)
+            deliverImageData(
+                data,
+                typeIdentifier: UTType.image.identifier,
+                editorIdentity: pasteEditorIdentity
+            )
             return
         }
 

--- a/Conduit/Views/Components/MarkdownSelectionCoordinator.swift
+++ b/Conduit/Views/Components/MarkdownSelectionCoordinator.swift
@@ -1,0 +1,814 @@
+import Combine
+import SwiftUI
+import UIKit
+
+struct MarkdownSelectionSegmentDescriptor: Equatable, Hashable {
+    let id: String
+    let order: Int
+    let separatorBefore: String
+}
+
+struct MarkdownSelectionEndpoint: Equatable, Hashable {
+    let segmentID: String
+    let offset: Int
+}
+
+struct MarkdownSelectionSpan: Equatable, Hashable {
+    let segmentID: String
+    let range: NSRange
+}
+
+enum MarkdownSelectionSegmentPlan {
+    static func descriptors(for blocks: [MarkdownBlock]) -> [MarkdownSelectionSegmentDescriptor] {
+        var descriptors: [MarkdownSelectionSegmentDescriptor] = []
+        var order = 0
+
+        func append(_ id: String, separatorBefore: String) {
+            descriptors.append(
+                MarkdownSelectionSegmentDescriptor(
+                    id: id,
+                    order: order,
+                    separatorBefore: descriptors.isEmpty ? "" : separatorBefore
+                )
+            )
+            order += 1
+        }
+
+        for (blockIndex, block) in blocks.enumerated() {
+            let blockSeparator = blockIndex == 0 ? "" : "\n\n"
+
+            switch block {
+            case .heading(_, let text), .paragraph(let text):
+                append("block-\(blockIndex)", separatorBefore: blockSeparator)
+                _ = text
+
+            case .quote(let lines):
+                if let first = lines.first, let marker = MarkdownParser.calloutMarker(first.text) {
+                    append("block-\(blockIndex)", separatorBefore: blockSeparator)
+                    _ = marker
+                } else {
+                    for (lineIndex, line) in lines.enumerated() {
+                        let id = lines.count == 1
+                            ? "block-\(blockIndex)"
+                            : "block-\(blockIndex)-quote-l\(lineIndex)"
+                        append(id, separatorBefore: lineIndex == 0 ? blockSeparator : "\n")
+                        _ = line
+                    }
+                }
+
+            case .unorderedList(let items), .orderedList(let items):
+                for (itemIndex, item) in items.enumerated() {
+                    let id = items.count == 1
+                        ? "block-\(blockIndex)"
+                        : "block-\(blockIndex)-list-i\(itemIndex)"
+                    append(id, separatorBefore: itemIndex == 0 ? blockSeparator : "\n")
+                    _ = item
+                }
+
+            case .table(let headers, _, let rows):
+                let tableRows = [headers] + rows
+                for (rowIndex, row) in tableRows.enumerated() {
+                    for (cellIndex, cell) in row.enumerated() {
+                        let separatorBefore: String
+                        if rowIndex == 0, cellIndex == 0 {
+                            separatorBefore = blockSeparator
+                        } else if cellIndex == 0 {
+                            separatorBefore = "\n"
+                        } else {
+                            separatorBefore = " | "
+                        }
+                        append("block-\(blockIndex)-table-r\(rowIndex)-c\(cellIndex)", separatorBefore: separatorBefore)
+                        _ = cell
+                    }
+                }
+
+            case .callout:
+                append("block-\(blockIndex)", separatorBefore: blockSeparator)
+
+            case .columns(let columns):
+                for (columnIndex, column) in columns.enumerated() {
+                    let id = columns.count == 1
+                        ? "block-\(blockIndex)"
+                        : "block-\(blockIndex)-column-\(columnIndex)"
+                    append(id, separatorBefore: columnIndex == 0 ? blockSeparator : " | ")
+                    _ = column
+                }
+
+            case .code(let language, let source):
+                if MarkdownLanguage.normalized(language) == "mermaid" {
+                    order += 1
+                } else {
+                    append("block-\(blockIndex)-code", separatorBefore: blockSeparator)
+                }
+                _ = source
+
+            case .image, .math, .divider:
+                order += 1
+            }
+        }
+
+        return descriptors
+    }
+}
+
+@MainActor
+final class MarkdownSelectionCoordinator: ObservableObject {
+    final class SegmentRecord {
+        var descriptor: MarkdownSelectionSegmentDescriptor
+        var textView: UITextView?
+
+        init(descriptor: MarkdownSelectionSegmentDescriptor, textView: UITextView?) {
+            self.descriptor = descriptor
+            self.textView = textView
+        }
+    }
+
+    struct ActiveSelectionState: Equatable {
+        var anchor: MarkdownSelectionEndpoint
+        var focus: MarkdownSelectionEndpoint
+        var anchorWindowPoint: CGPoint
+        var focusWindowPoint: CGPoint
+    }
+
+    private struct PendingSelectionState {
+        var anchor: MarkdownSelectionEndpoint
+        var windowPoint: CGPoint
+    }
+
+    private enum NativeSelectionEdge {
+        case lower
+        case upper
+    }
+
+    private struct VisibleSelectionSnapshot: Equatable {
+        var activeSelectionState: ActiveSelectionState?
+        var selectionGestureIsActive: Bool
+        var nativeSelectionOwnerSegmentID: String?
+    }
+
+    nonisolated let objectWillChange = ObservableObjectPublisher()
+    private static weak var activeVisibleSelectionCoordinator: MarkdownSelectionCoordinator?
+    private var currentRevision: String = ""
+    private var recordsByID: [String: SegmentRecord] = [:]
+    private var orderedSegmentIDs: [String] = []
+    private var activeSelectionState: ActiveSelectionState?
+    private var pendingSelectionState: PendingSelectionState?
+    private var selectionGestureIsActive = false
+    private var isApplyingSelectionRanges = false
+    private var nativeSelectionOwnerSegmentID: String?
+    private var nativeSelectionAnchorEdge: NativeSelectionEdge?
+
+    func replaceSegments(_ descriptors: [MarkdownSelectionSegmentDescriptor], revision: String) {
+        let before = visibleSelectionSnapshot()
+
+        let revisionChanged = revision != currentRevision
+        if revisionChanged {
+            if !currentRevision.isEmpty {
+                clearSelectionRanges()
+            }
+            resetSelectionState()
+        }
+
+        currentRevision = revision
+
+        var latestByID: [String: (descriptor: MarkdownSelectionSegmentDescriptor, index: Int)] = [:]
+        for (index, descriptor) in descriptors.enumerated() {
+            latestByID[descriptor.id] = (descriptor, index)
+        }
+
+        let ordered = latestByID.values
+            .sorted {
+                if $0.descriptor.order != $1.descriptor.order {
+                    return $0.descriptor.order < $1.descriptor.order
+                }
+                return $0.index < $1.index
+            }
+            .map(\.descriptor)
+
+        orderedSegmentIDs = ordered.map(\.id)
+        let currentIDs = Set(orderedSegmentIDs)
+        recordsByID = recordsByID.filter { currentIDs.contains($0.key) }
+
+        for descriptor in ordered {
+            if let record = recordsByID[descriptor.id] {
+                record.descriptor = descriptor
+            } else {
+                recordsByID[descriptor.id] = SegmentRecord(descriptor: descriptor, textView: nil)
+            }
+        }
+        applySelectionRanges()
+        publishIfVisibleSelectionChanged(from: before)
+    }
+
+    func register(descriptor: MarkdownSelectionSegmentDescriptor, textView: UITextView) {
+        let existingRecord = recordsByID[descriptor.id]
+        let registrationChanged = existingRecord?.descriptor != descriptor || existingRecord?.textView !== textView
+        guard registrationChanged || !orderedSegmentIDs.contains(descriptor.id) else {
+            applySelectionRanges()
+            return
+        }
+
+        recordsByID[descriptor.id] = SegmentRecord(descriptor: descriptor, textView: textView)
+        if !orderedSegmentIDs.contains(descriptor.id) {
+            orderedSegmentIDs.append(descriptor.id)
+            orderedSegmentIDs.sort { lhs, rhs in
+                let lhsOrder = recordsByID[lhs]?.descriptor.order ?? .max
+                let rhsOrder = recordsByID[rhs]?.descriptor.order ?? .max
+                if lhsOrder != rhsOrder { return lhsOrder < rhsOrder }
+                return lhs < rhs
+            }
+        }
+        applySelectionRanges()
+        if activeSelectionState != nil {
+            objectWillChange.send()
+        }
+    }
+
+    func unregister(segmentID: String, textView: UITextView) {
+        guard let current = recordsByID[segmentID]?.textView, current === textView else { return }
+        let before = visibleSelectionSnapshot()
+        let activeSelectionContainsSegment = activeSpans.contains { $0.segmentID == segmentID }
+
+        clearSelectionRange(in: current)
+        recordsByID[segmentID]?.textView = nil
+
+        if pendingSelectionState?.anchor.segmentID == segmentID {
+            pendingSelectionState = nil
+        }
+
+        if activeSelectionContainsSegment {
+            resetSelectionState()
+            clearSelectionRanges()
+        }
+
+        publishIfVisibleSelectionChanged(from: before)
+    }
+
+    func text(for segmentID: String) -> String? {
+        guard let textView = recordsByID[segmentID]?.textView else { return nil }
+        return textView.attributedText?.string ?? textView.text
+    }
+
+    func orderedEndpoints(
+        from start: MarkdownSelectionEndpoint,
+        to end: MarkdownSelectionEndpoint
+    ) -> (start: MarkdownSelectionEndpoint, end: MarkdownSelectionEndpoint) {
+        let startIndex = orderedIndex(for: start.segmentID)
+        let endIndex = orderedIndex(for: end.segmentID)
+
+        if let startIndex, let endIndex {
+            if startIndex == endIndex {
+                return start.offset <= end.offset ? (start, end) : (end, start)
+            }
+
+            return startIndex < endIndex ? (start, end) : (end, start)
+        }
+
+        return (start, end)
+    }
+
+    func spans(from anchor: MarkdownSelectionEndpoint, to focus: MarkdownSelectionEndpoint) -> [MarkdownSelectionSpan] {
+        let ordered = orderedEndpoints(from: anchor, to: focus)
+        guard
+            let startIndex = orderedIndex(for: ordered.start.segmentID),
+            let endIndex = orderedIndex(for: ordered.end.segmentID),
+            startIndex <= endIndex
+        else {
+            return []
+        }
+
+        if startIndex == endIndex {
+            let length = textLength(for: ordered.start.segmentID)
+            let lower = clamp(ordered.start.offset, to: length)
+            let upper = clamp(ordered.end.offset, to: length)
+            return [
+                MarkdownSelectionSpan(
+                    segmentID: ordered.start.segmentID,
+                    range: NSRange(location: lower, length: max(0, upper - lower))
+                )
+            ]
+        }
+
+        let barrierIndices = selectionBarrierIndices(from: startIndex, to: endIndex)
+        guard !barrierIndices.isEmpty else {
+            return normalizedSpans(
+                from: ordered.start,
+                to: ordered.end,
+                startIndex: startIndex,
+                endIndex: endIndex
+            )
+        }
+
+        guard let anchorIndex = orderedIndex(for: anchor.segmentID) else {
+            return normalizedSpans(
+                from: ordered.start,
+                to: ordered.end,
+                startIndex: startIndex,
+                endIndex: endIndex
+            )
+        }
+
+        if anchorIndex == startIndex {
+            let clippedEndIndex = barrierIndices[0]
+            let clippedEndSegmentID = orderedSegmentIDs[clippedEndIndex]
+            return normalizedSpans(
+                from: ordered.start,
+                to: MarkdownSelectionEndpoint(
+                    segmentID: clippedEndSegmentID,
+                    offset: textLength(for: clippedEndSegmentID)
+                ),
+                startIndex: startIndex,
+                endIndex: clippedEndIndex
+            )
+        }
+
+        if anchorIndex == endIndex {
+            let clippedStartIndex = barrierIndices[barrierIndices.count - 1] + 1
+            let clippedStartSegmentID = orderedSegmentIDs[clippedStartIndex]
+            return normalizedSpans(
+                from: MarkdownSelectionEndpoint(segmentID: clippedStartSegmentID, offset: 0),
+                to: ordered.end,
+                startIndex: clippedStartIndex,
+                endIndex: endIndex
+            )
+        }
+
+        return normalizedSpans(
+            from: ordered.start,
+            to: ordered.end,
+            startIndex: startIndex,
+            endIndex: endIndex
+        )
+    }
+
+    private func normalizedSpans(
+        from start: MarkdownSelectionEndpoint,
+        to end: MarkdownSelectionEndpoint,
+        startIndex: Int,
+        endIndex: Int
+    ) -> [MarkdownSelectionSpan] {
+        if startIndex == endIndex {
+            let length = textLength(for: start.segmentID)
+            let lower = clamp(start.offset, to: length)
+            let upper = clamp(end.offset, to: length)
+            return [
+                MarkdownSelectionSpan(
+                    segmentID: start.segmentID,
+                    range: NSRange(location: lower, length: max(0, upper - lower))
+                )
+            ]
+        }
+
+        var spans: [MarkdownSelectionSpan] = []
+        for index in startIndex...endIndex {
+            let segmentID = orderedSegmentIDs[index]
+            let length = textLength(for: segmentID)
+            let range: NSRange
+
+            if index == startIndex {
+                let lower = clamp(start.offset, to: length)
+                range = NSRange(location: lower, length: max(0, length - lower))
+            } else if index == endIndex {
+                let upper = clamp(end.offset, to: length)
+                range = NSRange(location: 0, length: upper)
+            } else {
+                range = NSRange(location: 0, length: length)
+            }
+
+            spans.append(MarkdownSelectionSpan(segmentID: segmentID, range: range))
+        }
+
+        return spans
+    }
+
+    func copiedAttributedText(from start: MarkdownSelectionEndpoint, to end: MarkdownSelectionEndpoint) -> NSAttributedString {
+        let spans = spans(from: start, to: end)
+        struct CopyPiece {
+            let separatorBefore: String
+            let text: NSAttributedString
+        }
+
+        var pieces: [CopyPiece] = []
+
+        for span in spans {
+            guard let record = recordsByID[span.segmentID], let textView = record.textView else { continue }
+            let attributed = textView.attributedText ?? NSAttributedString(string: textView.text ?? "")
+            let safeRange = clampedRange(span.range, to: attributed.length)
+            let selectedText = safeRange.length > 0
+                ? attributed.attributedSubstring(from: safeRange)
+                : NSAttributedString(string: "")
+
+            pieces.append(
+                CopyPiece(
+                    separatorBefore: record.descriptor.separatorBefore,
+                    text: selectedText
+                )
+            )
+        }
+
+        while pieces.first?.text.length == 0 {
+            pieces.removeFirst()
+        }
+        while pieces.last?.text.length == 0 {
+            pieces.removeLast()
+        }
+
+        let result = NSMutableAttributedString()
+
+        for (index, piece) in pieces.enumerated() {
+            if index > 0 {
+                result.append(NSAttributedString(string: piece.separatorBefore))
+            }
+
+            result.append(piece.text)
+        }
+
+        return result
+    }
+
+    private func orderedIndex(for segmentID: String) -> Int? {
+        orderedSegmentIDs.firstIndex(of: segmentID)
+    }
+
+    private func textLength(for segmentID: String) -> Int {
+        if let length = recordsByID[segmentID]?.textView?.attributedText?.length {
+            return length
+        }
+        return text(for: segmentID)?.utf16.count ?? 0
+    }
+
+    private func clamp(_ offset: Int, to length: Int) -> Int {
+        min(max(offset, 0), length)
+    }
+
+    private func clampedRange(_ range: NSRange, to length: Int) -> NSRange {
+        let lower = clamp(range.location, to: length)
+        let upper = clamp(NSMaxRange(range), to: length)
+        return NSRange(location: lower, length: max(0, upper - lower))
+    }
+
+    private func selectionBarrierExists(between leftSegmentID: String, and rightSegmentID: String) -> Bool {
+        guard
+            let leftOrder = recordsByID[leftSegmentID]?.descriptor.order,
+            let rightOrder = recordsByID[rightSegmentID]?.descriptor.order
+        else {
+            return false
+        }
+        return rightOrder - leftOrder > 1
+    }
+
+    private func selectionBarrierIndices(from startIndex: Int, to endIndex: Int) -> [Int] {
+        guard startIndex < endIndex else { return [] }
+        return (startIndex..<endIndex).filter { index in
+            selectionBarrierExists(between: orderedSegmentIDs[index], and: orderedSegmentIDs[index + 1])
+        }
+    }
+
+    private func initialNativeSelectionAnchorEdge(
+        segmentID: String,
+        lower: Int,
+        upper: Int
+    ) -> NativeSelectionEdge {
+        guard
+            let pendingSelectionState,
+            pendingSelectionState.anchor.segmentID == segmentID
+        else {
+            return .lower
+        }
+
+        let pendingOffset = clamp(pendingSelectionState.anchor.offset, to: textLength(for: segmentID))
+        let distanceToLower = abs(pendingOffset - lower)
+        let distanceToUpper = abs(pendingOffset - upper)
+        return distanceToUpper < distanceToLower ? .upper : .lower
+    }
+
+    var hasActiveSelection: Bool {
+        activeSelectionState != nil
+    }
+
+    var hasCrossSegmentSelection: Bool {
+        activeSpans.count > 1
+    }
+
+    var activeSpans: [MarkdownSelectionSpan] {
+        guard let activeSelectionState else { return [] }
+        return spans(from: activeSelectionState.anchor, to: activeSelectionState.focus)
+    }
+
+    var isApplyingNativeSelectionRanges: Bool {
+        isApplyingSelectionRanges
+    }
+
+    var isSelectionGestureActive: Bool {
+        selectionGestureIsActive
+    }
+
+    func beginSelection(segmentID: String, offset: Int, windowPoint: CGPoint) {
+        claimVisibleSelectionOwnership()
+        let before = visibleSelectionSnapshot()
+        let endpoint = MarkdownSelectionEndpoint(segmentID: segmentID, offset: offset)
+        activeSelectionState = ActiveSelectionState(
+            anchor: endpoint,
+            focus: endpoint,
+            anchorWindowPoint: windowPoint,
+            focusWindowPoint: windowPoint
+        )
+        pendingSelectionState = nil
+        nativeSelectionOwnerSegmentID = segmentID
+        nativeSelectionAnchorEdge = nil
+        selectionGestureIsActive = true
+        applySelectionRanges()
+        publishIfVisibleSelectionChanged(from: before)
+    }
+
+    func beginPendingSelection(segmentID: String, offset: Int, windowPoint: CGPoint) {
+        if let previous = Self.activeVisibleSelectionCoordinator, previous !== self {
+            previous.clearSelection()
+        }
+
+        if activeSelectionState != nil {
+            clearSelection()
+        }
+
+        pendingSelectionState = PendingSelectionState(
+            anchor: MarkdownSelectionEndpoint(segmentID: segmentID, offset: offset),
+            windowPoint: windowPoint
+        )
+    }
+
+    func cancelPendingSelection() {
+        pendingSelectionState = nil
+    }
+
+    func activateSelection(segmentID: String, selectedRange: NSRange, windowPoint: CGPoint) {
+        updateNativeSelection(
+            segmentID: segmentID,
+            selectedRange: selectedRange,
+            lowerWindowPoint: windowPoint,
+            upperWindowPoint: windowPoint
+        )
+    }
+
+    func updateNativeSelection(
+        segmentID: String,
+        selectedRange: NSRange,
+        lowerWindowPoint: CGPoint,
+        upperWindowPoint: CGPoint
+    ) {
+        let length = textLength(for: segmentID)
+        let lower = clamp(selectedRange.location, to: length)
+        let upper = clamp(NSMaxRange(selectedRange), to: length)
+        guard upper > lower else { return }
+
+        claimVisibleSelectionOwnership()
+        let before = visibleSelectionSnapshot()
+        let anchorEdge: NativeSelectionEdge
+        if activeSelectionState != nil,
+           nativeSelectionOwnerSegmentID == segmentID,
+           let nativeSelectionAnchorEdge {
+            anchorEdge = nativeSelectionAnchorEdge
+        } else {
+            anchorEdge = initialNativeSelectionAnchorEdge(
+                segmentID: segmentID,
+                lower: lower,
+                upper: upper
+            )
+        }
+
+        let lowerEndpoint = MarkdownSelectionEndpoint(segmentID: segmentID, offset: lower)
+        let upperEndpoint = MarkdownSelectionEndpoint(segmentID: segmentID, offset: upper)
+        let pendingWindowPoint = pendingSelectionState?.anchor.segmentID == segmentID
+            ? pendingSelectionState?.windowPoint
+            : nil
+        let anchor = anchorEdge == .upper ? upperEndpoint : lowerEndpoint
+        let focus = anchorEdge == .upper ? lowerEndpoint : upperEndpoint
+        let anchorWindowPoint = pendingWindowPoint
+            ?? (anchorEdge == .upper ? upperWindowPoint : lowerWindowPoint)
+        let focusWindowPoint = anchorEdge == .upper ? lowerWindowPoint : upperWindowPoint
+
+        activeSelectionState = ActiveSelectionState(
+            anchor: anchor,
+            focus: focus,
+            anchorWindowPoint: anchorWindowPoint,
+            focusWindowPoint: focusWindowPoint
+        )
+        pendingSelectionState = nil
+        nativeSelectionOwnerSegmentID = segmentID
+        nativeSelectionAnchorEdge = anchorEdge
+        selectionGestureIsActive = true
+        applySelectionRanges()
+        publishIfVisibleSelectionChanged(from: before)
+    }
+
+    func updateSelection(windowPoint: CGPoint) {
+        if let endpoint = endpoint(at: windowPoint) {
+            updateSelection(
+                segmentID: endpoint.segmentID,
+                offset: endpoint.offset,
+                windowPoint: windowPoint
+            )
+            return
+        }
+
+        guard var activeSelectionState else { return }
+        activeSelectionState.focusWindowPoint = windowPoint
+        self.activeSelectionState = activeSelectionState
+        applySelectionRanges()
+    }
+
+    func updateSelection(segmentID: String, offset: Int, windowPoint: CGPoint) {
+        guard var activeSelectionState else { return }
+
+        let before = visibleSelectionSnapshot()
+        activeSelectionState.focus = MarkdownSelectionEndpoint(segmentID: segmentID, offset: offset)
+        activeSelectionState.focusWindowPoint = windowPoint
+        self.activeSelectionState = activeSelectionState
+        applySelectionRanges()
+        publishIfVisibleSelectionChanged(from: before)
+    }
+
+    func endSelection() {
+        let before = visibleSelectionSnapshot()
+        selectionGestureIsActive = false
+        pendingSelectionState = nil
+        applySelectionRanges()
+        publishIfVisibleSelectionChanged(from: before)
+    }
+
+    func clearSelection() {
+        let before = visibleSelectionSnapshot()
+        resetSelectionState()
+        clearSelectionRanges()
+        publishIfVisibleSelectionChanged(from: before)
+    }
+
+    func copiedAttributedTextForActiveSelection() -> NSAttributedString {
+        guard let activeSelectionState else { return NSAttributedString(string: "") }
+        return copiedAttributedText(from: activeSelectionState.anchor, to: activeSelectionState.focus)
+    }
+
+    func highlightRects(in window: UIWindow?) -> [CGRect] {
+        guard let window, activeSelectionState != nil else { return [] }
+        let nativeSelectionOwnerSegmentID = nativeSelectionOwnerSegmentID
+
+        return activeSpans.flatMap { span -> [CGRect] in
+            guard span.segmentID != nativeSelectionOwnerSegmentID,
+                  let textView = recordsByID[span.segmentID]?.textView,
+                  textView.window === window
+            else {
+                return []
+            }
+            return selectionRects(for: span.range, in: textView, window: window)
+        }
+    }
+
+    private func endpoint(at windowPoint: CGPoint) -> MarkdownSelectionEndpoint? {
+        for segmentID in orderedSegmentIDs {
+            guard
+                let textView = recordsByID[segmentID]?.textView,
+                let window = textView.window
+            else {
+                continue
+            }
+
+            let windowBounds = textView.convert(textView.bounds, to: window)
+            guard windowBounds.contains(windowPoint) else { continue }
+
+            let localPoint = textView.convert(windowPoint, from: window)
+            return MarkdownSelectionEndpoint(
+                segmentID: segmentID,
+                offset: utf16Offset(for: localPoint, in: textView)
+            )
+        }
+
+        return nil
+    }
+
+    private func utf16Offset(for localPoint: CGPoint, in textView: UITextView) -> Int {
+        let length = textView.textStorage.length
+        guard length > 0 else { return 0 }
+
+        textView.layoutIfNeeded()
+        _ = textView.layoutManager.glyphRange(for: textView.textContainer)
+
+        let textContainerPoint = CGPoint(
+            x: localPoint.x - textView.textContainerInset.left + textView.contentOffset.x,
+            y: localPoint.y - textView.textContainerInset.top + textView.contentOffset.y
+        )
+        var fraction: CGFloat = 0
+        let characterIndex = textView.layoutManager.characterIndex(
+            for: textContainerPoint,
+            in: textView.textContainer,
+            fractionOfDistanceBetweenInsertionPoints: &fraction
+        )
+        let insertionIndex = characterIndex + (fraction > 0.5 ? 1 : 0)
+        return clamp(insertionIndex, to: length)
+    }
+
+    private func applySelectionRanges() {
+        guard activeSelectionState != nil else {
+            clearSelectionRanges()
+            return
+        }
+
+        isApplyingSelectionRanges = true
+        defer { isApplyingSelectionRanges = false }
+
+        let spansBySegmentID = Dictionary(uniqueKeysWithValues: activeSpans.map { ($0.segmentID, $0.range) })
+
+        for segmentID in orderedSegmentIDs {
+            guard let textView = recordsByID[segmentID]?.textView else { continue }
+            if let range = spansBySegmentID[segmentID] {
+                setSelectedRange(range, in: textView)
+            } else {
+                clearSelectionRange(in: textView)
+            }
+        }
+    }
+
+    private func clearSelectionRanges() {
+        isApplyingSelectionRanges = true
+        defer { isApplyingSelectionRanges = false }
+
+        for record in recordsByID.values {
+            guard let textView = record.textView else { continue }
+            clearSelectionRange(in: textView)
+        }
+    }
+
+    private func setSelectedRange(_ range: NSRange, in textView: UITextView) {
+        let safeRange = clampedRange(range, to: textView.textStorage.length)
+        guard textView.selectedRange != safeRange else { return }
+        textView.selectedRange = safeRange
+    }
+
+    private func clearSelectionRange(in textView: UITextView) {
+        let location = clamp(textView.selectedRange.location, to: textView.textStorage.length)
+        let emptyRange = NSRange(location: location, length: 0)
+        guard textView.selectedRange != emptyRange else { return }
+        textView.selectedRange = emptyRange
+    }
+
+    private func selectionRects(for range: NSRange, in textView: UITextView, window: UIWindow) -> [CGRect] {
+        let safeRange = clampedRange(range, to: textView.textStorage.length)
+        guard safeRange.length > 0 else { return [] }
+
+        textView.layoutIfNeeded()
+        _ = textView.layoutManager.glyphRange(for: textView.textContainer)
+
+        let glyphRange = textView.layoutManager.glyphRange(
+            forCharacterRange: safeRange,
+            actualCharacterRange: nil
+        )
+        guard glyphRange.length > 0 else { return [] }
+
+        var rects: [CGRect] = []
+        textView.layoutManager.enumerateEnclosingRects(
+            forGlyphRange: glyphRange,
+            withinSelectedGlyphRange: glyphRange,
+            in: textView.textContainer
+        ) { rect, _ in
+            let viewRect = rect.offsetBy(
+                dx: textView.textContainerInset.left - textView.contentOffset.x,
+                dy: textView.textContainerInset.top - textView.contentOffset.y
+            )
+            let windowRect = textView.convert(viewRect, to: window)
+            if !windowRect.isNull, !windowRect.isEmpty {
+                rects.append(windowRect.integral)
+            }
+        }
+        return rects
+    }
+
+    private func visibleSelectionSnapshot() -> VisibleSelectionSnapshot {
+        VisibleSelectionSnapshot(
+            activeSelectionState: activeSelectionState,
+            selectionGestureIsActive: selectionGestureIsActive,
+            nativeSelectionOwnerSegmentID: nativeSelectionOwnerSegmentID
+        )
+    }
+
+    private func publishIfVisibleSelectionChanged(from before: VisibleSelectionSnapshot) {
+        if visibleSelectionSnapshot() != before {
+            objectWillChange.send()
+        }
+    }
+
+    private func claimVisibleSelectionOwnership() {
+        if let previous = Self.activeVisibleSelectionCoordinator, previous !== self {
+            previous.clearSelection()
+        }
+        Self.activeVisibleSelectionCoordinator = self
+    }
+
+    private func resetSelectionState() {
+        activeSelectionState = nil
+        pendingSelectionState = nil
+        selectionGestureIsActive = false
+        nativeSelectionOwnerSegmentID = nil
+        nativeSelectionAnchorEdge = nil
+        if Self.activeVisibleSelectionCoordinator === self {
+            Self.activeVisibleSelectionCoordinator = nil
+        }
+    }
+}

--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -25,6 +25,7 @@ struct MarkdownText: View {
     /// to its trailing glyphs, allowing a streaming tail to fade independently
     /// while already-read text remains fully stable.
     var newestCharacterOpacities: [Double] = []
+    @StateObject private var selectionCoordinator = MarkdownSelectionCoordinator()
 
     /// True only for the actively streaming reply, whose `source` changes
     /// every frame. Settled messages (the default) populate the render cache;
@@ -40,6 +41,9 @@ struct MarkdownText: View {
             usesAccentSurface: usesAccentSurface,
             isStreaming: isStreaming
         )
+        let selectionSegments = rendering.selectableText == nil
+            ? MarkdownSelectionSegmentPlan.descriptors(for: rendering.blocks)
+            : []
 
         Group {
             if let baseText = rendering.selectableText {
@@ -60,18 +64,106 @@ struct MarkdownText: View {
                     ForEach(Array(rendering.blocks.enumerated()), id: \.offset) { index, block in
                         MarkdownBlockView(
                             block: block,
+                            blockIndex: index,
                             foregroundStyle: foregroundStyle,
                             usesAccentSurface: usesAccentSurface,
                             gatewayMediaDataURL: gatewayMediaDataURL,
+                            selectionCoordinator: selectionCoordinator,
+                            selectionSegments: selectionSegments,
                             newestCharacterOpacities: index == rendering.blocks.count - 1
                                 ? newestCharacterOpacities
                                 : []
                         )
                     }
                 }
+                .onAppear {
+                    selectionCoordinator.replaceSegments(selectionSegments, revision: source)
+                }
+                .onChange(of: source) { _, _ in
+                    selectionCoordinator.replaceSegments(selectionSegments, revision: source)
+                }
+                .modifier(MarkdownSelectionHost(coordinator: selectionCoordinator))
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct MarkdownSelectionHost: ViewModifier {
+    @ObservedObject var coordinator: MarkdownSelectionCoordinator
+
+    func body(content: Content) -> some View {
+        content
+            .contentShape(Rectangle())
+            .overlay {
+                MarkdownSelectionHighlightOverlay(coordinator: coordinator)
+                    .allowsHitTesting(false)
+            }
+            .simultaneousGesture(
+                TapGesture()
+                    .onEnded {
+                        coordinator.clearSelection()
+                    }
+            )
+            .simultaneousGesture(
+                DragGesture(minimumDistance: 0, coordinateSpace: .global)
+                    .onChanged { value in
+                        guard coordinator.isSelectionGestureActive else { return }
+                        coordinator.updateSelection(windowPoint: value.location)
+                    }
+                    .onEnded { _ in
+                        guard coordinator.isSelectionGestureActive else { return }
+                        coordinator.endSelection()
+                    }
+            )
+            .onDisappear {
+                coordinator.clearSelection()
+            }
+    }
+}
+
+private struct MarkdownSelectionHighlightOverlay: UIViewRepresentable {
+    @ObservedObject var coordinator: MarkdownSelectionCoordinator
+
+    func makeUIView(context: Context) -> MarkdownSelectionHighlightView {
+        let view = MarkdownSelectionHighlightView(frame: .zero)
+        view.coordinator = coordinator
+        return view
+    }
+
+    func updateUIView(_ uiView: MarkdownSelectionHighlightView, context: Context) {
+        uiView.coordinator = coordinator
+        uiView.setNeedsDisplay()
+    }
+}
+
+private final class MarkdownSelectionHighlightView: UIView {
+    weak var coordinator: MarkdownSelectionCoordinator?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        isOpaque = false
+        backgroundColor = .clear
+        isUserInteractionEnabled = false
+        contentMode = .redraw
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func draw(_ rect: CGRect) {
+        guard let coordinator, let window else { return }
+
+        UIColor.systemBlue.withAlphaComponent(0.24).setFill()
+        for windowRect in coordinator.highlightRects(in: window) {
+            let localRect = convert(windowRect, from: window)
+            guard localRect.intersects(bounds) else { continue }
+            UIBezierPath(
+                roundedRect: localRect.intersection(bounds).insetBy(dx: -0.5, dy: -0.5),
+                cornerRadius: 2
+            ).fill()
+        }
     }
 }
 
@@ -417,9 +509,12 @@ enum MarkdownHeading {
 
 private struct MarkdownBlockView: View {
     let block: MarkdownBlock
+    let blockIndex: Int
     let foregroundStyle: Color
     let usesAccentSurface: Bool
     let gatewayMediaDataURL: ((String) async -> String?)?
+    let selectionCoordinator: MarkdownSelectionCoordinator?
+    let selectionSegments: [MarkdownSelectionSegmentDescriptor]
     let newestCharacterOpacities: [Double]
 
     var body: some View {
@@ -430,6 +525,8 @@ private struct MarkdownBlockView: View {
                 foregroundStyle: foregroundStyle,
                 usesAccentSurface: usesAccentSurface,
                 font: headingFont(level),
+                selectionCoordinator: selectionCoordinator,
+                selectionSegment: blockDescriptor,
                 trailingCharacterOpacities: newestCharacterOpacities
             )
                 .padding(.top, level <= 2 ? 6 : 2)
@@ -440,6 +537,8 @@ private struct MarkdownBlockView: View {
                 foregroundStyle: foregroundStyle,
                 usesAccentSurface: usesAccentSurface,
                 lineSpacing: 4,
+                selectionCoordinator: selectionCoordinator,
+                selectionSegment: blockDescriptor,
                 trailingCharacterOpacities: newestCharacterOpacities
             )
 
@@ -448,6 +547,8 @@ private struct MarkdownBlockView: View {
                 lines: lines,
                 foregroundStyle: foregroundStyle,
                 usesAccentSurface: usesAccentSurface,
+                selectionCoordinator: selectionCoordinator,
+                selectionSegments: blockSelectionSegments,
                 trailingCharacterOpacities: newestCharacterOpacities
             )
 
@@ -457,6 +558,8 @@ private struct MarkdownBlockView: View {
                 ordered: false,
                 foregroundStyle: foregroundStyle,
                 usesAccentSurface: usesAccentSurface,
+                selectionCoordinator: selectionCoordinator,
+                selectionSegments: blockSelectionSegments,
                 trailingCharacterOpacities: newestCharacterOpacities
             )
 
@@ -466,6 +569,8 @@ private struct MarkdownBlockView: View {
                 ordered: true,
                 foregroundStyle: foregroundStyle,
                 usesAccentSurface: usesAccentSurface,
+                selectionCoordinator: selectionCoordinator,
+                selectionSegments: blockSelectionSegments,
                 trailingCharacterOpacities: newestCharacterOpacities
             )
 
@@ -475,7 +580,10 @@ private struct MarkdownBlockView: View {
                 alignments: alignments,
                 rows: rows,
                 foregroundStyle: foregroundStyle,
-                usesAccentSurface: usesAccentSurface
+                usesAccentSurface: usesAccentSurface,
+                selectionCoordinator: selectionCoordinator,
+                blockIndex: blockIndex,
+                selectionSegments: selectionSegments
             )
 
         case .image(let url, let alt):
@@ -490,6 +598,8 @@ private struct MarkdownBlockView: View {
                 text: text,
                 foregroundStyle: foregroundStyle,
                 usesAccentSurface: usesAccentSurface,
+                selectionCoordinator: selectionCoordinator,
+                selectionSegment: blockDescriptor,
                 trailingCharacterOpacities: newestCharacterOpacities
             )
 
@@ -498,6 +608,8 @@ private struct MarkdownBlockView: View {
                 columns: columns,
                 foregroundStyle: foregroundStyle,
                 usesAccentSurface: usesAccentSurface,
+                selectionCoordinator: selectionCoordinator,
+                selectionSegments: blockSelectionSegments,
                 trailingCharacterOpacities: newestCharacterOpacities
             )
 
@@ -505,7 +617,13 @@ private struct MarkdownBlockView: View {
             if MarkdownLanguage.normalized(language) == "mermaid" {
                 MermaidBlock(source: source)
             } else {
-                ChatCodeBlock(source: source, language: language, usesAccentSurface: usesAccentSurface)
+                ChatCodeBlock(
+                    source: source,
+                    language: language,
+                    usesAccentSurface: usesAccentSurface,
+                    selectionCoordinator: selectionCoordinator,
+                    selectionSegment: selectionSegment(id: "block-\(blockIndex)-code")
+                )
             }
 
         case .divider:
@@ -519,6 +637,22 @@ private struct MarkdownBlockView: View {
     private func headingFont(_ level: Int) -> UIFont {
         MarkdownHeading.font(for: level)
     }
+
+    private var blockDescriptor: MarkdownSelectionSegmentDescriptor? {
+        selectionSegment(id: "block-\(blockIndex)")
+    }
+
+    private var blockSelectionSegments: [MarkdownSelectionSegmentDescriptor] {
+        let blockID = "block-\(blockIndex)"
+        let blockPrefix = "\(blockID)-"
+        return selectionSegments.filter { descriptor in
+            descriptor.id == blockID || descriptor.id.hasPrefix(blockPrefix)
+        }
+    }
+
+    private func selectionSegment(id: String) -> MarkdownSelectionSegmentDescriptor? {
+        selectionSegments.first { $0.id == id }
+    }
 }
 
 private struct InlineMarkdown: View {
@@ -528,6 +662,8 @@ private struct InlineMarkdown: View {
     var font: UIFont = .preferredFont(forTextStyle: .body)
     var lineSpacing: CGFloat = 0
     var maximumNumberOfLines: Int = 0
+    var selectionCoordinator: MarkdownSelectionCoordinator?
+    var selectionSegment: MarkdownSelectionSegmentDescriptor?
     var trailingCharacterOpacities: [Double] = []
 
     private var attributed: AttributedString {
@@ -553,7 +689,9 @@ private struct InlineMarkdown: View {
             textColor: usesAccentSurface ? .white : UIColor(foregroundStyle),
             lineSpacing: lineSpacing,
             maximumNumberOfLines: maximumNumberOfLines,
-            linkColor: usesAccentSurface ? .white : .link
+            linkColor: usesAccentSurface ? .white : .link,
+            selectionCoordinator: selectionCoordinator,
+            selectionSegment: selectionSegment
         )
             .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -564,6 +702,8 @@ private struct MarkdownList: View {
     let ordered: Bool
     let foregroundStyle: Color
     let usesAccentSurface: Bool
+    let selectionCoordinator: MarkdownSelectionCoordinator?
+    let selectionSegments: [MarkdownSelectionSegmentDescriptor]
     var trailingCharacterOpacities: [Double] = []
 
     var body: some View {
@@ -588,6 +728,8 @@ private struct MarkdownList: View {
                         foregroundStyle: foregroundStyle,
                         usesAccentSurface: usesAccentSurface,
                         lineSpacing: 3,
+                        selectionCoordinator: selectionCoordinator,
+                        selectionSegment: selectionSegments.indices.contains(index) ? selectionSegments[index] : nil,
                         trailingCharacterOpacities: index == items.count - 1
                             ? trailingCharacterOpacities
                             : []
@@ -602,6 +744,8 @@ private struct MarkdownQuote: View {
     let lines: [MarkdownQuoteLine]
     let foregroundStyle: Color
     let usesAccentSurface: Bool
+    let selectionCoordinator: MarkdownSelectionCoordinator?
+    let selectionSegments: [MarkdownSelectionSegmentDescriptor]
     var trailingCharacterOpacities: [Double] = []
 
     private var callout: (kind: String, text: String)? {
@@ -619,6 +763,8 @@ private struct MarkdownQuote: View {
                 text: callout.text,
                 foregroundStyle: foregroundStyle,
                 usesAccentSurface: usesAccentSurface,
+                selectionCoordinator: selectionCoordinator,
+                selectionSegment: selectionSegments.first,
                 trailingCharacterOpacities: trailingCharacterOpacities
             )
         } else {
@@ -636,6 +782,8 @@ private struct MarkdownQuote: View {
                             usesAccentSurface: usesAccentSurface,
                             font: UIFont.preferredFont(forTextStyle: .body).withTraits(.traitItalic),
                             lineSpacing: 3,
+                            selectionCoordinator: selectionCoordinator,
+                            selectionSegment: selectionSegments.indices.contains(index) ? selectionSegments[index] : nil,
                             trailingCharacterOpacities: index == lines.count - 1
                                 ? trailingCharacterOpacities
                                 : []
@@ -658,6 +806,8 @@ private struct MarkdownCallout: View {
     let text: String
     let foregroundStyle: Color
     let usesAccentSurface: Bool
+    let selectionCoordinator: MarkdownSelectionCoordinator?
+    let selectionSegment: MarkdownSelectionSegmentDescriptor?
     var trailingCharacterOpacities: [Double] = []
 
     private var detail: (title: String, icon: String, color: Color) {
@@ -680,6 +830,8 @@ private struct MarkdownCallout: View {
                 foregroundStyle: foregroundStyle,
                 usesAccentSurface: usesAccentSurface,
                 lineSpacing: 3,
+                selectionCoordinator: selectionCoordinator,
+                selectionSegment: selectionSegment,
                 trailingCharacterOpacities: trailingCharacterOpacities
             )
         }
@@ -696,6 +848,8 @@ private struct MarkdownColumns: View {
     let columns: [String]
     let foregroundStyle: Color
     let usesAccentSurface: Bool
+    let selectionCoordinator: MarkdownSelectionCoordinator?
+    let selectionSegments: [MarkdownSelectionSegmentDescriptor]
     var trailingCharacterOpacities: [Double] = []
 
     var body: some View {
@@ -706,6 +860,8 @@ private struct MarkdownColumns: View {
                     foregroundStyle: foregroundStyle,
                     usesAccentSurface: usesAccentSurface,
                     lineSpacing: 3,
+                    selectionCoordinator: selectionCoordinator,
+                    selectionSegment: selectionSegments.indices.contains(index) ? selectionSegments[index] : nil,
                     trailingCharacterOpacities: index == columns.count - 1
                         ? trailingCharacterOpacities
                         : []
@@ -734,14 +890,17 @@ private struct MarkdownTable: View {
     let rows: [[String]]
     let foregroundStyle: Color
     let usesAccentSurface: Bool
+    let selectionCoordinator: MarkdownSelectionCoordinator?
+    let blockIndex: Int
+    let selectionSegments: [MarkdownSelectionSegmentDescriptor]
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             VStack(alignment: .leading, spacing: 0) {
-                tableRow(headers, isHeader: true)
-                ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                tableRow(headers, rowIndex: 0, isHeader: true)
+                ForEach(Array(rows.enumerated()), id: \.offset) { rowOffset, row in
                     Divider().overlay(usesAccentSurface ? Color.white.opacity(0.22) : Color.secondary.opacity(0.18))
-                    tableRow(row, isHeader: false)
+                    tableRow(row, rowIndex: rowOffset + 1, isHeader: false)
                 }
             }
             .background(
@@ -755,7 +914,7 @@ private struct MarkdownTable: View {
         }
     }
 
-    private func tableRow(_ cells: [String], isHeader: Bool) -> some View {
+    private func tableRow(_ cells: [String], rowIndex: Int, isHeader: Bool) -> some View {
         HStack(spacing: 0) {
             ForEach(Array(cells.enumerated()), id: \.offset) { index, cell in
                 InlineMarkdown(
@@ -765,7 +924,9 @@ private struct MarkdownTable: View {
                     font: isHeader
                         ? UIFont.preferredFont(forTextStyle: .caption1).withTraits(.traitBold)
                         : UIFont.preferredFont(forTextStyle: .footnote),
-                    maximumNumberOfLines: 4
+                    maximumNumberOfLines: 4,
+                    selectionCoordinator: selectionCoordinator,
+                    selectionSegment: selectionSegment(row: rowIndex, column: index)
                 )
                     .frame(minWidth: 112, maxWidth: 220, alignment: alignment(at: index).swiftUI)
                     .padding(.horizontal, 10)
@@ -779,6 +940,11 @@ private struct MarkdownTable: View {
 
     private func alignment(at index: Int) -> MarkdownTableAlignment {
         alignments.indices.contains(index) ? alignments[index] : .leading
+    }
+
+    private func selectionSegment(row: Int, column: Int) -> MarkdownSelectionSegmentDescriptor? {
+        let id = "block-\(blockIndex)-table-r\(row)-c\(column)"
+        return selectionSegments.first { $0.id == id }
     }
 }
 
@@ -1139,6 +1305,8 @@ struct ChatCodeBlock: View {
     let source: String
     var language: String = ""
     var usesAccentSurface = false
+    var selectionCoordinator: MarkdownSelectionCoordinator?
+    var selectionSegment: MarkdownSelectionSegmentDescriptor?
     @State private var copied = false
 
     private var normalizedLanguage: String { MarkdownLanguage.normalized(language) }
@@ -1171,7 +1339,9 @@ struct ChatCodeBlock: View {
                             font: .monospacedSystemFont(ofSize: UIFont.preferredFont(forTextStyle: .footnote).pointSize, weight: .regular),
                             textColor: UIColor.white.withAlphaComponent(0.96),
                             lineSpacing: 3,
-                            wrapsLines: false
+                            wrapsLines: false,
+                            selectionCoordinator: selectionCoordinator,
+                            selectionSegment: selectionSegment
                         )
                     } else {
                         SelectableTextView(
@@ -1179,7 +1349,9 @@ struct ChatCodeBlock: View {
                             font: .monospacedSystemFont(ofSize: UIFont.preferredFont(forTextStyle: .footnote).pointSize, weight: .regular),
                             textColor: .label,
                             lineSpacing: 3,
-                            wrapsLines: false
+                            wrapsLines: false,
+                            selectionCoordinator: selectionCoordinator,
+                            selectionSegment: selectionSegment
                         )
                     }
                 }
@@ -1545,7 +1717,7 @@ enum MarkdownParser {
     }
 }
 
-private enum MarkdownLanguage {
+enum MarkdownLanguage {
     static func normalized(_ value: String) -> String {
         switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
         case "", "text", "plaintext": return "plain"

--- a/Conduit/Views/Components/SelectableTextView.swift
+++ b/Conduit/Views/Components/SelectableTextView.swift
@@ -6,6 +6,8 @@ import UIKit
 /// selection API is intentionally kept for controls outside this surface,
 /// but it cannot select a range within a Text view on older OS releases.
 struct SelectableTextView: UIViewRepresentable {
+    typealias UIViewType = SelectableTextViewHostView
+
     let attributedText: NSAttributedString
     let font: UIFont
     let textColor: UIColor
@@ -13,6 +15,8 @@ struct SelectableTextView: UIViewRepresentable {
     let maximumNumberOfLines: Int
     let wrapsLines: Bool
     let linkColor: UIColor
+    let selectionCoordinator: MarkdownSelectionCoordinator?
+    let selectionSegment: MarkdownSelectionSegmentDescriptor?
 
     init(
         attributedText: NSAttributedString,
@@ -21,7 +25,9 @@ struct SelectableTextView: UIViewRepresentable {
         lineSpacing: CGFloat = 0,
         maximumNumberOfLines: Int = 0,
         wrapsLines: Bool = true,
-        linkColor: UIColor = .link
+        linkColor: UIColor = .link,
+        selectionCoordinator: MarkdownSelectionCoordinator? = nil,
+        selectionSegment: MarkdownSelectionSegmentDescriptor? = nil
     ) {
         self.attributedText = attributedText
         self.font = font
@@ -30,6 +36,8 @@ struct SelectableTextView: UIViewRepresentable {
         self.maximumNumberOfLines = maximumNumberOfLines
         self.wrapsLines = wrapsLines
         self.linkColor = linkColor
+        self.selectionCoordinator = selectionCoordinator
+        self.selectionSegment = selectionSegment
     }
 
     init(
@@ -39,7 +47,9 @@ struct SelectableTextView: UIViewRepresentable {
         lineSpacing: CGFloat = 0,
         maximumNumberOfLines: Int = 0,
         wrapsLines: Bool = true,
-        linkColor: UIColor = .link
+        linkColor: UIColor = .link,
+        selectionCoordinator: MarkdownSelectionCoordinator? = nil,
+        selectionSegment: MarkdownSelectionSegmentDescriptor? = nil
     ) {
         self.init(
             attributedText: Self.bridge(attributedText, defaultFont: font, defaultColor: textColor, linkColor: linkColor),
@@ -48,7 +58,9 @@ struct SelectableTextView: UIViewRepresentable {
             lineSpacing: lineSpacing,
             maximumNumberOfLines: maximumNumberOfLines,
             wrapsLines: wrapsLines,
-            linkColor: linkColor
+            linkColor: linkColor,
+            selectionCoordinator: selectionCoordinator,
+            selectionSegment: selectionSegment
         )
     }
 
@@ -59,7 +71,9 @@ struct SelectableTextView: UIViewRepresentable {
         lineSpacing: CGFloat = 0,
         maximumNumberOfLines: Int = 0,
         wrapsLines: Bool = true,
-        linkColor: UIColor = .link
+        linkColor: UIColor = .link,
+        selectionCoordinator: MarkdownSelectionCoordinator? = nil,
+        selectionSegment: MarkdownSelectionSegmentDescriptor? = nil
     ) {
         self.init(
             attributedText: NSAttributedString(
@@ -71,7 +85,9 @@ struct SelectableTextView: UIViewRepresentable {
             lineSpacing: lineSpacing,
             maximumNumberOfLines: maximumNumberOfLines,
             wrapsLines: wrapsLines,
-            linkColor: linkColor
+            linkColor: linkColor,
+            selectionCoordinator: selectionCoordinator,
+            selectionSegment: selectionSegment
         )
     }
 
@@ -79,6 +95,11 @@ struct SelectableTextView: UIViewRepresentable {
     /// tested directly instead of being inferred from a SwiftUI modifier.
     static func makeTextView() -> UITextView {
         let textView = UITextView(frame: .zero)
+        configureBaseTextView(textView)
+        return textView
+    }
+
+    private static func configureBaseTextView(_ textView: UITextView) {
         textView.isEditable = false
         textView.isSelectable = true
         textView.isScrollEnabled = false
@@ -87,23 +108,58 @@ struct SelectableTextView: UIViewRepresentable {
         textView.textContainer.lineFragmentPadding = 0
         textView.setContentHuggingPriority(.required, for: .vertical)
         textView.setContentCompressionResistancePriority(.required, for: .vertical)
-        return textView
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(linkColor: linkColor)
+        Coordinator(
+            linkColor: linkColor,
+            selectionCoordinator: selectionCoordinator,
+            selectionSegment: selectionSegment
+        )
     }
 
-    func makeUIView(context: Context) -> UITextView {
-        let textView = Self.makeTextView()
-        textView.delegate = context.coordinator
-        configure(textView)
-        return textView
+    func makeUIView(context: Context) -> SelectableTextViewHostView {
+        makeUIViewForTests(coordinator: context.coordinator)
     }
 
-    func updateUIView(_ textView: UITextView, context: Context) {
-        context.coordinator.linkColor = linkColor
+    func updateUIView(_ uiView: SelectableTextViewHostView, context: Context) {
+        updateUIViewForTests(uiView, coordinator: context.coordinator)
+    }
+
+    static func dismantleUIView(_ uiView: SelectableTextViewHostView, coordinator: Coordinator) {
+        tearDownMountedTextView(in: uiView)
+    }
+
+    @MainActor
+    func makeUIViewForTests(coordinator: Coordinator) -> SelectableTextViewHostView {
+        let hostView = SelectableTextViewHostView(frame: .zero)
+        updateUIViewForTests(hostView, coordinator: coordinator)
+        return hostView
+    }
+
+    @MainActor
+    func updateUIViewForTests(_ uiView: SelectableTextViewHostView, coordinator: Coordinator) {
+        coordinator.linkColor = linkColor
+        coordinator.selectionCoordinator = selectionCoordinator
+        coordinator.selectionSegment = selectionSegment
+
+        unregisterMountedTextViewIfNeeded(in: uiView, coordinator: coordinator)
+
+        let needsCoordinatedTextView = selectionCoordinator != nil && selectionSegment != nil
+        if uiView.isUsingCoordinatedTextView != needsCoordinatedTextView {
+            let replacementTextView = makeMountedTextView(needsCoordinatedTextView: needsCoordinatedTextView)
+            replacementTextView.attributedText = uiView.mountedTextView.attributedText
+            replacementTextView.selectedRange = uiView.mountedTextView.selectedRange
+            uiView.setMountedTextView(replacementTextView)
+        }
+
+        let textView = uiView.mountedTextView
+        textView.delegate = coordinator
+        configureSelectionBridge(for: textView, coordinator: coordinator)
         configure(textView)
+        registerSelectionIfNeeded(for: textView, coordinator: coordinator)
+        uiView.mountedSelectionCoordinator = coordinator.selectionCoordinator
+        uiView.mountedSelectionSegment = coordinator.selectionSegment
     }
 
     /// Extracted measurement logic so sizeThatFits and tests share one path.
@@ -136,13 +192,13 @@ struct SelectableTextView: UIViewRepresentable {
         )
     }
 
-    func sizeThatFits(_ proposal: ProposedViewSize, uiView: UITextView, context: Context) -> CGSize? {
+    func sizeThatFits(_ proposal: ProposedViewSize, uiView: SelectableTextViewHostView, context: Context) -> CGSize? {
         if !wrapsLines {
             return measureNonWrapping()
         }
 
         guard let width = proposal.width, width > 0 else { return nil }
-        let measured = uiView.sizeThatFits(CGSize(width: width, height: CGFloat.greatestFiniteMagnitude))
+        let measured = uiView.mountedTextView.sizeThatFits(CGSize(width: width, height: CGFloat.greatestFiniteMagnitude))
         return CGSize(width: width, height: ceil(measured.height))
     }
 
@@ -200,6 +256,80 @@ struct SelectableTextView: UIViewRepresentable {
         textView.invalidateIntrinsicContentSize()
     }
 
+    private func registerSelectionIfNeeded(for textView: UITextView, coordinator: Coordinator) {
+        guard
+            let selectionCoordinator = coordinator.selectionCoordinator,
+            let selectionSegment = coordinator.selectionSegment
+        else { return }
+
+        selectionCoordinator.register(descriptor: selectionSegment, textView: textView)
+    }
+
+    private func unregisterMountedTextViewIfNeeded(in hostView: SelectableTextViewHostView, coordinator: Coordinator) {
+        guard
+            let selectionCoordinator = hostView.mountedSelectionCoordinator,
+            let selectionSegment = hostView.mountedSelectionSegment
+        else { return }
+
+        if selectionCoordinator !== coordinator.selectionCoordinator || selectionSegment != coordinator.selectionSegment {
+            selectionCoordinator.unregister(segmentID: selectionSegment.id, textView: hostView.mountedTextView)
+            hostView.mountedSelectionCoordinator = nil
+            hostView.mountedSelectionSegment = nil
+        }
+    }
+
+    private func configureSelectionBridge(for textView: UITextView, coordinator: Coordinator) {
+        guard let coordinatedTextView = textView as? MarkdownSelectionTextView else { return }
+
+        coordinatedTextView.selectionCoordinator = coordinator.selectionCoordinator
+        coordinatedTextView.selectionSegment = coordinator.selectionSegment
+        coordinatedTextView.onTouchBegan = makeTouchHandler(coordinator: coordinator)
+    }
+
+    private func makeTouchHandler(coordinator: Coordinator) -> ((MarkdownSelectionTextView, CGPoint) -> Void)? {
+        guard coordinator.selectionCoordinator != nil, coordinator.selectionSegment != nil else {
+            return nil
+        }
+
+        return { [weak selectionCoordinator = coordinator.selectionCoordinator, selectionSegment = coordinator.selectionSegment] coordinatedTextView, localPoint in
+            guard
+                let selectionCoordinator,
+                let selectionSegment
+            else { return }
+            selectionCoordinator.beginPendingSelection(
+                segmentID: selectionSegment.id,
+                offset: coordinatedTextView.utf16Offset(for: localPoint),
+                windowPoint: coordinatedTextView.windowPoint(forLocalPoint: localPoint) ?? .zero
+            )
+        }
+    }
+
+    private func makeMountedTextView(needsCoordinatedTextView: Bool) -> UITextView {
+        if needsCoordinatedTextView {
+            let textView = MarkdownSelectionTextView(frame: .zero)
+            Self.configureBaseTextView(textView)
+            return textView
+        }
+        return Self.makeTextView()
+    }
+
+    private static func tearDownMountedTextView(in hostView: SelectableTextViewHostView) {
+        let textView = hostView.mountedTextView
+        textView.delegate = nil
+        if let coordinated = textView as? MarkdownSelectionTextView {
+            coordinated.onTouchBegan = nil
+            coordinated.selectionCoordinator = nil
+            coordinated.selectionSegment = nil
+        }
+        textView.resignFirstResponder()
+        if let selectionCoordinator = hostView.mountedSelectionCoordinator,
+           let selectionSegment = hostView.mountedSelectionSegment {
+            selectionCoordinator.unregister(segmentID: selectionSegment.id, textView: textView)
+        }
+        hostView.mountedSelectionCoordinator = nil
+        hostView.mountedSelectionSegment = nil
+    }
+
     /// Converts an AttributedString (from Markdown parsing) into an
     /// NSAttributedString with UIKit-compatible font traits. Exposed as
     /// internal so callers can convert without instantiating the full view.
@@ -255,9 +385,17 @@ struct SelectableTextView: UIViewRepresentable {
 
     final class Coordinator: NSObject, UITextViewDelegate {
         var linkColor: UIColor
+        weak var selectionCoordinator: MarkdownSelectionCoordinator?
+        var selectionSegment: MarkdownSelectionSegmentDescriptor?
 
-        init(linkColor: UIColor) {
+        init(
+            linkColor: UIColor,
+            selectionCoordinator: MarkdownSelectionCoordinator?,
+            selectionSegment: MarkdownSelectionSegmentDescriptor?
+        ) {
             self.linkColor = linkColor
+            self.selectionCoordinator = selectionCoordinator
+            self.selectionSegment = selectionSegment
         }
 
         // shouldInteractWith is formally deprecated in iOS 17 in favor of
@@ -284,6 +422,158 @@ struct SelectableTextView: UIViewRepresentable {
                 return true
             }
         }
+
+        func textViewDidChangeSelection(_ textView: UITextView) {
+            guard
+                let selectionCoordinator,
+                let selectionSegment,
+                !selectionCoordinator.isApplyingNativeSelectionRanges,
+                let textRange = textView.selectedTextRange
+            else { return }
+
+            let startOffset = textView.offset(from: textView.beginningOfDocument, to: textRange.start)
+            let endOffset = textView.offset(from: textView.beginningOfDocument, to: textRange.end)
+            let startWindowPoint = windowPoint(for: textRange.start, in: textView)
+            let endWindowPoint = windowPoint(for: textRange.end, in: textView)
+
+            let selectedRange: NSRange
+            let lowerWindowPoint: CGPoint
+            let upperWindowPoint: CGPoint
+            if startOffset <= endOffset {
+                selectedRange = NSRange(location: startOffset, length: endOffset - startOffset)
+                lowerWindowPoint = startWindowPoint
+                upperWindowPoint = endWindowPoint
+            } else {
+                selectedRange = NSRange(location: endOffset, length: startOffset - endOffset)
+                lowerWindowPoint = endWindowPoint
+                upperWindowPoint = startWindowPoint
+            }
+
+            selectionCoordinator.updateNativeSelection(
+                segmentID: selectionSegment.id,
+                selectedRange: selectedRange,
+                lowerWindowPoint: lowerWindowPoint,
+                upperWindowPoint: upperWindowPoint
+            )
+        }
+
+        private func windowPoint(for position: UITextPosition, in textView: UITextView) -> CGPoint {
+            let caretRect = textView.caretRect(for: position)
+            let caretPoint = CGPoint(x: caretRect.midX, y: caretRect.midY)
+            return (textView as? MarkdownSelectionTextView)?.windowPoint(forLocalPoint: caretPoint)
+                ?? textView.window.map { textView.convert(caretPoint, to: $0) }
+                ?? .zero
+        }
+    }
+}
+
+private final class MarkdownSelectionTextView: UITextView {
+    var onTouchBegan: ((MarkdownSelectionTextView, CGPoint) -> Void)?
+    weak var selectionCoordinator: MarkdownSelectionCoordinator?
+    var selectionSegment: MarkdownSelectionSegmentDescriptor?
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        if let touch = touches.first {
+            onTouchBegan?(self, touch.location(in: self))
+        }
+        super.touchesBegan(touches, with: event)
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        selectionCoordinator?.cancelPendingSelection()
+        super.touchesEnded(touches, with: event)
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        selectionCoordinator?.cancelPendingSelection()
+        super.touchesCancelled(touches, with: event)
+    }
+
+    override func copy(_ sender: Any?) {
+        guard let copied = coordinatedCopiedAttributedText() else {
+            super.copy(sender)
+            return
+        }
+
+        UIPasteboard.general.string = copied.string
+        if let rtf = try? copied.data(
+            from: NSRange(location: 0, length: copied.length),
+            documentAttributes: [.documentType: NSAttributedString.DocumentType.rtf]
+        ) {
+            UIPasteboard.general.setData(rtf, forPasteboardType: "public.rtf")
+        }
+    }
+
+    func simulateTouchBeganForTesting(_ localPoint: CGPoint) {
+        onTouchBegan?(self, localPoint)
+    }
+
+    func coordinatedCopiedAttributedText() -> NSAttributedString? {
+        guard
+            let selectionCoordinator,
+            selectionCoordinator.hasCrossSegmentSelection
+        else { return nil }
+
+        let copied = selectionCoordinator.copiedAttributedTextForActiveSelection()
+        return copied.length > 0 ? copied : nil
+    }
+
+    func utf16Offset(for localPoint: CGPoint) -> Int {
+        guard let position = closestPosition(to: localPoint) else {
+            return selectedRange.location
+        }
+        return offset(from: beginningOfDocument, to: position)
+    }
+
+    func windowPoint(forLocalPoint localPoint: CGPoint) -> CGPoint? {
+        guard let window else { return nil }
+        return convert(localPoint, to: window)
+    }
+}
+
+final class SelectableTextViewHostView: UIView {
+    private(set) var mountedTextView: UITextView
+    weak var mountedSelectionCoordinator: MarkdownSelectionCoordinator?
+    var mountedSelectionSegment: MarkdownSelectionSegmentDescriptor?
+
+    override init(frame: CGRect) {
+        self.mountedTextView = SelectableTextView.makeTextView()
+        super.init(frame: frame)
+        embedMountedTextView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    var isUsingCoordinatedTextView: Bool {
+        mountedTextView is MarkdownSelectionTextView
+    }
+
+    func setMountedTextView(_ textView: UITextView) {
+        guard mountedTextView !== textView else { return }
+        mountedTextView.removeFromSuperview()
+        mountedTextView = textView
+        embedMountedTextView()
+    }
+
+    func simulateTouchBeganForTesting(at localPoint: CGPoint) {
+        (mountedTextView as? MarkdownSelectionTextView)?.simulateTouchBeganForTesting(localPoint)
+    }
+
+    func coordinatedCopiedAttributedTextForTesting() -> NSAttributedString? {
+        (mountedTextView as? MarkdownSelectionTextView)?.coordinatedCopiedAttributedText()
+    }
+
+    private func embedMountedTextView() {
+        addSubview(mountedTextView)
+        mountedTextView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            mountedTextView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            mountedTextView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            mountedTextView.topAnchor.constraint(equalTo: topAnchor),
+            mountedTextView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
     }
 }
 

--- a/Conduit/Views/RootView.swift
+++ b/Conduit/Views/RootView.swift
@@ -64,12 +64,19 @@ struct MainView: View {
                     .accessibilityLabel("Open sessions")
                 }
                 ToolbarItem(placement: .principal) {
-                    Text(appState.activeSessionTitle)
-                        .font(.subheadline.weight(.semibold))
-                        .lineLimit(1)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 7)
-                        .conduitGlassSurface(cornerRadius: 16, tint: .conduitAccent.opacity(0.06))
+                    Button {
+                        appState.requestChatScrollToTop()
+                    } label: {
+                        Text(appState.activeSessionTitle)
+                            .font(.subheadline.weight(.semibold))
+                            .lineLimit(1)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 7)
+                            .conduitGlassSurface(cornerRadius: 16, tint: .conduitAccent.opacity(0.06))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(appState.activeSessionTitle)
+                    .accessibilityHint("Scroll to top of conversation")
                 }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -2253,6 +2253,282 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertTrue(submitted)
     }
 
+    func testStaleComposerSubmissionFailureDoesNotRecoverOrMutateNewSession() async {
+        let rpcGate = ControlledSuspension()
+        let origin = session("composer-origin")
+        let destination = session("composer-destination")
+        var loadCatalogCount = 0
+        var openSessionCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    loadCatalogCount += 1
+                    return [destination]
+                },
+                openSession: { _, sessionID in
+                    openSessionCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    await rpcGate.suspend()
+                    throw ControlledLifecycleError.failed
+                }
+            )
+        )
+        installComposerClient(in: harness)
+        harness.appState.sessions = [origin, destination]
+        harness.appState.activeSessionId = origin.id
+        let originContext = harness.appState.composerSubmissionContext()
+
+        let submission = Task { @MainActor in
+            await harness.appState.submitComposer(
+                text: "origin message",
+                context: originContext
+            )
+        }
+        await rpcGate.waitUntilSuspended()
+
+        harness.appState.activeSessionId = destination.id
+        harness.appState.errorMessage = "destination state"
+
+        rpcGate.resume()
+        let submitted = await submission.value
+
+        XCTAssertFalse(submitted)
+        XCTAssertEqual(harness.appState.errorMessage, "destination state")
+        XCTAssertEqual(loadCatalogCount, 0)
+        XCTAssertEqual(openSessionCount, 0)
+    }
+
+    func testStaleComposerSteerFailureDoesNotRecoverOrMutateNewSession() async {
+        let rpcGate = ControlledSuspension()
+        let origin = session("composer-origin")
+        let destination = session("composer-destination")
+        var loadCatalogCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    loadCatalogCount += 1
+                    return [destination]
+                },
+                refreshContext: { _, _ in },
+                steer: { _, _, _ in
+                    await rpcGate.suspend()
+                    throw ControlledLifecycleError.failed
+                }
+            )
+        )
+        installComposerClient(in: harness)
+        harness.appState.sessions = [origin, destination]
+        harness.appState.activeSessionId = origin.id
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: origin.id, busy: true))
+        let originContext = harness.appState.composerSubmissionContext()
+
+        let submission = Task { @MainActor in
+            await harness.appState.submitComposer(
+                text: "origin steer",
+                context: originContext
+            )
+        }
+        await rpcGate.waitUntilSuspended()
+
+        harness.appState.activeSessionId = destination.id
+        harness.appState.errorMessage = "destination state"
+
+        rpcGate.resume()
+        let submitted = await submission.value
+
+        XCTAssertFalse(submitted)
+        XCTAssertEqual(harness.appState.errorMessage, "destination state")
+        XCTAssertEqual(loadCatalogCount, 0)
+    }
+
+    func testStaleSlashOutputDoesNotAppendToNewSession() async {
+        let rpcGate = ControlledSuspension()
+        let origin = session("composer-origin")
+        let destination = session("composer-destination")
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                executeSlash: { _, _, _ in
+                    await rpcGate.suspend()
+                    return .object([
+                        "type": .string("exec"),
+                        "output": .string("origin output")
+                    ])
+                }
+            )
+        )
+        installComposerClient(in: harness)
+        harness.appState.sessions = [origin, destination]
+        harness.appState.activeSessionId = origin.id
+        let originContext = harness.appState.composerSubmissionContext()
+
+        let submission = Task { @MainActor in
+            await harness.appState.submitComposer(
+                text: "/status",
+                context: originContext
+            )
+        }
+        await rpcGate.waitUntilSuspended()
+
+        harness.appState.activeSessionId = destination.id
+        harness.appState.messages = []
+
+        rpcGate.resume()
+        let submitted = await submission.value
+
+        XCTAssertTrue(submitted)
+        XCTAssertTrue(harness.appState.messages.isEmpty)
+    }
+
+    func testAcceptedComposerSendRemainsSuccessfulAfterSessionHandoff() async {
+        let rpcGate = ControlledSuspension()
+        let origin = session("composer-origin")
+        let destination = session("composer-destination")
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                sendPrompt: { _, _, _ in
+                    await rpcGate.suspend()
+                }
+            )
+        )
+        installComposerClient(in: harness)
+        harness.appState.sessions = [origin, destination]
+        harness.appState.activeSessionId = origin.id
+        let originContext = harness.appState.composerSubmissionContext()
+
+        let submission = Task { @MainActor in
+            await harness.appState.submitComposer(
+                text: "accepted origin message",
+                context: originContext
+            )
+        }
+        await rpcGate.waitUntilSuspended()
+
+        harness.appState.activeSessionId = destination.id
+        harness.appState.messages = []
+        harness.appState.errorMessage = "destination state"
+
+        rpcGate.resume()
+        let submitted = await submission.value
+
+        XCTAssertTrue(submitted)
+        XCTAssertEqual(harness.appState.errorMessage, "destination state")
+        XCTAssertTrue(harness.appState.messages.isEmpty)
+    }
+
+    func testRedirectRecoveryRefreshesContextAfterRuntimeSessionRotation() async {
+        let origin = session("stored-origin", alternateIDs: ["runtime-origin"])
+        var redirectCalls = 0
+        var openedSessionIDs: [String] = []
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [origin] },
+                openSession: { _, sessionID in
+                    openedSessionIDs.append(sessionID)
+                    return SessionResumeResult(
+                        sessionId: "runtime-recovered",
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(true)])
+                    )
+                },
+                refreshContext: { _, _ in },
+                redirect: { _, sessionID, _ in
+                    redirectCalls += 1
+                    if redirectCalls == 1 {
+                        throw RpcError(code: 404, message: "session not found")
+                    }
+                    XCTAssertEqual(sessionID, "runtime-recovered")
+                    return .redirected
+                },
+                setBusyInputMode: { _, _ in }
+            )
+        )
+        installComposerClient(in: harness)
+        let changedMode = await harness.appState.setBusyInputMode(.interrupt)
+        XCTAssertTrue(changedMode)
+        harness.appState.sessions = [origin]
+        harness.appState.activeSessionId = "runtime-origin"
+        harness.appState.handleStreamEvent(
+            .sessionBusy(sessionId: "runtime-origin", busy: true)
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
+
+        let submitted = await harness.appState.submitComposer(text: "Retry this")
+
+        XCTAssertTrue(submitted)
+        XCTAssertEqual(redirectCalls, 2)
+        XCTAssertEqual(openedSessionIDs, ["stored-origin"])
+        XCTAssertEqual(harness.appState.activeSessionId, "runtime-recovered")
+    }
+
+    func testRedirectResumesAfterRuntimeRotationCompletesWhileRPCIsSuspended() async {
+        let redirectGate = ControlledSuspension()
+        let contextGate = ControlledSuspension()
+        let origin = session("stored-origin", alternateIDs: ["runtime-origin"])
+        var redirectCalls = 0
+        var contextRefreshes = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [origin] },
+                openSession: { _, _ in
+                    SessionResumeResult(
+                        sessionId: "runtime-recovered",
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(true)])
+                    )
+                },
+                refreshContext: { _, _ in
+                    contextRefreshes += 1
+                    if contextRefreshes == 1 {
+                        await contextGate.suspend()
+                    }
+                },
+                redirect: { _, sessionID, _ in
+                    redirectCalls += 1
+                    if redirectCalls == 1 {
+                        await redirectGate.suspend()
+                        throw RpcError(code: 404, message: "session not found")
+                    }
+                    XCTAssertEqual(sessionID, "runtime-recovered")
+                    return .redirected
+                },
+                setBusyInputMode: { _, _ in }
+            )
+        )
+        installComposerClient(in: harness)
+        let changedMode = await harness.appState.setBusyInputMode(.interrupt)
+        XCTAssertTrue(changedMode)
+        harness.appState.sessions = [origin]
+        harness.appState.activeSessionId = "runtime-origin"
+        harness.appState.handleStreamEvent(
+            .sessionBusy(sessionId: "runtime-origin", busy: true)
+        )
+
+        let submission = Task { @MainActor in
+            await harness.appState.submitComposer(text: "Retry this")
+        }
+        await redirectGate.waitUntilSuspended()
+
+        let synchronization = Task { @MainActor in
+            await harness.appState.syncSession()
+        }
+        await contextGate.waitUntilSuspended()
+        XCTAssertEqual(harness.appState.activeSessionId, "runtime-recovered")
+        contextGate.resume()
+        await synchronization.value
+
+        redirectGate.resume()
+        let submitted = await submission.value
+        XCTAssertTrue(submitted)
+        XCTAssertEqual(redirectCalls, 2)
+    }
+
     func testAcceptedSteerInvalidatesRestorationBeforeSteerRPCResumes() async {
         let rpcGate = ControlledSuspension()
         let harness = makeHarness(
@@ -2367,6 +2643,74 @@ final class AppStateChatResumeTests: XCTestCase {
         sendGate.resume()
         let submitted = await submission.value
         XCTAssertTrue(submitted)
+    }
+
+    func testLegacyInterruptAndSendRefreshesRuntimeAliasDuringInterrupt() async {
+        let interruptGate = ControlledSuspension()
+        let contextGate = ControlledSuspension()
+        let origin = session("stored-origin", alternateIDs: ["runtime-origin"])
+        var interruptSessionIDs: [String] = []
+        var sendSessionIDs: [String] = []
+        var contextRefreshes = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [origin] },
+                openSession: { _, _ in
+                    SessionResumeResult(
+                        sessionId: "runtime-recovered",
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(true)])
+                    )
+                },
+                refreshContext: { _, _ in
+                    contextRefreshes += 1
+                    if contextRefreshes == 1 {
+                        await contextGate.suspend()
+                    }
+                },
+                sendPrompt: { _, sessionID, _ in
+                    sendSessionIDs.append(sessionID)
+                },
+                redirect: { _, _, _ in
+                    throw RpcError(
+                        code: 4010,
+                        message: "Gateway does not support active-turn redirect"
+                    )
+                },
+                interrupt: { _, sessionID in
+                    interruptSessionIDs.append(sessionID)
+                    await interruptGate.suspend()
+                },
+                setBusyInputMode: { _, _ in }
+            )
+        )
+        installComposerClient(in: harness)
+        let changedMode = await harness.appState.setBusyInputMode(.interrupt)
+        XCTAssertTrue(changedMode)
+        harness.appState.sessions = [origin]
+        harness.appState.activeSessionId = "runtime-origin"
+        harness.appState.handleStreamEvent(
+            .sessionBusy(sessionId: "runtime-origin", busy: true)
+        )
+
+        let submission = Task { @MainActor in
+            await harness.appState.submitComposer(text: "Use legacy retry")
+        }
+        await interruptGate.waitUntilSuspended()
+
+        let synchronization = Task { @MainActor in
+            await harness.appState.syncSession()
+        }
+        await contextGate.waitUntilSuspended()
+        XCTAssertEqual(harness.appState.activeSessionId, "runtime-recovered")
+        contextGate.resume()
+        await synchronization.value
+
+        interruptGate.resume()
+        let submitted = await submission.value
+        XCTAssertTrue(submitted)
+        XCTAssertEqual(interruptSessionIDs, ["runtime-origin"])
+        XCTAssertEqual(sendSessionIDs, ["runtime-recovered"])
     }
 
     func testRejectedBusyAttachmentPreservesPendingRestoration() async {

--- a/ConduitTests/ChatTextSelectionTests.swift
+++ b/ConduitTests/ChatTextSelectionTests.swift
@@ -4,6 +4,271 @@ import SwiftUI
 @testable import Conduit
 
 final class ChatTextSelectionTests: XCTestCase {
+    @MainActor
+    func testSelectableTextViewDefaultsToNoSelectionCoordinatorHooks() {
+        let view = SelectableTextView(text: "plain text")
+
+        XCTAssertNil(view.selectionCoordinator)
+        XCTAssertNil(view.selectionSegment)
+    }
+
+    @MainActor
+    func testSelectableTextViewStoresOptionalSelectionCoordinatorHooks() {
+        let coordinator = MarkdownSelectionCoordinator()
+        let descriptor = MarkdownSelectionSegmentDescriptor(id: "paragraph", order: 0, separatorBefore: "")
+        let view = SelectableTextView(
+            text: "coordinated text",
+            selectionCoordinator: coordinator,
+            selectionSegment: descriptor
+        )
+
+        XCTAssertTrue(view.selectionCoordinator === coordinator)
+        XCTAssertEqual(view.selectionSegment, descriptor)
+    }
+
+    @MainActor
+    func testSelectionBridgeCanBeEnabledAndDisabledAcrossUpdates() {
+        let selectionCoordinator = MarkdownSelectionCoordinator()
+        let descriptor = MarkdownSelectionSegmentDescriptor(id: "paragraph", order: 0, separatorBefore: "")
+        selectionCoordinator.replaceSegments([descriptor], revision: "bridge-toggle-v1")
+
+        let coordinatedView = SelectableTextView(
+            text: "toggle me",
+            selectionCoordinator: selectionCoordinator,
+            selectionSegment: descriptor
+        )
+        let bridgeCoordinator = coordinatedView.makeCoordinator()
+        let hostView = coordinatedView.makeUIViewForTests(coordinator: bridgeCoordinator)
+
+        XCTAssertTrue(hostView.isUsingCoordinatedTextView)
+        hostView.simulateTouchBeganForTesting(at: CGPoint(x: 3, y: 3))
+        XCTAssertFalse(selectionCoordinator.hasActiveSelection)
+
+        hostView.mountedTextView.selectedRange = NSRange(location: 0, length: 3)
+        bridgeCoordinator.textViewDidChangeSelection(hostView.mountedTextView)
+
+        XCTAssertTrue(selectionCoordinator.hasActiveSelection)
+        XCTAssertEqual(
+            selectionCoordinator.activeSpans,
+            [MarkdownSelectionSpan(segmentID: descriptor.id, range: NSRange(location: 0, length: 3))]
+        )
+
+        selectionCoordinator.clearSelection()
+
+        let uncoordinatedView = SelectableTextView(text: "toggle me")
+        uncoordinatedView.updateUIViewForTests(hostView, coordinator: bridgeCoordinator)
+
+        XCTAssertFalse(hostView.isUsingCoordinatedTextView)
+        hostView.simulateTouchBeganForTesting(at: CGPoint(x: 3, y: 3))
+        XCTAssertFalse(selectionCoordinator.hasActiveSelection)
+    }
+
+    @MainActor
+    func testReverseNativeSelectionActivationPreservesTouchedUpperEndpointForCrossSegmentUpdate() {
+        let selectionCoordinator = MarkdownSelectionCoordinator()
+        let descriptors = [
+            MarkdownSelectionSegmentDescriptor(id: "first", order: 0, separatorBefore: ""),
+            MarkdownSelectionSegmentDescriptor(id: "second", order: 1, separatorBefore: "\n\n")
+        ]
+        selectionCoordinator.replaceSegments(descriptors, revision: "reverse-native-cross-segment-v1")
+
+        let firstTextView = SelectableTextView.makeTextView()
+        firstTextView.attributedText = NSAttributedString(string: "Alpha")
+        selectionCoordinator.register(descriptor: descriptors[0], textView: firstTextView)
+
+        let view = SelectableTextView(
+            text: "Bravo",
+            selectionCoordinator: selectionCoordinator,
+            selectionSegment: descriptors[1]
+        )
+        let bridgeCoordinator = view.makeCoordinator()
+        let hostView = view.makeUIViewForTests(coordinator: bridgeCoordinator)
+
+        selectionCoordinator.beginPendingSelection(
+            segmentID: descriptors[1].id,
+            offset: 4,
+            windowPoint: CGPoint(x: 40, y: 0)
+        )
+        hostView.mountedTextView.selectedRange = NSRange(location: 1, length: 3)
+        bridgeCoordinator.textViewDidChangeSelection(hostView.mountedTextView)
+
+        selectionCoordinator.updateSelection(
+            segmentID: descriptors[0].id,
+            offset: 2,
+            windowPoint: CGPoint(x: 0, y: 0)
+        )
+
+        XCTAssertEqual(
+            selectionCoordinator.activeSpans,
+            [
+                MarkdownSelectionSpan(segmentID: descriptors[0].id, range: NSRange(location: 2, length: 3)),
+                MarkdownSelectionSpan(segmentID: descriptors[1].id, range: NSRange(location: 0, length: 4))
+            ]
+        )
+    }
+
+    @MainActor
+    func testReverseNativeSelectionUpdateKeepsTouchedUpperEndpointAsAnchor() {
+        let selectionCoordinator = MarkdownSelectionCoordinator()
+        let descriptor = MarkdownSelectionSegmentDescriptor(id: "paragraph", order: 0, separatorBefore: "")
+        selectionCoordinator.replaceSegments([descriptor], revision: "reverse-native-update-v1")
+
+        let view = SelectableTextView(
+            text: "ABCDE",
+            selectionCoordinator: selectionCoordinator,
+            selectionSegment: descriptor
+        )
+        let bridgeCoordinator = view.makeCoordinator()
+        let hostView = view.makeUIViewForTests(coordinator: bridgeCoordinator)
+
+        selectionCoordinator.beginPendingSelection(
+            segmentID: descriptor.id,
+            offset: 4,
+            windowPoint: CGPoint(x: 40, y: 0)
+        )
+        hostView.mountedTextView.selectedRange = NSRange(location: 1, length: 3)
+        bridgeCoordinator.textViewDidChangeSelection(hostView.mountedTextView)
+
+        hostView.mountedTextView.selectedRange = NSRange(location: 0, length: 4)
+        bridgeCoordinator.textViewDidChangeSelection(hostView.mountedTextView)
+
+        XCTAssertEqual(
+            selectionCoordinator.activeSpans,
+            [
+                MarkdownSelectionSpan(segmentID: descriptor.id, range: NSRange(location: 0, length: 4))
+            ]
+        )
+    }
+
+    @MainActor
+    func testCoordinatedMountedTextViewUsesSelectableBaseConfiguration() {
+        let selectionCoordinator = MarkdownSelectionCoordinator()
+        let descriptor = MarkdownSelectionSegmentDescriptor(id: "paragraph", order: 0, separatorBefore: "")
+        selectionCoordinator.replaceSegments([descriptor], revision: "coordinated-config-v1")
+
+        let view = SelectableTextView(
+            text: "configured",
+            selectionCoordinator: selectionCoordinator,
+            selectionSegment: descriptor
+        )
+        let hostView = view.makeUIViewForTests(coordinator: view.makeCoordinator())
+        let textView = hostView.mountedTextView
+
+        XCTAssertTrue(hostView.isUsingCoordinatedTextView)
+        XCTAssertFalse(textView.isEditable)
+        XCTAssertTrue(textView.isSelectable)
+        XCTAssertFalse(textView.isScrollEnabled)
+        XCTAssertEqual(textView.backgroundColor, .clear)
+        XCTAssertEqual(textView.textContainerInset, .zero)
+        XCTAssertEqual(textView.textContainer.lineFragmentPadding, 0)
+        XCTAssertEqual(textView.contentHuggingPriority(for: .vertical), .required)
+        XCTAssertEqual(textView.contentCompressionResistancePriority(for: .vertical), .required)
+    }
+
+    @MainActor
+    func testSimpleTapClearsPreviousCrossBlockSelectionWithoutStartingANewOne() {
+        let selectionCoordinator = MarkdownSelectionCoordinator()
+        let descriptors = [
+            MarkdownSelectionSegmentDescriptor(id: "first", order: 0, separatorBefore: ""),
+            MarkdownSelectionSegmentDescriptor(id: "second", order: 1, separatorBefore: "\n\n")
+        ]
+        selectionCoordinator.replaceSegments(descriptors, revision: "tap-clear-v1")
+
+        let view = SelectableTextView(
+            text: "First",
+            selectionCoordinator: selectionCoordinator,
+            selectionSegment: descriptors[0]
+        )
+        let bridgeCoordinator = view.makeCoordinator()
+        let hostView = view.makeUIViewForTests(coordinator: bridgeCoordinator)
+
+        let secondTextView = SelectableTextView.makeTextView()
+        secondTextView.attributedText = NSAttributedString(string: "Second")
+        selectionCoordinator.register(descriptor: descriptors[1], textView: secondTextView)
+
+        selectionCoordinator.beginSelection(segmentID: "first", offset: 2, windowPoint: .zero)
+        selectionCoordinator.updateSelection(segmentID: "second", offset: 3, windowPoint: CGPoint(x: 0, y: 10))
+        XCTAssertTrue(selectionCoordinator.hasCrossSegmentSelection)
+
+        hostView.simulateTouchBeganForTesting(at: CGPoint(x: 3, y: 3))
+
+        XCTAssertFalse(selectionCoordinator.hasActiveSelection)
+        XCTAssertFalse(selectionCoordinator.hasCrossSegmentSelection)
+    }
+
+    @MainActor
+    func testDismantleUnregistersMountedCoordinatedTextView() {
+        let selectionCoordinator = MarkdownSelectionCoordinator()
+        let descriptor = MarkdownSelectionSegmentDescriptor(id: "paragraph", order: 0, separatorBefore: "")
+        selectionCoordinator.replaceSegments([descriptor], revision: "dismantle-v1")
+
+        let view = SelectableTextView(
+            text: "registered",
+            selectionCoordinator: selectionCoordinator,
+            selectionSegment: descriptor
+        )
+        let bridgeCoordinator = view.makeCoordinator()
+        let hostView = view.makeUIViewForTests(coordinator: bridgeCoordinator)
+
+        XCTAssertEqual(selectionCoordinator.text(for: descriptor.id), "registered")
+
+        SelectableTextView.dismantleUIView(hostView, coordinator: bridgeCoordinator)
+
+        XCTAssertNil(selectionCoordinator.text(for: descriptor.id))
+    }
+
+    @MainActor
+    func testCoordinatedCopyPathUsesCoordinatorActiveSelection() {
+        let selectionCoordinator = MarkdownSelectionCoordinator()
+        let descriptors = [
+            MarkdownSelectionSegmentDescriptor(id: "first", order: 0, separatorBefore: ""),
+            MarkdownSelectionSegmentDescriptor(id: "second", order: 1, separatorBefore: "\n\n")
+        ]
+        selectionCoordinator.replaceSegments(descriptors, revision: "copy-bridge-v1")
+
+        let view = SelectableTextView(
+            text: "First",
+            selectionCoordinator: selectionCoordinator,
+            selectionSegment: descriptors[0]
+        )
+        let bridgeCoordinator = view.makeCoordinator()
+        let hostView = view.makeUIViewForTests(coordinator: bridgeCoordinator)
+
+        let secondTextView = SelectableTextView.makeTextView()
+        secondTextView.attributedText = NSAttributedString(string: "Second")
+        selectionCoordinator.register(descriptor: descriptors[1], textView: secondTextView)
+
+        selectionCoordinator.beginSelection(
+            segmentID: descriptors[0].id,
+            offset: 2,
+            windowPoint: CGPoint(x: 0, y: 0)
+        )
+        selectionCoordinator.updateSelection(
+            segmentID: descriptors[1].id,
+            offset: 3,
+            windowPoint: CGPoint(x: 0, y: 10)
+        )
+
+        XCTAssertEqual(hostView.coordinatedCopiedAttributedTextForTesting()?.string, "rst\n\nSec")
+    }
+
+    @MainActor
+    func testLinkPreviewInteractionRemainsEnabled() {
+        let coordinator = SelectableTextView.Coordinator(
+            linkColor: .link,
+            selectionCoordinator: nil,
+            selectionSegment: nil
+        )
+        let shouldAllowPreview = coordinator.textView(
+            SelectableTextView.makeTextView(),
+            shouldInteractWith: URL(string: "https://example.com")!,
+            in: NSRange(location: 0, length: 4),
+            interaction: .preview
+        )
+
+        XCTAssertTrue(shouldAllowPreview)
+    }
+
     func testSelectableTextSurfaceSupportsCharacterRangeSelection() {
         let textView = SelectableTextView.makeTextView()
 
@@ -54,6 +319,16 @@ final class ChatTextSelectionTests: XCTestCase {
         XCTAssertEqual(codeFont.pointSize, expectedCodeSize,
                        "Code font point size must match the body font, not a hardcoded constant")
         XCTAssertEqual(link.absoluteString, "https://example.com")
+    }
+
+    func testMarkdownBridgeUsesLinkDisplayTextAndPreservesURLAttribute() throws {
+        let markdown = try AttributedString(markdown: "[display text](https://example.com/path)")
+        let text = SelectableTextView(attributedText: markdown).attributedText
+
+        XCTAssertEqual(text.string, "display text")
+
+        let link = try XCTUnwrap(text.attribute(.link, at: 0, effectiveRange: nil) as? URL)
+        XCTAssertEqual(link.absoluteString, "https://example.com/path")
     }
 
     func testMarkdownSelectionSpansParagraphBlocks() throws {

--- a/ConduitTests/ChatTitleScrollTests.swift
+++ b/ConduitTests/ChatTitleScrollTests.swift
@@ -1,0 +1,185 @@
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class ChatTitleScrollTests: XCTestCase {
+    func testTitleScrollRequestIsMonotonicAndObservableForRepeatedTaps() {
+        let appState = AppState(loadSavedConnection: false)
+        let initial = appState.chatScrollToTopRequest
+
+        appState.requestChatScrollToTop()
+        appState.requestChatScrollToTop()
+
+        XCTAssertEqual(appState.chatScrollToTopRequest, initial &+ 2)
+    }
+
+    func testTopAnchorIsScopedToTheActiveChatSession() {
+        let sessionA = ChatScrollSessionKey(profile: "default", sessionID: "session-a")
+        let sessionB = ChatScrollSessionKey(profile: "default", sessionID: "session-b")
+
+        let anchorA = ChatTitleScrollAnchor.id(for: sessionA)
+        let repeatedAnchorA = ChatTitleScrollAnchor.id(for: sessionA)
+        let anchorB = ChatTitleScrollAnchor.id(for: sessionB)
+
+        XCTAssertEqual(anchorA, repeatedAnchorA)
+        XCTAssertNotEqual(anchorA, anchorB)
+    }
+
+    func testTopScrollRetryRequiresCurrentRequestAndOwnerToken() {
+        var ownership = ChatScrollOwnerState()
+        let token = ownership.claimTop(request: 5)
+
+        XCTAssertEqual(
+            ownership.topRetryAnchor(
+                for: token,
+                currentRequest: 5,
+                currentAnchor: "chat-top-default-session-a",
+                isCancelled: false
+            ),
+            "chat-top-default-session-a"
+        )
+
+        XCTAssertNil(
+            ownership.topRetryAnchor(
+                for: token,
+                currentRequest: 6,
+                currentAnchor: "chat-top-default-session-a",
+                isCancelled: false
+            )
+        )
+        XCTAssertNil(
+            ownership.topRetryAnchor(
+                for: token,
+                currentRequest: 5,
+                currentAnchor: "chat-top-default-session-b",
+                isCancelled: true
+            )
+        )
+    }
+
+    func testExplicitTopOwnerSurvivesHandoffReadinessAndUsesCurrentAnchor() {
+        var ownership = ChatScrollOwnerState()
+        _ = ownership.claimLatest()
+        let topToken = ownership.claimTop(request: 7)
+
+        XCTAssertEqual(
+            ownership.topRetryAnchor(
+                for: topToken,
+                currentRequest: 7,
+                currentAnchor: "chat-top-default-canonical-session",
+                isCancelled: false
+            ),
+            "chat-top-default-canonical-session"
+        )
+        XCTAssertEqual(
+            ownership.handoffCompletionAction(
+                currentTopRequest: 7,
+                currentTopAnchor: "chat-top-default-canonical-session",
+                shouldFollowLatest: true
+            ),
+            .top(anchorID: "chat-top-default-canonical-session")
+        )
+    }
+
+    func testTopRetryIsSupersededByLaterOwnerGeneration() {
+        var userDragOwnership = ChatScrollOwnerState()
+        let userDragTop = userDragOwnership.claimTop(request: 1)
+        userDragOwnership.invalidateForUserDrag()
+        XCTAssertNil(
+            userDragOwnership.topRetryAnchor(
+                for: userDragTop,
+                currentRequest: 1,
+                currentAnchor: "chat-top-default-session-a",
+                isCancelled: false
+            )
+        )
+
+        var latestOwnership = ChatScrollOwnerState()
+        let latestTop = latestOwnership.claimTop(request: 1)
+        _ = latestOwnership.claimLatest()
+        XCTAssertNil(
+            latestOwnership.topRetryAnchor(
+                for: latestTop,
+                currentRequest: 1,
+                currentAnchor: "chat-top-default-session-a",
+                isCancelled: false
+            )
+        )
+
+        var sessionOwnership = ChatScrollOwnerState()
+        let sessionTop = sessionOwnership.claimTop(request: 1)
+        sessionOwnership.invalidateForSessionTransition()
+        XCTAssertNil(
+            sessionOwnership.topRetryAnchor(
+                for: sessionTop,
+                currentRequest: 1,
+                currentAnchor: "chat-top-default-session-b",
+                isCancelled: false
+            )
+        )
+
+        var newerTopOwnership = ChatScrollOwnerState()
+        let staleTop = newerTopOwnership.claimTop(request: 1)
+        let currentTop = newerTopOwnership.claimTop(request: 2)
+        XCTAssertNil(
+            newerTopOwnership.topRetryAnchor(
+                for: staleTop,
+                currentRequest: 2,
+                currentAnchor: "chat-top-default-session-a",
+                isCancelled: false
+            )
+        )
+        XCTAssertEqual(
+            newerTopOwnership.topRetryAnchor(
+                for: currentTop,
+                currentRequest: 2,
+                currentAnchor: "chat-top-default-session-a",
+                isCancelled: false
+            ),
+            "chat-top-default-session-a"
+        )
+    }
+
+    func testHandoffFallsBackToExistingLatestPolicyWithoutExplicitTopOwner() {
+        var ownership = ChatScrollOwnerState()
+        _ = ownership.claimLatest()
+
+        XCTAssertEqual(
+            ownership.handoffCompletionAction(
+                currentTopRequest: 0,
+                currentTopAnchor: "chat-top-default-session-a",
+                shouldFollowLatest: true
+            ),
+            .latest
+        )
+        XCTAssertEqual(
+            ownership.handoffCompletionAction(
+                currentTopRequest: 0,
+                currentTopAnchor: "chat-top-default-session-a",
+                shouldFollowLatest: false
+            ),
+            .none
+        )
+    }
+
+    func testSyntheticTopAnchorPersistsAsFirstMessageTarget() {
+        let messages = [
+            ChatMessage(id: "first", role: .user, content: "Hello", timestamp: "1"),
+            ChatMessage(id: "second", role: .assistant, content: "Hi", timestamp: "2")
+        ]
+        let targets = ChatMessageScrollTargets.make(for: messages)
+        let topAnchor = "chat-top-default-session-a"
+
+        let snapshot = ChatTitleScrollViewportSnapshot.make(
+            followsLatest: false,
+            topVisibleID: topAnchor,
+            topAnchorID: topAnchor,
+            targets: targets
+        )
+
+        XCTAssertEqual(snapshot?.anchorMessageID, targets[0].semanticID)
+        XCTAssertEqual(snapshot?.anchorMetadata, targets[0].restorationMetadata)
+        XCTAssertEqual(snapshot?.anchorSourceMessageID, "first")
+        XCTAssertNotEqual(snapshot?.anchorMessageID, topAnchor)
+    }
+}

--- a/ConduitTests/ComposerDraftStoreTests.swift
+++ b/ConduitTests/ComposerDraftStoreTests.swift
@@ -1,0 +1,416 @@
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class ComposerDraftStoreTests: XCTestCase {
+    func testProgrammaticRestoredSlashDraftKeepsSuggestionsHidden() {
+        XCTAssertFalse(
+            ComposerBar.shouldShowSlashSuggestions(
+                for: "/status",
+                isProgrammaticDraftRestore: true
+            )
+        )
+        XCTAssertTrue(
+            ComposerBar.shouldShowSlashSuggestions(
+                for: "/status",
+                isProgrammaticDraftRestore: false
+            )
+        )
+    }
+
+    func testFailedSubmissionDoesNotClobberNewerSavedDraftForOriginalKey() {
+        let store = ComposerDraftStore(capacity: 12)
+        let key = ComposerBar.composerDraftKey(for: "session-a", profile: "default")
+        let originalSubmittedDraft = ComposerDraft(text: "old submitted draft", attachments: [])
+        let newerDraft = ComposerDraft(text: "newer saved draft", attachments: [
+            Attachment(
+                id: "newer-attachment",
+                name: "newer.png",
+                uri: "file:///tmp/newer.png",
+                mimeType: "image/png",
+                kind: .image
+            )
+        ])
+
+        store.save(newerDraft, for: key)
+
+        store.saveIfMissing(originalSubmittedDraft, for: key)
+
+        XCTAssertEqual(store.draft(for: key), newerDraft)
+    }
+
+    func testSuccessfulSubmissionRemovesOnlyUnchangedSubmittedDraft() {
+        let store = ComposerDraftStore(capacity: 12)
+        let key = ComposerBar.composerDraftKey(for: "session-a", profile: "default")
+        let submittedDraft = ComposerDraft(text: "submitted draft", attachments: [
+            Attachment(
+                id: "submitted-attachment",
+                name: "submitted.txt",
+                uri: "file:///tmp/submitted.txt",
+                mimeType: "text/plain",
+                kind: .document
+            )
+        ])
+
+        store.save(submittedDraft, for: key)
+        let submittedBucket = store.submissionBucket(for: key)
+
+        store.removeDraft(for: submittedBucket)
+
+        XCTAssertEqual(store.draft(for: key), .empty)
+    }
+
+    func testSuccessfulSubmissionDoesNotDeleteNewerSavedDraftForOriginalKey() {
+        let store = ComposerDraftStore(capacity: 12)
+        let key = ComposerBar.composerDraftKey(for: "session-a", profile: "default")
+        let submittedDraft = ComposerDraft(text: "submitted draft", attachments: [
+            Attachment(
+                id: "submitted-attachment",
+                name: "submitted.txt",
+                uri: "file:///tmp/submitted.txt",
+                mimeType: "text/plain",
+                kind: .document
+            )
+        ])
+        let newerDraftWithSameContent = submittedDraft
+
+        store.save(submittedDraft, for: key)
+        let submittedBucket = store.submissionBucket(for: key)
+        store.save(newerDraftWithSameContent, for: key)
+
+        store.removeDraft(for: submittedBucket)
+
+        XCTAssertEqual(store.draft(for: key), newerDraftWithSameContent)
+    }
+
+    func testConfirmedRuntimeAliasUsesOneDraftIdentity() {
+        let identity = ChatScrollSessionIdentity(
+            profile: "default",
+            canonicalSessionID: "stored-session",
+            equivalentSessionIDs: ["runtime-session"],
+            isReconciling: false,
+            settledRevision: 1
+        )
+        let storedKey = ComposerBar.composerDraftKey(
+            for: "stored-session",
+            profile: "default"
+        )
+        let runtimeKey = ComposerBar.composerDraftKey(
+            for: "runtime-session",
+            profile: "default"
+        )
+        let unrelatedKey = ComposerBar.composerDraftKey(
+            for: "other-session",
+            profile: "default"
+        )
+
+        XCTAssertTrue(ComposerBar.draftKeysAreEquivalent(storedKey, runtimeKey, identity: identity))
+        XCTAssertFalse(ComposerBar.draftKeysAreEquivalent(storedKey, unrelatedKey, identity: identity))
+    }
+
+    func testDraftMigrationPreservesTextAndAttachmentsAcrossRuntimeAlias() {
+        let store = ComposerDraftStore(capacity: 12)
+        let runtimeKey = ComposerBar.composerDraftKey(
+            for: "runtime-session",
+            profile: "default"
+        )
+        let storedKey = ComposerBar.composerDraftKey(
+            for: "stored-session",
+            profile: "default"
+        )
+        let draft = ComposerDraft(
+            text: "keep this while Hermes rotates IDs",
+            attachments: [Attachment(
+                id: "attachment",
+                name: "notes.txt",
+                uri: "file:///tmp/notes.txt",
+                mimeType: "text/plain",
+                kind: .document
+            )]
+        )
+
+        store.save(draft, for: runtimeKey)
+        store.migrateDraft(from: runtimeKey, to: storedKey)
+
+        XCTAssertEqual(store.draft(for: storedKey), draft)
+        XCTAssertEqual(store.draft(for: runtimeKey), .empty)
+    }
+
+    func testPhotosPickerCompletionRequiresSameEditorAndDraftKey() {
+        let editorIdentity = UUID()
+        let originKey = ComposerBar.composerDraftKey(for: "session-a", profile: "default")
+        let destinationKey = ComposerBar.composerDraftKey(for: "session-b", profile: "default")
+        let origin = ComposerBar.AsyncAttachmentContext(
+            editorIdentity: editorIdentity,
+            draftKey: originKey,
+            attachmentGeneration: 4
+        )
+
+        XCTAssertTrue(
+            ComposerBar.shouldAcceptAsyncAttachmentCompletion(
+                startedIn: origin,
+                currentEditorIdentity: editorIdentity,
+                currentDraftKey: originKey,
+                currentAttachmentGeneration: 4
+            )
+        )
+        XCTAssertFalse(
+            ComposerBar.shouldAcceptAsyncAttachmentCompletion(
+                startedIn: origin,
+                currentEditorIdentity: UUID(),
+                currentDraftKey: originKey,
+                currentAttachmentGeneration: 4
+            )
+        )
+        XCTAssertFalse(
+            ComposerBar.shouldAcceptAsyncAttachmentCompletion(
+                startedIn: origin,
+                currentEditorIdentity: editorIdentity,
+                currentDraftKey: destinationKey,
+                currentAttachmentGeneration: 4
+            )
+        )
+        XCTAssertFalse(
+            ComposerBar.shouldAcceptAsyncAttachmentCompletion(
+                startedIn: origin,
+                currentEditorIdentity: editorIdentity,
+                currentDraftKey: originKey,
+                currentAttachmentGeneration: 5
+            )
+        )
+    }
+
+    func testLateAttachmentCompletionIsRejectedAfterSameSessionSubmission() {
+        let editorIdentity = UUID()
+        let key = ComposerBar.composerDraftKey(for: "session-a", profile: "default")
+        let openedBeforeSubmission = ComposerBar.photoImportContext(
+            editorIdentity: editorIdentity,
+            draftKey: key,
+            attachmentGeneration: 11
+        )
+
+        XCTAssertFalse(
+            ComposerBar.shouldAcceptPhotoPickerCompletion(
+                openedIn: openedBeforeSubmission,
+                currentEditorIdentity: editorIdentity,
+                currentDraftKey: key,
+                currentAttachmentGeneration: 12
+            )
+        )
+    }
+
+    func testPhotosPickerCompletionUsesContextCapturedWhenPickerOpened() {
+        let editorA = UUID()
+        let editorB = UUID()
+        let sessionA = ComposerBar.composerDraftKey(for: "session-a", profile: "default")
+        let sessionB = ComposerBar.composerDraftKey(for: "session-b", profile: "default")
+        let openedInA = ComposerBar.photoImportContext(
+            editorIdentity: editorA,
+            draftKey: sessionA,
+            attachmentGeneration: 3
+        )
+
+        XCTAssertFalse(
+            ComposerBar.shouldAcceptPhotoPickerCompletion(
+                openedIn: openedInA,
+                currentEditorIdentity: editorB,
+                currentDraftKey: sessionB,
+                currentAttachmentGeneration: 3
+            )
+        )
+        XCTAssertTrue(
+            ComposerBar.shouldAcceptPhotoPickerCompletion(
+                openedIn: openedInA,
+                currentEditorIdentity: editorA,
+                currentDraftKey: sessionA,
+                currentAttachmentGeneration: 3
+            )
+        )
+    }
+
+    func testStalePhotosPickerCompletionDoesNotClearNewerPickerContext() {
+        let sessionA = ComposerBar.composerDraftKey(for: "session-a", profile: "default")
+        let sessionB = ComposerBar.composerDraftKey(for: "session-b", profile: "default")
+        let openedInA = ComposerBar.photoImportContext(
+            editorIdentity: UUID(),
+            draftKey: sessionA,
+            attachmentGeneration: 1
+        )
+        let openedInB = ComposerBar.photoImportContext(
+            editorIdentity: UUID(),
+            draftKey: sessionB,
+            attachmentGeneration: 2
+        )
+
+        XCTAssertFalse(
+            ComposerBar.shouldClearPhotoImportContext(
+                completingGeneration: 1,
+                completingContext: openedInA,
+                currentGeneration: 2,
+                currentContext: openedInB
+            )
+        )
+        XCTAssertTrue(
+            ComposerBar.shouldClearPhotoImportContext(
+                completingGeneration: 2,
+                completingContext: openedInB,
+                currentGeneration: 2,
+                currentContext: openedInB
+            )
+        )
+    }
+
+    func testFileImporterCompletionRequiresSameEditorAndDraftKey() {
+        let editorIdentity = UUID()
+        let originKey = ComposerBar.composerDraftKey(for: "session-a", profile: "default")
+        let sameSessionOtherProfileKey = ComposerBar.composerDraftKey(for: "session-a", profile: "work")
+        let origin = ComposerBar.AsyncAttachmentContext(
+            editorIdentity: editorIdentity,
+            draftKey: originKey,
+            attachmentGeneration: 8
+        )
+
+        XCTAssertTrue(
+            ComposerBar.shouldAcceptAsyncAttachmentCompletion(
+                startedIn: origin,
+                currentEditorIdentity: editorIdentity,
+                currentDraftKey: originKey,
+                currentAttachmentGeneration: 8
+            )
+        )
+        XCTAssertFalse(
+            ComposerBar.shouldAcceptAsyncAttachmentCompletion(
+                startedIn: origin,
+                currentEditorIdentity: editorIdentity,
+                currentDraftKey: sameSessionOtherProfileKey,
+                currentAttachmentGeneration: 8
+            )
+        )
+    }
+
+    func testSessionHandoffRestoresIndependentDraftTextAndAttachments() {
+        let store = ComposerDraftStore(capacity: 12)
+        let sessionA = ComposerBar.composerDraftKey(for: "session-a", profile: "default")
+        let sessionB = ComposerBar.composerDraftKey(for: "session-b", profile: "default")
+        let attachmentA = Attachment(
+            id: "attachment-a",
+            name: "a.png",
+            uri: "file:///tmp/a.png",
+            mimeType: "image/png",
+            kind: .image
+        )
+        let attachmentB = Attachment(
+            id: "attachment-b",
+            name: "b.txt",
+            uri: "file:///tmp/b.txt",
+            mimeType: "text/plain",
+            kind: .document
+        )
+        let draftA = ComposerDraft(text: "draft A", attachments: [attachmentA])
+        let draftB = ComposerDraft(text: "draft B", attachments: [attachmentB])
+
+        store.save(draftA, for: sessionA)
+
+        XCTAssertEqual(store.draft(for: sessionB), .empty)
+
+        store.save(draftB, for: sessionB)
+
+        XCTAssertEqual(store.draft(for: sessionA), draftA)
+        XCTAssertEqual(store.draft(for: sessionB), draftB)
+    }
+
+    func testProfileSwitchUsesSeparateDraftKeyForSameSessionID() {
+        let defaultKey = ComposerBar.composerDraftKey(for: "same-session", profile: "default")
+        let workKey = ComposerBar.composerDraftKey(for: "same-session", profile: "work")
+
+        XCTAssertEqual(defaultKey, ComposerDraftKey(profile: "default", sessionID: "same-session"))
+        XCTAssertEqual(workKey, ComposerDraftKey(profile: "work", sessionID: "same-session"))
+        XCTAssertNotEqual(defaultKey, workKey)
+    }
+
+    func testDraftsAreIsolatedByProfileAndSession() {
+        let store = ComposerDraftStore(capacity: 12)
+        let first = ComposerDraftKey(profile: "default", sessionID: "one")
+        let second = ComposerDraftKey(profile: "default", sessionID: "two")
+        let otherProfile = ComposerDraftKey(profile: "work", sessionID: "one")
+        let draft = ComposerDraft(text: "draft one", attachments: [])
+
+        store.save(draft, for: first)
+
+        XCTAssertEqual(store.draft(for: first), draft)
+        XCTAssertEqual(store.draft(for: second), ComposerDraft.empty)
+        XCTAssertEqual(store.draft(for: otherProfile), ComposerDraft.empty)
+    }
+
+    func testSavingEmptyDraftRemovesTheBucket() {
+        let store = ComposerDraftStore()
+        let key = ComposerDraftKey(profile: "default", sessionID: "one")
+        store.save(ComposerDraft(text: "text", attachments: []), for: key)
+        store.save(.empty, for: key)
+
+        XCTAssertEqual(store.draft(for: key), .empty)
+    }
+
+    func testStoreEvictsTheOldestBucketWhenCapacityIsExceeded() {
+        let store = ComposerDraftStore(capacity: 1)
+        let first = ComposerDraftKey(profile: "default", sessionID: "one")
+        let second = ComposerDraftKey(profile: "default", sessionID: "two")
+        store.save(ComposerDraft(text: "one", attachments: []), for: first)
+        store.save(ComposerDraft(text: "two", attachments: []), for: second)
+
+        XCTAssertEqual(store.draft(for: first), .empty)
+        XCTAssertEqual(store.draft(for: second).text, "two")
+    }
+
+    func testGenerationMetadataDoesNotOutliveBoundedDraftBuckets() {
+        let store = ComposerDraftStore(capacity: 2)
+
+        for index in 0..<5 {
+            let key = ComposerDraftKey(profile: "default", sessionID: "session-\(index)")
+            store.save(ComposerDraft(text: "draft \(index)", attachments: []), for: key)
+        }
+
+        XCTAssertLessThanOrEqual(generationMetadataCount(in: store), 2)
+
+        store.save(.empty, for: ComposerDraftKey(profile: "default", sessionID: "session-4"))
+        XCTAssertLessThanOrEqual(generationMetadataCount(in: store), 1)
+
+        for index in 0..<5 {
+            let key = ComposerDraftKey(profile: "default", sessionID: "empty-\(index)")
+            store.save(.empty, for: key)
+        }
+
+        XCTAssertLessThanOrEqual(generationMetadataCount(in: store), 1)
+
+        store.removeAll()
+        XCTAssertEqual(generationMetadataCount(in: store), 0)
+    }
+
+    func testEvictedGenerationBucketDoesNotDeleteNewerDraft() {
+        let store = ComposerDraftStore(capacity: 1)
+        let submittedKey = ComposerDraftKey(profile: "default", sessionID: "submitted")
+        let otherKey = ComposerDraftKey(profile: "default", sessionID: "other")
+        let submittedDraft = ComposerDraft(text: "submitted", attachments: [])
+        let newerDraft = ComposerDraft(text: "newer", attachments: [])
+
+        store.save(submittedDraft, for: submittedKey)
+        let staleBucket = store.submissionBucket(for: submittedKey)
+        store.save(ComposerDraft(text: "other", attachments: []), for: otherKey)
+        store.save(newerDraft, for: submittedKey)
+
+        store.removeDraft(for: staleBucket)
+
+        XCTAssertEqual(store.draft(for: submittedKey), newerDraft)
+    }
+
+    private func generationMetadataCount(in store: ComposerDraftStore) -> Int {
+        let storeMirror = Mirror(reflecting: store)
+        guard let generations = storeMirror.children.first(where: { $0.label == "generations" })?.value else {
+            XCTFail("ComposerDraftStore should expose generation metadata for this bounded-capacity regression")
+            return Int.max
+        }
+        let generationsMirror = Mirror(reflecting: generations)
+        XCTAssertEqual(generationsMirror.displayStyle, .dictionary)
+        return generationsMirror.children.count
+    }
+}

--- a/ConduitTests/ComposerPasteTextViewTests.swift
+++ b/ConduitTests/ComposerPasteTextViewTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import ImageIO
+import SwiftUI
 import UniformTypeIdentifiers
 import UIKit
 import XCTest
@@ -94,6 +95,53 @@ final class ComposerPasteTextViewTests: XCTestCase {
         view.paste(nil as Any?)
 
         await fulfillment(of: [callback], timeout: 5.0)
+    }
+
+    func testProgrammaticTextApplicationDoesNotPublishAsUserEditing() {
+        var value = "old"
+        let view = ComposerPasteTextView(
+            text: Binding(get: { value }, set: { value = $0 }),
+            isFocused: .constant(false),
+            measuredHeight: .constant(44),
+            enabled: true,
+            onPastedImage: { _ in },
+            onPastedImageError: { _ in },
+            editorIdentity: UUID()
+        )
+        let coordinator = ComposerPasteTextView.Coordinator(view)
+        coordinator.isApplyingProgrammaticState = true
+
+        let textView = ImagePasteTextView()
+        textView.text = "restored"
+
+        coordinator.textViewDidChange(textView)
+
+        XCTAssertEqual(value, "old")
+    }
+
+    func testInactiveCoordinatorDoesNotPublishFocusOrMeasuredHeightChanges() {
+        var isFocused = false
+        var measuredHeight: CGFloat = 44
+        let view = ComposerPasteTextView(
+            text: .constant(""),
+            isFocused: Binding(get: { isFocused }, set: { isFocused = $0 }),
+            measuredHeight: Binding(get: { measuredHeight }, set: { measuredHeight = $0 }),
+            enabled: true,
+            onPastedImage: { _ in },
+            onPastedImageError: { _ in },
+            editorIdentity: UUID()
+        )
+        let coordinator = ComposerPasteTextView.Coordinator(view)
+        coordinator.isActive = false
+
+        let textView = ImagePasteTextView()
+
+        coordinator.textViewDidBeginEditing(textView)
+        coordinator.updateMeasuredHeight(88)
+        coordinator.textViewDidEndEditing(textView)
+
+        XCTAssertFalse(isFocused)
+        XCTAssertEqual(measuredHeight, 44)
     }
 
     func testPasteItemProvidersDeliversImageData() async {

--- a/ConduitTests/MarkdownSelectionCoordinatorTests.swift
+++ b/ConduitTests/MarkdownSelectionCoordinatorTests.swift
@@ -1,0 +1,676 @@
+import Combine
+import XCTest
+import UIKit
+@testable import Conduit
+
+@MainActor
+final class MarkdownSelectionCoordinatorTests: XCTestCase {
+    func testMixedMarkdownPlanIncludesTableCellsRowMajorAndOneCodeSegment() {
+        let blocks = MarkdownParser.parse(
+            "Before\n\n| A | B |\n| --- | --- |\n| [link](https://example.com) | 2 |\n\n```swift\nlet x = 1\n```\n\nAfter",
+            recognizesGatewayMedia: false
+        )
+
+        XCTAssertEqual(
+            MarkdownSelectionSegmentPlan.descriptors(for: blocks).map(\.id),
+            ["block-0", "block-1-table-r0-c0", "block-1-table-r0-c1", "block-1-table-r1-c0", "block-1-table-r1-c1", "block-2-code", "block-3"]
+        )
+    }
+
+    func testCopiedAttributedTextAcrossParagraphTableAndCodePreservesSeparatorsAndLinkAttributes() throws {
+        let blocks = MarkdownParser.parse(
+            "Before\n\n| A | B |\n| --- | --- |\n| [link](https://example.com) | 2 |\n\n```swift\nlet x = 1\n```\n\nAfter",
+            recognizesGatewayMedia: false
+        )
+        let descriptors = MarkdownSelectionSegmentPlan.descriptors(for: blocks)
+        let coordinator = MarkdownSelectionCoordinator()
+        coordinator.replaceSegments(descriptors, revision: "copy-rich-v1")
+
+        func register(_ id: String, attributedText: NSAttributedString) throws {
+            let descriptor = try XCTUnwrap(descriptors.first { $0.id == id })
+            let textView = SelectableTextView.makeTextView()
+            textView.attributedText = attributedText
+            coordinator.register(descriptor: descriptor, textView: textView)
+        }
+
+        try register("block-0", attributedText: NSAttributedString(string: "Before"))
+        try register("block-1-table-r0-c0", attributedText: NSAttributedString(string: "A"))
+        try register("block-1-table-r0-c1", attributedText: NSAttributedString(string: "B"))
+        try register(
+            "block-1-table-r1-c0",
+            attributedText: NSAttributedString(
+                string: "link",
+                attributes: [.link: URL(string: "https://example.com")!]
+            )
+        )
+        try register("block-1-table-r1-c1", attributedText: NSAttributedString(string: "2"))
+        try register("block-2-code", attributedText: NSAttributedString(string: "let x = 1"))
+
+        let copied = coordinator.copiedAttributedText(
+            from: MarkdownSelectionEndpoint(segmentID: "block-0", offset: 2),
+            to: MarkdownSelectionEndpoint(segmentID: "block-2-code", offset: 9)
+        )
+
+        XCTAssertEqual(copied.string, "fore\n\nA | B\nlink | 2\n\nlet x = 1")
+
+        let linkRange = (copied.string as NSString).range(of: "link")
+        let link = try XCTUnwrap(copied.attribute(.link, at: linkRange.location, effectiveRange: nil) as? URL)
+        XCTAssertEqual(link.absoluteString, "https://example.com")
+    }
+
+    func testCopiedAttributedTextPreservesIntermediateEmptyTableCellSeparators() {
+        let descriptors = [
+            MarkdownSelectionSegmentDescriptor(id: "table-r0-c0", order: 0, separatorBefore: ""),
+            MarkdownSelectionSegmentDescriptor(id: "table-r0-c1", order: 1, separatorBefore: " | "),
+            MarkdownSelectionSegmentDescriptor(id: "table-r0-c2", order: 2, separatorBefore: " | ")
+        ]
+        let coordinator = MarkdownSelectionCoordinator()
+        coordinator.replaceSegments(descriptors, revision: "empty-cell-middle-v1")
+
+        let firstTextView = SelectableTextView.makeTextView()
+        firstTextView.attributedText = NSAttributedString(string: "A")
+        coordinator.register(descriptor: descriptors[0], textView: firstTextView)
+
+        let emptyTextView = SelectableTextView.makeTextView()
+        emptyTextView.attributedText = NSAttributedString(string: "")
+        coordinator.register(descriptor: descriptors[1], textView: emptyTextView)
+
+        let thirdTextView = SelectableTextView.makeTextView()
+        thirdTextView.attributedText = NSAttributedString(string: "C")
+        coordinator.register(descriptor: descriptors[2], textView: thirdTextView)
+
+        XCTAssertEqual(
+            coordinator.copiedAttributedText(
+                from: MarkdownSelectionEndpoint(segmentID: "table-r0-c0", offset: 0),
+                to: MarkdownSelectionEndpoint(segmentID: "table-r0-c2", offset: 1)
+            ).string,
+            "A |  | C"
+        )
+    }
+
+    func testCopiedAttributedTextSuppressesBoundaryEmptyTableCells() {
+        let descriptors = [
+            MarkdownSelectionSegmentDescriptor(id: "table-r0-c0", order: 0, separatorBefore: ""),
+            MarkdownSelectionSegmentDescriptor(id: "table-r0-c1", order: 1, separatorBefore: " | "),
+            MarkdownSelectionSegmentDescriptor(id: "table-r0-c2", order: 2, separatorBefore: " | ")
+        ]
+        let coordinator = MarkdownSelectionCoordinator()
+        coordinator.replaceSegments(descriptors, revision: "empty-cell-boundary-v1")
+
+        let firstTextView = SelectableTextView.makeTextView()
+        firstTextView.attributedText = NSAttributedString(string: "")
+        coordinator.register(descriptor: descriptors[0], textView: firstTextView)
+
+        let secondTextView = SelectableTextView.makeTextView()
+        secondTextView.attributedText = NSAttributedString(string: "B")
+        coordinator.register(descriptor: descriptors[1], textView: secondTextView)
+
+        let trailingEmptyTextView = SelectableTextView.makeTextView()
+        trailingEmptyTextView.attributedText = NSAttributedString(string: "")
+        coordinator.register(descriptor: descriptors[2], textView: trailingEmptyTextView)
+
+        XCTAssertEqual(
+            coordinator.copiedAttributedText(
+                from: MarkdownSelectionEndpoint(segmentID: "table-r0-c0", offset: 0),
+                to: MarkdownSelectionEndpoint(segmentID: "table-r0-c1", offset: 1)
+            ).string,
+            "B"
+        )
+        XCTAssertEqual(
+            coordinator.copiedAttributedText(
+                from: MarkdownSelectionEndpoint(segmentID: "table-r0-c1", offset: 0),
+                to: MarkdownSelectionEndpoint(segmentID: "table-r0-c2", offset: 0)
+            ).string,
+            "B"
+        )
+    }
+
+    func testRepeatedRegistrationOfSameTextViewDoesNotPublishVisibleState() {
+        let descriptor = MarkdownSelectionSegmentDescriptor(id: "paragraph", order: 0, separatorBefore: "")
+        let coordinator = MarkdownSelectionCoordinator()
+        let cancellable = coordinator.objectWillChange.sink { XCTFail("Unchanged registration should not publish visible state") }
+        defer { cancellable.cancel() }
+
+        coordinator.replaceSegments([descriptor], revision: "idempotent-register-v1")
+
+        let textView = SelectableTextView.makeTextView()
+        textView.attributedText = NSAttributedString(string: "Stable")
+        coordinator.register(descriptor: descriptor, textView: textView)
+        coordinator.register(descriptor: descriptor, textView: textView)
+    }
+
+    func testRepeatedReplaceWithSameSegmentsDoesNotPublishVisibleState() {
+        let descriptor = MarkdownSelectionSegmentDescriptor(id: "paragraph", order: 0, separatorBefore: "")
+        let coordinator = MarkdownSelectionCoordinator()
+        coordinator.replaceSegments([descriptor], revision: "same-revision-v1")
+
+        let cancellable = coordinator.objectWillChange.sink { XCTFail("Unchanged replacement should not publish visible state") }
+        defer { cancellable.cancel() }
+
+        coordinator.replaceSegments([descriptor], revision: "same-revision-v1")
+    }
+
+    func testSegmentPlanLeavesBarrierBetweenSelectableSegmentsAroundMathBlock() {
+        let descriptors = MarkdownSelectionSegmentPlan.descriptors(for: [
+            .paragraph("First"),
+            .math("x^2"),
+            .paragraph("After")
+        ])
+
+        XCTAssertEqual(descriptors.map(\.id), ["block-0", "block-2"])
+        XCTAssertEqual(descriptors.map(\.order), [0, 2])
+    }
+
+    func testMixedResponseUsesRenderedOrderAndSelectsEveryIntermediateSegment() {
+        let descriptors = [
+            MarkdownSelectionSegmentDescriptor(id: "paragraph", order: 0, separatorBefore: ""),
+            MarkdownSelectionSegmentDescriptor(id: "table-r0-c0", order: 1, separatorBefore: "\n"),
+            MarkdownSelectionSegmentDescriptor(id: "table-r0-c1", order: 2, separatorBefore: " | "),
+            MarkdownSelectionSegmentDescriptor(id: "code", order: 3, separatorBefore: "\n\n"),
+            MarkdownSelectionSegmentDescriptor(id: "paragraph-2", order: 4, separatorBefore: "\n\n")
+        ]
+        let coordinator = MarkdownSelectionCoordinator()
+        coordinator.replaceSegments(descriptors, revision: "mixed-v1")
+
+        for descriptor in descriptors {
+            let text: String
+            switch descriptor.id {
+            case "paragraph": text = "First paragraph."
+            case "table-r0-c0": text = "A"
+            case "table-r0-c1": text = "B"
+            case "code": text = "let x = 1"
+            case "paragraph-2": text = "After"
+            default:
+                XCTFail("Unexpected descriptor \(descriptor.id)")
+                continue
+            }
+
+            let textView = SelectableTextView.makeTextView()
+            textView.attributedText = NSAttributedString(string: text)
+            coordinator.register(descriptor: descriptor, textView: textView)
+        }
+
+        XCTAssertEqual(
+            coordinator.spans(
+                from: MarkdownSelectionEndpoint(segmentID: "paragraph", offset: 6),
+                to: MarkdownSelectionEndpoint(segmentID: "paragraph-2", offset: 3)
+            ),
+            [
+                MarkdownSelectionSpan(segmentID: "paragraph", range: NSRange(location: 6, length: 10)),
+                MarkdownSelectionSpan(segmentID: "table-r0-c0", range: NSRange(location: 0, length: 1)),
+                MarkdownSelectionSpan(segmentID: "table-r0-c1", range: NSRange(location: 0, length: 1)),
+                MarkdownSelectionSpan(segmentID: "code", range: NSRange(location: 0, length: 9)),
+                MarkdownSelectionSpan(segmentID: "paragraph-2", range: NSRange(location: 0, length: 3))
+            ]
+        )
+    }
+
+    func testReverseSelectionNormalizesOnlyForRangeResolution() {
+        let coordinator = MarkdownSelectionCoordinator()
+        coordinator.replaceSegments([
+            MarkdownSelectionSegmentDescriptor(id: "a", order: 0, separatorBefore: ""),
+            MarkdownSelectionSegmentDescriptor(id: "b", order: 1, separatorBefore: "\n\n")
+        ], revision: "v1")
+
+        let ordered = coordinator.orderedEndpoints(
+            from: MarkdownSelectionEndpoint(segmentID: "b", offset: 5),
+            to: MarkdownSelectionEndpoint(segmentID: "a", offset: 2)
+        )
+        XCTAssertEqual(ordered.start, MarkdownSelectionEndpoint(segmentID: "a", offset: 2))
+        XCTAssertEqual(ordered.end, MarkdownSelectionEndpoint(segmentID: "b", offset: 5))
+    }
+
+    func testSelectionStopsAtBarrierCreatedByNonTextBlock() {
+        let coordinator = MarkdownSelectionCoordinator()
+        let descriptors = MarkdownSelectionSegmentPlan.descriptors(for: [
+            .paragraph("First"),
+            .math("x^2"),
+            .paragraph("After")
+        ])
+        coordinator.replaceSegments(descriptors, revision: "math-barrier-v1")
+
+        for descriptor in descriptors {
+            let textView = SelectableTextView.makeTextView()
+            switch descriptor.id {
+            case "block-0":
+                textView.attributedText = NSAttributedString(string: "First")
+            case "block-2":
+                textView.attributedText = NSAttributedString(string: "After")
+            default:
+                XCTFail("Unexpected descriptor \(descriptor.id)")
+            }
+            coordinator.register(descriptor: descriptor, textView: textView)
+        }
+
+        XCTAssertEqual(
+            coordinator.spans(
+                from: MarkdownSelectionEndpoint(segmentID: "block-0", offset: 1),
+                to: MarkdownSelectionEndpoint(segmentID: "block-2", offset: 2)
+            ),
+            [
+                MarkdownSelectionSpan(segmentID: "block-0", range: NSRange(location: 1, length: 4))
+            ]
+        )
+    }
+
+    func testReverseSelectionAcrossMathMermaidAndImageBarriersRetainsAnchorSideRun() {
+        let coordinator = MarkdownSelectionCoordinator()
+        let descriptors = MarkdownSelectionSegmentPlan.descriptors(for: [
+            .paragraph("Before"),
+            .math("x^2"),
+            .paragraph("After math"),
+            .code(language: "mermaid", source: "graph TD; A-->B;"),
+            .paragraph("After mermaid"),
+            .image(url: "https://example.com/image.png", alt: "diagram"),
+            .paragraph("After image")
+        ])
+        coordinator.replaceSegments(descriptors, revision: "reverse-barriers-v1")
+
+        let textByID = [
+            "block-0": "Before",
+            "block-2": "After math",
+            "block-4": "After mermaid",
+            "block-6": "After image"
+        ]
+        for descriptor in descriptors {
+            let textView = SelectableTextView.makeTextView()
+            textView.attributedText = NSAttributedString(string: textByID[descriptor.id] ?? "")
+            coordinator.register(descriptor: descriptor, textView: textView)
+        }
+
+        XCTAssertEqual(
+            coordinator.spans(
+                from: MarkdownSelectionEndpoint(segmentID: "block-6", offset: 5),
+                to: MarkdownSelectionEndpoint(segmentID: "block-0", offset: 1)
+            ),
+            [
+                MarkdownSelectionSpan(segmentID: "block-6", range: NSRange(location: 0, length: 5))
+            ]
+        )
+    }
+
+    func testRevisionChangeRetainsStableRegistrationsUpdatesDescriptorsAndDropsRemovedIDs() {
+        let originalDescriptors = [
+            MarkdownSelectionSegmentDescriptor(id: "stable", order: 0, separatorBefore: ""),
+            MarkdownSelectionSegmentDescriptor(id: "retained", order: 1, separatorBefore: "\n\n"),
+            MarkdownSelectionSegmentDescriptor(id: "removed", order: 2, separatorBefore: "\n\n")
+        ]
+        let coordinator = MarkdownSelectionCoordinator()
+
+        coordinator.replaceSegments(originalDescriptors, revision: "revision-v1")
+
+        let stableTextView = SelectableTextView.makeTextView()
+        stableTextView.attributedText = NSAttributedString(string: "Old stable text")
+        coordinator.register(descriptor: originalDescriptors[0], textView: stableTextView)
+
+        let retainedTextView = SelectableTextView.makeTextView()
+        retainedTextView.attributedText = NSAttributedString(string: "Old retained text")
+        coordinator.register(descriptor: originalDescriptors[1], textView: retainedTextView)
+
+        let removedTextView = SelectableTextView.makeTextView()
+        removedTextView.attributedText = NSAttributedString(string: "Removed text")
+        coordinator.register(descriptor: originalDescriptors[2], textView: removedTextView)
+
+        coordinator.beginSelection(segmentID: "stable", offset: 4, windowPoint: .zero)
+        coordinator.updateSelection(segmentID: "removed", offset: 3, windowPoint: CGPoint(x: 0, y: 20))
+        XCTAssertTrue(coordinator.hasActiveSelection)
+
+        stableTextView.attributedText = NSAttributedString(string: "New stable text")
+        stableTextView.selectedRange = NSRange(location: 4, length: 3)
+        retainedTextView.attributedText = NSAttributedString(string: "New retained text")
+
+        let replacementDescriptors = [
+            MarkdownSelectionSegmentDescriptor(id: "retained", order: 0, separatorBefore: ""),
+            MarkdownSelectionSegmentDescriptor(id: "stable", order: 1, separatorBefore: "\n\n")
+        ]
+        coordinator.replaceSegments(replacementDescriptors, revision: "revision-v2")
+
+        XCTAssertFalse(coordinator.hasActiveSelection)
+        XCTAssertEqual(coordinator.activeSpans, [])
+        XCTAssertEqual(stableTextView.selectedRange.length, 0)
+        XCTAssertEqual(removedTextView.selectedRange.length, 0)
+        XCTAssertEqual(coordinator.text(for: "stable"), "New stable text")
+        XCTAssertEqual(coordinator.text(for: "retained"), "New retained text")
+        XCTAssertNil(coordinator.text(for: "removed"))
+        XCTAssertEqual(
+            coordinator.spans(
+                from: MarkdownSelectionEndpoint(segmentID: "retained", offset: 0),
+                to: MarkdownSelectionEndpoint(segmentID: "stable", offset: 3)
+            ).map(\.segmentID),
+            ["retained", "stable"]
+        )
+        XCTAssertEqual(
+            coordinator.copiedAttributedText(
+                from: MarkdownSelectionEndpoint(segmentID: "retained", offset: 0),
+                to: MarkdownSelectionEndpoint(segmentID: "stable", offset: 3)
+            ).string,
+            "New retained text\n\nNew"
+        )
+    }
+
+    func testInitialReplaceKeepsTextViewRegisteredBeforeHostAppear() {
+        let descriptor = MarkdownSelectionSegmentDescriptor(id: "block-0", order: 0, separatorBefore: "")
+        let coordinator = MarkdownSelectionCoordinator()
+        let textView = SelectableTextView.makeTextView()
+        textView.attributedText = NSAttributedString(string: "Mounted before host")
+
+        coordinator.register(descriptor: descriptor, textView: textView)
+        coordinator.replaceSegments([descriptor], revision: "source-v1")
+
+        XCTAssertEqual(coordinator.text(for: descriptor.id), "Mounted before host")
+    }
+
+    func testCopiedAttributedTextSkipsEmptyLeadingSpanWithoutLeadingSeparator() {
+        let descriptors = [
+            MarkdownSelectionSegmentDescriptor(id: "paragraph", order: 0, separatorBefore: ""),
+            MarkdownSelectionSegmentDescriptor(id: "paragraph-2", order: 1, separatorBefore: "\n\n")
+        ]
+        let coordinator = MarkdownSelectionCoordinator()
+        coordinator.replaceSegments(descriptors, revision: "copy-v1")
+
+        let firstTextView = SelectableTextView.makeTextView()
+        firstTextView.attributedText = NSAttributedString(string: "A")
+        coordinator.register(descriptor: descriptors[0], textView: firstTextView)
+
+        let secondTextView = SelectableTextView.makeTextView()
+        secondTextView.attributedText = NSAttributedString(string: "B")
+        coordinator.register(descriptor: descriptors[1], textView: secondTextView)
+
+        XCTAssertEqual(
+            coordinator.copiedAttributedText(
+                from: MarkdownSelectionEndpoint(segmentID: "paragraph", offset: 1),
+                to: MarkdownSelectionEndpoint(segmentID: "paragraph-2", offset: 1)
+            ).string,
+            "B"
+        )
+    }
+
+    func testSameSegmentSelectionNormalizesAndClampsOffsets() {
+        let descriptor = MarkdownSelectionSegmentDescriptor(id: "paragraph", order: 0, separatorBefore: "")
+        let coordinator = MarkdownSelectionCoordinator()
+        coordinator.replaceSegments([descriptor], revision: "same-segment-v1")
+
+        let textView = SelectableTextView.makeTextView()
+        textView.attributedText = NSAttributedString(string: "abc")
+        coordinator.register(descriptor: descriptor, textView: textView)
+
+        let ordered = coordinator.orderedEndpoints(
+            from: MarkdownSelectionEndpoint(segmentID: "paragraph", offset: 9),
+            to: MarkdownSelectionEndpoint(segmentID: "paragraph", offset: 1)
+        )
+        XCTAssertEqual(ordered.start, MarkdownSelectionEndpoint(segmentID: "paragraph", offset: 1))
+        XCTAssertEqual(ordered.end, MarkdownSelectionEndpoint(segmentID: "paragraph", offset: 9))
+
+        XCTAssertEqual(
+            coordinator.spans(
+                from: MarkdownSelectionEndpoint(segmentID: "paragraph", offset: 9),
+                to: MarkdownSelectionEndpoint(segmentID: "paragraph", offset: 1)
+            ),
+            [
+                MarkdownSelectionSpan(segmentID: "paragraph", range: NSRange(location: 1, length: 2))
+            ]
+        )
+    }
+
+    func testActiveCrossSegmentSelectionProducesActiveSpansAndCopiedText() {
+        let descriptors = [
+            MarkdownSelectionSegmentDescriptor(id: "first", order: 0, separatorBefore: ""),
+            MarkdownSelectionSegmentDescriptor(id: "second", order: 1, separatorBefore: "\n\n")
+        ]
+        let coordinator = MarkdownSelectionCoordinator()
+        coordinator.replaceSegments(descriptors, revision: "active-selection-v1")
+
+        let firstTextView = SelectableTextView.makeTextView()
+        firstTextView.attributedText = NSAttributedString(string: "First")
+        coordinator.register(descriptor: descriptors[0], textView: firstTextView)
+
+        let secondTextView = SelectableTextView.makeTextView()
+        secondTextView.attributedText = NSAttributedString(string: "Second")
+        coordinator.register(descriptor: descriptors[1], textView: secondTextView)
+
+        coordinator.beginSelection(
+            segmentID: "first",
+            offset: 2,
+            windowPoint: CGPoint(x: 10, y: 10)
+        )
+        coordinator.updateSelection(
+            segmentID: "second",
+            offset: 3,
+            windowPoint: CGPoint(x: 10, y: 40)
+        )
+
+        XCTAssertTrue(coordinator.hasActiveSelection)
+        XCTAssertTrue(coordinator.hasCrossSegmentSelection)
+        XCTAssertEqual(
+            coordinator.activeSpans,
+            [
+                MarkdownSelectionSpan(segmentID: "first", range: NSRange(location: 2, length: 3)),
+                MarkdownSelectionSpan(segmentID: "second", range: NSRange(location: 0, length: 3))
+            ]
+        )
+        XCTAssertEqual(coordinator.copiedAttributedTextForActiveSelection().string, "rst\n\nSec")
+
+        coordinator.clearSelection()
+
+        XCTAssertFalse(coordinator.hasActiveSelection)
+        XCTAssertFalse(coordinator.hasCrossSegmentSelection)
+        XCTAssertEqual(coordinator.activeSpans, [])
+    }
+
+    func testEndingGesturePreservesSelectionRangesAndCoordinatedCopy() {
+        let descriptors = [
+            MarkdownSelectionSegmentDescriptor(id: "first", order: 0, separatorBefore: ""),
+            MarkdownSelectionSegmentDescriptor(id: "second", order: 1, separatorBefore: "\n\n")
+        ]
+        let coordinator = MarkdownSelectionCoordinator()
+        coordinator.replaceSegments(descriptors, revision: "gesture-end-v1")
+
+        let firstTextView = SelectableTextView.makeTextView()
+        firstTextView.attributedText = NSAttributedString(string: "First")
+        coordinator.register(descriptor: descriptors[0], textView: firstTextView)
+
+        let secondTextView = SelectableTextView.makeTextView()
+        secondTextView.attributedText = NSAttributedString(string: "Second")
+        coordinator.register(descriptor: descriptors[1], textView: secondTextView)
+
+        coordinator.beginSelection(segmentID: "first", offset: 2, windowPoint: CGPoint(x: 0, y: 0))
+        coordinator.updateSelection(segmentID: "second", offset: 3, windowPoint: CGPoint(x: 0, y: 10))
+
+        coordinator.endSelection()
+
+        XCTAssertTrue(coordinator.hasActiveSelection)
+        XCTAssertTrue(coordinator.hasCrossSegmentSelection)
+        XCTAssertEqual(firstTextView.selectedRange, NSRange(location: 2, length: 3))
+        XCTAssertEqual(secondTextView.selectedRange, NSRange(location: 0, length: 3))
+        XCTAssertEqual(coordinator.copiedAttributedTextForActiveSelection().string, "rst\n\nSec")
+
+        coordinator.clearSelection()
+
+        XCTAssertFalse(coordinator.hasActiveSelection)
+        XCTAssertEqual(firstTextView.selectedRange, NSRange(location: 2, length: 0))
+        XCTAssertEqual(secondTextView.selectedRange, NSRange(location: 0, length: 0))
+        XCTAssertEqual(coordinator.copiedAttributedTextForActiveSelection().string, "")
+    }
+
+    func testEndingOutsideTheFirstSegmentProducesAForwardCrossBlockSelection() {
+        let coordinator = MarkdownSelectionCoordinator()
+        coordinator.replaceSegments([
+            MarkdownSelectionSegmentDescriptor(id: "first", order: 0, separatorBefore: ""),
+            MarkdownSelectionSegmentDescriptor(id: "second", order: 1, separatorBefore: "\n\n")
+        ], revision: "v1")
+        coordinator.beginSelection(segmentID: "first", offset: 6, windowPoint: CGPoint(x: 20, y: 20))
+        coordinator.updateSelection(segmentID: "second", offset: 4, windowPoint: CGPoint(x: 20, y: 120))
+
+        XCTAssertTrue(coordinator.hasCrossSegmentSelection)
+        XCTAssertEqual(coordinator.activeSpans.map(\.segmentID), ["first", "second"])
+    }
+
+    func testHostGestureWindowPointResolvesCurrentRegisteredTextView() {
+        let descriptors = [
+            MarkdownSelectionSegmentDescriptor(id: "first", order: 0, separatorBefore: ""),
+            MarkdownSelectionSegmentDescriptor(id: "second", order: 1, separatorBefore: "\n\n")
+        ]
+        let coordinator = MarkdownSelectionCoordinator()
+        let window = makeSelectionWindow()
+        let firstTextView = mountedTextView(text: "Anchor", frame: CGRect(x: 10, y: 10, width: 180, height: 40), in: window)
+        let secondTextView = mountedTextView(text: "Focus", frame: CGRect(x: 10, y: 80, width: 180, height: 40), in: window)
+
+        coordinator.replaceSegments(descriptors, revision: "geometry-v1")
+        coordinator.register(descriptor: descriptors[0], textView: firstTextView)
+        coordinator.register(descriptor: descriptors[1], textView: secondTextView)
+
+        coordinator.beginSelection(segmentID: "first", offset: 3, windowPoint: CGPoint(x: 18, y: 20))
+        coordinator.updateSelection(windowPoint: CGPoint(x: 18, y: 90))
+
+        XCTAssertEqual(coordinator.activeSpans.map(\.segmentID), ["first", "second"])
+    }
+
+    func testHighlightRectsUseCurrentWindowGeometryForNonNativeOwnerSegments() {
+        let descriptors = [
+            MarkdownSelectionSegmentDescriptor(id: "first", order: 0, separatorBefore: ""),
+            MarkdownSelectionSegmentDescriptor(id: "second", order: 1, separatorBefore: "\n\n")
+        ]
+        let coordinator = MarkdownSelectionCoordinator()
+        let window = makeSelectionWindow()
+        let firstTextView = mountedTextView(text: "Anchor", frame: CGRect(x: 10, y: 10, width: 180, height: 40), in: window)
+        let secondTextView = mountedTextView(text: "Focus", frame: CGRect(x: 10, y: 80, width: 180, height: 40), in: window)
+
+        coordinator.replaceSegments(descriptors, revision: "highlights-v1")
+        coordinator.register(descriptor: descriptors[0], textView: firstTextView)
+        coordinator.register(descriptor: descriptors[1], textView: secondTextView)
+        coordinator.beginSelection(segmentID: "first", offset: 1, windowPoint: CGPoint(x: 18, y: 20))
+        coordinator.updateSelection(segmentID: "second", offset: 2, windowPoint: CGPoint(x: 28, y: 90))
+
+        let rects = coordinator.highlightRects(in: window)
+
+        XCTAssertEqual(firstTextView.selectedRange, NSRange(location: 1, length: 5))
+        XCTAssertEqual(secondTextView.selectedRange, NSRange(location: 0, length: 2))
+        XCTAssertFalse(rects.isEmpty)
+        XCTAssertTrue(rects.allSatisfy { $0.minY >= secondTextView.frame.minY && $0.maxY <= secondTextView.frame.maxY })
+    }
+
+    func testRevisionChangeClearsActiveSelectionState() {
+        let descriptors = [
+            MarkdownSelectionSegmentDescriptor(id: "first", order: 0, separatorBefore: ""),
+            MarkdownSelectionSegmentDescriptor(id: "second", order: 1, separatorBefore: "\n\n")
+        ]
+        let coordinator = MarkdownSelectionCoordinator()
+        coordinator.replaceSegments(descriptors, revision: "active-selection-v1")
+
+        let firstTextView = SelectableTextView.makeTextView()
+        firstTextView.attributedText = NSAttributedString(string: "First")
+        coordinator.register(descriptor: descriptors[0], textView: firstTextView)
+
+        let secondTextView = SelectableTextView.makeTextView()
+        secondTextView.attributedText = NSAttributedString(string: "Second")
+        coordinator.register(descriptor: descriptors[1], textView: secondTextView)
+
+        coordinator.beginSelection(segmentID: "first", offset: 1, windowPoint: CGPoint(x: 0, y: 0))
+        coordinator.updateSelection(segmentID: "second", offset: 2, windowPoint: CGPoint(x: 0, y: 10))
+
+        XCTAssertTrue(coordinator.hasActiveSelection)
+
+        coordinator.replaceSegments([
+            MarkdownSelectionSegmentDescriptor(id: "replacement", order: 0, separatorBefore: "")
+        ], revision: "active-selection-v2")
+
+        XCTAssertFalse(coordinator.hasActiveSelection)
+        XCTAssertFalse(coordinator.hasCrossSegmentSelection)
+        XCTAssertEqual(coordinator.activeSpans, [])
+        XCTAssertEqual(coordinator.copiedAttributedTextForActiveSelection().string, "")
+    }
+
+    func testRevisionChangeClearsStaleSelectionAndRegistrations() {
+        let coordinator = MarkdownSelectionCoordinator()
+        coordinator.replaceSegments([
+            MarkdownSelectionSegmentDescriptor(id: "old", order: 0, separatorBefore: "")
+        ], revision: "old")
+        coordinator.beginSelection(segmentID: "old", offset: 0, windowPoint: .zero)
+        coordinator.replaceSegments([
+            MarkdownSelectionSegmentDescriptor(id: "new", order: 0, separatorBefore: "")
+        ], revision: "new")
+
+        XCTAssertFalse(coordinator.hasActiveSelection)
+        XCTAssertNil(coordinator.text(for: "old"))
+    }
+
+    func testUnregisteringASelectedSegmentClearsActiveSelection() {
+        let descriptors = [
+            MarkdownSelectionSegmentDescriptor(id: "first", order: 0, separatorBefore: ""),
+            MarkdownSelectionSegmentDescriptor(id: "second", order: 1, separatorBefore: "\n\n")
+        ]
+        let coordinator = MarkdownSelectionCoordinator()
+        coordinator.replaceSegments(descriptors, revision: "unregister-active-v1")
+
+        let firstTextView = SelectableTextView.makeTextView()
+        firstTextView.attributedText = NSAttributedString(string: "First")
+        coordinator.register(descriptor: descriptors[0], textView: firstTextView)
+
+        let secondTextView = SelectableTextView.makeTextView()
+        secondTextView.attributedText = NSAttributedString(string: "Second")
+        coordinator.register(descriptor: descriptors[1], textView: secondTextView)
+
+        coordinator.beginSelection(segmentID: "first", offset: 2, windowPoint: .zero)
+        coordinator.updateSelection(segmentID: "second", offset: 3, windowPoint: CGPoint(x: 0, y: 10))
+
+        coordinator.unregister(segmentID: "first", textView: firstTextView)
+
+        XCTAssertFalse(coordinator.hasActiveSelection)
+        XCTAssertFalse(coordinator.hasCrossSegmentSelection)
+        XCTAssertEqual(firstTextView.selectedRange, NSRange(location: 2, length: 0))
+        XCTAssertEqual(secondTextView.selectedRange, NSRange(location: 0, length: 0))
+    }
+
+    func testActivatingNewResponseSelectionClearsPreviousResponseSelection() {
+        let descriptors = [
+            MarkdownSelectionSegmentDescriptor(id: "first", order: 0, separatorBefore: ""),
+            MarkdownSelectionSegmentDescriptor(id: "second", order: 1, separatorBefore: "\n\n")
+        ]
+        let firstCoordinator = MarkdownSelectionCoordinator()
+        let secondCoordinator = MarkdownSelectionCoordinator()
+        firstCoordinator.replaceSegments(descriptors, revision: "first-response-v1")
+        secondCoordinator.replaceSegments(descriptors, revision: "second-response-v1")
+
+        for descriptor in descriptors {
+            let firstTextView = SelectableTextView.makeTextView()
+            firstTextView.attributedText = NSAttributedString(string: descriptor.id == "first" ? "First" : "Second")
+            firstCoordinator.register(descriptor: descriptor, textView: firstTextView)
+
+            let secondTextView = SelectableTextView.makeTextView()
+            secondTextView.attributedText = NSAttributedString(string: descriptor.id == "first" ? "Alpha" : "Beta")
+            secondCoordinator.register(descriptor: descriptor, textView: secondTextView)
+        }
+
+        firstCoordinator.beginSelection(segmentID: "first", offset: 2, windowPoint: .zero)
+        firstCoordinator.updateSelection(segmentID: "second", offset: 3, windowPoint: CGPoint(x: 0, y: 10))
+        XCTAssertTrue(firstCoordinator.hasCrossSegmentSelection)
+
+        secondCoordinator.beginSelection(segmentID: "first", offset: 1, windowPoint: .zero)
+        secondCoordinator.updateSelection(segmentID: "second", offset: 2, windowPoint: CGPoint(x: 0, y: 10))
+
+        XCTAssertFalse(firstCoordinator.hasActiveSelection)
+        XCTAssertTrue(secondCoordinator.hasCrossSegmentSelection)
+    }
+
+    private func makeSelectionWindow() -> UIWindow {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 240, height: 180))
+        let rootView = UIView(frame: window.bounds)
+        window.addSubview(rootView)
+        window.isHidden = false
+        rootView.layoutIfNeeded()
+        return window
+    }
+
+    private func mountedTextView(text: String, frame: CGRect, in window: UIWindow) -> UITextView {
+        let textView = SelectableTextView.makeTextView()
+        textView.attributedText = NSAttributedString(
+            string: text,
+            attributes: [.font: UIFont.preferredFont(forTextStyle: .body)]
+        )
+        textView.frame = frame
+        window.subviews.first?.addSubview(textView)
+        textView.layoutIfNeeded()
+        _ = textView.layoutManager.glyphRange(for: textView.textContainer)
+        return textView
+    }
+}

--- a/docs/superpowers/plans/2026-08-13-composer-session-isolation.md
+++ b/docs/superpowers/plans/2026-08-13-composer-session-isolation.md
@@ -1,0 +1,225 @@
+# Composer Session Isolation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent composer crashes and synchronization stalls when switching sessions with text or attachments in the composer, while preserving drafts per session in memory.
+
+**Architecture:** Move draft data into a small profile/session-keyed in-memory store owned by `ComposerBar`, while treating first responder, slash suggestions, measured height, and UIKit identity as transient editor state. A session change saves the old draft, tears down the old UIKit editor, restores the destination draft without focusing it, and ignores callbacks from the old editor generation.
+
+**Tech Stack:** Swift 5.9, SwiftUI 17, UIKit `UITextView`, XCTest.
+
+## Global Constraints
+
+- Target iOS 17.0 with no new dependencies or server protocol changes.
+- Preserve drafts per profile/session in memory, including attachment metadata and temporary-file URIs; do not retain first-responder state across sessions.
+- The restored destination composer must not auto-focus.
+- Programmatic text restoration must not trigger user-edit callbacks, slash suggestion churn, or stale context work.
+- Existing AppState request-generation, client/session guards, rapid-switch tests, and cancellation tests remain authoritative.
+- Change `AppState.swift` only if a new failing lifecycle test proves the existing reconciliation ownership is incomplete.
+
+## File Map
+
+- Create: `Conduit/Views/Components/ComposerDraftStore.swift` — profile/session key and bounded in-memory draft storage.
+- Modify: `Conduit/Views/Components/ComposerBar.swift` — store ownership, session handoff, editor generation, and draft restoration.
+- Modify: `Conduit/Views/Components/ComposerPasteTextView.swift` — programmatic-update guard and UIKit teardown.
+- Create: `ConduitTests/ComposerDraftStoreTests.swift` — storage isolation and replacement tests.
+- Modify: `ConduitTests/ComposerPasteTextViewTests.swift` — editor callback/teardown regression coverage.
+- Modify: `ConduitTests/AppStateChatResumeTests.swift` only if a focused composer/session test demonstrates an AppState defect.
+
+### Task 1: Create the profile/session draft store with explicit isolation
+
+**Files:**
+- Create: `ConduitTests/ComposerDraftStoreTests.swift`
+- Create: `Conduit/Views/Components/ComposerDraftStore.swift`
+
+**Interfaces:**
+- `ComposerDraft` is `Equatable` and contains `text: String` and `attachments: [Attachment]`.
+- `ComposerDraftKey` is `Hashable` and contains `profile: String` and `sessionID: String`.
+- `ComposerDraftStore` is `@MainActor final class` with `init(capacity: Int = 12)`, `draft(for:)`, `save(_:for:)`, `removeDraft(for:)`, and `removeAll()`.
+- The store treats the key `sessionID == "new-conversation"` as the draft bucket for a new unsaved conversation.
+
+- [ ] **Step 1: Write failing storage-isolation tests**
+
+```swift
+@MainActor
+final class ComposerDraftStoreTests: XCTestCase {
+    func testDraftsAreIsolatedByProfileAndSession() {
+        let store = ComposerDraftStore(capacity: 12)
+        let first = ComposerDraftKey(profile: "default", sessionID: "one")
+        let second = ComposerDraftKey(profile: "default", sessionID: "two")
+        let otherProfile = ComposerDraftKey(profile: "work", sessionID: "one")
+        let draft = ComposerDraft(text: "draft one", attachments: [])
+
+        store.save(draft, for: first)
+
+        XCTAssertEqual(store.draft(for: first), draft)
+        XCTAssertEqual(store.draft(for: second), ComposerDraft.empty)
+        XCTAssertEqual(store.draft(for: otherProfile), ComposerDraft.empty)
+    }
+
+    func testSavingEmptyDraftRemovesTheBucket() {
+        let store = ComposerDraftStore()
+        let key = ComposerDraftKey(profile: "default", sessionID: "one")
+        store.save(ComposerDraft(text: "text", attachments: []), for: key)
+        store.save(.empty, for: key)
+
+        XCTAssertEqual(store.draft(for: key), .empty)
+    }
+
+    func testStoreEvictsTheOldestBucketWhenCapacityIsExceeded() {
+        let store = ComposerDraftStore(capacity: 1)
+        let first = ComposerDraftKey(profile: "default", sessionID: "one")
+        let second = ComposerDraftKey(profile: "default", sessionID: "two")
+        store.save(ComposerDraft(text: "one", attachments: []), for: first)
+        store.save(ComposerDraft(text: "two", attachments: []), for: second)
+
+        XCTAssertEqual(store.draft(for: first), .empty)
+        XCTAssertEqual(store.draft(for: second).text, "two")
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests and confirm the store types are missing**
+
+Run:
+
+```bash
+/Users/agrias/bin/bin/xcodegen generate
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit \
+  -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' \
+  -only-testing:ConduitTests/ComposerDraftStoreTests CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: compilation failure for the missing store types.
+
+- [ ] **Step 3: Implement bounded in-memory storage**
+
+Use a dictionary plus an insertion/access-order array. `save(.empty, for:)` removes the key; non-empty saves replace the existing value and move the key to the end. When the count exceeds `capacity`, remove the oldest key. `draft(for:)` returns `.empty` without creating a bucket and moves a hit to the end. This store owns no UIKit objects and performs no asynchronous work.
+
+- [ ] **Step 4: Run the store tests and commit**
+
+Expected: isolation, empty-removal, replacement, and capacity tests pass.
+
+```bash
+git add Conduit/Views/Components/ComposerDraftStore.swift ConduitTests/ComposerDraftStoreTests.swift
+git commit -m "feat: isolate composer drafts by session"
+```
+
+### Task 2: Make the UIKit bridge safe during programmatic handoff
+
+**Files:**
+- Modify: `Conduit/Views/Components/ComposerPasteTextView.swift`
+- Modify: `ConduitTests/ComposerPasteTextViewTests.swift`
+
+**Interfaces:**
+- `ComposerPasteTextView` gains an `editorIdentity: UUID` input used to identify a mounted editor generation.
+- `Coordinator` gains `isApplyingProgrammaticState` and `isActive` flags plus `apply(text:to:)` and `deactivate(textView:)` helpers.
+- `dismantleUIView` removes the delegate/callback closures and resigns first responder before the old bridge is released.
+
+- [ ] **Step 1: Add failing callback tests**
+
+Test that a text change delivered while `isApplyingProgrammaticState` is true does not mutate the SwiftUI binding, and that a deactivated coordinator does not publish focus or measured-height changes. Keep the existing paste metadata/error tests unchanged.
+
+```swift
+@MainActor
+func testProgrammaticTextApplicationDoesNotPublishAsUserEditing() {
+    var value = "old"
+    let view = ComposerPasteTextView(
+        text: Binding(get: { value }, set: { value = $0 }),
+        isFocused: .constant(false),
+        measuredHeight: .constant(44),
+        enabled: true,
+        onPastedImage: { _ in },
+        onPastedImageError: { _ in },
+        editorIdentity: UUID()
+    )
+    let coordinator = ComposerPasteTextView.Coordinator(view)
+    coordinator.isApplyingProgrammaticState = true
+
+    let textView = ImagePasteTextView()
+    textView.text = "restored"
+    coordinator.textViewDidChange(textView)
+
+    XCTAssertEqual(value, "old")
+}
+```
+
+- [ ] **Step 2: Run the test and confirm the guard/identity API is absent**
+
+Run the focused composer test command. Expected: compilation failure for the new initializer field or coordinator flags.
+
+- [ ] **Step 3: Implement guarded updates and deterministic teardown**
+
+In `updateUIView`, call `coordinator.apply(text:to:)` instead of assigning `uiView.text` directly. The helper wraps the assignment in `isApplyingProgrammaticState`, restores a clamped selection, and updates the editor identity. `textViewDidChange`, `textViewDidBeginEditing`, and `textViewDidEndEditing` return immediately when inactive or applying programmatic state. `dismantleUIView` clears the closures and delegate, marks the coordinator inactive, and calls `resignFirstResponder`.
+
+- [ ] **Step 4: Run the full composer bridge tests and commit**
+
+```bash
+git add Conduit/Views/Components/ComposerPasteTextView.swift ConduitTests/ComposerPasteTextViewTests.swift
+git commit -m "fix: isolate composer UIKit callbacks during handoff"
+```
+
+### Task 3: Save, tear down, and restore drafts at the session boundary
+
+**Files:**
+- Modify: `Conduit/Views/Components/ComposerBar.swift`
+- Modify: `Conduit/Views/Components/ComposerPasteTextView.swift`
+- Modify: `ConduitTests/ComposerDraftStoreTests.swift`
+
+**Interfaces:**
+- `ComposerBar` owns `@State private var draftStore = ComposerDraftStore()`, `@State private var editorIdentity = UUID()`, and `@State private var loadedDraftKey: ComposerDraftKey?`.
+- `ComposerBar` provides `composerDraftKey(for:)`, `saveDraft(for:)`, `loadDraft(for:)`, and `handoffComposer(to:)` helpers.
+- `ComposerPasteTextView` is rendered with `.id(editorIdentity)` and receives the identity input.
+
+- [ ] **Step 1: Add a failing handoff test around the pure key/draft operations**
+
+Cover this sequence: save `"draft A"` under session A, load an empty session B, save `"draft B"`, switch back to A, and assert the exact text and attachment arrays are restored independently. Add a test that a profile switch uses a separate key even if the session IDs match.
+
+- [ ] **Step 2: Run the test and confirm the ComposerBar handoff helpers are not present**
+
+Run the focused composer command. Expected: failure until the key and store integration exists.
+
+- [ ] **Step 3: Implement the session-change transaction**
+
+On first appearance, load the active session’s draft and set `loadedDraftKey`. Observe the combined `ComposerDraftKey(profile: appState.activeProfile, sessionID: appState.activeSessionId ?? "new-conversation")`, so both a session switch and a profile switch enter the same handoff. Save `loadedDraftKey` before changing any local state, set `isFocused = false`, set `isShowingSlashSuggestions = false`, increment `editorIdentity`, restore the new key’s text/attachments, set `loadedDraftKey` to the destination, reset `composerTextHeight` to `ComposerPasteTextView.minimumHeight`, and leave `isFocused` false. Use `withAnimation` only for the same visual collapse already used by `collapseSubmittedDraft`; do not await a network operation in the handoff.
+
+Use the active profile plus `activeSessionId ?? "new-conversation"` for the key. When a send succeeds, clear the current bucket; when a send fails and the current editor is still empty, restore the submitted draft as the existing method already does. Do not write drafts to `UserDefaults` or the server.
+
+- [ ] **Step 4: Guard delayed context refresh and paste callbacks by session/editor identity**
+
+Keep `.task(id: appState.activeSessionId)` for context refresh, but add a capture of the session ID and guard before applying any result in the callback path already protected by AppState. Capture `editorIdentity` in paste-image and paste-error closures; ignore a callback whose identity no longer matches the current editor. This prevents an image provider completing after a switch from mutating the destination composer.
+
+- [ ] **Step 5: Run focused tests and commit the ComposerBar integration**
+
+```bash
+git add Conduit/Views/Components/ComposerBar.swift Conduit/Views/Components/ComposerPasteTextView.swift ConduitTests/ComposerDraftStoreTests.swift
+git commit -m "fix: restore composer drafts per active session"
+```
+
+### Task 4: Verify the crash and synchronization regression against real session switches
+
+**Files:**
+- Modify: `ConduitTests/AppStateChatResumeTests.swift` only if a new test proves an AppState ownership defect.
+- No other source changes without a failing test identifying the exact stale callback or transition.
+
+- [ ] **Step 1: Run all focused session and composer tests**
+
+```bash
+/Users/agrias/bin/bin/xcodegen generate
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit \
+  -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' \
+  -only-testing:ConduitTests/ComposerDraftStoreTests \
+  -only-testing:ConduitTests/ComposerPasteTextViewTests \
+  -only-testing:ConduitTests/AppStateChatResumeTests \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: the existing 63 AppState resume tests plus new composer tests pass, with `turnState` settling to `.idle` after the latest session switch.
+
+- [ ] **Step 2: Exercise the user flow on Simulator**
+
+Type multiline text and add an attachment in session A. Switch to session B repeatedly while the keyboard is visible and while a context refresh is pending. Confirm there is no crash, no stuck “Synchronizing” composer, no focus in B, and B’s draft is independent. Switch back to A and confirm the text/attachment draft returns. Repeat while a paste-image provider is still loading.
+
+- [ ] **Step 3: Run the full suite and commit only evidence-backed AppState changes**
+
+Run the full simulator test command from the selection plan. If AppState remains unchanged, keep the existing cancellation tests as the regression proof. If a new AppState test fails, fix the specific token/settlement path and rerun the focused plus full suites before committing.

--- a/docs/superpowers/plans/2026-08-13-cross-block-markdown-selection.md
+++ b/docs/superpowers/plans/2026-08-13-cross-block-markdown-selection.md
@@ -1,0 +1,333 @@
+# Cross-Block Markdown Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let one Markdown response select and copy text across paragraphs, tables, and fenced code while preserving the existing rich visuals and native link behavior.
+
+**Architecture:** Keep `MarkdownBlockView`, `MarkdownTable`, and `ChatCodeBlock` as the visual source of truth. Add a response-scoped `MarkdownSelectionCoordinator` that registers the existing child `UITextView`s in rendered order, resolves a cross-child selection from global pointer coordinates, and supplies multi-segment copy/highlight behavior. The existing single `UITextView` fast path remains unchanged for responses containing only simple flow blocks.
+
+**Tech Stack:** Swift 5.9, SwiftUI 17, UIKit `UITextView`/`NSLayoutManager`, XCTest, XcodeGen.
+
+## Global Constraints
+
+- Target iOS 17.0 and keep the existing project dependency set.
+- Preserve the current table grid, code cards, horizontal table/code scrolling, copy buttons, syntax colors, Dynamic Type cache behavior, and inline link attributes.
+- Do not flatten a table or code block into a replacement textual card.
+- Coordinate only text-bearing blocks within one Markdown response; do not span separate chat messages or rendered Mermaid/LaTeX previews.
+- Invalidate registrations and UTF-16 offsets whenever the Markdown source revision changes.
+- Keep standalone `SelectableTextView` users, including tool cards, on their current native-selection path when no response coordinator is supplied.
+- Run the focused simulator test command after every task that changes Swift code:
+
+```bash
+/Users/agrias/bin/bin/xcodegen generate
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit \
+  -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' \
+  -only-testing:ConduitTests/MarkdownSelectionCoordinatorTests \
+  -only-testing:ConduitTests/ChatTextSelectionTests \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+## File Map
+
+- Create: `Conduit/Views/Components/MarkdownSelectionCoordinator.swift` — segment descriptors, source-order planning, range resolution, attributed copy, and registration state.
+- Modify: `Conduit/Views/Components/SelectableTextView.swift` — optional coordinator registration, touch/selection callbacks, coordinated copy, and teardown.
+- Modify: `Conduit/Views/Components/MarkdownText.swift` — stable segment IDs, coordinator lifetime, rich-block registration, and the response-level gesture/highlight modifier.
+- Create: `ConduitTests/MarkdownSelectionCoordinatorTests.swift` — pure segment ordering, range, revision, copy, and geometry tests.
+- Modify: `ConduitTests/ChatTextSelectionTests.swift` — preserve existing fast-path/link tests and add the bridge contract tests that belong to `SelectableTextView`.
+
+### Task 1: Define the ordered segment model and make its range behavior testable
+
+**Files:**
+- Create: `ConduitTests/MarkdownSelectionCoordinatorTests.swift`
+- Create: `Conduit/Views/Components/MarkdownSelectionCoordinator.swift`
+
+**Interfaces:**
+- Produces `MarkdownSelectionSegmentDescriptor`, `MarkdownSelectionEndpoint`, `MarkdownSelectionSpan`, `MarkdownSelectionCoordinator`, and `MarkdownSelectionSegmentPlan` for later tasks.
+- `MarkdownSelectionSegmentDescriptor` has `id: String`, `order: Int`, and `separatorBefore: String`.
+- `MarkdownSelectionEndpoint` has `segmentID: String` and `offset: Int`, where offsets are UTF-16 `NSRange` offsets.
+- `MarkdownSelectionSpan` has `segmentID: String` and `range: NSRange`.
+- `MarkdownSelectionCoordinator` is an `ObservableObject` that exposes `replaceSegments(_:revision:)`, `register(descriptor:textView:)`, `unregister(segmentID:textView:)`, `text(for:)`, `orderedEndpoints(from:to:) -> (start: MarkdownSelectionEndpoint, end: MarkdownSelectionEndpoint)`, `spans(from:to:)`, and `copiedAttributedText(from:to:)`.
+- `MarkdownSelectionSegmentPlan.descriptors(for:)` returns text-bearing segments in rendered order. Table cells are row-major, code is one segment, and non-text blocks return no segment.
+
+- [ ] **Step 1: Write failing tests for ordering, forward/reverse ranges, and intermediate segments**
+
+```swift
+@MainActor
+final class MarkdownSelectionCoordinatorTests: XCTestCase {
+    func testMixedResponseUsesRenderedOrderAndSelectsEveryIntermediateSegment() {
+        let descriptors = [
+            MarkdownSelectionSegmentDescriptor(id: "paragraph", order: 0, separatorBefore: ""),
+            MarkdownSelectionSegmentDescriptor(id: "table-r0-c0", order: 1, separatorBefore: "\n"),
+            MarkdownSelectionSegmentDescriptor(id: "table-r0-c1", order: 2, separatorBefore: " | "),
+            MarkdownSelectionSegmentDescriptor(id: "code", order: 3, separatorBefore: "\n\n"),
+            MarkdownSelectionSegmentDescriptor(id: "paragraph-2", order: 4, separatorBefore: "\n\n")
+        ]
+        let coordinator = MarkdownSelectionCoordinator()
+        coordinator.replaceSegments(descriptors, revision: "mixed-v1")
+        for descriptor in descriptors {
+            let text: String
+            switch descriptor.id {
+            case "paragraph": text = "First paragraph."
+            case "table-r0-c0": text = "A"
+            case "table-r0-c1": text = "B"
+            case "code": text = "let x = 1"
+            case "paragraph-2": text = "After"
+            default: XCTFail("Unexpected descriptor \(descriptor.id)"); continue
+            }
+            let textView = SelectableTextView.makeTextView()
+            textView.attributedText = NSAttributedString(string: text)
+            coordinator.register(descriptor: descriptor, textView: textView)
+        }
+
+        XCTAssertEqual(
+            coordinator.spans(
+                from: MarkdownSelectionEndpoint(segmentID: "paragraph", offset: 6),
+                to: MarkdownSelectionEndpoint(segmentID: "paragraph-2", offset: 3)
+            ),
+            [
+                MarkdownSelectionSpan(segmentID: "paragraph", range: NSRange(location: 6, length: 10)),
+                MarkdownSelectionSpan(segmentID: "table-r0-c0", range: NSRange(location: 0, length: 1)),
+                MarkdownSelectionSpan(segmentID: "table-r0-c1", range: NSRange(location: 0, length: 1)),
+                MarkdownSelectionSpan(segmentID: "code", range: NSRange(location: 0, length: 9)),
+                MarkdownSelectionSpan(segmentID: "paragraph-2", range: NSRange(location: 0, length: 3))
+            ]
+        )
+    }
+
+    func testReverseSelectionNormalizesOnlyForRangeResolution() {
+        let coordinator = MarkdownSelectionCoordinator()
+        coordinator.replaceSegments([
+            MarkdownSelectionSegmentDescriptor(id: "a", order: 0, separatorBefore: ""),
+            MarkdownSelectionSegmentDescriptor(id: "b", order: 1, separatorBefore: "\n\n")
+        ], revision: "v1")
+
+        let ordered = coordinator.orderedEndpoints(
+            from: MarkdownSelectionEndpoint(segmentID: "b", offset: 5),
+            to: MarkdownSelectionEndpoint(segmentID: "a", offset: 2)
+        )
+        XCTAssertEqual(ordered.start, MarkdownSelectionEndpoint(segmentID: "a", offset: 2))
+        XCTAssertEqual(ordered.end, MarkdownSelectionEndpoint(segmentID: "b", offset: 5))
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests and confirm they fail because the segment API does not exist**
+
+Run the focused command from Global Constraints. Expected: compilation failure naming the missing segment types and coordinator methods.
+
+- [ ] **Step 3: Implement the pure segment API and clamped range resolution**
+
+Implement `replaceSegments` by sorting descriptors on `order`, resetting all active selection state when `revision` changes, and retaining only the latest descriptor for a duplicate `id`. Resolve a forward or reverse endpoint pair by segment order; clamp offsets to each registered text view’s UTF-16 length. Emit a first-segment partial span, full intermediate spans, and a final-segment partial span. For a same-segment selection, emit one normalized range. The unit tests register concrete text views so expected lengths are deterministic.
+
+- [ ] **Step 4: Run the focused tests and confirm the model passes**
+
+Run the focused command. Expected: the new range tests pass and the existing selection tests remain green.
+
+- [ ] **Step 5: Commit the model as an independently reviewable change**
+
+```bash
+git add Conduit/Views/Components/MarkdownSelectionCoordinator.swift ConduitTests/MarkdownSelectionCoordinatorTests.swift
+git commit -m "test: define cross-block markdown selection ranges"
+```
+
+### Task 2: Add registration and touch hooks without changing standalone selection
+
+**Files:**
+- Modify: `Conduit/Views/Components/SelectableTextView.swift`
+- Modify: `ConduitTests/ChatTextSelectionTests.swift`
+- Modify: `ConduitTests/MarkdownSelectionCoordinatorTests.swift`
+
+**Interfaces:**
+- `SelectableTextView` gains optional `selectionCoordinator: MarkdownSelectionCoordinator?` and `selectionSegment: MarkdownSelectionSegmentDescriptor?` parameters on all initializers, defaulting to `nil`.
+- The existing `makeTextView()` test helper continues to return an uncoordinated, non-editable, non-scrolling `UITextView`.
+- A coordinated text view reports `touchesBegan`, `textViewDidChangeSelection`, and `copy(_:)` to the coordinator, and unregisters on dismantle.
+
+- [ ] **Step 1: Add failing tests for the optional hook and coordinated registration**
+
+```swift
+@MainActor
+func testUncoordinatedSelectableTextViewRetainsNativeConfiguration() {
+    let view = SelectableTextView.makeTextView()
+    XCTAssertFalse(view.isEditable)
+    XCTAssertTrue(view.isSelectable)
+    XCTAssertFalse(view.isScrollEnabled)
+}
+
+@MainActor
+func testRegisteredTextViewSuppliesItsAttributedTextToTheCoordinator() {
+    let coordinator = MarkdownSelectionCoordinator()
+    let descriptor = MarkdownSelectionSegmentDescriptor(id: "code", order: 0, separatorBefore: "")
+    let textView = SelectableTextView.makeTextView()
+    textView.attributedText = NSAttributedString(string: "let value = 1")
+    coordinator.register(descriptor: descriptor, textView: textView)
+
+    XCTAssertEqual(coordinator.text(for: "code")?.string, "let value = 1")
+}
+```
+
+- [ ] **Step 2: Run the tests and confirm the registration API is missing**
+
+Run the focused command. Expected: compilation failure for `register`/`text(for:)` and no production behavior change yet.
+
+- [ ] **Step 3: Implement opt-in coordinated UIKit behavior**
+
+Add a private `MarkdownSelectionTextView: UITextView` subclass with an `onTouchBegan` closure. In `makeUIView`, create that subclass only when both optional coordinator and segment are present; otherwise keep the existing `UITextView` path. Convert the touch point to window coordinates before calling `coordinator.beginSelection`. In the representable coordinator, keep the current link delegate implementation and add `textViewDidChangeSelection` forwarding. Implement `dismantleUIView` to nil the delegate and callbacks, resign first responder, and unregister the exact view instance. Do not add a global gesture recognizer in this task.
+
+- [ ] **Step 4: Add the coordinated copy entry point while preserving ordinary copy**
+
+Override `copy(_:)` in the subclass. If the response coordinator has a cross-segment active selection, write the coordinator’s attributed result to the pasteboard and return; otherwise call `super.copy(_:)`. Keep the native `shouldInteractWith` link delegate unchanged so a normal link tap still opens the URL.
+
+- [ ] **Step 5: Run tests and commit the opt-in bridge**
+
+Run the focused command. Expected: all current selection/link tests pass, the registration test passes, and standalone tool text remains unaffected.
+
+```bash
+git add Conduit/Views/Components/SelectableTextView.swift ConduitTests/ChatTextSelectionTests.swift ConduitTests/MarkdownSelectionCoordinatorTests.swift
+git commit -m "feat: register coordinated markdown text surfaces"
+```
+
+### Task 3: Implement the response host gesture, endpoint geometry, and highlights
+
+**Files:**
+- Modify: `Conduit/Views/Components/MarkdownSelectionCoordinator.swift`
+- Modify: `Conduit/Views/Components/SelectableTextView.swift`
+- Modify: `Conduit/Views/Components/MarkdownText.swift`
+- Modify: `ConduitTests/MarkdownSelectionCoordinatorTests.swift`
+
+**Interfaces:**
+- `MarkdownSelectionCoordinator` exposes `beginSelection(segmentID:offset:windowPoint:)`, `updateSelection(windowPoint:)`, `updateSelection(segmentID:offset:windowPoint:)`, `endSelection()`, `hasActiveSelection`, `hasCrossSegmentSelection`, `activeSpans`, and `highlightRects(in:)`.
+- The host modifier is `MarkdownSelectionHost(coordinator:)`; it attaches a simultaneous `DragGesture(minimumDistance: 0, coordinateSpace: .global)` and a non-interactive highlight overlay.
+- Endpoint resolution uses the registered text view’s current `window` frame and `layoutManager`; no cached frame is used across a scroll or layout pass.
+
+- [ ] **Step 1: Write failing geometry and lifecycle tests**
+
+```swift
+@MainActor
+func testEndingOutsideTheFirstSegmentProducesAForwardCrossBlockSelection() {
+    let coordinator = MarkdownSelectionCoordinator()
+    coordinator.replaceSegments([
+        MarkdownSelectionSegmentDescriptor(id: "first", order: 0, separatorBefore: ""),
+        MarkdownSelectionSegmentDescriptor(id: "second", order: 1, separatorBefore: "\n\n")
+    ], revision: "v1")
+    coordinator.beginSelection(segmentID: "first", offset: 6, windowPoint: CGPoint(x: 20, y: 20))
+    coordinator.updateSelection(segmentID: "second", offset: 4, windowPoint: CGPoint(x: 20, y: 120))
+
+    XCTAssertTrue(coordinator.hasCrossSegmentSelection)
+    XCTAssertEqual(coordinator.activeSpans.map(\.segmentID), ["first", "second"])
+}
+
+@MainActor
+func testRevisionChangeClearsStaleSelectionAndRegistrations() {
+    let coordinator = MarkdownSelectionCoordinator()
+    coordinator.replaceSegments([
+        MarkdownSelectionSegmentDescriptor(id: "old", order: 0, separatorBefore: "")
+    ], revision: "old")
+    coordinator.beginSelection(segmentID: "old", offset: 0, windowPoint: .zero)
+    coordinator.replaceSegments([
+        MarkdownSelectionSegmentDescriptor(id: "new", order: 0, separatorBefore: "")
+    ], revision: "new")
+
+    XCTAssertFalse(coordinator.hasActiveSelection)
+    XCTAssertNil(coordinator.text(for: "old"))
+}
+```
+
+- [ ] **Step 2: Run the tests and verify the geometry/lifecycle API fails**
+
+Run the focused command. Expected: compilation failure for the host lifecycle methods.
+
+- [ ] **Step 3: Implement pointer-to-caret resolution and nested-scroll-safe registration**
+
+When a coordinated text view begins, store the fixed anchor endpoint. On each host gesture update, locate the registered text view whose converted window bounds contains the pointer. Convert the global pointer into that text view’s coordinate system and call `layoutManager.characterIndex(for:in:fractionOfDistanceBetweenInsertionPoints:)`, clamping to `[0, textStorage.length]`. Because frames are converted from the current view hierarchy on every update, a table or code horizontal scroll automatically participates in hit testing. Do not let a pointer outside every segment erase the last valid endpoint; retain the last segment until the gesture ends.
+
+- [ ] **Step 4: Add the simultaneous host gesture and highlight overlay**
+
+Add `MarkdownSelectionHost` as a `ViewModifier` around the fallback `VStack`. Its gesture does nothing unless the coordinator has an active anchor, so ordinary taps, link activation, table horizontal scrolling, and the code copy button keep their existing recognizers. On selection updates, assign the resolved local `selectedRange` to registered text views and call `objectWillChange`. Add a `UIViewRepresentable` overlay with `isUserInteractionEnabled = false` that converts `highlightRects(in:)` from window coordinates into its own bounds and draws translucent selection rectangles for non-active segments. Keep native handles and the edit menu on the active endpoint text view.
+
+- [ ] **Step 5: Run focused tests and commit the host behavior**
+
+Run the focused command. Expected: model, bridge, and existing link tests pass.
+
+```bash
+git add Conduit/Views/Components/MarkdownSelectionCoordinator.swift Conduit/Views/Components/SelectableTextView.swift Conduit/Views/Components/MarkdownText.swift ConduitTests/MarkdownSelectionCoordinatorTests.swift
+git commit -m "feat: coordinate selection across markdown text blocks"
+```
+
+### Task 4: Wire stable segment IDs into every rich Markdown text surface
+
+**Files:**
+- Modify: `Conduit/Views/Components/MarkdownText.swift`
+- Modify: `ConduitTests/MarkdownSelectionCoordinatorTests.swift`
+- Modify: `ConduitTests/ChatTextSelectionTests.swift`
+
+**Interfaces:**
+- `MarkdownSelectionSegmentPlan.descriptors(for:)` is the single source for rendered order and IDs.
+- `MarkdownBlockView` receives `blockIndex` and an optional `MarkdownSelectionCoordinator`.
+- `InlineMarkdown`, heading/list/quote/callout/columns views, `MarkdownTable`, and `ChatCodeBlock` receive a descriptor and pass it into their `SelectableTextView`.
+
+- [ ] **Step 1: Write failing plan tests for the actual parser output**
+
+```swift
+func testMixedMarkdownPlanIncludesTableCellsRowMajorAndOneCodeSegment() {
+    let blocks = MarkdownParser.parse(
+        "Before\n\n| A | B |\n| --- | --- |\n| [link](https://example.com) | 2 |\n\n```swift\nlet x = 1\n```\n\nAfter",
+        recognizesGatewayMedia: false
+    )
+
+    XCTAssertEqual(
+        MarkdownSelectionSegmentPlan.descriptors(for: blocks).map(\.id),
+        ["block-0", "block-1-table-r0-c0", "block-1-table-r0-c1", "block-1-table-r1-c0", "block-1-table-r1-c1", "block-2-code", "block-3"]
+    )
+}
+```
+
+- [ ] **Step 2: Run the plan test and verify mixed blocks are not yet described**
+
+Run the focused command. Expected: failure because the fallback renderer has no segment plan.
+
+- [ ] **Step 3: Implement stable IDs, separators, and coordinator lifetime in `MarkdownText`**
+
+Keep the paragraph-only `rendering.selectableText` branch exactly as the fast path. For the fallback branch, create one `@StateObject` coordinator per `MarkdownText` identity, replace its descriptors using the exact `source` revision, and attach `MarkdownSelectionHost` plus the highlight overlay to the response `VStack`. Use `block-(index)` for a single text block, `block-(index)-table-r(row)-c(column)` in row-major order, and `block-(index)-code` for ordinary fenced code. Use `\n\n` between Markdown blocks, ` | ` within a table row, and `\n` between table rows as the `separatorBefore` values. Exclude images, dividers, Mermaid/LaTeX previews, and other non-text blocks from the plan.
+
+- [ ] **Step 4: Pass descriptors through the rich block tree without flattening the visual layout**
+
+Add the optional descriptor to each `SelectableTextView` used by `InlineMarkdown` and the code/table paths. Preserve the existing SwiftUI `VStack`/`HStack`, `ScrollView(.horizontal)`, padding, backgrounds, syntax highlighter, links, and copy buttons. Table cells continue to render as individual cells; their only new behavior is registration with the response coordinator. Tool-card `SelectableTextView`s in `ChatView.swift` receive no descriptor and remain independent.
+
+- [ ] **Step 5: Add copy and link regression assertions**
+
+Register a table-cell attributed string containing a URL and a code string, select from the paragraph through the code, and assert that copied text contains the configured separators, the link display text, and the `.link` URL attribute on the copied link run. Keep the existing `testMarkdownBridgePreservesEmphasisCodeAndLinks` as the standalone link contract.
+
+- [ ] **Step 6: Run the focused suite and commit the renderer integration**
+
+Run the focused command. Expected: all selection tests pass, including mixed paragraph/table/code ordering and link preservation.
+
+```bash
+git add Conduit/Views/Components/MarkdownText.swift ConduitTests/MarkdownSelectionCoordinatorTests.swift ConduitTests/ChatTextSelectionTests.swift
+git commit -m "feat: enable cross-block selection in rich markdown"
+```
+
+### Task 5: Verify the user-visible selection contract on Simulator
+
+**Files:**
+- No source changes unless a verification failure identifies a specific regression.
+- Test evidence: `ConduitTests/MarkdownSelectionCoordinatorTests.swift`, `ConduitTests/ChatTextSelectionTests.swift`.
+
+- [ ] **Step 1: Run the focused and full unit suites**
+
+Run the focused command, then run:
+
+```bash
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit \
+  -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: both commands finish with `TEST SUCCEEDED` and no new warnings that indicate a selection or layout failure.
+
+- [ ] **Step 2: Exercise both selection directions and nested scrolling manually**
+
+On the iPhone 17 Pro Simulator, open a response containing a paragraph, a Markdown table with a link, a fenced code block, and a trailing paragraph. Long-press/drag paragraph→table→code→paragraph, then repeat in reverse. Confirm every intermediate segment is highlighted, copy includes the expected separators, and the table remains horizontally scrollable. Tap the link without selecting and after clearing a selection; confirm it opens normally. Repeat at larger Dynamic Type sizes and in both color schemes.
+
+- [ ] **Step 3: Commit only verified test adjustments**
+
+If a test needed a deterministic UIKit layout fixture, add that fixture and run the full suite again before committing it. Do not weaken a test to hide a simulator-only gesture failure; record the exact failure in the handoff instead.

--- a/docs/superpowers/plans/2026-08-13-title-scroll-to-top.md
+++ b/docs/superpowers/plans/2026-08-13-title-scroll-to-top.md
@@ -1,0 +1,180 @@
+# Title Scroll-to-Top Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the active session title a reliable control that scrolls the current conversation to its first content without disturbing session restoration or latest-message behavior.
+
+**Architecture:** Add a monotonic `AppState` request signal parallel to `chatScrollRequest`. Render the existing title surface inside a plain-styled toolbar button. `ChatView` adds a stable, session-scoped top anchor and handles each request by invalidating drag/restoration state, disabling latest-following, and scrolling to the top with one layout-delayed retry.
+
+**Tech Stack:** Swift 5.9, SwiftUI 17, `ScrollViewReader`, `LazyVStack`, XCTest.
+
+## Global Constraints
+
+- Target iOS 17.0 with no new dependencies or navigation behavior changes.
+- Keep the existing title styling and make the hit target a button with an accessibility label describing “Scroll to top of conversation.”
+- Do not change the existing “scroll to latest” request or viewport restoration semantics except where the explicit top action must cancel them.
+- Work for populated, empty, restored, and long lazy transcripts.
+- The top request is monotonic so repeated title taps are observable even when the destination is already at the top.
+
+## File Map
+
+- Modify: `Conduit/Services/AppState.swift` — published top-scroll request and public request method.
+- Modify: `Conduit/Views/RootView.swift` — title button and accessibility label.
+- Modify: `Conduit/Views/ChatView.swift` — top anchor and request handler with cancellation/retry.
+- Create: `ConduitTests/ChatTitleScrollTests.swift` — monotonic request signal tests.
+
+### Task 1: Add the monotonic AppState command
+
+**Files:**
+- Create: `ConduitTests/ChatTitleScrollTests.swift`
+- Modify: `Conduit/Services/AppState.swift`
+
+**Interfaces:**
+- `AppState` adds `@Published private(set) var chatScrollToTopRequest = 0` beside `chatScrollRequest`.
+- `AppState` adds `func requestChatScrollToTop()` that increments the counter with `&+= 1`.
+
+- [ ] **Step 1: Write the failing signal test**
+
+```swift
+@MainActor
+final class ChatTitleScrollTests: XCTestCase {
+    func testTitleScrollRequestIsMonotonicAndObservableForRepeatedTaps() {
+        let appState = AppState(loadSavedConnection: false)
+        let initial = appState.chatScrollToTopRequest
+
+        appState.requestChatScrollToTop()
+        appState.requestChatScrollToTop()
+
+        XCTAssertEqual(appState.chatScrollToTopRequest, initial &+ 2)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test and confirm the command is missing**
+
+Run:
+
+```bash
+/Users/agrias/bin/bin/xcodegen generate
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit \
+  -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' \
+  -only-testing:ConduitTests/ChatTitleScrollTests CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: compilation failure for `chatScrollToTopRequest` or `requestChatScrollToTop`.
+
+- [ ] **Step 3: Implement the published signal and rerun the test**
+
+Place the property next to `chatScrollRequest` and the method next to `requestChatScrollToLatest()`. Do not reset the counter during a session switch; the view consumes changes, not an absolute value.
+
+- [ ] **Step 4: Commit the AppState command**
+
+```bash
+git add Conduit/Services/AppState.swift ConduitTests/ChatTitleScrollTests.swift
+git commit -m "feat: add chat scroll-to-top request"
+```
+
+### Task 2: Turn the toolbar title into an accessible control
+
+**Files:**
+- Modify: `Conduit/Views/RootView.swift`
+
+**Interfaces:**
+- The principal toolbar item remains the same title surface, but its root is `Button { appState.requestChatScrollToTop() } label: { ... }` with `.buttonStyle(.plain)`.
+
+- [ ] **Step 1: Preserve the title surface inside a button**
+
+Move the existing `Text(appState.activeSessionTitle)` font, line limit, padding, and `conduitGlassSurface` modifiers into the button label without changing visual values. Add `.accessibilityLabel("Scroll to top of conversation")` and keep the title text available to VoiceOver through the button label.
+
+- [ ] **Step 2: Build the app and inspect the toolbar**
+
+Run:
+
+```bash
+xcodebuild build -project Conduit.xcodeproj -scheme Conduit \
+  -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: build succeeds, the title retains its glass surface, and the button does not inherit a default blue tint or unwanted navigation transition.
+
+- [ ] **Step 3: Commit the toolbar control**
+
+```bash
+git add Conduit/Views/RootView.swift
+git commit -m "feat: make chat title scroll to top"
+```
+
+### Task 3: Add the lazy-layout top anchor and request handler
+
+**Files:**
+- Modify: `Conduit/Views/ChatView.swift`
+- Modify: `ConduitTests/ChatTitleScrollTests.swift`
+
+**Interfaces:**
+- `ChatView` adds a private `topAnchor` derived from the current `activeScrollSessionKey`, parallel to `bottomAnchor`.
+- `ChatView` adds a private `scrollToTop(using:request:)` helper that guards pending restoration, scrolls without changing the transcript, and retries once after 150 ms. The retry captures the request integer and checks it against `appState.chatScrollToTopRequest` before scrolling.
+
+- [ ] **Step 1: Add a stable top target inside `LazyVStack`**
+
+Insert a `Color.clear.frame(height: 1).id(topAnchor)` as the first child of the existing `LazyVStack`, before `EmptyChatState` and message rows. Keep the current bottom anchor in the lazy layout and keep `.scrollTargetLayout()` unchanged. Derive `topAnchor` from the active profile/session scope so a previous session’s top target cannot be reused after a switch.
+
+- [ ] **Step 2: Handle each top request with explicit state cancellation**
+
+Add `.onChange(of: appState.chatScrollToTopRequest)` beside the existing latest-request handler:
+
+```swift
+.onChange(of: appState.chatScrollToTopRequest) { _, request in
+    invalidateChatDrag()
+    cancelAutomaticRestoration()
+    followsLatest = false
+    scrollToTop(using: proxy, request: request)
+}
+```
+
+The handler must not call `scrollToLatest`, must not leave `chatResumeRestorationRequest` pending, and must not allow a delayed latest retry to win after the explicit top request.
+
+- [ ] **Step 3: Implement a layout-delayed top scroll**
+
+Use the same transaction style as restoration for the first scroll: no animation while changing the explicit destination, then one `Task { @MainActor in ... }` delayed by 150 ms that checks `!Task.isCancelled`, the request generation is still the latest observed value, and the active top anchor is still current before calling `proxy.scrollTo(topAnchor, anchor: .top)`. If the transcript is empty, the anchor remains valid and the request is still harmless.
+
+- [ ] **Step 4: Keep viewport persistence coherent after the top action**
+
+After the scroll settles, allow `topVisibleChatID` changes to flow through the existing `saveChatScrollPosition` path. If the top anchor itself is reported as visible, resolve the first message target before producing a non-latest snapshot; do not persist the synthetic anchor as a message ID. The next ordinary drag or session switch must continue using the existing restoration state machine.
+
+- [ ] **Step 5: Run focused tests and commit the ChatView behavior**
+
+```bash
+/Users/agrias/bin/bin/xcodegen generate
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit \
+  -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' \
+  -only-testing:ConduitTests/ChatTitleScrollTests \
+  -only-testing:ConduitTests/ChatScrollStateTests \
+  -only-testing:ConduitTests/AppStateChatResumeTests \
+  CODE_SIGNING_ALLOWED=NO
+
+git add Conduit/Views/ChatView.swift ConduitTests/ChatTitleScrollTests.swift
+git commit -m "fix: scroll chat to top from the title"
+```
+
+### Task 4: Verify title behavior across transcript states
+
+**Files:**
+- No source changes unless verification exposes a specific request-generation or anchor identity defect.
+
+- [ ] **Step 1: Run the full simulator test suite**
+
+```bash
+xcodebuild test -project Conduit.xcodeproj -scheme Conduit \
+  -destination 'platform=iOS Simulator,id=6930ECCE-D36C-4E11-8AB5-EDEC4DEA8355' \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: `TEST SUCCEEDED`, including the existing rapid session-switch, restoration, and scroll-state tests.
+
+- [ ] **Step 2: Manually verify the title control**
+
+Scroll deep into a long conversation, tap the title, and confirm the first message is visible. Tap it repeatedly, tap during streaming, tap while a restored session is settling, and tap in an empty conversation. Confirm the title remains responsive, the latest-message button still works afterward, and the next session switch restores the correct session’s viewport rather than the synthetic top anchor.
+
+- [ ] **Step 3: Verify accessibility and appearance**
+
+Use VoiceOver to confirm the principal control announces “Scroll to top of conversation.” Repeat in light/dark mode and with larger Dynamic Type; the title remains single-line and the button hit target stays usable.

--- a/docs/superpowers/specs/2026-08-13-cross-block-selection-session-scroll-design.md
+++ b/docs/superpowers/specs/2026-08-13-cross-block-selection-session-scroll-design.md
@@ -1,0 +1,140 @@
+# Cross-Block Markdown Selection, Composer Isolation, and Title Scroll Design
+
+Date: 2026-08-13
+Status: Proposed for review
+
+## Context
+
+Build 127 has three user-visible regressions:
+
+1. A response containing a Markdown table or fenced code block cannot be selected across paragraph boundaries. The current renderer creates one `UITextView` only when every parsed block is a simple selectable-flow block. The presence of a table or code block switches the entire response to a SwiftUI fallback in which paragraphs, code, and table cells are separate selectable views.
+2. Switching sessions while the composer contains text can crash or leave the app in synchronization. `ComposerBar` owns a stateful UIKit text view whose draft and first-responder state currently outlive the session identity that owns them.
+3. The custom toolbar title is a plain `Text`, and the chat has an explicit “scroll to latest” command but no explicit “scroll to top” command.
+
+The focused baseline suite currently passes. It covers the paragraph-only selection path and AppState session cancellation, but not mixed Markdown selection, UIKit composer teardown during a session switch, or title-driven top scrolling.
+
+## Goals
+
+- Preserve the current visual table grid, code card, horizontal table/code scrolling, copy buttons, and rich Markdown rendering.
+- Allow selection to span selectable text blocks within one Markdown response, including paragraphs, headings, lists, quotes, table cells, code, and inline links.
+- Keep links tappable when the user is performing a normal link interaction, and preserve link attributes in copied content.
+- Make composer ownership explicit across session changes so stale first-responder callbacks cannot affect a new session or keep synchronization stuck.
+- Make tapping the session title reliably scroll the current conversation to its first content.
+- Keep settled Markdown caching and Dynamic Type behavior intact.
+
+## Non-goals
+
+- Flattening tables or code into a single textual card.
+- Replacing the existing rich renderer with a single plain `UITextView`.
+- Making selection span separate chat messages, system cards, or the visual contents of a rendered Mermaid/LaTeX preview.
+- Changing the server-side session or resume protocol unless a new regression test proves the AppState transition itself is incomplete.
+
+## Design
+
+### 1. Response-level Markdown selection coordinator
+
+The existing rich block tree remains the visual source of truth. A Markdown response that uses the fallback renderer will also create a response-scoped selection coordinator. The coordinator manages a logical sequence of selectable child surfaces without replacing their layout.
+
+Each selectable child registers a stable segment containing:
+
+- a block/cell identity and ordering position;
+- its current `UITextView` instance;
+- the displayed attributed text and local character range;
+- a way to convert its bounds and selection rects into the response host’s coordinate space.
+
+The segment order follows rendered Markdown order. Table cells are ordered row-major; code is one segment; paragraphs and inline block views retain their existing local text and attributes.
+
+`SelectableTextView` gains an optional selection-session hook. The existing standalone behavior remains unchanged when no coordinator is supplied, so tool cards and other independent text surfaces keep their current native selection behavior.
+
+#### Selection lifecycle
+
+1. A child text view begins a native selection or long-press interaction and reports its local anchor/focus to the coordinator.
+2. A simultaneous, non-cancelling response-host gesture observes the pointer location while that selection is active. It does not intercept ordinary taps, link activation, table scrolling, or the code copy button.
+3. If the pointer remains within one child, UIKit continues to own the normal selection behavior.
+4. If the pointer crosses into another registered child, the coordinator resolves the destination segment and local caret position from the child’s current layout. It then updates the anchor-to-focus range across all affected segments:
+   - the first segment is selected from the anchor to its boundary;
+   - intermediate segments are fully selected;
+   - the final segment is selected from its boundary to the focus.
+5. Selection highlights are rendered in the child views or a response overlay using each text view’s current selection rects. Native handles and the edit menu remain attached to the active endpoint where UIKit supports them.
+6. On copy, the coordinator concatenates the selected segment text with the same logical separators used by the Markdown response. The copied attributed content retains inline links, emphasis, code traits, and syntax colors where available.
+7. When the gesture ends or the response content changes, the coordinator clears stale registrations and selection state. It never carries character offsets across a changed source revision.
+
+The coordinator must account for nested horizontal scroll views. Segment frames are converted after the table/code scroll view’s current content offset is applied, so a drag over a horizontally scrolled table cell resolves against what is actually visible.
+
+#### Link behavior
+
+The current `SelectableTextView` delegate link handling remains the link activation path. A tap that does not establish a cross-block selection continues to open the URL. Link runs are registered with the coordinator as ordinary character ranges, so a copied multi-block selection includes their display text and link metadata without disabling tapping.
+
+#### Rich block compatibility
+
+The coordinator is used for text-bearing blocks that currently render with one or more child `SelectableTextView`s: paragraphs, headings, lists, quotes, tables, code, callouts, and columns. Images, Mermaid/LaTeX previews, dividers, and other non-text blocks remain visual gaps and are not made selectable through this change. Existing standalone selection in tool input/output and preview source remains available.
+
+The paragraph-only fast path continues to use the existing single cached text view. The coordinator is only needed when the fallback renderer would otherwise split a response into multiple selectable surfaces.
+
+### 2. Composer session isolation
+
+Composer state is separated into:
+
+- session-owned draft data (text and attachments);
+- transient editor state (first responder, slash suggestions, paste error, measured height, and UIKit view identity).
+
+The recommended draft policy is to preserve drafts per profile/session in an in-memory draft store while never carrying first-responder state across sessions. On an active-session change, `ComposerBar` will:
+
+1. save the old session’s draft;
+2. resign the current text view and dismiss slash suggestions;
+3. invalidate the old editor identity so the UIKit bridge cannot deliver callbacks into the new session;
+4. restore the destination session’s draft, if any, without automatically focusing it;
+5. keep the existing AppState request-generation and reconciliation guards in force.
+
+If review chooses clearing drafts instead, the same lifecycle boundary applies but the store is discarded on each session transition.
+
+The `ComposerPasteTextView` coordinator will ignore callbacks caused by programmatic text/focus updates during this handoff. Context refresh tasks remain keyed to the active session and retain their existing client/session guards.
+
+The AppState implementation will only be changed if a new regression test demonstrates that a superseded explicit open can leave `turnState` or reconciliation ownership unresolved. Existing rapid-switch and cancellation tests remain mandatory.
+
+### 3. Explicit title-driven scroll to top
+
+`AppState` adds a monotonic `chatScrollToTopRequest` signal and `requestChatScrollToTop()` method, parallel to the existing latest-scroll request.
+
+The toolbar principal item becomes a plain-styled button containing the existing title surface. Its accessibility label describes the action as “Scroll to top of conversation.”
+
+`ChatView` adds a stable top anchor to the lazy chat layout. When the request changes, it:
+
+- invalidates an active drag and cancels pending automatic restoration;
+- stops following the latest message for this explicit user action;
+- scrolls to the top anchor, with one layout-delayed retry for lazy content;
+- allows the normal viewport persistence machinery to record the first visible message afterward.
+
+The command works for populated, empty, restored, and long transcripts without relying on implicit navigation-bar behavior.
+
+## Testing strategy
+
+### Unit tests
+
+- Extend `ChatTextSelectionTests` with mixed paragraph/table and paragraph/code fixtures. Assert that the response creates a coordinator, selection ranges span segment boundaries, and table links retain URL attributes.
+- Add coordinator tests for forward/reverse selection, full intermediate segments, table row/cell ordering, content revisions, and horizontal-offset geometry.
+- Add copy tests for separators and mixed attributed content.
+- Add composer lifecycle tests for saving/restoring or clearing drafts, resigning focus, editor identity invalidation, and ignoring programmatic UIKit callbacks.
+- Extend `AppStateChatResumeTests` only where a failing session-switch lifecycle case requires it; retain the existing rapid-switch and cancellation coverage.
+- Add an AppState scroll-command test verifying each title tap produces a distinct top-scroll request.
+
+### Simulator/UI verification
+
+- Select from a paragraph into a table, from a table into a paragraph, and across a code block in both directions.
+- Tap links before and after selection; verify they remain tappable.
+- Exercise table horizontal scrolling while selecting.
+- Type a multiline composer draft, switch sessions repeatedly, and verify no crash, no stuck synchronization, and the selected draft policy.
+- Scroll deep into a long conversation and tap the title; verify the first message is visible.
+- Repeat with Dynamic Type changes, light/dark mode, streaming Markdown, and repeated large local image attachment opens.
+
+## Risks and mitigations
+
+- Gesture arbitration may conflict with UIKit’s native selection or table horizontal scrolling. Use simultaneous, non-cancelling recognizers and fall back to native within-block selection when a cross-block gesture cannot be established.
+- Multiple selected child views may not all display native selection highlights when they are not first responder. The response overlay will draw selection rects for non-active segments.
+- SwiftUI view identity can change while streaming. Stable segment IDs plus source-revision invalidation prevent stale registrations and offsets.
+- Per-session draft retention can grow without bound. Limit the store to a small number of recent session keys and drop drafts on memory warning or explicit disconnect.
+- The coordinator adds layout work during selection only; Markdown parsing, syntax highlighting, and image decoding remain on their existing cached/off-main paths.
+
+## Rollout
+
+Implement behind no user-facing feature flag, because the old behavior is the reported regression. Land the regression tests first, then the coordinator, composer isolation, and title command in small commits. Run the focused suites, the full simulator test suite, and a manual UI pass before producing a new TestFlight build.


### PR DESCRIPTION
## Summary

- Restore text selection across mixed Markdown responses, including paragraphs separated by tables, code blocks, links, and tool output.
- Preserve selection anchors and lifecycle state for settled responses; a selection holds across re-renders once a reply finishes streaming (it resets while a reply is still streaming).
- Isolate composer submissions, attachment imports, slash-command continuations, and recovery from session/profile handoffs.
- Preserve composer text and attachments when Hermes rotates between runtime and stored session IDs.
- Restore title-tap scroll-to-top ownership across chat transitions and drag activity.

## Root cause

Markdown was rendered as independent selectable blocks, so native selection could not maintain one contiguous range when a response contained non-text blocks. Composer async work also relied on the currently visible session after suspension, allowing stale callbacks and recovery paths to mutate or restore the wrong draft. Runtime/stored session aliases were not consistently treated as the same composer identity.

## Validation

- Focused simulator suite: 100 tests passed, 0 failures.
- Full iOS simulator suite: 578 tests passed, 0 failures.
- Final whole-branch review: clean.

No release metadata or TestFlight upload is included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select and copy text across Markdown paragraphs, lists, tables, quotes, and code blocks with highlighted ranges.
  * Tap the conversation title to quickly scroll to the top.
  * Composer drafts are preserved separately across profiles and conversations, including attachments.
* **Bug Fixes**
  * Prevented delayed submissions, paste actions, attachment imports, and other asynchronous updates from affecting the wrong conversation.
  * Improved draft restoration and cleanup during conversation changes.
* **Accessibility**
  * Added an accessible label and hint for the conversation title scroll action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->