### PR TITLE
Prompt the notifier update for pre-0.2 plugins

### DIFF
--- a/Conduit/Services/PushNotificationService.swift
+++ b/Conduit/Services/PushNotificationService.swift
@@ -57,10 +57,11 @@ struct RelayMetaInfo: Decodable, Equatable {
         var supportsApprovalCards: Bool { pluginCapabilities.contains("approval-decisions") }
         var supportsClarifyCards: Bool { pluginCapabilities.contains("clarify-loop") }
 
-        /// A gateway that has sent events but never a plugin version runs a
-        /// pre-0.2 notifier (0.2 stamps every event) and should be prompted to
-        /// update, not shown as "waiting".
-        var isLegacyPlugin: Bool { pluginVersion == nil && lastEventAt != nil }
+        /// A gateway that has sent events but never reported a plugin version
+        /// runs a pre-0.2 notifier — every 0.2+ event carries the version, so
+        /// any version-less event is one. Only this evidence justifies the
+        /// update prompt; a gateway that has sent nothing stays "waiting".
+        var hasSentEventsButNeverReported: Bool { pluginVersion == nil && lastEventAt != nil }
 
         enum CodingKeys: String, CodingKey {
             case id

--- a/Conduit/Services/PushNotificationService.swift
+++ b/Conduit/Services/PushNotificationService.swift
@@ -52,15 +52,22 @@ struct RelayMetaInfo: Decodable, Equatable {
         let name: String
         let pluginVersion: String?
         let pluginCapabilities: [String]
+        let lastEventAt: String?
 
         var supportsApprovalCards: Bool { pluginCapabilities.contains("approval-decisions") }
         var supportsClarifyCards: Bool { pluginCapabilities.contains("clarify-loop") }
+
+        /// A gateway that has sent events but never a plugin version runs a
+        /// pre-0.2 notifier (0.2 stamps every event) and should be prompted to
+        /// update, not shown as "waiting".
+        var isLegacyPlugin: Bool { pluginVersion == nil && lastEventAt != nil }
 
         enum CodingKeys: String, CodingKey {
             case id
             case name
             case pluginVersion = "plugin_version"
             case pluginCapabilities = "plugin_capabilities"
+            case lastEventAt = "last_event_at"
         }
     }
 

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -1380,12 +1380,15 @@ private struct NotificationsSettingsDetail: View {
                                 version: gateway.pluginVersion,
                                 isSupported: gateway.supportsApprovalCards && gateway.supportsClarifyCards,
                                 supportedDetail: "Notifier supports approval and clarify cards",
-                                outdatedDetail: gateway.pluginVersion == nil
-                                    ? "Waiting for the first notification from this profile"
-                                    : "Notifier update available — approval and clarify cards need a newer plugin"
+                                outdatedDetail: gateway.isLegacyPlugin
+                                    ? "This profile's notifier predates decision cards — update it to receive them"
+                                    : gateway.pluginVersion == nil
+                                        ? "Waiting for the first notification from this profile"
+                                        : "Notifier update available — approval and clarify cards need a newer plugin"
                             )
-                            if gateway.pluginVersion != nil,
-                               !gateway.supportsApprovalCards || !gateway.supportsClarifyCards {
+                            // Prompt the update both for a reported-but-old
+                            // plugin and for a never-reporting (pre-0.2) one.
+                            if !gateway.supportsApprovalCards || !gateway.supportsClarifyCards || gateway.isLegacyPlugin {
                                 NotificationSetupCommand(step: 1, title: "Update the notifier", command: "hermes plugins update conduit_push")
                                 NotificationSetupCommand(step: 2, title: "Restart the gateway", command: "hermes gateway restart")
                             }

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -1380,15 +1380,19 @@ private struct NotificationsSettingsDetail: View {
                                 version: gateway.pluginVersion,
                                 isSupported: gateway.supportsApprovalCards && gateway.supportsClarifyCards,
                                 supportedDetail: "Notifier supports approval and clarify cards",
-                                outdatedDetail: gateway.isLegacyPlugin
+                                outdatedDetail: gateway.hasSentEventsButNeverReported
                                     ? "This profile's notifier predates decision cards — update it to receive them"
                                     : gateway.pluginVersion == nil
                                         ? "Waiting for the first notification from this profile"
                                         : "Notifier update available — approval and clarify cards need a newer plugin"
                             )
-                            // Prompt the update both for a reported-but-old
-                            // plugin and for a never-reporting (pre-0.2) one.
-                            if !gateway.supportsApprovalCards || !gateway.supportsClarifyCards || gateway.isLegacyPlugin {
+                            // The update prompt requires evidence of oldness:
+                            // either a reported-but-old version, or events that
+                            // never carried one (pre-0.2). A gateway that has
+                            // sent nothing keeps only the "waiting" copy.
+                            if gateway.hasSentEventsButNeverReported
+                                || (gateway.pluginVersion != nil
+                                    && (!gateway.supportsApprovalCards || !gateway.supportsClarifyCards)) {
                                 NotificationSetupCommand(step: 1, title: "Update the notifier", command: "hermes plugins update conduit_push")
                                 NotificationSetupCommand(step: 2, title: "Restart the gateway", command: "hermes gateway restart")
                             }

--- a/ConduitTests/MessageNormalizerTests.swift
+++ b/ConduitTests/MessageNormalizerTests.swift
@@ -344,7 +344,8 @@ final class MessageNormalizerTests: XCTestCase {
               "id": "gw-2",
               "name": "Old laptop",
               "plugin_version": null,
-              "plugin_capabilities": []
+              "plugin_capabilities": [],
+              "last_event_at": "2026-08-15T01:00:00Z"
             }
           ]
         }
@@ -358,11 +359,12 @@ final class MessageNormalizerTests: XCTestCase {
         XCTAssertTrue(current.supportsApprovalCards)
         XCTAssertTrue(current.supportsClarifyCards)
 
-        // A gateway that has never reported (paired against an older relay)
-        // renders as unknown, not as a false "outdated".
-        let neverReported = meta.gateways[1]
-        XCTAssertNil(neverReported.pluginVersion)
-        XCTAssertFalse(neverReported.supportsApprovalCards)
+        // Events sent but never a plugin version = pre-0.2 notifier: prompt
+        // the update instead of showing "waiting for the first notification".
+        let legacy = meta.gateways[1]
+        XCTAssertNil(legacy.pluginVersion)
+        XCTAssertNotNil(legacy.lastEventAt)
+        XCTAssertTrue(legacy.isLegacyPlugin)
     }
 
     func testRelayMetaDecodingDropsMalformedGatewayRowsLossily() throws {

--- a/ConduitTests/MessageNormalizerTests.swift
+++ b/ConduitTests/MessageNormalizerTests.swift
@@ -346,6 +346,13 @@ final class MessageNormalizerTests: XCTestCase {
               "plugin_version": null,
               "plugin_capabilities": [],
               "last_event_at": "2026-08-15T01:00:00Z"
+            },
+            {
+              "id": "gw-3",
+              "name": "Fresh pair",
+              "plugin_version": null,
+              "plugin_capabilities": [],
+              "last_event_at": null
             }
           ]
         }
@@ -353,7 +360,7 @@ final class MessageNormalizerTests: XCTestCase {
         let meta = try JSONDecoder().decode(RelayMetaInfo.self, from: Data(json.utf8))
 
         XCTAssertTrue(meta.supportsDecisionCards)
-        XCTAssertEqual(meta.gateways.count, 2)
+        XCTAssertEqual(meta.gateways.count, 3)
 
         let current = meta.gateways[0]
         XCTAssertTrue(current.supportsApprovalCards)
@@ -364,7 +371,14 @@ final class MessageNormalizerTests: XCTestCase {
         let legacy = meta.gateways[1]
         XCTAssertNil(legacy.pluginVersion)
         XCTAssertNotNil(legacy.lastEventAt)
-        XCTAssertTrue(legacy.isLegacyPlugin)
+        XCTAssertTrue(legacy.hasSentEventsButNeverReported)
+
+        // A gateway that has sent nothing keeps the waiting state — it is not
+        // evidence of an old plugin, so no contradictory update prompt.
+        let neverSent = meta.gateways[2]
+        XCTAssertNil(neverSent.pluginVersion)
+        XCTAssertNil(neverSent.lastEventAt)
+        XCTAssertFalse(neverSent.hasSentEventsButNeverReported)
     }
 
     func testRelayMetaDecodingDropsMalformedGatewayRowsLossily() throws {


### PR DESCRIPTION
## Summary

- The Compatibility section now distinguishes three gateway states: current (capabilities ✓), outdated (reported version, missing capabilities), and **legacy pre-0.2** — sent events but never a plugin version, which is by definition an old notifier since 0.2 stamps every event.
- Legacy gateways previously showed "waiting for the first notification" forever; they now read *"This profile's notifier predates decision cards — update it to receive them"* with the copy-paste `hermes plugins update conduit_push` / `hermes gateway restart` commands. This is the dominant rollout state (new app + updated shared relay + not-yet-updated plugin), so the prompt matters.
- `Gateway.lastEventAt` returns (it was dropped as unused in #62 — the legacy derivation is its use); decode + `isLegacyPlugin` unit-tested.

## Validation

Full suite: 661 passed, 0 failed. Companion relay PR stamps `last_event_at` per accepted event (kaishi00/hermes-conduit-notifier `legacy-plugin-prompt`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notification compatibility detection for legacy plugins.
  - Update guidance now appears correctly for older plugins, even when capability information is incomplete.
  - Better distinguishes integrations that have sent events without reporting a plugin version from those that have never sent events.
  - Preserved waiting guidance for inactive integrations without version information.

- **Tests**
  - Added coverage for gateway event timestamps and legacy plugin identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->