### PR TITLE
Manual per-message read aloud for assistant responses

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -7838,7 +7838,13 @@ final class AppState: ObservableObject {
     /// transcription, mic permission, or Apple Speech — a profile with TTS
     /// but no STT must still be able to read responses aloud.
     var readAloudUnavailableReason: String? {
-        MessageReadAloudController.unavailableReason(
+        // Opening a stream needs the dashboard bridge; while it is absent
+        // (mid sign-out, before the connection lands) disable the button
+        // instead of failing at tap time. Mirrors makeVoiceGateway().
+        guard dashboardTicketBridge != nil, connection != nil else {
+            return "Read aloud needs a connected Hermes gateway."
+        }
+        return MessageReadAloudController.unavailableReason(
             isConnected: isConnected,
             isVoiceEnabled: isVoiceEnabled,
             snapshot: voiceCapabilitySnapshot

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -500,6 +500,18 @@ final class AppState: ObservableObject {
             await self?.interruptForVoice()
         }
     )
+    /// Manual per-message read aloud for completed assistant responses.
+    /// TTS-only: independent of the voice conversation and of STT.
+    lazy var messageReadAloudController = MessageReadAloudController(
+        reportError: { [weak self] message in
+            self?.errorMessage = message
+        }
+    )
+    /// The bridge instance the read aloud gateway was built against. The
+    /// gateway captures its bridge at init, so a gateway outliving its bridge
+    /// (disconnect, re-login, bridge rotation) is dead and must be rebuilt
+    /// rather than kept.
+    private var readAloudGatewayBridge: DashboardTicketBridge?
 
     // MARK: - Cron
 
@@ -1828,6 +1840,11 @@ final class AppState: ObservableObject {
         dashboardTicketBridge?.invalidate()
         dashboardTicketBridge = nil
         voiceConversationController.stop()
+        messageReadAloudController.stop()
+        // The bridge is invalidated above; a gateway built against it can
+        // never open a stream again, so it must not survive the re-login.
+        messageReadAloudController.setGateway(nil)
+        readAloudGatewayBridge = nil
         showVoiceSheet = false
         voiceCapabilitySnapshot = .unavailable
         isVoiceEnabled = false
@@ -1948,6 +1965,11 @@ final class AppState: ObservableObject {
         connection = nil
         dashboardTicketBridge?.invalidate()
         dashboardTicketBridge = nil
+        // A forced sign-out kills the bridge mid-playback; stop the read
+        // aloud and drop its gateway the same way Disconnect does.
+        messageReadAloudController.stop()
+        messageReadAloudController.setGateway(nil)
+        readAloudGatewayBridge = nil
         projects = []
         supportsProjects = false
         projectsLoading = false
@@ -3701,6 +3723,7 @@ final class AppState: ObservableObject {
         case .active:
             isSceneActive = true
             voiceConversationController.setForegroundActive(true)
+            messageReadAloudController.setForegroundActive(true)
             guard connection != nil else { return nil }
             cancelScenePhaseAttempt()
             // Publish the foreground reconciliation boundary synchronously.
@@ -3760,6 +3783,7 @@ final class AppState: ObservableObject {
         case .background:
             isSceneActive = false
             voiceConversationController.setForegroundActive(false)
+            messageReadAloudController.setForegroundActive(false)
             showVoiceSheet = false
             // Drop any armed reconnect timer as well: in-flight cycles abort
             // at their next transportContinuation checkpoint, and foreground
@@ -3788,6 +3812,7 @@ final class AppState: ObservableObject {
             cancelScenePhaseAttempt()
             chatResumeCoordinator.freezeViewport()
             voiceConversationController.setForegroundActive(false)
+            messageReadAloudController.setForegroundActive(false)
             return nil
 
         @unknown default:
@@ -5910,6 +5935,9 @@ final class AppState: ObservableObject {
             return false
         }
         guard !isProfileSwitching else { return false }
+        // A profile change replaces the voice gateway; any in-flight read
+        // aloud belongs to the outgoing profile.
+        messageReadAloudController.stop()
         let transitionGeneration: UInt64
         if let viewportTransitionGeneration {
             guard chatViewportTransitionIsCurrent(
@@ -7676,12 +7704,47 @@ final class AppState: ObservableObject {
 
     var canStartVoiceConversation: Bool { voiceUnavailableReason == nil }
 
+    /// TTS-only availability for read aloud: a connected gateway with voice
+    /// enabled and a ready speech provider. Deliberately does not require
+    /// transcription, mic permission, or Apple Speech — a profile with TTS
+    /// but no STT must still be able to read responses aloud.
+    var readAloudUnavailableReason: String? {
+        MessageReadAloudController.unavailableReason(
+            isConnected: isConnected,
+            isVoiceEnabled: isVoiceEnabled,
+            snapshot: voiceCapabilitySnapshot
+        )
+    }
+
+    /// Chat bubble entry point for manual read aloud. Toggling the active
+    /// message stops it without touching the gateway; starting a different
+    /// message takes over from whatever is playing.
+    func toggleReadAloud(message: ChatMessage) {
+        if messageReadAloudController.isActiveMessage(message.id) {
+            messageReadAloudController.stop()
+            return
+        }
+        guard !message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        if let reason = readAloudUnavailableReason {
+            errorMessage = reason
+            return
+        }
+        // The capability refresh keeps the gateway current; this covers the
+        // gap before the next refresh has run — including right after a
+        // profile switch or re-login, when a stale gateway may still be set.
+        if !readAloudGatewayIsCurrent {
+            assignReadAloudGateway()
+        }
+        messageReadAloudController.toggle(messageID: message.id, content: message.content)
+    }
+
     func refreshVoiceCapabilities() async {
         let profile = activeProfile
         guard isConnected, let bridge = dashboardTicketBridge else {
             voiceCapabilitySnapshot = .unavailable
             isVoiceEnabled = false
             voiceConversationController.setGateway(nil)
+            refreshReadAloudGateway()
             return
         }
         installVoiceAssistantObserverIfNeeded()
@@ -7695,6 +7758,7 @@ final class AppState: ObservableObject {
         voiceTranscriptionMode = preferences.resolvedTranscriptionMode
         voiceConversationController.setProfilePreferences(preferences)
         refreshVoiceControllerGateway()
+        refreshReadAloudGateway()
     }
 
     @discardableResult
@@ -7703,6 +7767,7 @@ final class AppState: ObservableObject {
         defaults.set(enabled, forKey: voiceEnabledPreferenceKey(profile: activeProfile))
         isVoiceEnabled = enabled
         refreshVoiceControllerGateway()
+        refreshReadAloudGateway()
         if !enabled {
             voiceConversationController.stop()
             showVoiceSheet = false
@@ -7739,12 +7804,16 @@ final class AppState: ObservableObject {
         voiceTranscriptionMode = mode
         voiceConversationController.setProfilePreferences(preferences)
         refreshVoiceControllerGateway()
+        refreshReadAloudGateway()
         return true
     }
 
     @discardableResult
     func openVoiceConversation(_ intent: PendingVoiceIntent) async -> Bool {
         guard isConnected else { return false }
+        // Mutual exclusion: the voice conversation owns playback while its
+        // sheet is open, so a read aloud started before must not continue.
+        messageReadAloudController.stop()
         if showVoiceSheet { closeVoiceConversation() }
         if let rawProfile = intent.profile {
             let requestedProfile = rawProfile.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -7825,6 +7894,9 @@ final class AppState: ObservableObject {
         guard let gateway = makeVoiceGateway() else {
             return .failure("Conduit could not connect this test to the selected profile.")
         }
+        // The live TTS test shares the playback engine with read aloud; the
+        // test must not fight a message that is still being read.
+        messageReadAloudController.stop()
         voiceConversationController.setGateway(gateway)
         return await voiceConversationController.runSpeechTest(
             text: "Conduit voice is ready for this profile."
@@ -7852,6 +7924,31 @@ final class AppState: ObservableObject {
         voiceConversationController.setGateway(
             isVoiceEnabled && selectedTranscriptionIsAvailable ? makeVoiceGateway() : nil
         )
+    }
+
+    /// Keeps the read aloud gateway in step with capability refreshes without
+    /// churning a live instance: swapping the gateway mid-playback would stop
+    /// the message. A kept gateway must still match the active profile AND
+    /// the live dashboard bridge — a gateway built against an invalidated or
+    /// rotated bridge (re-login, profile switch) is rebuilt instead.
+    private var readAloudGatewayIsCurrent: Bool {
+        guard let gateway = messageReadAloudController.gateway else { return false }
+        return gateway.profile == activeProfile && readAloudGatewayBridge === dashboardTicketBridge
+    }
+
+    private func assignReadAloudGateway() {
+        messageReadAloudController.setGateway(makeVoiceGateway())
+        readAloudGatewayBridge = dashboardTicketBridge
+    }
+
+    private func refreshReadAloudGateway() {
+        if readAloudUnavailableReason != nil {
+            messageReadAloudController.setGateway(nil)
+            readAloudGatewayBridge = nil
+            return
+        }
+        guard !readAloudGatewayIsCurrent else { return }
+        assignReadAloudGateway()
     }
 
     private func loadVoiceProfilePreferences(profile: String) -> VoiceProfilePreferences {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -7932,8 +7932,9 @@ final class AppState: ObservableObject {
     /// the live dashboard bridge — a gateway built against an invalidated or
     /// rotated bridge (re-login, profile switch) is rebuilt instead.
     private var readAloudGatewayIsCurrent: Bool {
-        guard let gateway = messageReadAloudController.gateway else { return false }
-        return gateway.profile == activeProfile && readAloudGatewayBridge === dashboardTicketBridge
+        guard let gateway = messageReadAloudController.gateway,
+              let bridge = dashboardTicketBridge else { return false }
+        return gateway.profile == activeProfile && readAloudGatewayBridge === bridge
     }
 
     private func assignReadAloudGateway() {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -7870,6 +7870,11 @@ final class AppState: ObservableObject {
         if !readAloudGatewayIsCurrent {
             assignReadAloudGateway()
         }
+        // Mutual exclusion (reverse of openVoiceConversation / runVoiceTTSTest):
+        // the voice conversation and read aloud each own their own playback
+        // instance, so a speech test or conversation still speaking must stop
+        // before the manual stream opens — otherwise both engines play at once.
+        voiceConversationController.stop()
         messageReadAloudController.toggle(messageID: message.id, content: message.content)
     }
 
@@ -8029,8 +8034,11 @@ final class AppState: ObservableObject {
         guard let gateway = makeVoiceGateway() else {
             return .failure("Conduit could not connect this test to the selected profile.")
         }
-        // The live TTS test shares the playback engine with read aloud; the
-        // test must not fight a message that is still being read.
+        // The speech test speaks through the voice controller's own playback
+        // instance (the same AVSpeech infrastructure read aloud uses, but a
+        // separate instance), so the test and a still-playing message would
+        // otherwise both produce audio. AppState enforces mutual exclusion in
+        // both directions; toggleReadAloud stops this controller in turn.
         messageReadAloudController.stop()
         voiceConversationController.setGateway(gateway)
         return await voiceConversationController.runSpeechTest(
@@ -8085,6 +8093,23 @@ final class AppState: ObservableObject {
         }
         guard !readAloudGatewayIsCurrent else { return }
         assignReadAloudGateway()
+    }
+
+    /// Test-only: installs the post-connect voice capability state (bridge,
+    /// snapshot, preference) without a dashboard round trip, so the read
+    /// aloud / voice conversation mutual exclusion can be exercised with
+    /// mock controllers. `readAloudGatewayBridge` is set to the same bridge
+    /// so a mock read aloud gateway installed on the controller counts as
+    /// current and is not replaced by a real one at tap time.
+    func installVoiceCapabilityStateForTesting(
+        bridge: DashboardTicketBridge,
+        snapshot: VoiceCapabilitySnapshot,
+        isVoiceEnabled: Bool
+    ) {
+        dashboardTicketBridge = bridge
+        readAloudGatewayBridge = bridge
+        voiceCapabilitySnapshot = snapshot
+        self.isVoiceEnabled = isVoiceEnabled
     }
 
     private func loadVoiceProfilePreferences(profile: String) -> VoiceProfilePreferences {

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -773,7 +773,10 @@ struct MessageBubble: View {
         case .user:
             UserBubble(message: message)
         case .assistant:
-            AssistantBubble(message: message)
+            AssistantBubble(
+                message: message,
+                readAloudController: appState.messageReadAloudController
+            )
         case .reasoning:
             ThinkingCard(message: message)
         case .tool:
@@ -797,7 +800,10 @@ struct MessageBubble: View {
                 SystemBubble(message: message)
             }
         case .partial:
-            AssistantBubble(message: message)
+            AssistantBubble(
+                message: message,
+                readAloudController: appState.messageReadAloudController
+            )
         }
     }
 }
@@ -1055,7 +1061,13 @@ private struct UserDocumentAttachmentChip: View {
 struct AssistantBubble: View {
     let message: ChatMessage
     @EnvironmentObject var appState: AppState
+    @ObservedObject private var readAloudController: MessageReadAloudController
     @State private var copied = false
+
+    init(message: ChatMessage, readAloudController: MessageReadAloudController) {
+        self.message = message
+        self.readAloudController = readAloudController
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -1117,10 +1129,45 @@ struct AssistantBubble: View {
                 .disabled(appState.isBusy || appState.isBranchingChat)
                 .opacity(appState.isBusy || appState.isBranchingChat ? 0.45 : 1)
                 .accessibilityLabel("Branch from this response")
+
+                if message.role == .assistant {
+                    Button {
+                        if readAloudIsActive {
+                            Haptics.medium()
+                        } else {
+                            Haptics.light()
+                        }
+                        appState.toggleReadAloud(message: message)
+                    } label: {
+                        Group {
+                            if case .preparing(let id) = readAloudController.state, id == message.id {
+                                ProgressView()
+                                    .controlSize(.small)
+                            } else {
+                                Image(systemName: readAloudIsActive ? "stop.fill" : "speaker.wave.2")
+                            }
+                        }
+                        .font(.subheadline.weight(.semibold))
+                        .frame(width: 34, height: 34)
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(readAloudIsActive ? Color.conduitAccent : Color.secondary)
+                    .disabled(readAloudUnavailable && !readAloudIsActive)
+                    .opacity(readAloudUnavailable && !readAloudIsActive ? 0.45 : 1)
+                    .accessibilityLabel(readAloudIsActive ? "Stop reading response" : "Read response aloud")
+                }
             }
             .padding(.top, 2)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var readAloudIsActive: Bool {
+        readAloudController.isActiveMessage(message.id)
+    }
+
+    private var readAloudUnavailable: Bool {
+        appState.readAloudUnavailableReason != nil
     }
 
     private func copyResponse() {

--- a/Conduit/Voice/MessageReadAloudController.swift
+++ b/Conduit/Voice/MessageReadAloudController.swift
@@ -1,0 +1,210 @@
+//
+//  MessageReadAloudController.swift
+//  Conduit
+//
+//  Manual per-message read aloud. Deliberately a single-message playback
+//  operation rather than a voice conversation: it opens the same streaming
+//  TTS transport and plays through the same playback service, but never
+//  touches microphone, STT, or voice-conversation state, so it stays usable
+//  on profiles that configure TTS without transcription.
+//
+
+import Combine
+import Foundation
+
+@MainActor
+final class MessageReadAloudController: ObservableObject {
+    enum State: Equatable {
+        case idle
+        case preparing(messageID: String)
+        case playing(messageID: String)
+        case failed(messageID: String, message: String)
+    }
+
+    @Published private(set) var state: State = .idle
+
+    private let playback: SpeechPlaybackService
+    private let reportError: @MainActor (String) -> Void
+    private var activeGateway: VoiceGatewayService?
+    private var speechStream: VoiceSpeechStream?
+    private var playbackTask: Task<Void, Never>?
+    private var operationGeneration: UInt64 = 0
+    private var isForegroundActive = true
+
+    init(
+        playback: SpeechPlaybackService? = nil,
+        gateway: VoiceGatewayService? = nil,
+        reportError: @escaping @MainActor (String) -> Void = { _ in }
+    ) {
+        self.playback = playback ?? AVSpeechPlaybackService()
+        self.activeGateway = gateway
+        self.reportError = reportError
+    }
+
+    deinit { playbackTask?.cancel() }
+
+    var gateway: VoiceGatewayService? { activeGateway }
+
+    /// TTS-only availability, independent of transcription. Kept as a pure
+    /// function so the "no STT required" contract is testable in isolation.
+    static func unavailableReason(
+        isConnected: Bool,
+        isVoiceEnabled: Bool,
+        snapshot: VoiceCapabilitySnapshot
+    ) -> String? {
+        if !isConnected { return "Connect to Hermes before reading responses aloud." }
+        if !isVoiceEnabled { return "Enable voice for this profile in Settings." }
+        if !snapshot.supportsSpeech {
+            return "This Hermes profile has no ready text-to-speech provider."
+        }
+        return nil
+    }
+
+    func isActiveMessage(_ messageID: String) -> Bool {
+        switch state {
+        case .preparing(let id), .playing(let id): return id == messageID
+        case .idle, .failed: return false
+        }
+    }
+
+    /// Handles the read aloud action for one assistant message. Stops the
+    /// playback if this message already owns it; otherwise takes over from
+    /// whatever (if anything) is active. Whitespace-only content is a no-op
+    /// so tapping an unreadable message never kills active playback.
+    func toggle(messageID: String, content: String) {
+        if isActiveMessage(messageID) {
+            stop()
+            return
+        }
+        guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        guard isForegroundActive else { return }
+        stop()
+        startPlayback(messageID: messageID, content: content)
+    }
+
+    /// Cancels any active or in-flight read aloud operation and returns to
+    /// idle. Safe to call repeatedly, and safe to call mid-operation: a
+    /// superseded operation cannot observe this stop and resurrect playback.
+    func stop() {
+        operationGeneration &+= 1
+        let task = playbackTask
+        playbackTask = nil
+        let stream = speechStream
+        speechStream = nil
+        task?.cancel()
+        stream?.cancel()
+        playback.stop()
+        state = .idle
+    }
+
+    /// The active stream belongs to the gateway that opened it. A replaced or
+    /// cleared gateway (disconnect, profile change) invalidates the in-flight
+    /// operation, so any replacement stops it.
+    func setGateway(_ gateway: VoiceGatewayService?) {
+        guard activeGateway !== gateway else { return }
+        activeGateway = gateway
+        stop()
+    }
+
+    func setForegroundActive(_ active: Bool) {
+        isForegroundActive = active
+        guard !active else { return }
+        stop()
+    }
+
+    private func startPlayback(messageID: String, content: String) {
+        operationGeneration &+= 1
+        let generation = operationGeneration
+        state = .preparing(messageID: messageID)
+        playbackTask = Task { [weak self] in
+            await self?.runPlayback(generation: generation, messageID: messageID, content: content)
+        }
+    }
+
+    private func runPlayback(generation: UInt64, messageID: String, content: String) async {
+        defer { if operationGeneration == generation { playbackTask = nil } }
+        guard let gateway = activeGateway else {
+            fail(messageID: messageID, message: "Read aloud needs a connected Hermes gateway.", generation: generation)
+            return
+        }
+        do {
+            let stream = try await gateway.openSpeechStream(
+                onStart: { [weak self] sampleRate in
+                    guard let self, self.isCurrent(generation) else { return }
+                    try self.playback.start(sampleRate: sampleRate)
+                    self.transitionToPlaying(messageID: messageID, generation: generation)
+                },
+                onPCM16: { [weak self] data, sampleRate in
+                    guard let self, self.isCurrent(generation) else { return }
+                    _ = try self.playback.enqueuePCM16(data, sampleRate: sampleRate)
+                    self.transitionToPlaying(messageID: messageID, generation: generation)
+                },
+                onEncodedAudio: { [weak self] data in
+                    guard let self, self.isCurrent(generation) else { return }
+                    try self.playback.playEncodedAudioData(data)
+                    self.transitionToPlaying(messageID: messageID, generation: generation)
+                }
+            )
+            // The open can outlive a stop(): if this operation was superseded
+            // while the stream was being created, drop the stream immediately
+            // instead of adopting it into the newer operation's state.
+            guard isCurrent(generation) else {
+                stream.cancel()
+                return
+            }
+            speechStream = stream
+            try await stream.append(content)
+            guard isCurrent(generation) else { return }
+            _ = try await stream.finish()
+            guard isCurrent(generation) else { return }
+            speechStream = nil
+            try playback.finish()
+            await playback.drain()
+            guard isCurrent(generation) else { return }
+            state = .idle
+        } catch {
+            // A superseded operation must not touch shared state: the stream
+            // reference may now belong to a newer operation, and only that
+            // operation's stop() may release it.
+            guard isCurrent(generation) else { return }
+            let stream = speechStream
+            speechStream = nil
+            stream?.cancel()
+            if isCancellation(error) {
+                // The stream died on its own (or was stopped); settle back to
+                // idle so the message is tappable again.
+                playback.stop()
+                state = .idle
+                return
+            }
+            // The stream can die after audio is already sounding; settle the
+            // engine so no unattributed audio keeps playing under .failed.
+            playback.stop()
+            fail(messageID: messageID, message: error.localizedDescription, generation: generation)
+        }
+    }
+
+    private func transitionToPlaying(messageID: String, generation: UInt64) {
+        guard isCurrent(generation) else { return }
+        if case .preparing(let id) = state, id == messageID {
+            state = .playing(messageID: messageID)
+        }
+    }
+
+    private func fail(messageID: String, message: String, generation: UInt64) {
+        guard isCurrent(generation) else { return }
+        state = .failed(messageID: messageID, message: message)
+        reportError(message)
+    }
+
+    private func isCancellation(_ error: Error) -> Bool {
+        if error is CancellationError { return true }
+        if let urlError = error as? URLError, urlError.code == .cancelled { return true }
+        let nsError = error as NSError
+        return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
+    }
+
+    private func isCurrent(_ generation: UInt64) -> Bool {
+        generation == operationGeneration && isForegroundActive
+    }
+}

--- a/ConduitTests/AppStateReadAloudTests.swift
+++ b/ConduitTests/AppStateReadAloudTests.swift
@@ -1,0 +1,336 @@
+//
+//  AppStateReadAloudTests.swift
+//  Conduit
+//
+//  AppState-level regression coverage for audio ownership between the two
+//  playback owners: the voice conversation controller and the manual read
+//  aloud controller. Each owns a separate playback instance over the same
+//  AVSpeech infrastructure, so AppState enforces mutual exclusion in both
+//  directions — these tests pin that contract at the integration level
+//  rather than in the isolated controller unit tests.
+//
+
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class AppStateReadAloudTests: XCTestCase {
+    func testStartingReadAloudStopsInFlightSpeechTest() async {
+        let harness = makeHarness(snapshot: ttsOnlySnapshot)
+        let messageA = ChatMessage(id: "msg-a", role: .assistant, content: "Response A", timestamp: "1")
+
+        // The user started the Settings TTS test and navigated away while it
+        // was still speaking: the voice controller's own playback instance
+        // is live.
+        let speechTest = Task {
+            await harness.voiceController.runSpeechTest(
+                text: "Conduit voice is ready for this profile."
+            )
+        }
+        await awaitUntil("the speech test to start speaking") {
+            harness.voiceController.state == .speaking
+        }
+        XCTAssertTrue(harness.voicePlayback.isPlaying)
+
+        // The user taps Read Aloud on an assistant response.
+        harness.appState.toggleReadAloud(message: messageA)
+
+        // Synchronous at the call site: the voice controller is fully stopped
+        // before the manual playback task has even started.
+        XCTAssertFalse(harness.voicePlayback.isPlaying)
+        XCTAssertEqual(harness.voiceController.state, .idle)
+        XCTAssertEqual(harness.readAloudController.state, .preparing(messageID: "msg-a"))
+
+        await awaitUntil("read aloud to reach playing") {
+            harness.readAloudController.state == .playing(messageID: "msg-a")
+        }
+        XCTAssertTrue(harness.readAloudPlayback.isPlaying)
+        XCTAssertEqual(harness.voiceGateway.streams[0].cancelCount, 1)
+
+        // The interrupted test settles as a failure, never a success.
+        let result = await speechTest.value
+        XCTAssertFalse(result.passed, "A cancelled speech test must not report success")
+
+        harness.readAloudController.stop()
+    }
+
+    func testStoppingActiveReadAloudDoesNotResetVoiceController() async {
+        let harness = makeHarness(snapshot: ttsOnlySnapshot)
+        let messageA = ChatMessage(id: "msg-a", role: .assistant, content: "Response A", timestamp: "1")
+
+        harness.appState.toggleReadAloud(message: messageA)
+        await awaitUntil("read aloud to reach playing") {
+            harness.readAloudController.state == .playing(messageID: "msg-a")
+        }
+        // The start path already stopped the (idle) voice controller once;
+        // the stop-only path must add no further reset.
+        let voiceStopsAfterStart = harness.voicePlayback.stopCount
+        XCTAssertGreaterThanOrEqual(voiceStopsAfterStart, 1)
+        let voiceStateAfterStart = harness.voiceController.state
+
+        harness.appState.toggleReadAloud(message: messageA)
+
+        XCTAssertEqual(harness.readAloudController.state, .idle)
+        XCTAssertFalse(harness.readAloudPlayback.isPlaying)
+        XCTAssertEqual(harness.voicePlayback.stopCount, voiceStopsAfterStart)
+        XCTAssertEqual(harness.voiceController.state, voiceStateAfterStart)
+    }
+
+    func testReadAloudTakeoverBetweenMessagesStillWorks() async {
+        let harness = makeHarness(snapshot: ttsOnlySnapshot)
+        let messageA = ChatMessage(id: "msg-a", role: .assistant, content: "Response A", timestamp: "1")
+        let messageB = ChatMessage(id: "msg-b", role: .assistant, content: "Response B", timestamp: "2")
+
+        harness.appState.toggleReadAloud(message: messageA)
+        await awaitUntil("read aloud to play message A") {
+            harness.readAloudController.state == .playing(messageID: "msg-a")
+        }
+        XCTAssertEqual(harness.readAloudGateway.openCount, 1)
+
+        harness.appState.toggleReadAloud(message: messageB)
+        await awaitUntil("read aloud to play message B") {
+            harness.readAloudController.state == .playing(messageID: "msg-b")
+        }
+
+        XCTAssertEqual(harness.readAloudGateway.openCount, 2)
+        XCTAssertEqual(harness.readAloudGateway.streams[0].cancelCount, 1)
+        XCTAssertTrue(harness.readAloudPlayback.isPlaying)
+
+        harness.readAloudController.stop()
+    }
+
+    func testTTSOnlyAvailabilityIsIndependentOfTranscription() {
+        let harness = makeHarness(snapshot: ttsOnlySnapshot)
+
+        // TTS without any STT capability is exactly the case read aloud must
+        // support.
+        XCTAssertNil(harness.appState.readAloudUnavailableReason)
+
+        let sttOnly = VoiceCapabilitySnapshot(
+            isGatewayConnected: true,
+            supportsTranscription: true,
+            supportsSpeech: false,
+            unavailableReason: "no TTS provider configured"
+        )
+        harness.appState.installVoiceCapabilityStateForTesting(
+            bridge: harness.bridge,
+            snapshot: sttOnly,
+            isVoiceEnabled: true
+        )
+        XCTAssertEqual(
+            harness.appState.readAloudUnavailableReason,
+            "This Hermes profile has no ready text-to-speech provider."
+        )
+
+        harness.appState.installVoiceCapabilityStateForTesting(
+            bridge: harness.bridge,
+            snapshot: ttsOnlySnapshot,
+            isVoiceEnabled: false
+        )
+        XCTAssertEqual(
+            harness.appState.readAloudUnavailableReason,
+            "Enable voice for this profile in Settings."
+        )
+
+        harness.appState.installVoiceCapabilityStateForTesting(
+            bridge: harness.bridge,
+            snapshot: ttsOnlySnapshot,
+            isVoiceEnabled: true
+        )
+        harness.appState.isConnected = false
+        XCTAssertEqual(
+            harness.appState.readAloudUnavailableReason,
+            "Connect to Hermes before reading responses aloud."
+        )
+    }
+
+    private var ttsOnlySnapshot: VoiceCapabilitySnapshot {
+        VoiceCapabilitySnapshot(
+            isGatewayConnected: true,
+            supportsTranscription: false,
+            supportsSpeech: true,
+            unavailableReason: nil
+        )
+    }
+
+    private func makeHarness(snapshot: VoiceCapabilitySnapshot) -> Harness {
+        let suite = "AppStateReadAloudTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Failed to create test UserDefaults suite")
+        }
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suite)
+        }
+
+        let appState = AppState(defaults: defaults, loadSavedConnection: false)
+        appState.connection = HermesConnection(baseUrl: "https://example.com", ticket: "test-ticket")
+        appState.isConnected = true
+
+        let voicePlayback = MockVoicePlayback()
+        let voiceGateway = MockVoiceGateway(pausesAfterEmission: true)
+        let voiceController = VoiceConversationController(
+            capture: MockVoiceCapture(),
+            playback: voicePlayback,
+            deviceTranscriber: MockVoiceTranscriber(),
+            gateway: voiceGateway,
+            submit: { _ in false },
+            interrupt: {}
+        )
+        appState.voiceConversationController = voiceController
+
+        let readAloudPlayback = MockVoicePlayback()
+        let readAloudGateway = MockVoiceGateway(pausesAfterEmission: true)
+        let readAloudController = MessageReadAloudController(
+            playback: readAloudPlayback,
+            gateway: readAloudGateway,
+            reportError: { _ in }
+        )
+        appState.messageReadAloudController = readAloudController
+
+        let bridge = DashboardTicketBridge(baseURL: "https://example.com")
+        appState.installVoiceCapabilityStateForTesting(
+            bridge: bridge,
+            snapshot: snapshot,
+            isVoiceEnabled: true
+        )
+
+        return Harness(
+            appState: appState,
+            bridge: bridge,
+            voiceController: voiceController,
+            voicePlayback: voicePlayback,
+            voiceGateway: voiceGateway,
+            readAloudController: readAloudController,
+            readAloudPlayback: readAloudPlayback,
+            readAloudGateway: readAloudGateway
+        )
+    }
+
+    private func awaitUntil(
+        _ description: String,
+        timeout: TimeInterval = 2.0,
+        condition: @MainActor () -> Bool
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition() {
+            if Date() >= deadline {
+                XCTFail("Timed out waiting for \(description)")
+                return
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+}
+
+private struct Harness {
+    let appState: AppState
+    let bridge: DashboardTicketBridge
+    let voiceController: VoiceConversationController
+    let voicePlayback: MockVoicePlayback
+    let voiceGateway: MockVoiceGateway
+    let readAloudController: MessageReadAloudController
+    let readAloudPlayback: MockVoicePlayback
+    let readAloudGateway: MockVoiceGateway
+}
+
+@MainActor
+private final class MockVoiceCapture: AudioCaptureService {
+    let events: AsyncStream<VoiceCaptureEvent>
+
+    init() {
+        events = AsyncStream { _ in }
+    }
+
+    func requestPermission() async -> Bool { true }
+    func startListening(includePreRoll: Bool) throws {}
+    func beginBargeInMonitoring() throws {}
+    func pause() {}
+    func resume() throws {}
+    func finishUtterance() throws -> VoiceCapturedAudio {
+        VoiceCapturedAudio(wavData: Data(), pcm16Data: Data(), sampleRate: 16_000, duration: 0)
+    }
+    func stop() {}
+}
+
+@MainActor
+private final class MockVoicePlayback: SpeechPlaybackService {
+    var isPlaying = false
+    private(set) var stopCount = 0
+
+    func start(sampleRate: Double) throws { isPlaying = true }
+    func enqueuePCM16(_ data: Data, sampleRate: Double) throws -> Int { data.count / 2 }
+    func playEncodedAudioData(_ data: Data) throws { isPlaying = true }
+    func finish() throws {}
+    func drain() async { isPlaying = false }
+    func stop() {
+        isPlaying = false
+        stopCount += 1
+    }
+}
+
+@MainActor
+private final class MockVoiceTranscriber: DeviceSpeechTranscriptionService {
+    func requestPermission() async -> Bool { true }
+    func transcribe(_ audio: VoiceCapturedAudio) async throws -> String { "transcript" }
+    func cancel() {}
+}
+
+@MainActor
+private final class MockVoiceGateway: VoiceGatewayService {
+    let profile = "default"
+    private(set) var openCount = 0
+    private(set) var streams: [MockVoiceStream] = []
+    private let pausesAfterEmission: Bool
+
+    init(pausesAfterEmission: Bool) { self.pausesAfterEmission = pausesAfterEmission }
+
+    func transcribe(_ audio: VoiceCapturedAudio) async throws -> String { "transcript" }
+
+    func openSpeechStream(
+        onStart: @escaping @MainActor (Double) throws -> Void,
+        onPCM16: @escaping @MainActor (Data, Double) throws -> Void,
+        onEncodedAudio: @escaping @MainActor (Data) throws -> Void
+    ) async throws -> VoiceSpeechStream {
+        openCount += 1
+        let stream = MockVoiceStream(pausesAfterEmission: pausesAfterEmission)
+        streams.append(stream)
+        try onStart(24_000)
+        try onPCM16(Data(repeating: 1, count: 8), 24_000)
+        return stream
+    }
+}
+
+@MainActor
+private final class MockVoiceStream: VoiceSpeechStream {
+    private(set) var appended: [String] = []
+    private(set) var cancelCount = 0
+    private let pausesAfterEmission: Bool
+    private var appendContinuation: CheckedContinuation<Void, Error>?
+    private var isCancelled = false
+
+    init(pausesAfterEmission: Bool) { self.pausesAfterEmission = pausesAfterEmission }
+
+    func append(_ text: String) async throws {
+        appended.append(text)
+        guard pausesAfterEmission else { return }
+        if isCancelled { throw URLError(.cancelled) }
+        try await withCheckedThrowingContinuation { continuation in
+            appendContinuation = continuation
+            if isCancelled {
+                appendContinuation = nil
+                continuation.resume(throwing: URLError(.cancelled))
+            }
+        }
+    }
+
+    func finish() async throws -> Bool { true }
+
+    func cancel() {
+        guard !isCancelled else { return }
+        isCancelled = true
+        cancelCount += 1
+        let continuation = appendContinuation
+        appendContinuation = nil
+        continuation?.resume(throwing: URLError(.cancelled))
+    }
+}

--- a/ConduitTests/MessageReadAloudControllerTests.swift
+++ b/ConduitTests/MessageReadAloudControllerTests.swift
@@ -286,6 +286,22 @@ final class MessageReadAloudControllerTests: XCTestCase {
         XCTAssertEqual(controller.state, .idle, "A different message can start after a playback failure")
     }
 
+    func testPCMEnqueueFailureStopsAndFails() async {
+        let playback = MockReadAloudPlayback()
+        playback.enqueueError = ReadAloudTestError(description: "Enqueue failed")
+        let gateway = MockReadAloudGateway(emitsPCM: true)
+        var reported: [String] = []
+        let controller = makeController(playback: playback, gateway: gateway) { reported.append($0) }
+
+        controller.toggle(messageID: "message-a", content: "Broken queue")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(controller.state, .failed(messageID: "message-a", message: "Enqueue failed"))
+        XCTAssertEqual(reported, ["Enqueue failed"])
+        XCTAssertFalse(playback.isPlaying, "A failed enqueue must settle the engine")
+        XCTAssertEqual(gateway.streams.last?.cancelCount, 1)
+    }
+
     func testEmptyContentDoesNotStartOrStopPlayback() async {
         let playback = MockReadAloudPlayback()
         let gateway = MockReadAloudGateway(emitsPCM: true)
@@ -305,6 +321,11 @@ final class MessageReadAloudControllerTests: XCTestCase {
         try? await Task.sleep(nanoseconds: 50_000_000)
         XCTAssertEqual(controller.state, .playing(messageID: "message-b"), "An unreadable message must not interrupt active playback")
         XCTAssertEqual(gateway.openCount, 1)
+
+        // Release the paused mock stream so the test doesn't end with a
+        // suspended append continuation.
+        controller.stop()
+        XCTAssertEqual(controller.state, .idle)
     }
 
     func testRepeatedStopsAreHarmless() async {

--- a/ConduitTests/MessageReadAloudControllerTests.swift
+++ b/ConduitTests/MessageReadAloudControllerTests.swift
@@ -1,0 +1,638 @@
+import XCTest
+@testable import Conduit
+
+private struct ReadAloudTestError: LocalizedError {
+    let description: String
+    var errorDescription: String? { description }
+}
+
+@MainActor
+final class MessageReadAloudControllerTests: XCTestCase {
+    private func makeController(
+        playback: MockReadAloudPlayback,
+        gateway: MockReadAloudGateway,
+        reported: @escaping (String) -> Void = { _ in }
+    ) -> MessageReadAloudController {
+        MessageReadAloudController(playback: playback, gateway: gateway, reportError: reported)
+    }
+
+    func testToggleOpensOneStreamWithFullMessageText() async {
+        let playback = MockReadAloudPlayback()
+        let gateway = MockReadAloudGateway()
+        let controller = makeController(playback: playback, gateway: gateway)
+
+        controller.toggle(messageID: "message-a", content: "The full response text.")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(gateway.openCount, 1)
+        XCTAssertEqual(gateway.streams.last?.appended, ["The full response text."])
+        XCTAssertEqual(gateway.streams.last?.finishCount, 1)
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertEqual(playback.finishCount, 1)
+        XCTAssertEqual(playback.drainCount, 1)
+    }
+
+    func testStreamedPCMReachesPlaybackAndEntersPlayingState() async {
+        let playback = MockReadAloudPlayback()
+        let gateway = MockReadAloudGateway(emitsPCM: true)
+        gateway.pauseAfterEmission = true
+        let controller = makeController(playback: playback, gateway: gateway)
+
+        controller.toggle(messageID: "message-a", content: "Streaming")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(controller.state, .playing(messageID: "message-a"))
+        XCTAssertEqual(playback.startedSampleRates, [24_000])
+        XCTAssertEqual(playback.enqueuedPCM.count, 1)
+
+        gateway.streams.last?.releaseAppendForTest()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(controller.state, .idle)
+    }
+
+    func testEncodedFallbackReachesPlayback() async {
+        let playback = MockReadAloudPlayback()
+        let gateway = MockReadAloudGateway(emitsEncoded: true)
+        let controller = makeController(playback: playback, gateway: gateway)
+
+        controller.toggle(messageID: "message-a", content: "Fallback")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(playback.encodedFrames, [Data([0x01, 0x02, 0x03])])
+        XCTAssertTrue(playback.enqueuedPCM.isEmpty)
+        XCTAssertEqual(controller.state, .idle)
+    }
+
+    func testPlaybackFinishesAndDrainsBeforeReturningToIdle() async {
+        let playback = MockReadAloudPlayback()
+        playback.blockDrain = true
+        let gateway = MockReadAloudGateway(emitsPCM: true)
+        let controller = makeController(playback: playback, gateway: gateway)
+
+        controller.toggle(messageID: "message-a", content: "Drain")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(playback.finishCount, 1)
+        XCTAssertEqual(playback.drainCount, 1)
+        XCTAssertEqual(controller.state, .playing(messageID: "message-a"))
+
+        playback.stop()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertFalse(playback.isPlaying)
+    }
+
+    func testTappingActiveMessageStopsPlayback() async {
+        let playback = MockReadAloudPlayback()
+        let gateway = MockReadAloudGateway(emitsPCM: true)
+        gateway.pauseAfterEmission = true
+        let controller = makeController(playback: playback, gateway: gateway)
+
+        controller.toggle(messageID: "message-a", content: "Playing")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(controller.state, .playing(messageID: "message-a"))
+
+        controller.toggle(messageID: "message-a", content: "Playing")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertEqual(gateway.openCount, 1, "Tapping the active message must not open a new stream")
+        XCTAssertEqual(gateway.streams.last?.cancelCount, 1)
+        XCTAssertFalse(playback.isPlaying)
+    }
+
+    func testStartingAnotherMessageCancelsActivePlayback() async {
+        let playback = MockReadAloudPlayback()
+        let gateway = MockReadAloudGateway(emitsPCM: true)
+        gateway.pauseAfterEmission = true
+        let controller = makeController(playback: playback, gateway: gateway)
+
+        controller.toggle(messageID: "message-a", content: "First")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(controller.state, .playing(messageID: "message-a"))
+
+        controller.toggle(messageID: "message-b", content: "Second")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(gateway.openCount, 2)
+        XCTAssertEqual(gateway.streams.first?.cancelCount, 1)
+        XCTAssertEqual(gateway.streams.first?.finishCount, 0)
+        XCTAssertEqual(gateway.streams.last?.appended, ["Second"])
+        XCTAssertEqual(controller.state, .playing(messageID: "message-b"))
+
+        gateway.streams.last?.releaseAppendForTest()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(controller.state, .idle)
+    }
+
+    func testSupersededOperationCannotClearNewerState() async {
+        let playback = MockReadAloudPlayback()
+        playback.blockDrain = true
+        let gateway = MockReadAloudGateway(emitsPCM: true)
+        let controller = makeController(playback: playback, gateway: gateway)
+
+        controller.toggle(messageID: "message-a", content: "First")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        // A has emitted audio, finished its stream, and is now suspended in
+        // the playback drain.
+        XCTAssertEqual(controller.state, .playing(messageID: "message-a"))
+        XCTAssertEqual(playback.drainCount, 1)
+
+        // Starting B stops A's drain; A's late completion must not clear B.
+        controller.toggle(messageID: "message-b", content: "Second")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(controller.state, .playing(messageID: "message-b"))
+        XCTAssertEqual(gateway.openCount, 2)
+
+        controller.stop()
+        XCTAssertEqual(controller.state, .idle)
+    }
+
+    func testStopDuringStreamCreationCannotRevivePlayback() async {
+        let playback = MockReadAloudPlayback()
+        let gateway = MockReadAloudGateway()
+        gateway.blocksOpen = true
+        let controller = makeController(playback: playback, gateway: gateway)
+
+        controller.toggle(messageID: "message-a", content: "Slow open")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(controller.state, .preparing(messageID: "message-a"))
+
+        controller.stop()
+        XCTAssertEqual(controller.state, .idle)
+
+        gateway.resumeOpenForTest()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(controller.state, .idle, "A late stream-open must not be adopted after a stop")
+        XCTAssertEqual(gateway.streams.last?.cancelCount, 1)
+        XCTAssertFalse(playback.isPlaying)
+    }
+
+    func testStopDuringFinishCannotRevivePlayback() async {
+        let playback = MockReadAloudPlayback()
+        let gateway = MockReadAloudGateway(emitsPCM: true)
+        gateway.blocksFinish = true
+        let controller = makeController(playback: playback, gateway: gateway)
+
+        controller.toggle(messageID: "message-a", content: "Slow finish")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(controller.state, .playing(messageID: "message-a"))
+        XCTAssertEqual(gateway.streams.last?.finishCount, 1)
+
+        controller.stop()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertEqual(gateway.streams.last?.cancelCount, 1)
+        XCTAssertEqual(playback.finishCount, 0, "The superseded operation must not finish the newer operation's playback")
+        XCTAssertEqual(playback.drainCount, 0)
+    }
+
+    func testSupersededCatchCannotReleaseNewerStream() async {
+        let playback = MockReadAloudPlayback()
+        let gateway = MockReadAloudGateway(emitsPCM: true)
+        gateway.pauseAfterEmission = true
+        // A's cancel error is deferred so it lands only after B has adopted
+        // its own stream — the interleaving a stale catch must survive.
+        gateway.blocksCancelDelivery = true
+        var reported: [String] = []
+        let controller = makeController(playback: playback, gateway: gateway) { reported.append($0) }
+
+        controller.toggle(messageID: "message-a", content: "First")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(controller.state, .playing(messageID: "message-a"))
+
+        gateway.blocksCancelDelivery = false
+        controller.toggle(messageID: "message-b", content: "Second")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(controller.state, .playing(messageID: "message-b"))
+
+        gateway.streams.first?.releaseCancelForTest()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(controller.state, .playing(messageID: "message-b"), "A superseded operation's catch must not disturb the newer operation")
+        XCTAssertEqual(gateway.streams.first?.cancelCount, 1)
+        XCTAssertEqual(gateway.streams.last?.cancelCount, 0, "Only stop() may cancel the newer operation's stream")
+        XCTAssertTrue(reported.isEmpty)
+
+        controller.stop()
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertEqual(gateway.streams.last?.cancelCount, 1)
+    }
+
+    func testMidStreamFailureStopsPlayback() async {
+        let playback = MockReadAloudPlayback()
+        let gateway = MockReadAloudGateway(emitsPCM: true)
+        gateway.pauseAfterEmission = true
+        var reported: [String] = []
+        let controller = makeController(playback: playback, gateway: gateway) { reported.append($0) }
+
+        controller.toggle(messageID: "message-a", content: "Dying stream")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(controller.state, .playing(messageID: "message-a"))
+        XCTAssertTrue(playback.isPlaying)
+
+        gateway.streams.last?.releaseAppendForTest(throwing: ReadAloudTestError(description: "Stream lost mid-response"))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(controller.state, .failed(messageID: "message-a", message: "Stream lost mid-response"))
+        XCTAssertEqual(reported, ["Stream lost mid-response"])
+        XCTAssertFalse(playback.isPlaying, "A mid-stream failure must settle the audio, not leave it running under .failed")
+        XCTAssertEqual(gateway.streams.last?.cancelCount, 1)
+    }
+
+    func testGatewayFailureLeavesRecoverableState() async {
+        let playback = MockReadAloudPlayback()
+        let gateway = MockReadAloudGateway()
+        gateway.openError = ReadAloudTestError(description: "Speech provider exploded")
+        var reported: [String] = []
+        let controller = makeController(playback: playback, gateway: gateway) { reported.append($0) }
+
+        controller.toggle(messageID: "message-a", content: "Broken")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(controller.state, .failed(messageID: "message-a", message: "Speech provider exploded"))
+        XCTAssertEqual(reported, ["Speech provider exploded"])
+        XCTAssertFalse(playback.isPlaying)
+
+        gateway.openError = nil
+        controller.toggle(messageID: "message-a", content: "Broken")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(gateway.openCount, 2, "The failed message can be retried after recovery")
+        XCTAssertEqual(controller.state, .idle)
+    }
+
+    func testPlaybackStartFailureSurfacesRecoverableState() async {
+        let playback = MockReadAloudPlayback()
+        playback.startError = ReadAloudTestError(description: "Playback engine failed")
+        let gateway = MockReadAloudGateway(emitsPCM: true)
+        var reported: [String] = []
+        let controller = makeController(playback: playback, gateway: gateway) { reported.append($0) }
+
+        controller.toggle(messageID: "message-a", content: "Broken audio")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(controller.state, .failed(messageID: "message-a", message: "Playback engine failed"))
+        XCTAssertEqual(reported, ["Playback engine failed"])
+
+        playback.startError = nil
+        controller.toggle(messageID: "message-b", content: "Healthy audio")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(controller.state, .idle, "A different message can start after a playback failure")
+    }
+
+    func testEmptyContentDoesNotStartOrStopPlayback() async {
+        let playback = MockReadAloudPlayback()
+        let gateway = MockReadAloudGateway(emitsPCM: true)
+        gateway.pauseAfterEmission = true
+        let controller = makeController(playback: playback, gateway: gateway)
+
+        controller.toggle(messageID: "message-a", content: "   \n\t ")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(gateway.openCount, 0)
+        XCTAssertEqual(controller.state, .idle)
+
+        controller.toggle(messageID: "message-b", content: "Real content")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(controller.state, .playing(messageID: "message-b"))
+
+        controller.toggle(messageID: "message-c", content: "  ")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(controller.state, .playing(messageID: "message-b"), "An unreadable message must not interrupt active playback")
+        XCTAssertEqual(gateway.openCount, 1)
+    }
+
+    func testRepeatedStopsAreHarmless() async {
+        let playback = MockReadAloudPlayback()
+        let gateway = MockReadAloudGateway()
+        gateway.blocksOpen = true
+        let controller = makeController(playback: playback, gateway: gateway)
+
+        controller.stop()
+        controller.stop()
+        controller.stop()
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertEqual(gateway.openCount, 0)
+
+        controller.toggle(messageID: "message-a", content: "Preparing")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(controller.state, .preparing(messageID: "message-a"))
+        controller.stop()
+        controller.stop()
+        XCTAssertEqual(controller.state, .idle)
+
+        gateway.resumeOpenForTest()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(controller.state, .idle)
+    }
+
+    func testTTSONlyAvailabilityDoesNotRequireTranscription() {
+        let ttsOnly = VoiceCapabilitySnapshot(
+            isGatewayConnected: true,
+            supportsTranscription: false,
+            supportsSpeech: true,
+            unavailableReason: nil
+        )
+        XCTAssertNil(
+            MessageReadAloudController.unavailableReason(isConnected: true, isVoiceEnabled: true, snapshot: ttsOnly),
+            "Read aloud must work when TTS is configured even though STT is unavailable"
+        )
+
+        let noSpeech = VoiceCapabilitySnapshot(
+            isGatewayConnected: true,
+            supportsTranscription: true,
+            supportsSpeech: false,
+            unavailableReason: "no tts"
+        )
+        XCTAssertEqual(
+            MessageReadAloudController.unavailableReason(isConnected: true, isVoiceEnabled: true, snapshot: noSpeech),
+            "This Hermes profile has no ready text-to-speech provider."
+        )
+        XCTAssertNotNil(MessageReadAloudController.unavailableReason(isConnected: false, isVoiceEnabled: true, snapshot: ttsOnly))
+        XCTAssertNotNil(MessageReadAloudController.unavailableReason(isConnected: true, isVoiceEnabled: false, snapshot: ttsOnly))
+    }
+
+    func testSceneBackgroundCancelsActivePlayback() async {
+        let playback = MockReadAloudPlayback()
+        let gateway = MockReadAloudGateway(emitsPCM: true)
+        gateway.pauseAfterEmission = true
+        let controller = makeController(playback: playback, gateway: gateway)
+
+        controller.toggle(messageID: "message-a", content: "Background")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(controller.state, .playing(messageID: "message-a"))
+
+        controller.setForegroundActive(false)
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertEqual(gateway.streams.last?.cancelCount, 1)
+        XCTAssertFalse(playback.isPlaying)
+
+        controller.toggle(messageID: "message-b", content: "Refused")
+        XCTAssertEqual(gateway.openCount, 1, "Read aloud must not start while backgrounded")
+        XCTAssertEqual(controller.state, .idle)
+
+        controller.setForegroundActive(true)
+    }
+
+    func testGatewayReplacementCancelsActivePlayback() async {
+        let playback = MockReadAloudPlayback()
+        let gateway = MockReadAloudGateway(emitsPCM: true)
+        gateway.pauseAfterEmission = true
+        let controller = makeController(playback: playback, gateway: gateway)
+
+        controller.toggle(messageID: "message-a", content: "Replaced")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(controller.state, .playing(messageID: "message-a"))
+
+        controller.setGateway(nil)
+        XCTAssertEqual(controller.state, .idle, "Clearing the gateway (disconnect) invalidates the active operation")
+        XCTAssertEqual(gateway.streams.last?.cancelCount, 1)
+
+        let replacement = MockReadAloudGateway(emitsPCM: true)
+        replacement.pauseAfterEmission = true
+        controller.setGateway(replacement)
+        controller.toggle(messageID: "message-b", content: "Second gateway")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(controller.state, .playing(messageID: "message-b"))
+
+        controller.setGateway(MockReadAloudGateway())
+        XCTAssertEqual(controller.state, .idle, "A profile/connection change replaces the gateway and stops playback")
+        XCTAssertEqual(replacement.streams.last?.cancelCount, 1)
+    }
+}
+
+@MainActor
+private final class MockReadAloudPlayback: SpeechPlaybackService {
+    private(set) var startedSampleRates: [Double] = []
+    private(set) var enqueuedPCM: [(data: Data, sampleRate: Double)] = []
+    private(set) var encodedFrames: [Data] = []
+    private(set) var finishCount = 0
+    private(set) var drainCount = 0
+    private(set) var stopCount = 0
+    var isPlaying = false
+    var startError: Error?
+    var enqueueError: Error?
+    /// When set, drain() suspends until stop() releases it — models audio
+    /// that is still playing out.
+    var blockDrain = false
+    private var drainWaiter: CheckedContinuation<Void, Never>?
+
+    func start(sampleRate: Double) throws {
+        if let startError { throw startError }
+        startedSampleRates.append(sampleRate)
+        isPlaying = true
+    }
+
+    func enqueuePCM16(_ data: Data, sampleRate: Double) throws -> Int {
+        if let enqueueError { throw enqueueError }
+        enqueuedPCM.append((data, sampleRate))
+        isPlaying = true
+        return data.count - (data.count % 2)
+    }
+
+    func playEncodedAudioData(_ data: Data) throws {
+        encodedFrames.append(data)
+        isPlaying = true
+    }
+
+    func finish() throws { finishCount += 1 }
+
+    func drain() async {
+        drainCount += 1
+        guard blockDrain else {
+            isPlaying = false
+            return
+        }
+        await withCheckedContinuation { continuation in
+            drainWaiter = continuation
+        }
+        drainWaiter = nil
+    }
+
+    func stop() {
+        stopCount += 1
+        isPlaying = false
+        let waiter = drainWaiter
+        drainWaiter = nil
+        waiter?.resume()
+    }
+}
+
+@MainActor
+private final class MockReadAloudStream: VoiceSpeechStream {
+    private(set) var appended: [String] = []
+    private(set) var finishCount = 0
+    private(set) var cancelCount = 0
+    private let emitsPCM: Bool
+    private let emitsEncoded: Bool
+    private let sampleRate: Double
+    private let pauseAfterEmission: Bool
+    private let blocksFinish: Bool
+    private let blocksCancelDelivery: Bool
+    private let onStart: @MainActor (Double) throws -> Void
+    private let onPCM16: @MainActor (Data, Double) throws -> Void
+    private let onEncodedAudio: @MainActor (Data) throws -> Void
+    private var isCancelled = false
+    private var appendContinuation: CheckedContinuation<Void, Error>?
+    private var finishContinuation: CheckedContinuation<Bool, Error>?
+    private var deferredCancelResumes: [() -> Void] = []
+
+    init(
+        emitsPCM: Bool,
+        emitsEncoded: Bool,
+        sampleRate: Double,
+        pauseAfterEmission: Bool,
+        blocksFinish: Bool,
+        blocksCancelDelivery: Bool,
+        onStart: @escaping @MainActor (Double) throws -> Void,
+        onPCM16: @escaping @MainActor (Data, Double) throws -> Void,
+        onEncodedAudio: @escaping @MainActor (Data) throws -> Void
+    ) {
+        self.emitsPCM = emitsPCM
+        self.emitsEncoded = emitsEncoded
+        self.sampleRate = sampleRate
+        self.pauseAfterEmission = pauseAfterEmission
+        self.blocksFinish = blocksFinish
+        self.blocksCancelDelivery = blocksCancelDelivery
+        self.onStart = onStart
+        self.onPCM16 = onPCM16
+        self.onEncodedAudio = onEncodedAudio
+    }
+
+    func append(_ text: String) async throws {
+        appended.append(text)
+        guard !isCancelled else { throw URLError(.cancelled) }
+        if emitsPCM {
+            try onStart(sampleRate)
+            try onPCM16(Data(repeating: 1, count: 8), sampleRate)
+        }
+        if emitsEncoded {
+            try onEncodedAudio(Data([0x01, 0x02, 0x03]))
+        }
+        guard pauseAfterEmission else { return }
+        try await withCheckedThrowingContinuation { continuation in
+            appendContinuation = continuation
+            if isCancelled {
+                appendContinuation = nil
+                continuation.resume(throwing: URLError(.cancelled))
+            }
+        }
+    }
+
+    func finish() async throws -> Bool {
+        finishCount += 1
+        guard blocksFinish else { return false }
+        return try await withCheckedThrowingContinuation { continuation in
+            finishContinuation = continuation
+            if isCancelled {
+                finishContinuation = nil
+                continuation.resume(throwing: URLError(.cancelled))
+            }
+        }
+    }
+
+    func cancel() {
+        guard !isCancelled else { return }
+        isCancelled = true
+        cancelCount += 1
+        let append = appendContinuation
+        appendContinuation = nil
+        let finish = finishContinuation
+        finishContinuation = nil
+        // Deferred delivery models a superseded operation whose error lands
+        // only after a newer operation has already adopted its own stream.
+        guard !blocksCancelDelivery else {
+            if let append { deferredCancelResumes.append { append.resume(throwing: URLError(.cancelled)) } }
+            if let finish { deferredCancelResumes.append { finish.resume(throwing: URLError(.cancelled)) } }
+            return
+        }
+        append?.resume(throwing: URLError(.cancelled))
+        finish?.resume(throwing: URLError(.cancelled))
+    }
+
+    func releaseCancelForTest() {
+        let deferred = deferredCancelResumes
+        deferredCancelResumes.removeAll()
+        deferred.forEach { $0() }
+    }
+
+    func releaseAppendForTest(throwing error: Error? = nil) {
+        let continuation = appendContinuation
+        appendContinuation = nil
+        if let error {
+            continuation?.resume(throwing: error)
+        } else {
+            continuation?.resume()
+        }
+    }
+}
+
+@MainActor
+private final class MockReadAloudGateway: VoiceGatewayService {
+    let profile: String
+    let emitsPCM: Bool
+    let emitsEncoded: Bool
+    let sampleRate: Double
+    var openError: Error?
+    var blocksOpen = false
+    var pauseAfterEmission = false
+    var blocksFinish = false
+    var blocksCancelDelivery = false
+    private(set) var openCount = 0
+    private(set) var streams: [MockReadAloudStream] = []
+    private var openContinuation: CheckedContinuation<VoiceSpeechStream, Error>?
+
+    init(
+        profile: String = "default",
+        emitsPCM: Bool = false,
+        emitsEncoded: Bool = false,
+        sampleRate: Double = 24_000
+    ) {
+        self.profile = profile
+        self.emitsPCM = emitsPCM
+        self.emitsEncoded = emitsEncoded
+        self.sampleRate = sampleRate
+    }
+
+    func transcribe(_ audio: VoiceCapturedAudio) async throws -> String {
+        XCTFail("Read aloud must never transcribe.")
+        return ""
+    }
+
+    func openSpeechStream(
+        onStart: @escaping @MainActor (Double) throws -> Void,
+        onPCM16: @escaping @MainActor (Data, Double) throws -> Void,
+        onEncodedAudio: @escaping @MainActor (Data) throws -> Void
+    ) async throws -> VoiceSpeechStream {
+        openCount += 1
+        let stream = MockReadAloudStream(
+            emitsPCM: emitsPCM,
+            emitsEncoded: emitsEncoded,
+            sampleRate: sampleRate,
+            pauseAfterEmission: pauseAfterEmission,
+            blocksFinish: blocksFinish,
+            blocksCancelDelivery: blocksCancelDelivery,
+            onStart: onStart,
+            onPCM16: onPCM16,
+            onEncodedAudio: onEncodedAudio
+        )
+        streams.append(stream)
+        if let openError { throw openError }
+        guard !blocksOpen else {
+            return try await withCheckedThrowingContinuation { continuation in
+                openContinuation = continuation
+            }
+        }
+        return stream
+    }
+
+    func resumeOpenForTest() {
+        guard let continuation = openContinuation, let stream = streams.last else { return }
+        openContinuation = nil
+        continuation.resume(returning: stream)
+    }
+}

--- a/ConduitTests/MessageReadAloudControllerTests.swift
+++ b/ConduitTests/MessageReadAloudControllerTests.swift
@@ -256,6 +256,7 @@ final class MessageReadAloudControllerTests: XCTestCase {
         XCTAssertEqual(controller.state, .failed(messageID: "message-a", message: "Speech provider exploded"))
         XCTAssertEqual(reported, ["Speech provider exploded"])
         XCTAssertFalse(playback.isPlaying)
+        XCTAssertEqual(gateway.streams.count, 0, "A failed open must not leave a recorded stream")
 
         gateway.openError = nil
         controller.toggle(messageID: "message-a", content: "Broken")
@@ -620,8 +621,8 @@ private final class MockReadAloudGateway: VoiceGatewayService {
             onPCM16: onPCM16,
             onEncodedAudio: onEncodedAudio
         )
-        streams.append(stream)
         if let openError { throw openError }
+        streams.append(stream)
         guard !blocksOpen else {
             return try await withCheckedThrowingContinuation { continuation in
                 openContinuation = continuation


### PR DESCRIPTION
Adds the manual Read Aloud action from #81: a speaker control on completed assistant messages that streams the response through the existing TTS pipeline. No automatic TTS — playback only starts on tap.

## What changed

**`MessageReadAloudController`** (new, `Conduit/Voice/`) — UI-independent, `@MainActor`, mirrors the `VoiceConversationController` pattern:
- Owns the active message ID, `idle / preparing / playing / failed` state, the active `VoiceSpeechStream`, the playback task, and an operation generation token. Every post-`await` mutation of shared state sits behind an `isCurrent(generation)` guard, so a superseded operation (tap-to-stop, tap-to-switch, background, disconnect) can never clear or overwrite the newer operation's stream or state — including in the error path.
- Reuses `VoiceGatewayService.openSpeechStream` (streaming PCM + encoded fallback) and the shared `SpeechPlaybackService`; no second transport, no new endpoints, no `HermesVoiceGateway` changes.
- After stream completion it finishes and drains the playback engine, returning to idle only if it still owns the operation. Errors stop any in-flight audio and surface via the existing `errorMessage` convention.

**AppState** — TTS-only availability (`isConnected` + `isVoiceEnabled` + `snapshot.supportsSpeech`; deliberately no mic/STT/Apple Speech/transcription requirements). Lifecycle stops on scene background, disconnect, forced sign-out, and profile switch; mutual exclusion with the voice conversation sheet and the live TTS test. The capability refresh keeps the live gateway across refreshes so playback isn't churned — but a kept gateway must still match the active profile **and** the live `DashboardTicketBridge` (a gateway outliving its invalidated bridge is rebuilt, which is what a same-profile re-login would otherwise leak).

**ChatView** — 34×34 SF Symbol control in `AssistantBubble` beside Copy/Branch: `speaker.wave.2` idle, spinner while preparing, `stop.fill` playing (accent-tinted), existing haptic conventions, "Read response aloud" / "Stop reading response" labels. Only the owning message shows the active state; the button is absent on in-progress (partial) messages and disabled when read aloud is unavailable.

## Tests

18 focused tests in `MessageReadAloudControllerTests` (patterned after `VoiceConversationControllerTests`, checked-continuation mocks for deterministic interleavings), covering: full-content open, PCM and encoded fallback paths, finish→drain→idle, tap-to-stop, cross-message takeover, superseded-operation isolation (success, late-open, late-finish, and the deferred-catch path where a stale operation's error lands after the newer operation owns its stream), mid-stream failure settling the audio engine, empty-content no-op, repeated stops, TTS-only availability, background stop, and gateway replacement. Existing voice suites unchanged.

## Verification

- `MessageReadAloudControllerTests` 18/18 and `VoiceConversationControllerTests` 28/28 green locally; broader suites (AppState chat resume, chat title scroll, voice config, session cache/rename/yolo, audio session) green locally.
- Full suite + build via CI on this PR.
- UI flows reasoned through: idle start, tap-active stop, tap-different takeover, background stop, disconnect/logout stop, profile-switch stop, and voice-conversation/TTS-test mutual exclusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to read assistant messages aloud.
  * Added playback controls with preparation status, accessibility labels, and availability feedback.
  * Added persisted chat return-surface preferences.
  * Improved sessions-drawer presentation when returning to chat.
* **Bug Fixes**
  * Improved recovery from interruptions, cancellations, and failed speech generation.
  * Read-aloud playback now responds reliably to connectivity, voice settings, sign-out, backgrounding, and profile changes.
  * Prevented read-aloud playback from conflicting with voice conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->