### PR TITLE
Prepare 0.1.4 build 131 for TestFlight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
   test:
     name: Build & Test
     runs-on: macos-26
+    # A wedged simulator can hang a test invocation for hours (the default
+    # step timeout is 360 minutes). Healthy runs finish well under 15
+    # minutes; cap the job so a wedge surfaces as a bounded failure.
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v7
@@ -90,6 +94,9 @@ jobs:
               xcrun simctl shutdown "$SIMULATOR" || true
               sleep 3
               xcrun simctl boot "$SIMULATOR" || true
+              # Handing a half-booted simulator to xcodebuild wedges UI
+              # tests on cold-start services; wait for a complete boot.
+              xcrun simctl bootstatus "$SIMULATOR" -b -t 180 || true
             fi
             echo "::group::Test attempt $attempt"
             rm -rf "$BUNDLE"

--- a/project.yml
+++ b/project.yml
@@ -16,8 +16,8 @@ settings:
     ENABLE_BITCODE: NO
     DEVELOPMENT_TEAM: U2TH557QA8
     CODE_SIGN_STYLE: Manual
-    MARKETING_VERSION: "0.1.1"
-    CURRENT_PROJECT_VERSION: "117"
+    MARKETING_VERSION: "0.1.4"
+    CURRENT_PROJECT_VERSION: "131"
 targets:
   Conduit:
     type: application


### PR DESCRIPTION
## Release candidate

- **Marketing version:** 0.1.4
- **Build number:** 131
- **Cut from main:** `aaff0a1`
- **Supersedes:** build 130 (0.1.3), currently in the TestFlight review queue — to be pulled, as it predates the connection-stability fixes below.

## Scope

| PR | Change |
|---|---|
| #65 | Connection stabilization: cold-bridge reload recovery + 0x8BADF00D scene-gated reconnect (the flaky-tethering stuck-reconnect + crash-notice fixes) |
| #67 | Overnight wedge: WKWebView content-process revival + Swift-side request deadline |
| #68 | Deadline expiry marks stalled view for reload; full deadline cleanup |
| #66 | CI stabilization only — no app-binary change |

Release branch carries only this metadata commit; no cherry-picks needed (all PRs merged before the cut). Verification: chaos-gateway end-to-end (outage, overnight process-kill, bg/fg torture), 670-test unit suite, CI on all four PRs. Tag `ios/v0.1.4-build-131` will point at the shipped commit after upload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the CI test job timeout to 45 minutes.
  * Improved simulator restart handling by waiting for boot completion before retrying UI tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->