### PR TITLE
fix(chat): resolve Markdown reference-style links message-wide

### DIFF
--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -1632,15 +1632,20 @@ enum MarkdownParser {
         let lines = source.replacingOccurrences(of: "\r\n", with: "\n").components(separatedBy: "\n")
         var visibleLines: [String] = []
         var definitions: [String] = []
-        // Fenced code and math blocks are raw content — the same regions the
-        // block walker below consumes wholesale — so a definition-looking line
-        // inside them must stay put.
         var openFence: String?
         var mathClose: String?
 
         for line in lines {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
 
+            // Fenced code and math blocks are raw content — the same regions
+            // the block walker below consumes wholesale — so a
+            // definition-looking line inside them must stay put. One known
+            // divergence: a fence opener inside a blockquote ("> ```") reads
+            // as a quote line to the walker but opens a fence here, so a
+            // definition-looking line in that region is collected while the
+            // walker renders the region as prose. Quote-nested fences are not
+            // a construct this renderer supports; accepted as an edge case.
             if let close = mathClose {
                 visibleLines.append(line)
                 if trimmed == close { mathClose = nil }
@@ -1671,9 +1676,11 @@ enum MarkdownParser {
 
         let visibleSource = visibleLines.joined(separator: "\n")
         let blocks = parseBlocks(visibleLines, recognizesGatewayMedia: recognizesGatewayMedia)
-        // Preserve the original fallback (non-empty source must render), but
-        // against the stripped body so a definitions-only message doesn't
-        // resurface its definitions as a visible paragraph.
+        // Defensive safety net carried over from the original parse(): if the
+        // walker ever produces nothing for non-whitespace input, surface the
+        // stripped body rather than rendering an empty message. Definitions
+        // were already removed from visibleSource, so they cannot resurface
+        // here even in that fallback.
         let finalBlocks = blocks.isEmpty && !visibleSource.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             ? [.paragraph(visibleSource)]
             : blocks

--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -1637,7 +1637,9 @@ enum MarkdownParser {
         var openFence: String?
         var mathClose: String?
 
-        for line in lines {
+        var index = 0
+        while index < lines.count {
+            let line = lines[index]
             let trimmed = line.trimmingCharacters(in: .whitespaces)
 
             // Fenced code and math blocks are raw content — the same regions
@@ -1651,29 +1653,36 @@ enum MarkdownParser {
             if let close = mathClose {
                 visibleLines.append(line)
                 if trimmed == close { mathClose = nil }
+                index += 1
                 continue
             }
             if let fence = openFence {
                 visibleLines.append(line)
                 if trimmed.hasPrefix(fence) { openFence = nil }
+                index += 1
                 continue
             }
             if let fence = fenceStart(trimmed) {
                 openFence = fence
                 visibleLines.append(line)
+                index += 1
                 continue
             }
             if let close = mathBlockOpening(trimmed) {
                 mathClose = close
                 visibleLines.append(line)
+                index += 1
                 continue
             }
-            if isDefinitionIndent(line), let definition = referenceDefinition(trimmed) {
-                definitions.append(definition)
-                visibleLines.append("")
+            if isDefinitionIndent(line), let definition = referenceDefinition(trimmed),
+               let span = consumedDefinitionSpan(definition, following: lines, at: index) {
+                definitions.append(span.markdown)
+                for _ in 0..<span.lineCount { visibleLines.append("") }
+                index += span.lineCount
                 continue
             }
             visibleLines.append(line)
+            index += 1
         }
 
         let visibleSource = visibleLines.joined(separator: "\n")
@@ -1826,6 +1835,45 @@ enum MarkdownParser {
             options: .regularExpression
         ) else { return nil }
         return String(value[range])
+    }
+
+    /// Foundation is the authority on valid definitions; the regex above is
+    /// only a pre-filter. A regex match Foundation renders as text — e.g. a
+    /// destination with an unbalanced `)` — must stay visible in place:
+    /// stripping it here would delete it from its position and then
+    /// duplicate it after every block when the collected definitions are
+    /// re-appended to each fragment. A definition's title may also continue
+    /// on the following line; fold a title-shaped next line in only when
+    /// Foundation consumes the pair invisibly, so it cannot surface as a
+    /// stray paragraph. The shape check keeps block openers (fences, math,
+    /// directives) out of the fold even when a bare opener would parse empty.
+    private static func consumedDefinitionSpan(
+        _ definition: String,
+        following lines: [String],
+        at index: Int
+    ) -> (markdown: String, lineCount: Int)? {
+        func isConsumedInvisibly(_ markdown: String) -> Bool {
+            (try? AttributedString(
+                markdown: markdown,
+                options: .init(interpretedSyntax: .full)
+            ))?.characters.isEmpty == true
+        }
+
+        let next = index + 1 < lines.count
+            ? lines[index + 1].trimmingCharacters(in: .whitespaces)
+            : ""
+        if isTitleContinuation(next), isConsumedInvisibly(definition + "\n" + next) {
+            return (definition + "\n" + next, 2)
+        }
+        return isConsumedInvisibly(definition) ? (definition, 1) : nil
+    }
+
+    private static func isTitleContinuation(_ value: String) -> Bool {
+        guard value.count >= 2, let first = value.first, let last = value.last else { return false }
+        switch (first, last) {
+        case ("\"", "\""), ("'", "'"), ("(", ")"): return true
+        default: return false
+        }
     }
     private static func mathBlockOpening(_ value: String) -> String? { value == "$$" ? "$$" : (value == "\\[" ? "\\]" : nil) }
     private static func singleLineMath(_ value: String) -> String? {

--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -85,6 +85,11 @@ struct MarkdownText: View {
                 .modifier(MarkdownSelectionHost(coordinator: selectionCoordinator))
             }
         }
+        // Reference definitions ride the environment so every InlineMarkdown
+        // below — however deeply nested in tables, quotes, or callouts — sees
+        // the same message-level context without threading it through each
+        // container view. Scoped to this MarkdownText subtree only.
+        .environment(\.markdownReferences, rendering.references)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
@@ -170,10 +175,14 @@ private final class MarkdownSelectionHighlightView: UIView {
 /// the blocks need the full block-view path). A class so NSCache can hold it.
 private final class MarkdownRendering {
     let blocks: [MarkdownBlock]
+    /// The message's link reference definitions; block views need them to
+    /// resolve reference-style links when re-parsing each fragment.
+    let references: MarkdownReferenceContext
     let selectableText: NSAttributedString?
 
-    init(blocks: [MarkdownBlock], selectableText: NSAttributedString?) {
+    init(blocks: [MarkdownBlock], references: MarkdownReferenceContext, selectableText: NSAttributedString?) {
         self.blocks = blocks
+        self.references = references
         self.selectableText = selectableText
     }
 }
@@ -225,11 +234,13 @@ private enum MarkdownRenderCache {
         ].joined(separator: "|") as NSString
 
         if let cached = cache.object(forKey: key) { return cached }
-        let blocks = MarkdownParser.parse(source, recognizesGatewayMedia: recognizesGatewayMedia)
+        let document = MarkdownParser.parseDocument(source, recognizesGatewayMedia: recognizesGatewayMedia)
         let rendering = MarkdownRendering(
-            blocks: blocks,
+            blocks: document.blocks,
+            references: document.references,
             selectableText: MarkdownSelectionFormatter.attributedText(
-                for: blocks,
+                for: document.blocks,
+                references: document.references,
                 foregroundStyle: foregroundStyle,
                 usesAccentSurface: usesAccentSurface,
                 newestCharacterOpacities: []
@@ -251,7 +262,37 @@ private enum MarkdownRenderCache {
     }
 }
 
-enum MarkdownBlock {
+/// The message-wide link reference definitions (`[id]: url`) collected while
+/// parsing a chat message. Each block fragment is re-parsed together with
+/// these definitions so Foundation's Markdown parser — not this app — resolves
+/// reference-style links, labels, and titles.
+struct MarkdownReferenceContext: Equatable {
+    /// The original definition lines, newline-joined. Retained verbatim so
+    /// Foundation interprets destination/title semantics (case-insensitive
+    /// labels, collapsed/shortcut forms, escapes) instead of this app doing it.
+    let definitionsMarkdown: String
+
+    static let empty = MarkdownReferenceContext(definitionsMarkdown: "")
+
+    var containsDefinitions: Bool { !definitionsMarkdown.isEmpty }
+
+    /// Fragment + definitions parse as one document: the definition block is
+    /// block-level syntax that produces nothing visible, so fragments without
+    /// references render exactly as they would alone.
+    func markdownForParsing(_ fragment: String) -> String {
+        guard containsDefinitions else { return fragment }
+        return fragment + "\n\n" + definitionsMarkdown
+    }
+}
+
+/// A parsed chat message: its visible blocks plus the reference definitions
+/// that were removed from the visible body before block parsing.
+struct MarkdownParsedDocument {
+    let blocks: [MarkdownBlock]
+    let references: MarkdownReferenceContext
+}
+
+enum MarkdownBlock: Equatable {
     case heading(level: Int, text: String)
     case paragraph(String)
     case quote([MarkdownQuoteLine])
@@ -266,7 +307,7 @@ enum MarkdownBlock {
     case divider
 }
 
-struct MarkdownQuoteLine {
+struct MarkdownQuoteLine: Equatable {
     let depth: Int
     let text: String
 }
@@ -274,6 +315,7 @@ struct MarkdownQuoteLine {
 enum MarkdownSelectionFormatter {
     static func attributedText(
         for blocks: [MarkdownBlock],
+        references: MarkdownReferenceContext = .empty,
         foregroundStyle: Color,
         usesAccentSurface: Bool,
         newestCharacterOpacities: [Double]
@@ -288,6 +330,7 @@ enum MarkdownSelectionFormatter {
         for (index, block) in blocks.enumerated() {
             guard let segment = segment(
                 for: block,
+                references: references,
                 bodyFont: bodyFont,
                 textColor: textColor,
                 linkColor: linkColor,
@@ -315,6 +358,7 @@ enum MarkdownSelectionFormatter {
 
     private static func segment(
         for block: MarkdownBlock,
+        references: MarkdownReferenceContext,
         bodyFont: UIFont,
         textColor: UIColor,
         linkColor: UIColor,
@@ -325,18 +369,20 @@ enum MarkdownSelectionFormatter {
         case .heading(let level, let text):
             return inline(
                 text,
+                references: references,
                 font: headingFont(level),
                 textColor: textColor,
                 linkColor: linkColor
             )
 
         case .paragraph(let text):
-            return inline(text, font: bodyFont, textColor: textColor, linkColor: linkColor)
+            return inline(text, references: references, font: bodyFont, textColor: textColor, linkColor: linkColor)
 
         case .unorderedList(let items):
             return list(
                 items,
                 ordered: false,
+                references: references,
                 bodyFont: bodyFont,
                 textColor: textColor,
                 linkColor: linkColor,
@@ -347,6 +393,7 @@ enum MarkdownSelectionFormatter {
             return list(
                 items,
                 ordered: true,
+                references: references,
                 bodyFont: bodyFont,
                 textColor: textColor,
                 linkColor: linkColor,
@@ -372,7 +419,7 @@ enum MarkdownSelectionFormatter {
                         .foregroundColor: quoteColor
                     ]
                 ))
-                result.append(inline(line.text, font: quoteFont, textColor: quoteColor, linkColor: linkColor))
+                result.append(inline(line.text, references: references, font: quoteFont, textColor: quoteColor, linkColor: linkColor))
             }
             return result
 
@@ -384,6 +431,7 @@ enum MarkdownSelectionFormatter {
     private static func list(
         _ items: [String],
         ordered: Bool,
+        references: MarkdownReferenceContext,
         bodyFont: UIFont,
         textColor: UIColor,
         linkColor: UIColor,
@@ -413,6 +461,7 @@ enum MarkdownSelectionFormatter {
             ))
             result.append(inline(
                 task?.text ?? item,
+                references: references,
                 font: bodyFont,
                 textColor: textColor,
                 linkColor: linkColor
@@ -423,12 +472,13 @@ enum MarkdownSelectionFormatter {
 
     private static func inline(
         _ source: String,
+        references: MarkdownReferenceContext,
         font: UIFont,
         textColor: UIColor,
         linkColor: UIColor
     ) -> NSAttributedString {
         let attributed = (try? AttributedString(
-            markdown: source,
+            markdown: references.markdownForParsing(source),
             options: .init(interpretedSyntax: .full)
         )) ?? AttributedString(source)
         return SelectableTextView.bridge(attributed, defaultFont: font, defaultColor: textColor, linkColor: linkColor)
@@ -654,6 +704,21 @@ private struct MarkdownBlockView: View {
     }
 }
 
+/// Message-scoped link reference definitions for the block-view hierarchy.
+/// `MarkdownText` injects its parsed context; every `InlineMarkdown` in the
+/// subtree reads it. The default keeps `InlineMarkdown` renderable in
+/// isolation (no references), which matches pre-reference behavior.
+private struct MarkdownReferencesKey: EnvironmentKey {
+    static let defaultValue = MarkdownReferenceContext.empty
+}
+
+private extension EnvironmentValues {
+    var markdownReferences: MarkdownReferenceContext {
+        get { self[MarkdownReferencesKey.self] }
+        set { self[MarkdownReferencesKey.self] = newValue }
+    }
+}
+
 private struct InlineMarkdown: View {
     let source: String
     let foregroundStyle: Color
@@ -665,10 +730,15 @@ private struct InlineMarkdown: View {
     var selectionCoordinator: MarkdownSelectionCoordinator?
     var selectionSegment: MarkdownSelectionSegmentDescriptor?
     var trailingCharacterOpacities: [Double] = []
+    @Environment(\.markdownReferences) private var references
 
     private var attributed: AttributedString {
+        // Re-append the message's definitions so Foundation resolves
+        // reference-style links for this fragment too. The definition block
+        // is invisible under `.full`; if parsing fails, fall back to the bare
+        // fragment so definitions never surface as text.
         var attributed = (try? AttributedString(
-            markdown: source,
+            markdown: references.markdownForParsing(source),
             options: .init(interpretedSyntax: .full)
         )) ?? AttributedString(source)
 
@@ -1546,8 +1616,74 @@ enum MarkupHTML {
 }
 
 enum MarkdownParser {
+    /// Compatibility wrapper for callers that only need the visible blocks.
     static func parse(_ source: String, recognizesGatewayMedia: Bool = false) -> [MarkdownBlock] {
+        parseDocument(source, recognizesGatewayMedia: recognizesGatewayMedia).blocks
+    }
+
+    /// Splits a message into its visible blocks and its link reference
+    /// definitions. Definitions (`[id]: url`) are block-level Markdown that a
+    /// fragment-by-fragment renderer never sees — without this pass they end
+    /// up as visible paragraph text and every `[text][id]` use stays literal.
+    /// Definition lines are removed here (leaving a blank line behind so
+    /// neighboring paragraphs don't merge) and re-fed to Foundation with each
+    /// fragment at render time; see `MarkdownReferenceContext`.
+    static func parseDocument(_ source: String, recognizesGatewayMedia: Bool = false) -> MarkdownParsedDocument {
         let lines = source.replacingOccurrences(of: "\r\n", with: "\n").components(separatedBy: "\n")
+        var visibleLines: [String] = []
+        var definitions: [String] = []
+        // Fenced code and math blocks are raw content — the same regions the
+        // block walker below consumes wholesale — so a definition-looking line
+        // inside them must stay put.
+        var openFence: String?
+        var mathClose: String?
+
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            if let close = mathClose {
+                visibleLines.append(line)
+                if trimmed == close { mathClose = nil }
+                continue
+            }
+            if let fence = openFence {
+                visibleLines.append(line)
+                if trimmed.hasPrefix(fence) { openFence = nil }
+                continue
+            }
+            if let fence = fenceStart(trimmed) {
+                openFence = fence
+                visibleLines.append(line)
+                continue
+            }
+            if let close = mathBlockOpening(trimmed) {
+                mathClose = close
+                visibleLines.append(line)
+                continue
+            }
+            if let definition = referenceDefinition(trimmed) {
+                definitions.append(definition)
+                visibleLines.append("")
+                continue
+            }
+            visibleLines.append(line)
+        }
+
+        let visibleSource = visibleLines.joined(separator: "\n")
+        let blocks = parseBlocks(visibleLines, recognizesGatewayMedia: recognizesGatewayMedia)
+        // Preserve the original fallback (non-empty source must render), but
+        // against the stripped body so a definitions-only message doesn't
+        // resurface its definitions as a visible paragraph.
+        let finalBlocks = blocks.isEmpty && !visibleSource.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? [.paragraph(visibleSource)]
+            : blocks
+        return MarkdownParsedDocument(
+            blocks: finalBlocks,
+            references: MarkdownReferenceContext(definitionsMarkdown: definitions.joined(separator: "\n"))
+        )
+    }
+
+    private static func parseBlocks(_ lines: [String], recognizesGatewayMedia: Bool) -> [MarkdownBlock] {
         var blocks: [MarkdownBlock] = []
         var index = 0
 
@@ -1638,7 +1774,7 @@ enum MarkdownParser {
             }
             blocks.append(.paragraph(paragraph.joined(separator: "\n")))
         }
-        return blocks.isEmpty && !source.isEmpty ? [.paragraph(source)] : blocks
+        return blocks
     }
 
     static func taskItem(_ value: String) -> (complete: Bool, text: String)? {
@@ -1654,6 +1790,21 @@ enum MarkdownParser {
     }
 
     private static func fenceStart(_ value: String) -> String? { value.hasPrefix("```") ? "```" : (value.hasPrefix("~~~") ? "~~~" : nil) }
+
+    /// Recognizes the supported single-line subset of CommonMark link
+    /// reference definitions: `[label]: destination` with an optional
+    /// `"…"`, `'…'`, or `(…)` title and an optional `<…>` destination.
+    /// Labels containing brackets and footnote-style `[^…]` markers are out
+    /// of scope and return nil (they stay visible text). Definitions with
+    /// title continuation lines are deliberately unsupported; this renderer
+    /// documents and tests the single-line forms only.
+    private static func referenceDefinition(_ value: String) -> String? {
+        guard let range = value.range(
+            of: #"^\[([^\[\]\^][^\[\]]*)\]:[ \t]+(<[^>]+>|[^\s<][^\s]*)(?:[ \t]+("[^"]*"|'[^']*'|\([^)]*\)))?[ \t]*$"#,
+            options: .regularExpression
+        ) else { return nil }
+        return String(value[range])
+    }
     private static func mathBlockOpening(_ value: String) -> String? { value == "$$" ? "$$" : (value == "\\[" ? "\\]" : nil) }
     private static func singleLineMath(_ value: String) -> String? {
         guard value.hasPrefix("$$"), value.hasSuffix("$$"), value.count > 4 else { return nil }

--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -1617,6 +1617,8 @@ enum MarkupHTML {
 
 enum MarkdownParser {
     /// Compatibility wrapper for callers that only need the visible blocks.
+    /// Reference definitions are already stripped from them; call
+    /// `parseDocument` when the render context needs those definitions.
     static func parse(_ source: String, recognizesGatewayMedia: Bool = false) -> [MarkdownBlock] {
         parseDocument(source, recognizesGatewayMedia: recognizesGatewayMedia).blocks
     }
@@ -1666,7 +1668,7 @@ enum MarkdownParser {
                 visibleLines.append(line)
                 continue
             }
-            if let definition = referenceDefinition(trimmed) {
+            if isDefinitionIndent(line), let definition = referenceDefinition(trimmed) {
                 definitions.append(definition)
                 visibleLines.append("")
                 continue
@@ -1797,6 +1799,19 @@ enum MarkdownParser {
     }
 
     private static func fenceStart(_ value: String) -> String? { value.hasPrefix("```") ? "```" : (value.hasPrefix("~~~") ? "~~~" : nil) }
+
+    /// CommonMark allows a definition at most three spaces of indentation;
+    /// anything deeper is indented-code content that Foundation keeps as
+    /// visible paragraph text, so it must not be collected here.
+    private static func isDefinitionIndent(_ line: String) -> Bool {
+        var spaces = 0
+        for character in line {
+            if character == " " { spaces += 1 }
+            else if character == "\t" { return false }
+            else { break }
+        }
+        return spaces <= 3
+    }
 
     /// Recognizes the supported single-line subset of CommonMark link
     /// reference definitions: `[label]: destination` with an optional

--- a/ConduitTests/MarkdownReferenceLinkTests.swift
+++ b/ConduitTests/MarkdownReferenceLinkTests.swift
@@ -195,7 +195,7 @@ final class MarkdownReferenceLinkTests: XCTestCase {
         XCTAssertTrue(codeSource.contains("[in-code]: https://example.com/not-a-definition"))
     }
 
-    func testParseDocumentLeavesDefinitionsInsideMathBlocks() {
+    func testParseDocumentLeavesDefinitionInsideMathBlocks() {
         let source = """
         Before [x][in-math].
 
@@ -217,6 +217,50 @@ final class MarkdownReferenceLinkTests: XCTestCase {
             return XCTFail("Expected a math block, got \(document.blocks[1])")
         }
         XCTAssertTrue(mathSource.contains("[in-math]: https://example.com/not-a-definition"))
+    }
+
+    func testParseDocumentLeavesDefinitionsInsideUnclosedFence() {
+        // A streaming message often ends mid-fence; everything after an
+        // unclosed opener is code content, so a definition-looking line there
+        // must be neither collected nor made visible.
+        let source = """
+        See [x][docs].
+
+        ```swift
+        let line = "[docs]: https://example.com/in-fence"
+        """
+        let document = MarkdownParser.parseDocument(source, recognizesGatewayMedia: false)
+
+        XCTAssertFalse(
+            document.references.containsDefinitions,
+            "A definition-looking line inside an unclosed fence is code content"
+        )
+        guard case .code(let language, let codeSource) = document.blocks.last else {
+            return XCTFail("Expected a trailing code block, got \(document.blocks)")
+        }
+        XCTAssertEqual(language, "swift")
+        XCTAssertTrue(codeSource.contains("[docs]: https://example.com/in-fence"))
+    }
+
+    func testParseDocumentLeavesDefinitionLookingLineInsideListItem() {
+        let source = """
+        - See [docs].
+        - [id]: https://example.com/not-a-definition
+
+        [id]: https://example.com/real
+        """
+        let document = MarkdownParser.parseDocument(source, recognizesGatewayMedia: false)
+
+        XCTAssertEqual(
+            document.references.definitionsMarkdown,
+            "[id]: https://example.com/real",
+            "A definition-looking list item is item content, not a definition line"
+        )
+        guard case .unorderedList(let items) = document.blocks.first else {
+            return XCTFail("Expected an unordered list, got \(document.blocks)")
+        }
+        XCTAssertEqual(items.count, 2)
+        XCTAssertTrue(items[1].contains("[id]: https://example.com/not-a-definition"))
     }
 
     func testParseDocumentDoesNotSwallowFootnoteMarkers() {
@@ -443,7 +487,7 @@ final class MarkdownReferenceLinkTests: XCTestCase {
         let source = """
         | Kind | Detail |
         |---|---|
-        | inline | [inline](https://example.com/inline) |
+        | plain | [inline](https://example.com/inline) |
         | broken | [unresolved][missing] |
 
         [real]: https://example.com/real
@@ -455,12 +499,29 @@ final class MarkdownReferenceLinkTests: XCTestCase {
         host.view.setNeedsLayout()
         host.view.layoutIfNeeded()
 
-        let cellStrings = allSubviews(of: host.view)
-            .compactMap { $0 as? UITextView }
-            .map { $0.attributedText.string }
-        XCTAssertTrue(cellStrings.contains(where: { $0 == "inline" }))
-        XCTAssertTrue(cellStrings.contains(where: { $0.contains("[unresolved][missing]") }),
-                      "Unresolved reference must stay literal, got \(cellStrings)")
+        let cellTextViews = allSubviews(of: host.view).compactMap { $0 as? UITextView }
+
+        let inlineCell = try XCTUnwrap(
+            cellTextViews.first { $0.attributedText.string == "inline" },
+            "The inline-link cell must render standalone"
+        )
+        let inlineLink = try XCTUnwrap(
+            inlineCell.attributedText.attribute(.link, at: 0, effectiveRange: nil) as? URL
+        )
+        XCTAssertEqual(inlineLink.absoluteString, "https://example.com/inline")
+
+        let unresolvedCell = try XCTUnwrap(
+            cellTextViews.first { $0.attributedText.string.contains("[unresolved][missing]") },
+            "Unresolved reference must stay literal"
+        )
+        for offset in 0..<unresolvedCell.attributedText.length {
+            XCTAssertNil(
+                unresolvedCell.attributedText.attribute(.link, at: offset, effectiveRange: nil) as? URL,
+                "No link may be invented for an unresolved reference"
+            )
+        }
+
+        let cellStrings = cellTextViews.map { $0.attributedText.string }
         XCTAssertFalse(cellStrings.contains(where: { $0.contains("[real]:") }),
                        "The definition must not be visible anywhere in the rendered message")
     }

--- a/ConduitTests/MarkdownReferenceLinkTests.swift
+++ b/ConduitTests/MarkdownReferenceLinkTests.swift
@@ -1,0 +1,471 @@
+import XCTest
+import UIKit
+import SwiftUI
+@testable import Conduit
+
+/// Reference-style links (`[text][id]` + `[id]: url`) must resolve across the
+/// whole chat message even though Conduit parses each paragraph/list item/
+/// table cell as an isolated Markdown fragment. The fix: definitions are
+/// collected message-wide before block parsing and re-appended to each
+/// fragment before Foundation parses it.
+///
+/// The Foundation tests below characterize `AttributedString(markdown:)` with
+/// the exact options the production inline parsers use
+/// (`.init(interpretedSyntax: .full)`). If Foundation ever stops resolving
+/// reference links under those options, the extractor design in
+/// `MarkdownParser` must be revisited — do not silently weaken these tests.
+final class MarkdownReferenceLinkTests: XCTestCase {
+
+    private let fullSyntaxOptions: AttributedString.MarkdownParsingOptions = .init(interpretedSyntax: .full)
+
+    // MARK: - Foundation characterization
+
+    func testFoundationFullDocumentResolvesReferenceLinkAndHidesDefinition() throws {
+        let markdown = """
+        See [the docs][docs].
+
+        [docs]: https://example.com
+        """
+        let attributed = try AttributedString(markdown: markdown, options: fullSyntaxOptions)
+
+        XCTAssertEqual(String(attributed.characters), "See the docs.")
+        XCTAssertFalse(
+            String(attributed.characters).contains("[docs]:"),
+            "A consumed link reference definition must not remain visible"
+        )
+
+        let docsRange = try XCTUnwrap(attributed.characters.firstRange(of: "the docs"))
+        let link = try XCTUnwrap(attributed[docsRange].link)
+        XCTAssertEqual(link.absoluteString, "https://example.com")
+    }
+
+    func testFoundationFragmentCompositeResolvesReferenceLink() throws {
+        // This is the exact composite the production inline parsers build:
+        // one block's fragment, then the message's collected definitions.
+        let fragment = "Read [the docs][docs]."
+        let definitions = "[docs]: https://example.com/docs"
+        let composite = fragment + "\n\n" + definitions
+
+        let attributed = try AttributedString(markdown: composite, options: fullSyntaxOptions)
+
+        XCTAssertEqual(String(attributed.characters), "Read the docs.")
+        let docsRange = try XCTUnwrap(attributed.characters.firstRange(of: "the docs"))
+        let link = try XCTUnwrap(attributed[docsRange].link)
+        XCTAssertEqual(link.absoluteString, "https://example.com/docs")
+    }
+
+    func testFoundationCompositeLeavesFragmentsWithoutReferencesUnchanged() throws {
+        let fragment = "Plain [inline](https://example.com/inline) text."
+        let definitions = "[docs]: https://example.com/docs"
+
+        let alone = try AttributedString(markdown: fragment, options: fullSyntaxOptions)
+        let composite = try AttributedString(
+            markdown: fragment + "\n\n" + definitions,
+            options: fullSyntaxOptions
+        )
+
+        XCTAssertEqual(String(composite.characters), String(alone.characters))
+        XCTAssertEqual(composite.runs.count, alone.runs.count)
+        XCTAssertTrue(
+            String(composite.characters).contains("inline text."),
+            "Appending definitions must not disturb the fragment's visible text"
+        )
+    }
+
+    func testFoundationCompositePreservesFragmentContentWithSoftLineBreaks() throws {
+        // Paragraph accumulation keeps internal newlines in the fragment.
+        // Foundation renders soft breaks as spaces under `.full` — the same
+        // behavior production already relies on without definitions — and
+        // appending definitions must not disturb it beyond resolving the link.
+        let fragment = "first line\nsecond [link][id] line"
+        let definitions = "[id]: https://example.com"
+
+        let composite = try AttributedString(
+            markdown: fragment + "\n\n" + definitions,
+            options: fullSyntaxOptions
+        )
+        let alone = try AttributedString(markdown: fragment, options: fullSyntaxOptions)
+
+        XCTAssertEqual(String(alone.characters), "first line second [link][id] line")
+        XCTAssertEqual(String(composite.characters), "first line second link line")
+
+        let linkRange = try XCTUnwrap(composite.characters.firstRange(of: "link"))
+        let link = try XCTUnwrap(composite[linkRange].link)
+        XCTAssertEqual(link.absoluteString, "https://example.com")
+    }
+
+    func testFoundationSupportsCommonMarkReferenceVariants() throws {
+        let markdown = """
+        Full [one][l1], collapsed [two][], shortcut [l3], titled [four][l4],
+        angle [five][l5], case-insensitive [six][L6].
+
+        [l1]: https://example.com/1
+        [two]: https://example.com/2
+        [l3]: https://example.com/3
+        [l4]: https://example.com/4 "Optional title"
+        [l5]: <https://example.com/5>
+        [L6]: https://example.com/6
+        """
+        let attributed = try AttributedString(markdown: markdown, options: fullSyntaxOptions)
+
+        let characters = String(attributed.characters)
+        XCTAssertEqual(
+            characters,
+            "Full one, collapsed two, shortcut l3, titled four, angle five, case-insensitive six."
+        )
+
+        func link(on text: String) throws -> URL {
+            let range = try XCTUnwrap(
+                attributed.characters.firstRange(of: text),
+                "Expected visible text \"\(text)\" in \"\(characters)\""
+            )
+            return try XCTUnwrap(
+                attributed[range].link,
+                "Expected a link on \"\(text)\""
+            )
+        }
+        XCTAssertEqual(try link(on: "one").absoluteString, "https://example.com/1")
+        XCTAssertEqual(try link(on: "two").absoluteString, "https://example.com/2")
+        XCTAssertEqual(try link(on: "l3").absoluteString, "https://example.com/3")
+        XCTAssertEqual(try link(on: "four").absoluteString, "https://example.com/4")
+        XCTAssertEqual(try link(on: "five").absoluteString, "https://example.com/5")
+        XCTAssertEqual(try link(on: "six").absoluteString, "https://example.com/6")
+    }
+
+    func testFoundationUnresolvedReferenceRendersLiteralTextWithoutInventingDestination() throws {
+        let markdown = "See [missing][nope] and a lone [orphan].\n\n[other]: https://example.com"
+        let attributed = try AttributedString(markdown: markdown, options: fullSyntaxOptions)
+
+        let characters = String(attributed.characters)
+        XCTAssertTrue(characters.contains("[missing][nope]"), "Unresolved references keep their literal text")
+        XCTAssertTrue(characters.contains("[orphan]"))
+        for run in attributed.runs {
+            XCTAssertNil(run.link, "No destination may be invented for unresolved references")
+        }
+    }
+
+    // MARK: - Document extraction (MarkdownParser.parseDocument)
+
+    func testParseDocumentCollectsDefinitionAndOmitsItFromBlocks() {
+        let document = MarkdownParser.parseDocument(
+            "See [the docs][docs].\n\n[docs]: https://example.com",
+            recognizesGatewayMedia: false
+        )
+
+        XCTAssertTrue(document.references.containsDefinitions)
+        XCTAssertEqual(
+            document.references.definitionsMarkdown,
+            "[docs]: https://example.com"
+        )
+        XCTAssertEqual(document.blocks, [.paragraph("See [the docs][docs].")])
+    }
+
+    func testParseDocumentCollectsDefinitionUsedBeforeIt() {
+        let document = MarkdownParser.parseDocument(
+            "[first][one]\n\n[one]: https://example.com/one",
+            recognizesGatewayMedia: false
+        )
+
+        XCTAssertTrue(document.references.containsDefinitions)
+        XCTAssertEqual(document.blocks, [.paragraph("[first][one]")])
+    }
+
+    func testParseDocumentLeavesDefinitionsInsideFencedCodeBlocks() {
+        let source = """
+        Before [x][in-code].
+
+        ```swift
+        let docs = "[in-code]: https://example.com/not-a-definition"
+        ```
+
+        [in-code]: https://example.com/real
+        """
+        let document = MarkdownParser.parseDocument(source, recognizesGatewayMedia: false)
+
+        XCTAssertEqual(
+            document.references.definitionsMarkdown,
+            "[in-code]: https://example.com/real",
+            "Only the definition outside the fence may be collected"
+        )
+        XCTAssertEqual(document.blocks.count, 2)
+        guard case .code(let language, let codeSource) = document.blocks[1] else {
+            return XCTFail("Expected a code block, got \(document.blocks[1])")
+        }
+        XCTAssertEqual(language, "swift")
+        XCTAssertTrue(codeSource.contains("[in-code]: https://example.com/not-a-definition"))
+    }
+
+    func testParseDocumentLeavesDefinitionsInsideMathBlocks() {
+        let source = """
+        Before [x][in-math].
+
+        $$
+        [in-math]: https://example.com/not-a-definition
+        $$
+
+        [in-math]: https://example.com/real
+        """
+        let document = MarkdownParser.parseDocument(source, recognizesGatewayMedia: false)
+
+        XCTAssertEqual(
+            document.references.definitionsMarkdown,
+            "[in-math]: https://example.com/real",
+            "Only the definition outside the math block may be collected"
+        )
+        XCTAssertEqual(document.blocks.count, 2)
+        guard case .math(let mathSource) = document.blocks[1] else {
+            return XCTFail("Expected a math block, got \(document.blocks[1])")
+        }
+        XCTAssertTrue(mathSource.contains("[in-math]: https://example.com/not-a-definition"))
+    }
+
+    func testParseDocumentDoesNotSwallowFootnoteMarkers() {
+        let source = "Text with a footnote[^1].\n\n[^1]: https://example.com/footnote"
+        let document = MarkdownParser.parseDocument(source, recognizesGatewayMedia: false)
+
+        XCTAssertFalse(
+            document.references.containsDefinitions,
+            "[^1]: footnote definitions are out of scope and must stay visible text"
+        )
+        XCTAssertEqual(
+            document.blocks,
+            [
+                .paragraph("Text with a footnote[^1]."),
+                .paragraph("[^1]: https://example.com/footnote")
+            ]
+        )
+    }
+
+    func testParseDocumentRemovingDefinitionDoesNotJoinNeighboringParagraphs() {
+        let source = """
+        First paragraph.
+
+        [docs]: https://example.com
+
+        Second paragraph.
+        """
+        let document = MarkdownParser.parseDocument(source, recognizesGatewayMedia: false)
+
+        XCTAssertEqual(
+            document.blocks,
+            [.paragraph("First paragraph."), .paragraph("Second paragraph.")],
+            "A removed definition must leave a blank-line boundary so paragraphs stay separate blocks"
+        )
+    }
+
+    func testParseDocumentCollectsDefinitionAdjacentToParagraphWithoutBlankLine() {
+        let document = MarkdownParser.parseDocument(
+            "See [docs].\n[docs]: https://example.com",
+            recognizesGatewayMedia: false
+        )
+
+        XCTAssertEqual(document.references.definitionsMarkdown, "[docs]: https://example.com")
+        XCTAssertEqual(document.blocks, [.paragraph("See [docs].")])
+    }
+
+    func testParseDocumentSupportsDefinitionTitleForms() {
+        let source = """
+        [a][one] [b][two] [c][three]
+
+        [one]: https://example.com/one "Quoted title"
+        [two]: https://example.com/two 'Single title'
+        [three]: <https://example.com/three> (Parenthesized title)
+        """
+        let document = MarkdownParser.parseDocument(source, recognizesGatewayMedia: false)
+
+        XCTAssertEqual(
+            document.references.definitionsMarkdown.split(separator: "\n").count,
+            3,
+            "All three single-line definition title forms must be collected"
+        )
+        XCTAssertEqual(document.blocks, [.paragraph("[a][one] [b][two] [c][three]")])
+    }
+
+    func testParseDocumentWithoutDefinitionsYieldsEmptyReferenceContext() {
+        let document = MarkdownParser.parseDocument(
+            "# Heading\n\nPlain paragraph with [inline](https://example.com) link.",
+            recognizesGatewayMedia: false
+        )
+
+        XCTAssertFalse(document.references.containsDefinitions)
+        XCTAssertEqual(
+            document.blocks,
+            [
+                .heading(level: 1, text: "Heading"),
+                .paragraph("Plain paragraph with [inline](https://example.com) link.")
+            ]
+        )
+    }
+
+    // MARK: - Simple selectable-flow path (MarkdownSelectionFormatter)
+
+    func testSelectionFormatterResolvesReferenceLinksInSimpleFlow() throws {
+        let source = "Read [the docs][docs].\n\n[docs]: https://example.com/docs"
+        let document = MarkdownParser.parseDocument(source, recognizesGatewayMedia: false)
+        let content = try XCTUnwrap(
+            MarkdownSelectionFormatter.attributedText(
+                for: document.blocks,
+                references: document.references,
+                foregroundStyle: .primary,
+                usesAccentSurface: false,
+                newestCharacterOpacities: []
+            )
+        )
+
+        XCTAssertEqual(content.string, "Read the docs.")
+
+        let docsRange = (content.string as NSString).range(of: "the docs")
+        XCTAssertNotEqual(docsRange.location, NSNotFound)
+        let link = try XCTUnwrap(content.attribute(.link, at: docsRange.location, effectiveRange: nil) as? URL)
+        XCTAssertEqual(link.absoluteString, "https://example.com/docs")
+
+        XCTAssertFalse(content.string.contains("[docs]:"))
+    }
+
+    func testSelectionFormatterResolvesShortcutReferenceInListItem() throws {
+        let source = """
+        - See [docs].
+        - Also [the guide][guide].
+
+        [docs]: https://example.com/docs
+        [guide]: https://example.com/guide "Guide"
+        """
+        let document = MarkdownParser.parseDocument(source, recognizesGatewayMedia: false)
+        let content = try XCTUnwrap(
+            MarkdownSelectionFormatter.attributedText(
+                for: document.blocks,
+                references: document.references,
+                foregroundStyle: .primary,
+                usesAccentSurface: false,
+                newestCharacterOpacities: []
+            )
+        )
+
+        XCTAssertTrue(content.string.contains("See docs."), "Shortcut reference must resolve to its label text")
+        let docsRange = (content.string as NSString).range(of: "docs.")
+        let link = try XCTUnwrap(content.attribute(.link, at: docsRange.location, effectiveRange: nil) as? URL)
+        XCTAssertEqual(link.absoluteString, "https://example.com/docs")
+
+        let guideRange = (content.string as NSString).range(of: "the guide")
+        let guideLink = try XCTUnwrap(content.attribute(.link, at: guideRange.location, effectiveRange: nil) as? URL)
+        XCTAssertEqual(guideLink.absoluteString, "https://example.com/guide")
+    }
+
+    // MARK: - Rich block-view path (MarkdownText → blocks → InlineMarkdown)
+
+    /// A table forces MarkdownText down the block-view path, so this pins the
+    /// whole SwiftUI chain: MarkdownText → MarkdownTable → InlineMarkdown →
+    /// SelectableTextView, including the reference context handoff. (The
+    /// custom table parser requires two or more columns; single-column pipe
+    /// tables fall through to Foundation's own table handling instead.)
+    @MainActor
+    func testTableCellResolvesReferenceLinkThroughBlockViewChain() throws {
+        let source = """
+        | Label | Resource |
+        |---|---|
+        | docs | [Docs][docs] |
+
+        [docs]: https://example.com/docs
+        """
+        let host = UIHostingController(rootView: MarkdownText(source: source))
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.isHidden = false
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+
+        let cellTextView = try XCTUnwrap(
+            allSubviews(of: host.view)
+                .compactMap { $0 as? UITextView }
+                .first { $0.attributedText.string == "Docs" },
+            "The table cell's selectable text view must exist in the rendered hierarchy"
+        )
+
+        let link = try XCTUnwrap(
+            cellTextView.attributedText.attribute(.link, at: 0, effectiveRange: nil) as? URL
+        )
+        XCTAssertEqual(link.absoluteString, "https://example.com/docs")
+        XCTAssertFalse(cellTextView.attributedText.string.contains("[docs]:"))
+    }
+
+    /// Reference links must resolve in every container that ultimately routes
+    /// through an inline parser. The trailing divider forces MarkdownText off
+    /// the selectable-flow fast path and onto the block-view path, so these
+    /// links resolve through InlineMarkdown + the message-level reference
+    /// context, not MarkdownSelectionFormatter.
+    @MainActor
+    func testReferenceLinksResolveAcrossBlockContainers() throws {
+        let source = """
+        ## Notes on [release][r]
+
+        - item with [full][r] form
+        - item with [collapsed][] form
+
+        > quoted [shortcut] usage
+
+        ::: note
+        Callout with [styled][r] link.
+        :::
+
+        ---
+
+        [r]: https://example.com/r
+        [collapsed]: https://example.com/collapsed
+        [shortcut]: https://example.com/shortcut
+        """
+        let host = UIHostingController(rootView: MarkdownText(source: source))
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.isHidden = false
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+
+        let linkedURLs = Set(
+            allSubviews(of: host.view)
+                .compactMap { $0 as? UITextView }
+                .flatMap { textView -> [URL] in
+                    (0..<textView.attributedText.length).compactMap { offset in
+                        textView.attributedText.attribute(.link, at: offset, effectiveRange: nil) as? URL
+                    }
+                }
+                .map(\.absoluteString)
+        )
+
+        XCTAssertTrue(linkedURLs.contains("https://example.com/r"), "Heading/list/callout links must resolve; got \(linkedURLs)")
+        XCTAssertTrue(linkedURLs.contains("https://example.com/collapsed"), "Collapsed reference must resolve; got \(linkedURLs)")
+        XCTAssertTrue(linkedURLs.contains("https://example.com/shortcut"), "Quote shortcut reference must resolve; got \(linkedURLs)")
+    }
+
+    /// Ordinary inline links must be untouched by the reference work, and an
+    /// unresolved reference must degrade to literal text (no invented URL).
+    @MainActor
+    func testOrdinaryInlineLinksAndUnresolvedReferencesThroughBlockViewChain() throws {
+        let source = """
+        | Kind | Detail |
+        |---|---|
+        | inline | [inline](https://example.com/inline) |
+        | broken | [unresolved][missing] |
+
+        [real]: https://example.com/real
+        """
+        let host = UIHostingController(rootView: MarkdownText(source: source))
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.isHidden = false
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+
+        let cellStrings = allSubviews(of: host.view)
+            .compactMap { $0 as? UITextView }
+            .map { $0.attributedText.string }
+        XCTAssertTrue(cellStrings.contains(where: { $0 == "inline" }))
+        XCTAssertTrue(cellStrings.contains(where: { $0.contains("[unresolved][missing]") }),
+                      "Unresolved reference must stay literal, got \(cellStrings)")
+        XCTAssertFalse(cellStrings.contains(where: { $0.contains("[real]:") }),
+                       "The definition must not be visible anywhere in the rendered message")
+    }
+
+    private func allSubviews(of view: UIView) -> [UIView] {
+        view.subviews.flatMap { [$0] + allSubviews(of: $0) }
+    }
+}

--- a/ConduitTests/MarkdownReferenceLinkTests.swift
+++ b/ConduitTests/MarkdownReferenceLinkTests.swift
@@ -263,6 +263,57 @@ final class MarkdownReferenceLinkTests: XCTestCase {
         XCTAssertTrue(items[1].contains("[id]: https://example.com/not-a-definition"))
     }
 
+    func testParseDocumentLeavesDeeplyIndentedDefinitionLookingLineVisible() {
+        // CommonMark: 4+ spaces of indentation is indented code content, not a
+        // definition — and Foundation keeps such a line visible as paragraph
+        // text, so stripping it here would silently delete user content.
+        let source = "before\n    [id]: https://example.com\nafter"
+        let document = MarkdownParser.parseDocument(source, recognizesGatewayMedia: false)
+
+        XCTAssertFalse(document.references.containsDefinitions)
+        XCTAssertEqual(
+            document.blocks,
+            [.paragraph("before\n    [id]: https://example.com\nafter")]
+        )
+    }
+
+    func testParseDocumentCollectsModestlyIndentedDefinition() {
+        // Up to three spaces of indentation is still a definition in
+        // CommonMark (e.g. aligned under a list item).
+        let source = """
+        See [docs][id].
+
+          [id]: https://example.com/indented
+        """
+        let document = MarkdownParser.parseDocument(source, recognizesGatewayMedia: false)
+
+        XCTAssertEqual(document.references.definitionsMarkdown, "[id]: https://example.com/indented")
+        XCTAssertEqual(document.blocks, [.paragraph("See [docs][id].")])
+    }
+
+    func testParseDocumentCollectsDefinitionInsideDirectiveBody() {
+        // Definitions are collected from anywhere in the message, callout and
+        // column bodies included. Left in place, Foundation would render such
+        // a line as visible trailing paragraph text with the reference use
+        // unresolved (definitions cannot interrupt a paragraph), so stripping
+        // is also the better-looking outcome, not just the resolving one.
+        let source = """
+        ::: note
+        Read [docs][d].
+        [d]: https://example.com/from-callout
+        :::
+        """
+        let document = MarkdownParser.parseDocument(source, recognizesGatewayMedia: false)
+
+        XCTAssertEqual(
+            document.references.definitionsMarkdown,
+            "[d]: https://example.com/from-callout"
+        )
+        // The definition's blank-line substitute leaves a trailing newline in
+        // the joined callout body — invisible under .full parsing.
+        XCTAssertEqual(document.blocks, [.callout(kind: "note", text: "Read [docs][d].\n")])
+    }
+
     func testParseDocumentDoesNotSwallowFootnoteMarkers() {
         let source = "Text with a footnote[^1].\n\n[^1]: https://example.com/footnote"
         let document = MarkdownParser.parseDocument(source, recognizesGatewayMedia: false)

--- a/ConduitTests/MarkdownReferenceLinkTests.swift
+++ b/ConduitTests/MarkdownReferenceLinkTests.swift
@@ -314,6 +314,99 @@ final class MarkdownReferenceLinkTests: XCTestCase {
         XCTAssertEqual(document.blocks, [.callout(kind: "note", text: "Read [docs][d].\n")])
     }
 
+    func testParseDocumentLeavesFoundationRejectedDefinitionVisibleInPlace() {
+        // The destination's trailing ")" is unbalanced, so Foundation treats
+        // the line as text, not a definition. It must stay visible exactly
+        // once, in its original position — collecting it would delete it here
+        // and duplicate it after every block when definitions are re-appended
+        // to each fragment.
+        let source = """
+        Alpha.
+
+        [x]: http://example.com/foo)
+
+        Beta.
+        """
+        let document = MarkdownParser.parseDocument(source, recognizesGatewayMedia: false)
+
+        XCTAssertFalse(document.references.containsDefinitions)
+        XCTAssertEqual(
+            document.blocks,
+            [
+                .paragraph("Alpha."),
+                .paragraph("[x]: http://example.com/foo)"),
+                .paragraph("Beta.")
+            ]
+        )
+    }
+
+    func testParseDocumentCollectsBalancedParenDestination() {
+        let source = """
+        See [x][ref].
+
+        [ref]: https://example.com/a(b)c
+        """
+        let document = MarkdownParser.parseDocument(source, recognizesGatewayMedia: false)
+
+        XCTAssertEqual(
+            document.references.definitionsMarkdown,
+            "[ref]: https://example.com/a(b)c",
+            "Balanced parentheses are a valid destination; Foundation accepts them"
+        )
+        XCTAssertEqual(document.blocks, [.paragraph("See [x][ref].")])
+    }
+
+    func testParseDocumentFoldsTitleContinuationLineIntoDefinition() {
+        // CommonMark allows the definition title on the following line;
+        // Foundation consumes the two-line construct invisibly. The title
+        // line must not survive as a stray visible paragraph.
+        let source = """
+        See [ref][].
+
+        [ref]: /url
+            "The Title"
+        """
+        let document = MarkdownParser.parseDocument(source, recognizesGatewayMedia: false)
+
+        XCTAssertEqual(
+            document.references.definitionsMarkdown,
+            "[ref]: /url\n\"The Title\""
+        )
+        XCTAssertEqual(document.blocks, [.paragraph("See [ref][].")])
+    }
+
+    func testParseDocumentDoesNotFoldProseFollowingDefinition() {
+        // Prose that is not title-shaped must stay visible where it is. (A
+        // *quoted* line after a definition would be a CommonMark title
+        // continuation — Foundation consumes it, and the fold follows.)
+        let source = """
+        See [ref][].
+
+        [ref]: /url
+        Plain prose line
+        """
+        let document = MarkdownParser.parseDocument(source, recognizesGatewayMedia: false)
+
+        XCTAssertEqual(document.references.definitionsMarkdown, "[ref]: /url")
+        XCTAssertEqual(
+            document.blocks,
+            [.paragraph("See [ref][]."), .paragraph("Plain prose line")]
+        )
+    }
+
+    func testParseDocumentDefinitionsOnlyMessageRendersNoBlocks() {
+        let document = MarkdownParser.parseDocument(
+            "[a]: https://example.com/a\n[b]: https://example.com/b",
+            recognizesGatewayMedia: false
+        )
+
+        XCTAssertTrue(document.blocks.isEmpty, "Definitions alone are not visible content")
+        XCTAssertEqual(
+            document.references.definitionsMarkdown,
+            "[a]: https://example.com/a\n[b]: https://example.com/b"
+        )
+    }
+
     func testParseDocumentDoesNotSwallowFootnoteMarkers() {
         let source = "Text with a footnote[^1].\n\n[^1]: https://example.com/footnote"
         let document = MarkdownParser.parseDocument(source, recognizesGatewayMedia: false)


### PR DESCRIPTION
## Summary

Reference-style text links now resolve in chat messages:

```markdown
See the [Apple documentation][apple].

[apple]: https://developer.apple.com
```

renders as a tappable link, with the definition line hidden — in paragraphs, headings, lists, quotes, callouts, columns, and table cells. All CommonMark variants Foundation supports work: `[text][id]`, `[text][]` (collapsed), `[id]` (shortcut), case-insensitive labels, `"Title"` / `'Title'` / `(Title)` definition titles, and `<angle>` destinations. Ordinary inline links are untouched, and unresolved references degrade to literal text with no invented destination.

## Root cause

The renderer splits each message into blocks (paragraphs, list items, table cells, …) and parses every fragment **in isolation** with `AttributedString(markdown:, .init(interpretedSyntax: .full))`. A link reference definition elsewhere in the message is block-level Markdown that a fragment parser never sees, so `[text][id]` stayed literal — and a bare `[id]: url` line could end up as visible paragraph content.

## Approach

Keep Foundation as the single resolver — no regex rewriting of `[text][id]` uses:

- **`MarkdownParser.parseDocument`** (new) pre-scans the message and collects definition lines into a `MarkdownReferenceContext` (the raw definition Markdown, retained verbatim). Extracted lines leave a blank-line boundary so neighboring paragraphs don't merge. Collection skips fenced code and math blocks, requires CommonMark's ≤3-space indent, and — critically — only collects a line Foundation itself consumes invisibly (a regex match with, say, an unbalanced `)` in the destination stays visible in place instead of being duplicated after every block). A title-continuation line folds into its definition when Foundation consumes the pair. `MarkdownParser.parse` remains as a compatibility wrapper.
- **Both render paths** re-append the definitions when parsing each fragment (`fragment + "\n\n" + definitions`): the selectable-flow fast path via a `references` parameter on `MarkdownSelectionFormatter`, and the SwiftUI block path via a private, `MarkdownText`-scoped environment key read by `InlineMarkdown`. Fragments without references parse exactly as before (the context is appended only when non-empty), and a parse failure falls back to the bare fragment so definitions can never surface as text.
- **`MarkdownRenderCache`** retains the context alongside blocks; the existing cache key already contains the full source, so definition edits invalidate naturally.

Out of scope by design: footnotes (`[^1]:` stays visible text) and reference-style images.

## Tests

30 new tests in `MarkdownReferenceLinkTests.swift`:
- Foundation characterization pinning that `.full` resolves every reference form and hides definitions (the design's load-bearing assumption, verified first);
- extraction: before/after use, fence/math/unclosed-fence/indent/list-item/directive boundaries, footnote exclusion, blank-line boundary, Foundation-rejected and balanced-paren destinations, title folding, definitions-only messages;
- the selectable-flow path and the block-view path end-to-end (a table in `UIHostingController` forces `MarkdownText → MarkdownTable → InlineMarkdown → SelectableTextView`), plus `.link`-attribute assertions for ordinary links and no-invented-link assertions for unresolved ones.

All Markdown/selection suites green locally (99 tests). A local full-suite run hit the known simulator audio-subsystem crash (`AURemoteIO` RPC timeout) in unrelated `AppStateChatResumeTests` — 0 assertion failures; the same classes pass in isolation — so CI is the authoritative full-suite check for this PR.

Reviewed locally by three independent reviewers before push; findings triaged in the commit messages (taken: indent guard, Foundation-gated collection, title folding, test hardening; declined findings verified invalid with probe evidence).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Markdown reference-style links across messages, including rich text and selectable text.
  * Reference definitions can span paragraphs and lists while remaining hidden from rendered output.
  * Added support for titles and continuations in valid link definitions.
  * Unresolved references remain visible as plain text, while ordinary inline links continue to work.

* **Bug Fixes**
  * Prevented link definitions inside code blocks, math regions, directives, and footnotes from being incorrectly interpreted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->