### PR TITLE
fix(connection): revive dashboard bridge after web content process death (overnight stuck-reconnecting)

### DIFF
--- a/Conduit/Services/DashboardTicketBridge.swift
+++ b/Conduit/Services/DashboardTicketBridge.swift
@@ -254,6 +254,11 @@ final class DashboardTicketBridge: NSObject {
     }
 
     deinit {
+        // Stored-property access and Task.cancel() are safe from nonisolated
+        // deinit; cancelling here stops deadline tasks from outliving the
+        // bridge they were created to guard.
+        for deadline in requestDeadlines.values { deadline.cancel() }
+        requestDeadlines.removeAll()
         pendingRequests.rejectAll(with: DashboardTicketBridgeError.notReady)
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "dashboard-response")
     }
@@ -262,7 +267,7 @@ final class DashboardTicketBridge: NSObject {
         guard !isInvalidated else { return }
         isInvalidated = true
         isReady = false
-        pendingRequests.rejectAll(with: DashboardTicketBridgeError.notReady)
+        rejectPending(with: DashboardTicketBridgeError.notReady)
     }
 
     func reload() {
@@ -384,9 +389,14 @@ final class DashboardTicketBridge: NSObject {
                 requestDeadlines[id] = Task { [weak self] in
                     try? await Task.sleep(for: .milliseconds(timeout + 3_000))
                     guard !Task.isCancelled else { return }
+                    // .notReady (not .requestFailed) so the failure funnels
+                    // into mintTicket's internal reload-retry instead of
+                    // surfacing past it — a timed-out JavaScript response is
+                    // almost always a dead or stalled web view, i.e. exactly
+                    // the state reloading revives.
                     self?.failPendingRequest(
                         id: id,
-                        with: DashboardTicketBridgeError.requestFailed("Dashboard request timed out.")
+                        with: DashboardTicketBridgeError.notReady
                     )
                 }
                 let script = """

--- a/Conduit/Services/DashboardTicketBridge.swift
+++ b/Conduit/Services/DashboardTicketBridge.swift
@@ -203,6 +203,12 @@ final class DashboardTicketBridge: NSObject {
     private var isInvalidated = false
     private var requestID = 0
     private let pendingRequests: DashboardTicketBridgePendingRequests
+    /// Swift-side deadlines for in-flight `requestJSON` continuations. The
+    /// JavaScript timeout only fires inside a live web view; if the content
+    /// process is gone (or a response message is dropped), nothing but these
+    /// deadlines resumes the continuation — without them a single lost
+    /// response hangs ticket minting, and therefore reconnecting, forever.
+    private var requestDeadlines: [Int: Task<Void, Never>] = [:]
     private let readinessPollAttempts: Int
     private let readinessPollInterval: Duration
     /// Number of times `reload()` re-attempted the dashboard page load, from
@@ -369,6 +375,20 @@ final class DashboardTicketBridge: NSObject {
                 }
 
                 pendingRequests.insert(continuation, for: id)
+                // Swift-side deadline: the JavaScript AbortController above
+                // only runs inside a live web view. If the content process
+                // is gone or a response message is dropped, this is the only
+                // thing that resumes the continuation — convert the silent
+                // hang into a failure the reconnect loop can retry through
+                // the reload path.
+                requestDeadlines[id] = Task { [weak self] in
+                    try? await Task.sleep(for: .milliseconds(timeout + 3_000))
+                    guard !Task.isCancelled else { return }
+                    self?.failPendingRequest(
+                        id: id,
+                        with: DashboardTicketBridgeError.requestFailed("Dashboard request timed out.")
+                    )
+                }
                 let script = """
                 (async function() {
                     try {
@@ -428,8 +448,8 @@ final class DashboardTicketBridge: NSObject {
                 true;
                 """
                 webView.evaluateJavaScript(script) { _, error in
-                    guard let error, let pending = self.pendingRequests.removeValue(for: id) else { return }
-                    pending.resume(throwing: error)
+                    guard let error else { return }
+                    self.failPendingRequest(id: id, with: error)
                 }
             }
         }, onCancel: {
@@ -439,9 +459,17 @@ final class DashboardTicketBridge: NSObject {
         })
     }
 
-    private func cancelPendingRequest(id: Int) {
+    /// Cancels the Swift-side deadline and resumes the pending request, if
+    /// any, with `error`. All failure-side resume paths funnel through here
+    /// so the deadline task can never fire on an already-resumed request.
+    private func failPendingRequest(id: Int, with error: Error) {
+        requestDeadlines.removeValue(forKey: id)?.cancel()
         guard let continuation = pendingRequests.removeValue(for: id) else { return }
-        continuation.resume(throwing: CancellationError())
+        continuation.resume(throwing: error)
+    }
+
+    private func cancelPendingRequest(id: Int) {
+        failPendingRequest(id: id, with: CancellationError())
     }
 
     private func javaScriptLiteral(_ value: Any) throws -> String {
@@ -485,6 +513,8 @@ final class DashboardTicketBridge: NSObject {
     }
 
     private func rejectPending(with error: Error) {
+        for deadline in requestDeadlines.values { deadline.cancel() }
+        requestDeadlines.removeAll()
         pendingRequests.rejectAll(with: error)
     }
 }
@@ -551,6 +581,21 @@ extension DashboardTicketBridge: WKNavigationDelegate {
         isLoadFailed = true
         rejectPending(with: error)
     }
+
+    func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        // iOS reclaims the web content process under memory pressure —
+        // typically while the app is suspended overnight. From that moment
+        // the in-memory isReady flag is stale: evaluateJavaScript gets no
+        // usable page, and without this callback nothing ever reloads it,
+        // so the next ticket mint (and therefore every reconnect) hangs
+        // until the user force-quits the app. Treat the bridge as cold but
+        // reloadable: pending requests resume into the retry paths, and
+        // mintTicket's .notReady recovery revives the page.
+        isReady = false
+        isLoadFailed = true
+        didLandOnLogin = false
+        rejectPending(with: DashboardTicketBridgeError.notReady)
+    }
 }
 
 extension DashboardTicketBridge: WKScriptMessageHandler {
@@ -569,6 +614,7 @@ extension DashboardTicketBridge: WKScriptMessageHandler {
               payload["type"] as? String == "dashboard-response",
               let id = payload["id"] as? Int,
               let continuation = pendingRequests.removeValue(for: id) else { return }
+        requestDeadlines.removeValue(forKey: id)?.cancel()
 
         if payload["ok"] as? Bool == true {
             continuation.resume(returning: payload["body"] as? [String: Any] ?? [:])

--- a/ConduitTests/DashboardTicketBridgeTests.swift
+++ b/ConduitTests/DashboardTicketBridgeTests.swift
@@ -99,4 +99,72 @@ final class DashboardTicketBridgeTests: XCTestCase {
         // leave this at zero.
         XCTAssertEqual(bridge.reloadCount, 2)
     }
+
+    /// iOS reclaims the bridge's web content process under memory pressure —
+    /// typically while the app is suspended overnight. The termination
+    /// callback must mark the bridge cold-but-reloadable so the next mint
+    /// revives the page instead of awaiting a JavaScript response that can
+    /// never arrive (the overnight stuck-reconnecting wedge).
+    func testWebContentTerminationMarksBridgeReloadableAndMintRetries() async {
+        let bridge = DashboardTicketBridge(
+            baseURL: "http://127.0.0.1:1",
+            readinessPollAttempts: 2,
+            readinessPollInterval: .milliseconds(10)
+        )
+
+        bridge.webViewWebContentProcessDidTerminate(bridge.webView)
+        XCTAssertTrue(bridge.isLoadFailed, "Termination must make the bridge reloadable")
+
+        do {
+            _ = try await bridge.mintTicket()
+            XCTFail("Expected mintTicket to throw against a terminated web process")
+        } catch DashboardTicketBridgeError.notReady {
+            // expected
+        } catch {
+            XCTFail("Expected DashboardTicketBridgeError.notReady, got \(error)")
+        }
+
+        // The .notReady recovery must reload the dead page.
+        XCTAssertGreaterThanOrEqual(bridge.reloadCount, 1)
+    }
+
+    /// A requestJSON awaiting a JavaScript response when the content process
+    /// dies must be resumed with .notReady — not left pending forever.
+    func testWebContentTerminationResumesPendingRequestAsNotReady() async {
+        let requests = DashboardTicketBridgePendingRequests()
+        let bridge = DashboardTicketBridge(
+            baseURL: "https://example.com",
+            pendingRequests: requests
+        )
+        let requestRegistered = expectation(description: "pending request registered")
+        let resultTask = Task { @MainActor in
+            do {
+                _ = try await withCheckedThrowingContinuation {
+                    (continuation: CheckedContinuation<[String: Any], Error>) in
+                    requests.insert(continuation, for: 99)
+                    requestRegistered.fulfill()
+                }
+                return Result<Void, Error>.success(())
+            } catch {
+                return Result<Void, Error>.failure(error)
+            }
+        }
+
+        await fulfillment(of: [requestRegistered], timeout: 1.0)
+        bridge.webViewWebContentProcessDidTerminate(bridge.webView)
+
+        switch await resultTask.value {
+        case .success:
+            XCTFail("Termination must resume pending requests with an error")
+        case .failure(let error as DashboardTicketBridgeError):
+            if case .notReady = error {
+                // expected
+            } else {
+                XCTFail("Expected .notReady, got \(error)")
+            }
+        case .failure(let error):
+            XCTFail("Expected DashboardTicketBridgeError.notReady, got \(error)")
+        }
+        XCTAssertEqual(requests.count, 0)
+    }
 }


### PR DESCRIPTION
## Problem

Waking the phone after the app sat suspended overnight: Conduit shows "Reconnecting…" forever; force-closing and reopening works fine. Reported on TestFlight build 130, and — after checking — **still reproducible on `main` with #65 and #66 merged**. It is a third, distinct wedge.

## Root cause

The dashboard bridge hosts a hidden `WKWebView` to mint WebSocket tickets. Under memory pressure, iOS reclaims the web **content** process while the app is suspended overnight. Three facts combine into a permanent silent hang:

1. The bridge's `isReady` flag is in-memory and survives the suspension — it still says "ready" from yesterday.
2. Nothing observed the process death: the bridge never implemented `webViewWebContentProcessDidTerminate`.
3. `requestJSON`'s only timeout lives **inside the injected JavaScript** (`AbortController`), which never runs in a dead web view. The Swift continuation had no deadline.

So the morning reconnect goes: mint ticket → readiness passes instantly (stale flag) → `evaluateJavaScript` into a dead web view → response never arrives → **the await never returns**. No error is thrown, so no retry is scheduled; the reconnect state machine is simply suspended forever. Force-close is the only recovery — a fresh process gets a fresh web view.

Reproduced deterministically in the simulator against a chaos gateway: kill the content process **while the app is backgrounded**, drop the socket, foreground the app → main makes **zero network requests indefinitely** (log shows the socket death, then silence). Killing the process while foregrounded recovers in seconds, which is why this only surfaces after real overnight suspension.

## Fix — two layers

- **`webViewWebContentProcessDidTerminate`** (the proper recovery): marks the bridge cold-but-reloadable (`isReady=false`, `isLoadFailed=true`) and resumes any pending `requestJSON` with `.notReady` — flowing directly into `mintTicket`'s existing reload recovery from #65, which reloads the page and revives the web view.
- **Swift-side deadline on every `requestJSON` continuation** (the belt): request timeout + 3s. If a response is ever silently dropped for any other reason (origin-mismatch on a restored blank page, process-relaunch races), the hang becomes a retryable failure instead of wedging ticket minting forever. All failure-side resume paths funnel through one helper that cancels the deadline first; `rejectPending` cancels all of them.

## Verification

The exact overnight scenario against the fixed build: background → kill content process → drop socket → foreground → **ticket minted, socket reopened, session catalog + transcript restored ~1s after foreground** (vs. never on main). Screenshot in the investigation; unit suite **669/0** including two new regression tests (termination → reloadable state + mint retries the dead page; termination → pending requests resume as `.notReady`).

Fixes the "morning stuck-on-reconnecting" report from build 130 alongside #65 (which fixed the cold-bridge and watchdog wedges); #66 was CI-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeout handling for in-progress dashboard requests.
  * Improved cleanup when requests are canceled, rejected, or completed.
  * Added recovery when the embedded web content process terminates.
  * Pending requests now fail promptly, and the dashboard can recover after reloading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->