### PR TITLE
fix: keep session YOLO honest under global approval off and durable across gateway restarts

### DIFF
--- a/Conduit/Models/Models.swift
+++ b/Conduit/Models/Models.swift
@@ -527,6 +527,10 @@ struct RuntimeState: Equatable {
     var model: String = ""
     var provider: String = ""
     var reasoningEffort: String = ""
+    /// Last-known profile-wide approval mode ("manual", "smart", "off").
+    /// When "off", Hermes auto-approves globally and no per-session YOLO toggle
+    /// can require approvals; the indicator reflects that effective state.
+    var approvalsMode: String? = nil
     var yolo: Bool = false
 }
 

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -3280,9 +3280,14 @@ final class AppState: ObservableObject {
             runtime.yolo = storedOverride
         } else if let yolo = authoritativeYolo ?? snapshot.yolo {
             runtime.yolo = yolo
-        } else {
+        } else if runtime.approvalsMode != nil {
+            // A known non-off profile mode with no session-level signal means
+            // approvals apply.
             runtime.yolo = false
         }
+        // No approval signal has ever been observed: keep the last-known
+        // indicator value rather than flickering to "off" on partial
+        // projections that omit the approval fields.
     }
 
     /// The context breakdown RPC is the gateway's complete accounting source.
@@ -4539,6 +4544,14 @@ final class AppState: ObservableObject {
     ) async -> Bool {
         let submissionContext = context ?? composerSubmissionContext()
         guard isCurrentComposerSubmission(submissionContext) else { return false }
+        guard runtime.approvalsMode?.lowercased() != "off" else {
+            // Hermes auto-approves globally under approvals.mode == "off"; the
+            // per-session write is a server-side no-op, and persisting an
+            // override here would silently resurface when the profile mode
+            // changes back. Send nothing and keep the effective floor state.
+            runtime.yolo = true
+            return true
+        }
         guard let client, let sessionId = activeSessionId else { return false }
         do {
             if let setSessionYolo = chatResumeLifecycleOperations.setSessionYolo {
@@ -4581,7 +4594,11 @@ final class AppState: ObservableObject {
         snapshot: SessionRuntimeSnapshot,
         using client: HermesClient
     ) async {
-        guard snapshot.approvalsMode?.lowercased() != "off" else { return }
+        // Use the same resolved floor source applyRuntime just updated (the
+        // snapshot's value when present, else the last-known mode) so the
+        // floor decision and the re-assert decision can never diverge when a
+        // snapshot omits approvals_mode.
+        guard runtime.approvalsMode?.lowercased() != "off" else { return }
         let persistedSessionID = canonicalSessionID(for: sessionId) ?? sessionId
         guard let override = sessionYoloStore.storedOverride(
             for: activeProfile,
@@ -5641,6 +5658,10 @@ final class AppState: ObservableObject {
         defer { isProfileSwitching = false }
         invalidateReconciliation()
         turnState = .synchronizing
+        // The next profile's approval mode is unknown until its first session
+        // snapshot arrives; don't let the previous profile's floor leak across
+        // the switch.
+        runtime.approvalsMode = nil
 
         do {
             let ticket = try await mintChatResumeTicket(for: savedConnection)
@@ -6333,6 +6354,12 @@ final class AppState: ObservableObject {
                 method: "PUT",
                 body: ["config": config, "profile": profile]
             )
+            if key == "approvals.mode", let mode = value.textValue?.lowercased() {
+                // Mirror the saved profile mode immediately so the global floor
+                // and the Model Picker lock reflect it without waiting for the
+                // next session snapshot.
+                runtime.approvalsMode = mode
+            }
             return true
         } catch {
             errorMessage = "Could not save \(key): \(error.localizedDescription)"

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -3263,6 +3263,21 @@ final class AppState: ObservableObject {
                 aliases: [requestedSessionID]
             )
         }
+        applyEffectiveYolo(
+            sessionIDsForOverride: sessionIDsForOverride,
+            snapshotYolo: authoritativeYolo ?? snapshot.yolo
+        )
+    }
+
+    /// Resolve the effective session YOLO state from the current profile
+    /// approval mode and the stored per-session override. Shared by
+    /// `applyRuntime` (snapshot reconciliation) and the Settings save path so
+    /// the indicator, the floor, and the Model Picker lock can never disagree
+    /// with the saved mode.
+    private func applyEffectiveYolo(
+        sessionIDsForOverride: [String],
+        snapshotYolo: Bool?
+    ) {
         let storedOverride = sessionYoloStore.storedOverride(
             for: activeProfile,
             sessionIDs: sessionIDsForOverride
@@ -3278,7 +3293,7 @@ final class AppState: ObservableObject {
             // flag in memory only and forgets it on restart, so AppState
             // re-asserts it after resume (see reassertSessionYolo).
             runtime.yolo = storedOverride
-        } else if let yolo = authoritativeYolo ?? snapshot.yolo {
+        } else if let yolo = snapshotYolo {
             runtime.yolo = yolo
         } else if runtime.approvalsMode != nil {
             // A known non-off profile mode with no session-level signal means
@@ -6355,10 +6370,18 @@ final class AppState: ObservableObject {
                 body: ["config": config, "profile": profile]
             )
             if key == "approvals.mode", let mode = value.textValue?.lowercased() {
-                // Mirror the saved profile mode immediately so the global floor
-                // and the Model Picker lock reflect it without waiting for the
-                // next session snapshot.
+                // Mirror the saved profile mode immediately and re-resolve the
+                // effective indicator state through the same precedence
+                // applyRuntime uses, so the floor and the picker lock take
+                // effect without waiting for the next session snapshot.
                 runtime.approvalsMode = mode
+                let requestedSessionID = activeSessionId
+                let resolvedCanonicalSessionID = canonicalSessionID(for: requestedSessionID)
+                applyEffectiveYolo(
+                    sessionIDsForOverride: [resolvedCanonicalSessionID, requestedSessionID]
+                        .compactMap { $0 },
+                    snapshotYolo: nil
+                )
             }
             return true
         } catch {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2532,9 +2532,10 @@ final class AppState: ObservableObject {
                 )
             }
             let bufferedYoloAuthority = reconcileExplicitYolo ? result.snapshot.yolo : nil
-            let bufferedApprovalsModeAuthority = reconcileExplicitYolo
-                ? result.snapshot.approvalsMode
-                : nil
+            // The approval mode is profile-scoped and independent of the
+            // per-session YOLO write gate: a user toggle during the resume must
+            // not let a stale buffered event re-impose an outdated floor.
+            let bufferedApprovalsModeAuthority = result.snapshot.approvalsMode
             bufferedEvents.forEach { event in
                 applyStreamEvent(
                     event,
@@ -5732,6 +5733,9 @@ final class AppState: ObservableObject {
         }
 
         let previousProfile = activeProfile
+        let previousApprovalsMode = runtime.approvalsMode
+        let previousYolo = runtime.yolo
+        let previousLastReportedSessionYolo = lastReportedSessionYolo
         let previousSessions = sessions
         let previousCronSessions = cronSessions
         let previousArchivedSessions = archivedSessions
@@ -5812,6 +5816,12 @@ final class AppState: ObservableObject {
             errorMessage = "Could not switch workspace: \(error.localizedDescription)"
             clearPendingDecisionRestorationGuard()
             activeProfile = previousProfile
+            // The pre-switch reset neutralized the approval state; restore it
+            // with the rest of the previous profile or a failed switch loses
+            // the floor while the previous profile is still the active one.
+            runtime.approvalsMode = previousApprovalsMode
+            runtime.yolo = previousYolo
+            lastReportedSessionYolo = previousLastReportedSessionYolo
             sessions = previousSessions
             cronSessions = previousCronSessions
             archivedSessions = previousArchivedSessions
@@ -6440,7 +6450,7 @@ final class AppState: ObservableObject {
                 method: "PUT",
                 body: ["config": config, "profile": profile]
             )
-            if key == "approvals.mode", let mode = value.textValue?.lowercased() {
+            if key == "approvals.mode", let mode = value.textValue?.lowercased(), profile == activeProfile {
                 // Mirror the saved profile mode immediately and re-resolve the
                 // effective indicator state through the same precedence
                 // applyRuntime uses, so the floor and the picker lock take

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -653,6 +653,15 @@ final class AppState: ObservableObject {
     private let sessionYoloStore: SessionYoloStore
     private var sessionYoloWriteRevision: UInt64 = 0
     private var sessionYoloWriteRevisions: [ChatScrollSessionKey: UInt64] = [:]
+    /// Sessions whose user-initiated YOLO write is awaiting its RPC. The
+    /// override store is only updated after the gateway accepts, so readers
+    /// (notably the resume re-assert) must not treat the store as current
+    /// while a write is in flight.
+    private var inFlightSessionYoloWrites: Set<ChatScrollSessionKey> = []
+    /// The last session-level `yolo` the gateway itself reported, distinct
+    /// from `runtime.yolo`, which also folds in the profile floor and the
+    /// stored override.
+    private var lastReportedSessionYolo: Bool?
 
     /// The dashboard's persisted transcript is richer than `session.resume`:
     /// it retains database timestamps, complete tool-call inputs, and other
@@ -2538,14 +2547,18 @@ final class AppState: ObservableObject {
                 automaticWorkToken: automaticWorkToken,
                 automaticSyncOperationID: automaticSyncOperationID
             )
-            if settled {
+            if settled, reconcileExplicitYolo {
                 // Re-assert only after the ownership guard above (token,
                 // profile, client) re-validated this reconciliation and after
                 // the synchronous settle, so a profile or client switch during
                 // the suspending context refresh above cannot push a stale
                 // write through the old client for the old profile's session.
-                // The mid-RPC race is accepted: the value was chosen under
-                // verified ownership, and the next resume reconciles.
+                // A user YOLO write that completed since the resume began
+                // already pushed the server, so skip instead of duplicating
+                // it; one still in flight is skipped inside
+                // reassertSessionYolo. The mid-RPC race is accepted: the value
+                // was chosen under verified ownership, and the next resume
+                // reconciles.
                 await reassertSessionYolo(
                     for: result.sessionId,
                     snapshot: result.snapshot,
@@ -2661,6 +2674,21 @@ final class AppState: ObservableObject {
             receivedReasoningForCurrentTurn = false
             turnState = .idle
             errorMessage = nil
+            // A fresh conversation has no per-session override and no
+            // server-reported flag yet; re-resolve from the profile mode
+            // (still valid — it is profile-scoped) so the new chat does not
+            // inherit the previous session's effective indicator until the
+            // first snapshot arrives.
+            lastReportedSessionYolo = nil
+            if runtime.approvalsMode != nil {
+                applyEffectiveYolo(
+                    sessionIDsForOverride: [runtimeSessionID],
+                    snapshotYolo: nil,
+                    snapshotReportedApprovalsMode: runtime.approvalsMode
+                )
+            } else {
+                runtime.yolo = false
+            }
 
             let storedID = created.storedSessionId ?? runtimeSessionID
             let summary = SessionSummary(
@@ -3238,6 +3266,20 @@ final class AppState: ObservableObject {
         }
     }
 
+    private func beginSessionYoloWrite(for sessionIDs: [String]) {
+        inFlightSessionYoloWrites.formUnion(sessionYoloKeys(for: sessionIDs))
+    }
+
+    private func endSessionYoloWrite(for sessionIDs: [String]) {
+        for key in sessionYoloKeys(for: sessionIDs) {
+            inFlightSessionYoloWrites.remove(key)
+        }
+    }
+
+    private func hasInFlightSessionYoloWrite(sessionIDs: [String]) -> Bool {
+        !sessionYoloKeys(for: sessionIDs).isDisjoint(with: inFlightSessionYoloWrites)
+    }
+
     private func applyRuntime(
         _ snapshot: SessionRuntimeSnapshot,
         for sessionID: String? = nil,
@@ -3257,6 +3299,9 @@ final class AppState: ObservableObject {
         if let fast = snapshot.fast { runtime.fast = fast }
         if let approvalsMode = authoritativeApprovalsMode ?? snapshot.approvalsMode {
             runtime.approvalsMode = approvalsMode
+        }
+        if let reportedYolo = authoritativeYolo ?? snapshot.yolo {
+            lastReportedSessionYolo = reportedYolo
         }
         let requestedSessionID = sessionID ?? activeSessionId
         let resolvedCanonicalSessionID = canonicalSessionID(for: requestedSessionID)
@@ -4578,6 +4623,9 @@ final class AppState: ObservableObject {
             return true
         }
         guard let client, let sessionId = activeSessionId else { return false }
+        let persistedSessionID = canonicalSessionID(for: sessionId) ?? sessionId
+        beginSessionYoloWrite(for: [sessionId, persistedSessionID])
+        defer { endSessionYoloWrite(for: [sessionId, persistedSessionID]) }
         do {
             if let setSessionYolo = chatResumeLifecycleOperations.setSessionYolo {
                 try await setSessionYolo(client, sessionId, enabled)
@@ -4587,13 +4635,13 @@ final class AppState: ObservableObject {
             // Hermes accepted the setting. Avoid publishing it into a new
             // session if the composer origin was handed off while awaiting.
             guard isCurrentComposerSubmission(submissionContext) else { return true }
-            let persistedSessionID = canonicalSessionID(for: sessionId) ?? sessionId
             sessionYoloStore.setOverride(
                 enabled,
                 for: activeProfile,
                 sessionID: persistedSessionID
             )
             recordSessionYoloWrite(for: [sessionId, persistedSessionID])
+            lastReportedSessionYolo = enabled
             runtime.yolo = enabled
             return true
         } catch {
@@ -4626,6 +4674,11 @@ final class AppState: ObservableObject {
         // snapshot omits approvals_mode.
         guard runtime.approvalsMode?.lowercased() != "off" else { return }
         let persistedSessionID = canonicalSessionID(for: sessionId) ?? sessionId
+        // A user write awaiting its RPC has not reached the store yet;
+        // re-asserting now could read the pre-toggle override and land after
+        // the user's write, leaving the server on the stale value. Skip — the
+        // user's write settles the server and the next resume reconciles.
+        guard !hasInFlightSessionYoloWrite(sessionIDs: [persistedSessionID, sessionId]) else { return }
         guard let override = sessionYoloStore.storedOverride(
             for: activeProfile,
             sessionIDs: [persistedSessionID, sessionId]
@@ -5694,6 +5747,7 @@ final class AppState: ObservableObject {
         // (approvals required) until the new profile resolves it.
         runtime.approvalsMode = nil
         runtime.yolo = false
+        lastReportedSessionYolo = nil
 
         do {
             let ticket = try await mintChatResumeTicket(for: savedConnection)
@@ -6391,15 +6445,16 @@ final class AppState: ObservableObject {
                 // effective indicator state through the same precedence
                 // applyRuntime uses, so the floor and the picker lock take
                 // effect without waiting for the next session snapshot. The
-                // session-level value is carried through unchanged: only the
-                // floor/override precedence re-runs.
+                // last server-reported session value carries through when
+                // known (runtime.yolo may be the floor-forced value, not the
+                // session flag); only the floor/override precedence re-runs.
                 runtime.approvalsMode = mode
                 let requestedSessionID = activeSessionId
                 let resolvedCanonicalSessionID = canonicalSessionID(for: requestedSessionID)
                 applyEffectiveYolo(
                     sessionIDsForOverride: [resolvedCanonicalSessionID, requestedSessionID]
                         .compactMap { $0 },
-                    snapshotYolo: runtime.yolo,
+                    snapshotYolo: lastReportedSessionYolo ?? runtime.yolo,
                     snapshotReportedApprovalsMode: nil
                 )
             }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -15,6 +15,7 @@ import WebKit
 
 private let sessionCatalogLog = Logger(subsystem: "com.milim.conduit", category: "SessionCatalog")
 private let titleGenerationLog = Logger(subsystem: "com.milim.conduit", category: "TitleGeneration")
+private let sessionYoloLog = Logger(subsystem: "com.milim.conduit", category: "SessionYolo")
 
 typealias ChatResumeReconnectCancellation = @MainActor () -> Void
 typealias ChatResumeReconnectExecutor = @MainActor (ChatResumeSyncPurpose) async -> Void
@@ -2434,14 +2435,17 @@ final class AppState: ObservableObject {
             guard applyChatResume(
                 presentationResult,
                 automaticWorkToken: automaticWorkToken,
-                automaticSyncOperationID: automaticSyncOperationID,
-                yoloWriteBaseline: yoloWriteBaseline,
-                reconcileExplicitYolo: reconcileExplicitYolo
+                automaticSyncOperationID: automaticSyncOperationID
             ) else {
                 settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
                 return false
             }
             await refreshChatResumeContext(sessionId: result.sessionId, using: client)
+            await reassertSessionYolo(
+                for: result.sessionId,
+                snapshot: result.snapshot,
+                using: client
+            )
 
             guard automaticChatResumeWorkIsCurrent(
                     automaticWorkToken,
@@ -2712,22 +2716,6 @@ final class AppState: ObservableObject {
         automaticWorkToken: ChatResumeAutomaticWorkToken? = nil,
         automaticSyncOperationID: UUID? = nil
     ) -> Bool {
-        applyChatResume(
-            result,
-            automaticWorkToken: automaticWorkToken,
-            automaticSyncOperationID: automaticSyncOperationID,
-            yoloWriteBaseline: nil
-        )
-    }
-
-    @discardableResult
-    private func applyChatResume(
-        _ result: SessionResumeResult,
-        automaticWorkToken: ChatResumeAutomaticWorkToken? = nil,
-        automaticSyncOperationID: UUID? = nil,
-        yoloWriteBaseline: SessionYoloWriteBaseline?,
-        reconcileExplicitYolo: Bool? = nil
-    ) -> Bool {
         guard automaticChatResumeWorkIsCurrent(
             automaticWorkToken,
             syncOperationID: automaticSyncOperationID
@@ -2839,13 +2827,7 @@ final class AppState: ObservableObject {
         receivedReasoningForCurrentTurn = false
         applyRuntime(
             result.snapshot,
-            for: result.sessionId,
-            reconcileExplicitYolo: reconcileExplicitYolo ?? yoloWriteBaseline.map {
-                !hasNewerSessionYoloWrite(
-                    since: $0,
-                    sessionIDs: [result.sessionId, reconciliation?.requestedSessionId].compactMap { $0 }
-                )
-            } ?? true
+            for: result.sessionId
         )
 
         // An omitted running state is ambiguous while a decision or live
@@ -3242,7 +3224,6 @@ final class AppState: ObservableObject {
     private func applyRuntime(
         _ snapshot: SessionRuntimeSnapshot,
         for sessionID: String? = nil,
-        reconcileExplicitYolo: Bool = false,
         authoritativeYolo: Bool? = nil
     ) {
         if let model = snapshot.model { runtime.model = model }
@@ -3256,6 +3237,9 @@ final class AppState: ObservableObject {
             runtime.reasoningEffort = reasoningEffort.lowercased() == "none" ? "" : reasoningEffort
         }
         if let fast = snapshot.fast { runtime.fast = fast }
+        if let approvalsMode = snapshot.approvalsMode {
+            runtime.approvalsMode = approvalsMode
+        }
         let requestedSessionID = sessionID ?? activeSessionId
         let resolvedCanonicalSessionID = canonicalSessionID(for: requestedSessionID)
         let sessionIDsForOverride = [resolvedCanonicalSessionID, requestedSessionID]
@@ -3273,27 +3257,21 @@ final class AppState: ObservableObject {
             for: activeProfile,
             sessionIDs: sessionIDsForOverride
         )
-        if let yolo = authoritativeYolo ?? snapshot.yolo {
-            if let storedOverride {
-                if reconcileExplicitYolo, storedOverride != yolo {
-                    sessionYoloStore.clearOverride(
-                        for: activeProfile,
-                        sessionIDs: sessionIDsForOverride
-                    )
-                    runtime.yolo = yolo
-                } else {
-                    // Live session.info pushes can be older than a client
-                    // initiated config.set RPC. Keep the local choice until a
-                    // fresh resume snapshot can reconcile server authority.
-                    runtime.yolo = storedOverride
-                }
-            } else {
-                runtime.yolo = yolo
-            }
+        let globalYoloFloor = runtime.approvalsMode?.lowercased() == "off"
+        if globalYoloFloor {
+            // Hermes auto-approves globally when approvals.mode == "off"; a
+            // per-session toggle cannot require approvals. Reflect the server's
+            // effective state so the indicator does not claim otherwise.
+            runtime.yolo = true
         } else if let storedOverride {
+            // The per-session choice is authoritative. The gateway holds the
+            // flag in memory only and forgets it on restart, so AppState
+            // re-asserts it after resume (see reassertSessionYolo).
             runtime.yolo = storedOverride
-        } else if let approvalsMode = snapshot.approvalsMode {
-            runtime.yolo = approvalsMode.lowercased() == "off"
+        } else if let yolo = authoritativeYolo ?? snapshot.yolo {
+            runtime.yolo = yolo
+        } else {
+            runtime.yolo = false
         }
     }
 
@@ -4574,6 +4552,43 @@ final class AppState: ObservableObject {
             guard isCurrentComposerSubmission(submissionContext) else { return false }
             errorMessage = "Unable to change YOLO mode: \(error.localizedDescription)"
             return false
+        }
+    }
+
+    /// Re-assert a persisted per-session YOLO override after a resume.
+    ///
+    /// The Hermes gateway keeps the per-session YOLO flag in memory only and
+    /// never persists it (unlike the CLI), so a gateway restart or rebuilt
+    /// agent forgets the flag and reverts to the profile default. Re-sending
+    /// `config.set` restores the user's explicit choice so the server keeps
+    /// honoring it. No-op when the profile approval mode is already "off" (the
+    /// flag is then moot), when there is no stored override, or when the
+    /// server's reported value already matches the override. Failure is
+    /// non-fatal: the local override still governs the indicator and the next
+    /// resume retries.
+    private func reassertSessionYolo(
+        for sessionId: String,
+        snapshot: SessionRuntimeSnapshot,
+        using client: HermesClient
+    ) async {
+        guard snapshot.approvalsMode?.lowercased() != "off" else { return }
+        let persistedSessionID = canonicalSessionID(for: sessionId) ?? sessionId
+        guard let override = sessionYoloStore.storedOverride(
+            for: activeProfile,
+            sessionIDs: [persistedSessionID, sessionId]
+        ) else { return }
+        guard snapshot.yolo.map({ $0 != override }) ?? true else { return }
+        do {
+            if let setSessionYolo = chatResumeLifecycleOperations.setSessionYolo {
+                try await setSessionYolo(client, sessionId, override)
+            } else {
+                try await client.setSessionYolo(sessionId, enabled: override)
+            }
+            recordSessionYoloWrite(for: [sessionId, persistedSessionID])
+        } catch {
+            sessionYoloLog.error(
+                "Failed to re-assert session YOLO override \(override, privacy: .public) for \(sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
         }
     }
 

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2523,8 +2523,15 @@ final class AppState: ObservableObject {
                 )
             }
             let bufferedYoloAuthority = reconcileExplicitYolo ? result.snapshot.yolo : nil
+            let bufferedApprovalsModeAuthority = reconcileExplicitYolo
+                ? result.snapshot.approvalsMode
+                : nil
             bufferedEvents.forEach { event in
-                applyStreamEvent(event, authoritativeYolo: bufferedYoloAuthority)
+                applyStreamEvent(
+                    event,
+                    authoritativeYolo: bufferedYoloAuthority,
+                    authoritativeApprovalsMode: bufferedApprovalsModeAuthority
+                )
             }
             let settled = settleReconciliationAndPublish(
                 token,
@@ -3234,7 +3241,8 @@ final class AppState: ObservableObject {
     private func applyRuntime(
         _ snapshot: SessionRuntimeSnapshot,
         for sessionID: String? = nil,
-        authoritativeYolo: Bool? = nil
+        authoritativeYolo: Bool? = nil,
+        authoritativeApprovalsMode: String? = nil
     ) {
         if let model = snapshot.model { runtime.model = model }
         if let provider = snapshot.provider { runtime.provider = provider }
@@ -3247,7 +3255,7 @@ final class AppState: ObservableObject {
             runtime.reasoningEffort = reasoningEffort.lowercased() == "none" ? "" : reasoningEffort
         }
         if let fast = snapshot.fast { runtime.fast = fast }
-        if let approvalsMode = snapshot.approvalsMode {
+        if let approvalsMode = authoritativeApprovalsMode ?? snapshot.approvalsMode {
             runtime.approvalsMode = approvalsMode
         }
         let requestedSessionID = sessionID ?? activeSessionId
@@ -3265,7 +3273,8 @@ final class AppState: ObservableObject {
         }
         applyEffectiveYolo(
             sessionIDsForOverride: sessionIDsForOverride,
-            snapshotYolo: authoritativeYolo ?? snapshot.yolo
+            snapshotYolo: authoritativeYolo ?? snapshot.yolo,
+            snapshotReportedApprovalsMode: authoritativeApprovalsMode ?? snapshot.approvalsMode
         )
     }
 
@@ -3276,7 +3285,8 @@ final class AppState: ObservableObject {
     /// with the saved mode.
     private func applyEffectiveYolo(
         sessionIDsForOverride: [String],
-        snapshotYolo: Bool?
+        snapshotYolo: Bool?,
+        snapshotReportedApprovalsMode: String?
     ) {
         let storedOverride = sessionYoloStore.storedOverride(
             for: activeProfile,
@@ -3295,14 +3305,14 @@ final class AppState: ObservableObject {
             runtime.yolo = storedOverride
         } else if let yolo = snapshotYolo {
             runtime.yolo = yolo
-        } else if runtime.approvalsMode != nil {
-            // A known non-off profile mode with no session-level signal means
-            // approvals apply.
+        } else if let mode = snapshotReportedApprovalsMode, mode.lowercased() != "off" {
+            // Only the snapshot's own non-off mode report resolves to "approvals
+            // apply" — a last-known mode with the signal omitted entirely is
+            // unknown, not a disagreement, and must not flicker the indicator.
             runtime.yolo = false
         }
-        // No approval signal has ever been observed: keep the last-known
-        // indicator value rather than flickering to "off" on partial
-        // projections that omit the approval fields.
+        // Otherwise keep the last-known indicator value; a partial projection
+        // omitting the approval fields must not flicker it.
     }
 
     /// The context breakdown RPC is the gateway's complete accounting source.
@@ -4600,10 +4610,11 @@ final class AppState: ObservableObject {
     /// agent forgets the flag and reverts to the profile default. Re-sending
     /// `config.set` restores the user's explicit choice so the server keeps
     /// honoring it. No-op when the profile approval mode is already "off" (the
-    /// flag is then moot), when there is no stored override, or when the
-    /// server's reported value already matches the override. Failure is
-    /// non-fatal: the local override still governs the indicator and the next
-    /// resume retries.
+    /// flag is then moot), when there is no stored override, when the snapshot
+    /// does not report a session-level yolo (unknown is not a disagreement),
+    /// or when the server's reported value already matches the override.
+    /// Failure is non-fatal: the local override still governs the indicator
+    /// and the next resume retries.
     private func reassertSessionYolo(
         for sessionId: String,
         snapshot: SessionRuntimeSnapshot,
@@ -4619,7 +4630,11 @@ final class AppState: ObservableObject {
             for: activeProfile,
             sessionIDs: [persistedSessionID, sessionId]
         ) else { return }
-        guard snapshot.yolo.map({ $0 != override }) ?? true else { return }
+        // A snapshot that omits the session-level yolo is unknown, not a
+        // disagreement; re-asserting on every resume for gateways that omit the
+        // field would be pure churn. The gateway's session.info projection
+        // reports yolo as a boolean, so a real conflict is always visible.
+        guard let reportedYolo = snapshot.yolo, reportedYolo != override else { return }
         do {
             if let setSessionYolo = chatResumeLifecycleOperations.setSessionYolo {
                 try await setSessionYolo(client, sessionId, override)
@@ -5675,8 +5690,10 @@ final class AppState: ObservableObject {
         turnState = .synchronizing
         // The next profile's approval mode is unknown until its first session
         // snapshot arrives; don't let the previous profile's floor leak across
-        // the switch.
+        // the switch, and neutralize the indicator to the safe display
+        // (approvals required) until the new profile resolves it.
         runtime.approvalsMode = nil
+        runtime.yolo = false
 
         do {
             let ticket = try await mintChatResumeTicket(for: savedConnection)
@@ -6373,14 +6390,17 @@ final class AppState: ObservableObject {
                 // Mirror the saved profile mode immediately and re-resolve the
                 // effective indicator state through the same precedence
                 // applyRuntime uses, so the floor and the picker lock take
-                // effect without waiting for the next session snapshot.
+                // effect without waiting for the next session snapshot. The
+                // session-level value is carried through unchanged: only the
+                // floor/override precedence re-runs.
                 runtime.approvalsMode = mode
                 let requestedSessionID = activeSessionId
                 let resolvedCanonicalSessionID = canonicalSessionID(for: requestedSessionID)
                 applyEffectiveYolo(
                     sessionIDsForOverride: [resolvedCanonicalSessionID, requestedSessionID]
                         .compactMap { $0 },
-                    snapshotYolo: nil
+                    snapshotYolo: runtime.yolo,
+                    snapshotReportedApprovalsMode: nil
                 )
             }
             return true
@@ -6752,7 +6772,11 @@ final class AppState: ObservableObject {
         return reconciliation.acceptedSessionIDs.contains(sessionId)
     }
 
-    private func applyStreamEvent(_ event: StreamEvent, authoritativeYolo: Bool? = nil) {
+    private func applyStreamEvent(
+        _ event: StreamEvent,
+        authoritativeYolo: Bool? = nil,
+        authoritativeApprovalsMode: String? = nil
+    ) {
         let streamSessionId = sessionID(for: event)
         guard eventBelongsToActiveSession(streamSessionId) else { return }
         defer { schedulePresentationCacheFlush(for: streamSessionId) }
@@ -6814,7 +6838,12 @@ final class AppState: ObservableObject {
             }
 
         case .sessionInfo(let sessionID, let snapshot):
-            applyRuntime(snapshot, for: sessionID, authoritativeYolo: authoritativeYolo)
+            applyRuntime(
+                snapshot,
+                for: sessionID,
+                authoritativeYolo: authoritativeYolo,
+                authoritativeApprovalsMode: authoritativeApprovalsMode
+            )
             if let running = snapshot.running {
                 setRunning(running)
             }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2441,11 +2441,6 @@ final class AppState: ObservableObject {
                 return false
             }
             await refreshChatResumeContext(sessionId: result.sessionId, using: client)
-            await reassertSessionYolo(
-                for: result.sessionId,
-                snapshot: result.snapshot,
-                using: client
-            )
 
             guard automaticChatResumeWorkIsCurrent(
                     automaticWorkToken,
@@ -2531,11 +2526,26 @@ final class AppState: ObservableObject {
             bufferedEvents.forEach { event in
                 applyStreamEvent(event, authoritativeYolo: bufferedYoloAuthority)
             }
-            return settleReconciliationAndPublish(
+            let settled = settleReconciliationAndPublish(
                 token,
                 automaticWorkToken: automaticWorkToken,
                 automaticSyncOperationID: automaticSyncOperationID
             )
+            if settled {
+                // Re-assert only after the ownership guard above (token,
+                // profile, client) re-validated this reconciliation and after
+                // the synchronous settle, so a profile or client switch during
+                // the suspending context refresh above cannot push a stale
+                // write through the old client for the old profile's session.
+                // The mid-RPC race is accepted: the value was chosen under
+                // verified ownership, and the next resume reconciles.
+                await reassertSessionYolo(
+                    for: result.sessionId,
+                    snapshot: result.snapshot,
+                    using: client
+                )
+            }
+            return settled
 
         } catch {
             guard automaticChatResumeWorkIsCurrent(

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -561,7 +561,7 @@ struct SettingsView: View {
     private static let workspaceFields: [ProfileSettingField] = [
         .init(key: "terminal.cwd", label: "Default working directory", help: "Server-side path for new workspaces.", control: .text(defaultValue: "")),
         .init(key: "code_execution.mode", label: "Code execution mode", help: "Default execution boundary.", control: .options(["project", "strict"], defaultValue: "project")),
-        .init(key: "approvals.mode", label: "Approval mode", help: "Profile-wide default: manual asks every time; smart asks when risk warrants it; off is YOLO mode. A chat can enable YOLO without changing this profile setting.", control: .options(["manual", "smart", "off"], defaultValue: "smart")),
+        .init(key: "approvals.mode", label: "Approval mode", help: "Profile-wide default: manual asks every time; smart asks when risk warrants it; off is YOLO mode. When set to off, Hermes auto-approves everything and per-session YOLO toggles have no effect — that's a Hermes limitation, not a Conduit bug. To use per-session YOLO, set this to manual or smart.", control: .options(["manual", "smart", "off"], defaultValue: "smart")),
         .init(key: "security.redact_secrets", label: "Redact secrets", help: "Hide detected credentials from tool output where possible.", control: .toggle(defaultValue: true)),
         .init(key: "security.allow_private_urls", label: "Allow private URLs", help: "Permit tool access to private-network URLs.", control: .toggle(defaultValue: false)),
     ]

--- a/Conduit/Views/ModelPickerView.swift
+++ b/Conduit/Views/ModelPickerView.swift
@@ -238,15 +238,23 @@ struct ModelPickerView: View {
         ModelPickerSection(title: "Run settings", symbol: "slider.horizontal.3", tint: .conduitAccent) {
             Toggle("Fast mode", isOn: $fastEnabled)
             if globalYoloFloor {
-                Toggle("YOLO mode", isOn: $yoloEnabled)
-                    .disabled(true)
-                    .accessibilityHint("Locked on because the profile approval mode is off. Change it in Workspace & safety.")
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("YOLO mode", isOn: $yoloEnabled)
+                        .disabled(true)
+                    Text(yoloHelpText)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                // VoiceOver can skim past disabled controls and their separate
+                // footnotes; merge the locked toggle with its rationale so the
+                // reason is always read with the control.
+                .accessibilityElement(children: .combine)
             } else {
                 Toggle("YOLO mode", isOn: $yoloEnabled)
+                Text(yoloHelpText)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
             }
-            Text(yoloHelpText)
-                .font(.footnote)
-                .foregroundStyle(.secondary)
         }
     }
 

--- a/Conduit/Views/ModelPickerView.swift
+++ b/Conduit/Views/ModelPickerView.swift
@@ -87,14 +87,9 @@ struct ModelPickerView: View {
             }
         }
         .preferredColorScheme(appState.themePreference.colorScheme)
-        .onAppear {
-            if let draft = ModelPickerYoloDraft.seededIfNeeded(
-                initial: initialYoloEnabled,
-                runtimeYolo: appState.runtime.yolo
-            ) {
-                yoloEnabled = draft.selected
-                initialYoloEnabled = draft.initial
-            }
+        .onAppear { refreshYoloToggle(force: false) }
+        .onChange(of: appState.runtime.approvalsMode) { _, _ in
+            refreshYoloToggle(force: true)
         }
         .task { await loadModels() }
     }
@@ -232,10 +227,25 @@ struct ModelPickerView: View {
         ModelPickerSection(title: "Run settings", symbol: "slider.horizontal.3", tint: .conduitAccent) {
             Toggle("Fast mode", isOn: $fastEnabled)
             Toggle("YOLO mode", isOn: $yoloEnabled)
-            Text("YOLO automatically approves tool actions for this conversation only. Set the profile default in Workspace & safety.")
+                .disabled(globalYoloFloor)
+            Text(yoloHelpText)
                 .font(.footnote)
                 .foregroundStyle(.secondary)
         }
+    }
+
+    /// Hermes auto-approves globally when the profile approval mode is "off", so
+    /// a per-session YOLO toggle cannot require approvals. Lock the toggle on
+    /// and explain why rather than offering a control that silently does nothing.
+    private var globalYoloFloor: Bool {
+        appState.runtime.approvalsMode?.lowercased() == "off"
+    }
+
+    private var yoloHelpText: String {
+        if globalYoloFloor {
+            return "Profile approval mode is off, so Hermes auto-approves this conversation regardless. This toggle is locked on until you change the profile mode in Workspace & safety."
+        }
+        return "YOLO automatically approves tool actions for this conversation only. Set the profile default in Workspace & safety."
     }
 
     private var visibleProviders: [ProviderInfo] {
@@ -413,13 +423,33 @@ struct ModelPickerView: View {
                 reasoningEffort = appState.runtime.reasoningEffort
             }
             fastEnabled = appState.runtime.fast
-            if initialYoloEnabled == nil {
-                let draft = ModelPickerYoloDraft(runtimeYolo: appState.runtime.yolo)
-                yoloEnabled = draft.selected
-                initialYoloEnabled = draft.initial
-            }
+            refreshYoloToggle(force: false)
         } catch {
             // Model options are supplementary to the current session state.
+        }
+    }
+
+    /// Seed the YOLO toggle from the effective runtime value. While the global
+    /// approval floor is active the toggle is pinned on (and marked unchanged so
+    /// `applyModel` sends no spurious write). Otherwise it follows the runtime
+    /// value, respecting an in-progress draft unless `force` re-seeds after a
+    /// global approval-mode change.
+    private func refreshYoloToggle(force: Bool) {
+        if globalYoloFloor {
+            yoloEnabled = true
+            initialYoloEnabled = true
+            return
+        }
+        if force {
+            let draft = ModelPickerYoloDraft(runtimeYolo: appState.runtime.yolo)
+            yoloEnabled = draft.selected
+            initialYoloEnabled = draft.initial
+        } else if let draft = ModelPickerYoloDraft.seededIfNeeded(
+            initial: initialYoloEnabled,
+            runtimeYolo: appState.runtime.yolo
+        ) {
+            yoloEnabled = draft.selected
+            initialYoloEnabled = draft.initial
         }
     }
 

--- a/Conduit/Views/ModelPickerView.swift
+++ b/Conduit/Views/ModelPickerView.swift
@@ -12,6 +12,13 @@ func sessionYoloSelectionChanged(from initial: Bool?, to selected: Bool) -> Bool
     return initial != selected
 }
 
+/// Whether an approval-mode change crosses the global "off" floor boundary.
+/// Only such transitions affect the YOLO toggle; e.g. manual ↔ smart must not
+/// discard an in-progress draft.
+func yoloFloorBoundaryCrossed(from previousMode: String?, to newMode: String?) -> Bool {
+    (previousMode?.lowercased() == "off") != (newMode?.lowercased() == "off")
+}
+
 struct ModelPickerYoloDraft: Equatable {
     let initial: Bool
     let selected: Bool
@@ -88,7 +95,11 @@ struct ModelPickerView: View {
         }
         .preferredColorScheme(appState.themePreference.colorScheme)
         .onAppear { refreshYoloToggle(force: false) }
-        .onChange(of: appState.runtime.approvalsMode) { _, _ in
+        .onChange(of: appState.runtime.approvalsMode) { oldMode, newMode in
+            // Only transitions into/out of the global floor affect the toggle;
+            // other mode changes (manual ↔ smart) must not discard an
+            // in-progress draft.
+            guard yoloFloorBoundaryCrossed(from: oldMode, to: newMode) else { return }
             refreshYoloToggle(force: true)
         }
         .task { await loadModels() }
@@ -226,8 +237,13 @@ struct ModelPickerView: View {
     private var runSettingsSection: some View {
         ModelPickerSection(title: "Run settings", symbol: "slider.horizontal.3", tint: .conduitAccent) {
             Toggle("Fast mode", isOn: $fastEnabled)
-            Toggle("YOLO mode", isOn: $yoloEnabled)
-                .disabled(globalYoloFloor)
+            if globalYoloFloor {
+                Toggle("YOLO mode", isOn: $yoloEnabled)
+                    .disabled(true)
+                    .accessibilityHint("Locked on because the profile approval mode is off. Change it in Workspace & safety.")
+            } else {
+                Toggle("YOLO mode", isOn: $yoloEnabled)
+            }
             Text(yoloHelpText)
                 .font(.footnote)
                 .foregroundStyle(.secondary)

--- a/ConduitTests/ModelPickerTests.swift
+++ b/ConduitTests/ModelPickerTests.swift
@@ -33,4 +33,18 @@ final class ModelPickerTests: XCTestCase {
     func testSelectionBeforeInitialLoadDoesNotPersistAnOverride() {
         XCTAssertFalse(sessionYoloSelectionChanged(from: nil, to: true))
     }
+
+    func testFloorBoundaryOnlyCrossesBetweenOffAndNonOff() {
+        // Boundary crossings re-seed the toggle.
+        XCTAssertTrue(yoloFloorBoundaryCrossed(from: nil, to: "off"))
+        XCTAssertTrue(yoloFloorBoundaryCrossed(from: "manual", to: "off"))
+        XCTAssertTrue(yoloFloorBoundaryCrossed(from: "off", to: "manual"))
+        XCTAssertTrue(yoloFloorBoundaryCrossed(from: "off", to: nil))
+        // Same-side transitions must not discard an in-progress draft.
+        XCTAssertFalse(yoloFloorBoundaryCrossed(from: nil, to: "manual"))
+        XCTAssertFalse(yoloFloorBoundaryCrossed(from: "manual", to: "smart"))
+        XCTAssertFalse(yoloFloorBoundaryCrossed(from: "smart", to: "manual"))
+        XCTAssertFalse(yoloFloorBoundaryCrossed(from: "off", to: "off"))
+        XCTAssertFalse(yoloFloorBoundaryCrossed(from: nil, to: nil))
+    }
 }

--- a/ConduitTests/ModelPickerTests.swift
+++ b/ConduitTests/ModelPickerTests.swift
@@ -38,6 +38,8 @@ final class ModelPickerTests: XCTestCase {
         // Boundary crossings re-seed the toggle.
         XCTAssertTrue(yoloFloorBoundaryCrossed(from: nil, to: "off"))
         XCTAssertTrue(yoloFloorBoundaryCrossed(from: "manual", to: "off"))
+        XCTAssertTrue(yoloFloorBoundaryCrossed(from: "manual", to: "OFF"))
+        XCTAssertTrue(yoloFloorBoundaryCrossed(from: "Off", to: "manual"))
         XCTAssertTrue(yoloFloorBoundaryCrossed(from: "off", to: "manual"))
         XCTAssertTrue(yoloFloorBoundaryCrossed(from: "off", to: nil))
         // Same-side transitions must not discard an in-progress draft.

--- a/ConduitTests/SessionYoloPersistenceTests.swift
+++ b/ConduitTests/SessionYoloPersistenceTests.swift
@@ -949,6 +949,133 @@ final class SessionYoloPersistenceTests: XCTestCase {
         XCTAssertFalse(appState.runtime.yolo)
     }
 
+    // A user YOLO write that completed while the resume RPC was in flight
+    // already pushed the server; the recovery re-assert must not fire on top
+    // of it.
+    func testResumeSkipsReassertWhenUserToggledDuringResume() async {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let openGate = SessionYoloResumeGate()
+        let recorder = YoloSetCallRecorder()
+        let operations = ChatResumeLifecycleOperations(
+            loadCatalog: { _, _ in [self.session("session-a")] },
+            openSession: { _, sessionID in
+                await openGate.suspend()
+                return SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: [
+                        "running": .bool(false),
+                        "yolo": .bool(false),
+                        "approvals_mode": .string("manual")
+                    ])
+                )
+            },
+            refreshContext: { _, _ in },
+            setSessionYolo: { _, sessionID, enabled in recorder.record(sessionID, enabled) }
+        )
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        let appState = makeAppState(defaults: defaults, store: store, lifecycleOperations: operations)
+        appState.sessions = [session("session-a")]
+        appState.activeSessionId = "session-a"
+        appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+
+        let resume = Task { @MainActor in
+            await appState.syncSession()
+        }
+        await openGate.waitUntilSuspended()
+
+        // The user toggles YOLO on while the resume is suspended; the write
+        // completes (and bumps the write revision) before the resume returns.
+        let enabled = await appState.setYoloMode(true)
+        XCTAssertTrue(enabled)
+
+        openGate.resume()
+        await resume.value
+
+        // Only the user's write fired; the snapshot's stale false did not
+        // trigger a duplicate re-assert.
+        XCTAssertEqual(recorder.invocations.count, 1)
+        XCTAssertEqual(recorder.invocations.first?.enabled, true)
+        XCTAssertTrue(appState.runtime.yolo)
+        XCTAssertEqual(store.storedOverride(for: "default", sessionID: "session-a"), true)
+    }
+
+    // A user write still awaiting its RPC has not reached the store; the
+    // re-assert must not read the pre-toggle override and race the user's
+    // write with a stale value.
+    func testResumeSkipsReassertWhileUserWriteIsInFlight() async {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let writeGate = SessionYoloResumeGate()
+        let recorder = YoloSetCallRecorder()
+        let operations = ChatResumeLifecycleOperations(
+            loadCatalog: { _, _ in [self.session("session-a")] },
+            openSession: { _, sessionID in
+                SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: [
+                        "running": .bool(false),
+                        "yolo": .bool(false),
+                        "approvals_mode": .string("manual")
+                    ])
+                )
+            },
+            refreshContext: { _, _ in },
+            setSessionYolo: { _, sessionID, enabled in
+                await writeGate.suspend()
+                recorder.record(sessionID, enabled)
+            }
+        )
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        // The pre-toggle override the store still holds while the write is
+        // in flight.
+        store.setOverride(true, for: "default", sessionID: "session-a")
+        let appState = makeAppState(defaults: defaults, store: store, lifecycleOperations: operations)
+        appState.sessions = [session("session-a")]
+        appState.activeSessionId = "session-a"
+        appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: "session-a",
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false),
+                "yolo": .bool(true),
+                "approvals_mode": .string("manual")
+            ])
+        ))
+        XCTAssertTrue(appState.runtime.yolo)
+
+        // Start the user's toggle-off; its RPC suspends inside the stub, so
+        // the store still holds the old true override.
+        let toggle = Task { @MainActor in
+            await appState.setYoloMode(false)
+        }
+        await writeGate.waitUntilSuspended()
+
+        // The resume settles while the user's write is in flight. Its
+        // snapshot disagrees with the OLD override, so only the in-flight
+        // guard can stop the re-assert from racing the user's write with a
+        // stale true.
+        await appState.syncSession()
+        XCTAssertTrue(recorder.invocations.isEmpty)
+
+        writeGate.resume()
+        await toggle.value
+
+        XCTAssertEqual(recorder.invocations.count, 1)
+        XCTAssertEqual(recorder.invocations.first?.enabled, false)
+        XCTAssertEqual(store.storedOverride(for: "default", sessionID: "session-a"), false)
+        XCTAssertFalse(appState.runtime.yolo)
+    }
+
     private func makeAppState(
         defaults: UserDefaults,
         store: SessionYoloStore,

--- a/ConduitTests/SessionYoloPersistenceTests.swift
+++ b/ConduitTests/SessionYoloPersistenceTests.swift
@@ -59,7 +59,11 @@ final class SessionYoloPersistenceTests: XCTestCase {
         XCTAssertNil(store.storedOverride(for: "default", sessionID: "runtime-session"))
     }
 
-    func testExplicitGatewayYoloReplacesConflictingLocalOverride() {
+    // The Hermes gateway holds the per-session YOLO flag in memory only and
+    // forgets it on resume, so a resume snapshot's `yolo` is the reverted
+    // profile default rather than an authoritative value. The local override
+    // must survive a conflicting resume snapshot (AppState re-asserts it).
+    func testExplicitGatewayYoloDoesNotReplaceConflictingLocalOverride() {
         let (suite, defaults) = makeDefaults()
         defer { defaults.removePersistentDomain(forName: suite) }
         let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
@@ -77,11 +81,14 @@ final class SessionYoloPersistenceTests: XCTestCase {
             ])
         ))
 
-        XCTAssertFalse(appState.runtime.yolo)
-        XCTAssertNil(store.storedOverride(for: "default", sessionID: "session-a"))
+        XCTAssertTrue(appState.runtime.yolo)
+        XCTAssertEqual(store.storedOverride(for: "default", sessionID: "session-a"), true)
     }
 
-    func testServerSessionYoloWinsOverProfileApprovalFallbackWhenNoOverrideExists() {
+    // With no per-session override, the snapshot's `yolo` wins while the
+    // profile approval mode is not "off"; once the profile is "off", the global
+    // floor forces auto-approve regardless of the snapshot.
+    func testNoOverrideFallsBackToSnapshotThenGlobalFloor() {
         let (suite, defaults) = makeDefaults()
         defer { defaults.removePersistentDomain(forName: suite) }
         let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
@@ -94,7 +101,7 @@ final class SessionYoloPersistenceTests: XCTestCase {
             snapshot: SessionRuntimeSnapshot(object: [
                 "running": .bool(false),
                 "yolo": .bool(false),
-                "approvals_mode": .string("off")
+                "approvals_mode": .string("manual")
             ])
         ))
 
@@ -265,10 +272,14 @@ final class SessionYoloPersistenceTests: XCTestCase {
         XCTAssertEqual(store.storedOverride(for: "default", sessionID: "session-a"), true)
     }
 
-    func testBufferedStaleSessionInfoCannotReapplyClearedOverride() async {
+    // A buffered live `session.info` that predates a resume must not overwrite
+    // the retained per-session override. The override survives the stale
+    // buffered event, and AppState re-asserts it once the resume settles.
+    func testBufferedSessionInfoDoesNotOverwriteRetainedOverride() async {
         let (suite, defaults) = makeDefaults()
         defer { defaults.removePersistentDomain(forName: suite) }
         let openGate = SessionYoloResumeGate()
+        let recorder = YoloSetCallRecorder()
         let operations = ChatResumeLifecycleOperations(
             loadCatalog: { _, _ in [self.session("session-a")] },
             openSession: { _, sessionID in
@@ -283,7 +294,8 @@ final class SessionYoloPersistenceTests: XCTestCase {
                     ])
                 )
             },
-            refreshContext: { _, _ in }
+            refreshContext: { _, _ in },
+            setSessionYolo: { _, sessionID, enabled in recorder.record(sessionID, enabled) }
         )
         let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
         store.setOverride(true, for: "default", sessionID: "session-a")
@@ -316,8 +328,10 @@ final class SessionYoloPersistenceTests: XCTestCase {
         openGate.resume()
         await resume.value
 
-        XCTAssertFalse(appState.runtime.yolo)
-        XCTAssertNil(store.storedOverride(for: "default", sessionID: "session-a"))
+        XCTAssertTrue(appState.runtime.yolo)
+        XCTAssertEqual(store.storedOverride(for: "default", sessionID: "session-a"), true)
+        XCTAssertEqual(recorder.invocations.count, 1)
+        XCTAssertEqual(recorder.invocations.first?.enabled, true)
     }
 
     func testBufferedConflictingSessionInfoPreservesNonYoloRuntimeFields() async {
@@ -405,6 +419,217 @@ final class SessionYoloPersistenceTests: XCTestCase {
         XCTAssertFalse(appState.runtime.yolo)
     }
 
+    // MARK: - Global approval floor (approvals.mode == "off")
+
+    func testGlobalApprovalOffForcesIndicatorYoloDespiteSessionOverrideOff() {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        store.setOverride(false, for: "default", sessionID: "session-a")
+
+        let appState = makeAppState(defaults: defaults, store: store)
+        appState.sessions = [session("session-a")]
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: "session-a",
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false),
+                "yolo": .bool(true),
+                "approvals_mode": .string("off")
+            ])
+        ))
+
+        // Hermes auto-approves globally under approvals.mode == "off"; the
+        // indicator must reflect that effective state, not the stale override.
+        XCTAssertTrue(appState.runtime.yolo)
+        XCTAssertEqual(appState.runtime.approvalsMode, "off")
+        // The override is retained so it applies again if the profile changes.
+        XCTAssertEqual(store.storedOverride(for: "default", sessionID: "session-a"), false)
+    }
+
+    func testApprovalModeChangeOffThenManualRestoresOverrideEffect() {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        store.setOverride(false, for: "default", sessionID: "session-a")
+
+        let appState = makeAppState(defaults: defaults, store: store)
+        appState.sessions = [session("session-a")]
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: "session-a",
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false),
+                "approvals_mode": .string("off")
+            ])
+        ))
+        XCTAssertTrue(appState.runtime.yolo)
+
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: "session-a",
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false),
+                "approvals_mode": .string("manual")
+            ])
+        ))
+        // Floor gone; the retained per-session override (off) takes effect.
+        XCTAssertFalse(appState.runtime.yolo)
+    }
+
+    // MARK: - Resume re-assertion (gateway forgets the in-memory session flag)
+
+    func testResumeReassertsSessionYoloWhenGatewayForgot() async {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let recorder = YoloSetCallRecorder()
+        let operations = ChatResumeLifecycleOperations(
+            loadCatalog: { _, _ in [self.session("session-a")] },
+            openSession: { _, sessionID in
+                SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: [
+                        "running": .bool(false),
+                        "yolo": .bool(false),
+                        "approvals_mode": .string("manual")
+                    ])
+                )
+            },
+            refreshContext: { _, _ in },
+            setSessionYolo: { _, sessionID, enabled in recorder.record(sessionID, enabled) }
+        )
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        store.setOverride(true, for: "default", sessionID: "session-a")
+        let appState = makeAppState(defaults: defaults, store: store, lifecycleOperations: operations)
+        appState.sessions = [session("session-a")]
+        appState.activeSessionId = "session-a"
+        appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+
+        await appState.syncSession()
+
+        XCTAssertTrue(appState.runtime.yolo)
+        XCTAssertEqual(store.storedOverride(for: "default", sessionID: "session-a"), true)
+        XCTAssertEqual(recorder.invocations.count, 1)
+        XCTAssertEqual(recorder.invocations.first?.enabled, true)
+    }
+
+    func testResumeSkipsReassertWhenServerAlreadyAgrees() async {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let recorder = YoloSetCallRecorder()
+        let operations = ChatResumeLifecycleOperations(
+            loadCatalog: { _, _ in [self.session("session-a")] },
+            openSession: { _, sessionID in
+                SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: [
+                        "running": .bool(false),
+                        "yolo": .bool(true),
+                        "approvals_mode": .string("manual")
+                    ])
+                )
+            },
+            refreshContext: { _, _ in },
+            setSessionYolo: { _, sessionID, enabled in recorder.record(sessionID, enabled) }
+        )
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        store.setOverride(true, for: "default", sessionID: "session-a")
+        let appState = makeAppState(defaults: defaults, store: store, lifecycleOperations: operations)
+        appState.sessions = [session("session-a")]
+        appState.activeSessionId = "session-a"
+        appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+
+        await appState.syncSession()
+
+        XCTAssertTrue(appState.runtime.yolo)
+        XCTAssertEqual(store.storedOverride(for: "default", sessionID: "session-a"), true)
+        // The server already reports the override value; no re-assert needed.
+        XCTAssertTrue(recorder.invocations.isEmpty)
+    }
+
+    func testResumeSkipsReassertUnderGlobalOff() async {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let recorder = YoloSetCallRecorder()
+        let operations = ChatResumeLifecycleOperations(
+            loadCatalog: { _, _ in [self.session("session-a")] },
+            openSession: { _, sessionID in
+                SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: [
+                        "running": .bool(false),
+                        "yolo": .bool(true),
+                        "approvals_mode": .string("off")
+                    ])
+                )
+            },
+            refreshContext: { _, _ in },
+            setSessionYolo: { _, sessionID, enabled in recorder.record(sessionID, enabled) }
+        )
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        store.setOverride(true, for: "default", sessionID: "session-a")
+        let appState = makeAppState(defaults: defaults, store: store, lifecycleOperations: operations)
+        appState.sessions = [session("session-a")]
+        appState.activeSessionId = "session-a"
+        appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+
+        await appState.syncSession()
+
+        // Global floor forces auto-approve; per-session re-assert is moot.
+        XCTAssertTrue(appState.runtime.yolo)
+        XCTAssertEqual(store.storedOverride(for: "default", sessionID: "session-a"), true)
+        XCTAssertTrue(recorder.invocations.isEmpty)
+    }
+
+    func testResumeReassertFailureIsNonFatal() async {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let operations = ChatResumeLifecycleOperations(
+            loadCatalog: { _, _ in [self.session("session-a")] },
+            openSession: { _, sessionID in
+                SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: [
+                        "running": .bool(false),
+                        "yolo": .bool(false),
+                        "approvals_mode": .string("manual")
+                    ])
+                )
+            },
+            refreshContext: { _, _ in },
+            setSessionYolo: { _, _, _ in throw TestError.rejected }
+        )
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        store.setOverride(true, for: "default", sessionID: "session-a")
+        let appState = makeAppState(defaults: defaults, store: store, lifecycleOperations: operations)
+        appState.sessions = [session("session-a")]
+        appState.activeSessionId = "session-a"
+        appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+
+        await appState.syncSession()
+
+        // The re-assert failed, but the resume still settled and the local
+        // override continues to govern the indicator.
+        XCTAssertTrue(appState.runtime.yolo)
+        XCTAssertEqual(store.storedOverride(for: "default", sessionID: "session-a"), true)
+    }
+
     private func makeAppState(
         defaults: UserDefaults,
         store: SessionYoloStore,
@@ -474,5 +699,13 @@ private final class SessionYoloResumeGate {
     func resume() {
         suspension?.resume()
         suspension = nil
+    }
+}
+
+private final class YoloSetCallRecorder {
+    private(set) var invocations: [(sessionID: String, enabled: Bool)] = []
+
+    func record(_ sessionID: String, _ enabled: Bool) {
+        invocations.append((sessionID, enabled))
     }
 }

--- a/ConduitTests/SessionYoloPersistenceTests.swift
+++ b/ConduitTests/SessionYoloPersistenceTests.swift
@@ -630,6 +630,60 @@ final class SessionYoloPersistenceTests: XCTestCase {
         XCTAssertEqual(store.storedOverride(for: "default", sessionID: "session-a"), true)
     }
 
+    // A profile or client switch during the suspending context refresh makes
+    // the reconciliation stale. The recovery write must abort: re-asserting
+    // through the old client could otherwise apply the wrong profile's
+    // override to the old profile's session.
+    func testResumeSkipsReassertWhenClientIsReplacedDuringContextRefresh() async {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let refreshGate = SessionYoloResumeGate()
+        let recorder = YoloSetCallRecorder()
+        let operations = ChatResumeLifecycleOperations(
+            loadCatalog: { _, _ in [self.session("session-a")] },
+            openSession: { _, sessionID in
+                SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: [
+                        "running": .bool(false),
+                        "yolo": .bool(false),
+                        "approvals_mode": .string("manual")
+                    ])
+                )
+            },
+            refreshContext: { _, _ in await refreshGate.suspend() },
+            setSessionYolo: { _, sessionID, enabled in recorder.record(sessionID, enabled) }
+        )
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        store.setOverride(true, for: "default", sessionID: "session-a")
+        let appState = makeAppState(defaults: defaults, store: store, lifecycleOperations: operations)
+        appState.sessions = [session("session-a")]
+        appState.activeSessionId = "session-a"
+        appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+
+        let resume = Task { @MainActor in
+            await appState.syncSession()
+        }
+        await refreshGate.waitUntilSuspended()
+
+        // Simulate a reconnect replacing the client while the context refresh
+        // is suspended; the in-flight reconciliation becomes stale.
+        appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://two.example", ticket: "ticket"),
+            profile: "default"
+        )
+
+        refreshGate.resume()
+        await resume.value
+
+        XCTAssertTrue(recorder.invocations.isEmpty)
+        XCTAssertEqual(store.storedOverride(for: "default", sessionID: "session-a"), true)
+    }
+
     private func makeAppState(
         defaults: UserDefaults,
         store: SessionYoloStore,

--- a/ConduitTests/SessionYoloPersistenceTests.swift
+++ b/ConduitTests/SessionYoloPersistenceTests.swift
@@ -803,6 +803,152 @@ final class SessionYoloPersistenceTests: XCTestCase {
         XCTAssertTrue(appState.runtime.yolo)
     }
 
+    // A known non-off mode with the approval signals omitted entirely from a
+    // later snapshot is unknown, not a disagreement: the last-known indicator
+    // value must survive instead of flickering to "approvals on".
+    func testSnapshotOmittingApprovalSignalsKeepsLastKnownYoloUnderKnownNonOffMode() {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        let appState = makeAppState(defaults: defaults, store: store)
+        appState.sessions = [session("session-a")]
+
+        // Prime a known non-off mode plus an on session flag.
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: "session-a",
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false),
+                "yolo": .bool(true),
+                "approvals_mode": .string("manual")
+            ])
+        ))
+        XCTAssertTrue(appState.runtime.yolo)
+
+        // A partial projection omitting both signals must keep the last value.
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: "session-a",
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false)
+            ])
+        ))
+        XCTAssertTrue(appState.runtime.yolo)
+        XCTAssertEqual(appState.runtime.approvalsMode, "manual")
+
+        // A snapshot that itself reports a non-off mode with no session flag
+        // still resolves to approvals-required.
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: "session-a",
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false),
+                "approvals_mode": .string("manual")
+            ])
+        ))
+        XCTAssertFalse(appState.runtime.yolo)
+    }
+
+    // A resume snapshot that omits the session-level yolo is unknown, not a
+    // disagreement: the re-assert must not fire on every resume for gateways
+    // that omit the field.
+    func testResumeSkipsReassertWhenSnapshotOmitsSessionYolo() async {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let recorder = YoloSetCallRecorder()
+        let operations = ChatResumeLifecycleOperations(
+            loadCatalog: { _, _ in [self.session("session-a")] },
+            openSession: { _, sessionID in
+                SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: [
+                        "running": .bool(false),
+                        "approvals_mode": .string("manual")
+                        // yolo deliberately omitted
+                    ])
+                )
+            },
+            refreshContext: { _, _ in },
+            setSessionYolo: { _, sessionID, enabled in recorder.record(sessionID, enabled) }
+        )
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        store.setOverride(true, for: "default", sessionID: "session-a")
+        let appState = makeAppState(defaults: defaults, store: store, lifecycleOperations: operations)
+        appState.sessions = [session("session-a")]
+        appState.activeSessionId = "session-a"
+        appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+
+        await appState.syncSession()
+
+        // The stored override still governs the indicator, but no config.set
+        // churn is sent for a value the server never reported.
+        XCTAssertTrue(appState.runtime.yolo)
+        XCTAssertTrue(recorder.invocations.isEmpty)
+        XCTAssertEqual(store.storedOverride(for: "default", sessionID: "session-a"), true)
+    }
+
+    // A buffered live session.info that predates the resume must not re-impose
+    // a stale profile approval mode over the fresh resume snapshot's mode.
+    func testBufferedSessionInfoCannotReimposeStaleApprovalMode() async {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let openGate = SessionYoloResumeGate()
+        let operations = ChatResumeLifecycleOperations(
+            loadCatalog: { _, _ in [self.session("session-a")] },
+            openSession: { _, sessionID in
+                await openGate.suspend()
+                return SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: [
+                        "running": .bool(false),
+                        "approvals_mode": .string("manual")
+                    ])
+                )
+            },
+            refreshContext: { _, _ in },
+            setSessionYolo: { _, _, _ in }
+        )
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        let appState = makeAppState(
+            defaults: defaults,
+            store: store,
+            lifecycleOperations: operations
+        )
+        appState.sessions = [session("session-a")]
+        appState.activeSessionId = "session-a"
+        appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+
+        let resume = Task { @MainActor in
+            await appState.syncSession()
+        }
+        await openGate.waitUntilSuspended()
+
+        // Stale buffered push claiming the profile was globally off.
+        appState.handleStreamEvent(.sessionInfo(
+            sessionId: "session-a",
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false),
+                "approvals_mode": .string("off")
+            ])
+        ))
+
+        openGate.resume()
+        await resume.value
+
+        // The fresh resume's manual mode is authoritative; the stale floor
+        // must not engage.
+        XCTAssertEqual(appState.runtime.approvalsMode, "manual")
+        XCTAssertFalse(appState.runtime.yolo)
+    }
+
     private func makeAppState(
         defaults: UserDefaults,
         store: SessionYoloStore,

--- a/ConduitTests/SessionYoloPersistenceTests.swift
+++ b/ConduitTests/SessionYoloPersistenceTests.swift
@@ -684,6 +684,125 @@ final class SessionYoloPersistenceTests: XCTestCase {
         XCTAssertEqual(store.storedOverride(for: "default", sessionID: "session-a"), true)
     }
 
+    // MARK: - Global floor vs. manual toggle paths
+
+    // The /yolo slash command routes through toggleYolo → setYoloMode. Under
+    // the global floor that write is a server-side no-op, and persisting the
+    // override would silently resurface when the profile mode changes, so
+    // nothing must be sent and the floor must stay visible.
+    func testToggleYoloUnderGlobalOffSendsNothingAndKeepsFloor() async {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let recorder = YoloSetCallRecorder()
+        let operations = ChatResumeLifecycleOperations(
+            setSessionYolo: { _, sessionID, enabled in recorder.record(sessionID, enabled) }
+        )
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        let appState = makeAppState(defaults: defaults, store: store, lifecycleOperations: operations)
+        appState.sessions = [session("session-a")]
+        appState.activeSessionId = "session-a"
+        appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: "session-a",
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false),
+                "approvals_mode": .string("off")
+            ])
+        ))
+        XCTAssertTrue(appState.runtime.yolo)
+
+        await appState.toggleYolo()
+
+        XCTAssertTrue(appState.runtime.yolo)
+        XCTAssertTrue(recorder.invocations.isEmpty)
+        XCTAssertNil(store.storedOverride(for: "default", sessionID: "session-a"))
+    }
+
+    // applyRuntime derives the floor from the last-known approvalsMode, so a
+    // resume snapshot that omits approvals_mode must not let the re-assert
+    // proceed under an "off" floor it cannot see in the snapshot alone.
+    func testReassertUsesLastKnownApprovalModeWhenSnapshotOmitsIt() async {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let recorder = YoloSetCallRecorder()
+        let operations = ChatResumeLifecycleOperations(
+            loadCatalog: { _, _ in [self.session("session-a")] },
+            openSession: { _, sessionID in
+                SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: [
+                        "running": .bool(false),
+                        "yolo": .bool(true)
+                        // approvals_mode deliberately omitted
+                    ])
+                )
+            },
+            refreshContext: { _, _ in },
+            setSessionYolo: { _, sessionID, enabled in recorder.record(sessionID, enabled) }
+        )
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        store.setOverride(false, for: "default", sessionID: "session-a")
+        let appState = makeAppState(defaults: defaults, store: store, lifecycleOperations: operations)
+        appState.sessions = [session("session-a")]
+        appState.activeSessionId = "session-a"
+        appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+        // Prime the last-known profile mode before the resume.
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: "session-a",
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false),
+                "approvals_mode": .string("off")
+            ])
+        ))
+
+        await appState.syncSession()
+
+        // The last-known floor still governs the indicator and suppresses the
+        // moot re-assert even though the resume snapshot omitted the mode.
+        XCTAssertTrue(appState.runtime.yolo)
+        XCTAssertTrue(recorder.invocations.isEmpty)
+        XCTAssertEqual(store.storedOverride(for: "default", sessionID: "session-a"), false)
+    }
+
+    // A snapshot that carries no approval signal at all (older gateways /
+    // partial projections) must not flip the indicator off; keep the
+    // last-known value instead.
+    func testSnapshotOmittingAllApprovalSignalsKeepsLastKnownYolo() {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        let appState = makeAppState(defaults: defaults, store: store)
+        appState.sessions = [session("session-a")]
+
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: "session-a",
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false),
+                "yolo": .bool(true)
+            ])
+        ))
+        XCTAssertTrue(appState.runtime.yolo)
+
+        appState.applyChatResume(SessionResumeResult(
+            sessionId: "session-a",
+            messages: [],
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false)
+            ])
+        ))
+        XCTAssertTrue(appState.runtime.yolo)
+    }
+
     private func makeAppState(
         defaults: UserDefaults,
         store: SessionYoloStore,

--- a/ConduitTests/SessionYoloPersistenceTests.swift
+++ b/ConduitTests/SessionYoloPersistenceTests.swift
@@ -1076,6 +1076,75 @@ final class SessionYoloPersistenceTests: XCTestCase {
         XCTAssertFalse(appState.runtime.yolo)
     }
 
+    // The buffered-mode anchoring is independent of the per-session YOLO write
+    // gate: even when the user toggled during the resume
+    // (reconcileExplicitYolo == false), a stale buffered event must not
+    // re-impose an outdated floor over the fresh resume's mode.
+    func testBufferedSessionInfoCannotReimposeStaleApprovalModeWhenUserToggledDuringResume() async {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let openGate = SessionYoloResumeGate()
+        let recorder = YoloSetCallRecorder()
+        let operations = ChatResumeLifecycleOperations(
+            loadCatalog: { _, _ in [self.session("session-a")] },
+            openSession: { _, sessionID in
+                await openGate.suspend()
+                return SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: [
+                        "running": .bool(false),
+                        "approvals_mode": .string("manual")
+                    ])
+                )
+            },
+            refreshContext: { _, _ in },
+            setSessionYolo: { _, sessionID, enabled in recorder.record(sessionID, enabled) }
+        )
+        let store = SessionYoloStore(defaults: defaults, storageKey: "test.session-yolo")
+        let appState = makeAppState(
+            defaults: defaults,
+            store: store,
+            lifecycleOperations: operations
+        )
+        appState.sessions = [session("session-a")]
+        appState.activeSessionId = "session-a"
+        appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://one.example", ticket: "ticket"),
+            profile: "default"
+        )
+
+        let resume = Task { @MainActor in
+            await appState.syncSession()
+        }
+        await openGate.waitUntilSuspended()
+
+        // The user toggles YOLO on during the resume (bumps the write revision,
+        // so reconcileExplicitYolo will be false)...
+        let enabled = await appState.setYoloMode(true)
+        XCTAssertTrue(enabled)
+
+        // ...and a stale buffered push claims the profile was globally off.
+        appState.handleStreamEvent(.sessionInfo(
+            sessionId: "session-a",
+            snapshot: SessionRuntimeSnapshot(object: [
+                "running": .bool(false),
+                "approvals_mode": .string("off")
+            ])
+        ))
+
+        openGate.resume()
+        await resume.value
+
+        // The fresh resume's manual mode stays authoritative; the stale floor
+        // must not engage, and the recovery re-assert stays skipped because
+        // the user's write is newer.
+        XCTAssertEqual(appState.runtime.approvalsMode, "manual")
+        XCTAssertTrue(appState.runtime.yolo)
+        XCTAssertEqual(recorder.invocations.count, 1)
+        XCTAssertEqual(recorder.invocations.first?.enabled, true)
+    }
+
     private func makeAppState(
         defaults: UserDefaults,
         store: SessionYoloStore,

--- a/docs/superpowers/specs/2026-08-13-session-yolo-server-authority-followup.md
+++ b/docs/superpowers/specs/2026-08-13-session-yolo-server-authority-followup.md
@@ -95,8 +95,12 @@ slash command and any other caller. The override is retained in the store so it
 applies again if the profile mode changes.
 
 `runtime.approvalsMode` is refreshed from snapshots, is mirrored immediately
-when Approval mode is saved in Workspace & safety, and is reset on profile
-switch so one profile's floor cannot leak into the next.
+when Approval mode is saved in Workspace & safety (re-resolving the effective
+indicator through the same precedence `applyRuntime` uses, via the shared
+`applyEffectiveYolo` helper), and is reset on profile switch so one profile's
+floor cannot leak into the next. The picker re-seeds its draft only when the
+save or push crosses the `off` boundary — other mode changes (e.g.
+`manual ↔ smart`) leave an in-progress draft untouched.
 
 ### Settings copy
 

--- a/docs/superpowers/specs/2026-08-13-session-yolo-server-authority-followup.md
+++ b/docs/superpowers/specs/2026-08-13-session-yolo-server-authority-followup.md
@@ -40,21 +40,41 @@ precedence in `applyRuntime` is:
    Hermes auto-approves globally; a per-session toggle cannot require approvals).
 2. Else a stored per-session override wins (the user's explicit choice).
 3. Else the snapshot's `yolo` (or buffered-resume authority).
-4. Else `false`.
+4. Else a known non-off profile mode means approvals apply (`false`); if no
+   approval signal has ever been seen, the last-known indicator value is kept
+   so partial projections cannot flicker it off.
 
 ### Resume re-assertion (`reassertSessionYolo`)
 
-After every successful resume (`reconcile`, immediately after
-`refreshChatResumeContext`), if a stored override exists and the server's
+After every successful resume, if a stored override exists and the server's
 reported `yolo` disagrees, AppState re-sends `config.set { key: "yolo",
-session_id, value }` via the same seam `setYoloMode` uses. It is a no-op under
-`approvalsMode == "off"` (the floor dominates), when there is no override, or
-when the server already agrees. Failure is non-fatal (logged via the `SessionYolo`
-OSLog category); the local override still governs the indicator and the next
-resume retries.
+session_id, value }` via the same seam `setYoloMode` uses. Ordering inside
+`reconcile`: the suspending `refreshChatResumeContext` runs first, then the
+existing token/profile/client ownership guard re-validates the reconciliation,
+then the buffered-event replay and the synchronous
+`settleReconciliationAndPublish` complete atomically, and only then — gated on
+the settle succeeding — does the re-assert fire. A profile or client switch
+during the context refresh therefore aborts the write instead of pushing a
+stale one. A residual race (a switch after the send begins) is accepted: the
+value was chosen under verified ownership and the next resume reconciles.
+
+It is a no-op under `approvalsMode == "off"` (the floor dominates), when there
+is no override, or when the server already agrees. The floor check reads the
+same resolved source `applyRuntime` maintains (`runtime.approvalsMode`: the
+snapshot's value when present, else the last-known mode), so a snapshot that
+omits `approvals_mode` cannot make the floor and the re-assert decision
+diverge. Failure is non-fatal (logged via the `SessionYolo` OSLog category);
+the local override still governs the indicator and the next resume retries.
 
 This single hook covers cold start, foreground re-sync, WebSocket reconnect, and
 session switching because they all funnel through `reconcile`.
+
+**Known trade-off:** with clear-on-conflict removed, an override is only
+cleared by an explicit toggle (or archive/delete). If a conversation were ever
+reset server-side while reusing the same session ID, a stale override would be
+re-asserted into it. Session IDs are freshly minted per conversation in
+practice, so the store cannot distinguish a reconnect from a genuine new
+conversation and this risk is accepted.
 
 ### Reversal of the PR-55 clear-on-conflict semantic
 
@@ -63,12 +83,20 @@ disagrees. The `reconcileExplicitYolo` parameter was removed from `applyRuntime`
 and `applyChatResume` (it is still computed in `reconcile` to drive the buffered
 `session.info` replay authority).
 
-### UX: Model Picker toggle lock
+### UX: Model Picker toggle lock and manual-toggle guard
 
 When `approvalsMode == "off"`, the Model Picker YOLO toggle is locked on
 (`.disabled`) with a note explaining the global floor, so users are not offered a
-control that silently does nothing. The override is retained in the store so it
+control that silently does nothing. The same floor guards `setYoloMode` itself:
+under `off` it returns early without sending `config.set` or persisting an
+override (a write would be a server-side no-op, and a persisted override would
+silently resurface when the profile mode changes back). This covers the `/yolo`
+slash command and any other caller. The override is retained in the store so it
 applies again if the profile mode changes.
+
+`runtime.approvalsMode` is refreshed from snapshots, is mirrored immediately
+when Approval mode is saved in Workspace & safety, and is reset on profile
+switch so one profile's floor cannot leak into the next.
 
 ### Settings copy
 

--- a/docs/superpowers/specs/2026-08-13-session-yolo-server-authority-followup.md
+++ b/docs/superpowers/specs/2026-08-13-session-yolo-server-authority-followup.md
@@ -1,0 +1,92 @@
+# Design Follow-up: Session YOLO Server Authority
+
+**Date:** 2026-08-13
+**Branch:** `fix/session-yolo-server-authority`
+**Follows:** [2026-08-13-session-yolo-persistence-design.md](2026-08-13-session-yolo-persistence-design.md) (PR #55)
+**Status:** Implemented
+
+## Problem
+
+After PR #55 the per-session YOLO indicator persisted locally across turns and
+relaunches, but it could disagree with what the server actually enforced:
+
+1. **Global floor:** Hermes auto-approves whenever `approvals.mode == "off"`
+   (`tools/approval.py`: `_YOLO_MODE_FROZEN or session_flag or approval_mode == "off"`).
+   It is an OR, so no per-session toggle can require approvals while the profile
+   is `off`. The local override made the indicator show the per-session choice,
+   so it could claim "approvals on" while the server auto-approved everything.
+2. **Gateway ephemerality:** the Hermes `tui_gateway` holds the per-session YOLO
+   flag in an in-memory set (`tools/approval._session_yolo`) and its `config.set`
+   handler never persists it. (The CLI *does* persist it, via
+   `SessionDB.set_session_yolo` → `model_config.yolo_mode`, and restores it on
+   resume — `cli.py:_restore_session_yolo`. Desktop/Conduit talk to the gateway,
+   not the CLI, so they hit the gap.) After a gateway process restart or rebuilt
+   agent the flag reverts to the profile default while the indicator keeps the
+   user's choice.
+
+The original PR-55 design assumed the server's fresh-resume `yolo` was
+authoritative and cleared a conflicting local override. That assumption is wrong
+for the gateway path: the post-resume value is the forgotten profile default,
+not authority.
+
+## Changes
+
+### Indicator accuracy + global floor (`applyRuntime`)
+
+`RuntimeState` now carries the last-known `approvalsMode`. The effective `yolo`
+precedence in `applyRuntime` is:
+
+1. Global floor: `approvalsMode == "off"` → `runtime.yolo = true` (be honest that
+   Hermes auto-approves globally; a per-session toggle cannot require approvals).
+2. Else a stored per-session override wins (the user's explicit choice).
+3. Else the snapshot's `yolo` (or buffered-resume authority).
+4. Else `false`.
+
+### Resume re-assertion (`reassertSessionYolo`)
+
+After every successful resume (`reconcile`, immediately after
+`refreshChatResumeContext`), if a stored override exists and the server's
+reported `yolo` disagrees, AppState re-sends `config.set { key: "yolo",
+session_id, value }` via the same seam `setYoloMode` uses. It is a no-op under
+`approvalsMode == "off"` (the floor dominates), when there is no override, or
+when the server already agrees. Failure is non-fatal (logged via the `SessionYolo`
+OSLog category); the local override still governs the indicator and the next
+resume retries.
+
+This single hook covers cold start, foreground re-sync, WebSocket reconnect, and
+session switching because they all funnel through `reconcile`.
+
+### Reversal of the PR-55 clear-on-conflict semantic
+
+`applyRuntime` no longer clears a stored override when a fresh-resume snapshot
+disagrees. The `reconcileExplicitYolo` parameter was removed from `applyRuntime`
+and `applyChatResume` (it is still computed in `reconcile` to drive the buffered
+`session.info` replay authority).
+
+### UX: Model Picker toggle lock
+
+When `approvalsMode == "off"`, the Model Picker YOLO toggle is locked on
+(`.disabled`) with a note explaining the global floor, so users are not offered a
+control that silently does nothing. The override is retained in the store so it
+applies again if the profile mode changes.
+
+### Settings copy
+
+Workspace & safety → Approval mode help text now documents the Hermes limitation:
+when set to `off`, per-session YOLO toggles have no effect; use `manual` or
+`smart` to enable per-session YOLO.
+
+## What is NOT changed
+
+- The Hermes `config.set` / `approvals.mode` protocol is untouched (Conduit
+  cannot fix the gateway-side persistence; that lives in `nousresearch/hermes-agent`).
+- `SessionYoloStore` remains a local cache of the explicit per-session choice.
+- The global floor under `off` is a server-imposed limitation; Conduit reflects
+  it honestly rather than masking it.
+
+## Tests
+
+`ConduitTests/SessionYoloPersistenceTests` was updated: the
+clear-on-conflict cases were rewritten to assert the override now survives, and
+new tests cover the global floor, the resume re-assertion (fire / skip-when-agree
+/ skip-under-off / failure-is-non-fatal). See the file for the full list.

--- a/docs/superpowers/specs/2026-08-13-session-yolo-server-authority-followup.md
+++ b/docs/superpowers/specs/2026-08-13-session-yolo-server-authority-followup.md
@@ -77,14 +77,19 @@ cannot make the floor and the re-assert decision diverge. Failure is non-fatal
 the indicator and the next resume retries.
 
 Buffered `session.info` replay anchors the approval mode to the fresh resume
-snapshot the same way it anchors `yolo` (`authoritativeApprovalsMode`), so a
-stale buffered event cannot re-impose an outdated global floor.
+snapshot (`authoritativeApprovalsMode`, unconditionally — the mode is
+profile-scoped and independent of the per-session YOLO write gate, unlike the
+`yolo` authority which respects `reconcileExplicitYolo`), so a stale buffered
+event cannot re-impose an outdated global floor even when the user toggled
+YOLO during the resume.
 
 This single hook covers cold start, foreground re-sync, WebSocket reconnect, and
 session switching because they all funnel through `reconcile`.
 
 **Known trade-off:** with clear-on-conflict removed, an override is only
-cleared by an explicit toggle (or archive/delete). If a conversation were ever
+cleared by an explicit toggle (possible only once the profile mode leaves
+`off` — under the floor the picker toggle is disabled and `setYoloMode`
+returns early) or by archive/delete. If a conversation were ever
 reset server-side while reusing the same session ID, a stale override would be
 re-asserted into it. Session IDs are freshly minted per conversation in
 practice, so the store cannot distinguish a reconnect from a genuine new

--- a/docs/superpowers/specs/2026-08-13-session-yolo-server-authority-followup.md
+++ b/docs/superpowers/specs/2026-08-13-session-yolo-server-authority-followup.md
@@ -56,8 +56,13 @@ then the buffered-event replay and the synchronous
 `settleReconciliationAndPublish` complete atomically, and only then — gated on
 the settle succeeding — does the re-assert fire. A profile or client switch
 during the context refresh therefore aborts the write instead of pushing a
-stale one. A residual race (a switch after the send begins) is accepted: the
-value was chosen under verified ownership and the next resume reconciles.
+stale one. The re-assert is also gated on `reconcileExplicitYolo` (a user
+write that completed since the resume began already pushed the server) and on
+a per-session in-flight marker (a user write still awaiting its RPC has not
+reached the store; re-asserting could read the pre-toggle override and land
+after the user's write). A residual race (a switch after the send begins) is
+accepted: the value was chosen under verified ownership and the next resume
+reconciles.
 
 It is a no-op under `approvalsMode == "off"` (the floor dominates), when there
 is no override, when the snapshot does not report a session-level `yolo`
@@ -106,12 +111,15 @@ applies again if the profile mode changes.
 `runtime.approvalsMode` is refreshed from snapshots, is mirrored immediately
 when Approval mode is saved in Workspace & safety (re-resolving the effective
 indicator through the same precedence `applyRuntime` uses, via the shared
-`applyEffectiveYolo` helper, carrying the session-level value through so only
-the floor/override precedence re-runs), and is reset on profile switch — along
-with neutralizing `runtime.yolo` to the safe display — so one profile's floor
-cannot leak into the next. The picker re-seeds its draft only when the save or
-push crosses the `off` boundary — other mode changes (e.g. `manual ↔ smart`)
-leave an in-progress draft untouched.
+`applyEffectiveYolo` helper, carrying the last server-reported session value —
+`lastReportedSessionYolo`, distinct from the floor-forced `runtime.yolo` — so
+only the floor/override precedence re-runs), and is reset on profile switch —
+along with neutralizing `runtime.yolo` to the safe display — so one profile's
+floor cannot leak into the next. A newly created conversation (`/new`)
+re-resolves from the profile mode instead of inheriting the previous
+session's effective indicator. The picker re-seeds its draft only when the
+save or push crosses the `off` boundary — other mode changes (e.g.
+`manual ↔ smart`) leave an in-progress draft untouched.
 
 ### Settings copy
 

--- a/docs/superpowers/specs/2026-08-13-session-yolo-server-authority-followup.md
+++ b/docs/superpowers/specs/2026-08-13-session-yolo-server-authority-followup.md
@@ -40,9 +40,10 @@ precedence in `applyRuntime` is:
    Hermes auto-approves globally; a per-session toggle cannot require approvals).
 2. Else a stored per-session override wins (the user's explicit choice).
 3. Else the snapshot's `yolo` (or buffered-resume authority).
-4. Else a known non-off profile mode means approvals apply (`false`); if no
-   approval signal has ever been seen, the last-known indicator value is kept
-   so partial projections cannot flicker it off.
+4. Else a non-off approval mode **reported by the snapshot itself** means
+   approvals apply (`false`). A last-known mode with the signals omitted
+   entirely is unknown, not a disagreement — the last-known indicator value is
+   kept so partial projections cannot flicker it.
 
 ### Resume re-assertion (`reassertSessionYolo`)
 
@@ -59,12 +60,20 @@ stale one. A residual race (a switch after the send begins) is accepted: the
 value was chosen under verified ownership and the next resume reconciles.
 
 It is a no-op under `approvalsMode == "off"` (the floor dominates), when there
-is no override, or when the server already agrees. The floor check reads the
-same resolved source `applyRuntime` maintains (`runtime.approvalsMode`: the
-snapshot's value when present, else the last-known mode), so a snapshot that
-omits `approvals_mode` cannot make the floor and the re-assert decision
-diverge. Failure is non-fatal (logged via the `SessionYolo` OSLog category);
-the local override still governs the indicator and the next resume retries.
+is no override, when the snapshot does not report a session-level `yolo`
+(unknown is not a disagreement — the gateway's `session.info` projection always
+reports `yolo` as a boolean, so omitting it means "no signal", and re-asserting
+every resume would be churn), or when the server's reported value already
+matches the override. The floor check reads the same resolved source
+`applyRuntime` maintains (`runtime.approvalsMode`: the snapshot's value when
+present, else the last-known mode), so a snapshot that omits `approvals_mode`
+cannot make the floor and the re-assert decision diverge. Failure is non-fatal
+(logged via the `SessionYolo` OSLog category); the local override still governs
+the indicator and the next resume retries.
+
+Buffered `session.info` replay anchors the approval mode to the fresh resume
+snapshot the same way it anchors `yolo` (`authoritativeApprovalsMode`), so a
+stale buffered event cannot re-impose an outdated global floor.
 
 This single hook covers cold start, foreground re-sync, WebSocket reconnect, and
 session switching because they all funnel through `reconcile`.
@@ -97,10 +106,12 @@ applies again if the profile mode changes.
 `runtime.approvalsMode` is refreshed from snapshots, is mirrored immediately
 when Approval mode is saved in Workspace & safety (re-resolving the effective
 indicator through the same precedence `applyRuntime` uses, via the shared
-`applyEffectiveYolo` helper), and is reset on profile switch so one profile's
-floor cannot leak into the next. The picker re-seeds its draft only when the
-save or push crosses the `off` boundary — other mode changes (e.g.
-`manual ↔ smart`) leave an in-progress draft untouched.
+`applyEffectiveYolo` helper, carrying the session-level value through so only
+the floor/override precedence re-runs), and is reset on profile switch — along
+with neutralizing `runtime.yolo` to the safe display — so one profile's floor
+cannot leak into the next. The picker re-seeds its draft only when the save or
+push crosses the `off` boundary — other mode changes (e.g. `manual ↔ smart`)
+leave an in-progress draft untouched.
 
 ### Settings copy
 


### PR DESCRIPTION
Follow-up to #55. Two discrepancies between the session YOLO indicator and what Hermes actually enforces, traced through the Hermes source (`nousresearch/hermes-agent`):

## Root cause
- **Gateway ephemerality:** the `tui_gateway`'s `config.set` key=`yolo` handler (`tui_gateway/server.py:11199`) toggles only the in-memory `_session_yolo` set and never calls `SessionDB.set_session_yolo` — the CLI persists and restores it (`cli.py:11659` / `_restore_session_yolo` at `:7715`), but Conduit talks to the gateway. After a gateway restart / rebuilt agent, the server forgot the session flag and reverted to the profile default while #55's local override kept the indicator showing the user's choice.
- **Global floor:** Hermes auto-approves whenever `approvals.mode == "off"` (`tools/approval.py:4033` — an OR), so no per-session toggle can require approvals while global is `off`; the indicator could show "approvals on" while the server auto-approved everything. This is a Hermes limitation; it cannot be fixed client-side, so it is documented and reflected honestly instead.

## Changes
- `applyRuntime`: capture `runtime.approvalsMode`; a **global floor** forces `runtime.yolo = true` under `approvals.mode == "off"`; a stored override is now **authoritative** — a conflicting fresh-resume snapshot no longer clears it, because the gateway's post-resume value is the forgotten default, not authority (deliberate reversal of #55's clear-on-conflict; see the design follow-up doc).
- **`reassertSessionYolo`**: after every successful resume, re-send `config.set(yolo)` when the stored override diverges from the server's reported value. No-op under global off, with no override, or when the server already agrees; failure is non-fatal (OSLog `SessionYolo`). Hooked once in `reconcile`, which covers cold start, foreground re-sync, reconnect, and session switching.
- **Model Picker:** the YOLO toggle is locked on and disabled under global off, with a note explaining why (no control that silently does nothing); the draft is pinned and reactively re-seeded so `applyModel` sends no spurious write.
- **Settings:** Approval mode help documents the limitation and how to enable per-session YOLO (`manual`/`smart`).
- **Signature cleanup:** `reconcileExplicitYolo` removed from `applyRuntime`/`applyChatResume` (still computed in `reconcile` for buffered-replay authority); redundant `applyChatResume` arity collapsed.

## Tests
- Rewrote the three clear-on-conflict expectations to the new semantics (override retained; buffered event cannot overwrite it; re-assert fires once).
- Added: global floor forces indicator despite override-off; floor clears when mode returns to manual; re-assert fires when gateway forgot / skips when server agrees / skips under global off / failure is non-fatal.

## Validation
- Focused: `SessionYoloPersistenceTests` 27 passed (incl. review regression tests), `ModelPickerTests` 7 passed, `SessionYoloStoreTests` 6 passed — 0 failures (40 total), on a clean isolated build.
- `git diff --check` clean.
- Full suite: the unrelated image-paste tests (`ComposerPasteTextViewTests`) currently stall in the local simulator environment (`XPC connection interrupted`) — A/B-verified that `origin/main` stalls identically on the same fresh simulator + fresh DerivedData, so this is CoreSimulator degradation after heavy churn, not a regression from this change. Earlier today `origin/main`'s full suite passed 100% (314 tests) on the same machine. CI run recommended for the definitive full-suite signal.

## Docs
`docs/superpowers/specs/2026-08-13-session-yolo-server-authority-followup.md` records the root cause, the new precedence, the re-assertion mechanism, and the reversal rationale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added profile-wide approval mode support, including automatic approvals that enable YOLO behavior.
  * Preserved per-session YOLO preferences across session restoration and approval-mode changes.
  * Restored saved session settings automatically when reconnecting.

* **Bug Fixes**
  * Prevented conflicting session updates from clearing YOLO settings unexpectedly.
  * Made restoration failures non-blocking during recovery.

* **UI Updates**
  * Disabled the YOLO toggle when approvals are globally turned off and added explanatory guidance.
  * Updated approval-mode help text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





