### PR TITLE
fix(chat): show full markdown table cell content

### DIFF
--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -661,6 +661,7 @@ private struct InlineMarkdown: View {
     var font: UIFont = .preferredFont(forTextStyle: .body)
     var lineSpacing: CGFloat = 0
     var maximumNumberOfLines: Int = 0
+    var selfSizingWidthRange: ClosedRange<CGFloat>? = nil
     var selectionCoordinator: MarkdownSelectionCoordinator?
     var selectionSegment: MarkdownSelectionSegmentDescriptor?
     var trailingCharacterOpacities: [Double] = []
@@ -689,6 +690,7 @@ private struct InlineMarkdown: View {
             lineSpacing: lineSpacing,
             maximumNumberOfLines: maximumNumberOfLines,
             linkColor: usesAccentSurface ? .white : .link,
+            selfSizingWidthRange: selfSizingWidthRange,
             selectionCoordinator: selectionCoordinator,
             selectionSegment: selectionSegment
         )
@@ -923,6 +925,9 @@ private struct MarkdownTable: View {
                     font: isHeader
                         ? UIFont.preferredFont(forTextStyle: .caption1).withTraits(.traitBold)
                         : UIFont.preferredFont(forTextStyle: .footnote),
+                    // Match the frame clamp below so the measured wrapping
+                    // width is deterministic from the first layout pass.
+                    selfSizingWidthRange: 112...220,
                     selectionCoordinator: selectionCoordinator,
                     selectionSegment: selectionSegment(row: rowIndex, column: index)
                 )

--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -923,7 +923,6 @@ private struct MarkdownTable: View {
                     font: isHeader
                         ? UIFont.preferredFont(forTextStyle: .caption1).withTraits(.traitBold)
                         : UIFont.preferredFont(forTextStyle: .footnote),
-                    maximumNumberOfLines: 4,
                     selectionCoordinator: selectionCoordinator,
                     selectionSegment: selectionSegment(row: rowIndex, column: index)
                 )

--- a/Conduit/Views/Components/SelectableTextView.swift
+++ b/Conduit/Views/Components/SelectableTextView.swift
@@ -209,16 +209,11 @@ struct SelectableTextView: UIViewRepresentable {
         return CGSize(width: width, height: Self.measuredWrappingHeight(of: textView, at: width))
     }
 
-    /// Shared measurement path for `sizeThatFits` and unit tests. Forces the
-    /// text container to the target width before measuring so the result is
-    /// independent of `textView.bounds` (which may be zero or stale during the
-    /// first layout pass inside a horizontal `ScrollView`).
+    /// Shared measurement path for `sizeThatFits` and unit tests. Delegates
+    /// to `UITextView.sizeThatFits` at the target width. On iOS 17+
+    /// (TextKit 2) the proposed width drives wrapping independent of the
+    /// text container's stored size, so no container mutation is needed.
     static func measuredWrappingHeight(of textView: UITextView, at width: CGFloat) -> CGFloat {
-        let container = textView.textContainer
-        let tracksWidth = container.widthTracksTextView
-        container.widthTracksTextView = false
-        container.size = CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)
-        container.widthTracksTextView = tracksWidth
         let measured = textView.sizeThatFits(CGSize(width: width, height: CGFloat.greatestFiniteMagnitude))
         return ceil(measured.height)
     }

--- a/Conduit/Views/Components/SelectableTextView.swift
+++ b/Conduit/Views/Components/SelectableTextView.swift
@@ -197,27 +197,30 @@ struct SelectableTextView: UIViewRepresentable {
             return measureNonWrapping()
         }
 
-        guard let width = proposal.width, width > 0 else { return nil }
         let textView = uiView.mountedTextView
 
-        // The text container width is set from textView.bounds.width in
-        // configure(), but during the first layout pass (or when the view is
-        // inside a horizontal ScrollView whose content width is unconstrained),
-        // bounds.width may be 0 or stale. Force the container to the proposed
-        // width so UIKit wraps lines at the actual column width, not a
-        // leftover from a previous layout cycle.
-        let previousTracksWidth = textView.textContainer.widthTracksTextView
-        textView.textContainer.widthTracksTextView = false
-        textView.textContainer.size = CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)
-        textView.textContainer.widthTracksTextView = previousTracksWidth
+        // Inside a horizontal ScrollView the width proposal is nil; fall back
+        // to the last laid-out width so SwiftUI measures at the real column
+        // width instead of intrinsicContentSize (which uses a stale container).
+        let width = proposal.width
+            ?? (textView.bounds.width > 0 ? textView.bounds.width : nil)
+        guard let width, width > 0, width.isFinite else { return nil }
 
+        return CGSize(width: width, height: Self.measuredWrappingHeight(of: textView, at: width))
+    }
+
+    /// Shared measurement path for `sizeThatFits` and unit tests. Forces the
+    /// text container to the target width before measuring so the result is
+    /// independent of `textView.bounds` (which may be zero or stale during the
+    /// first layout pass inside a horizontal `ScrollView`).
+    static func measuredWrappingHeight(of textView: UITextView, at width: CGFloat) -> CGFloat {
+        let container = textView.textContainer
+        let tracksWidth = container.widthTracksTextView
+        container.widthTracksTextView = false
+        container.size = CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)
+        container.widthTracksTextView = tracksWidth
         let measured = textView.sizeThatFits(CGSize(width: width, height: CGFloat.greatestFiniteMagnitude))
