### PR TITLE
Render push-delivered approval cards after background arrival

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -4161,17 +4161,21 @@ final class AppState: ObservableObject {
     /// it. The card is recorded as pending and answerable through the existing
     /// `respondToApproval` path; the bounded unconfirmed marker is stamped by
     /// `SessionPresentationCache` so a stale card expires rather than lingering.
+    /// The decision's session key must match one of the routed session
+    /// identities — a mismatched key could not be answered via
+    /// `approval.respond` and would only duplicate or contradict the live card.
     private func recordNotificationDecision(
         _ decision: PendingDecisionPayload,
         sessionIDs: [String]
     ) {
         switch decision {
         case let .approval(sessionKey, description, choices):
+            guard sessionIDs.contains(sessionKey) else { return }
             let activity = ApprovalActivity(
                 sessionId: sessionKey,
                 command: "",
                 description: description,
-                choices: choices.isEmpty ? nil : choices,
+                choices: choices,
                 allowPermanent: false,
                 smartDenied: false,
                 status: .pending,

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -5275,8 +5275,12 @@ final class AppState: ObservableObject {
             guard let updatedIndex = messages.firstIndex(where: { $0.clarify?.requestId == requestId }) else { return }
             messages[updatedIndex].clarify?.status = .error
             messages[updatedIndex].clarify?.answer = nil
-            messages[updatedIndex].clarify?.error = "Hermes did not accept that answer."
-            errorMessage = error.localizedDescription
+            if Self.isExpiredPromptError(error) {
+                messages[updatedIndex].clarify?.error = "This question is no longer active — Hermes timed it out and continued."
+            } else {
+                messages[updatedIndex].clarify?.error = "Hermes did not accept that answer."
+                errorMessage = error.localizedDescription
+            }
             cacheMessagePresentation()
         }
     }
@@ -5781,6 +5785,20 @@ final class AppState: ObservableObject {
         }
     }
 
+    /// Hermes blocks a clarify/approval prompt for only ~5 minutes server-side
+    /// (JSON-RPC error 4009, "no pending … request"), while a restored or
+    /// push-delivered card can legitimately outlive it — a notification opened
+    /// an hour later is the feature's ordinary case, not an error. Treat that
+    /// outcome as "the decision is no longer active" instead of a generic
+    /// failure the user can retry forever.
+    static func isExpiredPromptError(_ error: Error) -> Bool {
+        if let rpcError = error as? RpcError {
+            if rpcError.code == 4009 { return true }
+            return rpcError.message.lowercased().contains("no pending")
+        }
+        return error.localizedDescription.lowercased().contains("no pending")
+    }
+
     func respondToApproval(messageId: String, choice: String) async {
         guard let index = messages.firstIndex(where: { $0.id == messageId }),
               let current = messages[index].approval,
@@ -5808,8 +5826,12 @@ final class AppState: ObservableObject {
             guard let updatedIndex = messages.firstIndex(where: { $0.id == messageId }) else { return }
             messages[updatedIndex].approval?.status = .error
             messages[updatedIndex].approval?.choice = nil
-            messages[updatedIndex].approval?.error = "Hermes did not accept that decision."
-            errorMessage = error.localizedDescription
+            if Self.isExpiredPromptError(error) {
+                messages[updatedIndex].approval?.error = "This approval is no longer active — Hermes timed it out and continued."
+            } else {
+                messages[updatedIndex].approval?.error = "Hermes did not accept that decision."
+                errorMessage = error.localizedDescription
+            }
             cacheMessagePresentation()
         }
     }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -4138,6 +4138,14 @@ final class AppState: ObservableObject {
             for: requestedID,
             in: sessions + cronSessions
         )
+        // A decision raised while the app was backgrounded is delivered as a
+        // structured payload on the notification (the one-shot gateway stream
+        // event was missed). Cache it under both the runtime and resolved
+        // stored IDs so the upcoming resume's `merge` restores the card
+        // regardless of which identity the gateway resumes against.
+        if let decision = target.decision {
+            recordNotificationDecision(decision, sessionIDs: [resumableID, requestedID])
+        }
         let opened = await openSession(
             resumableID,
             reusing: transitionGeneration
@@ -4147,6 +4155,42 @@ final class AppState: ObservableObject {
             transitionGeneration: transitionGeneration
         ) else { return false }
         return opened
+    }
+
+    /// Caches a push-delivered decision card so the resume merge can restore
+    /// it. The card is recorded as pending and answerable through the existing
+    /// `respondToApproval` path; the bounded unconfirmed marker is stamped by
+    /// `SessionPresentationCache` so a stale card expires rather than lingering.
+    private func recordNotificationDecision(
+        _ decision: PendingDecisionPayload,
+        sessionIDs: [String]
+    ) {
+        switch decision {
+        case let .approval(sessionKey, description, choices):
+            let activity = ApprovalActivity(
+                sessionId: sessionKey,
+                command: "",
+                description: description,
+                choices: choices.isEmpty ? nil : choices,
+                allowPermanent: false,
+                smartDenied: false,
+                status: .pending,
+                choice: nil,
+                error: nil
+            )
+            let message = ChatMessage(
+                id: "approval-\(sessionKey)",
+                role: .approval,
+                content: description,
+                timestamp: Self.localTimestamp(),
+                approval: activity
+            )
+            sessionPresentationCache.recordPendingDecision(
+                message,
+                profile: activeProfile,
+                sessionIDs: sessionIDs
+            )
+        }
     }
 
     private func notificationOpenAttemptIsCurrent(

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -704,10 +704,19 @@ final class AppState: ObservableObject {
         let pendingDecisionKeys = SessionPresentationCache.pendingDecisionKeys(in: cacheableMessages)
         // Gateway-provided cards do not create a restoration guard, so keep
         // their bounded expiry marker across ordinary cache flushes as well.
+        // Push-recorded cards (recordPendingDecision) live only in the store —
+        // the in-memory transcript has never seen them — so union in the
+        // store's pending keys or the flush would drop the card before the
+        // notification-open resume merge could restore it.
+        let storedPendingDecisionKeys = sessionPresentationCache.storedPendingDecisionKeys(
+            profile: activeProfile,
+            sessionIDs: ids
+        )
         let pendingDecisionKeysToPreserve = restorationKeys
-            ?? pendingDecisionKeys
+            ?? pendingDecisionKeys.union(storedPendingDecisionKeys)
         let preservePendingDecisionCards = restorationKeys == nil
             || !pendingDecisionKeys.isEmpty
+            || !storedPendingDecisionKeys.isEmpty
         sessionPresentationCache.save(
             cacheableMessages,
             profile: activeProfile,
@@ -4170,7 +4179,13 @@ final class AppState: ObservableObject {
     ) {
         switch decision {
         case let .approval(sessionKey, description, choices):
-            guard sessionIDs.contains(sessionKey) else { return }
+            // Compare trimmed on both sides: the payload parser trims the
+            // session key, but the routed ids arrive as the notification
+            // delivered them.
+            let knownKeys = sessionIDs.map {
+                $0.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            guard knownKeys.contains(sessionKey) else { return }
             let activity = ApprovalActivity(
                 sessionId: sessionKey,
                 command: "",

--- a/Conduit/Services/PushNotificationService.swift
+++ b/Conduit/Services/PushNotificationService.swift
@@ -6,7 +6,33 @@ struct ConduitNotificationTarget: Equatable, Identifiable {
     let profile: String?
     let sessionId: String
     let type: String?
+    /// Structured decision content carried alongside a decision notification.
+    /// Lets Conduit render an answerable card from the push payload alone when
+    /// the one-shot gateway stream event was missed while the app was
+    /// backgrounded. Nil for non-decision notifications.
+    let decision: PendingDecisionPayload?
     var id: String { "\(profile ?? "default"):\(sessionId):\(type ?? "")" }
+
+    init(
+        profile: String?,
+        sessionId: String,
+        type: String?,
+        decision: PendingDecisionPayload? = nil
+    ) {
+        self.profile = profile
+        self.sessionId = sessionId
+        self.type = type
+        self.decision = decision
+    }
+}
+
+/// The structured card content for a decision notification. Approval is
+/// session-keyed (`approval.respond { choice, session_id }`), so a payload
+/// carrying the session key is fully answerable. Clarify is keyed by a
+/// gateway-generated request id that no plugin hook exposes, so it is not
+/// representable here yet (see the background-arrival design doc).
+enum PendingDecisionPayload: Equatable {
+    case approval(sessionKey: String, description: String, choices: [String])
 }
 
 enum NotificationSessionResolver {
@@ -237,8 +263,37 @@ final class PushNotificationService: ObservableObject {
         return ConduitNotificationTarget(
             profile: profile?.isEmpty == false ? profile : nil,
             sessionId: sessionId,
-            type: type?.isEmpty == false ? type : nil
+            type: type?.isEmpty == false ? type : nil,
+            decision: pendingDecision(from: payload)
         )
+    }
+
+    /// Parses the structured decision content the relay forwards alongside a
+    /// decision notification (see the background-arrival design doc). Returns
+    /// nil for non-decision notifications or malformed/unknown payloads so the
+    /// notification degrades to its ordinary routing target.
+    private func pendingDecision(from payload: [String: Any]) -> PendingDecisionPayload? {
+        guard let decision = payload["decision"] as? [String: Any],
+              let kind = (decision["kind"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !kind.isEmpty else {
+            return nil
+        }
+        switch kind {
+        case "approval":
+            guard let sessionKey = (decision["session_key"] as? String)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+                !sessionKey.isEmpty else {
+                return nil
+            }
+            let description = (decision["description"] as? String)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let choices = ((decision["choices"] as? [Any])?
+                .compactMap { ($0 as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }) ?? []
+            return .approval(sessionKey: sessionKey, description: description, choices: choices)
+        default:
+            return nil
+        }
     }
 
     private func requestDeviceToken() async throws -> String {

--- a/Conduit/Services/PushNotificationService.swift
+++ b/Conduit/Services/PushNotificationService.swift
@@ -64,6 +64,11 @@ struct ConduitNotificationPreferences: Codable, Equatable {
     var backgroundTaskFinished = true
     var completionSound = true
     var showPreviews = false
+    /// Independent of `showPreviews`: controls whether pushes carry structured
+    /// decision content (answerable approval cards). Defaults on because the
+    /// feature's audience is exactly the approval-gate crowd; privacy-focused
+    /// users can turn just this off.
+    var decisionCards = true
 
     enum CodingKeys: String, CodingKey {
         case enabled
@@ -74,6 +79,7 @@ struct ConduitNotificationPreferences: Codable, Equatable {
         case backgroundTaskFinished = "background_task_finished"
         case completionSound = "completion_sound"
         case showPreviews = "show_previews"
+        case decisionCards = "decision_cards"
     }
 }
 

--- a/Conduit/Services/PushNotificationService.swift
+++ b/Conduit/Services/PushNotificationService.swift
@@ -271,7 +271,10 @@ final class PushNotificationService: ObservableObject {
     /// Parses the structured decision content the relay forwards alongside a
     /// decision notification (see the background-arrival design doc). Returns
     /// nil for non-decision notifications or malformed/unknown payloads so the
-    /// notification degrades to its ordinary routing target.
+    /// notification degrades to its ordinary routing target. An approval
+    /// requires a session key to answer, a description to display, and at
+    /// least one usable choice — otherwise a cached card could render the
+    /// approval view's default action set, which the payload never promised.
     private func pendingDecision(from payload: [String: Any]) -> PendingDecisionPayload? {
         guard let decision = payload["decision"] as? [String: Any],
               let kind = (decision["kind"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
@@ -282,14 +285,17 @@ final class PushNotificationService: ObservableObject {
         case "approval":
             guard let sessionKey = (decision["session_key"] as? String)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
-                !sessionKey.isEmpty else {
+                !sessionKey.isEmpty,
+                let description = (decision["description"] as? String)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                !description.isEmpty,
+                let rawChoices = decision["choices"] as? [Any] else {
                 return nil
             }
-            let description = (decision["description"] as? String)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            let choices = ((decision["choices"] as? [Any])?
+            let choices = rawChoices
                 .compactMap { ($0 as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) }
-                .filter { !$0.isEmpty }) ?? []
+                .filter { !$0.isEmpty }
+            guard !choices.isEmpty else { return nil }
             return .approval(sessionKey: sessionKey, description: description, choices: choices)
         default:
             return nil

--- a/Conduit/Services/PushNotificationService.swift
+++ b/Conduit/Services/PushNotificationService.swift
@@ -83,6 +83,27 @@ struct ConduitNotificationPreferences: Codable, Equatable {
     }
 }
 
+extension ConduitNotificationPreferences {
+    /// Decoding must tolerate registrations persisted by older builds, which
+    /// predate later-added keys — a `keyNotFound` failure would make the
+    /// `try?` in the init drop the whole stored registration and silently
+    /// disable push for an upgrading user. Every key falls back to its
+    /// default when absent. (Declared in an extension so the synthesized
+    /// `init()` is preserved.)
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
+        approvalNeeded = try container.decodeIfPresent(Bool.self, forKey: .approvalNeeded) ?? true
+        inputNeeded = try container.decodeIfPresent(Bool.self, forKey: .inputNeeded) ?? true
+        responseReady = try container.decodeIfPresent(Bool.self, forKey: .responseReady) ?? true
+        turnFailed = try container.decodeIfPresent(Bool.self, forKey: .turnFailed) ?? true
+        backgroundTaskFinished = try container.decodeIfPresent(Bool.self, forKey: .backgroundTaskFinished) ?? true
+        completionSound = try container.decodeIfPresent(Bool.self, forKey: .completionSound) ?? true
+        showPreviews = try container.decodeIfPresent(Bool.self, forKey: .showPreviews) ?? false
+        decisionCards = try container.decodeIfPresent(Bool.self, forKey: .decisionCards) ?? true
+    }
+}
+
 @MainActor
 final class PushNotificationService: ObservableObject {
     static let shared = PushNotificationService()

--- a/Conduit/Services/SessionPresentationCache.swift
+++ b/Conduit/Services/SessionPresentationCache.swift
@@ -274,6 +274,51 @@ final class SessionPresentationCache {
         return merged
     }
 
+    /// Records a pending decision card observed outside the live stream —
+    /// today, from a push notification's structured payload, which is the only
+    /// source for a decision raised while the app was backgrounded and missed
+    /// the one-shot gateway event. Upserts the single card into whatever is
+    /// already cached for each session (the transcript is otherwise the
+    /// gateway's source of truth), dedupes by decision key, and stamps the
+    /// bounded unconfirmed marker so a stale card expires rather than
+    /// lingering. `merge(includePendingApprovals:)` restores it on resume.
+    func recordPendingDecision(
+        _ message: ChatMessage,
+        profile: String,
+        sessionIDs: [String]
+    ) {
+        guard Self.pendingDecisionKey(for: message) != nil,
+              let targetKey = Self.decisionKey(for: message) else { return }
+        let ids = Set(sessionIDs.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty })
+        guard !ids.isEmpty else { return }
+
+        var store = load()
+        let record = CachedMessage(message)
+        let stampedAt = now()
+        var changed = false
+        for id in ids {
+            let cacheKey = key(profile: profile, sessionID: id)
+            var session = store[cacheKey] ?? CachedSession(
+                updatedAt: stampedAt,
+                messages: [],
+                unconfirmedPendingDecisionAt: nil
+            )
+            // Replace any prior card for this exact decision, then append the
+            // fresh one. Other cached rows (the transcript) are untouched.
+            session.messages.removeAll { existing in
+                decisionKey(for: existing) == targetKey
+            }
+            session.messages.append(record)
+            session.unconfirmedPendingDecisionAt = session.unconfirmedPendingDecisionAt ?? stampedAt
+            session.updatedAt = stampedAt
+            store[cacheKey] = session
+            changed = true
+        }
+        guard changed else { return }
+        trim(&store)
+        persist(store)
+    }
+
     func save(
         _ messages: [ChatMessage],
         profile: String,

--- a/Conduit/Services/SessionPresentationCache.swift
+++ b/Conduit/Services/SessionPresentationCache.swift
@@ -274,6 +274,24 @@ final class SessionPresentationCache {
         return merged
     }
 
+    /// Pending decision keys currently held in the store for the given
+    /// sessions, regardless of what the live in-memory transcript contains.
+    /// A presentation-cache flush rebuilds its records from the in-memory
+    /// transcript, so without this a flush for a session whose store holds a
+    /// push-recorded card (`recordPendingDecision`) would silently drop that
+    /// card — most notably the open-from-notification path, which records and
+    /// then immediately flushes when the notified session is already active.
+    func storedPendingDecisionKeys(
+        profile: String,
+        sessionIDs: [String]
+    ) -> Set<String> {
+        let stored = load()
+        let keys = sessionIDs
+            .compactMap { stored[key(profile: profile, sessionID: $0)] }
+            .flatMap { session in session.messages.compactMap(pendingDecisionKey(for:)) }
+        return Set(keys)
+    }
+
     /// Records a pending decision card observed outside the live stream —
     /// today, from a push notification's structured payload, which is the only
     /// source for a decision raised while the app was backgrounded and missed

--- a/Conduit/Services/SessionPresentationCache.swift
+++ b/Conduit/Services/SessionPresentationCache.swift
@@ -309,7 +309,14 @@ final class SessionPresentationCache {
                 decisionKey(for: existing) == targetKey
             }
             session.messages.append(record)
-            session.unconfirmedPendingDecisionAt = session.unconfirmedPendingDecisionAt ?? stampedAt
+            // Restart the bounded unconfirmed window from this observation.
+            // The marker is per session, and expiry strips every pending card
+            // in the session at once, so preserving an old marker would let a
+            // near-24h stamp immediately expire a decision that just arrived.
+            // (The card is also written under each session identity; an
+            // answered card can linger under an identity the answer flow did
+            // not update, but this same bounded window retires that copy.)
+            session.unconfirmedPendingDecisionAt = stampedAt
             session.updatedAt = stampedAt
             store[cacheKey] = session
             changed = true

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -1358,6 +1358,7 @@ private struct NotificationsSettingsDetail: View {
                     notificationToggle("Background task finished", detail: "A delegated agent completes", keyPath: \.backgroundTaskFinished)
                     notificationToggle("Completion sound", detail: "Play a sound with notifications", keyPath: \.completionSound)
                     notificationToggle("Show previews", detail: "Include response text in notifications", keyPath: \.showPreviews)
+                    notificationToggle("Approval cards in pushes", detail: "Include approval details so cards work from notifications. Disable for maximum privacy.", keyPath: \.decisionCards)
                 }
 
                 ConduitSettingsSection(title: "Connect a Hermes profile", symbol: "link.badge.plus", tint: .conduitAura) {

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -665,6 +665,121 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertFalse(harness.appState.isOpeningNotificationSession)
     }
 
+    func testNotificationDecisionSurvivesOpenWhenNotifiedSessionIsActive() async {
+        // The warm-resume case: the tapped notification targets the session
+        // that is already active. The push-recorded card lives only in the
+        // presentation cache, while the pre-resume flush inside openSession
+        // rebuilds the cache entry from the in-memory transcript — which has
+        // never seen the card. The flush must preserve store-only pending
+        // decisions or the merge finds nothing and the card never appears.
+        let cacheSuite = "conduit.tests.notification-decision-open-\(UUID().uuidString)"
+        guard let cacheDefaults = UserDefaults(suiteName: cacheSuite) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: cacheDefaults)
+        defer {
+            cache.clear()
+            cacheDefaults.removePersistentDomain(forName: cacheSuite)
+        }
+        let transcript = [
+            ChatMessage(id: "a1", role: .assistant, content: "Prior turn text", timestamp: "1")
+        ]
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [self.session("stored-a")] },
+                openSession: { _, sessionID in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: transcript,
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            ),
+            sessionPresentationCache: cache
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.connection = connection
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+        harness.appState.sessions = [session("stored-a")]
+        harness.appState.activeSessionId = "stored-a"
+        harness.appState.messages = transcript
+
+        let opened = await harness.appState.openNotificationTarget(
+            ConduitNotificationTarget(
+                profile: nil,
+                sessionId: "stored-a",
+                type: "approval.needed",
+                decision: .approval(
+                    sessionKey: "stored-a",
+                    description: "Run a dangerous shell command",
+                    choices: ["once", "deny"]
+                )
+            )
+        )
+
+        XCTAssertTrue(opened)
+        let restoredCard = harness.appState.messages.first { $0.role == .approval }
+        XCTAssertEqual(restoredCard?.approval?.sessionId, "stored-a")
+        XCTAssertEqual(restoredCard?.approval?.status, .pending, "The push-delivered card must survive the open and render answerable")
+    }
+
+    func testNotificationDecisionWithMismatchedSessionKeyIsNotRecorded() async {
+        let cacheSuite = "conduit.tests.notification-decision-mismatch-\(UUID().uuidString)"
+        guard let cacheDefaults = UserDefaults(suiteName: cacheSuite) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: cacheDefaults)
+        defer {
+            cache.clear()
+            cacheDefaults.removePersistentDomain(forName: cacheSuite)
+        }
+        let transcript = [
+            ChatMessage(id: "a1", role: .assistant, content: "Prior turn text", timestamp: "1")
+        ]
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [self.session("stored-a")] },
+                openSession: { _, sessionID in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: transcript,
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            ),
+            sessionPresentationCache: cache
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.connection = connection
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+        harness.appState.sessions = [session("stored-a")]
+        harness.appState.activeSessionId = "stored-a"
+        harness.appState.messages = transcript
+
+        let opened = await harness.appState.openNotificationTarget(
+            ConduitNotificationTarget(
+                profile: nil,
+                sessionId: "stored-a",
+                type: "approval.needed",
+                decision: .approval(
+                    sessionKey: "some-other-session",
+                    description: "Not this session's approval",
+                    choices: ["once", "deny"]
+                )
+            )
+        )
+
+        XCTAssertTrue(opened)
+        XCTAssertFalse(
+            harness.appState.messages.contains { $0.role == .approval },
+            "A decision whose session key does not match the routed session must not be recorded"
+        )
+    }
+
     func testStaleSameTokenSyncCannotSettleNewerOpeningReconciliation() async {
         let staleCatalogGate = ControlledSuspension()
         let newerOpenGate = ControlledSuspension()
@@ -2901,7 +3016,8 @@ final class AppStateChatResumeTests: XCTestCase {
         configureDefaults: (UserDefaults) -> Void = { _ in },
         reconnectScheduler: ChatResumeReconnectScheduler? = nil,
         reconnectExecutor: ChatResumeReconnectExecutor? = nil,
-        lifecycleOperations: ChatResumeLifecycleOperations = .live
+        lifecycleOperations: ChatResumeLifecycleOperations = .live,
+        sessionPresentationCache: SessionPresentationCache = .shared
     ) -> (
         appState: AppState,
         coordinator: ChatResumeCoordinator,
@@ -2932,7 +3048,8 @@ final class AppStateChatResumeTests: XCTestCase {
             clearSessionPresentationCache: { cacheClearSpy.count += 1 },
             reconnectScheduler: reconnectScheduler,
             reconnectExecutor: reconnectExecutor,
-            chatResumeLifecycleOperations: lifecycleOperations
+            chatResumeLifecycleOperations: lifecycleOperations,
+            sessionPresentationCache: sessionPresentationCache
         )
         return (appState, coordinator, store, recoverySequence, cacheClearSpy, defaults, suite)
     }

--- a/ConduitTests/MessageNormalizerTests.swift
+++ b/ConduitTests/MessageNormalizerTests.swift
@@ -233,6 +233,61 @@ final class MessageNormalizerTests: XCTestCase {
         XCTAssertNil(service.pendingTarget?.decision)
     }
 
+    func testNotificationPayloadDecisionRejectedWithoutDisplayText() {
+        let service = PushNotificationService(retryDelay: .zero)
+        defer {
+            if let target = service.pendingTarget {
+                service.clearPendingTarget(target)
+            }
+        }
+        service.receiveNotificationPayload([
+            "conduit": [
+                "session_id": "session-1",
+                "type": "approval.needed",
+                "decision": [
+                    "kind": "approval",
+                    "session_key": "session-1",
+                    "description": "   ",
+                    "choices": ["once", "deny"],
+                ] as [String: Any],
+            ] as [String: Any],
+        ])
+        XCTAssertNil(service.pendingTarget?.decision, "An approval with no display text must degrade to a routing target")
+    }
+
+    func testNotificationPayloadDecisionRejectedWithoutUsableChoices() {
+        let service = PushNotificationService(retryDelay: .zero)
+        defer {
+            if let target = service.pendingTarget {
+                service.clearPendingTarget(target)
+            }
+        }
+        // Absent choices.
+        service.receiveNotificationPayload([
+            "conduit": [
+                "session_id": "session-1",
+                "type": "approval.needed",
+                "decision": ["kind": "approval", "session_key": "session-1", "description": "d"] as [String: Any],
+            ] as [String: Any],
+        ])
+        XCTAssertNil(service.pendingTarget?.decision, "Absent choices must degrade to a routing target")
+
+        // All-empty/invalid choices.
+        service.receiveNotificationPayload([
+            "conduit": [
+                "session_id": "session-1",
+                "type": "approval.needed",
+                "decision": [
+                    "kind": "approval",
+                    "session_key": "session-1",
+                    "description": "d",
+                    "choices": ["  ", ""],
+                ] as [String: Any],
+            ] as [String: Any],
+        ])
+        XCTAssertNil(service.pendingTarget?.decision, "Choices with no usable entries must degrade to a routing target")
+    }
+
     func testFailedNotificationRouteRetriesOnceThenClearsTarget() async {
         let service = PushNotificationService(retryDelay: .zero)
         service.receiveNotificationPayload([

--- a/ConduitTests/MessageNormalizerTests.swift
+++ b/ConduitTests/MessageNormalizerTests.swift
@@ -302,6 +302,32 @@ final class MessageNormalizerTests: XCTestCase {
         XCTAssertFalse(decoded.decisionCards)
     }
 
+    func testNotificationPreferencesDecodeLegacyRegistrationWithoutDecisionCardsKey() throws {
+        // A registration persisted by a build that predated decision_cards.
+        // Decoding must fall back to the default rather than throwing — a
+        // throw would make the `try?` in the service init drop the whole
+        // stored registration and silently disable push on upgrade.
+        let legacyJSON = """
+        {
+          "enabled": true,
+          "approval_needed": false,
+          "input_needed": true,
+          "response_ready": true,
+          "turn_failed": true,
+          "background_task_finished": true,
+          "completion_sound": true,
+          "show_previews": true
+        }
+        """
+        let decoded = try JSONDecoder().decode(
+            ConduitNotificationPreferences.self,
+            from: Data(legacyJSON.utf8)
+        )
+        XCTAssertFalse(decoded.approvalNeeded, "Persisted values must survive")
+        XCTAssertTrue(decoded.showPreviews, "Persisted values must survive")
+        XCTAssertTrue(decoded.decisionCards, "Absent decision_cards must fall back to the default-on value")
+    }
+
     func testFailedNotificationRouteRetriesOnceThenClearsTarget() async {
         let service = PushNotificationService(retryDelay: .zero)
         service.receiveNotificationPayload([

--- a/ConduitTests/MessageNormalizerTests.swift
+++ b/ConduitTests/MessageNormalizerTests.swift
@@ -288,6 +288,20 @@ final class MessageNormalizerTests: XCTestCase {
         XCTAssertNil(service.pendingTarget?.decision, "Choices with no usable entries must degrade to a routing target")
     }
 
+    func testNotificationPreferencesRoundTripDecisionCardsKey() throws {
+        var preferences = ConduitNotificationPreferences()
+        XCTAssertTrue(preferences.decisionCards, "Decision cards default on, independent of show previews")
+        XCTAssertFalse(preferences.showPreviews)
+
+        preferences.decisionCards = false
+        let data = try JSONEncoder().encode(preferences)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertEqual(object?["decision_cards"] as? Bool, false, "The relay expects the snake_case decision_cards key")
+
+        let decoded = try JSONDecoder().decode(ConduitNotificationPreferences.self, from: data)
+        XCTAssertFalse(decoded.decisionCards)
+    }
+
     func testFailedNotificationRouteRetriesOnceThenClearsTarget() async {
         let service = PushNotificationService(retryDelay: .zero)
         service.receiveNotificationPayload([

--- a/ConduitTests/MessageNormalizerTests.swift
+++ b/ConduitTests/MessageNormalizerTests.swift
@@ -328,6 +328,17 @@ final class MessageNormalizerTests: XCTestCase {
         XCTAssertTrue(decoded.decisionCards, "Absent decision_cards must fall back to the default-on value")
     }
 
+    func testExpiredPromptErrorClassification() {
+        // The gateway's one-shot prompt timeout: JSON-RPC 4009.
+        XCTAssertTrue(AppState.isExpiredPromptError(RpcError(code: 4009, message: "no pending approval request")))
+        // Code-less variants still classify via the message, case-insensitively.
+        XCTAssertTrue(AppState.isExpiredPromptError(RpcError(code: nil, message: "No Pending clarify request")))
+        // Genuine failures must not be misread as expiry.
+        XCTAssertFalse(AppState.isExpiredPromptError(RpcError(code: 4004, message: "session not found")))
+        XCTAssertFalse(AppState.isExpiredPromptError(HermesError.timeout("approval.respond")))
+        XCTAssertFalse(AppState.isExpiredPromptError(HermesError.notConnected))
+    }
+
     func testFailedNotificationRouteRetriesOnceThenClearsTarget() async {
         let service = PushNotificationService(retryDelay: .zero)
         service.receiveNotificationPayload([

--- a/ConduitTests/MessageNormalizerTests.swift
+++ b/ConduitTests/MessageNormalizerTests.swift
@@ -170,6 +170,69 @@ final class MessageNormalizerTests: XCTestCase {
         XCTAssertNil(service.pendingTarget)
     }
 
+    func testNotificationPayloadCarriesApprovalDecision() {
+        let service = PushNotificationService(retryDelay: .zero)
+        defer {
+            if let target = service.pendingTarget {
+                service.clearPendingTarget(target)
+            }
+        }
+        service.receiveNotificationPayload([
+            "conduit": [
+                "session_id": "runtime-1",
+                "profile": "default",
+                "type": "approval.needed",
+                "decision": [
+                    "kind": "approval",
+                    "session_key": "runtime-1",
+                    "description": "Run a dangerous shell command",
+                    "choices": ["once", "deny"],
+                ] as [String: Any],
+            ] as [String: Any],
+        ])
+
+        guard case let .approval(sessionKey, description, choices) = service.pendingTarget?.decision else {
+            return XCTFail("Expected an approval decision carried on the notification target")
+        }
+        XCTAssertEqual(sessionKey, "runtime-1")
+        XCTAssertEqual(description, "Run a dangerous shell command")
+        XCTAssertEqual(choices, ["once", "deny"])
+    }
+
+    func testNotificationPayloadDecisionAbsentForNonDecisionEvents() {
+        let service = PushNotificationService(retryDelay: .zero)
+        defer {
+            if let target = service.pendingTarget {
+                service.clearPendingTarget(target)
+            }
+        }
+        service.receiveNotificationPayload([
+            "conduit": [
+                "session_id": "session-1",
+                "type": "response.ready",
+            ] as [String: Any],
+        ])
+        XCTAssertNil(service.pendingTarget?.decision, "Non-decision notifications must not carry a decision")
+    }
+
+    func testNotificationPayloadDecisionRejectedWithoutSessionKey() {
+        let service = PushNotificationService(retryDelay: .zero)
+        defer {
+            if let target = service.pendingTarget {
+                service.clearPendingTarget(target)
+            }
+        }
+        // An approval with no answerable session key is not useful; drop it.
+        service.receiveNotificationPayload([
+            "conduit": [
+                "session_id": "session-1",
+                "type": "approval.needed",
+                "decision": ["kind": "approval", "description": "something"] as [String: Any],
+            ] as [String: Any],
+        ])
+        XCTAssertNil(service.pendingTarget?.decision)
+    }
+
     func testFailedNotificationRouteRetriesOnceThenClearsTarget() async {
         let service = PushNotificationService(retryDelay: .zero)
         service.receiveNotificationPayload([

--- a/ConduitTests/SessionPresentationCacheTests.swift
+++ b/ConduitTests/SessionPresentationCacheTests.swift
@@ -551,6 +551,59 @@ final class SessionPresentationCacheTests: XCTestCase {
         )
     }
 
+    func testRecordPendingDecisionRestartsExpiryWindowForFreshObservation() {
+        let suiteName = "conduit.tests.record-decision-expiry-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        var now = Date(timeIntervalSince1970: 1_700_000_000)
+        let cache = SessionPresentationCache(defaults: defaults, now: { now })
+        let sessionId = "test-record-expiry-\(UUID().uuidString)"
+        let profile = "test"
+        defer {
+            cache.clear(profile: profile)
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        func card(description: String) -> ChatMessage {
+            ChatMessage(
+                id: "approval-\(sessionId)",
+                role: .approval,
+                content: description,
+                timestamp: "t",
+                approval: ApprovalActivity(
+                    sessionId: sessionId,
+                    command: "",
+                    description: description,
+                    choices: ["once", "deny"],
+                    allowPermanent: false,
+                    smartDenied: false,
+                    status: .pending,
+                    choice: nil,
+                    error: nil
+                )
+            )
+        }
+
+        // A card recorded yesterday, beyond the 24h unconfirmed window...
+        cache.recordPendingDecision(card(description: "stale"), profile: profile, sessionIDs: [sessionId])
+        // ...then a fresh push-delivered observation for the same decision today.
+        now = now.addingTimeInterval(25 * 60 * 60)
+        cache.recordPendingDecision(card(description: "fresh"), profile: profile, sessionIDs: [sessionId])
+        // An hour later the fresh card must still restore: recording it
+        // restarted the bounded window instead of inheriting yesterday's stamp.
+        now = now.addingTimeInterval(60 * 60)
+
+        let merged = cache.merge([], profile: profile, sessionIDs: [sessionId], includePendingApprovals: true)
+        let restored = merged.first { $0.role == .approval }
+        XCTAssertEqual(
+            restored?.approval?.description,
+            "fresh",
+            "A freshly recorded decision must not inherit an expired session marker"
+        )
+    }
+
     func testMergeDoesNotRestoreApprovalWhenNotRequested() {
         let cache = SessionPresentationCache.shared
         let sessionId = "test-merge-approval-off-\(UUID().uuidString)"

--- a/ConduitTests/SessionPresentationCacheTests.swift
+++ b/ConduitTests/SessionPresentationCacheTests.swift
@@ -404,6 +404,153 @@ final class SessionPresentationCacheTests: XCTestCase {
         XCTAssertEqual(restoredApproval?.approval?.status, .pending)
     }
 
+    func testRecordPendingDecisionRestoresApprovalWithoutDisturbingTranscript() {
+        let suiteName = "conduit.tests.record-decision-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: defaults)
+        let sessionId = "test-record-\(UUID().uuidString)"
+        let profile = "test"
+        defer {
+            cache.clear(profile: profile)
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        // Seed the cached transcript the way a normal save would.
+        let transcript = [
+            ChatMessage(id: "u1", role: .user, content: "please clean tmp", timestamp: "t1"),
+            ChatMessage(id: "a1", role: .assistant, content: "on it", timestamp: "t2"),
+        ]
+        cache.save(transcript, profile: profile, sessionIDs: [sessionId])
+
+        // A push delivers a pending approval card that arrived while backgrounded.
+        let approval = ApprovalActivity(
+            sessionId: sessionId,
+            command: "",
+            description: "Delete temp files",
+            choices: ["once", "deny"],
+            allowPermanent: false,
+            smartDenied: false,
+            status: .pending,
+            choice: nil,
+            error: nil
+        )
+        let card = ChatMessage(
+            id: "approval-\(sessionId)",
+            role: .approval,
+            content: "Delete temp files",
+            timestamp: "t3",
+            approval: approval
+        )
+        cache.recordPendingDecision(card, profile: profile, sessionIDs: [sessionId])
+
+        // Gateway resume replays the transcript but omits the one-shot approval event.
+        let merged = cache.merge(
+            transcript,
+            profile: profile,
+            sessionIDs: [sessionId],
+            includePendingApprovals: true
+        )
+
+        let restored = merged.first { $0.role == .approval }
+        XCTAssertEqual(restored?.approval?.sessionId, sessionId)
+        XCTAssertEqual(restored?.approval?.status, .pending)
+        // The transcript rows survive the upsert (non-destructive).
+        XCTAssertTrue(merged.contains { $0.id == "u1" })
+        XCTAssertTrue(merged.contains { $0.id == "a1" })
+    }
+
+    func testRecordPendingDecisionReplacesExistingCardForSameDecision() {
+        let suiteName = "conduit.tests.record-decision-dedupe-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: defaults)
+        let sessionId = "test-record-dedupe-\(UUID().uuidString)"
+        let profile = "test"
+        defer {
+            cache.clear(profile: profile)
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        func card(description: String) -> ChatMessage {
+            ChatMessage(
+                id: "approval-\(sessionId)",
+                role: .approval,
+                content: description,
+                timestamp: "t",
+                approval: ApprovalActivity(
+                    sessionId: sessionId,
+                    command: "",
+                    description: description,
+                    choices: ["once", "deny"],
+                    allowPermanent: false,
+                    smartDenied: false,
+                    status: .pending,
+                    choice: nil,
+                    error: nil
+                )
+            )
+        }
+        cache.recordPendingDecision(card(description: "old"), profile: profile, sessionIDs: [sessionId])
+        cache.recordPendingDecision(card(description: "new"), profile: profile, sessionIDs: [sessionId])
+
+        let merged = cache.merge([], profile: profile, sessionIDs: [sessionId], includePendingApprovals: true)
+        let approvals = merged.filter { $0.role == .approval }
+        XCTAssertEqual(approvals.count, 1, "Recording the same decision twice must not duplicate the card")
+        XCTAssertEqual(approvals.first?.approval?.description, "new")
+    }
+
+    func testRecordPendingDecisionAppliesAcrossRuntimeAndStoredSessionIDs() {
+        let suiteName = "conduit.tests.record-decision-ids-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: defaults)
+        let profile = "test"
+        let runtimeID = "runtime-\(UUID().uuidString)"
+        let storedID = "stored-\(UUID().uuidString)"
+        defer {
+            cache.clear(profile: profile)
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let card = ChatMessage(
+            id: "approval-\(runtimeID)",
+            role: .approval,
+            content: "Delete temp files",
+            timestamp: "t",
+            approval: ApprovalActivity(
+                sessionId: runtimeID,
+                command: "",
+                description: "Delete temp files",
+                choices: ["once", "deny"],
+                allowPermanent: false,
+                smartDenied: false,
+                status: .pending,
+                choice: nil,
+                error: nil
+            )
+        )
+        // Written under both identities, as openNotificationTarget does.
+        cache.recordPendingDecision(card, profile: profile, sessionIDs: [storedID, runtimeID])
+
+        XCTAssertTrue(
+            cache.merge([], profile: profile, sessionIDs: [storedID], includePendingApprovals: true)
+                .contains { $0.role == .approval },
+            "Card recorded under the stored id should restore on merge"
+        )
+        XCTAssertTrue(
+            cache.merge([], profile: profile, sessionIDs: [runtimeID], includePendingApprovals: true)
+                .contains { $0.role == .approval },
+            "Card recorded under the runtime id should restore on merge"
+        )
+    }
+
     func testMergeDoesNotRestoreApprovalWhenNotRequested() {
         let cache = SessionPresentationCache.shared
         let sessionId = "test-merge-approval-off-\(UUID().uuidString)"

--- a/docs/superpowers/specs/2026-08-13-decision-cards-after-background-arrival-design.md
+++ b/docs/superpowers/specs/2026-08-13-decision-cards-after-background-arrival-design.md
@@ -1,0 +1,314 @@
+# Design Spec: Surface Decision Cards That Arrive While Conduit Is Backgrounded
+
+**Date:** 2026-08-13
+**Branch:** `fix/decision-cards-after-background-arrival`
+**Follow-up to:** PR #54 (Keep pending decisions visible after background resume)
+**Status:** Proposed — awaiting sign-off
+
+## Problem
+
+When Hermes raises a clarification or approval request while the Conduit iOS
+app is backgrounded, the user gets a push notification, taps it, the app
+returns to the correct session — but **the answerable card never appears.**
+
+PR #54 fixed a narrower case: a card that was already observed and cached
+locally before the app was backgrounded survives a foreground resume. It does
+**not** help when the decision event is raised *after* the app is already
+backgrounded, because in that case the card was never observed and there is
+nothing cached to restore.
+
+## Root cause (confirmed against Hermes source)
+
+A pending decision can only reach the iOS client today via a **one-shot live
+WebSocket event** — `clarify`/`clarify.request` or `approval.request`
+(`Conduit/Services/StreamEventParser.swift:93-106`), materialized by
+`AppState.applyStreamEvent` (`AppState.swift:6810-6847`) and gated on the app
+being foregrounded with that session active. When the decision is raised while
+the app is backgrounded, iOS is suspended and never receives that event.
+
+There is **no client-side fallback source** for the decision content after the
+fact. Verified in `github.com/nousresearch/hermes-agent`:
+
+- **`session.resume` does not carry the decision.** The cold-resume path
+  (`tui_gateway/methods_session.py`, `@method("session.resume")`) returns
+  `inflight: None`, `messages` = the stored transcript, and `status: "idle"`/
+  `"waiting"`. The stored transcript never contains a decision card: decisions
+  are live blocking prompts, not persisted message rows.
+- **The decision is held only in gateway memory.** `_block()` in
+  `tui_gateway/server.py` emits the `*.request` event **exactly once**
+  (`_emit(event, sid, payload)`) and blocks the agent thread up to ~5 min. The
+  payload lives in `_pending`/`_pending_prompt_payloads` (approval/sudo/secret)
+  and `tools/clarify_gateway.py::_entries` (clarify).
+- **No replay on reconnect, and no fetch RPC.** `_pending_prompt_payloads` is
+  read only by `_session_pending_kind()` to derive `status: "waiting"`. There
+  is no re-emit-on-transport-reattach and no `prompts.list` /
+  `session.pending_prompt` RPC. Plugins cannot register gateway RPCs either
+  (`hermes_cli/plugins.py::PluginContext` exposes `register_tool`,
+  `register_approval_transport`, `register_middleware`, hooks — but no RPC
+  registration).
+- **`MessageNormalizer.normalizeMessages`** (`HermesClient.swift:1404`) maps
+  only user/system/reasoning/tool/assistant roles. It has no clarify/approval
+  handling, so any decision-shaped row would be dropped. This is also why PR
+  #54's "gateway-provided pending decision" path is unreachable in production:
+  `normalizeMessages` never emits `.clarify`/`.approval` messages, and PR #54's
+  test builds that message by hand (`testApplyChatResumePreservesGatewayPendingDecisionWhenRunningIsNil`).
+
+**Net:** the decision content is genuinely unreachable from the client after a
+background gap. No purely client-side change can show the card.
+
+## Existing notification pipeline (already a plugin → relay → APNs path)
+
+Conduit already has a delivery channel for these events. From the Conduit
+README and `kaishi00/hermes-conduit-notifier`:
+
+1. **Notifier plugin** (`hermes-conduit-notifier`, repo `kaishi00/...`).
+   `register(ctx)` subscribes to Hermes hooks (`__init__.py`):
+   - `pre_tool_call` with `tool_name == "clarify"` → sends an `input.needed`
+     event whose `body` is `clarification_text(args)` (the question text only).
+   - `pre_approval_request` → sends an `approval.needed` event whose `body` is
+     the approval `description` (skips `surface == "smart"`).
+   - Each event is `push_event(type, session_id, profile, title, body)`
+     (`events.py`) — **routing + a short text body only. No structured card
+     data (request id, choices, command).**
+   - `client.py` POSTs the event to `{relay_url}/v1/events` as a background
+     worker.
+
+2. **Relay server** (`push.milim.dev`; source is `relay/` in
+   `kaishi00/hermes-conduit-notifier` — Node.js, self-hostable). Receives
+   `/v1/events`, maps them to APNs, and pushes to iOS. `notificationFor()`
+   builds the APNs `conduit` payload, which currently carries only
+   `session_id` / `profile` / `type`; `validateEvent()` whitelists event fields
+   and drops everything else.
+
+3. **iOS** `PushNotificationService.receiveNotificationPayload`
+   (`PushNotificationService.swift:192`) parses only `session_id`/`profile`/
+   `type` into a `ConduitNotificationTarget` and discards everything else.
+
+So the pipe that could carry card content already exists end to end — it just
+only carries a routing stub today.
+
+## Goal
+
+When a clarification or approval is raised while Conduit is backgrounded, the
+full answerable card (question + choices for clarify; description + choices +
+the identity needed to respond for approval) is delivered to the device **at
+notification time**, cached locally, and rendered on the next foreground —
+without depending on the one-shot stream event or any new gateway RPC.
+
+## Non-goals
+
+- Do not change the Hermes gateway itself (no upstream PR; Nous have no mobile
+  client and the merge outlook is poor). The gateway-side work is a **plugin**
+  the user already ships and controls.
+- Do not change the foreground decision flow. When the app is foregrounded and
+  connected, the existing `*.request` stream event path is unchanged.
+- Do not introduce a new gateway RPC or a "decision inbox."
+- Do not change `clarify.respond` / `approval.respond`.
+
+## Design
+
+Enrich the existing pipeline so decision **content** rides along the
+notification, then cache it on receipt (which runs from the APNs handler and
+therefore works while backgrounded). On resume, PR #54's cache-restore path
+(`SessionPresentationCache.merge` with `includePendingClarifications` /
+`includePendingApprovals`) renders the cached card.
+
+This is strictly stronger than fetch-on-resume: the card is captured on the
+device the moment the push lands, so it is visible even if the user does not
+immediately open the notification, and it survives the agent's ~5-minute
+server-side prompt timeout (the card stays visible; only a late *response*
+would be rejected).
+
+### Approval — clean and fully answerable
+
+The `pre_approval_request` hook already has everything needed:
+
+- `session_key` (approvals are session-keyed; `approval.respond` takes
+  `{choice, session_id}` — confirmed at `HermesClient.swift:932`. No separate
+  request id required to respond.)
+- `command`, `description`, `pattern_key`, and the allowed choices
+  (derivable from `allow_permanent` / `smart_denied` per
+  `_emit_approval_request` in `server.py`).
+
+**Plugin change:** in `_pre_approval_request`, include a structured
+`approval` object in the event: `{session_key, description, command (redacted),
+choices, allow_permanent}`. (Use observer-hook capture — additive, leaves the
+foreground `approval.request` event path untouched. This matches the chosen
+"Observer hook" direction.)
+
+**Relay change** (`relay/src/server.mjs` in the notifier repo): accept the
+`approval` object in `validateEvent()` and forward it into the APNs `conduit`
+payload in `notificationFor()`.
+
+**iOS change:** `PushNotificationService` parses the `approval` object, builds
+an `ApprovalActivity` (status `.pending`), wraps it in a `.approval`
+`ChatMessage`, and writes it to `SessionPresentationCache.save` for that
+session on receipt. PR #54 restores it on resume; the existing
+`respondToApproval(sessionId:choice:)` answers it.
+
+### Clarify — answerability is blocked by the gateway; only visibility is plugin-reachable
+
+Verified against Hermes source (`tui_gateway/server.py`, `tools/clarify_gateway.py`,
+`hermes_cli/plugins.py`):
+
+- `clarify.respond` resolves **only** by `request_id`
+  (`server.py::_respond`: `_pending.get(r)`). It is **not** session-keyed,
+  unlike approval. (`resolve_text_response_for_session` in `clarify_gateway`
+  is a separate text-fallback path for new prompts, not a `clarify.respond`
+  route.)
+- That `request_id` is the `rid` generated inside `_block()`. The gateway's
+  clarify callback is `clarify_callback → _block("clarify.request", sid,
+  {question, choices})` (`server.py:5879`); `_block` mints the `rid`, sets
+  `payload["request_id"] = rid`, stores it in `_pending`/
+  `_pending_prompt_payloads`, and emits `clarify.request` exactly once.
+- **No plugin hook surfaces it.** `VALID_HOOKS` has only `pre_tool_call` /
+  `post_tool_call` (they fire before/after execution, with no id).
+  `clarify_gateway`'s `register_notify` callbacks are a gateway-internal
+  adapter bridge, not a plugin hook.
+- **Overriding the clarify *tool* does not help either.** The rid is created
+  inside the gateway callback the tool delegates to, so a plugin-provided
+  clarify tool still never sees it.
+
+So, unlike approval, a pure observer-hook capture cannot make clarify
+answerable after a background gap. The options are:
+
+- **B. Visibility-only (plugin-only; ships now).** `pre_tool_call` ships the
+  question + choices so the card appears (fixes "cards do not appear"), but the
+  cached card carries no `request_id`, so it **cannot be answered** after a
+  background miss (the live `clarify.request` is gone and the id is
+  unreachable). Use only as an interim, with explicit "reopen within the
+  waiting window to answer" framing — and accept that if the user does reopen,
+  the live event will not re-deliver, so answering still fails. Honest about
+  the limitation; addresses visibility only.
+- **C. Plugin-owned clarify loop (plugin-only; answerable; larger build).**
+  Override the clarify tool with an implementation that mints its **own** id,
+  routes question + choices + id through the relay, and resolves the answer
+  through a relay → plugin response channel (not `clarify.respond`). Requires a
+  new relay response-forwarding endpoint and iOS responding via the relay
+  instead of `clarify.respond`. Risk: bypasses the gateway clarify path, so a
+  co-resident desktop/CLI client would need the plugin to also emit
+  `clarify.request` on its behalf.
+- **D. Gateway re-emit (cleanest; upstream).** Re-emit the pending
+  `clarify.request` (and `approval.request`) when a transport reattaches to a
+  session. Fixes clarify answerability for every client and removes the need
+  for C's parallel loop. This is small and generally useful (helps desktop
+  reconnects too), so its merge outlook is better than a mobile-specific
+  feature — but it still depends on Nous accepting it, which is uncertain.
+
+**Recommendation:** ship **approval fully now** (Phase 1). For clarify, start
+with **B** so the reported symptom ("cards do not appear") is addressed, then
+pursue **D** for answerability (fall back to **C** only if upstream is refused
+and clarify answerability is required).
+
+### Component changes summary
+
+| Component | Repo | Change |
+| --- | --- | --- |
+| Notifier plugin | `kaishi00/hermes-conduit-notifier` | Add structured `clarify`/`approval` content (incl. `clarify_id` for clarify) to `input.needed`/`approval.needed` events. Clarify via tool override (option A). |
+| Relay server | `kaishi00/hermes-conduit-notifier` under `relay/` (Node.js; same repo as the plugin) | Extend `validateEvent()` + `notificationFor()` in `relay/src/server.mjs` to pass `decision` into the APNs `conduit` payload. Contract below. |
+| iOS client | `hermes-conduit` (this repo) | Parse `clarify`/`approval` from the APNs payload; build + cache the card on receipt; PR #54 restores on resume. |
+
+### Relay → APNs payload contract
+
+Extend the existing `conduit` object. Keep `session_id`/`profile`/`type` as
+today; add an optional `decision` object:
+
+```jsonc
+{
+  "conduit": {
+    "session_id": "<stored-or-runtime-session-id>",
+    "profile": "default",
+    "type": "input_needed",            // or "approval_needed"
+    "decision": {                       // optional; present only for decision notifications
+      "kind": "clarify",                // "clarify" | "approval"
+      "request_id": "<clarify_id>",     // clarify only (from option A)
+      "session_key": "<approval session key>", // approval only
+      "question": "Which color?",       // clarify
+      "description": "...",             // approval
+      "command": "<redacted>",          // approval, redacted
+      "choices": [                      // clarify: {label,value}; approval: ["once","session","always","deny"]
+        { "label": "Red", "value": "red" }
+      ],
+      "allow_permanent": true           // approval
+    }
+  }
+}
+```
+
+Constraints: APNs allows ~4 KB; decision payloads are tiny. **Security:** the
+approval `command` MUST be redacted before it leaves the gateway (reuse the
+gateway's `_redact_approval_command` semantics; the approval transport contract
+already treats the request as display-only/redacted). Prefer sending
+`description` over raw `command`; never echo credentials. This matters because
+the README promises no third-party data handling, and APNs/relay is an
+additional egress path.
+
+### iOS changes (this repo)
+
+1. `PushNotificationService.notificationTarget(from:)` /
+   `receiveNotificationPayload`: parse the optional `decision` object into a
+   typed structure (mirror `ClarifyActivity` / `ApprovalActivity`).
+2. On receipt, build the corresponding `.clarify` / `.approval` `ChatMessage`
+   (status `.pending`) and persist it via `SessionPresentationCache.save`
+   (`preservePendingDecisionCards: true`, with the bounded unconfirmed marker
+   so it cannot linger forever — same safeguard PR #54 uses). This runs from
+   the APNs delivery callback, so it works while backgrounded.
+3. On resume, PR #54's `applyChatResume` → `merge` path already restores
+   cached pending cards; verify it renders a card cached this way (it should,
+   since the cache shape is identical to a live-observed card). Reconcile by
+   decision key so a later live/gateway card replaces the cached one without a
+   duplicate.
+4. Keep the existing foreground path authoritative: if a live `*.request`
+   arrives for the same key, it supersedes the cached push card.
+
+## Open issues / decisions
+
+- **Clarify answerability** — RESOLVED by investigation: no plugin hook exposes
+  the clarify `request_id`, and `clarify.respond` is request-id-only (not
+  session-keyed). So plugin-only clarify is visibility-only (B); answerability
+  needs C (plugin-owned loop) or D (gateway re-emit). See the Clarify section.
+- **Relay is in-repo.** The relay source is `relay/` in
+  `kaishi00/hermes-conduit-notifier` (Node.js, self-hostable), so the
+  payload-forwarding change is a normal PR alongside the plugin — no closed
+  component blocks the fix.
+- **Self-hosting.** Because the relay is published, self-hosters receive
+  decision content too once they update. (Conduit still defaults to the shared
+  `push.milim.dev` for zero-setup use.)
+- **Redaction** — must be enforced for approval `command` before it enters the
+  payload (security-sensitive egress).
+- **Coalescing** — multiple decision notifications while backgrounded: approvals
+  are one in-flight per session; clarify is keyable by `clarify_id`. Cache by
+  decision key so the latest pending card per session wins.
+
+## Phasing
+
+1. **Phase 1 — Approval end-to-end (vertical slice).** Plugin observer hook →
+   relay payload → iOS parse/cache → card renders + is answerable on resume.
+   Approval needs no new gateway RPC and no clarify-id work, so it proves the
+   whole pipe with the least risk.
+2. **Phase 2 — Clarify visibility (plugin-only, option B).** Extend
+   `input.needed` to carry question + choices so the clarify card appears after
+   a background gap. Answerability after backgrounding remains a known
+   limitation pending D (or C).
+3. **Phase 3 — Clarify answerability (option D preferred).** Pursue the
+   gateway re-emit of pending `*.request` events on transport reattach
+   upstream; fall back to C (plugin-owned loop) only if upstream is refused.
+4. **Phase 4 — Hardening.** Redaction, bounded-expiry sweep, duplicate-key
+   reconciliation, and regression tests for the background-arrival cache path.
+
+## Acceptance tests
+
+- An approval raised while the app is backgrounded produces an APNs payload
+  whose `conduit.decision` carries description + redacted command + choices.
+- iOS, on receipt (backgrounded), writes a pending `ApprovalActivity` to the
+  session cache. Foregrounding renders the card answerable via the existing
+  `respondToApproval` path, with `turnState == .idle`.
+- A clarify raised while backgrounded yields a cached `.clarify` card carrying
+  the `clarify_id`; foregrounding renders it answerable via
+  `respondToClarification`.
+- A later live `*.request` for the same decision key supersedes the cached
+  push card without producing a duplicate.
+- An unconfirmed cached card expires after
+  `SessionPresentationCache.maxUnconfirmedPendingDecisionAge`.
+- The existing `SessionPresentationCacheTests` and full XCTest suite remain
+  green.

--- a/docs/superpowers/specs/2026-08-13-decision-cards-after-background-arrival-design.md
+++ b/docs/superpowers/specs/2026-08-13-decision-cards-after-background-arrival-design.md
@@ -275,7 +275,12 @@ section), degrading either case to the plain routing stub.
    inherited from an old card would otherwise expire a brand-new decision
    immediately). The card is written under both the runtime and resolved
    stored session ids, and only when the decision's session key matches one
-   of those identities.
+   of those identities. Presentation-cache flushes union the store's pending
+   decision keys into the preserve set, so the pre-resume flush inside
+   `openSession` — which rebuilds the cache entry from the in-memory
+   transcript that has never seen the push card — cannot wipe a store-only
+   card when the notified session is already active (regression-tested at the
+   AppState level).
 3. On resume, PR #54's `applyChatResume` → `merge` path restores cached
    pending cards; reconcile by decision key means a later live/gateway card
    replaces the cached one without a duplicate.

--- a/docs/superpowers/specs/2026-08-13-decision-cards-after-background-arrival-design.md
+++ b/docs/superpowers/specs/2026-08-13-decision-cards-after-background-arrival-design.md
@@ -223,7 +223,7 @@ and clarify answerability is required).
 | Component | Repo | Change |
 | --- | --- | --- |
 | Notifier plugin | `kaishi00/hermes-conduit-notifier` | Attach structured **approval** `decision` content (`session_key`, `description`, `once`/`deny` choices) to `approval.needed` events. Clarify is deliberately not emitted (see the Clarify section). |
-| Relay server | `kaishi00/hermes-conduit-notifier` under `relay/` (Node.js; same repo as the plugin) | `relay/src/server.mjs`: re-validate the decision (approval-only, kind↔type bound, choice whitelist) and forward it into the APNs `conduit` payload, gated on `show_previews` and the APNs size cap. Contract below. |
+| Relay server | `kaishi00/hermes-conduit-notifier` under `relay/` (Node.js; same repo as the plugin) | `relay/src/server.mjs`: re-validate the decision (approval-only, kind↔type bound, choice whitelist) and forward it into the APNs `conduit` payload, gated on `decision_cards` and the APNs size cap. Contract below. |
 | iOS client | `hermes-conduit` (this repo) | Parse `decision` from the APNs payload; record the card via `SessionPresentationCache.recordPendingDecision` when the notification is opened; PR #54 restores it on resume. |
 
 ### Relay → APNs payload contract (shipped)
@@ -342,7 +342,7 @@ section), degrading either case to the plain routing stub.
 
 - An approval raised while the app is backgrounded produces an APNs payload
   whose `conduit.decision` carries `kind`/`session_key`/`description` and the
-  `once`/`deny` choices — but only when `show_previews` is enabled, and never
+  `once`/`deny` choices — but only when `decision_cards` is enabled, and never
   the raw `command`.
 - iOS, when the notification is opened, records a pending `ApprovalActivity`
   to the session cache under both session identities; the resume renders the

--- a/docs/superpowers/specs/2026-08-13-decision-cards-after-background-arrival-design.md
+++ b/docs/superpowers/specs/2026-08-13-decision-cards-after-background-arrival-design.md
@@ -146,11 +146,12 @@ untouched.
 at the trust boundary (kind must be `approval` and agree with the event type;
 choices whitelisted to the gateway approval vocabulary; `session_key` +
 `description` + non-empty choices required) and forwards it into the APNs
-`conduit` payload — **gated on the user's `show_previews` preference**, exactly
-like `title`/`body`, so a previews-off installation never has approval
-descriptions in the payload. If the encoded payload would exceed the ~4 KB
-APNs cap, the decision is dropped and the notification degrades to the
-routing stub.
+`conduit` payload — **gated on a dedicated `decision_cards` preference**
+(default on, independent of `show_previews`: previews only control banner
+text, while this controls functional answerability, and the audience running
+approval gates is exactly who the cards are for). If the encoded payload
+would exceed the ~4 KB APNs cap, the decision is dropped and the notification
+degrades to the routing stub.
 
 **iOS change (shipped):** `PushNotificationService` parses the `decision`
 (strictly — an approval without display text or usable choices degrades to a
@@ -229,9 +230,9 @@ and clarify answerability is required).
 
 Extend the existing `conduit` object. Keep `session_id`/`profile`/`type` as
 today; add an optional `decision` object, present only for
-`approval.needed` notifications, only when the user's `show_previews`
-preference is enabled, and only when the encoded payload stays under the
-APNs ~4 KB cap:
+`approval.needed` notifications, only when the user's `decision_cards`
+preference is enabled (default on; independent of `show_previews`), and only
+when the encoded payload stays under the APNs ~4 KB cap:
 
 ```jsonc
 {
@@ -302,8 +303,11 @@ section), degrading either case to the plain routing stub.
   decision content too once they update. (Conduit still defaults to the shared
   `push.milim.dev` for zero-setup use.)
 - **Privacy** — the raw approval `command` never enters the payload (omitted
-  at the plugin), and the `decision` content is gated on `show_previews` at
-  the relay, matching how `title`/`body` previews already work.
+  at the plugin), and the `decision` content is gated on a dedicated
+  `decision_cards` preference (default on, Settings > Notifications > Approval
+  cards in pushes). It is deliberately independent of `show_previews`:
+  previews control banner text, this controls functional answerability, and
+  privacy-focused users can turn just this off.
 - **Receipt-time capture** — alert pushes cannot wake a suspended app, so the
   card is cached when the notification is **opened** (tap or cold-launch via
   the notification). Covering "dismiss the banner, foreground manually" would

--- a/docs/superpowers/specs/2026-08-13-decision-cards-after-background-arrival-design.md
+++ b/docs/superpowers/specs/2026-08-13-decision-cards-after-background-arrival-design.md
@@ -108,43 +108,60 @@ without depending on the one-shot stream event or any new gateway RPC.
 ## Design
 
 Enrich the existing pipeline so decision **content** rides along the
-notification, then cache it on receipt (which runs from the APNs handler and
-therefore works while backgrounded). On resume, PR #54's cache-restore path
-(`SessionPresentationCache.merge` with `includePendingClarifications` /
-`includePendingApprovals`) renders the cached card.
+notification, then cache the card when the app processes that notification.
+On the subsequent resume, PR #54's cache-restore path
+(`SessionPresentationCache.merge` with `includePendingApprovals`) renders the
+cached card.
 
-This is strictly stronger than fetch-on-resume: the card is captured on the
-device the moment the push lands, so it is visible even if the user does not
-immediately open the notification, and it survives the agent's ~5-minute
-server-side prompt timeout (the card stays visible; only a late *response*
-would be rejected).
+**Scope of "receipt":** these are alert-style pushes; iOS does not wake a
+suspended app on delivery, so the payload reaches the app only when the user
+taps the notification or cold-launches from it. The card is therefore cached
+at **notification-open time** (in `openNotificationTarget`, where the session
+catalog is also available to resolve the runtime id to the stored id), not at
+banner-display time. If the user dismisses the banner and foregrounds the app
+manually, no payload is delivered to the app and the card cannot be
+reconstructed — that case would require a silent (`content-available`) push
+or the Phase 3 gateway work. Within its scope the card still survives the
+agent's ~5-minute server-side prompt timeout: once cached, the card is
+visible even though a late *response* would be rejected.
 
 ### Approval — clean and fully answerable
 
-The `pre_approval_request` hook already has everything needed:
+The `pre_approval_request` hook has what is needed for an answerable card:
+`session_key` (approvals are session-keyed; `approval.respond` takes
+`{choice, session_id}` — confirmed at `HermesClient.swift:932`, no separate
+request id required to respond), `description`, and — because the hook does
+**not** expose `allow_session`/`allow_permanent` — the always-valid
+`once`/`deny` choice subset (Hermes builds every `ApprovalRequest` with at
+least those two).
 
-- `session_key` (approvals are session-keyed; `approval.respond` takes
-  `{choice, session_id}` — confirmed at `HermesClient.swift:932`. No separate
-  request id required to respond.)
-- `command`, `description`, `pattern_key`, and the allowed choices
-  (derivable from `allow_permanent` / `smart_denied` per
-  `_emit_approval_request` in `server.py`).
+**Plugin change (shipped):** in `_pre_approval_request`, attach a structured
+`decision` object: `{kind: "approval", session_key, description,
+choices: ["once","deny"]}`. The raw `command` is intentionally **omitted** —
+it can carry secrets and the relay/APNs path is an extra egress transport.
+Observer-hook capture only; the foreground `approval.request` event path is
+untouched.
 
-**Plugin change:** in `_pre_approval_request`, include a structured
-`approval` object in the event: `{session_key, description, command (redacted),
-choices, allow_permanent}`. (Use observer-hook capture — additive, leaves the
-foreground `approval.request` event path untouched. This matches the chosen
-"Observer hook" direction.)
+**Relay change (shipped):** `relay/src/server.mjs` re-validates the decision
+at the trust boundary (kind must be `approval` and agree with the event type;
+choices whitelisted to the gateway approval vocabulary; `session_key` +
+`description` + non-empty choices required) and forwards it into the APNs
+`conduit` payload — **gated on the user's `show_previews` preference**, exactly
+like `title`/`body`, so a previews-off installation never has approval
+descriptions in the payload. If the encoded payload would exceed the ~4 KB
+APNs cap, the decision is dropped and the notification degrades to the
+routing stub.
 
-**Relay change** (`relay/src/server.mjs` in the notifier repo): accept the
-`approval` object in `validateEvent()` and forward it into the APNs `conduit`
-payload in `notificationFor()`.
-
-**iOS change:** `PushNotificationService` parses the `approval` object, builds
-an `ApprovalActivity` (status `.pending`), wraps it in a `.approval`
-`ChatMessage`, and writes it to `SessionPresentationCache.save` for that
-session on receipt. PR #54 restores it on resume; the existing
-`respondToApproval(sessionId:choice:)` answers it.
+**iOS change (shipped):** `PushNotificationService` parses the `decision`
+(strictly — an approval without display text or usable choices degrades to a
+plain routing target) onto `ConduitNotificationTarget`. When the user opens
+the notification, `AppState.openNotificationTarget` builds the `.pending`
+`ApprovalActivity` card and records it via a new non-destructive
+`SessionPresentationCache.recordPendingDecision` upsert, under both the
+notification's runtime session id and the resolved stored id, guarded so the
+decision's session key must match one of those identities. PR #54's merge
+restores it on resume; the existing `respondToApproval(sessionId:choice:)`
+answers it.
 
 ### Clarify — answerability is blocked by the gateway; only visibility is plugin-reachable
 
@@ -204,62 +221,67 @@ and clarify answerability is required).
 
 | Component | Repo | Change |
 | --- | --- | --- |
-| Notifier plugin | `kaishi00/hermes-conduit-notifier` | Add structured `clarify`/`approval` content (incl. `clarify_id` for clarify) to `input.needed`/`approval.needed` events. Clarify via tool override (option A). |
-| Relay server | `kaishi00/hermes-conduit-notifier` under `relay/` (Node.js; same repo as the plugin) | Extend `validateEvent()` + `notificationFor()` in `relay/src/server.mjs` to pass `decision` into the APNs `conduit` payload. Contract below. |
-| iOS client | `hermes-conduit` (this repo) | Parse `clarify`/`approval` from the APNs payload; build + cache the card on receipt; PR #54 restores on resume. |
+| Notifier plugin | `kaishi00/hermes-conduit-notifier` | Attach structured **approval** `decision` content (`session_key`, `description`, `once`/`deny` choices) to `approval.needed` events. Clarify is deliberately not emitted (see the Clarify section). |
+| Relay server | `kaishi00/hermes-conduit-notifier` under `relay/` (Node.js; same repo as the plugin) | `relay/src/server.mjs`: re-validate the decision (approval-only, kind↔type bound, choice whitelist) and forward it into the APNs `conduit` payload, gated on `show_previews` and the APNs size cap. Contract below. |
+| iOS client | `hermes-conduit` (this repo) | Parse `decision` from the APNs payload; record the card via `SessionPresentationCache.recordPendingDecision` when the notification is opened; PR #54 restores it on resume. |
 
-### Relay → APNs payload contract
+### Relay → APNs payload contract (shipped)
 
 Extend the existing `conduit` object. Keep `session_id`/`profile`/`type` as
-today; add an optional `decision` object:
+today; add an optional `decision` object, present only for
+`approval.needed` notifications, only when the user's `show_previews`
+preference is enabled, and only when the encoded payload stays under the
+APNs ~4 KB cap:
 
 ```jsonc
 {
   "conduit": {
-    "session_id": "<stored-or-runtime-session-id>",
+    "session_id": "<runtime session id>",
     "profile": "default",
-    "type": "input_needed",            // or "approval_needed"
-    "decision": {                       // optional; present only for decision notifications
-      "kind": "clarify",                // "clarify" | "approval"
-      "request_id": "<clarify_id>",     // clarify only (from option A)
-      "session_key": "<approval session key>", // approval only
-      "question": "Which color?",       // clarify
-      "description": "...",             // approval
-      "command": "<redacted>",          // approval, redacted
-      "choices": [                      // clarify: {label,value}; approval: ["once","session","always","deny"]
-        { "label": "Red", "value": "red" }
-      ],
-      "allow_permanent": true           // approval
+    "type": "approval.needed",
+    "decision": {                       // optional; approval only in Phase 1
+      "kind": "approval",
+      "session_key": "<approval session key>", // same value as session_id
+      "description": "Run a dangerous shell command",
+      "choices": ["once", "deny"]       // always-valid subset; hook hides allow flags
     }
   }
 }
 ```
 
-Constraints: APNs allows ~4 KB; decision payloads are tiny. **Security:** the
-approval `command` MUST be redacted before it leaves the gateway (reuse the
-gateway's `_redact_approval_command` semantics; the approval transport contract
-already treats the request as display-only/redacted). Prefer sending
-`description` over raw `command`; never echo credentials. This matters because
-the README promises no third-party data handling, and APNs/relay is an
-additional egress path.
+Deliberately **absent**: the raw `command` (can carry secrets; this is an
+extra egress transport through the relay and APNs) and `allow_permanent` /
+`smart_denied` (not exposed by the `pre_approval_request` hook — the push card
+offers only the always-accepted `once`/`deny`, while the foreground card shows
+the full server-side choice set). The relay additionally whitelists choices to
+the gateway's approval vocabulary (`once`/`session`/`always`/`deny`) and
+rejects a `clarify` decision (unanswerable from the payload — see the Clarify
+section), degrading either case to the plain routing stub.
 
-### iOS changes (this repo)
+### iOS changes (this repo, shipped)
 
-1. `PushNotificationService.notificationTarget(from:)` /
-   `receiveNotificationPayload`: parse the optional `decision` object into a
-   typed structure (mirror `ClarifyActivity` / `ApprovalActivity`).
-2. On receipt, build the corresponding `.clarify` / `.approval` `ChatMessage`
-   (status `.pending`) and persist it via `SessionPresentationCache.save`
-   (`preservePendingDecisionCards: true`, with the bounded unconfirmed marker
-   so it cannot linger forever — same safeguard PR #54 uses). This runs from
-   the APNs delivery callback, so it works while backgrounded.
-3. On resume, PR #54's `applyChatResume` → `merge` path already restores
-   cached pending cards; verify it renders a card cached this way (it should,
-   since the cache shape is identical to a live-observed card). Reconcile by
-   decision key so a later live/gateway card replaces the cached one without a
-   duplicate.
-4. Keep the existing foreground path authoritative: if a live `*.request`
-   arrives for the same key, it supersedes the cached push card.
+1. `PushNotificationService.notificationTarget(from:)`: parse the optional
+   `decision` object onto `ConduitNotificationTarget`. Strict validation — an
+   approval requires a non-empty `session_key`, non-empty `description`, and
+   at least one usable choice; anything less degrades to the plain routing
+   target (a cached card with no choices would otherwise render the approval
+   view's wider default action set, which the payload never promised).
+2. When the notification is opened, `AppState.openNotificationTarget` builds
+   the `.pending` `ApprovalActivity` card and records it via
+   `SessionPresentationCache.recordPendingDecision` — a new **non-destructive**
+   upsert that touches only the decision card (the cached transcript is
+   preserved), dedupes by decision key, and **restarts** the bounded
+   unconfirmed-expiry window from the fresh observation (a per-session marker
+   inherited from an old card would otherwise expire a brand-new decision
+   immediately). The card is written under both the runtime and resolved
+   stored session ids, and only when the decision's session key matches one
+   of those identities.
+3. On resume, PR #54's `applyChatResume` → `merge` path restores cached
+   pending cards; reconcile by decision key means a later live/gateway card
+   replaces the cached one without a duplicate.
+4. The existing foreground path stays authoritative: if a live
+   `approval.request` arrives for the same key, it supersedes the cached push
+   card.
 
 ## Open issues / decisions
 
@@ -274,11 +296,22 @@ additional egress path.
 - **Self-hosting.** Because the relay is published, self-hosters receive
   decision content too once they update. (Conduit still defaults to the shared
   `push.milim.dev` for zero-setup use.)
-- **Redaction** — must be enforced for approval `command` before it enters the
-  payload (security-sensitive egress).
-- **Coalescing** — multiple decision notifications while backgrounded: approvals
-  are one in-flight per session; clarify is keyable by `clarify_id`. Cache by
-  decision key so the latest pending card per session wins.
+- **Privacy** — the raw approval `command` never enters the payload (omitted
+  at the plugin), and the `decision` content is gated on `show_previews` at
+  the relay, matching how `title`/`body` previews already work.
+- **Receipt-time capture** — alert pushes cannot wake a suspended app, so the
+  card is cached when the notification is **opened** (tap or cold-launch via
+  the notification). Covering "dismiss the banner, foreground manually" would
+  need a silent (`content-available`) push or the Phase 3 gateway work; tracked
+  as a follow-up, not shipped.
+- **Per-card expiry** — the unconfirmed marker is per session and recording a
+  fresh card restarts it (so a new decision is never expired by an old stamp).
+  Per-card stamps and superseding an answered card across *all* cached session
+  identities (the alternate-id copy is retired only by the bounded window)
+  are follow-up refinements.
+- **Coalescing** — multiple decision notifications while backgrounded:
+  approvals are one in-flight per session, and the cache dedupes by decision
+  key so the latest pending card per session wins.
 
 ## Phasing
 
@@ -299,15 +332,21 @@ additional egress path.
 ## Acceptance tests
 
 - An approval raised while the app is backgrounded produces an APNs payload
-  whose `conduit.decision` carries description + redacted command + choices.
-- iOS, on receipt (backgrounded), writes a pending `ApprovalActivity` to the
-  session cache. Foregrounding renders the card answerable via the existing
-  `respondToApproval` path, with `turnState == .idle`.
-- A clarify raised while backgrounded yields a cached `.clarify` card carrying
-  the `clarify_id`; foregrounding renders it answerable via
-  `respondToClarification`.
-- A later live `*.request` for the same decision key supersedes the cached
-  push card without producing a duplicate.
+  whose `conduit.decision` carries `kind`/`session_key`/`description` and the
+  `once`/`deny` choices — but only when `show_previews` is enabled, and never
+  the raw `command`.
+- iOS, when the notification is opened, records a pending `ApprovalActivity`
+  to the session cache under both session identities; the resume renders the
+  card answerable via the existing `respondToApproval` path.
+- A malformed decision — missing session key, missing display text, or no
+  usable choices — is rejected on both sides and degrades to the plain
+  routing target.
+- A decision whose `session_key` does not match the routed session identity
+  is not recorded.
+- Recording a fresh card restarts the bounded expiry window; a card is never
+  expired by a stamp older than its own observation.
+- A later live `approval.request` for the same decision key supersedes the
+  cached push card without producing a duplicate.
 - An unconfirmed cached card expires after
   `SessionPresentationCache.maxUnconfirmedPendingDecisionAge`.
 - The existing `SessionPresentationCacheTests` and full XCTest suite remain


### PR DESCRIPTION
## Summary

- Approval cards now appear (and are answerable) when the approval was raised **while the app was backgrounded** and the user foregrounds via the notification — the case PR #54 could not cover, because the card was never observed or cached locally.
- Parses the structured `decision` content forwarded by the notifier plugin + relay (companion PR: kaishi00/hermes-conduit-notifier#5) and caches it via a new **non-destructive** `SessionPresentationCache.recordPendingDecision` upsert, so the existing PR #54 background-resume merge restores an answerable card.
- Adds a design doc covering the full root-cause analysis (verified against Hermes source), the payload contract, and the phased plan for clarify.

## Root cause

A pending decision can only reach the client through the **one-shot** `approval.request` gateway stream event. When the app is backgrounded, that event is missed, and there is no fallback: `session.resume` returns only the stored transcript (decisions are live blocking prompts, not persisted rows), the snapshot carries no decision content (`status: "waiting"` at best), no RPC fetches pending decisions, and `SessionPresentationCache` is empty because the card was never observed. Verified against `nousresearch/hermes-agent`: the gateway emits `*.request` exactly once, holds it in-memory only, has no replay-on-reconnect, and plugins cannot register RPCs — so the content must ride the existing notification pipeline.

## Changes

- `ConduitNotificationTarget` gains an optional `decision` (`PendingDecisionPayload`); nil for non-decision notifications, existing callers unchanged via an explicit defaulted init.
- `PushNotificationService` parses and bounds the payload, dropping approvals without an answerable session key.
- `SessionPresentationCache.recordPendingDecision`: upserts a single card without disturbing the cached transcript, dedupes by decision key, and stamps the bounded unconfirmed-expiry marker (same safeguard as PR #54).
- `AppState.openNotificationTarget` records the card under **both** the notification's runtime session id and the resolved stored id, before opening, so the resume merge finds it regardless of which identity the gateway resumes against.
- Card is answered through the existing `respondToApproval(sessionId:choice:)` path; the live foreground `approval.request` event remains authoritative and supersedes a cached card by decision key.

## Design notes (flagged for review)

- The push payload carries `description` + the always-valid `["once","deny"]` choices; the raw `command` is deliberately omitted upstream (privacy — the relay/APNs path is an extra egress transport). The foreground card still shows the full command and full choice set.
- **Clarify is intentionally deferred** (phases 2–3 in the design doc): `clarify.respond` is request-id-only and that id is minted inside the gateway, so a clarify card cannot be made answerable from a push payload without gateway changes.
- Backward-compatible: a payload without `decision` changes nothing.

## Validation

- Full iOS Simulator XCTest suite: **615 passed, 0 failed** (incl. 3 new `recordPendingDecision` tests and 3 new payload-parsing tests).
- Focused `SessionPresentationCacheTests` (36) + `MessageNormalizerTests` (34): all green.
- `git diff --check` clean.
- Companion plugin/relay tests: 8 plugin + 5 relay green (hermes-conduit-notifier#5).

**To go live:** deploy the relay change to `push.milim.dev`; self-hosters update the plugin + relay. The iOS side degrades gracefully until then.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Approval decisions received while the app is in the background now appear as answerable decision cards when the related session is opened or resumed.
  * Decision cards persist across session restoration, preserve conversation history, reconcile duplicates, and expire stale items automatically.
  * Added an “Approval cards in pushes” setting to control whether approval details appear in notifications.
  * The setting is enabled by default and remains compatible with existing notification preferences.

* **Documentation**
  * Added design documentation covering background decision delivery, notification handling, caching, privacy safeguards, and rollout considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->