### PR TITLE
Allow private-LAN HTTP dashboards (restore RFC1918 policy)

### DIFF
--- a/Conduit/Services/ConnectionURLPolicy.swift
+++ b/Conduit/Services/ConnectionURLPolicy.swift
@@ -9,7 +9,7 @@ enum ConnectionURLPolicyError: LocalizedError, Equatable {
         case .invalidURL:
             return "Enter a valid dashboard URL."
         case .insecureTransport:
-            return "Remote dashboards must use HTTPS; HTTP is allowed only for localhost and Tailscale tailnet hosts."
+            return "Remote dashboards must use HTTPS; HTTP is allowed only for local networks (localhost, private LAN, and Tailscale)."
         }
     }
 }
@@ -143,7 +143,7 @@ enum ConnectionURLPolicy {
 
     private static func isInsecureTransportAllowed(_ value: String) -> Bool {
         let host = value.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
-        return isLoopbackHost(host) || isTailscaleHost(host)
+        return isLoopbackHost(host) || isPrivateLANHost(host) || isTailscaleHost(host)
     }
 
     private static func isLoopbackHost(_ value: String) -> Bool {
@@ -158,9 +158,31 @@ enum ConnectionURLPolicy {
         // Tailscale CGNAT range: 100.64.0.0/10 (100.64.0.0 – 100.127.255.255)
         // Require a well-formed IPv4 address to prevent label-based bypasses
         // like 100.64.attacker.example being accepted.
-        let octets = host.split(separator: ".").compactMap { Int($0) }
-        guard octets.count == 4,
-              octets.allSatisfy({ (0...255).contains($0) }) else { return false }
+        guard let octets = ipv4Octets(host) else { return false }
         return octets[0] == 100 && octets[1] >= 64 && octets[1] <= 127
+    }
+
+    private static func isPrivateLANHost(_ value: String) -> Bool {
+        // RFC1918 private ranges: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
+        guard let octets = ipv4Octets(value) else { return false }
+        switch octets[0] {
+        case 10:
+            return true
+        case 172:
+            return (16...31).contains(octets[1])
+        case 192:
+            return octets[1] == 168
+        default:
+            return false
+        }
+    }
+
+    private static func ipv4Octets(_ value: String) -> [Int]? {
+        let components = value.split(separator: ".", omittingEmptySubsequences: false)
+        guard components.count == 4 else { return nil }
+        let octets = components.compactMap { Int($0) }
+        guard octets.count == 4,
+              octets.allSatisfy({ (0...255).contains($0) }) else { return nil }
+        return octets
     }
 }

--- a/ConduitTests/SecurityBoundaryTests.swift
+++ b/ConduitTests/SecurityBoundaryTests.swift
@@ -51,6 +51,30 @@ final class SecurityBoundaryTests: XCTestCase {
         XCTAssertFalse(ConnectionURLPolicy.isAllowedTransport(URL(string: "http://100.64.1")))
     }
 
+    func testPrivateLANHTTPIsAllowed() {
+        XCTAssertTrue(ConnectionURLPolicy.isAllowedTransport(URL(string: "http://192.168.1.42:9119")))
+        XCTAssertEqual(
+            try? ConnectionURLPolicy.normalizedBaseURL("http://192.168.1.42:9119/"),
+            "http://192.168.1.42:9119"
+        )
+        XCTAssertTrue(ConnectionURLPolicy.isAllowedTransport(URL(string: "http://10.0.0.1")))
+        XCTAssertTrue(ConnectionURLPolicy.isAllowedTransport(URL(string: "http://172.16.0.1")))
+        XCTAssertTrue(ConnectionURLPolicy.isAllowedTransport(URL(string: "http://172.31.255.254")))
+        XCTAssertTrue(ConnectionURLPolicy.isAllowedTransport(URL(string: "http://192.168.255.254")))
+        XCTAssertFalse(ConnectionURLPolicy.isAllowedTransport(URL(string: "http://172.15.255.255")))
+        XCTAssertFalse(ConnectionURLPolicy.isAllowedTransport(URL(string: "http://172.32.0.1")))
+        XCTAssertFalse(ConnectionURLPolicy.isAllowedTransport(URL(string: "http://192.167.0.1")))
+        XCTAssertFalse(ConnectionURLPolicy.isAllowedTransport(URL(string: "http://192.168.1.999")))
+        XCTAssertFalse(ConnectionURLPolicy.isAllowedTransport(URL(string: "http://192.168.attacker.1")))
+    }
+
+    func testInsecureTransportErrorExplainsAllowedLocalNetworks() {
+        XCTAssertEqual(
+            ConnectionURLPolicyError.insecureTransport.errorDescription,
+            "Remote dashboards must use HTTPS; HTTP is allowed only for local networks (localhost, private LAN, and Tailscale)."
+        )
+    }
+
     func testCGNATOctetBoundaryRejectsInvalidValues() {
         // Octet > 255 is not a valid IPv4 octet
         XCTAssertFalse(ConnectionURLPolicy.isAllowedTransport(URL(string: "http://100.64.256.1")))


### PR DESCRIPTION
## Summary

Restores private-LAN HTTP dashboard support that was previously implemented on the old PR #9 integration branch (commit `609fef2`) and lost when main was rebuilt.

`http://192.168.x.x` dashboards were rejected with the insecure-transport error after the rebuild — this ports the previously-supported RFC1918 semantics forward as the smallest possible patch against current main.

## Changes

**`Conduit/Services/ConnectionURLPolicy.swift`**
- `isInsecureTransportAllowed` now also permits RFC1918 private IPv4 via a restored `isPrivateLANHost` helper:
  - `10.0.0.0/8`
  - `172.16.0.0/12`
  - `192.168.0.0/16`
- Extracted a shared strict `ipv4Octets` parser (exactly 4 dot-separated components, each an integer 0–255) used by both the private-LAN check and the existing Tailscale CGNAT check, so malformed hosts are rejected: `192.168.1.999`, `192.168.attacker.1`, partial IPv4 addresses. This also slightly tightens the CGNAT check (the previous inline split accepted trailing/leading-dot forms).
- Updated the insecure-transport error copy to mention private LAN again.

**`ConduitTests/SecurityBoundaryTests.swift`**
- Restored `testPrivateLANHTTPIsAllowed` (equivalent to the old test): pins `http://192.168.1.42:9119` — the user-visible regression — plus positive/negative RFC1918 boundaries (`172.15.255.255` / `172.32.0.1` / `192.167.0.1` rejected, `172.31.255.254` / `192.168.255.254` / `10.0.0.1` allowed) and malformed-host rejections.
- Restored `testInsecureTransportErrorExplainsAllowedLocalNetworks`.

## What this is NOT

- No revert/cherry-pick of PR #9: all later security/origin-matching and connection work on main is untouched (`originMatches`, `effectivePort`, URL normalization, WebSocket construction, Cloudflare/Tailscale handling, `DashboardTicketBridge`, `HermesClient`, reconnect/recovery state).
- Not an "allow arbitrary insecure HTTP host" preference — WireGuard/VPN host opt-in is separate scope (#74).

## Test plan

- [x] TDD: new tests fail against unmodified main (7 assertion failures), all pre-existing tests pass
- [x] Focused `SecurityBoundaryTests`: 11/11 passed
- [x] Full suite: 710 unit + 6 UI tests, 0 failures
- Historical reference only: PR #9's `isPrivateLANHost`/`ipv4Octets` semantics; the historical file was not restored wholesale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP connections are now supported for private local-network addresses, alongside localhost and Tailscale hosts.
  * Private-network URLs are normalized for consistent handling.
  * Insecure-connection messaging now explains which network types support HTTP.

* **Bug Fixes**
  * Improved validation prevents invalid or out-of-range private IP addresses from being accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->