### PR TITLE
fix(ci): retry full test suite after simulator reset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,61 +67,63 @@ jobs:
 
       - name: Run tests
         run: |
-          # The synthesized-drag selection UI tests occasionally lose the race
-          # against slow CI runners (gesture timing, background-assertion
-          # acquisition timeouts). The tests retry drags in-process; if the
-          # full run still fails, retry the UI target once so an
-          # infrastructure blip does not paint the build red. A genuine
-          # double failure still fails the build.
+          # If the full suite fails, reset the simulator and retry the full
+          # suite once. A genuine double failure still fails CI. Attempt 2
+          # runs the entire suite (not just UI tests) because attempt 1 can
+          # fail in a unit test; a UI-only retry would mask that failure.
           #
-          # Attempt 1 always runs the full suite in ONE xcodebuild
-          # invocation (unit + UI). Do not split unit and UI into separate
-          # invocations: on a cold simulator the composer paste unit tests
-          # can stall against the pasteboard XPC service before the UI
-          # runner has warmed the device (observed hanging 35+ minutes on
-          # CI with -only-testing:ConduitTests; reproduced locally on an
-          # erased simulator).
+          # NOTE: GitHub Actions runs `bash -eo pipefail {0}` by default.
+          # We wrap the piped xcodebuild|xcpretty invocation in an `if`
+          # block so that an expected nonzero exit code is intentionally
+          # handled by the loop instead of killed by errexit.  (Running
+          # `set +e` would also work but the `if` scopes the failure
+          # cleanly and makes the intent obvious.)
           set -uo pipefail
           for attempt in 1 2; do
             if [ "$attempt" -eq 1 ]; then
-              SCOPE=""
               BUNDLE=TestResults.xcresult
             else
-              SCOPE="-only-testing:ConduitUITests"
               BUNDLE=TestResults-retry.xcresult
               # A wedged simulator is the one failure mode in-test retries
               # cannot clear; restart the device so the retry starts clean.
               xcrun simctl shutdown "$SIMULATOR" || true
               sleep 3
               xcrun simctl boot "$SIMULATOR" || true
-              # Handing a half-booted simulator to xcodebuild wedges UI
-              # tests on cold-start services; wait for a complete boot.
+              # Wait for a complete boot before handing the device to
+              # xcodebuild; a half-booted simulator wedges UI tests.
               xcrun simctl bootstatus "$SIMULATOR" -b -t 180 || true
             fi
             echo "::group::Test attempt $attempt"
             rm -rf "$BUNDLE"
-            # Unquoted $SCOPE intentionally: empty on attempt 1, one token
-            # on the UI-only retry.
-            xcodebuild test \
+            status=0
+            if xcodebuild test \
               -project Conduit.xcodeproj \
               -scheme Conduit \
               -destination "platform=iOS Simulator,id=$SIMULATOR" \
               -configuration Debug \
-              $SCOPE \
               -resultBundlePath "$BUNDLE" \
               CODE_SIGN_IDENTITY="" \
               CODE_SIGNING_REQUIRED=NO \
               CODE_SIGNING_ALLOWED=NO \
               DEVELOPMENT_TEAM="" \
               PROVISIONING_PROFILE_SPECIFIER="" \
-              | xcpretty --color
-            status=${PIPESTATUS[0]}
+              | xcpretty --color; then
+              status=0
+            else
+              # Preserve both pipeline statuses: xcodebuild may succeed
+              # while xcpretty fails (or vice versa). Fail/retry if
+              # either command fails.
+              ps=("${PIPESTATUS[@]}")
+              status=$(( ps[0] != 0 ? ps[0] : ps[1] ))
+            fi
             echo "::endgroup::"
             if [ "$status" -eq 0 ]; then
+              echo "tests passed on attempt $attempt"
               exit 0
             fi
-            echo "tests failed on attempt $attempt (status $status)"
+            echo "tests failed on attempt $attempt (exit status $status)"
           done
+          echo "both test attempts failed"
           exit 1
 
       - name: Upload test results on failure


### PR DESCRIPTION
## Problem

CI run 316 failed because `ComposerPasteTextViewTests.testPasteItemProvidersFallsBackToUIImageWhenImageDataFails` timed out waiting 5 seconds for a "fallback image callback". The `DashboardTicketBridgeTests` all passed, confirming this is unrelated CI/test-runner flakiness.

## Root cause: retry never reliably executes

GitHub Actions runs each `run:` step under `bash -eo pipefail {0}`. When the `xcodebuild test | xcpretty` pipeline fails, the shell exits immediately on the pipeline result. The line `status=${PIPESTATUS[0]}` never executes, and the retry loop never reaches attempt 2.

## Root cause: UI-only retry masks unit failures

Attempt 2 was scoped to `-only-testing:ConduitUITests`. If attempt 1 failed in a unit test, a subsequent UI-only retry could pass and make CI green while the original unit-test failure was never retried.

## Fix

1. **Wrap the pipeline in `if`/`else`** — this is an exception context; errexit sees success (the condition evaluated) and does not kill the step. Both `PIPESTATUS` values are preserved: if xcodebuild succeeds but xcpretty fails (or vice versa), CI still fails and retries.

2. **Remove `-only-testing:ConduitUITests`** — both attempts run the full suite. A genuine double failure still fails CI.

3. **Preserve separate result bundles** (`TestResults.xcresult` / `TestResults-retry.xcresult`) uploaded on final failure.

## Validation

- Local shell reproduction confirmed: `bash -eo pipefail -c "if true | false; then ...; else ps=(\"${PIPESTATUS[@]}\"); status=$(( ps[0] != 0 ? ps[0] : ps[1] )); fi"` correctly captures status=1 when xcpretty fails.
- Attempt 2 has no `-only-testing:ConduitUITests`.
- A failed second attempt returns nonzero (`exit 1` after the loop).
- Successful attempt 1 exits successfully without retrying (`exit 0` inside the loop).
- No other files modified; no changes to test code or assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated test reliability by fully resetting and restarting the simulator before retries.
  * The complete test suite now retries after failures, with clearer reporting of each attempt.
  * Test runs correctly fail when either build or test execution is unsuccessful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->