### PR TITLE
Version 0.1.5 build 134 for App Store

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -17,7 +17,7 @@ settings:
     DEVELOPMENT_TEAM: U2TH557QA8
     CODE_SIGN_STYLE: Manual
     MARKETING_VERSION: "0.1.5"
-    CURRENT_PROJECT_VERSION: "133"
+    CURRENT_PROJECT_VERSION: "134"
 targets:
   Conduit:
     type: application

--- a/project.yml
+++ b/project.yml
@@ -16,8 +16,8 @@ settings:
     ENABLE_BITCODE: NO
     DEVELOPMENT_TEAM: U2TH557QA8
     CODE_SIGN_STYLE: Manual
-    MARKETING_VERSION: "0.1.4"
-    CURRENT_PROJECT_VERSION: "131"
+    MARKETING_VERSION: "0.1.5"
+    CURRENT_PROJECT_VERSION: "133"
 targets:
   Conduit:
     type: application


### PR DESCRIPTION
## Release candidate

- **Marketing version:** `0.1.5`
- **Build number:** `134`
- **Starting main commit:** `7ccf5e8` (merge of #76)
- **Release scope:** PR #76 — restore RFC1918 private-LAN HTTP dashboards (`isPrivateLANHost` + shared strict `ipv4Octets`, error copy, regression tests)

## Ship record

- **Release branch commit:** `2f938e3` (`Prepare 0.1.5 build 133 for TestFlight`)
- **Tag:** `ios/v0.1.5-build-133` → `2f938e3` (pushed)
- **Archive/export:** Release config, manual signing (`Conduit App Store` profile, team `U2TH557QA8`)
- **ASC delivery UUID:** `bcd5844f-ce08-4fcf-ac69-3062db6a9fdc`
- **IPA:** `CFBundleShortVersionString=0.1.5`, `CFBundleVersion=133`, `com.milim.relay` (verified pre-upload)
- **Validate:** VERIFY SUCCEEDED · **Upload:** UPLOAD SUCCEEDED (2026-08-17 23:53 EDT)

## Test plan

- [x] Full unit + UI suite green on the release branch (710 unit + 6 UI, 0 failures)
- [x] `altool` validate + upload succeeded
- [x] Build 133 processing → **VALID** on App Store Connect (2026-08-17 23:55 EDT)

Draft until final QA; tag + uploaded archive are the canonical record of the shipped candidate.