### PR TITLE
ci: cap test job at 45 min, wait for full boot between retry attempts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
   test:
     name: Build & Test
     runs-on: macos-26
+    # A wedged simulator can hang a test invocation for hours (the default
+    # step timeout is 360 minutes). Healthy runs finish well under 15
+    # minutes; cap the job so a wedge surfaces as a bounded failure.
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v7
@@ -90,6 +94,9 @@ jobs:
               xcrun simctl shutdown "$SIMULATOR" || true
               sleep 3
               xcrun simctl boot "$SIMULATOR" || true
+              # Handing a half-booted simulator to xcodebuild wedges UI
+              # tests on cold-start services; wait for a complete boot.
+              xcrun simctl bootstatus "$SIMULATOR" -b -t 180 || true
             fi
             echo "::group::Test attempt $attempt"
             rm -rf "$BUNDLE"


### PR DESCRIPTION
The release/0.1.4 candidate run wedged 29+ minutes inside Run tests with no bound — a hung simulator stalls xcodebuild until the 360-minute default step timeout. Two bounds:

1. `timeout-minutes: 45` on the job — a wedge now fails visibly instead of hanging for hours (healthy runs finish under 15).
2. The #66 retry's simulator reset booted the device but didn't wait for boot completion; UI tests on a half-booted sim can hit the cold-start wedge. `simctl bootstatus -b -t 180` now gates the retry.

Workflow-only change; no app code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated UI test reliability by waiting for the simulator to finish booting before tests run.
  * Added a 45-minute timeout to the CI test job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->