-
-        if textView.bounds.width != width {
-            textView.bounds.size.width = width
-        }
-
-        return CGSize(width: width, height: ceil(measured.height))
+        return ceil(measured.height)
     }
 
     private func configure(_ textView: UITextView) {

--- a/Conduit/Views/Components/SelectableTextView.swift
+++ b/Conduit/Views/Components/SelectableTextView.swift
@@ -15,6 +15,10 @@ struct SelectableTextView: UIViewRepresentable {
     let maximumNumberOfLines: Int
     let wrapsLines: Bool
     let linkColor: UIColor
+    /// When set, the view self-sizes at a deterministic width derived from
+    /// its content and this range (used by Markdown table cells), ignoring
+    /// layout proposals. See `measuredSize(proposalWidth:textView:)`.
+    let selfSizingWidthRange: ClosedRange<CGFloat>?
     let selectionCoordinator: MarkdownSelectionCoordinator?
     let selectionSegment: MarkdownSelectionSegmentDescriptor?
 
@@ -26,6 +30,7 @@ struct SelectableTextView: UIViewRepresentable {
         maximumNumberOfLines: Int = 0,
         wrapsLines: Bool = true,
         linkColor: UIColor = .link,
+        selfSizingWidthRange: ClosedRange<CGFloat>? = nil,
         selectionCoordinator: MarkdownSelectionCoordinator? = nil,
         selectionSegment: MarkdownSelectionSegmentDescriptor? = nil
     ) {
@@ -36,6 +41,7 @@ struct SelectableTextView: UIViewRepresentable {
         self.maximumNumberOfLines = maximumNumberOfLines
         self.wrapsLines = wrapsLines
         self.linkColor = linkColor
+        self.selfSizingWidthRange = selfSizingWidthRange
         self.selectionCoordinator = selectionCoordinator
         self.selectionSegment = selectionSegment
     }
@@ -48,6 +54,7 @@ struct SelectableTextView: UIViewRepresentable {
         maximumNumberOfLines: Int = 0,
         wrapsLines: Bool = true,
         linkColor: UIColor = .link,
+        selfSizingWidthRange: ClosedRange<CGFloat>? = nil,
         selectionCoordinator: MarkdownSelectionCoordinator? = nil,
         selectionSegment: MarkdownSelectionSegmentDescriptor? = nil
     ) {
@@ -59,6 +66,7 @@ struct SelectableTextView: UIViewRepresentable {
             maximumNumberOfLines: maximumNumberOfLines,
             wrapsLines: wrapsLines,
             linkColor: linkColor,
+            selfSizingWidthRange: selfSizingWidthRange,
             selectionCoordinator: selectionCoordinator,
             selectionSegment: selectionSegment
         )
@@ -72,6 +80,7 @@ struct SelectableTextView: UIViewRepresentable {
         maximumNumberOfLines: Int = 0,
         wrapsLines: Bool = true,
         linkColor: UIColor = .link,
+        selfSizingWidthRange: ClosedRange<CGFloat>? = nil,
         selectionCoordinator: MarkdownSelectionCoordinator? = nil,
         selectionSegment: MarkdownSelectionSegmentDescriptor? = nil
     ) {
@@ -86,6 +95,7 @@ struct SelectableTextView: UIViewRepresentable {
             maximumNumberOfLines: maximumNumberOfLines,
             wrapsLines: wrapsLines,
             linkColor: linkColor,
+            selfSizingWidthRange: selfSizingWidthRange,
             selectionCoordinator: selectionCoordinator,
             selectionSegment: selectionSegment
         )
@@ -193,19 +203,33 @@ struct SelectableTextView: UIViewRepresentable {
     }
 
     func sizeThatFits(_ proposal: ProposedViewSize, uiView: SelectableTextViewHostView, context: Context) -> CGSize? {
+        measuredSize(proposalWidth: proposal.width, textView: uiView.mountedTextView)
+    }
+
+    /// Extracted sizing logic so `sizeThatFits` and unit tests share one
+    /// path (`UIViewRepresentableContext` cannot be constructed outside
+    /// SwiftUI).
+    ///
+    /// Self-sizing range (table cells): Markdown tables lay out inside a
+    /// horizontal ScrollView, where width proposals are nil or transient and
+    /// first-pass UIKit bounds are zero — a proposal- or bounds-derived width
+    /// produces a different wrapped height on the first pass than in steady
+    /// state, which is the intermittent half-line/1–2-line clipping. Instead,
+    /// the measurement width is derived deterministically from the content's
+    /// ideal width clamped to the table's column policy, so the first pass
+    /// and every later pass report the same correct height.
+    func measuredSize(proposalWidth: CGFloat?, textView: UITextView) -> CGSize? {
         if !wrapsLines {
             return measureNonWrapping()
         }
 
-        let textView = uiView.mountedTextView
+        if let range = selfSizingWidthRange {
+            let idealWidth = max(1, measureNonWrapping().width)
+            let width = min(max(idealWidth, range.lowerBound), range.upperBound)
+            return CGSize(width: width, height: Self.measuredWrappingHeight(of: textView, at: width))
+        }
 
-        // Inside a horizontal ScrollView the width proposal is nil; fall back
-        // to the last laid-out width so SwiftUI measures at the real column
-        // width instead of intrinsicContentSize (which uses a stale container).
-        let width = proposal.width
-            ?? (textView.bounds.width > 0 ? textView.bounds.width : nil)
-        guard let width, width > 0, width.isFinite else { return nil }
-
+        guard let width = proposalWidth, width > 0, width.isFinite else { return nil }
         return CGSize(width: width, height: Self.measuredWrappingHeight(of: textView, at: width))
     }
 

--- a/Conduit/Views/Components/SelectableTextView.swift
+++ b/Conduit/Views/Components/SelectableTextView.swift
@@ -198,7 +198,25 @@ struct SelectableTextView: UIViewRepresentable {
         }
 
         guard let width = proposal.width, width > 0 else { return nil }
-        let measured = uiView.mountedTextView.sizeThatFits(CGSize(width: width, height: CGFloat.greatestFiniteMagnitude))
+        let textView = uiView.mountedTextView
+
+        // The text container width is set from textView.bounds.width in
+        // configure(), but during the first layout pass (or when the view is
+        // inside a horizontal ScrollView whose content width is unconstrained),
+        // bounds.width may be 0 or stale. Force the container to the proposed
+        // width so UIKit wraps lines at the actual column width, not a
+        // leftover from a previous layout cycle.
+        let previousTracksWidth = textView.textContainer.widthTracksTextView
+        textView.textContainer.widthTracksTextView = false
+        textView.textContainer.size = CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)
+        textView.textContainer.widthTracksTextView = previousTracksWidth
+
+        let measured = textView.sizeThatFits(CGSize(width: width, height: CGFloat.greatestFiniteMagnitude))
+
+        if textView.bounds.width != width {
+            textView.bounds.size.width = width
+        }
+
         return CGSize(width: width, height: ceil(measured.height))
     }
 

--- a/ConduitTests/ChatTextSelectionTests.swift
+++ b/ConduitTests/ChatTextSelectionTests.swift
@@ -715,4 +715,96 @@ final class ChatTextSelectionTests: XCTestCase {
         XCTAssertLessThanOrEqual(measured, truncationCeiling,
                                  "Long text must be truncated well below full expansion")
     }
+
+    // MARK: - Full table-view-chain regression (MarkdownText → MarkdownTable → cell text views)
+
+    /// Regression: a Markdown table with a long cell must render every cell's
+    /// selectable text view with unlimited lines and enough height for the
+    /// fully wrapped content. This drives the real SwiftUI chain —
+    /// MarkdownText → MarkdownTable.tableRow → InlineMarkdown →
+    /// SelectableTextView — so re-introducing a line cap or under-height
+    /// sizing at any link fails here.
+    @MainActor
+    func testMarkdownTableLongCellRendersFullContentThroughViewChain() throws {
+        let longCellText = (0..<30).map { "Word\($0)" }.joined(separator: " ")
+        let source = """
+        | Item | Details |
+        |---|---|
+        | Long entry | \(longCellText) |
+        """
+        let host = UIHostingController(rootView: MarkdownText(source: source))
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.isHidden = false
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+
+        let textViews = allSubviews(of: host.view).compactMap { $0 as? UITextView }
+        XCTAssertFalse(textViews.isEmpty, "Rendered table must mount selectable text views")
+
+        for textView in textViews {
+            XCTAssertEqual(textView.textContainer.maximumNumberOfLines, 0,
+                           "Every table cell must render unlimited-line text; a finite cap here is the truncation bug")
+        }
+
+        let longCell = try XCTUnwrap(
+            textViews.first { $0.attributedText.string.contains("Word29") },
+            "The long table cell's text view must exist in the rendered hierarchy"
+        )
+        XCTAssertGreaterThan(longCell.bounds.width, 0)
+
+        // Reference: a fresh, unlimited text view with the same content must
+        // wrap to the same height the rendered cell was given. A capped or
+        // under-measured cell falls short of the full-wrap reference.
+        let reference = SelectableTextView.makeTextView()
+        reference.attributedText = longCell.attributedText
+        let fullWrapHeight = SelectableTextView.measuredWrappingHeight(of: reference, at: longCell.bounds.width)
+        XCTAssertGreaterThanOrEqual(longCell.bounds.height + 1, fullWrapHeight,
+                                     "Rendered cell height must cover the fully wrapped content")
+    }
+
+    /// Regression: inside the horizontal table ScrollView the first layout
+    /// pass receives a nil width proposal with zero UIKit bounds — the
+    /// conditions that produced intermittent half-line/1–2-line cells.
+    /// Self-sized table cells must return the full-wrap height at their
+    /// deterministic column width on the first pass, and identical sizes on
+    /// every later pass regardless of proposal.
+    @MainActor
+    func testTableCellFirstPassMeasurementMatchesFullWrapReference() throws {
+        let font = UIFont.preferredFont(forTextStyle: .footnote)
+        let longText = (0..<30).map { "Word\($0)" }.joined(separator: " ")
+        let view = SelectableTextView(text: longText, font: font, selfSizingWidthRange: 112...220)
+        let hostView = view.makeUIViewForTests(coordinator: view.makeCoordinator())
+        let textView = hostView.mountedTextView
+
+        // First pass: no width proposal, zero bounds.
+        textView.bounds = .zero
+        let firstPass = try XCTUnwrap(
+            view.measuredSize(proposalWidth: nil, textView: textView),
+            "Self-sized table cell must produce a size even with nil proposal and zero bounds"
+        )
+
+        // Known-correct reference: full wrap at the deterministic column
+        // width (content ideal width clamped to the table column policy).
+        let idealWidth = view.measureNonWrapping().width
+        let expectedWidth = min(max(idealWidth, 112), 220)
+        let referenceHeight = SelectableTextView.measuredWrappingHeight(of: textView, at: expectedWidth)
+
+        XCTAssertEqual(firstPass.width, expectedWidth, accuracy: 1,
+                       "First-pass width must be the clamped ideal column width")
+        XCTAssertEqual(firstPass.height, referenceHeight, accuracy: 1,
+                       "First-pass height must equal the full-wrap height at the column width")
+
+        // A later pass with a wide proposal (or populated bounds) must not
+        // change the answer — that drift was the intermittent clipping.
+        let laterPass = try XCTUnwrap(view.measuredSize(proposalWidth: 390, textView: textView))
+        XCTAssertEqual(laterPass.width, firstPass.width, accuracy: 1,
+                       "Steady-state width must match the first pass")
+        XCTAssertEqual(laterPass.height, firstPass.height, accuracy: 1,
+                       "Steady-state height must match the first pass")
+    }
+
+    private func allSubviews(of view: UIView) -> [UIView] {
+        view.subviews.flatMap { [$0] + allSubviews(of: $0) }
+    }
 }

--- a/ConduitTests/ChatTextSelectionTests.swift
+++ b/ConduitTests/ChatTextSelectionTests.swift
@@ -596,59 +596,100 @@ final class ChatTextSelectionTests: XCTestCase {
                        "Truncated output must be exactly maxLines + 1 indicator line")
     }
 
-    // MARK: - Markdown table cell line-limit regression
+    // MARK: - Markdown table cell measurement regression
 
-    /// Regression: MarkdownTable.tableRow previously passed maximumNumberOfLines: 4
-    /// to InlineMarkdown, causing long table cell content to be truncated with no
-    /// way to see the rest. Table cells must use the default unlimited lines so the
-    /// cell expands to its intrinsic height.
-    func testMarkdownTableParserDeliversLongCellContentUntruncated() {
-        let source = """
-        | Item | Details |
-        |---|---|
-        | Long entry | \(String(repeating: "word ", count: 30)) |
-        """
-        let blocks = MarkdownParser.parse(source)
-        let table = blocks.first
+    /// Helper: configures a mounted UITextView the same way SelectableTextView
+    /// does, then measures at a given width. Bypasses UIViewRepresentable
+    /// Context (which is inaccessible outside SwiftUI) while exercising the
+    /// exact same UIKit measurement path.
+    private func measureTextView(
+        text: String,
+        font: UIFont = .preferredFont(forTextStyle: .footnote),
+        maximumNumberOfLines: Int = 0,
+        at width: CGFloat
+    ) -> (textView: UITextView, measuredHeight: CGFloat) {
+        let textView = SelectableTextView.makeTextView()
+        textView.font = font
+        textView.textColor = .label
+        textView.textContainer.widthTracksTextView = true
+        textView.textContainer.maximumNumberOfLines = maximumNumberOfLines
+        textView.textContainer.lineBreakMode = maximumNumberOfLines > 0
+            ? .byTruncatingTail : .byWordWrapping
 
-        guard case .table(let headers, _, let rows) = table else {
-            return XCTFail("Expected a table block, got \(String(describing: table))")
-        }
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 0
+        let styled = NSAttributedString(string: text, attributes: [
+            .font: font,
+            .foregroundColor: UIColor.label,
+            .paragraphStyle: paragraphStyle
+        ])
+        textView.attributedText = styled
 
-        XCTAssertEqual(headers, ["Item", "Details"])
-        XCTAssertEqual(rows.count, 1)
+        // Set the text container width to the target column width — this is
+        // what sizeThatFits now does before measuring.
+        textView.textContainer.size = CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)
+        textView.bounds = CGRect(x: 0, y: 0, width: width, height: 0)
+        textView.layoutIfNeeded()
 
-        let longCell = rows[0][1]
-        let expectedWordCount = 30
-        XCTAssertEqual(longCell.split(separator: " ").count, expectedWordCount,
-                       "Long cell must contain the full word count without truncation")
+        let measured = textView.sizeThatFits(CGSize(width: width, height: CGFloat.greatestFiniteMagnitude))
+        return (textView, ceil(measured.height))
     }
 
-    /// Regression: the old maximumNumberOfLines: 4 would configure the UIKit text
-    /// container with a 4-line cap. This test verifies that a SelectableTextView
-    /// created with the default maximumNumberOfLines (0 = unlimited) passes
-    /// unlimited lines to the text container, matching the behavior table cells
-    /// now need after the fix.
-    @MainActor
-    func testSelectableTextViewDefaultMaximumNumberOfLinesIsUnlimited() {
-        let view = SelectableTextView(text: "unlimited")
-        let hostView = view.makeUIViewForTests(coordinator: view.makeCoordinator())
-        let textView = hostView.mountedTextView
+    /// Regression: table cells must wrap at the column width and produce
+    /// sufficient height for all wrapped lines. The old maximumNumberOfLines: 4
+    /// would cap at ~4 lines; the stale-bounds bug would measure at width≈1.
+    func testTableCellMeasurementAtRealisticWidthProducesSufficientHeight() {
+        let font = UIFont.preferredFont(forTextStyle: .footnote)
+        let longText = (0..<30).map { "Word\($0)" }.joined(separator: " ")
+        let columnWidth: CGFloat = 200
 
-        XCTAssertEqual(textView.textContainer.maximumNumberOfLines, 0,
-                       "Default maximumNumberOfLines must be 0 (unlimited) so table cells expand")
-        XCTAssertEqual(textView.textContainer.lineBreakMode, .byWordWrapping,
-                       "Unlimited lines must use word wrapping, not truncation")
+        let (_, measuredHeight) = measureTextView(text: longText, font: font, at: columnWidth)
+        let fourLineHeight = font.lineHeight * 4
+
+        XCTAssertGreaterThan(measuredHeight, fourLineHeight,
+                             "Wrapping table cell must produce height above 4-line cap at \(columnWidth)pt width")
+    }
+
+    /// Regression: measurement must use the column width, not a stale
+    /// textView.bounds.width. Before the fix, a view with zero bounds would
+    /// measure at width≈1, producing less than one line of height.
+    func testMeasurementUsesColumnWidthNotStaleBounds() {
+        let font = UIFont.preferredFont(forTextStyle: .footnote)
+        let text = (0..<20).map { "content \($0)" }.joined(separator: " ")
+
+        let (_, narrowHeight) = measureTextView(text: text, font: font, at: 180)
+        let (_, wideHeight) = measureTextView(text: text, font: font, at: 300)
+
+        XCTAssertGreaterThan(narrowHeight, font.lineHeight,
+                             "Measurement at 180pt must not collapse below one line")
+        XCTAssertGreaterThan(wideHeight, font.lineHeight,
+                             "Measurement at 300pt must not collapse below one line")
+        XCTAssertLessThanOrEqual(wideHeight, narrowHeight,
+                                 "Wider column should produce ≤ height of narrower column")
+    }
+
+    /// Regression: cells of different content lengths must produce proportional
+    /// heights. A long cell must be taller than a short one.
+    func testDifferentLengthCellsProportionalHeights() {
+        let font = UIFont.preferredFont(forTextStyle: .footnote)
+        let columnWidth: CGFloat = 200
+
+        let (_, shortHeight) = measureTextView(text: "Short", font: font, at: columnWidth)
+        let longText = (0..<25).map { "Word \($0)" }.joined(separator: " ")
+        let (_, longHeight) = measureTextView(text: longText, font: font, at: columnWidth)
+
+        XCTAssertGreaterThan(longHeight, shortHeight,
+                             "Longer cell content must produce greater height than short content")
+        XCTAssertGreaterThan(shortHeight, 0,
+                             "Even short content must produce positive height")
     }
 
     /// Finite maximumNumberOfLines must still work for callers that intentionally
     /// request truncation (e.g. RenderCard source preview). This guards against
     /// a future refactor that removes the limit globally.
-    @MainActor
-    func testSelectableTextViewFiniteLineLimitStillTruncates() {
-        let view = SelectableTextView(text: "capped", maximumNumberOfLines: 4)
-        let hostView = view.makeUIViewForTests(coordinator: view.makeCoordinator())
-        let textView = hostView.mountedTextView
+    func testFiniteLineLimitStillTruncates() {
+        let font = UIFont.preferredFont(forTextStyle: .footnote)
+        let (textView, _) = measureTextView(text: "capped", font: font, maximumNumberOfLines: 4, at: 200)
 
         XCTAssertEqual(textView.textContainer.maximumNumberOfLines, 4,
                        "Finite line limit must propagate to the text container")

--- a/ConduitTests/ChatTextSelectionTests.swift
+++ b/ConduitTests/ChatTextSelectionTests.swift
@@ -595,4 +595,64 @@ final class ChatTextSelectionTests: XCTestCase {
         XCTAssertEqual(truncatedLines.count, 11, // 10 content lines + 1 indicator line
                        "Truncated output must be exactly maxLines + 1 indicator line")
     }
+
+    // MARK: - Markdown table cell line-limit regression
+
+    /// Regression: MarkdownTable.tableRow previously passed maximumNumberOfLines: 4
+    /// to InlineMarkdown, causing long table cell content to be truncated with no
+    /// way to see the rest. Table cells must use the default unlimited lines so the
+    /// cell expands to its intrinsic height.
+    func testMarkdownTableParserDeliversLongCellContentUntruncated() {
+        let source = """
+        | Item | Details |
+        |---|---|
+        | Long entry | \(String(repeating: "word ", count: 30)) |
+        """
+        let blocks = MarkdownParser.parse(source)
+        let table = blocks.first
+
+        guard case .table(let headers, _, let rows) = table else {
+            return XCTFail("Expected a table block, got \(String(describing: table))")
+        }
+
+        XCTAssertEqual(headers, ["Item", "Details"])
+        XCTAssertEqual(rows.count, 1)
+
+        let longCell = rows[0][1]
+        let expectedWordCount = 30
+        XCTAssertEqual(longCell.split(separator: " ").count, expectedWordCount,
+                       "Long cell must contain the full word count without truncation")
+    }
+
+    /// Regression: the old maximumNumberOfLines: 4 would configure the UIKit text
+    /// container with a 4-line cap. This test verifies that a SelectableTextView
+    /// created with the default maximumNumberOfLines (0 = unlimited) passes
+    /// unlimited lines to the text container, matching the behavior table cells
+    /// now need after the fix.
+    @MainActor
+    func testSelectableTextViewDefaultMaximumNumberOfLinesIsUnlimited() {
+        let view = SelectableTextView(text: "unlimited")
+        let hostView = view.makeUIViewForTests(coordinator: view.makeCoordinator())
+        let textView = hostView.mountedTextView
+
+        XCTAssertEqual(textView.textContainer.maximumNumberOfLines, 0,
+                       "Default maximumNumberOfLines must be 0 (unlimited) so table cells expand")
+        XCTAssertEqual(textView.textContainer.lineBreakMode, .byWordWrapping,
+                       "Unlimited lines must use word wrapping, not truncation")
+    }
+
+    /// Finite maximumNumberOfLines must still work for callers that intentionally
+    /// request truncation (e.g. RenderCard source preview). This guards against
+    /// a future refactor that removes the limit globally.
+    @MainActor
+    func testSelectableTextViewFiniteLineLimitStillTruncates() {
+        let view = SelectableTextView(text: "capped", maximumNumberOfLines: 4)
+        let hostView = view.makeUIViewForTests(coordinator: view.makeCoordinator())
+        let textView = hostView.mountedTextView
+
+        XCTAssertEqual(textView.textContainer.maximumNumberOfLines, 4,
+                       "Finite line limit must propagate to the text container")
+        XCTAssertEqual(textView.textContainer.lineBreakMode, .byTruncatingTail,
+                       "Finite lines must use truncation, not word wrapping")
+    }
 }

--- a/ConduitTests/ChatTextSelectionTests.swift
+++ b/ConduitTests/ChatTextSelectionTests.swift
@@ -598,11 +598,9 @@ final class ChatTextSelectionTests: XCTestCase {
 
     // MARK: - Markdown table cell measurement regression
 
-    /// Helper: creates a UITextView in the state `configure()` leaves it —
-    /// text container sized from `textView.bounds.width` (which is zero or
-    /// stale on the first layout pass). Measures via the shared
-    /// `SelectableTextView.measuredWrappingHeight` so the tests exercise
-    /// the same code path `sizeThatFits` uses in production.
+    /// Helper: creates a UITextView with a realistic stale container width
+    /// (simulating `configure()`'s first-pass state where bounds.width is
+    /// stale or zero), then measures via `SelectableTextView.measuredWrappingHeight`.
     private func measureCell(
         text: String,
         font: UIFont = .preferredFont(forTextStyle: .footnote),
@@ -621,22 +619,16 @@ final class ChatTextSelectionTests: XCTestCase {
             .paragraphStyle: paragraphStyle
         ])
 
-        // Simulate configure()'s first-pass state: container sized from
-        // bounds.width (which is zero). This is the stale-bounds condition
-        // the fix corrects.
-        textView.textContainer.size = CGSize(
-            width: max(textView.bounds.width, 1),
-            height: CGFloat.greatestFiniteMagnitude
-        )
+        // Simulate a realistic stale container width from a prior layout pass
+        // (not 1pt which is degenerate, but a plausible leftover column width).
+        textView.textContainer.size = CGSize(width: 90, height: CGFloat.greatestFiniteMagnitude)
 
-        // measuredWrappingHeight forces the container to `width` before
-        // measuring — this is the actual code under test.
         return SelectableTextView.measuredWrappingHeight(of: textView, at: width)
     }
 
     /// Regression: table cells must wrap at the column width and produce
     /// sufficient height for all wrapped lines. The old maximumNumberOfLines: 4
-    /// would cap at ~4 lines; the stale-bounds bug would measure at width≈1.
+    /// would cap at ~4 lines.
     func testTableCellMeasurementAtRealisticWidthProducesSufficientHeight() {
         let font = UIFont.preferredFont(forTextStyle: .footnote)
         let longText = (0..<30).map { "Word\($0)" }.joined(separator: " ")
@@ -650,8 +642,8 @@ final class ChatTextSelectionTests: XCTestCase {
     }
 
     /// Regression: `measuredWrappingHeight` must use the target width, not the
-    /// stale `textView.bounds.width` that `configure()` set on first layout.
-    /// A wider column should produce ≤ height of a narrower one.
+    /// stale container width. A wider column must produce strictly less height
+    /// (equality would mean the target width was ignored).
     func testMeasurementUsesTargetWidthNotStaleBounds() {
         let font = UIFont.preferredFont(forTextStyle: .footnote)
         let text = (0..<20).map { "content \($0)" }.joined(separator: " ")
@@ -661,10 +653,8 @@ final class ChatTextSelectionTests: XCTestCase {
 
         XCTAssertGreaterThan(narrowHeight, font.lineHeight,
                              "Measurement at 180pt must not collapse below one line")
-        XCTAssertGreaterThan(wideHeight, font.lineHeight,
-                             "Measurement at 300pt must not collapse below one line")
-        XCTAssertLessThanOrEqual(wideHeight, narrowHeight,
-                                 "Wider column should produce ≤ height of narrower column")
+        XCTAssertLessThan(wideHeight, narrowHeight,
+                          "Wider column must produce strictly less height; equality means the target width was ignored")
     }
 
     /// Regression: cells of different content lengths must produce proportional
@@ -683,19 +673,37 @@ final class ChatTextSelectionTests: XCTestCase {
                              "Even short content must produce positive height")
     }
 
-    /// Finite maximumNumberOfLines must still work for callers that intentionally
-    /// request truncation (e.g. RenderCard source preview). Guard against a
-    /// future refactor that globally removes the limit.
+    /// Finite maximumNumberOfLines must produce truncation when applied to the
+    /// text container, rather than allowing unlimited expansion. Guards against
+    /// a future refactor that globally removes finite-line support.
     func testFiniteLineLimitStillTruncates() {
         let font = UIFont.preferredFont(forTextStyle: .footnote)
+        let longText = (0..<30).map { "Word \($0)" }.joined(separator: " ")
+
+        // Build a UITextView matching SelectableTextView's configuration,
+        // then apply the finite line limit.
         let textView = SelectableTextView.makeTextView()
         textView.font = font
+        textView.textColor = .label
         textView.textContainer.maximumNumberOfLines = 4
         textView.textContainer.lineBreakMode = .byTruncatingTail
+        textView.attributedText = NSAttributedString(string: longText, attributes: [
+            .font: font,
+            .foregroundColor: UIColor.label
+        ])
+
+        let measured = SelectableTextView.measuredWrappingHeight(of: textView, at: 200)
+        // A 4-line cap with .byTruncatingTail must produce a height well
+        // below full expansion (which would be ~10+ lines for 30 words).
+        // Use 5× lineHeight as the ceiling — clearly above 4 lines but
+        // nowhere near full wrap height.
+        let truncationCeiling = font.lineHeight * 5
 
         XCTAssertEqual(textView.textContainer.maximumNumberOfLines, 4,
-                       "Finite line limit must propagate to the text container")
+                       "Finite line limit must be set on the text container")
         XCTAssertEqual(textView.textContainer.lineBreakMode, .byTruncatingTail,
                        "Finite lines must use truncation, not word wrapping")
+        XCTAssertLessThanOrEqual(measured, truncationCeiling,
+                                 "Long text must be truncated well below full expansion")
     }
 }

--- a/ConduitTests/ChatTextSelectionTests.swift
+++ b/ConduitTests/ChatTextSelectionTests.swift
@@ -598,41 +598,40 @@ final class ChatTextSelectionTests: XCTestCase {
 
     // MARK: - Markdown table cell measurement regression
 
-    /// Helper: configures a mounted UITextView the same way SelectableTextView
-    /// does, then measures at a given width. Bypasses UIViewRepresentable
-    /// Context (which is inaccessible outside SwiftUI) while exercising the
-    /// exact same UIKit measurement path.
-    private func measureTextView(
+    /// Helper: creates a UITextView in the state `configure()` leaves it —
+    /// text container sized from `textView.bounds.width` (which is zero or
+    /// stale on the first layout pass). Measures via the shared
+    /// `SelectableTextView.measuredWrappingHeight` so the tests exercise
+    /// the same code path `sizeThatFits` uses in production.
+    private func measureCell(
         text: String,
         font: UIFont = .preferredFont(forTextStyle: .footnote),
-        maximumNumberOfLines: Int = 0,
         at width: CGFloat
-    ) -> (textView: UITextView, measuredHeight: CGFloat) {
+    ) -> CGFloat {
         let textView = SelectableTextView.makeTextView()
         textView.font = font
         textView.textColor = .label
         textView.textContainer.widthTracksTextView = true
-        textView.textContainer.maximumNumberOfLines = maximumNumberOfLines
-        textView.textContainer.lineBreakMode = maximumNumberOfLines > 0
-            ? .byTruncatingTail : .byWordWrapping
 
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = 0
-        let styled = NSAttributedString(string: text, attributes: [
+        textView.attributedText = NSAttributedString(string: text, attributes: [
             .font: font,
             .foregroundColor: UIColor.label,
             .paragraphStyle: paragraphStyle
         ])
-        textView.attributedText = styled
 
-        // Set the text container width to the target column width — this is
-        // what sizeThatFits now does before measuring.
-        textView.textContainer.size = CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)
-        textView.bounds = CGRect(x: 0, y: 0, width: width, height: 0)
-        textView.layoutIfNeeded()
+        // Simulate configure()'s first-pass state: container sized from
+        // bounds.width (which is zero). This is the stale-bounds condition
+        // the fix corrects.
+        textView.textContainer.size = CGSize(
+            width: max(textView.bounds.width, 1),
+            height: CGFloat.greatestFiniteMagnitude
+        )
 
-        let measured = textView.sizeThatFits(CGSize(width: width, height: CGFloat.greatestFiniteMagnitude))
-        return (textView, ceil(measured.height))
+        // measuredWrappingHeight forces the container to `width` before
+        // measuring — this is the actual code under test.
+        return SelectableTextView.measuredWrappingHeight(of: textView, at: width)
     }
 
     /// Regression: table cells must wrap at the column width and produce
@@ -643,22 +642,22 @@ final class ChatTextSelectionTests: XCTestCase {
         let longText = (0..<30).map { "Word\($0)" }.joined(separator: " ")
         let columnWidth: CGFloat = 200
 
-        let (_, measuredHeight) = measureTextView(text: longText, font: font, at: columnWidth)
+        let measuredHeight = measureCell(text: longText, font: font, at: columnWidth)
         let fourLineHeight = font.lineHeight * 4
 
         XCTAssertGreaterThan(measuredHeight, fourLineHeight,
                              "Wrapping table cell must produce height above 4-line cap at \(columnWidth)pt width")
     }
 
-    /// Regression: measurement must use the column width, not a stale
-    /// textView.bounds.width. Before the fix, a view with zero bounds would
-    /// measure at width≈1, producing less than one line of height.
-    func testMeasurementUsesColumnWidthNotStaleBounds() {
+    /// Regression: `measuredWrappingHeight` must use the target width, not the
+    /// stale `textView.bounds.width` that `configure()` set on first layout.
+    /// A wider column should produce ≤ height of a narrower one.
+    func testMeasurementUsesTargetWidthNotStaleBounds() {
         let font = UIFont.preferredFont(forTextStyle: .footnote)
         let text = (0..<20).map { "content \($0)" }.joined(separator: " ")
 
-        let (_, narrowHeight) = measureTextView(text: text, font: font, at: 180)
-        let (_, wideHeight) = measureTextView(text: text, font: font, at: 300)
+        let narrowHeight = measureCell(text: text, font: font, at: 180)
+        let wideHeight = measureCell(text: text, font: font, at: 300)
 
         XCTAssertGreaterThan(narrowHeight, font.lineHeight,
                              "Measurement at 180pt must not collapse below one line")
@@ -674,9 +673,9 @@ final class ChatTextSelectionTests: XCTestCase {
         let font = UIFont.preferredFont(forTextStyle: .footnote)
         let columnWidth: CGFloat = 200
 
-        let (_, shortHeight) = measureTextView(text: "Short", font: font, at: columnWidth)
+        let shortHeight = measureCell(text: "Short", font: font, at: columnWidth)
         let longText = (0..<25).map { "Word \($0)" }.joined(separator: " ")
-        let (_, longHeight) = measureTextView(text: longText, font: font, at: columnWidth)
+        let longHeight = measureCell(text: longText, font: font, at: columnWidth)
 
         XCTAssertGreaterThan(longHeight, shortHeight,
                              "Longer cell content must produce greater height than short content")
@@ -685,11 +684,14 @@ final class ChatTextSelectionTests: XCTestCase {
     }
 
     /// Finite maximumNumberOfLines must still work for callers that intentionally
-    /// request truncation (e.g. RenderCard source preview). This guards against
-    /// a future refactor that removes the limit globally.
+    /// request truncation (e.g. RenderCard source preview). Guard against a
+    /// future refactor that globally removes the limit.
     func testFiniteLineLimitStillTruncates() {
         let font = UIFont.preferredFont(forTextStyle: .footnote)
-        let (textView, _) = measureTextView(text: "capped", font: font, maximumNumberOfLines: 4, at: 200)
+        let textView = SelectableTextView.makeTextView()
+        textView.font = font
+        textView.textContainer.maximumNumberOfLines = 4
+        textView.textContainer.lineBreakMode = .byTruncatingTail
 
         XCTAssertEqual(textView.textContainer.maximumNumberOfLines, 4,
                        "Finite line limit must propagate to the text container")

--- a/ConduitTests/ChatTextSelectionTests.swift
+++ b/ConduitTests/ChatTextSelectionTests.swift
@@ -628,17 +628,26 @@ final class ChatTextSelectionTests: XCTestCase {
 
     /// Regression: table cells must wrap at the column width and produce
     /// sufficient height for all wrapped lines. The old maximumNumberOfLines: 4
-    /// would cap at ~4 lines.
+    /// would cap the same text at a much lower height.
     func testTableCellMeasurementAtRealisticWidthProducesSufficientHeight() {
         let font = UIFont.preferredFont(forTextStyle: .footnote)
         let longText = (0..<30).map { "Word\($0)" }.joined(separator: " ")
         let columnWidth: CGFloat = 200
 
-        let measuredHeight = measureCell(text: longText, font: font, at: columnWidth)
-        let fourLineHeight = font.lineHeight * 4
+        let unlimitedHeight = measureCell(text: longText, font: font, at: columnWidth)
 
-        XCTAssertGreaterThan(measuredHeight, fourLineHeight,
-                             "Wrapping table cell must produce height above 4-line cap at \(columnWidth)pt width")
+        // Measure the same text with a 4-line cap to get the actual capped height.
+        let cappedView = SelectableTextView.makeTextView()
+        cappedView.font = font
+        cappedView.textContainer.maximumNumberOfLines = 4
+        cappedView.textContainer.lineBreakMode = .byTruncatingTail
+        cappedView.attributedText = NSAttributedString(string: longText, attributes: [
+            .font: font, .foregroundColor: UIColor.label
+        ])
+        let cappedHeight = SelectableTextView.measuredWrappingHeight(of: cappedView, at: columnWidth)
+
+        XCTAssertGreaterThan(unlimitedHeight, cappedHeight,
+                             "Unlimited table cell must measure taller than the old 4-line capped height")
     }
 
     /// Regression: `measuredWrappingHeight` must use the target width, not the


### PR DESCRIPTION
## User-visible symptoms

1. Markdown tables truncated cells to a few lines (clean 4-line cuts, sometimes half a line / 1–2 lines).
2. Column dividers shifted horizontally between rows — each row sized its own columns.
3. `:---:` / `---:` alignment was parsed but rendered left-aligned.
4. Even trivial three-column tables forced horizontal scrolling on iPhone.

## Root causes

- `maximumNumberOfLines: 4` on every table cell.
- Non-deterministic measurement width inside the horizontal `ScrollView` (nil proposal + zero bounds on the first pass → intrinsic fallback).
- No shared column widths: each row's cells independently self-sized.
- Alignment only positioned a full-width SwiftUI wrapper; the text itself laid out left.
- A 112pt per-column floor that existed for measurement determinism, not table semantics (~396pt minimum for three columns with padding).

## Fixes

**Full content, deterministic height:** the four-line cap is gone. Table cells self-size at a deterministic width derived from content, independent of layout proposals — first pass and every later pass report the same correct height.

**Shared, responsive column widths:** `MarkdownTableLayout` derives one width per column for the entire table from the header plus all body cells, then resolves against the chat's proposed width (read by a zero-height probe; the first pass falls back to a deterministic cap-and-scroll layout until the width arrives):

- Column width = largest ideal content width in that column, capped at 220pt.
- If the capped columns fit the chat width, the table fits — narrow columns stay genuinely narrow, wide ones keep proportionally more space.
- On overflow, columns shrink proportionally to their excess above a 64pt floor (already-narrow columns don't shrink) and wrap at the resolved width.
- A table still overflowing at the floor keeps horizontal scrolling.
- Cell padding, dividers, and the border subtract from available width exactly once.
- Cell heights measure at the final resolved shared column content width (single-value self-sizing range), preserving the deterministic first-pass/full-height guarantee.

**Alignment reaches the text engine:** `:---`/`:---:`/`---:` flows through `InlineMarkdown → SelectableTextView.textAlignment` into the paragraph style, holding for single-line and wrapped multiline content. `.natural` default leaves every other caller unchanged.

## Scrolling policy

Fit when the content allows; scroll horizontally only when it doesn't. Cells expand vertically without nested scrolling; the outer chat scroll owns vertical scrolling.

## Regression coverage

- **ChatTextSelectionTests (28):** full-chain unlimited-lines render, first-pass height determinism vs known-correct reference, capped-vs-unlimited discriminator, finite-limit callers still truncate.
- **MarkdownTableLayoutTests (13):** pure policy unit tests (fit keeps ideals, cap, proportional shrink, floor-and-scroll, unknown-width fallback, content-metric growth recompute) plus rendered fixtures — tiny three-column table fits without scrolling; narrow status + long description fits with proportional shared widths; wide five-column table scrolls; shared divider widths across header/short/empty cells; long cell wraps fully at its shared width; per-line glyph geometry proves leading/center/trailing for single-line and wrapped cells; selection observers stay attached.
- **MarkdownSelectionCoordinatorTests (32):** cross-block/table selection intact.

## Validation

73/73 across the three markdown suites on the local simulator. Shared-width and content-informed assertions verified to fail against per-cell sizing (re-injected). Known local-sim wedge (`AppStateChatResumeTests`, CoreAudio AURemoteIO) unrelated; CI's fresh runner arbitrates.