### PR TITLE
ci+test: bound hung test attempts with per-attempt wall-clock timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,12 @@ jobs:
   test:
     name: Build & Test
     runs-on: macos-26
-    # A wedged simulator can hang a test invocation for hours (the default
-    # step timeout is 360 minutes). Healthy runs finish well under 15
-    # minutes; cap the job so a wedge surfaces as a bounded failure.
+    # Outer emergency limit only — wedge detection lives in
+    # scripts/ci-run-tests.sh (per-attempt wall-clock budget of 16 min).
+    # Worst case: ~4 min setup + 2 × (≤3 min bootstatus-bounded reset +
+    # 16 min budget + ~25 s kill/diagnostics) ≈ 43 min, so a bounded run
+    # fits; this cap exists for the residual cases the budget cannot reach
+    # (e.g. a wedged CoreSimulatorService blocking simctl itself).
     timeout-minutes: 45
 
     steps:
@@ -66,65 +69,15 @@ jobs:
           echo "SIMULATOR=$SIMULATOR" >> "$GITHUB_ENV"
 
       - name: Run tests
-        run: |
-          # If the full suite fails, reset the simulator and retry the full
-          # suite once. A genuine double failure still fails CI. Attempt 2
-          # runs the entire suite (not just UI tests) because attempt 1 can
-          # fail in a unit test; a UI-only retry would mask that failure.
-          #
-          # NOTE: GitHub Actions runs `bash -eo pipefail {0}` by default.
-          # We wrap the piped xcodebuild|xcpretty invocation in an `if`
-          # block so that an expected nonzero exit code is intentionally
-          # handled by the loop instead of killed by errexit.  (Running
-          # `set +e` would also work but the `if` scopes the failure
-          # cleanly and makes the intent obvious.)
-          set -uo pipefail
-          for attempt in 1 2; do
-            if [ "$attempt" -eq 1 ]; then
-              BUNDLE=TestResults.xcresult
-            else
-              BUNDLE=TestResults-retry.xcresult
-              # A wedged simulator is the one failure mode in-test retries
-              # cannot clear; restart the device so the retry starts clean.
-              xcrun simctl shutdown "$SIMULATOR" || true
-              sleep 3
-              xcrun simctl boot "$SIMULATOR" || true
-              # Wait for a complete boot before handing the device to
-              # xcodebuild; a half-booted simulator wedges UI tests.
-              xcrun simctl bootstatus "$SIMULATOR" -b -t 180 || true
-            fi
-            echo "::group::Test attempt $attempt"
-            rm -rf "$BUNDLE"
-            status=0
-            if xcodebuild test \
-              -project Conduit.xcodeproj \
-              -scheme Conduit \
-              -destination "platform=iOS Simulator,id=$SIMULATOR" \
-              -configuration Debug \
-              -resultBundlePath "$BUNDLE" \
-              CODE_SIGN_IDENTITY="" \
-              CODE_SIGNING_REQUIRED=NO \
-              CODE_SIGNING_ALLOWED=NO \
-              DEVELOPMENT_TEAM="" \
-              PROVISIONING_PROFILE_SPECIFIER="" \
-              | xcpretty --color; then
-              status=0
-            else
-              # Preserve both pipeline statuses: xcodebuild may succeed
-              # while xcpretty fails (or vice versa). Fail/retry if
-              # either command fails.
-              ps=("${PIPESTATUS[@]}")
-              status=$(( ps[0] != 0 ? ps[0] : ps[1] ))
-            fi
-            echo "::endgroup::"
-            if [ "$status" -eq 0 ]; then
-              echo "tests passed on attempt $attempt"
-              exit 0
-            fi
-            echo "tests failed on attempt $attempt (exit status $status)"
-          done
-          echo "both test attempts failed"
-          exit 1
+        # scripts/ci-run-tests.sh owns the retry loop. Each attempt gets its
+        # own wall-clock budget (default 16 min; healthy runs take 7-13) so a
+        # hung test or wedged simulator is killed and retried instead of
+        # stalling until the 45-min job timeout — which remains the outer
+        # emergency limit, not the wedge-detection mechanism. The script also
+        # boots the simulator before every attempt, streams raw xcodebuild
+        # output into this step's log, and leaves per-attempt logs + any
+        # partial .xcresult bundles for the upload step below.
+        run: bash scripts/ci-run-tests.sh
 
       - name: Upload test results on failure
         if: failure()
