### PR TITLE
Answerable clarify cards delivered through the push relay loop

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -7145,11 +7145,12 @@ final class AppState: ObservableObject {
                 // .submitting card is left alone: its relay answer may already
                 // be in flight and will settle it by request id.
                 var supersededRequestIds: [String] = []
+                let liveQuestion = question.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
                 messages.removeAll { message in
                     guard let clarify = message.clarify,
                           clarify.requestId.hasPrefix(PendingDecisionPayload.relayRequestPrefix),
                           clarify.status == .pending,
-                          clarify.question == question else {
+                          clarify.question.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == liveQuestion else {
                         return false
                     }
                     supersededRequestIds.append(clarify.requestId)

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -5409,18 +5409,21 @@ final class AppState: ObservableObject {
         setRunning(true)
         cacheMessagePresentation()
 
+        // Plugin-minted clarify ids are answered through the relay's decision
+        // loop (the gateway's own clarify id never reached this device); the
+        // gateway-side middleware polls the relay and resolves the tool call.
+        // Routed BEFORE the gateway-client guard: the relay answer needs only
+        // the relay registration, and answering from a freshly-resumed push
+        // is exactly when the gateway client may still be reconnecting.
+        if requestId.hasPrefix(PendingDecisionPayload.relayRequestPrefix) {
+            await respondToRelayClarify(requestId: requestId, answer: trimmedAnswer)
+            return
+        }
         guard let client else {
             messages[index].clarify?.status = .error
             messages[index].clarify?.answer = nil
             messages[index].clarify?.error = "Gateway connection is unavailable."
             cacheMessagePresentation()
-            return
-        }
-        // Plugin-minted clarify ids are answered through the relay's decision
-        // loop (the gateway's own clarify id never reached this device); the
-        // gateway-side middleware polls the relay and resolves the tool call.
-        if requestId.hasPrefix(PendingDecisionPayload.relayRequestPrefix) {
-            await respondToRelayClarify(requestId: requestId, answer: trimmedAnswer)
             return
         }
         do {
@@ -5450,11 +5453,15 @@ final class AppState: ObservableObject {
             )
             guard let updatedIndex = messages.firstIndex(where: { $0.clarify?.requestId == requestId }) else { return }
             switch outcome {
-            case .answered, .alreadyAnsweredElsewhere:
-                // Someone answered it (possibly this device on an earlier
-                // attempt); either way the decision is settled.
+            case .answered:
                 messages[updatedIndex].clarify?.status = .answered
                 messages[updatedIndex].clarify?.answer = answer
+            case .alreadyAnsweredElsewhere:
+                // Another device resolved the decision with its own answer;
+                // settle the card but do not display this device's rejected
+                // text as if it were what Hermes received.
+                messages[updatedIndex].clarify?.status = .answered
+                messages[updatedIndex].clarify?.answer = nil
             case .noLongerActive:
                 messages[updatedIndex].clarify?.status = .error
                 messages[updatedIndex].clarify?.answer = nil
@@ -7131,12 +7138,17 @@ final class AppState: ObservableObject {
                 messages[index].content = question
                 messages[index].clarify = activity
             } else {
-                // A push-delivered card for the same question is superseded by
-                // the live event (different ids: gateway vs plugin-minted), so
-                // one logical clarify never renders two cards.
-                messages.removeAll {
-                    $0.clarify?.requestId.hasPrefix(PendingDecisionPayload.relayRequestPrefix) == true
-                        && $0.clarify?.question == question
+                // A still-pending push-delivered card for the same question is
+                // superseded by the live event (different ids: gateway vs
+                // plugin-minted), so one logical clarify never renders two
+                // answerable cards. Resolved history stays visible.
+                messages.removeAll { message in
+                    guard let clarify = message.clarify,
+                          clarify.requestId.hasPrefix(PendingDecisionPayload.relayRequestPrefix),
+                          clarify.status == .pending || clarify.status == .submitting else {
+                        return false
+                    }
+                    return clarify.question == question
                 }
                 messages.append(ChatMessage(
                     id: "clarify-\(requestId)",

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -5465,7 +5465,7 @@ final class AppState: ObservableObject {
             case .noLongerActive:
                 messages[updatedIndex].clarify?.status = .error
                 messages[updatedIndex].clarify?.answer = nil
-                messages[updatedIndex].clarify?.error = "This question is no longer active — Hermes timed it out and continued."
+                messages[updatedIndex].clarify?.error = "This question is no longer active — it was timed out or already resolved."
             }
             cacheMessagePresentation()
         } catch {
@@ -7141,14 +7141,35 @@ final class AppState: ObservableObject {
                 // A still-pending push-delivered card for the same question is
                 // superseded by the live event (different ids: gateway vs
                 // plugin-minted), so one logical clarify never renders two
-                // answerable cards. Resolved history stays visible.
+                // answerable cards. Resolved history stays visible, and a
+                // .submitting card is left alone: its relay answer may already
+                // be in flight and will settle it by request id.
+                var supersededRequestIds: [String] = []
                 messages.removeAll { message in
                     guard let clarify = message.clarify,
                           clarify.requestId.hasPrefix(PendingDecisionPayload.relayRequestPrefix),
-                          clarify.status == .pending || clarify.status == .submitting else {
+                          clarify.status == .pending,
+                          clarify.question == question else {
                         return false
                     }
-                    return clarify.question == question
+                    supersededRequestIds.append(clarify.requestId)
+                    return true
+                }
+                // The superseded card must also leave the presentation cache —
+                // the ordinary flush re-appends still-pending stored cards, so
+                // an in-memory-only removal would resurface as a duplicate
+                // answerable card after the next cold-start resume.
+                let cacheSessionIDs = [
+                    activeSessionId,
+                    reconciliation?.requestedSessionId,
+                    reconciliation?.resolvedSessionId
+                ].compactMap { $0 }
+                for requestId in supersededRequestIds {
+                    sessionPresentationCache.removePendingDecision(
+                        key: "clarify:\(requestId)",
+                        profile: activeProfile,
+                        sessionIDs: cacheSessionIDs
+                    )
                 }
                 messages.append(ChatMessage(
                     id: "clarify-\(requestId)",

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -4273,6 +4273,30 @@ final class AppState: ObservableObject {
                 profile: activeProfile,
                 sessionIDs: sessionIDs
             )
+        case let .clarify(requestId, question, choices):
+            // Relay-delivered clarify: the plugin middleware minted this id and
+            // is polling the relay, so the standard card renders with working
+            // buttons routed through respondToRelayClarify.
+            let activity = ClarifyActivity(
+                requestId: requestId,
+                question: question,
+                choices: choices.map { ClarifyChoice(label: $0, value: $0) },
+                status: .pending,
+                answer: nil,
+                error: nil
+            )
+            let message = ChatMessage(
+                id: "clarify-\(requestId)",
+                role: .clarify,
+                content: question,
+                timestamp: Self.localTimestamp(),
+                clarify: activity
+            )
+            sessionPresentationCache.recordPendingDecision(
+                message,
+                profile: activeProfile,
+                sessionIDs: sessionIDs
+            )
         }
     }
 
@@ -5392,6 +5416,13 @@ final class AppState: ObservableObject {
             cacheMessagePresentation()
             return
         }
+        // Plugin-minted clarify ids are answered through the relay's decision
+        // loop (the gateway's own clarify id never reached this device); the
+        // gateway-side middleware polls the relay and resolves the tool call.
+        if requestId.hasPrefix(PendingDecisionPayload.relayRequestPrefix) {
+            await respondToRelayClarify(requestId: requestId, answer: trimmedAnswer)
+            return
+        }
         do {
             try await client.respondToClarification(requestId: requestId, answer: trimmedAnswer)
             guard let updatedIndex = messages.firstIndex(where: { $0.clarify?.requestId == requestId }) else { return }
@@ -5407,6 +5438,34 @@ final class AppState: ObservableObject {
                 messages[updatedIndex].clarify?.error = "Hermes did not accept that answer."
                 errorMessage = error.localizedDescription
             }
+            cacheMessagePresentation()
+        }
+    }
+
+    private func respondToRelayClarify(requestId: String, answer: String) async {
+        do {
+            let outcome = try await PushNotificationService.shared.respondToRelayDecision(
+                requestId: requestId,
+                answer: answer
+            )
+            guard let updatedIndex = messages.firstIndex(where: { $0.clarify?.requestId == requestId }) else { return }
+            switch outcome {
+            case .answered, .alreadyAnsweredElsewhere:
+                // Someone answered it (possibly this device on an earlier
+                // attempt); either way the decision is settled.
+                messages[updatedIndex].clarify?.status = .answered
+                messages[updatedIndex].clarify?.answer = answer
+            case .noLongerActive:
+                messages[updatedIndex].clarify?.status = .error
+                messages[updatedIndex].clarify?.answer = nil
+                messages[updatedIndex].clarify?.error = "This question is no longer active — Hermes timed it out and continued."
+            }
+            cacheMessagePresentation()
+        } catch {
+            guard let updatedIndex = messages.firstIndex(where: { $0.clarify?.requestId == requestId }) else { return }
+            messages[updatedIndex].clarify?.status = .error
+            messages[updatedIndex].clarify?.answer = nil
+            messages[updatedIndex].clarify?.error = error.localizedDescription
             cacheMessagePresentation()
         }
     }
@@ -7072,6 +7131,13 @@ final class AppState: ObservableObject {
                 messages[index].content = question
                 messages[index].clarify = activity
             } else {
+                // A push-delivered card for the same question is superseded by
+                // the live event (different ids: gateway vs plugin-minted), so
+                // one logical clarify never renders two cards.
+                messages.removeAll {
+                    $0.clarify?.requestId.hasPrefix(PendingDecisionPayload.relayRequestPrefix) == true
+                        && $0.clarify?.question == question
+                }
                 messages.append(ChatMessage(
                     id: "clarify-\(requestId)",
                     role: .clarify,

--- a/Conduit/Services/PushNotificationService.swift
+++ b/Conduit/Services/PushNotificationService.swift
@@ -393,12 +393,13 @@ final class PushNotificationService: ObservableObject {
             guard !choices.isEmpty else { return nil }
             return .approval(sessionKey: sessionKey, description: description, choices: choices)
         case "clarify":
-            // The request id is plugin-minted (`conduit-push-…`); without it
-            // the card is not answerable and the notification degrades to a
-            // plain routing target.
+            // The request id must be a plugin-minted `conduit-push-…` id: any
+            // other id would be routed to the gateway's clarify.respond, which
+            // can never resolve it.
             guard let requestId = (decision["request_id"] as? String)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
-                !requestId.isEmpty,
+                requestId.hasPrefix(PendingDecisionPayload.relayRequestPrefix),
+                requestId.count > PendingDecisionPayload.relayRequestPrefix.count,
                 let question = (decision["question"] as? String)?
                     .trimmingCharacters(in: .whitespacesAndNewlines),
                 !question.isEmpty else {

--- a/Conduit/Services/PushNotificationService.swift
+++ b/Conduit/Services/PushNotificationService.swift
@@ -27,7 +27,7 @@ struct ConduitNotificationTarget: Equatable, Identifiable {
 }
 
 /// The structured card content for a decision notification. Approval is
-/// session-keyed (`approval.respond {choice, session_id}`), so a payload
+/// session-keyed (`approval.respond { choice, session_id }`), so a payload
 /// carrying the session key is fully answerable. Clarify is keyed by a
 /// plugin-minted id (`conduit-push-…`) whose answers return through the push
 /// relay rather than the gateway — the gateway's own clarify id is unreachable

--- a/Conduit/Services/PushNotificationService.swift
+++ b/Conduit/Services/PushNotificationService.swift
@@ -27,12 +27,18 @@ struct ConduitNotificationTarget: Equatable, Identifiable {
 }
 
 /// The structured card content for a decision notification. Approval is
-/// session-keyed (`approval.respond { choice, session_id }`), so a payload
+/// session-keyed (`approval.respond {choice, session_id}`), so a payload
 /// carrying the session key is fully answerable. Clarify is keyed by a
-/// gateway-generated request id that no plugin hook exposes, so it is not
-/// representable here yet (see the background-arrival design doc).
+/// plugin-minted id (`conduit-push-…`) whose answers return through the push
+/// relay rather than the gateway — the gateway's own clarify id is unreachable
+/// to plugins (see the background-arrival design docs).
 enum PendingDecisionPayload: Equatable {
     case approval(sessionKey: String, description: String, choices: [String])
+    case clarify(requestId: String, question: String, choices: [String])
+
+    /// Request ids minted by the notifier plugin's clarify loop; answers to
+    /// these route through the relay instead of `clarify.respond`.
+    static let relayRequestPrefix = "conduit-push-"
 }
 
 enum NotificationSessionResolver {
@@ -153,6 +159,68 @@ final class PushNotificationService: ObservableObject {
     func refresh() async {
         let settings = await UNUserNotificationCenter.current().notificationSettings()
         authorizationStatus = settings.authorizationStatus
+    }
+
+    /// Outcome of answering a plugin-minted clarify (`conduit-push-…`) through
+    /// the relay's decision loop.
+    enum RelayDecisionOutcome {
+        case answered
+        /// The decision expired (clarify timed out server-side or was answered
+        /// on another surface first).
+        case noLongerActive
+        /// Another device already answered this decision.
+        case alreadyAnsweredElsewhere
+    }
+
+    enum RelayDecisionError: LocalizedError {
+        case unregistered
+        case transport(String)
+        case server(Int)
+
+        var errorDescription: String? {
+            switch self {
+            case .unregistered: return "This device is not paired with a push relay."
+            case .transport(let message): return "Could not reach the push relay: \(message)"
+            case .server(let status): return "The push relay rejected the answer (HTTP \(status))."
+            }
+        }
+    }
+
+    /// Answers a plugin-minted clarify decision through the relay. The gateway
+    /// polls the relay for this answer while its clarify middleware blocks, so
+    /// the agent thread unblocks exactly as if `clarify.respond` had been used.
+    @discardableResult
+    func respondToRelayDecision(
+        requestId: String,
+        answer: String
+    ) async throws -> RelayDecisionOutcome {
+        guard let registration else { throw RelayDecisionError.unregistered }
+        var request = URLRequest(url: relayURL.appending(path: "/v1/decisions/\(requestId)/respond"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(registration.credential)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONSerialization.data(withJSONObject: ["answer": answer])
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                throw RelayDecisionError.transport("invalid response")
+            }
+            switch http.statusCode {
+            case 200:
+                return .answered
+            case 404:
+                return .noLongerActive
+            case 409:
+                return .alreadyAnsweredElsewhere
+            default:
+                _ = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+                throw RelayDecisionError.server(http.statusCode)
+            }
+        } catch let error as RelayDecisionError {
+            throw error
+        } catch {
+            throw RelayDecisionError.transport(error.localizedDescription)
+        }
     }
 
     func enable() async {
@@ -324,6 +392,22 @@ final class PushNotificationService: ObservableObject {
                 .filter { !$0.isEmpty }
             guard !choices.isEmpty else { return nil }
             return .approval(sessionKey: sessionKey, description: description, choices: choices)
+        case "clarify":
+            // The request id is plugin-minted (`conduit-push-…`); without it
+            // the card is not answerable and the notification degrades to a
+            // plain routing target.
+            guard let requestId = (decision["request_id"] as? String)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+                !requestId.isEmpty,
+                let question = (decision["question"] as? String)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                !question.isEmpty else {
+                return nil
+            }
+            let choices = ((decision["choices"] as? [Any])?
+                .compactMap { ($0 as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }) ?? []
+            return .clarify(requestId: requestId, question: question, choices: choices)
         default:
             return nil
         }

--- a/Conduit/Services/PushNotificationService.swift
+++ b/Conduit/Services/PushNotificationService.swift
@@ -213,7 +213,6 @@ final class PushNotificationService: ObservableObject {
             case 409:
                 return .alreadyAnsweredElsewhere
             default:
-                _ = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
                 throw RelayDecisionError.server(http.statusCode)
             }
         } catch let error as RelayDecisionError {

--- a/Conduit/Services/SessionPresentationCache.swift
+++ b/Conduit/Services/SessionPresentationCache.swift
@@ -292,6 +292,37 @@ final class SessionPresentationCache {
         return Set(keys)
     }
 
+    /// Evicts a still-pending decision record from the cache. Used when a
+    /// live event supersedes a push-delivered card: the two carry different
+    /// decision keys (gateway vs plugin-minted ids), so the merge can never
+    /// dedupe them, and without eviction the superseded card would resurface
+    /// as a duplicate answerable card after the next cold-start resume.
+    /// Non-pending records and unrelated cards are untouched.
+    func removePendingDecision(
+        key targetKey: String,
+        profile: String,
+        sessionIDs: [String]
+    ) {
+        let ids = Set(sessionIDs.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty })
+        guard !ids.isEmpty else { return }
+        var store = load()
+        var changed = false
+        for id in ids {
+            let cacheKey = key(profile: profile, sessionID: id)
+            guard var session = store[cacheKey] else { continue }
+            let before = session.messages
+            session.messages.removeAll { existing in
+                decisionKey(for: existing) == targetKey && pendingDecisionKey(for: existing) != nil
+            }
+            guard session.messages != before else { continue }
+            session.updatedAt = now()
+            store[cacheKey] = session
+            changed = true
+        }
+        guard changed else { return }
+        persist(store)
+    }
+
     /// Records a pending decision card observed outside the live stream —
     /// today, from a push notification's structured payload, which is the only
     /// source for a decision raised while the app was backgrounded and missed

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -1786,7 +1786,10 @@ struct ClarifyCard: View {
                     Spacer(minLength: 8)
                     if clarify.status == .submitting {
                         ProgressView().controlSize(.small)
-                    } else if clarify.status == .answered {
+                    } else if clarify.status == .answered, clarify.answer != nil {
+                        // Only this device's accepted answer earns the check;
+                        // an answered-elsewhere settle renders no checkmark so
+                        // the header agrees with the body copy.
                         Image(systemName: "checkmark.circle.fill")
                             .foregroundStyle(.green)
                     }

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -1807,6 +1807,13 @@ struct ClarifyCard: View {
                     }
                     .padding(12)
                     .background(Color.green.opacity(0.10), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                } else if clarify.status == .answered {
+                    // Answered elsewhere (relay 409): settled, but this device's
+                    // rejected text must not display as what Hermes received —
+                    // and the disabled controls should not linger either.
+                    Text("Answered on another device")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 } else {
                     ForEach(clarify.choices) { choice in
                         Button {

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -725,6 +725,95 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertEqual(restoredCard?.approval?.status, .pending, "The push-delivered card must survive the open and render answerable")
     }
 
+    func testNotificationClarifyDecisionSurvivesOpenAndRendersAnswerable() async {
+        let cacheSuite = "conduit.tests.notification-clarify-open-\(UUID().uuidString)"
+        guard let cacheDefaults = UserDefaults(suiteName: cacheSuite) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: cacheDefaults)
+        defer {
+            cache.clear()
+            cacheDefaults.removePersistentDomain(forName: cacheSuite)
+        }
+        let transcript = [
+            ChatMessage(id: "a1", role: .assistant, content: "Prior turn text", timestamp: "1")
+        ]
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [self.session("stored-a")] },
+                openSession: { _, sessionID in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: transcript,
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            ),
+            sessionPresentationCache: cache
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.connection = connection
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+        harness.appState.sessions = [session("stored-a")]
+        harness.appState.activeSessionId = "stored-a"
+        harness.appState.messages = transcript
+
+        let opened = await harness.appState.openNotificationTarget(
+            ConduitNotificationTarget(
+                profile: nil,
+                sessionId: "stored-a",
+                type: "input.needed",
+                decision: .clarify(
+                    requestId: "conduit-push-abc123",
+                    question: "Which color?",
+                    choices: ["Red", "Blue"]
+                )
+            )
+        )
+
+        XCTAssertTrue(opened)
+        let restoredCard = harness.appState.messages.first { $0.role == .clarify }
+        XCTAssertEqual(restoredCard?.clarify?.requestId, "conduit-push-abc123")
+        XCTAssertEqual(restoredCard?.clarify?.status, .pending, "A relay-delivered clarify must render as a normal answerable card")
+        XCTAssertEqual(restoredCard?.clarify?.choices.map(\.label), ["Red", "Blue"])
+    }
+
+    func testLiveClarifyEventSupersedesPushDeliveredCardForSameQuestion() async {
+        let harness = makeHarness()
+        harness.appState.activeSessionId = "stored-a"
+        harness.appState.messages = [
+            ChatMessage(
+                id: "clarify-conduit-push-abc123",
+                role: .clarify,
+                content: "Which color?",
+                timestamp: "1",
+                clarify: ClarifyActivity(
+                    requestId: "conduit-push-abc123",
+                    question: "Which color?",
+                    choices: [ClarifyChoice(label: "Red", value: "Red")],
+                    status: .pending,
+                    answer: nil,
+                    error: nil
+                )
+            )
+        ]
+
+        harness.appState.handleStreamEvent(
+            .clarify(
+                sessionId: "stored-a",
+                requestId: "gateway-rid-1",
+                question: "Which color?",
+                choices: [("Red", "Red")]
+            )
+        )
+
+        let clarifyCards = harness.appState.messages.filter { $0.role == .clarify }
+        XCTAssertEqual(clarifyCards.count, 1, "The push-delivered card must be superseded by the live event")
+        XCTAssertEqual(clarifyCards.first?.clarify?.requestId, "gateway-rid-1")
+    }
+
     func testNotificationDecisionWithMismatchedSessionKeyIsNotRecorded() async {
         let cacheSuite = "conduit.tests.notification-decision-mismatch-\(UUID().uuidString)"
         guard let cacheDefaults = UserDefaults(suiteName: cacheSuite) else {

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -814,6 +814,43 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertEqual(clarifyCards.first?.clarify?.requestId, "gateway-rid-1")
     }
 
+    func testLiveClarifyEventSupersedeMatchesNormalizedQuestion() async {
+        // The push question is flattened plugin-side while the live event
+        // carries the gateway's text; formatting drift (whitespace, case)
+        // must not defeat the supersede and render two answerable cards.
+        let harness = makeHarness()
+        harness.appState.activeSessionId = "stored-a"
+        harness.appState.messages = [
+            ChatMessage(
+                id: "clarify-conduit-push-abc123",
+                role: .clarify,
+                content: "  Which Color?  ",
+                timestamp: "1",
+                clarify: ClarifyActivity(
+                    requestId: "conduit-push-abc123",
+                    question: "  Which Color?  ",
+                    choices: [ClarifyChoice(label: "Red", value: "Red")],
+                    status: .pending,
+                    answer: nil,
+                    error: nil
+                )
+            )
+        ]
+
+        harness.appState.handleStreamEvent(
+            .clarify(
+                sessionId: "stored-a",
+                requestId: "gateway-rid-1",
+                question: "which color?",
+                choices: [("Red", "Red")]
+            )
+        )
+
+        let clarifyCards = harness.appState.messages.filter { $0.role == .clarify }
+        XCTAssertEqual(clarifyCards.count, 1, "Formatting drift must not defeat the supersede")
+        XCTAssertEqual(clarifyCards.first?.clarify?.requestId, "gateway-rid-1")
+    }
+
     func testLiveClarifyEventEvictsSupersededPushCardFromCache() async {
         // The supersede must evict the push card from the presentation cache,
         // not just the in-memory transcript: the flush re-appends still-pending

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -810,8 +810,82 @@ final class AppStateChatResumeTests: XCTestCase {
         )
 
         let clarifyCards = harness.appState.messages.filter { $0.role == .clarify }
-        XCTAssertEqual(clarifyCards.count, 1, "The push-delivered card must be superseded by the live event")
+        XCTAssertEqual(clarifyCards.count, 1, "The still-pending push card must be superseded by the live event")
         XCTAssertEqual(clarifyCards.first?.clarify?.requestId, "gateway-rid-1")
+    }
+
+    func testLiveClarifyEventPreservesAnsweredPushCardHistory() async {
+        let harness = makeHarness()
+        harness.appState.activeSessionId = "stored-a"
+        harness.appState.messages = [
+            ChatMessage(
+                id: "clarify-conduit-push-abc123",
+                role: .clarify,
+                content: "Which color?",
+                timestamp: "1",
+                clarify: ClarifyActivity(
+                    requestId: "conduit-push-abc123",
+                    question: "Which color?",
+                    choices: [ClarifyChoice(label: "Red", value: "Red")],
+                    status: .answered,
+                    answer: "Red",
+                    error: nil
+                )
+            )
+        ]
+
+        harness.appState.handleStreamEvent(
+            .clarify(
+                sessionId: "stored-a",
+                requestId: "gateway-rid-2",
+                question: "Which color?",
+                choices: [("Red", "Red")]
+            )
+        )
+
+        // Resolved history stays: an earlier answered card is not deleted by a
+        // later clarify with identical text.
+        let clarifyCards = harness.appState.messages.filter { $0.role == .clarify }
+        XCTAssertEqual(clarifyCards.count, 2)
+        XCTAssertTrue(clarifyCards.contains { $0.clarify?.status == .answered && $0.clarify?.answer == "Red" })
+        XCTAssertTrue(clarifyCards.contains { $0.clarify?.requestId == "gateway-rid-2" })
+    }
+
+    func testRelayClarifyAnswerRoutedWithoutGatewayClient() async {
+        // Answering a relay-delivered clarify must not require the gateway
+        // client: the relay answer needs only the relay registration, and a
+        // push just-resumed session is exactly when the gateway client may
+        // still be nil. (Unpaired in tests, so the relay call surfaces its
+        // own error rather than the gateway-unavailable one.)
+        let harness = makeHarness()
+        harness.appState.activeSessionId = "stored-a"
+        harness.appState.messages = [
+            ChatMessage(
+                id: "clarify-conduit-push-abc123",
+                role: .clarify,
+                content: "Which color?",
+                timestamp: "1",
+                clarify: ClarifyActivity(
+                    requestId: "conduit-push-abc123",
+                    question: "Which color?",
+                    choices: [ClarifyChoice(label: "Red", value: "Red")],
+                    status: .pending,
+                    answer: nil,
+                    error: nil
+                )
+            )
+        ]
+        harness.appState.client = nil
+
+        await harness.appState.respondToClarify(requestId: "conduit-push-abc123", answer: "Red")
+
+        let card = harness.appState.messages.first { $0.role == .clarify }
+        XCTAssertEqual(card?.clarify?.status, .error)
+        XCTAssertEqual(
+            card?.clarify?.error,
+            "This device is not paired with a push relay.",
+            "The relay path must run before the gateway-client guard and surface relay errors"
+        )
     }
 
     func testNotificationDecisionWithMismatchedSessionKeyIsNotRecorded() async {

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -814,6 +814,68 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertEqual(clarifyCards.first?.clarify?.requestId, "gateway-rid-1")
     }
 
+    func testLiveClarifyEventEvictsSupersededPushCardFromCache() async {
+        // The supersede must evict the push card from the presentation cache,
+        // not just the in-memory transcript: the flush re-appends still-pending
+        // stored cards, and the ids can never dedupe (gateway vs plugin-minted),
+        // so an in-memory-only removal would resurface as a duplicate
+        // answerable card after the next cold-start resume.
+        let cacheSuite = "conduit.tests.clarify-supersede-cache-\(UUID().uuidString)"
+        guard let cacheDefaults = UserDefaults(suiteName: cacheSuite) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: cacheDefaults)
+        defer {
+            cache.clear()
+            cacheDefaults.removePersistentDomain(forName: cacheSuite)
+        }
+        let harness = makeHarness(sessionPresentationCache: cache)
+        harness.appState.activeSessionId = "stored-a"
+        harness.appState.messages = [
+            ChatMessage(
+                id: "clarify-conduit-push-abc123",
+                role: .clarify,
+                content: "Which color?",
+                timestamp: "1",
+                clarify: ClarifyActivity(
+                    requestId: "conduit-push-abc123",
+                    question: "Which color?",
+                    choices: [ClarifyChoice(label: "Red", value: "Red")],
+                    status: .pending,
+                    answer: nil,
+                    error: nil
+                )
+            )
+        ]
+        cache.recordPendingDecision(
+            harness.appState.messages[0],
+            profile: harness.appState.activeProfile,
+            sessionIDs: ["stored-a"]
+        )
+
+        harness.appState.handleStreamEvent(
+            .clarify(
+                sessionId: "stored-a",
+                requestId: "gateway-rid-1",
+                question: "Which color?",
+                choices: [("Red", "Red")]
+            )
+        )
+
+        XCTAssertEqual(harness.appState.messages.filter { $0.role == .clarify }.count, 1)
+        let restored = cache.merge(
+            [],
+            profile: harness.appState.activeProfile,
+            sessionIDs: ["stored-a"],
+            includePendingClarifications: true
+        )
+        XCTAssertFalse(
+            restored.contains { $0.clarify?.requestId == "conduit-push-abc123" },
+            "The superseded push card must not resurface from the cache after a cold restart"
+        )
+    }
+
     func testLiveClarifyEventPreservesAnsweredPushCardHistory() async {
         let harness = makeHarness()
         harness.appState.activeSessionId = "stored-a"

--- a/ConduitTests/MessageNormalizerTests.swift
+++ b/ConduitTests/MessageNormalizerTests.swift
@@ -339,6 +339,53 @@ final class MessageNormalizerTests: XCTestCase {
         XCTAssertFalse(AppState.isExpiredPromptError(HermesError.notConnected))
     }
 
+    func testNotificationPayloadCarriesClarifyDecision() {
+        let service = PushNotificationService(retryDelay: .zero)
+        defer {
+            if let target = service.pendingTarget {
+                service.clearPendingTarget(target)
+            }
+        }
+        service.receiveNotificationPayload([
+            "conduit": [
+                "session_id": "runtime-1",
+                "profile": "default",
+                "type": "input.needed",
+                "decision": [
+                    "kind": "clarify",
+                    "request_id": "conduit-push-abc123",
+                    "question": "Which color?",
+                    "choices": ["Red", "Blue"],
+                ] as [String: Any],
+            ] as [String: Any],
+        ])
+
+        guard case let .clarify(requestId, question, choices) = service.pendingTarget?.decision else {
+            return XCTFail("Expected a clarify decision carried on the notification target")
+        }
+        XCTAssertEqual(requestId, "conduit-push-abc123")
+        XCTAssertEqual(question, "Which color?")
+        XCTAssertEqual(choices, ["Red", "Blue"])
+    }
+
+    func testNotificationPayloadClarifyDecisionRejectedWithoutRequestId() {
+        let service = PushNotificationService(retryDelay: .zero)
+        defer {
+            if let target = service.pendingTarget {
+                service.clearPendingTarget(target)
+            }
+        }
+        // Without the plugin-minted id the card is not answerable; degrade.
+        service.receiveNotificationPayload([
+            "conduit": [
+                "session_id": "session-1",
+                "type": "input.needed",
+                "decision": ["kind": "clarify", "question": "Which color?"] as [String: Any],
+            ] as [String: Any],
+        ])
+        XCTAssertNil(service.pendingTarget?.decision)
+    }
+
     func testFailedNotificationRouteRetriesOnceThenClearsTarget() async {
         let service = PushNotificationService(retryDelay: .zero)
         service.receiveNotificationPayload([

--- a/ConduitTests/MessageNormalizerTests.swift
+++ b/ConduitTests/MessageNormalizerTests.swift
@@ -384,6 +384,27 @@ final class MessageNormalizerTests: XCTestCase {
             ] as [String: Any],
         ])
         XCTAssertNil(service.pendingTarget?.decision)
+
+        // A non-prefixed id would be routed to the gateway's clarify.respond,
+        // which can never resolve a plugin-minted decision; reject it too.
+        service.receiveNotificationPayload([
+            "conduit": [
+                "session_id": "session-1",
+                "type": "input.needed",
+                "decision": ["kind": "clarify", "request_id": "gateway-rid-1", "question": "Which color?"] as [String: Any],
+            ] as [String: Any],
+        ])
+        XCTAssertNil(service.pendingTarget?.decision)
+
+        // The bare prefix with no unique suffix is equally unanswerable.
+        service.receiveNotificationPayload([
+            "conduit": [
+                "session_id": "session-1",
+                "type": "input.needed",
+                "decision": ["kind": "clarify", "request_id": "conduit-push-", "question": "Which color?"] as [String: Any],
+            ] as [String: Any],
+        ])
+        XCTAssertNil(service.pendingTarget?.decision)
     }
 
     func testFailedNotificationRouteRetriesOnceThenClearsTarget() async {

--- a/docs/superpowers/specs/2026-08-14-clarify-cards-relay-loop-design.md
+++ b/docs/superpowers/specs/2026-08-14-clarify-cards-relay-loop-design.md
@@ -1,0 +1,118 @@
+# Design Spec: Answerable Clarify Cards After Background Arrival (Plugin-Owned Loop)
+
+**Date:** 2026-08-14
+**Branches:** `clarify-visibility-decisions` (notifier), `clarify-cards-background-arrival` (iOS)
+**Follow-up to:** PRs #60 / #5 (approval cards; merged)
+**Status:** Implementing
+
+## Problem
+
+A clarify raised while Conduit is backgrounded misses the one-shot
+`clarify.request` stream event. Unlike approval, `clarify.respond` is
+request-id-only and that id is minted inside the gateway (`_block`), so no
+plugin hook can observe it — Phase 1's approval architecture (observer hook +
+session-keyed respond) cannot apply. Verified 2026-08-14 against Hermes
+source:
+
+- The clarify text-intercept (`resolve_text_response_for_session`,
+  `get_pending_for_session(include_choice_prompts=True)`) is wired only into
+  chat-platform adapters (`gateway/platforms/base.py`), not the TUI/desktop
+  WebSocket path Conduit uses.
+- Typed replies during a pending clarify are **queued** (`prompt.submit`
+  mid-turn queueing), not intercepted — they reach the agent only after the
+  clarify resolves (default `agent.clarify_timeout` = 3600s; `<= 0` unlimited).
+- A late `clarify.respond` returns **success** `{"status": "expired"}`
+  (allow-expired bridge), so a card with a synthetic id would falsely render
+  ANSWERED — visibility-only cards must not render answer controls.
+
+## Chosen approach (user decision): plugin-owned loop
+
+The notifier plugin already runs on the user's gateway; it mints its OWN
+clarify id, pushes an answerable card, and answers flow back through the
+relay. No upstream dependency.
+
+### Key discovery: `tool_execution` middleware, not tool override
+
+`agent/tool_executor.py` dispatches `clarify` through a hardcoded
+`elif function_name == "clarify":` branch that imports the built-in
+`clarify_tool` directly (`callback=agent.clarify_callback`) — a
+`register_tool(override=True)` registration is not consulted on this path.
+However, the same call runs through
+`_run_agent_tool_execution_middleware(..., execute=_execute)`, and the
+middleware contract explicitly supports wrapping the execution callback.
+
+So the plugin registers **`tool_execution` middleware** filtered to
+`tool_name == "clarify"`:
+
+1. Read `args` (question, choices, multi_select).
+2. Mint `clarify_id = "conduit-push-" + uuid4().hex[:12]` (prefix lets iOS
+   route answers to the relay instead of `clarify.respond`).
+3. Enqueue the `input.needed` event with the structured decision
+   `{kind: "clarify", request_id, question, choices}` (labels flattened via
+   the same label/description/text/title unwrap the built-in tool uses).
+4. Run `next_call(args)` on a worker thread — this is the ORIGINAL path, so
+   the gateway emits its own `clarify.request` and desktop/CLI answering is
+   completely unchanged — while the middleware polls the relay for the
+   plugin id's answer.
+5. **First answer wins.** Relay answer → format the result exactly like the
+   built-in tool (`strip_recommended`, multi-select parsing via the
+   importable helpers) and return it. `next_call` answer → return that; the
+   losing relay answer is ignored (a late respond to the plugin id after the
+   gateway already resolved returns an "already resolved" status).
+6. Orphaned worker threads are bounded daemon threads that exit at the
+   clarify timeout; clarify frequency is human-scale.
+
+Timeout: respect the gateway's configured clarify timeout
+(`tools.clarify_gateway.resolve_clarify_timeout`), defaulting to 3600s; the
+middleware never extends the wait beyond what the original path allows.
+
+### Relay: pending-decision store + answer endpoints
+
+New store slice `pendingDecisions: {id → {installationId, gatewayId, answer?,
+answerAt?, createdAt, question, choices}}` (pruned past a 2h TTL, bounded
+like eventIds):
+
+- **Intake** — `validateEvent` keeps a decision when it is well-formed; the
+  `/v1/events` handler saves it to the pending store after delivery.
+  Clarify decisions require `request_id` + `question` (answerable contract);
+  approval decisions unchanged (session-keyed; no pending entry needed —
+  approvals answer via the gateway directly).
+- `POST /v1/decisions/{id}/respond` — **device** credential; body
+  `{answer}`. Resolves only for the same installation; first answer wins,
+  later answers get `409 already_resolved`.
+- `GET /v1/decisions/{id}` — **gateway** credential; same installation +
+  gateway. Returns `{status: "pending" | "answered" | "expired" | "unknown", answer?}`.
+  The plugin polls this (~2s interval) while its clarify blocks.
+
+### iOS
+
+- `PendingDecisionPayload.clarify(requestId, question, choices)` — parser
+  requires the request id (relay rejects unanswerable clarify anyway).
+- `recordNotificationDecision` records a normal pending `ClarifyActivity`
+  with the plugin request id — the standard clarify card renders with
+  working buttons.
+- `AppState.respondToClarify` routes by id prefix: `conduit-push-` ids POST
+  to the relay via `PushNotificationService` (relay URL the device already
+  holds); gateway ids keep the `clarify.respond` RPC. Relay `unknown/expired`
+  failures reuse the expired-prompt card UX from #60.
+- Supersede: when a live `clarify.request` arrives (foreground case), drop
+  any push-recorded card with the same question so the two paths never show
+  duplicate cards for one logical clarify.
+
+### Security / privacy
+
+- Decision content remains gated on `decision_cards` (default on, dedicated
+  preference) and bounded by the existing sanitizer + `validateDecision`.
+- The answer channel is authenticated: devices answer with their own
+  installation credential; the gateway polls with the gateway credential;
+  the relay enforces installation match on both. Answers are bounded text.
+- The plugin id carries no gateway capability — a compromised relay can at
+  most answer a clarify the user already sees pushed.
+
+## Phasing
+
+1. Relay: pending-decision store + two endpoints + tests.
+2. Plugin: middleware + push + poll + tests (poll client against a stubbed
+   HTTP server).
+3. iOS: parser/card/answer routing + supersede + tests; full suite.
+4. End-to-end validation on a real gateway; docs.


### PR DESCRIPTION
## Summary

- Clarify decisions raised while the app is backgrounded now render as **fully answerable cards** — same UX as approvals after PR #60 — with answers routed through the push relay instead of the gateway.
- Companion plugin/relay PR: **kaishi00/hermes-conduit-notifier#6** (the plugin's `tool_execution` middleware mints the id, blocks the tool call, and polls the relay; the relay stores pending decisions and serves answers).
- Adds the Phase 2 design doc (`2026-08-14-clarify-cards-relay-loop-design.md`) with the full root-cause verification and the option analysis (visibility-only vs plugin loop vs upstream patch).

## Why the relay loop (verified against Hermes source)

The gateway mints its clarify request id inside `_block` where no plugin hook can observe it, and `clarify.respond` is request-id-only (not session-keyed like approval) — so a push card can never answer via the gateway. The chat-platform text-intercept isn't wired to the WebSocket path, and typed replies during a pending clarify only queue. A late `clarify.respond` even returns **success** `{"status":"expired"}`, which is why the parser strictly requires the plugin-minted id: a synthetic-id card would falsely render ANSWERED.

## Changes

- `PendingDecisionPayload.clarify(requestId:question:choices:)`; strict parsing (id + question required, else degrade to plain routing target).
- `recordNotificationDecision` records a standard pending `ClarifyActivity` — the normal card UI renders with working buttons.
- `respondToClarify` routes `conduit-push-*` ids to `PushNotificationService.respondToRelayDecision` (`POST /v1/decisions/{id}/respond`, device credential); 404 → existing "no longer active" UX, 409 → settled as answered.
- A live `clarify.request` supersedes a push-delivered card with the same question, so foreground and push paths never duplicate a card.

## Validation

- Full iOS Simulator suite: **644 passed, 0 failed** (new: parser valid/missing-id, notification-open records an answerable clarify card, live-event supersede).
- One full-suite run hit the known `ComposerPasteTextViewTests` XPC stall after simulator churn; clean rerun is the recorded result.
- Plugin/relay side (notifier#6): 8 middleware + 14 relay tests green, including a nothing-mocked e2e of the answer loop.

**Rollout note:** requires the notifier plugin + relay from notifier#6 deployed; a payload without `decision` changes nothing (older deployments degrade to plain routing targets).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for clarification requests delivered through push notifications.
  - Clarification cards persist when reopening sessions and support selectable answers.
  - Answers report success, expiration, or error outcomes.
  - Duplicate pending cards are removed when matching live updates arrive.
  - Answered cards from another device display “Answered on another device.”
  - Invalid clarification notifications continue through normal notification handling.
  - Pending cards are replaced when newer matching requests arrive.

- **Documentation**
  - Added documentation covering clarification card behavior, security, timeouts, and response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->