### PR TITLE
Add preferred return surface: open to sessions

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -1091,6 +1091,16 @@ final class AppState: ObservableObject {
         requestPreferredReturnSurface()
     }
 
+    /// Auth teardown (sign-out) is not a qualifying return. Retire any
+    /// outstanding preferred-return request at the boundary — claimed,
+    /// unclaimed, or deferred — so a MainView recreated on the next sign-in
+    /// can never present a stale request. The monotonic counter is left
+    /// untouched; only the consumed watermark advances.
+    private func retireOutstandingPreferredReturnSurfaceRequests() {
+        consumedReturnSurfaceRequest = max(consumedReturnSurfaceRequest, preferredReturnSurfaceRequest)
+        deferredReturnSurfaceRequest = nil
+    }
+
     /// Claims the pending preferred-return-surface request for presentation.
     /// Returns true exactly once per issued request — the watermark lives in
     /// AppState, so a MainView recreated after sign-out/sign-in can never
@@ -1937,6 +1947,7 @@ final class AppState: ObservableObject {
         isVoiceEnabled = false
         voiceTranscriptionMode = .hermes
         appleSpeechAvailability = AppleOnDeviceSpeechTranscriber.currentAvailability()
+        retireOutstandingPreferredReturnSurfaceRequests()
         showLogin = true
         sessions = []
         archivedSessions = []
@@ -2057,6 +2068,7 @@ final class AppState: ObservableObject {
         projectsLoading = false
         KeychainHelper.clearConnection()
         turnState = .idle
+        retireOutstandingPreferredReturnSurfaceRequests()
         showLogin = true
         errorMessage = message
     }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -372,6 +372,13 @@ final class AppState: ObservableObject {
     @Published private(set) var activeSessionTitle = "New conversation"
     @Published private(set) var isChatRefreshing = false
     @Published private(set) var chatResumeBehavior: ChatResumeBehavior = .continueWhereLeftOff
+    @Published private(set) var chatReturnSurface: ChatReturnSurface = .conversation
+    /// One-shot request for MainView to present the sessions drawer as the
+    /// preferred return surface. MainView consumes the latest value once per
+    /// increment; the request is only issued for qualifying returns (cold
+    /// launch or a real background → active transition) when the preference
+    /// is `.sessions` and no explicit navigation or modal owns the surface.
+    @Published private(set) var preferredReturnSurfaceRequest: UInt64 = 0
     @Published private(set) var chatResumeRestorationRequest: ChatResumeRestorationRequest?
     @Published private(set) var chatViewportTransitionGeneration: UInt64 = 0
     /// Keeps the current transcript visible while a notification destination is
@@ -474,6 +481,9 @@ final class AppState: ObservableObject {
     @Published var showGatewaySheet = false
     @Published var showAgentsSheet = false
     @Published var showVoiceSheet = false
+    /// Mirrors MainView's Settings sheet item so return-surface decisions can
+    /// tell whether Settings owns the surface across a background/foreground cycle.
+    @Published var isSettingsSheetPresented = false
     @Published var errorMessage: String?
     @Published var showLogin = true
     @Published private(set) var composerPrefillText = ""
@@ -581,6 +591,10 @@ final class AppState: ObservableObject {
     private var responseHaptics = ResponseHapticState()
     private var scenePhaseTask: Task<Void, Never>?
     private var scenePhaseAttemptID: UUID?
+    /// Armed only by a real .background phase. Ordinary inactive → active
+    /// transitions (Control Center, incoming-call banner) must not be treated
+    /// as reopening the app, so they never arm the preferred return surface.
+    private var hasEnteredBackgroundScenePhase = false
     private var explicitSessionOpenTask: Task<Bool, Never>?
     private var explicitSessionOpenRequestID: UUID?
     private var activeAutomaticChatResumeWork: ChatResumeAutomaticWorkToken?
@@ -784,6 +798,9 @@ final class AppState: ObservableObject {
     // MARK: - Persistence
 
     private let defaults: UserDefaults
+    /// Kept outside ChatResumeStore on purpose: the return surface is a
+    /// presentation preference, not part of the resume schema.
+    static let chatReturnSurfaceKey = "conduit.chatReturnSurface.v1"
     private let activeSessionTitlesByProfileKey = "conduit.activeSessionTitlesByProfile.v1"
     private let pinnedSessionIDsByProfileKey = "conduit.pinnedSessionIdsByProfile.v1"
     private let activeProfileKey = "conduit.activeProfile"
@@ -874,6 +891,8 @@ final class AppState: ObservableObject {
             ?? defaults.string(forKey: "conduit.dashboardURL")
                 .flatMap(Self.normalizedChatResumeServerIdentity)
         chatResumeBehavior = self.chatResumeCoordinator.behavior
+        chatReturnSurface = defaults.string(forKey: Self.chatReturnSurfaceKey)
+            .flatMap(ChatReturnSurface.init(rawValue:)) ?? .conversation
         defaultProfileName = ProfileAppearanceStore.loadDefaultName()
         profileAvatarURLs = ProfileAppearanceStore.loadAvatarURLs()
         appIconChoice = UIApplication.shared.alternateIconName == AppIconChoice.light.alternateIconName ? .light : .dark
@@ -1015,6 +1034,33 @@ final class AppState: ObservableObject {
         recoverySequence.preserveTransportAfterAutomaticIntentCancellation()
         chatResumeBehavior = chatResumeCoordinator.behavior
         chatResumeRestorationRequest = nil
+    }
+
+    /// True when any presented sheet owns the surface other than the sessions
+    /// drawer itself. Explicit navigation and existing modals take precedence
+    /// over the preferred return surface.
+    var isModalSheetPresented: Bool {
+        showModelPicker || showContextSheet || showWorkspaceSheet || showGatewaySheet
+            || showAgentsSheet || showVoiceSheet || isSettingsSheetPresented
+    }
+
+    /// Persisted separately from the resume store: this only changes which
+    /// surface is presented first on a qualifying return, and deliberately
+    /// issues no presentation request — the next qualifying return picks it up.
+    func setChatReturnSurface(_ surface: ChatReturnSurface) {
+        guard surface != chatReturnSurface else { return }
+        chatReturnSurface = surface
+        defaults.set(surface.rawValue, forKey: Self.chatReturnSurfaceKey)
+    }
+
+    /// Issues a one-shot preferred-return-surface request. Suppressed when a
+    /// notification destination is being opened or a modal sheet already owns
+    /// the surface; MainView re-checks at presentation time as a backstop.
+    func requestPreferredReturnSurface() {
+        guard chatReturnSurface == .sessions else { return }
+        guard !isOpeningNotificationSession else { return }
+        guard !isModalSheetPresented else { return }
+        preferredReturnSurfaceRequest &+= 1
     }
 
     func recordChatViewport(_ snapshot: ChatScrollSnapshot, for key: ChatScrollSessionKey) {
@@ -1523,6 +1569,7 @@ final class AppState: ObservableObject {
             theme: themePreference,
             busyInputMode: busyInputMode,
             chatResumeBehavior: chatResumeBehavior,
+            chatReturnSurface: chatReturnSurface,
             displayPreferences: displayPreferences,
             cloudflareAccess: KeychainHelper.loadCloudflareAccess(for: connection?.baseUrl)
         )
@@ -3701,6 +3748,14 @@ final class AppState: ObservableObject {
         case .active:
             isSceneActive = true
             voiceConversationController.setForegroundActive(true)
+            // Issue before the transport work below: MainView presents the
+            // drawer while the automatic resume sync restores the chat
+            // underneath, and explicit navigation still wins via the
+            // suppression guards on both sides.
+            if hasEnteredBackgroundScenePhase {
+                hasEnteredBackgroundScenePhase = false
+                requestPreferredReturnSurface()
+            }
             guard connection != nil else { return nil }
             cancelScenePhaseAttempt()
             // Publish the foreground reconciliation boundary synchronously.
@@ -3759,6 +3814,7 @@ final class AppState: ObservableObject {
 
         case .background:
             isSceneActive = false
+            hasEnteredBackgroundScenePhase = true
             voiceConversationController.setForegroundActive(false)
             showVoiceSheet = false
             // Drop any armed reconnect timer as well: in-flight cycles abort

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -595,6 +595,7 @@ final class AppState: ObservableObject {
     /// transitions (Control Center, incoming-call banner) must not be treated
     /// as reopening the app, so they never arm the preferred return surface.
     private var hasEnteredBackgroundScenePhase = false
+    private var hasRequestedColdLaunchReturnSurface = false
     private var explicitSessionOpenTask: Task<Bool, Never>?
     private var explicitSessionOpenRequestID: UUID?
     private var activeAutomaticChatResumeWork: ChatResumeAutomaticWorkToken?
@@ -1061,6 +1062,15 @@ final class AppState: ObservableObject {
         guard !isOpeningNotificationSession else { return }
         guard !isModalSheetPresented else { return }
         preferredReturnSurfaceRequest &+= 1
+    }
+
+    /// MainView's first authenticated appearance in this process is the
+    /// cold-launch return. Mid-process re-entries (disconnect → sign back
+    /// in) are not cold launches; they rely on the scene-phase path.
+    func requestPreferredReturnSurfaceForColdLaunch() {
+        guard !hasRequestedColdLaunchReturnSurface else { return }
+        hasRequestedColdLaunchReturnSurface = true
+        requestPreferredReturnSurface()
     }
 
     func recordChatViewport(_ snapshot: ChatScrollSnapshot, for key: ChatScrollSessionKey) {
@@ -3748,15 +3758,19 @@ final class AppState: ObservableObject {
         case .active:
             isSceneActive = true
             voiceConversationController.setForegroundActive(true)
-            // Issue before the transport work below: MainView presents the
-            // drawer while the automatic resume sync restores the chat
-            // underneath, and explicit navigation still wins via the
-            // suppression guards on both sides.
-            if hasEnteredBackgroundScenePhase {
-                hasEnteredBackgroundScenePhase = false
+            // Consume the background arming even while signed out, so a
+            // background → active cycle on the login screen doesn't surface
+            // a stale request after the user signs back in.
+            let didReturnFromBackground = hasEnteredBackgroundScenePhase
+            hasEnteredBackgroundScenePhase = false
+            guard connection != nil else { return nil }
+            // The preferred return surface belongs to the authenticated
+            // app: MainView presents the drawer while the automatic resume
+            // sync restores the chat underneath, and explicit navigation
+            // still wins via the suppression guards on both sides.
+            if didReturnFromBackground {
                 requestPreferredReturnSurface()
             }
-            guard connection != nil else { return nil }
             cancelScenePhaseAttempt()
             // Publish the foreground reconciliation boundary synchronously.
             // ChatView may receive the same scene transition before the health

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -596,6 +596,11 @@ final class AppState: ObservableObject {
     /// as reopening the app, so they never arm the preferred return surface.
     private var hasEnteredBackgroundScenePhase = false
     private var hasRequestedColdLaunchReturnSurface = false
+    /// Presentation watermark for the preferred return surface: how far
+    /// through `preferredReturnSurfaceRequest` MainView has consumed, kept
+    /// here (not in view state) so it survives MainView teardown on sign-out.
+    private var consumedReturnSurfaceRequest: UInt64 = 0
+    private var deferredReturnSurfaceRequest: UInt64?
     private var explicitSessionOpenTask: Task<Bool, Never>?
     private var explicitSessionOpenRequestID: UUID?
     private var activeAutomaticChatResumeWork: ChatResumeAutomaticWorkToken?
@@ -1084,6 +1089,35 @@ final class AppState: ObservableObject {
         guard !hasRequestedColdLaunchReturnSurface else { return }
         hasRequestedColdLaunchReturnSurface = true
         requestPreferredReturnSurface()
+    }
+
+    /// Claims the pending preferred-return-surface request for presentation.
+    /// Returns true exactly once per issued request — the watermark lives in
+    /// AppState, so a MainView recreated after sign-out/sign-in can never
+    /// re-present an already-claimed request.
+    ///
+    /// Consumption semantics: while explicit navigation is pending the claim
+    /// defers without consuming; the next unblocked claim of the same request
+    /// then drops it, because the explicit route fully won that qualifying
+    /// return. In-flight notification opens, modals, and preference changes
+    /// consume-and-drop immediately (established precedence losers).
+    func claimPreferredReturnSurfacePresentation() -> Bool {
+        let current = preferredReturnSurfaceRequest
+        guard current > consumedReturnSurfaceRequest else { return false }
+        if hasPendingExplicitNavigation {
+            deferredReturnSurfaceRequest = current
+            return false
+        }
+        defer { deferredReturnSurfaceRequest = nil }
+        if deferredReturnSurfaceRequest == current {
+            consumedReturnSurfaceRequest = current
+            return false
+        }
+        consumedReturnSurfaceRequest = current
+        guard chatReturnSurface == .sessions,
+              !isOpeningNotificationSession,
+              !isModalSheetPresented else { return false }
+        return true
     }
 
     func recordChatViewport(_ snapshot: ChatScrollSnapshot, for key: ChatScrollSessionKey) {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -1045,6 +1045,17 @@ final class AppState: ObservableObject {
             || showAgentsSheet || showVoiceSheet || isSettingsSheetPresented
     }
 
+    /// True when an explicit destination exists but has not been routed yet
+    /// (a notification tap or voice intent recorded before the app was
+    /// connected). Routing services own this fact; only the read lives here,
+    /// mirroring how syncSession already defers to a pending notification
+    /// target. Explicit navigation outranks the preferred return surface from
+    /// the moment the destination exists, not just once routing starts.
+    var hasPendingExplicitNavigation: Bool {
+        PushNotificationService.shared.pendingTarget != nil
+            || PendingVoiceIntentStore.shared.hasPendingIntent
+    }
+
     /// Persisted separately from the resume store: this only changes which
     /// surface is presented first on a qualifying return, and deliberately
     /// issues no presentation request — the next qualifying return picks it up.
@@ -1054,11 +1065,13 @@ final class AppState: ObservableObject {
         defaults.set(surface.rawValue, forKey: Self.chatReturnSurfaceKey)
     }
 
-    /// Issues a one-shot preferred-return-surface request. Suppressed when a
-    /// notification destination is being opened or a modal sheet already owns
-    /// the surface; MainView re-checks at presentation time as a backstop.
+    /// Issues a one-shot preferred-return-surface request. Suppressed while
+    /// an explicit destination is pending or being opened, or when a modal
+    /// sheet already owns the surface; MainView re-checks at presentation
+    /// time as a backstop.
     func requestPreferredReturnSurface() {
         guard chatReturnSurface == .sessions else { return }
+        guard !hasPendingExplicitNavigation else { return }
         guard !isOpeningNotificationSession else { return }
         guard !isModalSheetPresented else { return }
         preferredReturnSurfaceRequest &+= 1

--- a/Conduit/Services/ChatReturnSurface.swift
+++ b/Conduit/Services/ChatReturnSurface.swift
@@ -7,7 +7,7 @@ import Foundation
 /// conversation is active underneath. Choosing `.sessions` still performs
 /// the normal chat resume behind the drawer; dismissing the drawer without
 /// picking another conversation reveals the restored chat.
-enum ChatReturnSurface: String, CaseIterable {
+enum ChatReturnSurface: String, CaseIterable, Hashable {
     case conversation
     case sessions
 

--- a/Conduit/Services/ChatReturnSurface.swift
+++ b/Conduit/Services/ChatReturnSurface.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// The surface Conduit presents first when returning to the app.
+///
+/// This is a presentation-layer preference only: it decides what the user
+/// sees on top, while `ChatResumeBehavior` independently decides which
+/// conversation is active underneath. Choosing `.sessions` still performs
+/// the normal chat resume behind the drawer; dismissing the drawer without
+/// picking another conversation reveals the restored chat.
+enum ChatReturnSurface: String, CaseIterable {
+    case conversation
+    case sessions
+
+    var title: String {
+        switch self {
+        case .conversation: "Conversation"
+        case .sessions: "Sessions"
+        }
+    }
+}

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -809,7 +809,11 @@ private struct ChatReturnBehaviorSettings: View {
                     }
                 }
                 .pickerStyle(.segmented)
-                .accessibilityHint("Used if you dismiss the session list without choosing another conversation.")
+                .accessibilityHint(
+                    surface == .sessions
+                        ? "Conduit opens to the session list. Used if you dismiss it without choosing another conversation."
+                        : "Conduit opens to your conversation."
+                )
                 if surface == .sessions {
                     Text("Used if you dismiss the session list without choosing another conversation.")
                         .font(.footnote)

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -111,6 +111,7 @@ struct SettingsSnapshot: Identifiable {
     let theme: ThemePreference
     let busyInputMode: BusyInputMode
     let chatResumeBehavior: ChatResumeBehavior
+    let chatReturnSurface: ChatReturnSurface
     let displayPreferences: ProfileDisplayPreferences
     let cloudflareAccess: CloudflareAccessCredentials?
 }
@@ -456,6 +457,7 @@ struct SettingsView: View {
     let saveTheme: (ThemePreference) -> Void
     let persistBusyInputMode: (BusyInputMode) async -> Bool
     let persistChatResumeBehavior: (ChatResumeBehavior) -> Void
+    let persistChatReturnSurface: (ChatReturnSurface) -> Void
     let loadProfileSettings: ([String]) async -> [String: ProfileSettingValue]
     let persistProfileSetting: (String, ProfileSettingValue) async -> Bool
     let loadProfileConfigOptions: () async -> ProfileConfigOptions
@@ -499,6 +501,8 @@ struct SettingsView: View {
                 persistBusyInputMode: persistBusyInputMode,
                 chatResumeBehavior: snapshot.chatResumeBehavior,
                 persistChatResumeBehavior: persistChatResumeBehavior,
+                chatReturnSurface: snapshot.chatReturnSurface,
+                persistChatReturnSurface: persistChatReturnSurface,
                 load: loadProfileSettings,
                 save: persistProfileSetting,
                 loadOptions: loadProfileConfigOptions
@@ -703,6 +707,8 @@ private struct ChatSettingsDetail: View {
     let persistBusyInputMode: (BusyInputMode) async -> Bool
     let chatResumeBehavior: ChatResumeBehavior
     let persistChatResumeBehavior: (ChatResumeBehavior) -> Void
+    let chatReturnSurface: ChatReturnSurface
+    let persistChatReturnSurface: (ChatReturnSurface) -> Void
     let load: ([String]) async -> [String: ProfileSettingValue]
     let save: (String, ProfileSettingValue) async -> Bool
     let loadOptions: () async -> ProfileConfigOptions
@@ -721,7 +727,9 @@ private struct ChatSettingsDetail: View {
                 VStack(spacing: 14) {
                     ChatReturnBehaviorSettings(
                         initialBehavior: chatResumeBehavior,
-                        persist: persistChatResumeBehavior
+                        persistBehavior: persistChatResumeBehavior,
+                        initialSurface: chatReturnSurface,
+                        persistSurface: persistChatReturnSurface
                     )
                     ResponseBehaviorSettings(initialMode: busyInputMode, save: persistBusyInputMode)
                 }
@@ -766,15 +774,21 @@ private struct DeviceHapticsSettings: View {
 }
 
 private struct ChatReturnBehaviorSettings: View {
-    let persist: (ChatResumeBehavior) -> Void
+    let persistBehavior: (ChatResumeBehavior) -> Void
+    let persistSurface: (ChatReturnSurface) -> Void
     @State private var behavior: ChatResumeBehavior
+    @State private var surface: ChatReturnSurface
 
     init(
         initialBehavior: ChatResumeBehavior,
-        persist: @escaping (ChatResumeBehavior) -> Void
+        persistBehavior: @escaping (ChatResumeBehavior) -> Void,
+        initialSurface: ChatReturnSurface,
+        persistSurface: @escaping (ChatReturnSurface) -> Void
     ) {
-        self.persist = persist
+        self.persistBehavior = persistBehavior
+        self.persistSurface = persistSurface
         _behavior = State(initialValue: initialBehavior)
+        _surface = State(initialValue: initialSurface)
     }
 
     var body: some View {
@@ -783,22 +797,47 @@ private struct ChatReturnBehaviorSettings: View {
             symbol: "arrow.uturn.backward.circle",
             tint: .conduitAccent
         ) {
-            Text("Stored only on this device, not in your Hermes profile. Choose whether Conduit preserves your exact reading position or follows the newest conversation.")
+            Text("Stored only on this device, not in your Hermes profile. Choose which surface Conduit opens to and whether it preserves your exact reading position or follows the newest conversation.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
-            Picker("When returning to Conduit", selection: Binding(get: { behavior }, set: choose)) {
-                Text("Continue").tag(ChatResumeBehavior.continueWhereLeftOff)
-                Text("Latest").tag(ChatResumeBehavior.latestActivity)
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Open to")
+                    .font(.subheadline.weight(.semibold))
+                Picker("Open to", selection: Binding(get: { surface }, set: chooseSurface)) {
+                    ForEach(ChatReturnSurface.allCases, id: \.self) { choice in
+                        Text(choice.title).tag(choice)
+                    }
+                }
+                .pickerStyle(.segmented)
+                if surface == .sessions {
+                    Text("Used if you dismiss the session list without choosing another conversation.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
             }
-            .pickerStyle(.segmented)
-            .accessibilityHint("Stored only on this device, not in your Hermes profile.")
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Conversation")
+                    .font(.subheadline.weight(.semibold))
+                Picker("Conversation", selection: Binding(get: { behavior }, set: chooseBehavior)) {
+                    Text("Continue").tag(ChatResumeBehavior.continueWhereLeftOff)
+                    Text("Latest").tag(ChatResumeBehavior.latestActivity)
+                }
+                .pickerStyle(.segmented)
+                .accessibilityHint("Used if you dismiss the session list without choosing another conversation.")
+            }
         }
     }
 
-    private func choose(_ next: ChatResumeBehavior) {
+    private func chooseBehavior(_ next: ChatResumeBehavior) {
         guard next != behavior else { return }
         behavior = next
-        persist(next)
+        persistBehavior(next)
+    }
+
+    private func chooseSurface(_ next: ChatReturnSurface) {
+        guard next != surface else { return }
+        surface = next
+        persistSurface(next)
     }
 }
 private struct ResponseBehaviorSettings: View {

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -809,6 +809,7 @@ private struct ChatReturnBehaviorSettings: View {
                     }
                 }
                 .pickerStyle(.segmented)
+                .accessibilityHint("Used if you dismiss the session list without choosing another conversation.")
                 if surface == .sessions {
                     Text("Used if you dismiss the session list without choosing another conversation.")
                         .font(.footnote)
@@ -823,7 +824,7 @@ private struct ChatReturnBehaviorSettings: View {
                     Text("Latest").tag(ChatResumeBehavior.latestActivity)
                 }
                 .pickerStyle(.segmented)
-                .accessibilityHint("Used if you dismiss the session list without choosing another conversation.")
+                .accessibilityHint("Choose whether Conduit preserves your exact reading position or follows the newest conversation.")
             }
         }
     }

--- a/Conduit/Views/RootView.swift
+++ b/Conduit/Views/RootView.swift
@@ -40,7 +40,6 @@ struct MainView: View {
     @EnvironmentObject var appState: AppState
     @State private var settingsPresentation: SettingsSnapshot?
     @State private var shouldPresentSettingsAfterSidebarDismissal = false
-    @State private var consumedReturnSurfaceRequest: UInt64 = 0
 
     var body: some View {
         NavigationStack {
@@ -198,18 +197,11 @@ struct MainView: View {
     }
 
     /// Presents the sessions drawer for a preferred-return-surface request.
-    /// A pending explicit navigation defers without consuming, so the request
-    /// survives if the route is dropped before routing starts; once past that
-    /// point the request is consumed once, and suppressed — dropped for this
-    /// return — when the preference changed, navigation is in flight, or
-    /// another modal owns the surface.
+    /// Consumption semantics (defer-while-pending, claim-once-per-request,
+    /// drop on precedence losers) live in AppState so they survive MainView
+    /// teardown; this layer only owns the actual sheet presentation.
     private func presentPreferredReturnSurfaceIfNeeded() {
-        guard appState.preferredReturnSurfaceRequest > consumedReturnSurfaceRequest else { return }
-        guard !appState.hasPendingExplicitNavigation else { return }
-        consumedReturnSurfaceRequest = appState.preferredReturnSurfaceRequest
-        guard appState.chatReturnSurface == .sessions else { return }
-        guard !appState.isOpeningNotificationSession else { return }
-        guard !appState.isModalSheetPresented else { return }
+        guard appState.claimPreferredReturnSurfacePresentation() else { return }
         guard !appState.showSidebar else { return }
         appState.showSidebar = true
     }

--- a/Conduit/Views/RootView.swift
+++ b/Conduit/Views/RootView.swift
@@ -178,10 +178,11 @@ struct MainView: View {
             await appState.refreshVoiceCapabilities()
         }
         // Cold launch: MainView first becoming the authenticated surface is
-        // the qualifying return. Issue via the guarded AppState hook (a
-        // scene-activation request may already be pending), then consume.
+        // the qualifying return. The hook fires once per process (re-login
+        // cycles rely on the scene-phase path instead), then any pending
+        // request — including one from scene activation — is consumed.
         .task {
-            appState.requestPreferredReturnSurface()
+            appState.requestPreferredReturnSurfaceForColdLaunch()
             presentPreferredReturnSurfaceIfNeeded()
         }
         .onChange(of: appState.preferredReturnSurfaceRequest) { _, _ in
@@ -197,11 +198,13 @@ struct MainView: View {
     }
 
     /// Presents the sessions drawer for a preferred-return-surface request.
-    /// Consumes at most once per issued request; suppressed when explicit
-    /// navigation or another modal owns the surface at presentation time.
+    /// Consumes at most once per issued request; suppressed when the
+    /// preference has since changed, or when explicit navigation or another
+    /// modal owns the surface at presentation time.
     private func presentPreferredReturnSurfaceIfNeeded() {
         guard appState.preferredReturnSurfaceRequest > consumedReturnSurfaceRequest else { return }
         consumedReturnSurfaceRequest = appState.preferredReturnSurfaceRequest
+        guard appState.chatReturnSurface == .sessions else { return }
         guard !appState.isOpeningNotificationSession else { return }
         guard !appState.isModalSheetPresented else { return }
         guard !appState.showSidebar else { return }

--- a/Conduit/Views/RootView.swift
+++ b/Conduit/Views/RootView.swift
@@ -40,6 +40,7 @@ struct MainView: View {
     @EnvironmentObject var appState: AppState
     @State private var settingsPresentation: SettingsSnapshot?
     @State private var shouldPresentSettingsAfterSidebarDismissal = false
+    @State private var consumedReturnSurfaceRequest: UInt64 = 0
 
     var body: some View {
         NavigationStack {
@@ -148,6 +149,7 @@ struct MainView: View {
                 .presentationDragIndicator(.visible)
         }
         .sheet(item: $settingsPresentation, onDismiss: {
+            appState.isSettingsSheetPresented = false
             Task { await appState.refreshVoiceCapabilities() }
         }) { snapshot in
             SettingsView(
@@ -155,6 +157,7 @@ struct MainView: View {
                 saveTheme: { appState.themePreference = $0 },
                 persistBusyInputMode: { mode in await appState.setBusyInputMode(mode) },
                 persistChatResumeBehavior: { appState.setChatResumeBehavior($0) },
+                persistChatReturnSurface: { appState.setChatReturnSurface($0) },
                 loadProfileSettings: { keys in await appState.loadProfileSettings(keys: keys) },
                 persistProfileSetting: { key, value in await appState.setProfileSetting(key, value: value) },
                 loadProfileConfigOptions: { await appState.loadProfileConfigOptions() },
@@ -174,12 +177,35 @@ struct MainView: View {
         .task(id: voiceCapabilityRefreshKey) {
             await appState.refreshVoiceCapabilities()
         }
+        // Cold launch: MainView first becoming the authenticated surface is
+        // the qualifying return. Issue via the guarded AppState hook (a
+        // scene-activation request may already be pending), then consume.
+        .task {
+            appState.requestPreferredReturnSurface()
+            presentPreferredReturnSurfaceIfNeeded()
+        }
+        .onChange(of: appState.preferredReturnSurfaceRequest) { _, _ in
+            presentPreferredReturnSurfaceIfNeeded()
+        }
     }
 
     private func presentSettingsAfterSidebarDismissal() {
         guard shouldPresentSettingsAfterSidebarDismissal else { return }
         shouldPresentSettingsAfterSidebarDismissal = false
+        appState.isSettingsSheetPresented = true
         settingsPresentation = appState.makeSettingsSnapshot()
+    }
+
+    /// Presents the sessions drawer for a preferred-return-surface request.
+    /// Consumes at most once per issued request; suppressed when explicit
+    /// navigation or another modal owns the surface at presentation time.
+    private func presentPreferredReturnSurfaceIfNeeded() {
+        guard appState.preferredReturnSurfaceRequest > consumedReturnSurfaceRequest else { return }
+        consumedReturnSurfaceRequest = appState.preferredReturnSurfaceRequest
+        guard !appState.isOpeningNotificationSession else { return }
+        guard !appState.isModalSheetPresented else { return }
+        guard !appState.showSidebar else { return }
+        appState.showSidebar = true
     }
 
     private var voiceCapabilityRefreshKey: String {

--- a/Conduit/Views/RootView.swift
+++ b/Conduit/Views/RootView.swift
@@ -198,11 +198,14 @@ struct MainView: View {
     }
 
     /// Presents the sessions drawer for a preferred-return-surface request.
-    /// Consumes at most once per issued request; suppressed when the
-    /// preference has since changed, or when explicit navigation or another
-    /// modal owns the surface at presentation time.
+    /// A pending explicit navigation defers without consuming, so the request
+    /// survives if the route is dropped before routing starts; once past that
+    /// point the request is consumed once, and suppressed — dropped for this
+    /// return — when the preference changed, navigation is in flight, or
+    /// another modal owns the surface.
     private func presentPreferredReturnSurfaceIfNeeded() {
         guard appState.preferredReturnSurfaceRequest > consumedReturnSurfaceRequest else { return }
+        guard !appState.hasPendingExplicitNavigation else { return }
         consumedReturnSurfaceRequest = appState.preferredReturnSurfaceRequest
         guard appState.chatReturnSurface == .sessions else { return }
         guard !appState.isOpeningNotificationSession else { return }

--- a/Conduit/Voice/Wake/PendingVoiceIntentStore.swift
+++ b/Conduit/Voice/Wake/PendingVoiceIntentStore.swift
@@ -13,6 +13,11 @@ final class PendingVoiceIntentStore: ObservableObject {
     @Published private(set) var revision: UInt64 = 0
     private var pending: PendingVoiceIntent?
 
+    /// True while an enqueued intent has not been routed. The store owns this
+    /// fact; presentation decisions (e.g. the preferred return surface) read
+    /// it rather than duplicating routing logic.
+    var hasPendingIntent: Bool { pending != nil }
+
     func enqueue(_ intent: PendingVoiceIntent) {
         // One voice sheet can only honor one launch request. The newest source
         // is intentional: it reflects the user's latest explicit action.

--- a/ConduitTests/ChatReturnSurfaceTests.swift
+++ b/ConduitTests/ChatReturnSurfaceTests.swift
@@ -1,0 +1,381 @@
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class ChatReturnSurfaceTests: XCTestCase {
+    func testDefaultConversationPreferenceIssuesNoReturnSurfaceRequest() {
+        let harness = makeHarness()
+
+        XCTAssertEqual(harness.appState.chatReturnSurface, .conversation)
+        harness.appState.handleScenePhase(.background)
+        harness.appState.handleScenePhase(.active)
+
+        XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 0)
+        XCTAssertFalse(harness.appState.showSidebar)
+    }
+
+    func testSessionsPreferenceOnColdLaunchRequestsDrawer() {
+        let harness = makeHarness(surface: .sessions)
+
+        // Cold launch reads the persisted preference, and MainView's
+        // first-appearance task issues the one-shot request.
+        XCTAssertEqual(harness.appState.chatReturnSurface, .sessions)
+        harness.appState.requestPreferredReturnSurface()
+
+        XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 1)
+    }
+
+    func testSessionsPreferenceOnBackgroundToActiveRequestsDrawer() {
+        let harness = makeHarness(surface: .sessions)
+
+        harness.appState.handleScenePhase(.background)
+        harness.appState.handleScenePhase(.active)
+
+        XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 1)
+    }
+
+    func testInactiveToActiveAloneDoesNotRequestDrawer() {
+        let harness = makeHarness(surface: .sessions)
+
+        harness.appState.handleScenePhase(.inactive)
+        harness.appState.handleScenePhase(.active)
+        // A second inactive → active cycle (Control Center twice) still
+        // must not count as reopening the app.
+        harness.appState.handleScenePhase(.inactive)
+        harness.appState.handleScenePhase(.active)
+
+        XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 0)
+    }
+
+    func testSessionsWithContinueBehaviorStillRestoresSavedSessionUnderneath() {
+        let harness = makeHarness(behavior: .continueWhereLeftOff, surface: .sessions)
+        let saved = session("stored-saved")
+        let other = session("stored-other")
+        harness.coordinator.rememberSessionID(saved.id, for: "default")
+        harness.appState.sessions = [other, saved]
+        // Continue-where-left-off returns into the remembered session.
+        harness.appState.activeSessionId = saved.id
+
+        let token = harness.appState.beginReconciliation()
+        let target = harness.appState.selectChatResumeTarget(
+            in: [other, saved],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: saved.id
+        )
+        XCTAssertTrue(harness.appState.settleReconciliationAndPublish(token))
+        XCTAssertEqual(target?.id, saved.id)
+        XCTAssertEqual(
+            harness.appState.chatResumeRestorationRequest?.sessionKey.sessionID,
+            saved.id
+        )
+
+        harness.appState.handleScenePhase(.background)
+        harness.appState.handleScenePhase(.active)
+        XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 1)
+    }
+
+    func testSessionsWithLatestActivityStillResolvesLatestChatUnderneath() {
+        let harness = makeHarness(behavior: .latestActivity, surface: .sessions)
+        let olderChat = session("stored-old-chat")
+        let newestChat = session("stored-new-chat")
+        let cronEntry = session("stored-cron", source: .cron)
+        // Latest-activity ignores the remembered ID and targets the newest
+        // chat conversation, not the cron entry or the saved older chat.
+        harness.coordinator.rememberSessionID(olderChat.id, for: "default")
+        harness.appState.sessions = [newestChat, cronEntry, olderChat]
+        harness.appState.activeSessionId = newestChat.id
+
+        let token = harness.appState.beginReconciliation()
+        let target = harness.appState.selectChatResumeTarget(
+            in: [newestChat, cronEntry, olderChat],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: newestChat.id
+        )
+        XCTAssertTrue(harness.appState.settleReconciliationAndPublish(token))
+        XCTAssertEqual(target?.id, newestChat.id)
+        XCTAssertEqual(
+            harness.appState.chatResumeRestorationRequest?.sessionKey.sessionID,
+            newestChat.id
+        )
+
+        harness.appState.handleScenePhase(.background)
+        harness.appState.handleScenePhase(.active)
+        XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 1)
+    }
+
+    func testNotificationOpenSuppressesPreferredReturnSurfaceRequest() async {
+        let catalogGate = ReturnSurfaceSuspension()
+        let harness = makeHarness(
+            surface: .sessions,
+            reconnectScheduler: ReturnSurfaceReconnectScheduler().schedule(after:operation:),
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    await catalogGate.suspend()
+                    return [self.session("stored-a")]
+                },
+                mintTicket: { _ in throw ReturnSurfaceTestError.mintUnavailable },
+                openSession: { _, sessionID in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [
+                            ChatMessage(id: "m", role: .assistant, content: "Hi", timestamp: "1")
+                        ],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            )
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.connection = connection
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+
+        let notificationTask = Task { @MainActor in
+            await harness.appState.openNotificationTarget(
+                ConduitNotificationTarget(profile: nil, sessionId: "stored-a", type: nil)
+            )
+        }
+        await catalogGate.waitUntilSuspended()
+        XCTAssertTrue(harness.appState.isOpeningNotificationSession)
+
+        // The user returns to the foreground while the notification open is
+        // in flight: explicit navigation wins, no drawer request is issued.
+        harness.appState.handleScenePhase(.background)
+        let sceneTask = harness.appState.handleScenePhase(.active)
+        XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 0)
+
+        catalogGate.resume()
+        let opened = await notificationTask.value
+        XCTAssertTrue(opened)
+        XCTAssertFalse(harness.appState.isOpeningNotificationSession)
+        _ = await sceneTask?.value
+    }
+
+    func testActiveModalSheetsSuppressReturnSurfaceRequest() {
+        let harness = makeHarness(surface: .sessions)
+
+        harness.appState.showModelPicker = true
+        harness.appState.handleScenePhase(.background)
+        harness.appState.handleScenePhase(.active)
+        XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 0)
+
+        harness.appState.showModelPicker = false
+        harness.appState.isSettingsSheetPresented = true
+        harness.appState.handleScenePhase(.background)
+        harness.appState.handleScenePhase(.active)
+        XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 0)
+
+        // Once no modal owns the surface, the next qualifying return asks again.
+        harness.appState.isSettingsSheetPresented = false
+        harness.appState.handleScenePhase(.background)
+        harness.appState.handleScenePhase(.active)
+        XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 1)
+    }
+
+    func testSelectingSessionFromReturnSurfaceDrawerClosesDrawer() async {
+        let harness = makeHarness(
+            surface: .sessions,
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [
+                            ChatMessage(id: "m", role: .assistant, content: "Hi", timestamp: "1")
+                        ],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            )
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.connection = connection
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+        let target = session("stored-a")
+        harness.appState.sessions = [target]
+        harness.appState.activeSessionId = target.id
+        harness.appState.showSidebar = true
+
+        // Mirrors the SidebarView row action: the drawer dismisses itself,
+        // then the existing explicit session-open flow runs.
+        harness.appState.showSidebar = false
+        let opened = await harness.appState.requestOpenSession(target.id).value
+
+        XCTAssertTrue(opened)
+        XCTAssertFalse(harness.appState.showSidebar)
+        XCTAssertEqual(harness.appState.activeSessionId, target.id)
+    }
+
+    func testChangingReturnSurfaceSettingDoesNotImmediatelyPresentDrawer() {
+        let harness = makeHarness()
+
+        harness.appState.setChatReturnSurface(.sessions)
+
+        XCTAssertEqual(harness.appState.chatReturnSurface, .sessions)
+        XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 0)
+        XCTAssertFalse(harness.appState.showSidebar)
+        XCTAssertEqual(
+            harness.defaults.string(forKey: AppState.chatReturnSurfaceKey),
+            ChatReturnSurface.sessions.rawValue
+        )
+    }
+
+    func testReturnSurfacePreferencePersistsAcrossAppStateInstances() {
+        let harness = makeHarness(surface: .sessions)
+
+        harness.appState.setChatReturnSurface(.conversation)
+        let reloaded = AppState(
+            defaults: harness.defaults,
+            loadSavedConnection: false
+        )
+        XCTAssertEqual(reloaded.chatReturnSurface, .conversation)
+
+        reloaded.setChatReturnSurface(.sessions)
+        XCTAssertEqual(
+            harness.defaults.string(forKey: AppState.chatReturnSurfaceKey),
+            ChatReturnSurface.sessions.rawValue
+        )
+    }
+
+    func testInvalidPersistedReturnSurfaceFallsBackToConversation() {
+        let harness = makeHarness(configureDefaults: { defaults in
+            defaults.set("gibberish", forKey: AppState.chatReturnSurfaceKey)
+        })
+
+        XCTAssertEqual(harness.appState.chatReturnSurface, .conversation)
+    }
+
+    func testSettingsSnapshotCarriesReturnSurface() {
+        let harness = makeHarness(surface: .sessions)
+
+        let snapshot = harness.appState.makeSettingsSnapshot()
+
+        XCTAssertEqual(snapshot.chatReturnSurface, .sessions)
+        XCTAssertEqual(snapshot.chatResumeBehavior, .continueWhereLeftOff)
+    }
+
+    func testReturnSurfacePreferenceDoesNotTouchResumeStoreSchema() {
+        let harness = makeHarness(surface: .sessions)
+        // The store persists its initial payload at init; the preference
+        // must leave that payload byte-for-byte untouched.
+        let payloadBefore = harness.defaults.data(forKey: ChatResumeStore.defaultStorageKey)
+
+        harness.appState.setChatReturnSurface(.conversation)
+
+        XCTAssertEqual(
+            harness.defaults.data(forKey: ChatResumeStore.defaultStorageKey),
+            payloadBefore
+        )
+    }
+}
+
+@MainActor
+private final class ReturnSurfaceReconnectScheduler {
+    private final class Work {
+        let operation: @MainActor () async -> Void
+        init(operation: @escaping @MainActor () async -> Void) {
+            self.operation = operation
+        }
+    }
+
+    private var work: [Work] = []
+
+    func schedule(
+        after delay: TimeInterval,
+        operation: @escaping @MainActor () async -> Void
+    ) -> ChatResumeReconnectCancellation {
+        let item = Work(operation: operation)
+        work.append(item)
+        return {}
+    }
+}
+
+private enum ReturnSurfaceTestError: Error {
+    case mintUnavailable
+}
+
+@MainActor
+private final class ReturnSurfaceSuspension {
+    private var suspension: CheckedContinuation<Void, Never>?
+    private var observer: CheckedContinuation<Void, Never>?
+
+    func suspend() async {
+        await withCheckedContinuation { continuation in
+            suspension = continuation
+            observer?.resume()
+            observer = nil
+        }
+    }
+
+    func waitUntilSuspended() async {
+        guard suspension == nil else { return }
+        await withCheckedContinuation { continuation in
+            observer = continuation
+        }
+    }
+
+    func resume() {
+        suspension?.resume()
+        suspension = nil
+    }
+}
+
+private extension ChatReturnSurfaceTests {
+    func makeHarness(
+        behavior: ChatResumeBehavior = .continueWhereLeftOff,
+        surface: ChatReturnSurface = .conversation,
+        configureDefaults: (UserDefaults) -> Void = { _ in },
+        reconnectScheduler: ChatResumeReconnectScheduler? = nil,
+        lifecycleOperations: ChatResumeLifecycleOperations = .live
+    ) -> (
+        appState: AppState,
+        coordinator: ChatResumeCoordinator,
+        store: ChatResumeStore,
+        defaults: UserDefaults,
+        suite: String
+    ) {
+        let suite = "ChatReturnSurfaceTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Failed to create test UserDefaults suite")
+        }
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suite)
+        }
+        configureDefaults(defaults)
+        if surface != .conversation {
+            defaults.set(surface.rawValue, forKey: AppState.chatReturnSurfaceKey)
+        }
+        let store = ChatResumeStore(defaults: defaults)
+        store.setBehavior(behavior)
+        let coordinator = ChatResumeCoordinator(store: store)
+        let appState = AppState(
+            defaults: defaults,
+            chatResumeCoordinator: coordinator,
+            recoverySequence: ChatResumeRecoverySequence(),
+            loadSavedConnection: false,
+            reconnectScheduler: reconnectScheduler,
+            chatResumeLifecycleOperations: lifecycleOperations
+        )
+        return (appState, coordinator, store, defaults, suite)
+    }
+
+    func session(
+        _ id: String,
+        source: SessionSource = .chat
+    ) -> SessionSummary {
+        SessionSummary(
+            id: id,
+            alternateIds: [],
+            title: id,
+            model: "Hermes",
+            updatedLabel: "now",
+            profile: "default",
+            source: source,
+            isActive: false,
+            isArchived: false,
+            lineageRootId: nil
+        )
+    }
+}

--- a/ConduitTests/ChatReturnSurfaceTests.swift
+++ b/ConduitTests/ChatReturnSurfaceTests.swift
@@ -3,6 +3,17 @@ import XCTest
 
 @MainActor
 final class ChatReturnSurfaceTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        // The return-surface decision reads the routing singletons; make
+        // every test start from a clean explicit-navigation state regardless
+        // of ordering or cross-class leftovers.
+        if let target = PushNotificationService.shared.pendingTarget {
+            PushNotificationService.shared.clearPendingTarget(target)
+        }
+        PendingVoiceIntentStore.shared.clear()
+    }
+
     func testDefaultConversationPreferenceIssuesNoReturnSurfaceRequest() {
         let harness = makeHarness()
         // Authenticated so the scene path reaches the preference guard —
@@ -74,6 +85,53 @@ final class ChatReturnSurfaceTests: XCTestCase {
         harness.appState.requestPreferredReturnSurfaceForColdLaunch()
 
         XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 1)
+    }
+
+    func testColdLaunchWithPendingNotificationSuppressesReturnSurfaceRequest() {
+        let service = PushNotificationService.shared
+        defer { if let target = service.pendingTarget { service.clearPendingTarget(target) } }
+        service.receiveNotificationPayload([
+            "conduit": ["session_id": "runtime-1", "type": "response_ready"] as [String: Any]
+        ])
+
+        let harness = makeHarness(surface: .sessions)
+        XCTAssertTrue(harness.appState.hasPendingExplicitNavigation)
+
+        // Cold launch from a notification tap: the destination is recorded
+        // before the UI exists, so the preferred surface must not issue or
+        // flash while routing waits for the connection.
+        harness.appState.requestPreferredReturnSurfaceForColdLaunch()
+        XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 0)
+
+        // A background → active cycle during the same wait is equally
+        // suppressed: the pending destination outranks the preference.
+        harness.appState.connection = HermesConnection(
+            baseUrl: "https://one.example",
+            ticket: "ticket"
+        )
+        harness.appState.handleScenePhase(.background)
+        harness.appState.handleScenePhase(.active)
+        XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 0)
+
+        // After the route completes nothing retro-fires: the explicit
+        // navigation fully won that qualifying return.
+        if let target = service.pendingTarget { service.clearPendingTarget(target) }
+        XCTAssertFalse(harness.appState.hasPendingExplicitNavigation)
+        XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 0)
+    }
+
+    func testColdLaunchWithPendingVoiceIntentSuppressesReturnSurfaceRequest() {
+        let store = PendingVoiceIntentStore.shared
+        defer { store.clear() }
+        store.enqueue(
+            PendingVoiceIntent(profile: "default", startsFreshConversation: true, source: .siri)
+        )
+
+        let harness = makeHarness(surface: .sessions)
+        XCTAssertTrue(harness.appState.hasPendingExplicitNavigation)
+
+        harness.appState.requestPreferredReturnSurfaceForColdLaunch()
+        XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 0)
     }
 
     func testInactiveToActiveAloneDoesNotRequestDrawer() {

--- a/ConduitTests/ChatReturnSurfaceTests.swift
+++ b/ConduitTests/ChatReturnSurfaceTests.swift
@@ -134,6 +134,66 @@ final class ChatReturnSurfaceTests: XCTestCase {
         XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 0)
     }
 
+    func testClaimedRequestCannotBeReclaimedAfterMainViewRecreation() {
+        let harness = makeHarness(surface: .sessions)
+
+        harness.appState.requestPreferredReturnSurface()
+        XCTAssertTrue(harness.appState.claimPreferredReturnSurfacePresentation())
+
+        // A recreated MainView (sign-out → sign-in) starts with no view
+        // state; the AppState-side watermark must keep the consumed request
+        // consumed so the drawer cannot appear without a qualifying return.
+        XCTAssertFalse(harness.appState.claimPreferredReturnSurfacePresentation())
+    }
+
+    func testRequestDeferredByPendingNavigationIsDroppedOnceRouteWins() {
+        let harness = makeHarness(surface: .sessions)
+        harness.appState.connection = HermesConnection(
+            baseUrl: "https://one.example",
+            ticket: "ticket"
+        )
+
+        // Issued before the notification tap arrived: the request exists,
+        // and the payload lands before MainView presents.
+        harness.appState.requestPreferredReturnSurface()
+        XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 1)
+        let service = PushNotificationService.shared
+        defer { if let target = service.pendingTarget { service.clearPendingTarget(target) } }
+        service.receiveNotificationPayload([
+            "conduit": ["session_id": "runtime-1", "type": "response_ready"] as [String: Any]
+        ])
+
+        // The claim defers without consuming while the destination is pending.
+        XCTAssertFalse(harness.appState.claimPreferredReturnSurfacePresentation())
+
+        // The route completed; the explicit navigation fully won that
+        // qualifying return — the deferred request is dropped, not presented.
+        if let target = service.pendingTarget { service.clearPendingTarget(target) }
+        XCTAssertFalse(harness.appState.claimPreferredReturnSurfacePresentation())
+
+        // A later qualifying return issues a fresh request that claims once.
+        harness.appState.handleScenePhase(.background)
+        harness.appState.handleScenePhase(.active)
+        XCTAssertTrue(harness.appState.claimPreferredReturnSurfacePresentation())
+        XCTAssertFalse(harness.appState.claimPreferredReturnSurfacePresentation())
+    }
+
+    func testPrecedenceLoserConsumesAndDropsRequest() {
+        let harness = makeHarness(surface: .sessions)
+        harness.appState.connection = HermesConnection(
+            baseUrl: "https://one.example",
+            ticket: "ticket"
+        )
+        harness.appState.requestPreferredReturnSurface()
+
+        // A modal owning the surface consumes-and-drops the request; closing
+        // the modal must not resurrect the drawer for that return.
+        harness.appState.showModelPicker = true
+        XCTAssertFalse(harness.appState.claimPreferredReturnSurfacePresentation())
+        harness.appState.showModelPicker = false
+        XCTAssertFalse(harness.appState.claimPreferredReturnSurfacePresentation())
+    }
+
     func testInactiveToActiveAloneDoesNotRequestDrawer() {
         let harness = makeHarness(surface: .sessions)
         harness.appState.connection = HermesConnection(

--- a/ConduitTests/ChatReturnSurfaceTests.swift
+++ b/ConduitTests/ChatReturnSurfaceTests.swift
@@ -5,6 +5,13 @@ import XCTest
 final class ChatReturnSurfaceTests: XCTestCase {
     func testDefaultConversationPreferenceIssuesNoReturnSurfaceRequest() {
         let harness = makeHarness()
+        // Authenticated so the scene path reaches the preference guard —
+        // the assertion must depend on the .conversation default, not on the
+        // signed-out early return.
+        harness.appState.connection = HermesConnection(
+            baseUrl: "https://one.example",
+            ticket: "ticket"
+        )
 
         XCTAssertEqual(harness.appState.chatReturnSurface, .conversation)
         harness.appState.handleScenePhase(.background)
@@ -20,7 +27,7 @@ final class ChatReturnSurfaceTests: XCTestCase {
         // Cold launch reads the persisted preference, and MainView's
         // first-appearance task issues the one-shot request.
         XCTAssertEqual(harness.appState.chatReturnSurface, .sessions)
-        harness.appState.requestPreferredReturnSurface()
+        harness.appState.requestPreferredReturnSurfaceForColdLaunch()
 
         XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 1)
     }
@@ -71,6 +78,10 @@ final class ChatReturnSurfaceTests: XCTestCase {
 
     func testInactiveToActiveAloneDoesNotRequestDrawer() {
         let harness = makeHarness(surface: .sessions)
+        harness.appState.connection = HermesConnection(
+            baseUrl: "https://one.example",
+            ticket: "ticket"
+        )
 
         harness.appState.handleScenePhase(.inactive)
         harness.appState.handleScenePhase(.active)

--- a/ConduitTests/ChatReturnSurfaceTests.swift
+++ b/ConduitTests/ChatReturnSurfaceTests.swift
@@ -194,6 +194,64 @@ final class ChatReturnSurfaceTests: XCTestCase {
         XCTAssertFalse(harness.appState.claimPreferredReturnSurfacePresentation())
     }
 
+    func testTeardownRetiresUnclaimedRequestBeforeForegroundReLogin() {
+        let harness = makeHarness(surface: .sessions)
+        harness.appState.connection = HermesConnection(
+            baseUrl: "https://one.example",
+            ticket: "ticket"
+        )
+
+        // A qualifying return issues request 1; before MainView claims it,
+        // the user disconnects — the actual teardown API — tearing MainView
+        // down while the app stays foregrounded.
+        harness.appState.handleScenePhase(.background)
+        harness.appState.handleScenePhase(.active)
+        XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 1)
+
+        harness.appState.disconnect()
+
+        // Foregrounded sign-in recreates MainView; the stale unclaimed
+        // request must not present — re-login is not a qualifying return.
+        XCTAssertFalse(harness.appState.claimPreferredReturnSurfacePresentation())
+
+        // Retirement advances the watermark without resetting the counter:
+        // the next genuine background → active issues a fresh request that
+        // still claims exactly once.
+        harness.appState.connection = HermesConnection(
+            baseUrl: "https://one.example",
+            ticket: "ticket"
+        )
+        harness.appState.handleScenePhase(.background)
+        harness.appState.handleScenePhase(.active)
+        XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 2)
+        XCTAssertTrue(harness.appState.claimPreferredReturnSurfacePresentation())
+        XCTAssertFalse(harness.appState.claimPreferredReturnSurfacePresentation())
+    }
+
+    func testTeardownRetiresDeferredRequest() {
+        let harness = makeHarness(surface: .sessions)
+        harness.appState.connection = HermesConnection(
+            baseUrl: "https://one.example",
+            ticket: "ticket"
+        )
+        harness.appState.requestPreferredReturnSurface()
+
+        // The request is deferred by a pending notification destination.
+        let service = PushNotificationService.shared
+        defer { if let target = service.pendingTarget { service.clearPendingTarget(target) } }
+        service.receiveNotificationPayload([
+            "conduit": ["session_id": "runtime-1", "type": "response_ready"] as [String: Any]
+        ])
+        XCTAssertFalse(harness.appState.claimPreferredReturnSurfacePresentation())
+
+        // The user disconnects while the route is still pending, then signs
+        // back in foregrounded after the destination cleared: the deferred
+        // request must be retired, not presented.
+        harness.appState.disconnect()
+        if let target = service.pendingTarget { service.clearPendingTarget(target) }
+        XCTAssertFalse(harness.appState.claimPreferredReturnSurfacePresentation())
+    }
+
     func testInactiveToActiveAloneDoesNotRequestDrawer() {
         let harness = makeHarness(surface: .sessions)
         harness.appState.connection = HermesConnection(

--- a/ConduitTests/ChatReturnSurfaceTests.swift
+++ b/ConduitTests/ChatReturnSurfaceTests.swift
@@ -27,9 +27,44 @@ final class ChatReturnSurfaceTests: XCTestCase {
 
     func testSessionsPreferenceOnBackgroundToActiveRequestsDrawer() {
         let harness = makeHarness(surface: .sessions)
+        harness.appState.connection = HermesConnection(
+            baseUrl: "https://one.example",
+            ticket: "ticket"
+        )
 
         harness.appState.handleScenePhase(.background)
         harness.appState.handleScenePhase(.active)
+
+        XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 1)
+    }
+
+    func testBackgroundToActiveWhileSignedOutDoesNotLeakIntoNextSignIn() {
+        let harness = makeHarness(surface: .sessions)
+
+        // A background → active cycle on the login screen must consume the
+        // arming without issuing: signing back in is not a qualifying return.
+        harness.appState.handleScenePhase(.background)
+        harness.appState.handleScenePhase(.active)
+        XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 0)
+
+        harness.appState.connection = HermesConnection(
+            baseUrl: "https://one.example",
+            ticket: "ticket"
+        )
+        harness.appState.handleScenePhase(.active)
+        XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 0)
+
+        // The next genuine authenticated return does request the drawer.
+        harness.appState.handleScenePhase(.background)
+        harness.appState.handleScenePhase(.active)
+        XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 1)
+    }
+
+    func testColdLaunchRequestFiresOnlyOncePerProcess() {
+        let harness = makeHarness(surface: .sessions)
+
+        harness.appState.requestPreferredReturnSurfaceForColdLaunch()
+        harness.appState.requestPreferredReturnSurfaceForColdLaunch()
 
         XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 1)
     }
@@ -70,6 +105,10 @@ final class ChatReturnSurfaceTests: XCTestCase {
             saved.id
         )
 
+        harness.appState.connection = HermesConnection(
+            baseUrl: "https://one.example",
+            ticket: "ticket"
+        )
         harness.appState.handleScenePhase(.background)
         harness.appState.handleScenePhase(.active)
         XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 1)
@@ -80,8 +119,8 @@ final class ChatReturnSurfaceTests: XCTestCase {
         let olderChat = session("stored-old-chat")
         let newestChat = session("stored-new-chat")
         let cronEntry = session("stored-cron", source: .cron)
-        // Latest-activity ignores the remembered ID and targets the newest
-        // chat conversation, not the cron entry or the saved older chat.
+        // Latest-activity ignores the remembered ID and picks the first chat
+        // entry of the automatic-return catalog, which is newest-first.
         harness.coordinator.rememberSessionID(olderChat.id, for: "default")
         harness.appState.sessions = [newestChat, cronEntry, olderChat]
         harness.appState.activeSessionId = newestChat.id
@@ -100,6 +139,10 @@ final class ChatReturnSurfaceTests: XCTestCase {
             newestChat.id
         )
 
+        harness.appState.connection = HermesConnection(
+            baseUrl: "https://one.example",
+            ticket: "ticket"
+        )
         harness.appState.handleScenePhase(.background)
         harness.appState.handleScenePhase(.active)
         XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 1)
@@ -155,6 +198,10 @@ final class ChatReturnSurfaceTests: XCTestCase {
 
     func testActiveModalSheetsSuppressReturnSurfaceRequest() {
         let harness = makeHarness(surface: .sessions)
+        harness.appState.connection = HermesConnection(
+            baseUrl: "https://one.example",
+            ticket: "ticket"
+        )
 
         harness.appState.showModelPicker = true
         harness.appState.handleScenePhase(.background)
@@ -174,7 +221,7 @@ final class ChatReturnSurfaceTests: XCTestCase {
         XCTAssertEqual(harness.appState.preferredReturnSurfaceRequest, 1)
     }
 
-    func testSelectingSessionFromReturnSurfaceDrawerClosesDrawer() async {
+    func testSelectingSessionFromDrawerUsesNormalOpenFlowAndStaysClosed() async {
         let harness = makeHarness(
             surface: .sessions,
             lifecycleOperations: ChatResumeLifecycleOperations(
@@ -198,8 +245,9 @@ final class ChatReturnSurfaceTests: XCTestCase {
         harness.appState.activeSessionId = target.id
         harness.appState.showSidebar = true
 
-        // Mirrors the SidebarView row action: the drawer dismisses itself,
-        // then the existing explicit session-open flow runs.
+        // Mirrors the SidebarView row action: the drawer dismisses itself
+        // (existing view behavior), then the existing explicit session-open
+        // flow runs and must not re-open the drawer.
         harness.appState.showSidebar = false
         let opened = await harness.appState.requestOpenSession(target.id).value
 
@@ -355,7 +403,8 @@ private extension ChatReturnSurfaceTests {
             chatResumeCoordinator: coordinator,
             recoverySequence: ChatResumeRecoverySequence(),
             loadSavedConnection: false,
-            reconnectScheduler: reconnectScheduler,
+            reconnectScheduler: reconnectScheduler
+                ?? ReturnSurfaceReconnectScheduler().schedule(after:operation:),
             chatResumeLifecycleOperations: lifecycleOperations
         )
         return (appState, coordinator, store, defaults, suite)


### PR DESCRIPTION
Closes #52.

Adds the requested "open Conduit into the sessions drawer" option as a small, presentation-layer preference. This is **not** a third `ChatResumeBehavior` — the existing resume setting still answers *which conversation is active*; the new setting answers *which surface you see first*:

- `ChatReturnSurface` (`.conversation` / `.sessions`), default `.conversation`, persisted separately under `conduit.chatReturnSurface.v1` (resume store schema untouched, verified by test)
- Settings ▸ Chat: "When returning to Conduit" now has an "Open to [Conversation|Sessions]" picker above the existing behavior picker, with helper text when Sessions is selected. Changing the setting affects the next qualifying return only.

## Semantics

- **Sessions + Continue where I left off** → saved conversation and viewport restore normally underneath, then the drawer presents; dismissing it without choosing another conversation reveals the restored chat
- **Sessions + Jump to latest activity** → latest conversation resolves underneath, then the drawer presents
- No "no active session" state is introduced

## Triggers

- Cold launch into the authenticated app (once per process — disconnect → re-login cycles don't re-trigger)
- A real background → active transition, and only while authenticated (a background cycle on the login screen consumes the arming without issuing, so it can't leak into the next sign-in)
- Ordinary inactive → active (Control Center, call banner) never triggers

## Precedence

notification / deep-link > existing modal presentation > preferred return surface > normal chat surface. Suppression is enforced at issuance (`requestPreferredReturnSurface`) and re-checked at presentation time in MainView. Single scenePhase ownership stays in `RootView`; MainView consumes a one-shot `preferredReturnSurfaceRequest` token and presents the existing `showSidebar` sheet.

Untouched per spec: ChatResumeCoordinator, ChatResumeSessionResolver, ChatResumeStore schema, viewport restoration, notification routing, reconnect/recovery, connection state machine, streaming, markdown/selection/composer.

## Tests

16 new tests in `ChatReturnSurfaceTests` covering all ten spec scenarios plus persistence, once-per-process cold launch, and the signed-out-cycle leak guard. Full local run: 783 pass / 1 fail in `SelectionObserverUITests` selection UI test — known local-sim flake, green on CI for this exact base commit (37fd7c3); CI here is the authoritative check.

Review triage: local reviewer pass (code-reviewer, second-reviewer, third) produced 7 findings — 6 taken (re-login over-trigger, stale-request leak, presentation-time preference re-check, misplaced accessibility hint, two test-strength fixes, one rename), 1 declined with evidence (claimed second settings-presentation path doesn't exist — `settingsPresentation` has a single assignment site).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate chat return preferences for opening the conversation or sessions view.
  * Added independent options for resuming the previous position or showing the latest activity.
  * Preferences are saved and restored across launches and available in chat settings.
  * Sessions view now opens automatically on qualifying returns when no navigation or modal takes precedence.
* **Bug Fixes**
  * Improved return behavior across cold launches, authentication changes, notifications, voice navigation, and restored sessions.
  * Prevented duplicate or premature sessions-view openings during pending navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->