### PR TITLE
fix(chat): shared responsive table column widths and text-level alignment

### DIFF
--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -721,21 +721,18 @@ private extension EnvironmentValues {
     }
 }
 
-private struct InlineMarkdown: View {
-    let source: String
-    let foregroundStyle: Color
-    let usesAccentSurface: Bool
-    var font: UIFont = .preferredFont(forTextStyle: .body)
-    var lineSpacing: CGFloat = 0
-    var maximumNumberOfLines: Int = 0
-    var textAlignment: NSTextAlignment = .natural
-    var selfSizingWidthRange: ClosedRange<CGFloat>? = nil
-    var selectionCoordinator: MarkdownSelectionCoordinator?
-    var selectionSegment: MarkdownSelectionSegmentDescriptor?
-    var trailingCharacterOpacities: [Double] = []
-    @Environment(\.markdownReferences) private var references
-
-    private var attributed: AttributedString {
+/// The single inline-attributed-string construction shared by
+/// `InlineMarkdown` rendering and `MarkdownTableLayout` width measurement,
+/// so a table column is always measured at exactly the content its cells
+/// render — reference-style links resolve to their labels in both paths,
+/// and any future inline-syntax change updates measurement with it.
+enum InlineMarkdownContent {
+    static func attributed(
+        source: String,
+        references: MarkdownReferenceContext,
+        foregroundStyle: Color = .primary,
+        trailingCharacterOpacities: [Double] = []
+    ) -> AttributedString {
         // Re-append the message's definitions so Foundation resolves
         // reference-style links for this fragment too. The definition block
         // is invisible under `.full`; if parsing fails, fall back to the bare
@@ -753,6 +750,30 @@ private struct InlineMarkdown: View {
             endIndex = startIndex
         }
         return attributed
+    }
+}
+
+private struct InlineMarkdown: View {
+    let source: String
+    let foregroundStyle: Color
+    let usesAccentSurface: Bool
+    var font: UIFont = .preferredFont(forTextStyle: .body)
+    var lineSpacing: CGFloat = 0
+    var maximumNumberOfLines: Int = 0
+    var textAlignment: NSTextAlignment = .natural
+    var selfSizingWidthRange: ClosedRange<CGFloat>? = nil
+    var selectionCoordinator: MarkdownSelectionCoordinator?
+    var selectionSegment: MarkdownSelectionSegmentDescriptor?
+    var trailingCharacterOpacities: [Double] = []
+    @Environment(\.markdownReferences) private var references
+
+    private var attributed: AttributedString {
+        InlineMarkdownContent.attributed(
+            source: source,
+            references: references,
+            foregroundStyle: foregroundStyle,
+            trailingCharacterOpacities: trailingCharacterOpacities
+        )
     }
 
     var body: some View {
@@ -985,17 +1006,24 @@ enum MarkdownTableLayout {
     }()
 
     @MainActor
-    static func columnWidths(headers: [String], rows: [[String]], availableWidth: CGFloat) -> [CGFloat] {
+    static func columnWidths(
+        headers: [String],
+        rows: [[String]],
+        availableWidth: CGFloat,
+        references: MarkdownReferenceContext = .empty
+    ) -> [CGFloat] {
         let columnCount = max(headers.count, rows.map(\.count).max() ?? 0)
         guard columnCount > 0 else { return [] }
 
         // Fonts resolve against the current Dynamic Type size, so the widths
-        // key on the content category just like MarkdownRenderCache, and on
-        // the viewport width that feeds the fit-or-shrink decision.
+        // key on the content category just like MarkdownRenderCache, on the
+        // viewport width that feeds the fit-or-shrink decision, and on the
+        // reference definitions (they change how cell source measures).
         let key = (
             [
                 UIApplication.shared.preferredContentSizeCategory.rawValue,
-                String(format: "%.1f", availableWidth)
+                String(format: "%.1f", availableWidth),
+                references.definitionsMarkdown
             ]
                 + headers
                 + rows.flatMap { $0.isEmpty ? ["<empty-row>"] : $0 }
@@ -1008,11 +1036,11 @@ enum MarkdownTableLayout {
 
         var ideals = [CGFloat](repeating: 0, count: columnCount)
         for (index, header) in headers.enumerated() {
-            ideals[index] = max(ideals[index], idealWidth(of: header, font: headerFont))
+            ideals[index] = max(ideals[index], idealWidth(of: header, font: headerFont, references: references))
         }
         for row in rows {
             for (index, cell) in row.enumerated() where index < columnCount {
-                ideals[index] = max(ideals[index], idealWidth(of: cell, font: bodyFont))
+                ideals[index] = max(ideals[index], idealWidth(of: cell, font: bodyFont, references: references))
             }
         }
 
@@ -1057,18 +1085,18 @@ enum MarkdownTableLayout {
         widths.map { ($0 * 2).rounded() / 2 }
     }
 
-    /// Measures the ideal (single-fragment) width of a cell the same way the
-    /// cell's own text view measures itself — InlineMarkdown's attributed
-    /// string bridged with the cell font — so the shared column widths and
-    /// the rendered wrapping agree.
-    private static func idealWidth(of source: String, font: UIFont) -> CGFloat {
-        let attributed = (try? AttributedString(
-            markdown: source,
-            options: .init(interpretedSyntax: .full)
-        )) ?? AttributedString(source)
+    /// Measures the ideal (single-fragment) width of a cell from the exact
+    /// attributed content InlineMarkdown renders (`InlineMarkdownContent`
+    /// bridged with the cell font), so the shared column widths and the
+    /// rendered wrapping agree — including message-level reference links,
+    /// which measure as their resolved labels.
+    private static func idealWidth(of source: String, font: UIFont, references: MarkdownReferenceContext) -> CGFloat {
         let bridged = NSMutableAttributedString(
             attributedString: SelectableTextView.bridge(
-                attributed, defaultFont: font, defaultColor: .label, linkColor: .link
+                InlineMarkdownContent.attributed(source: source, references: references),
+                defaultFont: font,
+                defaultColor: .label,
+                linkColor: .link
             )
         )
         let fullRange = NSRange(location: 0, length: bridged.length)
@@ -1103,9 +1131,15 @@ private struct MarkdownTable: View {
     /// the layout then falls back to cap-and-scroll and re-resolves a frame
     /// later, once the width is known.
     @State private var availableWidth: CGFloat = 0
+    @Environment(\.markdownReferences) private var references
 
     private var columnWidths: [CGFloat] {
-        MarkdownTableLayout.columnWidths(headers: headers, rows: rows, availableWidth: availableWidth)
+        MarkdownTableLayout.columnWidths(
+            headers: headers,
+            rows: rows,
+            availableWidth: availableWidth,
+            references: references
+        )
     }
 
     var body: some View {

--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -1151,12 +1151,13 @@ private struct MarkdownTable: View {
             }
             .frame(height: 0)
 
+            let widths = columnWidths
             ScrollView(.horizontal, showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 0) {
-                    tableRow(headers, rowIndex: 0, isHeader: true)
+                    tableRow(headers, rowIndex: 0, isHeader: true, widths: widths)
                     ForEach(Array(rows.enumerated()), id: \.offset) { rowOffset, row in
                         Divider().overlay(usesAccentSurface ? Color.white.opacity(0.22) : Color.secondary.opacity(0.18))
-                        tableRow(row, rowIndex: rowOffset + 1, isHeader: false)
+                        tableRow(row, rowIndex: rowOffset + 1, isHeader: false, widths: widths)
                     }
                 }
                 .background(
@@ -1171,9 +1172,8 @@ private struct MarkdownTable: View {
         }
     }
 
-    private func tableRow(_ cells: [String], rowIndex: Int, isHeader: Bool) -> some View {
-        let widths = columnWidths
-        return HStack(spacing: 0) {
+    private func tableRow(_ cells: [String], rowIndex: Int, isHeader: Bool, widths: [CGFloat]) -> some View {
+        HStack(spacing: 0) {
             ForEach(Array(cells.enumerated()), id: \.offset) { index, cell in
                 let width = widths.indices.contains(index)
                     ? widths[index]

--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -960,12 +960,22 @@ private struct MarkdownColumns: View {
 }
 
 /// Table-wide column layout: one width per column shared by the header and
-/// every row, so vertical dividers align across rows. Each column width is
-/// the largest ideal (unwrapped) text width among its cells — header
-/// included — clamped to the table's 112–220pt column policy; wider content
-/// wraps within the shared width instead of widening one row's cell.
+/// every row, so vertical dividers align across rows. Each column's width
+/// is the largest ideal (unwrapped) text width among its cells — header
+/// included — capped at `maxColumnContentWidth`. When the capped columns
+/// fit the chat width the table fits too (narrow columns stay narrow, wide
+/// ones keep their earned space); when they overflow, columns above the
+/// shrink floor give up width proportionally to their excess and wrap, and
+/// a table that still overflows at the floor keeps horizontal scrolling.
 enum MarkdownTableLayout {
-    static let columnWidthRange: ClosedRange<CGFloat> = 112...220
+    /// Widest a column's text may be before it wraps.
+    static let maxColumnContentWidth: CGFloat = 220
+    /// Narrowest a column shrinks to when the table must compress; columns
+    /// whose ideal is already below this keep their ideal width.
+    static let shrinkFloorContentWidth: CGFloat = 64
+    static let cellHorizontalPadding: CGFloat = 10
+    static let dividerWidth: CGFloat = 1
+    static let borderAllowance: CGFloat = 2
 
     private static let cache: NSCache<NSString, NSArray> = {
         let cache = NSCache<NSString, NSArray>()
@@ -975,14 +985,18 @@ enum MarkdownTableLayout {
     }()
 
     @MainActor
-    static func columnWidths(headers: [String], rows: [[String]]) -> [CGFloat] {
+    static func columnWidths(headers: [String], rows: [[String]], availableWidth: CGFloat) -> [CGFloat] {
         let columnCount = max(headers.count, rows.map(\.count).max() ?? 0)
         guard columnCount > 0 else { return [] }
 
         // Fonts resolve against the current Dynamic Type size, so the widths
-        // key on the content category just like MarkdownRenderCache.
+        // key on the content category just like MarkdownRenderCache, and on
+        // the viewport width that feeds the fit-or-shrink decision.
         let key = (
-            [UIApplication.shared.preferredContentSizeCategory.rawValue]
+            [
+                UIApplication.shared.preferredContentSizeCategory.rawValue,
+                String(format: "%.1f", availableWidth)
+            ]
                 + headers
                 + rows.flatMap { $0.isEmpty ? ["<empty-row>"] : $0 }
         ).joined(separator: "\u{1F}") as NSString
@@ -992,22 +1006,55 @@ enum MarkdownTableLayout {
         let headerFont = UIFont.preferredFont(forTextStyle: .caption1).withTraits(.traitBold)
         let bodyFont = UIFont.preferredFont(forTextStyle: .footnote)
 
-        var widths = [CGFloat](repeating: columnWidthRange.lowerBound, count: columnCount)
+        var ideals = [CGFloat](repeating: 0, count: columnCount)
         for (index, header) in headers.enumerated() {
-            widths[index] = max(widths[index], clampedColumnWidth(idealWidth(of: header, font: headerFont)))
+            ideals[index] = max(ideals[index], idealWidth(of: header, font: headerFont))
         }
         for row in rows {
             for (index, cell) in row.enumerated() where index < columnCount {
-                widths[index] = max(widths[index], clampedColumnWidth(idealWidth(of: cell, font: bodyFont)))
+                ideals[index] = max(ideals[index], idealWidth(of: cell, font: bodyFont))
             }
         }
 
+        let widths = resolveColumnContentWidths(ideals: ideals, availableWidth: availableWidth)
         cache.setObject(widths as NSArray, forKey: key, cost: key.length)
         return widths
     }
 
-    private static func clampedColumnWidth(_ width: CGFloat) -> CGFloat {
-        min(max(width, columnWidthRange.lowerBound), columnWidthRange.upperBound)
+    /// Pure distribution step so the policy is directly unit-testable.
+    /// A non-positive available width means the viewport is not yet known
+    /// (first layout pass): fall back to the cap-and-scroll layout, which is
+    /// deterministic and re-resolves once the real width arrives.
+    static func resolveColumnContentWidths(ideals: [CGFloat], availableWidth: CGFloat) -> [CGFloat] {
+        guard !ideals.isEmpty else { return [] }
+        let capped = ideals.map { min($0, maxColumnContentWidth) }
+        guard availableWidth > 0 else { return halfPointRounded(capped) }
+
+        // Cell padding, dividers, and the table border consume viewport width
+        // exactly once, before any column sees it.
+        let overhead = CGFloat(capped.count) * cellHorizontalPadding * 2
+            + CGFloat(capped.count - 1) * dividerWidth
+            + borderAllowance
+        let available = max(0, availableWidth - overhead)
+
+        let total = capped.reduce(0, +)
+        if total <= available { return halfPointRounded(capped) }
+
+        let shrinkable = capped.reduce(0) { $0 + max($1 - shrinkFloorContentWidth, 0) }
+        let deficit = total - available
+        if deficit >= shrinkable {
+            // Everything compressible is at the floor; columns that were
+            // already narrower keep their ideal. The table scrolls.
+            return halfPointRounded(capped.map { $0 > shrinkFloorContentWidth ? shrinkFloorContentWidth : $0 })
+        }
+        // Shrink proportionally to the excess above the floor: wide columns
+        // contribute more, narrow ones may not shrink at all.
+        let factor = deficit / shrinkable
+        return halfPointRounded(capped.map { $0 - max($0 - shrinkFloorContentWidth, 0) * factor })
+    }
+
+    private static func halfPointRounded(_ widths: [CGFloat]) -> [CGFloat] {
+        widths.map { ($0 * 2).rounded() / 2 }
     }
 
     /// Measures the ideal (single-fragment) width of a cell the same way the
@@ -1051,26 +1098,41 @@ private struct MarkdownTable: View {
     let blockIndex: Int
     let selectionSegments: [MarkdownSelectionSegmentDescriptor]
 
+    /// The chat's proposed width for this block, read by a zero-height
+    /// probe above the scroll view. Zero means "unknown yet" (first pass);
+    /// the layout then falls back to cap-and-scroll and re-resolves a frame
+    /// later, once the width is known.
+    @State private var availableWidth: CGFloat = 0
+
     private var columnWidths: [CGFloat] {
-        MarkdownTableLayout.columnWidths(headers: headers, rows: rows)
+        MarkdownTableLayout.columnWidths(headers: headers, rows: rows, availableWidth: availableWidth)
     }
 
     var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 0) {
-                tableRow(headers, rowIndex: 0, isHeader: true)
-                ForEach(Array(rows.enumerated()), id: \.offset) { rowOffset, row in
-                    Divider().overlay(usesAccentSurface ? Color.white.opacity(0.22) : Color.secondary.opacity(0.18))
-                    tableRow(row, rowIndex: rowOffset + 1, isHeader: false)
-                }
+        VStack(spacing: 0) {
+            GeometryReader { proxy in
+                Color.clear
+                    .onAppear { availableWidth = proxy.size.width }
+                    .onChange(of: proxy.size.width) { _, width in availableWidth = width }
             }
-            .background(
-                usesAccentSurface ? Color.black.opacity(0.13) : Color.primary.opacity(0.035),
-                in: RoundedRectangle(cornerRadius: 12, style: .continuous)
-            )
-            .overlay {
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .strokeBorder(usesAccentSurface ? Color.white.opacity(0.26) : Color.secondary.opacity(0.20), lineWidth: 1)
+            .frame(height: 0)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 0) {
+                    tableRow(headers, rowIndex: 0, isHeader: true)
+                    ForEach(Array(rows.enumerated()), id: \.offset) { rowOffset, row in
+                        Divider().overlay(usesAccentSurface ? Color.white.opacity(0.22) : Color.secondary.opacity(0.18))
+                        tableRow(row, rowIndex: rowOffset + 1, isHeader: false)
+                    }
+                }
+                .background(
+                    usesAccentSurface ? Color.black.opacity(0.13) : Color.primary.opacity(0.035),
+                    in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+                )
+                .overlay {
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .strokeBorder(usesAccentSurface ? Color.white.opacity(0.26) : Color.secondary.opacity(0.20), lineWidth: 1)
+                }
             }
         }
     }
@@ -1081,7 +1143,7 @@ private struct MarkdownTable: View {
             ForEach(Array(cells.enumerated()), id: \.offset) { index, cell in
                 let width = widths.indices.contains(index)
                     ? widths[index]
-                    : MarkdownTableLayout.columnWidthRange.lowerBound
+                    : MarkdownTableLayout.shrinkFloorContentWidth
                 InlineMarkdown(
                     source: cell,
                     foregroundStyle: foregroundStyle,

--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -534,11 +534,13 @@ private extension MarkdownBlock {
 enum MarkdownTableAlignment {
     case leading, center, trailing
 
-    var swiftUI: Alignment {
+    /// Carried into the cell text's paragraph style so alignment governs
+    /// every wrapped line, not just the position of a full-width wrapper.
+    var nsText: NSTextAlignment {
         switch self {
-        case .leading: .leading
+        case .leading: .natural
         case .center: .center
-        case .trailing: .trailing
+        case .trailing: .right
         }
     }
 }
@@ -726,6 +728,7 @@ private struct InlineMarkdown: View {
     var font: UIFont = .preferredFont(forTextStyle: .body)
     var lineSpacing: CGFloat = 0
     var maximumNumberOfLines: Int = 0
+    var textAlignment: NSTextAlignment = .natural
     var selfSizingWidthRange: ClosedRange<CGFloat>? = nil
     var selectionCoordinator: MarkdownSelectionCoordinator?
     var selectionSegment: MarkdownSelectionSegmentDescriptor?
@@ -760,6 +763,7 @@ private struct InlineMarkdown: View {
             lineSpacing: lineSpacing,
             maximumNumberOfLines: maximumNumberOfLines,
             linkColor: usesAccentSurface ? .white : .link,
+            textAlignment: textAlignment,
             selfSizingWidthRange: selfSizingWidthRange,
             selectionCoordinator: selectionCoordinator,
             selectionSegment: selectionSegment
@@ -955,6 +959,88 @@ private struct MarkdownColumns: View {
     }
 }
 
+/// Table-wide column layout: one width per column shared by the header and
+/// every row, so vertical dividers align across rows. Each column width is
+/// the largest ideal (unwrapped) text width among its cells — header
+/// included — clamped to the table's 112–220pt column policy; wider content
+/// wraps within the shared width instead of widening one row's cell.
+enum MarkdownTableLayout {
+    static let columnWidthRange: ClosedRange<CGFloat> = 112...220
+
+    private static let cache: NSCache<NSString, NSArray> = {
+        let cache = NSCache<NSString, NSArray>()
+        cache.countLimit = 64
+        cache.totalCostLimit = 4 * 1024 * 1024
+        return cache
+    }()
+
+    @MainActor
+    static func columnWidths(headers: [String], rows: [[String]]) -> [CGFloat] {
+        let columnCount = max(headers.count, rows.map(\.count).max() ?? 0)
+        guard columnCount > 0 else { return [] }
+
+        // Fonts resolve against the current Dynamic Type size, so the widths
+        // key on the content category just like MarkdownRenderCache.
+        let key = (
+            [UIApplication.shared.preferredContentSizeCategory.rawValue]
+                + headers
+                + rows.flatMap { $0.isEmpty ? ["<empty-row>"] : $0 }
+        ).joined(separator: "\u{1F}") as NSString
+
+        if let cached = cache.object(forKey: key) as? [CGFloat] { return cached }
+
+        let headerFont = UIFont.preferredFont(forTextStyle: .caption1).withTraits(.traitBold)
+        let bodyFont = UIFont.preferredFont(forTextStyle: .footnote)
+
+        var widths = [CGFloat](repeating: columnWidthRange.lowerBound, count: columnCount)
+        for (index, header) in headers.enumerated() {
+            widths[index] = max(widths[index], clampedColumnWidth(idealWidth(of: header, font: headerFont)))
+        }
+        for row in rows {
+            for (index, cell) in row.enumerated() where index < columnCount {
+                widths[index] = max(widths[index], clampedColumnWidth(idealWidth(of: cell, font: bodyFont)))
+            }
+        }
+
+        cache.setObject(widths as NSArray, forKey: key, cost: key.length)
+        return widths
+    }
+
+    private static func clampedColumnWidth(_ width: CGFloat) -> CGFloat {
+        min(max(width, columnWidthRange.lowerBound), columnWidthRange.upperBound)
+    }
+
+    /// Measures the ideal (single-fragment) width of a cell the same way the
+    /// cell's own text view measures itself — InlineMarkdown's attributed
+    /// string bridged with the cell font — so the shared column widths and
+    /// the rendered wrapping agree.
+    private static func idealWidth(of source: String, font: UIFont) -> CGFloat {
+        let attributed = (try? AttributedString(
+            markdown: source,
+            options: .init(interpretedSyntax: .full)
+        )) ?? AttributedString(source)
+        let bridged = NSMutableAttributedString(
+            attributedString: SelectableTextView.bridge(
+                attributed, defaultFont: font, defaultColor: .label, linkColor: .link
+            )
+        )
+        let fullRange = NSRange(location: 0, length: bridged.length)
+        if fullRange.length > 0 {
+            bridged.addAttribute(
+                .paragraphStyle,
+                value: NSMutableParagraphStyle(),
+                range: fullRange
+            )
+        }
+        let measured = bridged.boundingRect(
+            with: CGSize(width: 100_000, height: CGFloat.greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            context: nil
+        )
+        return ceil(measured.width)
+    }
+}
+
 private struct MarkdownTable: View {
     let headers: [String]
     let alignments: [MarkdownTableAlignment]
@@ -964,6 +1050,10 @@ private struct MarkdownTable: View {
     let selectionCoordinator: MarkdownSelectionCoordinator?
     let blockIndex: Int
     let selectionSegments: [MarkdownSelectionSegmentDescriptor]
+
+    private var columnWidths: [CGFloat] {
+        MarkdownTableLayout.columnWidths(headers: headers, rows: rows)
+    }
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
@@ -986,8 +1076,12 @@ private struct MarkdownTable: View {
     }
 
     private func tableRow(_ cells: [String], rowIndex: Int, isHeader: Bool) -> some View {
-        HStack(spacing: 0) {
+        let widths = columnWidths
+        return HStack(spacing: 0) {
             ForEach(Array(cells.enumerated()), id: \.offset) { index, cell in
+                let width = widths.indices.contains(index)
+                    ? widths[index]
+                    : MarkdownTableLayout.columnWidthRange.lowerBound
                 InlineMarkdown(
                     source: cell,
                     foregroundStyle: foregroundStyle,
@@ -995,13 +1089,16 @@ private struct MarkdownTable: View {
                     font: isHeader
                         ? UIFont.preferredFont(forTextStyle: .caption1).withTraits(.traitBold)
                         : UIFont.preferredFont(forTextStyle: .footnote),
-                    // Match the frame clamp below so the measured wrapping
-                    // width is deterministic from the first layout pass.
-                    selfSizingWidthRange: 112...220,
+                    textAlignment: alignment(at: index).nsText,
+                    // The exact shared column width — a single-value range keeps
+                    // the cell's measured/committed height deterministic from the
+                    // first layout pass, and .frame(width:) below pins the
+                    // displayed width so every row's dividers align.
+                    selfSizingWidthRange: width...width,
                     selectionCoordinator: selectionCoordinator,
                     selectionSegment: selectionSegment(row: rowIndex, column: index)
                 )
-                    .frame(minWidth: 112, maxWidth: 220, alignment: alignment(at: index).swiftUI)
+                    .frame(width: width)
                     .padding(.horizontal, 10)
                     .padding(.vertical, 9)
                 if index < cells.count - 1 {

--- a/Conduit/Views/Components/SelectableTextView.swift
+++ b/Conduit/Views/Components/SelectableTextView.swift
@@ -15,6 +15,10 @@ struct SelectableTextView: UIViewRepresentable {
     let maximumNumberOfLines: Int
     let wrapsLines: Bool
     let linkColor: UIColor
+    /// Paragraph-style alignment applied to laid-out text, so it governs
+    /// every wrapped line (Markdown table `:---:`/`---:` cells). `.natural`
+    /// preserves the default for all other callers.
+    let textAlignment: NSTextAlignment
     /// When set, the view self-sizes at a deterministic width derived from
     /// its content and this range (used by Markdown table cells), ignoring
     /// layout proposals. See `measuredSize(proposalWidth:textView:)`.
@@ -30,6 +34,7 @@ struct SelectableTextView: UIViewRepresentable {
         maximumNumberOfLines: Int = 0,
         wrapsLines: Bool = true,
         linkColor: UIColor = .link,
+        textAlignment: NSTextAlignment = .natural,
         selfSizingWidthRange: ClosedRange<CGFloat>? = nil,
         selectionCoordinator: MarkdownSelectionCoordinator? = nil,
         selectionSegment: MarkdownSelectionSegmentDescriptor? = nil
@@ -41,6 +46,7 @@ struct SelectableTextView: UIViewRepresentable {
         self.maximumNumberOfLines = maximumNumberOfLines
         self.wrapsLines = wrapsLines
         self.linkColor = linkColor
+        self.textAlignment = textAlignment
         self.selfSizingWidthRange = selfSizingWidthRange
         self.selectionCoordinator = selectionCoordinator
         self.selectionSegment = selectionSegment
@@ -54,6 +60,7 @@ struct SelectableTextView: UIViewRepresentable {
         maximumNumberOfLines: Int = 0,
         wrapsLines: Bool = true,
         linkColor: UIColor = .link,
+        textAlignment: NSTextAlignment = .natural,
         selfSizingWidthRange: ClosedRange<CGFloat>? = nil,
         selectionCoordinator: MarkdownSelectionCoordinator? = nil,
         selectionSegment: MarkdownSelectionSegmentDescriptor? = nil
@@ -66,6 +73,7 @@ struct SelectableTextView: UIViewRepresentable {
             maximumNumberOfLines: maximumNumberOfLines,
             wrapsLines: wrapsLines,
             linkColor: linkColor,
+            textAlignment: textAlignment,
             selfSizingWidthRange: selfSizingWidthRange,
             selectionCoordinator: selectionCoordinator,
             selectionSegment: selectionSegment
@@ -80,6 +88,7 @@ struct SelectableTextView: UIViewRepresentable {
         maximumNumberOfLines: Int = 0,
         wrapsLines: Bool = true,
         linkColor: UIColor = .link,
+        textAlignment: NSTextAlignment = .natural,
         selfSizingWidthRange: ClosedRange<CGFloat>? = nil,
         selectionCoordinator: MarkdownSelectionCoordinator? = nil,
         selectionSegment: MarkdownSelectionSegmentDescriptor? = nil
@@ -95,6 +104,7 @@ struct SelectableTextView: UIViewRepresentable {
             maximumNumberOfLines: maximumNumberOfLines,
             wrapsLines: wrapsLines,
             linkColor: linkColor,
+            textAlignment: textAlignment,
             selfSizingWidthRange: selfSizingWidthRange,
             selectionCoordinator: selectionCoordinator,
             selectionSegment: selectionSegment
@@ -260,6 +270,7 @@ struct SelectableTextView: UIViewRepresentable {
 
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = lineSpacing
+        paragraphStyle.alignment = textAlignment
 
         // Single-pass styling: preserve per-run font and foregroundColor from
         // attributedText, fill only missing attributes with the configured

--- a/ConduitTests/MarkdownTableLayoutTests.swift
+++ b/ConduitTests/MarkdownTableLayoutTests.swift
@@ -113,6 +113,45 @@ final class MarkdownTableLayoutTests: XCTestCase {
         }
     }
 
+    /// Regression: a reference-style link cell must be measured at its
+    /// resolved label, not the raw `[label][id]` syntax. The message's
+    /// reference definitions thread into column-width measurement through
+    /// the same attributed-string construction InlineMarkdown renders.
+    @MainActor
+    func testReferenceStyleLinkCellMeasuresAtResolvedLabelWidth() {
+        // Two columns: the parser's table delimiter requires at least two.
+        let source = """
+        | Docs | Note |
+        |---|---|
+        | [Handbook][1] | x |
+
+        [1]: https://example.com/handbook
+        """
+        let document = MarkdownParser.parseDocument(source)
+        guard case .table(let headers, _, let rows)? = document.blocks.first else {
+            return XCTFail("Expected a table block")
+        }
+        XCTAssertTrue(document.references.containsDefinitions,
+                      "The definition must be extracted into the reference context")
+
+        let resolved = MarkdownTableLayout.columnWidths(
+            headers: headers, rows: rows, availableWidth: 390, references: document.references
+        )
+        let literal = MarkdownTableLayout.columnWidths(
+            headers: ["Docs"], rows: [["Handbook"]], availableWidth: 390
+        )
+        XCTAssertEqual(resolved[0], literal[0], accuracy: 2,
+                       "Column width must match the resolved label's width")
+
+        // Without the context (the pre-fix measurement), the raw syntax is
+        // visibly wider than the label.
+        let raw = MarkdownTableLayout.columnWidths(
+            headers: headers, rows: rows, availableWidth: 390, references: .empty
+        )
+        XCTAssertLessThan(resolved[0], raw[0] - 5,
+                          "Raw [label][id] measurement must be wider than the resolved label")
+    }
+
     // MARK: - Rendered fixtures (full MarkdownText view chain)
 
     /// QA fixture: three tiny columns fit an iPhone viewport with no
@@ -171,6 +210,45 @@ final class MarkdownTableLayoutTests: XCTestCase {
         let tableScroll = try XCTUnwrap(scrollViews.first)
         XCTAssertLessThanOrEqual(tableScroll.contentSize.width, tableScroll.bounds.width + 0.5,
                                  "This table fits the viewport and must not scroll horizontally")
+    }
+
+    /// Regression, rendered: through the full MarkdownText chain, a
+    /// reference-style link cell renders its resolved label as a link, and
+    /// the column is sized to the label — identical to a table whose cell
+    /// contains the label literally.
+    @MainActor
+    func testRenderedReferenceLinkTableSizesColumnAtLabelWidth() throws {
+        let withLink = """
+        | Name | Docs |
+        |---|---|
+        | Alpha | [Handbook][1] |
+
+        [1]: https://example.com/handbook
+        """
+        let literal = """
+        | Name | Docs |
+        |---|---|
+        | Alpha | Handbook |
+        """
+        let (linkHost, linkWindow) = renderedTableHost(source: withLink)
+        let (literalHost, literalWindow) = renderedTableHost(source: literal)
+        defer { linkWindow.isHidden = true; literalWindow.isHidden = true }
+
+        let linkCell = try XCTUnwrap(
+            allTextViews(in: linkHost.view).first { $0.attributedText.string == "Handbook" },
+            "The reference link must render as its resolved label"
+        )
+        let link = try XCTUnwrap(
+            linkCell.attributedText.attribute(.link, at: 0, effectiveRange: nil) as? URL,
+            "The resolved label must carry the definition's URL"
+        )
+        XCTAssertEqual(link.absoluteString, "https://example.com/handbook")
+
+        let literalCell = try XCTUnwrap(
+            allTextViews(in: literalHost.view).first { $0.attributedText.string == "Handbook" }
+        )
+        XCTAssertEqual(linkCell.bounds.width, literalCell.bounds.width, accuracy: 1,
+                       "The link column must be sized to the resolved label, not the raw [label][id] syntax")
     }
 
     /// QA fixture: a genuinely wide table still scrolls horizontally.

--- a/ConduitTests/MarkdownTableLayoutTests.swift
+++ b/ConduitTests/MarkdownTableLayoutTests.swift
@@ -1,0 +1,267 @@
+import XCTest
+import UIKit
+import SwiftUI
+@testable import Conduit
+
+final class MarkdownTableLayoutTests: XCTestCase {
+    // MARK: - Table-wide column widths (unit)
+
+    /// One width per column, driven by the longest cell anywhere in that
+    /// column — header included — so rows with the longest value in
+    /// different columns still share widths.
+    @MainActor
+    func testColumnWidthsAreSharedAcrossRowsAndHeaderParticipates() {
+        let headers = ["A", "B", "C"]
+        // Drivers sized to land mid-range (no clamp): each column's longest
+        // value lives in a different row.
+        let rows = [
+            ["short", "column-two-driver-here", "ok"],
+            ["column-one-driver-longer", "mid", "fine"],
+            ["tiny", "", "x"],
+        ]
+
+        let widths = MarkdownTableLayout.columnWidths(headers: headers, rows: rows)
+
+        XCTAssertEqual(widths.count, 3)
+        for width in widths {
+            XCTAssertTrue(MarkdownTableLayout.columnWidthRange.contains(width),
+                          "Column width \(width) must stay inside the table column policy")
+        }
+        // Content-informed, not equal-width: A's longest value is longer than
+        // B's, which is longer than C's clamp floor.
+        XCTAssertGreaterThan(widths[0], widths[1])
+        XCTAssertGreaterThan(widths[1], widths[2])
+    }
+
+    @MainActor
+    func testColumnWidthsClampToPolicyBounds() {
+        let narrow = MarkdownTableLayout.columnWidths(
+            headers: ["a", "b"],
+            rows: [["x", ""]]
+        )
+        XCTAssertTrue(narrow.allSatisfy { $0 == MarkdownTableLayout.columnWidthRange.lowerBound },
+                      "Short/empty columns clamp to the minimum column width")
+
+        let wide = MarkdownTableLayout.columnWidths(
+            headers: ["a"],
+            rows: [[String(repeating: "very-long-value ", count: 30)]]
+        )
+        XCTAssertEqual(wide[0], MarkdownTableLayout.columnWidthRange.upperBound,
+                       "Over-long content clamps to the max width and wraps there")
+    }
+
+    // MARK: - Shared widths + wrap + scroll through the real view chain
+
+    /// Renders a real table and asserts every cell in a column — header,
+    /// long driver cells, short cells, and an empty cell — has the same
+    /// rendered width, which is what keeps dividers aligned down the table.
+    @MainActor
+    func testRenderedTableSharesColumnWidthsAcrossRowsIncludingEmptyCells() throws {
+        let source = """
+        | ColA | ColB | ColC |
+        |:---|:---:|---:|
+        | aaa | bbbb-col-two-driver | c |
+        | aaaa-column-one-driver | b | cc |
+        | a |  | c |
+        """
+        let (host, window) = renderedTableHost(source: source)
+
+        let cells = allTextViews(in: host.view)
+        XCTAssertEqual(cells.count, 12, "3 headers + 3 rows × 3 columns")
+
+        // Map marker → view. Markers identify every non-empty cell; the empty
+        // cell is found by elimination.
+        func cell(containing marker: String) throws -> UITextView {
+            for candidate in cells where candidate.attributedText.string.contains(marker) {
+                return candidate
+            }
+            return try XCTUnwrap(nil, "No cell contains marker \(marker)")
+        }
+
+        let columnDriverA = try cell(containing: "column-one-driver")
+        let columnDriverB = try cell(containing: "col-two-driver")
+        let headerA = try cell(containing: "ColA")
+        let headerB = try cell(containing: "ColB")
+        let shortA = try cell(containing: "aaa")
+        let shortB2 = try XCTUnwrap(cells.first { $0.attributedText.string == "b" },
+                                    "The lone short column-B cell must be findable by exact text")
+
+        // All column-A cells share one width.
+        XCTAssertEqual(headerA.bounds.width, columnDriverA.bounds.width, accuracy: 0.5)
+        XCTAssertEqual(shortA.bounds.width, columnDriverA.bounds.width, accuracy: 0.5)
+
+        // All column-B cells share one (different) width.
+        XCTAssertEqual(headerB.bounds.width, columnDriverB.bounds.width, accuracy: 0.5)
+        XCTAssertGreaterThan(columnDriverA.bounds.width, columnDriverB.bounds.width,
+                             "Columns are content-informed, not fixed equal widths")
+
+        // The empty cell keeps column B's shared width. Identify it as the one
+        // cell with empty text, then verify its x-position matches column B's
+        // driver (same column band).
+        let emptyCell = try XCTUnwrap(cells.first { $0.attributedText.string.isEmpty })
+        XCTAssertEqual(emptyCell.bounds.width, columnDriverB.bounds.width, accuracy: 0.5,
+                       "Empty cells must occupy the full shared column width")
+        let columnBBand = columnDriverB.frame.minX...columnDriverB.frame.maxX
+        XCTAssertTrue(columnBBand.contains(emptyCell.frame.minX),
+                      "The empty cell must sit in the same column band as its column driver")
+
+        // Dividers align because every cell in a column has equal width: the
+        // right edges of column A's cells across different rows must agree.
+        let rightEdges = [headerA, shortA, columnDriverA].map { $0.frame.maxX }
+        XCTAssertEqual((rightEdges.max() ?? 0) - (rightEdges.min() ?? 0), 0, accuracy: 1,
+                       "Column boundaries must not shift between rows")
+
+        // Selection machinery stays attached to shared-width cells.
+        XCTAssertTrue(cells.allSatisfy { cell in
+            cell.gestureRecognizers?.contains { $0 is MarkdownSelectionObserverGestureRecognizer } == true
+        }, "Table cells must keep the cross-block selection observer attached")
+
+        window.isHidden = true
+    }
+
+    /// A long cell wraps at its shared column width and stays fully visible
+    /// vertically; short cells in the same column keep the column width.
+    @MainActor
+    func testLongCellWrapsAtSharedColumnWidthAndStaysFullyVisible() throws {
+        let longText = (0..<30).map { "Word\($0)" }.joined(separator: " ")
+        let source = """
+        | Item | Details |
+        |---|---|
+        | Short | \(longText) |
+        | Also short | tiny |
+        """
+        let (host, window) = renderedTableHost(source: source)
+
+        let cells = allTextViews(in: host.view)
+        let longCell = try XCTUnwrap(cells.first { $0.attributedText.string.contains("Word29") })
+        let headerDetails = try XCTUnwrap(cells.first { $0.attributedText.string == "Details" })
+        let tinyCell = try XCTUnwrap(cells.first { $0.attributedText.string == "tiny" })
+
+        // Shared width: header, long cell, and the short cell below all equal.
+        XCTAssertEqual(longCell.bounds.width, headerDetails.bounds.width, accuracy: 0.5)
+        XCTAssertEqual(tinyCell.bounds.width, headerDetails.bounds.width, accuracy: 0.5)
+
+        // Unlimited lines and full vertical visibility at the shared width.
+        XCTAssertEqual(longCell.textContainer.maximumNumberOfLines, 0)
+        let reference = SelectableTextView.makeTextView()
+        reference.attributedText = longCell.attributedText
+        let fullWrapHeight = SelectableTextView.measuredWrappingHeight(of: reference, at: longCell.bounds.width)
+        XCTAssertGreaterThanOrEqual(longCell.bounds.height + 1, fullWrapHeight,
+                                    "Long cell must show every wrapped line at the shared column width")
+
+        window.isHidden = true
+    }
+
+    /// Wide tables stay horizontally scrollable: the table's backing scroll
+    /// view content must exceed the viewport when columns run wide.
+    @MainActor
+    func testWideTableRemainsHorizontallyScrollable() throws {
+        let source = """
+        | One | Two | Three | Four | Five |
+        |---|---|---|---|---|
+        | \(String(repeating: "first-column ", count: 6)) | \(String(repeating: "second-column ", count: 6)) | \(String(repeating: "third-column ", count: 6)) | \(String(repeating: "fourth-column ", count: 6)) | \(String(repeating: "fifth-column ", count: 6)) |
+        """
+        let (host, window) = renderedTableHost(source: source)
+
+        let scrollViews = allTextViewsDeep(in: host.view).compactMap { $0 as? UIScrollView }
+        XCTAssertTrue(
+            scrollViews.contains { $0.contentSize.width > $0.bounds.width + 10 },
+            "A table wider than the viewport must be backed by a horizontally scrollable UIScrollView"
+        )
+
+        window.isHidden = true
+    }
+
+    // MARK: - Alignment reaches the text layout
+
+    /// `:---`, `:---:`, and `---:` must produce leading, centered, and
+    /// trailing paragraph alignment on the real cell text views, and the
+    /// geometry must hold for wrapped multiline content.
+    @MainActor
+    func testMarkdownAlignmentReachesTextLayoutForSingleLineAndWrappedCells() throws {
+        let source = """
+        | Left | Center | Right |
+        |:---|:---:|---:|
+        | left text | center text | right text |
+        | wrap-left-alignment-value long enough to wrap across several lines inside its column | wrap-center-alignment-value long enough to wrap across several lines inside its column | wrap-right-alignment-value long enough to wrap across several lines inside its column |
+        """
+        let (host, window) = renderedTableHost(source: source)
+        defer { window.isHidden = true }
+
+        let cells = allTextViews(in: host.view)
+        func cell(containing marker: String) throws -> UITextView {
+            try XCTUnwrap(cells.first { $0.attributedText.string.contains(marker) })
+        }
+
+        // Paragraph style carries the alignment into the text engine.
+        for (marker, expected) in [
+            ("left text", NSTextAlignment.natural),
+            ("center text", NSTextAlignment.center),
+            ("right text", NSTextAlignment.right),
+            ("wrap-left-alignment", NSTextAlignment.natural),
+            ("wrap-center-alignment", NSTextAlignment.center),
+            ("wrap-right-alignment", NSTextAlignment.right),
+        ] {
+            let view = try cell(containing: marker)
+            let style = try XCTUnwrap(
+                view.attributedText.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+            )
+            XCTAssertEqual(style.alignment, expected, "Cell '\(marker)' must carry \(expected) paragraph alignment")
+        }
+
+        // Geometry: every laid-out line's glyph rect must sit at the aligned
+        // position within the cell. Uses the layout manager's per-line glyph
+        // bounding rects (container line fragments are always full width).
+        func assertLines(_ view: UITextView, aligned: NSTextAlignment, marker: String) throws {
+            let layoutManager = view.layoutManager
+            let glyphRange = layoutManager.glyphRange(for: view.textContainer)
+            var rects: [CGRect] = []
+            layoutManager.enumerateLineFragments(forGlyphRange: glyphRange) { _, _, _, lineGlyphRange, _ in
+                rects.append(layoutManager.boundingRect(forGlyphRange: lineGlyphRange, in: view.textContainer))
+            }
+
+            XCTAssertFalse(rects.isEmpty, "Cell '\(marker)' must lay out at least one line")
+            for rect in rects {
+                switch aligned {
+                case .center:
+                    XCTAssertEqual(rect.midX, view.bounds.width / 2, accuracy: 3,
+                                   "Centered line must be centered in cell '\(marker)'")
+                case .right:
+                    XCTAssertEqual(rect.maxX, view.bounds.width, accuracy: 3,
+                                   "Trailing line must end at the cell edge in '\(marker)'")
+                default:
+                    XCTAssertLessThanOrEqual(rect.minX, 3,
+                                             "Leading line must start at the cell edge in '\(marker)'")
+                }
+            }
+        }
+
+        try assertLines(try cell(containing: "left text"), aligned: .natural, marker: "left")
+        try assertLines(try cell(containing: "center text"), aligned: .center, marker: "center")
+        try assertLines(try cell(containing: "right text"), aligned: .right, marker: "right")
+        // Wrapped multiline cells: every wrapped line keeps the alignment.
+        try assertLines(try cell(containing: "wrap-center-alignment"), aligned: .center, marker: "wrap-center")
+        try assertLines(try cell(containing: "wrap-right-alignment"), aligned: .right, marker: "wrap-right")
+    }
+
+    // MARK: - Helpers
+
+    @MainActor
+    private func renderedTableHost(source: String) -> (UIHostingController<MarkdownText>, UIWindow) {
+        let host = UIHostingController(rootView: MarkdownText(source: source))
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.isHidden = false
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+        return (host, window)
+    }
+
+    private func allTextViews(in view: UIView) -> [UITextView] {
+        allTextViewsDeep(in: view).compactMap { $0 as? UITextView }
+    }
+
+    private func allTextViewsDeep(in view: UIView) -> [UIView] {
+        view.subviews.flatMap { [$0] + allTextViewsDeep(in: $0) }
+    }
+}

--- a/ConduitTests/MarkdownTableLayoutTests.swift
+++ b/ConduitTests/MarkdownTableLayoutTests.swift
@@ -4,7 +4,85 @@ import SwiftUI
 @testable import Conduit
 
 final class MarkdownTableLayoutTests: XCTestCase {
-    // MARK: - Table-wide column widths (unit)
+    // MARK: - Responsive width policy (pure distribution step)
+
+    /// When the capped columns fit the available width, each column keeps its
+    /// ideal width — genuinely narrow columns stay narrow.
+    func testResolveKeepsIdealWidthsWhenTableFits() {
+        let widths = MarkdownTableLayout.resolveColumnContentWidths(
+            ideals: [140, 125, 30],
+            availableWidth: 390
+        )
+        XCTAssertEqual(widths, [140, 125, 30])
+    }
+
+    /// Over-long content caps at the max column width and wraps there.
+    func testResolveCapsWideColumns() {
+        let widths = MarkdownTableLayout.resolveColumnContentWidths(
+            ideals: [900],
+            availableWidth: 390
+        )
+        XCTAssertEqual(widths, [MarkdownTableLayout.maxColumnContentWidth])
+    }
+
+    /// Overflowing tables shrink columns proportionally to their excess above
+    /// the floor; wide columns give up more, narrow ones may not shrink.
+    func testResolveShrinksProportionallyToExcess() {
+        // overhead for 3 columns = 3×20 + 2×1 + 2 = 64 → available 236
+        // total 295, deficit 59; shrinkable = 76 + 61 + 0 = 137 → factor ≈ 0.43
+        let widths = MarkdownTableLayout.resolveColumnContentWidths(
+            ideals: [140, 125, 30],
+            availableWidth: 300
+        )
+        // Wide columns shrank; the already-narrow column is untouched.
+        XCTAssertLessThan(widths[0], 140)
+        XCTAssertLessThan(widths[1], 125)
+        XCTAssertEqual(widths[2], 30, "Columns below the floor must not shrink")
+        XCTAssertGreaterThan(widths[0], widths[1], "Wider columns keep proportionally more space")
+        // Sum fits the available content width (allow half-point rounding).
+        let overhead: CGFloat = 3 * 20 + 2 * 1 + 2
+        XCTAssertLessThanOrEqual(widths.reduce(0, +), 300 - overhead + 1.5)
+    }
+
+    /// A genuinely wide table: everything compressible hits the floor and the
+    /// table keeps horizontal scrolling rather than crushing to nothing.
+    func testResolveFallsToFloorAndScrollsWhenDeficitExceedsShrinkable() {
+        let widths = MarkdownTableLayout.resolveColumnContentWidths(
+            ideals: [500, 500, 500, 500, 500],
+            availableWidth: 390
+        )
+        XCTAssertEqual(widths, [64, 64, 64, 64, 64])
+        XCTAssertEqual(widths[0], MarkdownTableLayout.shrinkFloorContentWidth)
+        let overhead: CGFloat = 5 * 20 + 4 * 1 + 2
+        XCTAssertGreaterThan(widths.reduce(0, +) + overhead, 390,
+                             "At the floor the table still overflows and must scroll")
+    }
+
+    /// Unknown viewport (first layout pass): deterministic cap-and-scroll
+    /// layout until the real width arrives.
+    func testResolveWithUnknownWidthUsesCappedWidths() {
+        let widths = MarkdownTableLayout.resolveColumnContentWidths(
+            ideals: [900, 30],
+            availableWidth: 0
+        )
+        XCTAssertEqual(widths, [MarkdownTableLayout.maxColumnContentWidth, 30])
+    }
+
+    /// Dynamic Type proxy: larger text metrics grow the ideal widths, and the
+    /// resolved layout recomputes (fit → shrink as the same content gets
+    /// wider relative to the viewport).
+    func testResolveRecomputesWhenContentMetricsGrow() {
+        let ideals: [CGFloat] = [100, 80]
+        let scaled = ideals.map { $0 * 1.4 } // larger Dynamic Type → wider text
+
+        XCTAssertEqual(MarkdownTableLayout.resolveColumnContentWidths(ideals: ideals, availableWidth: 320), [100, 80])
+        let resolvedScaled = MarkdownTableLayout.resolveColumnContentWidths(ideals: scaled, availableWidth: 250)
+        // Same viewport, wider content: the columns now compress instead of fitting.
+        XCTAssertLessThan(resolvedScaled[0], scaled[0])
+        XCTAssertLessThan(resolvedScaled[1], scaled[1])
+    }
+
+    // MARK: - Table-wide shared widths from real content
 
     /// One width per column, driven by the longest cell anywhere in that
     /// column — header included — so rows with the longest value in
@@ -12,7 +90,7 @@ final class MarkdownTableLayoutTests: XCTestCase {
     @MainActor
     func testColumnWidthsAreSharedAcrossRowsAndHeaderParticipates() {
         let headers = ["A", "B", "C"]
-        // Drivers sized to land mid-range (no clamp): each column's longest
+        // Drivers sized to land mid-range (no cap): each column's longest
         // value lives in a different row.
         let rows = [
             ["short", "column-two-driver-here", "ok"],
@@ -20,41 +98,102 @@ final class MarkdownTableLayoutTests: XCTestCase {
             ["tiny", "", "x"],
         ]
 
-        let widths = MarkdownTableLayout.columnWidths(headers: headers, rows: rows)
+        let widths = MarkdownTableLayout.columnWidths(headers: headers, rows: rows, availableWidth: 390)
 
         XCTAssertEqual(widths.count, 3)
-        for width in widths {
-            XCTAssertTrue(MarkdownTableLayout.columnWidthRange.contains(width),
-                          "Column width \(width) must stay inside the table column policy")
-        }
         // Content-informed, not equal-width: A's longest value is longer than
-        // B's, which is longer than C's clamp floor.
+        // B's, which is longer than C's tiny value — and the tiny column is
+        // allowed to stay genuinely narrow.
         XCTAssertGreaterThan(widths[0], widths[1])
         XCTAssertGreaterThan(widths[1], widths[2])
+        XCTAssertLessThan(widths[2], MarkdownTableLayout.shrinkFloorContentWidth,
+                          "A tiny column must not be forced to the old 112pt floor")
+        for width in widths {
+            XCTAssertLessThanOrEqual(width, MarkdownTableLayout.maxColumnContentWidth)
+        }
     }
 
+    // MARK: - Rendered fixtures (full MarkdownText view chain)
+
+    /// QA fixture: three tiny columns fit an iPhone viewport with no
+    /// horizontal overflow.
     @MainActor
-    func testColumnWidthsClampToPolicyBounds() {
-        let narrow = MarkdownTableLayout.columnWidths(
-            headers: ["a", "b"],
-            rows: [["x", ""]]
-        )
-        XCTAssertTrue(narrow.allSatisfy { $0 == MarkdownTableLayout.columnWidthRange.lowerBound },
-                      "Short/empty columns clamp to the minimum column width")
+    func testTinyThreeColumnTableFitsViewportWithoutHorizontalScrolling() throws {
+        let source = """
+        | A | B | C |
+        |---|---|---|
+        | 1 | 2 | 3 |
+        """
+        let (host, window) = renderedTableHost(source: source)
+        defer { window.isHidden = true }
 
-        let wide = MarkdownTableLayout.columnWidths(
-            headers: ["a"],
-            rows: [[String(repeating: "very-long-value ", count: 30)]]
-        )
-        XCTAssertEqual(wide[0], MarkdownTableLayout.columnWidthRange.upperBound,
-                       "Over-long content clamps to the max width and wraps there")
+        let cells = allTextViews(in: host.view)
+        XCTAssertEqual(cells.count, 6, "3 headers + 1 row × 3 columns")
+
+        // No cell is anywhere near the old 112pt floor.
+        XCTAssertTrue(cells.allSatisfy { $0.bounds.width < MarkdownTableLayout.shrinkFloorContentWidth + 20 },
+                      "Tiny columns must stay narrow")
+
+        // The table fits: the horizontal scroll view has no overflow.
+        let scrollViews = allTextViewsDeep(in: host.view).compactMap { $0 as? UIScrollView }
+        let tableScroll = try XCTUnwrap(scrollViews.first)
+        XCTAssertLessThanOrEqual(tableScroll.contentSize.width, tableScroll.bounds.width + 0.5,
+                                 "A tiny table must not need horizontal scrolling")
     }
 
-    // MARK: - Shared widths + wrap + scroll through the real view chain
+    /// QA fixture: a genuinely narrow status column beside a long description
+    /// column — status stays narrow, description gets the wide share, and the
+    /// table fits without scrolling.
+    @MainActor
+    func testNarrowStatusColumnBesideLongDescriptionColumnFits() throws {
+        let source = """
+        | Status | Description |
+        |---|---|
+        | OK | \(String(repeating: "a long description of the thing ", count: 3)) |
+        | Retry | short |
+        """
+        let (host, window) = renderedTableHost(source: source)
+        defer { window.isHidden = true }
 
-    /// Renders a real table and asserts every cell in a column — header,
-    /// long driver cells, short cells, and an empty cell — has the same
-    /// rendered width, which is what keeps dividers aligned down the table.
+        let cells = allTextViews(in: host.view)
+        let statusCell = try XCTUnwrap(cells.first { $0.attributedText.string == "Retry" })
+        let descriptionCell = try XCTUnwrap(cells.first { $0.attributedText.string.contains("a long description") })
+        let descriptionHeader = try XCTUnwrap(cells.first { $0.attributedText.string == "Description" })
+
+        XCTAssertLessThan(statusCell.bounds.width, MarkdownTableLayout.shrinkFloorContentWidth + 10,
+                          "The narrow status column must stay narrow")
+        XCTAssertGreaterThan(descriptionCell.bounds.width, statusCell.bounds.width * 2,
+                             "The long description column gets proportionally more space")
+        XCTAssertEqual(descriptionCell.bounds.width, descriptionHeader.bounds.width, accuracy: 0.5)
+        XCTAssertLessThanOrEqual(descriptionCell.bounds.width, MarkdownTableLayout.maxColumnContentWidth)
+
+        let scrollViews = allTextViewsDeep(in: host.view).compactMap { $0 as? UIScrollView }
+        let tableScroll = try XCTUnwrap(scrollViews.first)
+        XCTAssertLessThanOrEqual(tableScroll.contentSize.width, tableScroll.bounds.width + 0.5,
+                                 "This table fits the viewport and must not scroll horizontally")
+    }
+
+    /// QA fixture: a genuinely wide table still scrolls horizontally.
+    @MainActor
+    func testWideTableRemainsHorizontallyScrollable() throws {
+        let source = """
+        | One | Two | Three | Four | Five |
+        |---|---|---|---|---|
+        | \(String(repeating: "first-column ", count: 6)) | \(String(repeating: "second-column ", count: 6)) | \(String(repeating: "third-column ", count: 6)) | \(String(repeating: "fourth-column ", count: 6)) | \(String(repeating: "fifth-column ", count: 6)) |
+        """
+        let (host, window) = renderedTableHost(source: source)
+        defer { window.isHidden = true }
+
+        let scrollViews = allTextViewsDeep(in: host.view).compactMap { $0 as? UIScrollView }
+        XCTAssertTrue(
+            scrollViews.contains { $0.contentSize.width > $0.bounds.width + 10 },
+            "A table wider than the viewport must be backed by a horizontally scrollable UIScrollView"
+        )
+    }
+
+    /// Shared column widths through the real chain: every cell in a column —
+    /// header, long driver cells, short cells, and an empty cell — renders at
+    /// the same width, keeping dividers aligned down the table.
     @MainActor
     func testRenderedTableSharesColumnWidthsAcrossRowsIncludingEmptyCells() throws {
         let source = """
@@ -65,12 +204,11 @@ final class MarkdownTableLayoutTests: XCTestCase {
         | a |  | c |
         """
         let (host, window) = renderedTableHost(source: source)
+        defer { window.isHidden = true }
 
         let cells = allTextViews(in: host.view)
         XCTAssertEqual(cells.count, 12, "3 headers + 3 rows × 3 columns")
 
-        // Map marker → view. Markers identify every non-empty cell; the empty
-        // cell is found by elimination.
         func cell(containing marker: String) throws -> UITextView {
             for candidate in cells where candidate.attributedText.string.contains(marker) {
                 return candidate
@@ -115,8 +253,6 @@ final class MarkdownTableLayoutTests: XCTestCase {
         XCTAssertTrue(cells.allSatisfy { cell in
             cell.gestureRecognizers?.contains { $0 is MarkdownSelectionObserverGestureRecognizer } == true
         }, "Table cells must keep the cross-block selection observer attached")
-
-        window.isHidden = true
     }
 
     /// A long cell wraps at its shared column width and stays fully visible
@@ -131,6 +267,7 @@ final class MarkdownTableLayoutTests: XCTestCase {
         | Also short | tiny |
         """
         let (host, window) = renderedTableHost(source: source)
+        defer { window.isHidden = true }
 
         let cells = allTextViews(in: host.view)
         let longCell = try XCTUnwrap(cells.first { $0.attributedText.string.contains("Word29") })
@@ -148,31 +285,7 @@ final class MarkdownTableLayoutTests: XCTestCase {
         let fullWrapHeight = SelectableTextView.measuredWrappingHeight(of: reference, at: longCell.bounds.width)
         XCTAssertGreaterThanOrEqual(longCell.bounds.height + 1, fullWrapHeight,
                                     "Long cell must show every wrapped line at the shared column width")
-
-        window.isHidden = true
     }
-
-    /// Wide tables stay horizontally scrollable: the table's backing scroll
-    /// view content must exceed the viewport when columns run wide.
-    @MainActor
-    func testWideTableRemainsHorizontallyScrollable() throws {
-        let source = """
-        | One | Two | Three | Four | Five |
-        |---|---|---|---|---|
-        | \(String(repeating: "first-column ", count: 6)) | \(String(repeating: "second-column ", count: 6)) | \(String(repeating: "third-column ", count: 6)) | \(String(repeating: "fourth-column ", count: 6)) | \(String(repeating: "fifth-column ", count: 6)) |
-        """
-        let (host, window) = renderedTableHost(source: source)
-
-        let scrollViews = allTextViewsDeep(in: host.view).compactMap { $0 as? UIScrollView }
-        XCTAssertTrue(
-            scrollViews.contains { $0.contentSize.width > $0.bounds.width + 10 },
-            "A table wider than the viewport must be backed by a horizontally scrollable UIScrollView"
-        )
-
-        window.isHidden = true
-    }
-
-    // MARK: - Alignment reaches the text layout
 
     /// `:---`, `:---:`, and `---:` must produce leading, centered, and
     /// trailing paragraph alignment on the real cell text views, and the
@@ -246,12 +359,21 @@ final class MarkdownTableLayoutTests: XCTestCase {
 
     // MARK: - Helpers
 
+    /// Hosts the markdown and lets the width probe settle: the probe's state
+    /// update lands a frame after the first layout pass, so pump the runloop
+    /// and lay out again before asserting geometry.
     @MainActor
     private func renderedTableHost(source: String) -> (UIHostingController<MarkdownText>, UIWindow) {
         let host = UIHostingController(rootView: MarkdownText(source: source))
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
         window.rootViewController = host
         window.isHidden = false
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+
+        let settled = XCTestExpectation(description: "width probe settles")
+        DispatchQueue.main.async { settled.fulfill() }
+        wait(for: [settled], timeout: 2)
         host.view.setNeedsLayout()
         host.view.layoutIfNeeded()
         return (host, window)

--- a/ConduitTests/MarkdownTableLayoutTests.swift
+++ b/ConduitTests/MarkdownTableLayoutTests.swift
@@ -298,7 +298,9 @@ final class MarkdownTableLayoutTests: XCTestCase {
         let columnDriverB = try cell(containing: "col-two-driver")
         let headerA = try cell(containing: "ColA")
         let headerB = try cell(containing: "ColB")
-        let shortA = try cell(containing: "aaa")
+        // Exact match: the substring "aaa" also occurs in "aaaa-column-one-driver".
+        let shortA = try XCTUnwrap(cells.first { $0.attributedText.string == "aaa" },
+                                   "The lone short column-A cell must be findable by exact text")
         let shortB2 = try XCTUnwrap(cells.first { $0.attributedText.string == "b" },
                                     "The lone short column-B cell must be findable by exact text")
 
@@ -400,9 +402,12 @@ final class MarkdownTableLayoutTests: XCTestCase {
             XCTAssertEqual(style.alignment, expected, "Cell '\(marker)' must carry \(expected) paragraph alignment")
         }
 
-        // Geometry: every laid-out line's glyph rect must sit at the aligned
-        // position within the cell. Uses the layout manager's per-line glyph
-        // bounding rects (container line fragments are always full width).
+        // Geometry smoke check: every laid-out line's glyph rect sits at the
+        // aligned position. Accessing `layoutManager` switches this test view
+        // into TextKit-1 compatibility mode, so this measures compat layout —
+        // an end-to-end sanity signal, not a TextKit-2-faithful measurement.
+        // The paragraph-style assertions above are the production contract;
+        // don't grow this block.
         func assertLines(_ view: UITextView, aligned: NSTextAlignment, marker: String) throws {
             let layoutManager = view.layoutManager
             let glyphRange = layoutManager.glyphRange(for: view.textContainer)


### PR DESCRIPTION
Continues the Markdown-table work from #73 (merged at `5845ddc`): the remaining QA layout bugs whose commits landed on the old branch after it was merged. Rebased cleanly onto current main (incl. #75 reference links); all markdown-suite tests pass on the combined state.

## User-visible symptoms (from QA)

1. **Column dividers shifted horizontally between rows** — each row sized its own columns, so vertical boundaries didn't line up down the table.
2. **`:---:` / `---:` alignment was parsed but rendered left-aligned everywhere.**
3. **Even trivial three-column tables forced horizontal scrolling on iPhone** — the 112pt per-column minimum (a measurement artifact, not a table semantic) made three columns need ~396pt with padding.

## Fixes

**Shared column widths:** `MarkdownTableLayout` derives one width per column for the entire table — the largest ideal (unwrapped) text width among that column's header and body cells — and every cell in the column renders at exactly that width (`.frame(width:)` + single-value self-sizing range), so dividers align. Wider content wraps within the shared column.

**Alignment reaches the text engine:** the parsed alignment flows `MarkdownTable → InlineMarkdown → SelectableTextView.textAlignment` into the paragraph style, so center/trailing hold for single-line *and* wrapped multiline content. `.natural` default leaves every other caller unchanged.

**Responsive width policy:** a zero-height probe reads the chat's proposed width; the pure `resolveColumnContentWidths(ideals:availableWidth:)` step then decides:
- capped columns (≤220pt) that fit the chat width → table fits, narrow columns stay genuinely narrow, wide columns keep proportionally more space;
- on overflow, columns shrink proportionally to their excess above a 64pt floor (already-narrow columns don't shrink) and wrap at the resolved width;
- still overflowing at the floor → horizontal scrolling, as before;
- cell padding, dividers, and border subtract from available width exactly once;
- cell heights measure at the final resolved shared column content width, preserving #73's deterministic first-pass/full-height guarantee.

**Reference-aware measurement:** table cells can contain message-level reference-style links (#75). The exact inline-attributed-string construction `InlineMarkdown` renders is extracted into `InlineMarkdownContent.attributed(source:references:)` and used for both rendering and column-width measurement, with `MarkdownTable` threading the injected `\.markdownReferences` environment into `MarkdownTableLayout` (cache keys on the definitions). A `[Handbook][1]` cell now measures as `Handbook`, so widths and rendered content cannot diverge.

## Scrolling policy

Fit when the content allows; scroll horizontally only when it doesn't. Cells expand vertically without nested scrolling; the outer chat scroll owns vertical scrolling.

## Regression coverage

New `MarkdownTableLayoutTests` (15): pure policy unit tests (fit keeps ideals, cap, proportional shrink, floor-and-scroll, unknown-width fallback, content-metric growth recompute, reference-link measured at its resolved label) plus rendered fixtures through the real `MarkdownText` chain — tiny three-column table fits without scrolling; narrow status + long description fits with proportional shared widths; wide five-column table still scrolls; identical column widths/divider edges across header/short/empty cells; long cell wraps fully at its shared width; per-line glyph-rect geometry proves leading/center/trailing for single-line and wrapped cells; selection observers stay attached; reference-link column sized identically to a literal-label table with the URL attribute intact. The existing 28 `ChatTextSelectionTests` and 32 `MarkdownSelectionCoordinatorTests` pass unchanged.

## Validation

75/75 across the three markdown suites on the rebased branch (includes #75's reference-link changes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Markdown table layout with content-aware column sizing and consistent alignment.
  * Wide tables now shrink proportionally when possible and retain horizontal scrolling when needed.
  * Selectable text supports consistent alignment across rendered content.

* **Bug Fixes**
  * Improved text wrapping, divider alignment, link rendering, and selection behavior in Markdown tables.
  * Improved table display across different screen sizes and Dynamic Type settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->