### PR TITLE
fix(chat): restore touch + selection on table/code responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ build/
 .build/
 Package.resolved
 
+# Local Git worktrees
+.worktrees/
+
 # macOS
 .DS_Store
 *.swp

--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -94,28 +94,20 @@ struct MarkdownSelectionHost: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .contentShape(Rectangle())
+            // The SwiftUI TapGesture + DragGesture that used to wrap this
+            // content were removed: any SwiftUI gesture here fought the
+            // enclosing chat ScrollView's vertical pan and deadened the message
+            // area whenever a response contained a table or code block, and the
+            // selection handles flashed and vanished. Removing them restores
+            // scrolling and stable per-block text selection. Cross-block
+            // selection across table/code blocks is not currently wired — it
+            // needs a mechanism that can coexist with UITextView's private
+            // text-selection gesture; the coordinator infrastructure and this
+            // non-interactive highlight overlay remain for that future use.
             .overlay {
                 MarkdownSelectionHighlightOverlay(coordinator: coordinator)
                     .allowsHitTesting(false)
             }
-            .simultaneousGesture(
-                TapGesture()
-                    .onEnded {
-                        coordinator.clearSelection()
-                    }
-            )
-            .simultaneousGesture(
-                DragGesture(minimumDistance: 0, coordinateSpace: .global)
-                    .onChanged { value in
-                        guard coordinator.isSelectionGestureActive else { return }
-                        coordinator.updateSelection(windowPoint: value.location)
-                    }
-                    .onEnded { _ in
-                        guard coordinator.isSelectionGestureActive else { return }
-                        coordinator.endSelection()
-                    }
-            )
             .onDisappear {
                 coordinator.clearSelection()
             }


### PR DESCRIPTION
## Summary

- Remove the SwiftUI `TapGesture` + `DragGesture(minimumDistance: 0)` that `MarkdownSelectionHost` (from #57) armed over the entire message body via `contentShape(Rectangle())`.
- Also includes a tiny chore commit ignoring the local `.worktrees/` directory.

## Root cause

`MarkdownSelectionHost` was attached only on the multi-block render path — i.e. exactly when a response contained a **Markdown table or fenced code block**. Its always-on SwiftUI recognizers claimed touches on finger-down and fought the embedded `UITextView` selection recognizers and the code/table horizontal `ScrollView` pans. Result: the message area stopped responding to touch (couldn't scroll vertically), and the text-selection handles flashed and vanished. Paragraph-only responses took the single-`SelectableTextView` fast path with no host gestures, which is why they worked fine.

## What this fixes

- ✅ Vertical scrolling over responses containing tables/code blocks (the reported "screen doesn't respond to touch").
- ✅ Stable within-block text selection on those responses (no more selector flicker/disappear).
- ✅ Code/table horizontal scrolling, links, and the code Copy button work untouched.
- ✅ Cross-paragraph selection on responses without tables/code (single-text-view fast path) unchanged.

## Known gap (deferred, out of scope here)

Cross-block selection *across* a table/code block boundary is still not available. It was never practically functional: #57's host-drag mechanism is precisely what deadened touch, and simulator instrumentation confirmed UIKit's private text-selection gesture unpredictably fails coexisting recognizers (a gated `UIPanGestureRecognizer` engages only intermittently; `touchesMoved` is starved). Reliable cross-block needs a different architecture (single selectable text surface or a custom selection-overlay system). The `MarkdownSelectionCoordinator` infrastructure and non-interactive highlight overlay are retained for that future work.

## Validation

- Focused suite: `MarkdownSelectionCoordinatorTests` + `ChatTextSelectionTests` — 43/43 passed.
- Full iOS simulator suite: **609 tests, 0 failures**.
- Manual pass on iPhone 17 Pro Max simulator: scroll responsive, within-block selection stable (no flicker), code/table horizontal scroll intact, links open, Copy works — including reverse-direction selection and repeated attempts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved markdown text selection behavior by removing unintended tap and drag interactions.
  * Selection highlights now display without intercepting other interactions and clear when the view disappears.

* **Chores**
  * Added local worktree directories to Git ignore rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->