@@ -134,4 +87,5 @@ jobs:
           path: |
             TestResults.xcresult
             TestResults-retry.xcresult
+            ci-logs/
           if-no-files-found: ignore

--- a/ConduitTests/HermesClientTests.swift
+++ b/ConduitTests/HermesClientTests.swift
@@ -6,7 +6,7 @@ final class HermesClientTests: XCTestCase {
 
     // MARK: - rpc() guard
 
-    func testRPCGuardRejectsBeforeHandshake() async {
+    func testRPCGuardRejectsBeforeHandshake() async throws {
         // The handshake is held open (we never call transport.open), so the
         // socket is installed but `isConnected` is still false. `rpc()`'s
         // `isConnected` requirement must reject the call — the pre-fix
@@ -19,7 +19,7 @@ final class HermesClientTests: XCTestCase {
         let client = makeClient(transport: transport)
 
         let connectTask = Task { try? await client.connect() }
-        await reachedResume.wait()  // connect() has installed + resumed the socket and is now suspended in the handshake
+        try await reachedResume.wait("connect() to resume the socket (handshake pending)")  // connect() has installed + resumed the socket and is now suspended in the handshake
 
         do {
             try await client.healthCheck()
@@ -31,12 +31,12 @@ final class HermesClientTests: XCTestCase {
         }
 
         client.disconnect()  // resumes the suspended handshake so connect() unwinds
-        _ = await connectTask.value
+        try await awaitCompletion(of: connectTask, "connect() to unwind after disconnect()")
     }
 
     // MARK: - receive-failure teardown
 
-    func testReceiveFailureOnOwningSocketTearsDown() async {
+    func testReceiveFailureOnOwningSocketTearsDown() async throws {
         let transport = FakeTransport()
         let socket = FakeSocket()
         let receivePending = Gate()
@@ -48,9 +48,9 @@ final class HermesClientTests: XCTestCase {
 
         let connectTask = Task { try? await client.connect() }
         transport.open(socket)
-        _ = await connectTask.value
+        try await awaitCompletion(of: connectTask, "connect() to complete after the handshake")
         XCTAssertTrue(client.isConnected)
-        await receivePending.wait()  // the receive loop is now suspended in socket.receive()
+        try await receivePending.wait("the receive loop to suspend in socket.receive()")  // the receive loop is now suspended in socket.receive()
 
         socket.failReceive(URLError(.networkConnectionLost))
         await flushMainActor()       // let the catch run
@@ -60,7 +60,7 @@ final class HermesClientTests: XCTestCase {
         client.disconnect()
     }
 
-    func testSupersededReceiveLoopDoesNotClobberNewConnection() async {
+    func testSupersededReceiveLoopDoesNotClobberNewConnection() async throws {
         let transport = FakeTransport()
         let socketA = FakeSocket()
         let aReceivePending = Gate()
@@ -72,9 +72,9 @@ final class HermesClientTests: XCTestCase {
 
         let connectA = Task { try? await client.connect() }
         transport.open(socketA)
-        _ = await connectA.value
+        try await awaitCompletion(of: connectA, "connect A to complete after the handshake")
         XCTAssertTrue(client.isConnected)
-        await aReceivePending.wait()  // A's receive loop is suspended in socket.receive()
+        try await aReceivePending.wait("socket A's receive loop to suspend in socket.receive()")  // A's receive loop is suspended in socket.receive()
 
         // Same-instance reconnect (the latent scenario this PR hardens):
         // connect() tears down socketA → A's receive() errors → A's late catch
@@ -83,7 +83,7 @@ final class HermesClientTests: XCTestCase {
         transport.nextSocket = { socketB }
         let connectB = Task { try? await client.connect() }
         transport.open(socketB)
-        _ = await connectB.value
+        try await awaitCompletion(of: connectB, "connect B to complete after the handshake")
         await flushMainActor()  // let A's superseded catch run
 
         XCTAssertTrue(socketA.cancelled, "Reconnect should cancel the superseded socket")
@@ -92,7 +92,7 @@ final class HermesClientTests: XCTestCase {
         client.disconnect()
     }
 
-    func testSupersededLoopDropsStaleFrame() async {
+    func testSupersededLoopDropsStaleFrame() async throws {
         // The success path of receiveLoop is identity-guarded too: a frame
         // delivered to a superseded socket must not reach handleMessage.
         let transport = FakeTransport()
@@ -107,8 +107,8 @@ final class HermesClientTests: XCTestCase {
 
         let connectA = Task { try? await client.connect() }
         transport.open(socketA)
-        _ = await connectA.value
-        await aReceivePending.wait()
+        try await awaitCompletion(of: connectA, "connect A to complete after the handshake")
+        try await aReceivePending.wait("socket A's receive loop to suspend in socket.receive()")
 
         // Reconnect to B, then deliver a frame to the old socket A. The guard
         // must drop it (onEvent not fired for A's stale frame).
@@ -116,7 +116,7 @@ final class HermesClientTests: XCTestCase {
         transport.nextSocket = { socketB }
         let connectB = Task { try? await client.connect() }
         transport.open(socketB)
-        _ = await connectB.value
+        try await awaitCompletion(of: connectB, "connect B to complete after the handshake")
 
         socketA.deliver(someEventJSON())
         await flushMainActor()
@@ -127,7 +127,7 @@ final class HermesClientTests: XCTestCase {
 
     // MARK: - connect() teardown of the prior connection
 
-    func testConnectInvalidatesPriorTransport() async {
+    func testConnectInvalidatesPriorTransport() async throws {
         let transport = FakeTransport()
         let socketA = FakeSocket()
         transport.nextSocket = { socketA }
@@ -135,21 +135,21 @@ final class HermesClientTests: XCTestCase {
 
         let connectA = Task { try? await client.connect() }
         transport.open(socketA)
-        _ = await connectA.value
+        try await awaitCompletion(of: connectA, "connect A to complete after the handshake")
         XCTAssertFalse(transport.invalidated)
 
         let socketB = FakeSocket()
         transport.nextSocket = { socketB }
         let connectB = Task { try? await client.connect() }
         transport.open(socketB)
-        _ = await connectB.value
+        try await awaitCompletion(of: connectB, "connect B to complete after the handshake")
 
         XCTAssertTrue(transport.invalidated, "Reconnect must invalidate the prior transport/session")
         XCTAssertEqual(transport.socketsMade.count, 2)
         client.disconnect()
     }
 
-    func testConcurrentConnectSupersedesPriorWithoutHanging() async {
+    func testConcurrentConnectSupersedesPriorWithoutHanging() async throws {
         // A second connect() while the first is still mid-handshake must resume
         // the first's open continuation (via the teardown, mirroring disconnect),
         // so the first connect() throws instead of hanging forever.
@@ -161,16 +161,17 @@ final class HermesClientTests: XCTestCase {
         let client = makeClient(transport: transport)
 
         let connectA = Task { try? await client.connect() }
-        await aResumed.wait()  // connectA has installed A and is suspended in the handshake (A is never opened)
+        try await aResumed.wait("connect A to resume its socket (handshake pending)")  // connectA has installed A and is suspended in the handshake (A is never opened)
 
         let socketB = FakeSocket()
         transport.nextSocket = { socketB }
         let connectB = Task { try? await client.connect() }
         transport.open(socketB)
-        _ = await connectB.value
+        try await awaitCompletion(of: connectB, "connect B to complete after the handshake")
 
-        // If the continuation were leaked this await would hang and time out.
-        _ = await connectA.value
+        // If the continuation were leaked this would time out (boundedly) and
+        // fail the test instead of hanging the run.
+        try await awaitCompletion(of: connectA, "superseded connect A to unwind after connect B")
         XCTAssertTrue(client.isConnected)
         client.disconnect()
     }
@@ -188,6 +189,28 @@ final class HermesClientTests: XCTestCase {
         for _ in 0..<10 { await Task.yield() }
     }
 
+    /// Bounded wait for a spawned task to finish — the task-side counterpart
+    /// of `Gate.wait`. A `connect()` that never unwinds fails the test naming
+    /// `phase` instead of suspending forever on `task.value`. If the deadline
+    /// fires, the watcher is left leaked on `task.value` by design: checked
+    /// continuations ignore cancellation, and the test process is on its way
+    /// to a failure report anyway.
+    private func awaitCompletion<T>(
+        of task: Task<T, Never>,
+        _ phase: String,
+        timeout: TimeInterval = 10,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let finished = Gate()
+        let watcher = Task<Void, Never>.detached(priority: .userInitiated) {
+            _ = await task.value
+            finished.signal()
+        }
+        defer { watcher.cancel() }
+        try await finished.wait(phase, timeout: timeout, file: file, line: line)
+    }
+
     /// A gateway stream-event frame (`message.start`) that StreamEventParser
     /// accepts, so `deliver` genuinely exercises the receive success path —
     /// without the identity guard this would fire `onEvent`.
@@ -201,22 +224,79 @@ final class HermesClientTests: XCTestCase {
 // MARK: - Test doubles
 
 /// Single-use gate that survives a `signal()` arriving before `wait()` (the
-/// flag is sticky). All access is on the MainActor, so no locking is needed.
-private final class Gate {
+/// flag is sticky). `wait` is bounded: XCTest has no per-test timeout for
+/// async tests, so a missed signal would suspend the test forever and wedge
+/// xcodebuild until the CI job-level kill. A missed signal must instead fail
+/// the test naming the phase it was waiting for.
+///
+/// NSLock rather than MainActor confinement because the deadline timer runs
+/// detached from any actor; whoever takes the continuation under the lock
+/// resumes it exactly once, which makes the signal/timeout race safe.
+private final class Gate: @unchecked Sendable {
+    private let lock = NSLock()
     private var signalled = false
-    private var continuation: CheckedContinuation<Void, Never>?
+    /// Resumed with `true` when the deadline wins the race.
+    private var continuation: CheckedContinuation<Bool, Never>?
 
     func signal() {
-        guard !signalled else { return }
+        lock.lock()
         signalled = true
-        continuation?.resume()
-        continuation = nil
+        let continuation = self.continuation
+        self.continuation = nil
+        lock.unlock()
+        continuation?.resume(returning: false)
     }
 
-    func wait() async {
-        if signalled { return }
-        await withCheckedContinuation { continuation = $0 }
+    func wait(
+        _ phase: String,
+        timeout: TimeInterval = 10,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let timedOut = await withCheckedContinuation { continuation in
+            lock.lock()
+            if signalled {
+                lock.unlock()
+                continuation.resume(returning: false)
+                return
+            }
+            self.continuation = continuation
+            lock.unlock()
+
+            // Detached so the deadline fires even if the actor the awaited
+            // work runs on never gets scheduled again.
+            Task<Void, Never>.detached(priority: .userInitiated) { [weak self] in
+                try? await Task.sleep(for: .seconds(timeout))
+                self?.fireDeadline()
+            }
+        }
+        if timedOut {
+            XCTFail("Timed out after \(timeout)s waiting for \(phase)", file: file, line: line)
+            throw TestSyncTimedOut(phase: phase)
+        }
     }
+
+    /// Deadline half of the signal/timeout race. Whoever takes the
+    /// continuation under the lock resumes it; the loser sees nil, making the
+    /// race exactly-once. Synchronous (no awaits) so the NSLock critical
+    /// sections stay out of async contexts.
+    private func fireDeadline() {
+        lock.lock()
+        let continuation = self.continuation
+        self.continuation = nil
+        let signalled = self.signalled
+        lock.unlock()
+        if !signalled {
+            continuation?.resume(returning: true)
+        }
+    }
+}
+
+/// Thrown by the bounded wait helpers after the failure has been recorded;
+/// aborts the test method so a wedged phase does not cascade into misleading
+/// downstream assertion failures.
+private struct TestSyncTimedOut: Error {
+    let phase: String
 }
 
 /// Controllable HermesWebSocket. `receive()` suspends until the test delivers a

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+#
+# Full-suite test runner with a per-attempt wall-clock budget.
+#
+# WHY THIS EXISTS: a single hung async test (or a wedged simulator) makes
+# xcodebuild emit no output and never exit. Without a per-attempt deadline the
+# retry loop below can never advance — the 45-minute job timeout kills the job
+# instead, attempt 2 never runs, and no diagnostics survive (CI run #328).
+#
+# Contract:
+#   - Runs the full suite up to 2 times. Exit 0 = some attempt passed.
+#     Exit 1 = every attempt failed or timed out.
+#   - Each attempt gets ATTEMPT_TIMEOUT_SECS (default 960 = 16 min; healthy
+#     runs finish in 7-13 min). Sized so the worst case — setup + a killed
+#     attempt 1 + simulator reboots (bootstatus is bounded at 180s each) + a
+#     full attempt 2 — stays under the 45-minute job timeout. A timed-out
+#     attempt is killed by process group and its status flows through the
+#     retry loop exactly like a test failure.
+#   - The simulator is explicitly booted (shutdown → boot → bootstatus) before
+#     EVERY attempt, including the first.
+#   - Raw xcodebuild logs land in ci-logs/ and stream into the step log; any
+#     partial .xcresult bundles are left on disk for the artifact upload.
+#
+# Required env:
+#   SIMULATOR            UDID of the iOS simulator to test against.
+# Optional env:
+#   ATTEMPT_TIMEOUT_SECS per-attempt budget in seconds (default 960).
+#   ATTEMPTS             max attempts (default 2).
+#
+# Bash 3.2 compatible (GitHub macOS runners default to /bin/bash).
+
+set -uo pipefail
+
+SIMULATOR="${SIMULATOR:-}"
+ATTEMPT_TIMEOUT_SECS="${ATTEMPT_TIMEOUT_SECS:-960}"
+ATTEMPTS="${ATTEMPTS:-2}"
+
+if [ -z "$SIMULATOR" ]; then
+  echo "::error::SIMULATOR (UDID) must be set"
+  exit 1
+fi
+
+LOG_DIR="ci-logs"
+mkdir -p "$LOG_DIR"
+
+# Boot the simulator to a known-clean state. All failures are tolerated: on a
+# fresh runner the device may already be shut down (or booted), and a wedged
+# device is exactly what this reset is here to clear. bootstatus is bounded
+# by -t; shutdown/boot themselves can in principle stall on a wedged
+# CoreSimulatorService — the job-level timeout is the backstop for that.
+reset_and_boot_simulator() {
+  xcrun simctl shutdown "$SIMULATOR" >/dev/null 2>&1 || true
+  sleep 3
+  xcrun simctl boot "$SIMULATOR" 2>/dev/null || true
+  # Wait for a complete boot before handing the device to xcodebuild; a
+  # half-booted simulator wedges tests.
+  xcrun simctl bootstatus "$SIMULATOR" -b -t 180 || true
+}
+
+# Stream log lines not yet printed. $1 = log path, $2 = NAME of the caller's
+# variable holding the last printed line count (written back via printf -v).
+# NOTE: no local may share that variable's name — a local would shadow the
+# caller's binding under bash dynamic scoping and the counter would never
+# advance, re-printing the whole log every poll.
+stream_new_lines() {
+  local logfile="$1"
+  local printed_var="$2"
+  local total=0
+  if [ -f "$logfile" ]; then
+    total=$(wc -l < "$logfile" | tr -d ' ')
+  fi
+  if [ "$total" -gt "${!printed_var}" ]; then
+    tail -n +"$(( ${!printed_var} + 1 ))" "$logfile"
+    printf -v "$printed_var" '%s' "$total"
+  fi
+}
+
+# Run one xcodebuild attempt with a wall-clock deadline. Echoes the attempt's
+# exit status: xcodebuild's own status, or 124 when the deadline killed it.
+run_attempt() {
+  local attempt="$1"
+  local bundle="$2"
+  local log="$LOG_DIR/attempt-${attempt}.log"
+
+  rm -rf "$bundle"
+
+  # Job control (set -m) puts this one background job into its own process
+  # group so a deadline kill takes down xcodebuild AND its children (xctest,
+  # simulator agents) without signalling this script itself.
+  set -m
+  xcodebuild test \
+    -project Conduit.xcodeproj \
+    -scheme Conduit \
+    -destination "platform=iOS Simulator,id=$SIMULATOR" \
+    -configuration Debug \
+    -resultBundlePath "$bundle" \
+    CODE_SIGN_IDENTITY="" \
+    CODE_SIGNING_REQUIRED=NO \
+    CODE_SIGNING_ALLOWED=NO \
+    DEVELOPMENT_TEAM="" \
+    PROVISIONING_PROFILE_SPECIFIER="" \
+    >"$log" 2>&1 &
+  local runner=$!
+  set +m
+
+  # Poll liveness, stream new output, and enforce the deadline. Sleeps never
+  # cross the deadline, so the kill lands within one poll of the budget.
+  local deadline=$(( $(date +%s) + ATTEMPT_TIMEOUT_SECS ))
+  local poll=15
+  local printed=0
+  local heartbeat=0
+  local timed_out=0
+  while kill -0 "$runner" 2>/dev/null; do
+    local now=$(date +%s)
+    local remaining=$(( deadline - now ))
+    if [ "$remaining" -le 0 ]; then
+      timed_out=1
+      break
+    fi
+    stream_new_lines "$log" printed
+    heartbeat=$(( heartbeat + 1 ))
+    if [ "$(( heartbeat % 4 ))" -eq 0 ]; then
+      echo "… attempt ${attempt} still running ($(( ATTEMPT_TIMEOUT_SECS - remaining ))s elapsed, ${remaining}s of budget left)"
+    fi
+    [ "$remaining" -lt "$poll" ] && poll="$remaining"
+    sleep "$poll"
+    poll=15
+  done
+  stream_new_lines "$log" printed
+
+  if [ "$timed_out" -eq 1 ]; then
+    echo "::error::Attempt ${attempt} exceeded its ${ATTEMPT_TIMEOUT_SECS}s budget — killing the xcodebuild process group (pid $runner)"
+    # xcodebuild spawns children (xctest, simulator agents); TERM the whole
+    # group so nothing is orphaned, give it a grace window, then KILL.
+    kill -TERM -- "-$runner" 2>/dev/null || kill -TERM "$runner" 2>/dev/null || true
+    local grace=10
+    while [ "$grace" -gt 0 ] && kill -0 "$runner" 2>/dev/null; do
+      sleep 1
+      grace=$(( grace - 1 ))
+    done
+    kill -KILL -- "-$runner" 2>/dev/null || kill -KILL "$runner" 2>/dev/null || true
+    wait "$runner" 2>/dev/null
+    # Diagnostics: whatever the (progressively written) result bundle holds
+    # stays on disk for the upload step; capture the device state and the
+    # wedge point in the log tail.
+    xcrun simctl list devices >"$LOG_DIR/simctl-devices-after-timeout-attempt-${attempt}.txt" 2>&1 || true
+    ls -l "$log" || true
+    echo "---- last 200 log lines of the timed-out attempt ----"
+    tail -n 200 "$log" || true
+    echo "------------------------------------------------------"
+    return 124
+  fi
+
+  wait "$runner"
+}
+
+for attempt in $(seq 1 "$ATTEMPTS"); do
+  if [ "$attempt" -eq 1 ]; then
+    bundle="TestResults.xcresult"
+  else
+    bundle="TestResults-retry.xcresult"
+  fi
+
+  # A wedged or half-booted simulator is the one failure mode in-test retries
+  # cannot clear; reset it before every attempt, including the first.
+  echo "Booting simulator $SIMULATOR for attempt $attempt"
+  reset_and_boot_simulator
+
+  echo "::group::Test attempt $attempt (budget ${ATTEMPT_TIMEOUT_SECS}s)"
+  status=0
+  run_attempt "$attempt" "$bundle" || status=$?
+  echo "::endgroup::"
+
+  if [ "$status" -eq 0 ]; then
+    echo "tests passed on attempt $attempt"
+    exit 0
+  fi
+  echo "tests failed on attempt $attempt (exit status $status)"
+done
+
+echo "all $ATTEMPTS test attempts failed"
+exit 1


### PR DESCRIPTION
## Problem

CI run #328 (PR #75) wedged for 37 minutes: a HermesClient test suspended forever on an unbounded wait (XCTest has **no per-test timeout for async tests**), xcodebuild emitted nothing further and never exited, and the #72 retry loop could never advance — the 45-minute job timeout killed the job and attempt 2 never ran. The job cap was doing wedge *detection*; it should only be an emergency limit.

## Fix — two layers

**1. Tests fail boundedly (`ConduitTests/HermesClientTests.swift`)**
- `Gate.wait()` is now deadline-bounded (NSLock + detached timer racing the signal; exactly-once continuation handoff under the lock — same shape as `HermesClient.waitForSocketOpen`'s open-timeout task). A missed signal records `XCTFail` naming the phase ("Timed out after 10.0s waiting for socket A's receive loop to suspend in socket.receive()") and throws to abort the test.
- New `awaitCompletion(of:_:)` helper bounds every `Task.value` wait the same way.
- All tests in the file use the helpers, not just the observed `testSupersededReceiveLoopDoesNotClobberNewConnection`.

**2. CI bounds each attempt (`scripts/ci-run-tests.sh`, new; retry loop moved out of `ci.yml`)**
- Per-attempt wall-clock budget: **16 min** (healthy runs are 7–13 min; sized so worst case — setup + killed attempt 1 + bootstatus-bounded reboots + full attempt 2 — fits the 45-min cap).
- xcodebuild runs backgrounded under `set -m` in its own process group; on deadline the whole group gets TERM → 10s grace → KILL, so xcodebuild's children (xctest, sim agents) die with it.
- A timed-out attempt exits **124** and flows through the retry loop exactly like a test failure → simulator shutdown/boot/bootstatus → **attempt 2 runs the full suite**.
- Simulator is explicitly booted before **every attempt, including the first**.
- Diagnostics survive: raw per-attempt logs stream into the step log and upload via `ci-logs/`, plus `simctl list devices` state and any partial `.xcresult` (upload step now includes `ci-logs/`).
- The 45-min job timeout stays as the outer emergency limit only.

## Validation

| Scenario | Result |
|---|---|
| Deliberately hung attempt killed within budget | ✅ harness: status 124, killed ~1s past deadline, group-kill verified against child pids |
| Attempt 2 executes after a timeout | ✅ harness: full reboot + attempt 2 runs |
| Normal test failure still retries | ✅ harness: exit 65 → attempt 2 → pass |
| Two failed/timed-out attempts fail CI | ✅ harness: exit 1 |
| Healthy run succeeds on attempt 1 | ✅ harness + this PR's own CI run |
| HermesClientTests cannot hang | ✅ injected never-signalling gate + never-completing task each fail boundedly in ~2s with the phase named; all 6 tests green on simulator |

Harness: mock-xcodebuild/xcrun via PATH driving the real script under `/bin/bash` 3.2 (GitHub's macOS default) — 13/13 checks.

## Review

Three local reviewer passes pre-push. Taken: a real bash dynamic-scoping bug where `local printed` shadowed the pass-by-name counter (log would re-print fully every poll), honest worst-case budget math vs the job cap, log-`ls` diagnostics, and Swift-6-friendly lock/sleep cleanups. Declined: perl-alarm wrappers around `simctl shutdown/boot` (job cap is the documented backstop), and a cancellation-handler rework of `Gate.wait` (XCTest never cancels a suspended async test; checked continuations are documented as cancellation-inert).

PR #75 touches only `MarkdownText.swift` + its own test file, so no conflict; it picks this up on merge to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved automated test reliability with bounded waits and clearer timeout reporting.
  * Added simulator reset and boot handling before each test attempt.
  * Test runs now retry automatically after failures or timeouts.
  * Live output, diagnostics, and partial results are preserved for failed attempts.

* **Chores**
  * Extended CI failure artifacts to include additional test-run logs.
  * Added an emergency time limit to prevent indefinitely stalled CI jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->