### PR TITLE
Show plugin and relay compatibility in notification settings

### DIFF
--- a/Conduit/Services/PushNotificationService.swift
+++ b/Conduit/Services/PushNotificationService.swift
@@ -52,7 +52,6 @@ struct RelayMetaInfo: Decodable, Equatable {
         let name: String
         let pluginVersion: String?
         let pluginCapabilities: [String]
-        let lastEventAt: String?
 
         var supportsApprovalCards: Bool { pluginCapabilities.contains("approval-decisions") }
         var supportsClarifyCards: Bool { pluginCapabilities.contains("clarify-loop") }
@@ -62,7 +61,6 @@ struct RelayMetaInfo: Decodable, Equatable {
             case name
             case pluginVersion = "plugin_version"
             case pluginCapabilities = "plugin_capabilities"
-            case lastEventAt = "last_event_at"
         }
     }
 
@@ -71,6 +69,33 @@ struct RelayMetaInfo: Decodable, Equatable {
     let gateways: [Gateway]
 
     var supportsDecisionCards: Bool { capabilities.contains("decisions") }
+
+    /// One malformed gateway record must not hide the whole section: decode
+    /// gateway rows lossily so a single incompatible record degrades to just
+    /// its row while the relay and other gateways still render.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        version = try container.decode(String.self, forKey: .version)
+        capabilities = try container.decode([String].self, forKey: .capabilities)
+        var gateways: [Gateway] = []
+        var array = try container.nestedUnkeyedContainer(forKey: .gateways)
+        while !array.isAtEnd {
+            if let gateway = try? array.decode(Gateway.self) {
+                gateways.append(gateway)
+            } else {
+                _ = try? array.decode(Empty.self)
+            }
+        }
+        self.gateways = gateways
+    }
+
+    private struct Empty: Decodable {}
+
+    private enum CodingKeys: String, CodingKey {
+        case version
+        case capabilities
+        case gateways
+    }
 }
 
 enum NotificationSessionResolver {
@@ -155,6 +180,7 @@ final class PushNotificationService: ObservableObject {
     @Published private(set) var navigationAttempt = 0
     @Published var preferences = ConduitNotificationPreferences()
     @Published private(set) var relayMeta: RelayMetaInfo?
+    @Published private(set) var isFetchingMeta = false
 
     private var relayURL: URL {
         if let saved = UserDefaults.standard.string(forKey: "conduit.relayURL"),
@@ -195,12 +221,18 @@ final class PushNotificationService: ObservableObject {
     }
 
     /// Loads relay + plugin compatibility state for Settings > Notifications.
-    /// Nil (also on 404 from older/self-hosted relays) renders as unknown.
+    /// Nil after a completed fetch (also on 404 from older/self-hosted relays)
+    /// renders as unknown; `isFetchingMeta` distinguishes that from an
+    /// in-flight request so the UI never diagnoses "predates version
+    /// reporting" while still loading.
     func refreshMeta() async {
         guard let registration else {
             relayMeta = nil
+            isFetchingMeta = false
             return
         }
+        isFetchingMeta = true
+        defer { isFetchingMeta = false }
         var request = URLRequest(url: relayURL.appending(path: "/v1/meta"))
         request.setValue("Bearer \(registration.credential)", forHTTPHeaderField: "Authorization")
         do {

--- a/Conduit/Services/PushNotificationService.swift
+++ b/Conduit/Services/PushNotificationService.swift
@@ -41,6 +41,38 @@ enum PendingDecisionPayload: Equatable {
     static let relayRequestPrefix = "conduit-push-"
 }
 
+/// Relay + paired-plugin compatibility state (`GET /v1/meta`), rendered in
+/// Settings > Notifications so users can see when the notifier plugin or the
+/// relay needs an update for decision cards to work. Capability flags (not
+/// version parsing) drive the checks; a relay without the endpoint (older or
+/// self-hosted pre-0.2) surfaces as `nil` and renders an unknown state.
+struct RelayMetaInfo: Decodable, Equatable {
+    struct Gateway: Decodable, Equatable, Identifiable {
+        let id: String
+        let name: String
+        let pluginVersion: String?
+        let pluginCapabilities: [String]
+        let lastEventAt: String?
+
+        var supportsApprovalCards: Bool { pluginCapabilities.contains("approval-decisions") }
+        var supportsClarifyCards: Bool { pluginCapabilities.contains("clarify-loop") }
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case pluginVersion = "plugin_version"
+            case pluginCapabilities = "plugin_capabilities"
+            case lastEventAt = "last_event_at"
+        }
+    }
+
+    let version: String
+    let capabilities: [String]
+    let gateways: [Gateway]
+
+    var supportsDecisionCards: Bool { capabilities.contains("decisions") }
+}
+
 enum NotificationSessionResolver {
     /// Hermes notifications identify a live runtime session, while
     /// `session.resume` is keyed by the durable stored session. Catalog rows
@@ -122,6 +154,7 @@ final class PushNotificationService: ObservableObject {
     @Published private(set) var pendingTarget: ConduitNotificationTarget?
     @Published private(set) var navigationAttempt = 0
     @Published var preferences = ConduitNotificationPreferences()
+    @Published private(set) var relayMeta: RelayMetaInfo?
 
     private var relayURL: URL {
         if let saved = UserDefaults.standard.string(forKey: "conduit.relayURL"),
@@ -159,6 +192,27 @@ final class PushNotificationService: ObservableObject {
     func refresh() async {
         let settings = await UNUserNotificationCenter.current().notificationSettings()
         authorizationStatus = settings.authorizationStatus
+    }
+
+    /// Loads relay + plugin compatibility state for Settings > Notifications.
+    /// Nil (also on 404 from older/self-hosted relays) renders as unknown.
+    func refreshMeta() async {
+        guard let registration else {
+            relayMeta = nil
+            return
+        }
+        var request = URLRequest(url: relayURL.appending(path: "/v1/meta"))
+        request.setValue("Bearer \(registration.credential)", forHTTPHeaderField: "Authorization")
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                relayMeta = nil
+                return
+            }
+            relayMeta = try JSONDecoder().decode(RelayMetaInfo.self, from: data)
+        } catch {
+            relayMeta = nil
+        }
     }
 
     /// Outcome of answering a plugin-minted clarify (`conduit-push-…`) through

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -1362,13 +1362,17 @@ private struct NotificationsSettingsDetail: View {
                 }
 
                 ConduitSettingsSection(title: "Compatibility", symbol: "checkmark.seal", tint: .conduitAura) {
-                    if let meta = notifications.relayMeta {
+                    if notifications.isFetchingMeta {
+                        Text("Checking compatibility…")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    } else if let meta = notifications.relayMeta {
                         compatibilityRow(
                             title: "Push relay",
                             version: meta.version,
                             isSupported: meta.supportsDecisionCards,
                             supportedDetail: "Supports decision cards",
-                            outdatedDetail: "Decision cards need a relay update (0.2.0 or newer)"
+                            outdatedDetail: "Decision cards need a relay update"
                         )
                         ForEach(meta.gateways) { gateway in
                             compatibilityRow(
@@ -1378,7 +1382,7 @@ private struct NotificationsSettingsDetail: View {
                                 supportedDetail: "Notifier supports approval and clarify cards",
                                 outdatedDetail: gateway.pluginVersion == nil
                                     ? "Waiting for the first notification from this profile"
-                                    : "Notifier update available — approval and clarify cards need 0.2.0 or newer"
+                                    : "Notifier update available — approval and clarify cards need a newer plugin"
                             )
                             if gateway.pluginVersion != nil,
                                !gateway.supportsApprovalCards || !gateway.supportsClarifyCards {
@@ -1392,6 +1396,7 @@ private struct NotificationsSettingsDetail: View {
                             .foregroundStyle(.secondary)
                     }
                 }
+                .task { await notifications.refreshMeta() }
 
                 ConduitSettingsSection(title: "Connect a Hermes profile", symbol: "link.badge.plus", tint: .conduitAura) {
                     Text("Install the notifier once on the gateway, then create a short-lived pairing code here for each Hermes profile you want to reach.")
@@ -1441,6 +1446,9 @@ private struct NotificationsSettingsDetail: View {
                         .autocorrectionDisabled()
                         .textInputAutocapitalization(.never)
                         .keyboardType(.URL)
+                        .onSubmit {
+                            Task { await notifications.refreshMeta() }
+                        }
                     Text("Leave blank to use the default relay. Change this if you run your own push relay server.")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
@@ -1465,6 +1473,7 @@ private struct NotificationsSettingsDetail: View {
         HStack(spacing: 10) {
             Image(systemName: isSupported ? "checkmark.circle.fill" : "exclamationmark.circle")
                 .foregroundStyle(isSupported ? .green : .orange)
+                .accessibilityLabel(isSupported ? "Supported" : "Update needed")
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
                     Text(title).font(.subheadline.weight(.medium))
@@ -1480,6 +1489,7 @@ private struct NotificationsSettingsDetail: View {
             }
         }
         .padding(.vertical, 2)
+        .accessibilityElement(children: .combine)
     }
 
     @ViewBuilder

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -1361,6 +1361,38 @@ private struct NotificationsSettingsDetail: View {
                     notificationToggle("Approval cards in pushes", detail: "Include approval details so cards work from notifications. Disable for maximum privacy.", keyPath: \.decisionCards)
                 }
 
+                ConduitSettingsSection(title: "Compatibility", symbol: "checkmark.seal", tint: .conduitAura) {
+                    if let meta = notifications.relayMeta {
+                        compatibilityRow(
+                            title: "Push relay",
+                            version: meta.version,
+                            isSupported: meta.supportsDecisionCards,
+                            supportedDetail: "Supports decision cards",
+                            outdatedDetail: "Decision cards need a relay update (0.2.0 or newer)"
+                        )
+                        ForEach(meta.gateways) { gateway in
+                            compatibilityRow(
+                                title: gateway.name,
+                                version: gateway.pluginVersion,
+                                isSupported: gateway.supportsApprovalCards && gateway.supportsClarifyCards,
+                                supportedDetail: "Notifier supports approval and clarify cards",
+                                outdatedDetail: gateway.pluginVersion == nil
+                                    ? "Waiting for the first notification from this profile"
+                                    : "Notifier update available — approval and clarify cards need 0.2.0 or newer"
+                            )
+                            if gateway.pluginVersion != nil,
+                               !gateway.supportsApprovalCards || !gateway.supportsClarifyCards {
+                                NotificationSetupCommand(step: 1, title: "Update the notifier", command: "hermes plugins update conduit_push")
+                                NotificationSetupCommand(step: 2, title: "Restart the gateway", command: "hermes gateway restart")
+                            }
+                        }
+                    } else {
+                        Text("Compatibility unknown. Your relay predates version reporting; decision cards may not be available until it updates.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
                 ConduitSettingsSection(title: "Connect a Hermes profile", symbol: "link.badge.plus", tint: .conduitAura) {
                     Text("Install the notifier once on the gateway, then create a short-lived pairing code here for each Hermes profile you want to reach.")
                         .font(.footnote)
@@ -1416,7 +1448,38 @@ private struct NotificationsSettingsDetail: View {
             }
         }
         .navigationTitle("Notifications")
-        .task { await notifications.refresh() }
+        .task {
+            await notifications.refresh()
+            await notifications.refreshMeta()
+        }
+    }
+
+    @ViewBuilder
+    private func compatibilityRow(
+        title: String,
+        version: String?,
+        isSupported: Bool,
+        supportedDetail: String,
+        outdatedDetail: String
+    ) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: isSupported ? "checkmark.circle.fill" : "exclamationmark.circle")
+                .foregroundStyle(isSupported ? .green : .orange)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(title).font(.subheadline.weight(.medium))
+                    if let version {
+                        Text("v\(version)")
+                            .font(.caption.monospaced())
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Text(isSupported ? supportedDetail : outdatedDetail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 2)
     }
 
     @ViewBuilder

--- a/ConduitTests/MessageNormalizerTests.swift
+++ b/ConduitTests/MessageNormalizerTests.swift
@@ -338,15 +338,13 @@ final class MessageNormalizerTests: XCTestCase {
               "id": "gw-1",
               "name": "Mac Studio Hermes",
               "plugin_version": "0.2.0",
-              "plugin_capabilities": ["approval-decisions", "clarify-loop", "version-reporting"],
-              "last_event_at": "2026-08-15T00:00:00Z"
+              "plugin_capabilities": ["approval-decisions", "clarify-loop", "version-reporting"]
             },
             {
               "id": "gw-2",
               "name": "Old laptop",
               "plugin_version": null,
-              "plugin_capabilities": [],
-              "last_event_at": null
+              "plugin_capabilities": []
             }
           ]
         }
@@ -365,6 +363,23 @@ final class MessageNormalizerTests: XCTestCase {
         let neverReported = meta.gateways[1]
         XCTAssertNil(neverReported.pluginVersion)
         XCTAssertFalse(neverReported.supportsApprovalCards)
+    }
+
+    func testRelayMetaDecodingDropsMalformedGatewayRowsLossily() throws {
+        // One incompatible gateway record must not hide the whole section.
+        let json = """
+        {
+          "version": "0.2.0",
+          "capabilities": ["decisions"],
+          "gateways": [
+            { "id": "gw-bad" },
+            { "id": "gw-good", "name": "Main", "plugin_version": "0.2.0", "plugin_capabilities": ["clarify-loop"] }
+          ]
+        }
+        """
+        let meta = try JSONDecoder().decode(RelayMetaInfo.self, from: Data(json.utf8))
+        XCTAssertEqual(meta.gateways.map(\.id), ["gw-good"])
+        XCTAssertTrue(meta.supportsDecisionCards)
     }
 
     func testExpiredPromptErrorClassification() {

--- a/ConduitTests/MessageNormalizerTests.swift
+++ b/ConduitTests/MessageNormalizerTests.swift
@@ -328,6 +328,45 @@ final class MessageNormalizerTests: XCTestCase {
         XCTAssertTrue(decoded.decisionCards, "Absent decision_cards must fall back to the default-on value")
     }
 
+    func testRelayMetaDecodingAndCapabilityChecks() throws {
+        let json = """
+        {
+          "version": "0.2.0",
+          "capabilities": ["decisions", "decision-cards", "meta"],
+          "gateways": [
+            {
+              "id": "gw-1",
+              "name": "Mac Studio Hermes",
+              "plugin_version": "0.2.0",
+              "plugin_capabilities": ["approval-decisions", "clarify-loop", "version-reporting"],
+              "last_event_at": "2026-08-15T00:00:00Z"
+            },
+            {
+              "id": "gw-2",
+              "name": "Old laptop",
+              "plugin_version": null,
+              "plugin_capabilities": [],
+              "last_event_at": null
+            }
+          ]
+        }
+        """
+        let meta = try JSONDecoder().decode(RelayMetaInfo.self, from: Data(json.utf8))
+
+        XCTAssertTrue(meta.supportsDecisionCards)
+        XCTAssertEqual(meta.gateways.count, 2)
+
+        let current = meta.gateways[0]
+        XCTAssertTrue(current.supportsApprovalCards)
+        XCTAssertTrue(current.supportsClarifyCards)
+
+        // A gateway that has never reported (paired against an older relay)
+        // renders as unknown, not as a false "outdated".
+        let neverReported = meta.gateways[1]
+        XCTAssertNil(neverReported.pluginVersion)
+        XCTAssertFalse(neverReported.supportsApprovalCards)
+    }
+
     func testExpiredPromptErrorClassification() {
         // The gateway's one-shot prompt timeout: JSON-RPC 4009.
         XCTAssertTrue(AppState.isExpiredPromptError(RpcError(code: 4009, message: "no pending approval request")))


### PR DESCRIPTION
## Summary

- Settings > Notifications gains a **Compatibility** section so a stale notifier plugin or relay is visible instead of silently degrading decision cards to plain notifications.
- Backed by the relay's `GET /v1/meta` (device credential — the app already holds it): a relay row (version + decision-card support) and one row per paired Hermes profile (plugin version + approval/clarify card support), with copy-paste `hermes plugins update conduit_push` / `hermes gateway restart` commands when the notifier is outdated.
- Capability flags drive the checks, not version parsing. Graceful degradation on both ends: a relay without the endpoint (older or self-hosted) renders "compatibility unknown"; a gateway that has never reported renders "waiting for the first notification from this profile" rather than a false outdated state.

## Validation

- Decoding + capability-check unit test (current gateway, never-reported gateway, relay flags).
- Full iOS Simulator suite: **649 passed, 0 failed**.
- Companion plugin/relay PR: kaishi00/hermes-conduit-notifier `compatibility-version-reporting` (e2e covers the endpoint contract end to end).

**Rollout:** the section shows "unknown" until the relay is redeployed at 0.2.0 — which is exactly the signal it exists to give.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added relay and gateway compatibility details to notification settings, including versions and decision-card support.
  * Added gateway capability indicators for approval and clarification actions.
  * Added guidance and available update or restart actions when a plugin is outdated.
  * Compatibility information now refreshes when notification tasks load or a custom relay URL is submitted.
  * Unsupported or unavailable compatibility information is handled gracefully without disrupting valid gateway details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->