### PR TITLE
Omit Hermes compaction summaries from resumed transcripts

### DIFF
--- a/Conduit/Services/HermesClient.swift
+++ b/Conduit/Services/HermesClient.swift
@@ -1438,9 +1438,19 @@ enum MessageNormalizer {
                 ?? obj["message_id"]?.descriptiveStringValue
                 ?? String(index)
 
-            let rawContent = isToolResult
+            let extractedContent = isToolResult
                 ? extractToolOutput(obj)
                 : extractContent(obj["content"] ?? obj["text"] ?? .null)
+            // Compaction bookkeeping is removed before role/system/runtime
+            // normalization so no summary text — standalone or merged onto a
+            // real prompt — can reach a ChatMessage and the renderer.
+            guard let rawContent = visibleContentRemovingCompaction(
+                from: obj,
+                content: extractedContent,
+                isToolResult: isToolResult
+            ) else {
+                continue
+            }
             let modelChange = modelChangeActivity(fromText: rawContent)
             let systemNotice = systemNoticeText(fromText: rawContent)
             if modelChange != nil || systemNotice != nil { role = .system }
@@ -1598,6 +1608,68 @@ enum MessageNormalizer {
     static func isUserCorrectionInterruptionNotice(_ text: String) -> Bool {
         text.trimmingCharacters(in: .whitespacesAndNewlines)
             .caseInsensitiveCompare("[This response was interrupted by a user correction.]") == .orderedSame
+    }
+
+    /// Hermes persists context-compaction summaries as ordinary transcript
+    /// records — usually under a conversational role, and sometimes appended
+    /// to a row that still holds the genuine user prompt. They are
+    /// model-context bookkeeping, not chat messages, and can be large enough
+    /// to stall the Markdown pipeline when mistaken for a visible bubble.
+    /// Returns the content that should remain visible, or nil when the whole
+    /// record is compaction bookkeeping and must not produce a ChatMessage.
+    /// Tool-result rows bypass the filter: compaction artifacts only ride
+    /// conversational roles, while a tool's own output may legitimately print
+    /// the delimiter text.
+    private static func visibleContentRemovingCompaction(
+        from obj: [String: AnyCodable],
+        content: String,
+        isToolResult: Bool
+    ) -> String? {
+        if isToolResult { return content }
+
+        if let range = content.range(of: compactionSummaryDelimiter) {
+            // Merged row: the genuine prompt sits before the delimiter behind
+            // an optional wrapper header; the summary suffix is never shown.
+            var visible = String(content[..<range.lowerBound])
+            // Strip the wrapper only as a leading header — a copy the user
+            // quoted mid-message belongs to their message.
+            if visible.trimmingCharacters(in: .whitespacesAndNewlines)
+                .hasPrefix(priorContextWrapperHeader),
+                let wrapperRange = visible.range(of: priorContextWrapperHeader) {
+                visible.removeSubrange(wrapperRange)
+            }
+            let trimmed = visible.trimmingCharacters(in: .whitespacesAndNewlines)
+            // After a second compaction the retained prefix can itself be an
+            // older summary rather than a genuine prompt.
+            guard !trimmed.isEmpty, !hasCompactionSummaryPrefix(trimmed) else { return nil }
+            return trimmed
+        }
+
+        let flaggedAsSummary = obj["_compressed_summary"]?.boolValue == true
+            || obj["metadata"]?.objectValue?["_compressed_summary"]?.boolValue == true
+        if flaggedAsSummary || hasCompactionSummaryPrefix(content) {
+            return nil
+        }
+        return content
+    }
+
+    private static let compactionSummaryDelimiter =
+        "[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]"
+
+    private static let priorContextWrapperHeader =
+        "[PRIOR CONTEXT — for reference only; not a new message]"
+
+    /// Hermes emits two generations of compaction headers, and the reload
+    /// path can drop the `_compressed_summary` flag while keeping the
+    /// recognizable text. Match case-insensitively like the other Hermes
+    /// bracketed notices, anchored at the start of the content so ordinary
+    /// discussion of "context compaction" is never mistaken for a summary.
+    /// Only a short head is lowercased — the payload being tested can be a
+    /// multi-megabyte summary that must not be copied before being dropped.
+    private static func hasCompactionSummaryPrefix(_ content: String) -> Bool {
+        let head = content.trimmingCharacters(in: .whitespacesAndNewlines).prefix(32).lowercased()
+        return head.hasPrefix("[context compaction")
+            || head.hasPrefix("[context summary]:")
     }
 
     /// Normalizes the gateway's native clarification event. Current Hermes

--- a/Conduit/Services/HermesClient.swift
+++ b/Conduit/Services/HermesClient.swift
@@ -1627,9 +1627,16 @@ enum MessageNormalizer {
     ) -> String? {
         if isToolResult { return content }
 
+        // Standalone summaries announce themselves within the first bytes.
+        // Dropping them here skips the merged-delimiter search, which would
+        // otherwise walk a potentially multi-megabyte payload end-to-end.
+        if hasCompactionSummaryPrefix(content) { return nil }
+
         if let range = content.range(of: compactionSummaryDelimiter) {
             // Merged row: the genuine prompt sits before the delimiter behind
             // an optional wrapper header; the summary suffix is never shown.
+            // The flag does not preempt this branch — it marks the record as
+            // carrying a summary, not as lacking a genuine prompt.
             var visible = String(content[..<range.lowerBound])
             // Strip the wrapper only as a leading header — a copy the user
             // quoted mid-message belongs to their message.
@@ -1647,10 +1654,8 @@ enum MessageNormalizer {
 
         let flaggedAsSummary = obj["_compressed_summary"]?.boolValue == true
             || obj["metadata"]?.objectValue?["_compressed_summary"]?.boolValue == true
-        if flaggedAsSummary || hasCompactionSummaryPrefix(content) {
-            return nil
-        }
-        return content
+        // Flagged with no merged form is pure bookkeeping.
+        return flaggedAsSummary ? nil : content
     }
 
     private static let compactionSummaryDelimiter =
@@ -1664,10 +1669,15 @@ enum MessageNormalizer {
     /// recognizable text. Match case-insensitively like the other Hermes
     /// bracketed notices, anchored at the start of the content so ordinary
     /// discussion of "context compaction" is never mistaken for a summary.
-    /// Only a short head is lowercased — the payload being tested can be a
-    /// multi-megabyte summary that must not be copied before being dropped.
-    private static func hasCompactionSummaryPrefix(_ content: String) -> Bool {
-        let head = content.trimmingCharacters(in: .whitespacesAndNewlines).prefix(32).lowercased()
+    /// Classification reads only a bounded head: leading whitespace is
+    /// skipped by index and only the next 32 characters are compared, so a
+    /// multi-megabyte summary is never copied or tail-scanned to classify it.
+    static func hasCompactionSummaryPrefix(_ content: String) -> Bool {
+        var headStart = content.startIndex
+        while headStart < content.endIndex, content[headStart].isWhitespace {
+            headStart = content.index(after: headStart)
+        }
+        let head = content[headStart...].prefix(32).lowercased()
         return head.hasPrefix("[context compaction")
             || head.hasPrefix("[context summary]:")
     }

--- a/ConduitTests/MessageNormalizerTests.swift
+++ b/ConduitTests/MessageNormalizerTests.swift
@@ -1138,6 +1138,45 @@ final class MessageNormalizerTests: XCTestCase {
         XCTAssertEqual(messages.first?.content, "Still here after the summary was dropped.")
     }
 
+    func testLargeStandalonePrefixSummaryIsDroppedByPrefixAlone() {
+        // No flag and no merged delimiter anywhere: classification must rest
+        // on the prefix alone, without the full-payload delimiter search.
+        let hugeSummary = "[CONTEXT COMPACTION 12:04 — 48% of window used]\n"
+            + String(repeating: "Turn summary with no merged marker in the body. ", count: 100_000)
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(97),
+                "role": .string("user"),
+                "content": .string(hugeSummary)
+            ]),
+            .object([
+                "id": .number(98),
+                "role": .string("assistant"),
+                "content": .string("Neighbor row survives.")
+            ])
+        ])
+
+        XCTAssertEqual(messages.map(\.content), ["Neighbor row survives."])
+    }
+
+    func testCompactionPrefixHelperClassifiesFromABoundedHead() {
+        // Multi-megabyte payloads must be classifiable from their head
+        // without trimming or copying the whole string.
+        let hugeTail = String(repeating: "Summary detail line. ", count: 250_000)
+
+        XCTAssertTrue(MessageNormalizer.hasCompactionSummaryPrefix(
+            "[CONTEXT COMPACTION 12:04]\n" + hugeTail + "\n  \n"
+        ))
+        XCTAssertTrue(MessageNormalizer.hasCompactionSummaryPrefix(
+            "\n\t  [context summary]: legacy opening\n" + hugeTail
+        ))
+        XCTAssertFalse(MessageNormalizer.hasCompactionSummaryPrefix(
+            "Can you explain how context compaction works?\n" + hugeTail
+        ))
+        XCTAssertFalse(MessageNormalizer.hasCompactionSummaryPrefix("   \n\t"))
+        XCTAssertFalse(MessageNormalizer.hasCompactionSummaryPrefix(""))
+    }
+
     func testInterruptedIdenticalCorrectionDoesNotCreateASecondUserBubble() {
         let messages = MessageNormalizer.normalizeMessages([
             .object([

--- a/ConduitTests/MessageNormalizerTests.swift
+++ b/ConduitTests/MessageNormalizerTests.swift
@@ -889,6 +889,255 @@ final class MessageNormalizerTests: XCTestCase {
         XCTAssertEqual(messages[0].rawContent, original)
     }
 
+    // MARK: - Persisted context-compaction summaries
+
+    func testPersistedCompactionSummaryFlaggedByMetadataIsOmitted() {
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(81),
+                "role": .string("user"),
+                "_compressed_summary": .bool(true),
+                "content": .string("[CONTEXT COMPACTION 12:04 — 48% of window used]")
+            ]),
+            // The flag may survive only inside the record's metadata object
+            // after a persistence round-trip.
+            .object([
+                "id": .number(82),
+                "role": .string("user"),
+                "metadata": .object(["_compressed_summary": .bool(true)]),
+                "content": .string("Summary of the session so far without the top-level flag")
+            ])
+        ])
+
+        XCTAssertTrue(messages.isEmpty)
+    }
+
+    func testPersistedCompactionSummaryRecognizedByCurrentPrefixWithoutMetadata() {
+        // Large on purpose: the prefix detector must decide from a bounded
+        // head without copying a summary-sized payload.
+        let largeSummary = "[CONTEXT COMPACTION 12:04 — 48% of window used]\n"
+            + String(repeating: "The user asked about the deploy pipeline and a config bug was fixed. ", count: 20_000)
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(83),
+                "role": .string("user"),
+                "content": .string(largeSummary)
+            ])
+        ])
+
+        XCTAssertTrue(messages.isEmpty)
+    }
+
+    func testPersistedLegacyContextSummaryPrefixIsOmitted() {
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(84),
+                "role": .string("user"),
+                "content": .string("[CONTEXT SUMMARY]: Earlier the user asked about the deploy pipeline.")
+            ])
+        ])
+
+        XCTAssertTrue(messages.isEmpty)
+    }
+
+    func testPersistedCompactionSummaryIsOmittedRegardlessOfRole() {
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(85),
+                "role": .string("assistant"),
+                "_compressed_summary": .bool(true),
+                "content": .string("Summary of everything the assistant did so far in this session.")
+            ])
+        ])
+
+        XCTAssertTrue(messages.isEmpty)
+    }
+
+    func testMergedPriorContextRecordKeepsOnlyGenuineUserContent() {
+        let genuine = "This is the user's real message."
+        let merged = "[PRIOR CONTEXT — for reference only; not a new message]\n\n"
+            + genuine
+            + "\n\n[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]\n\n"
+            + "[CONTEXT COMPACTION 12:04]\n"
+            + String(repeating: "Summary of the prior turns. ", count: 1_000)
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(86),
+                "role": .string("user"),
+                "content": .string(merged)
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .user)
+        XCTAssertEqual(messages[0].content, genuine)
+        XCTAssertFalse(messages[0].content.contains("PRIOR CONTEXT"))
+        XCTAssertFalse(messages[0].content.contains("COMPACTION"))
+    }
+
+    func testMergedCompactionRecordWithoutGenuineContentIsOmitted() {
+        let merged = "[PRIOR CONTEXT — for reference only; not a new message]\n\n"
+            + "[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]\n\n"
+            + "[CONTEXT SUMMARY]: Everything before this point.\n"
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(87),
+                "role": .string("user"),
+                "content": .string(merged)
+            ])
+        ])
+
+        XCTAssertTrue(messages.isEmpty)
+    }
+
+    func testMergedRecordWhosePrefixIsItselfASummaryIsOmitted() {
+        // Double compaction: the row above the delimiter is an older summary,
+        // not a genuine prompt. Splitting at the delimiter alone would keep
+        // the older summary as a visible bubble.
+        let merged = "[CONTEXT COMPACTION 12:04]\n"
+            + String(repeating: "Prior summary of the session. ", count: 2_000)
+            + "\n\n[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]\n\n"
+            + "[CONTEXT COMPACTION 12:05]\n"
+            + String(repeating: "Newer summary of the session. ", count: 2_000)
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(91),
+                "role": .string("user"),
+                "content": .string(merged)
+            ])
+        ])
+
+        XCTAssertTrue(messages.isEmpty)
+    }
+
+    func testMergedRecordKeepsGenuineContentEvenWhenFlagged() {
+        // The flag marks the row as carrying a summary, not as lacking a
+        // genuine prompt; the merged split still owns it.
+        let genuine = "Rebuild the release after the config change."
+        let merged = "[PRIOR CONTEXT — for reference only; not a new message]\n\n"
+            + genuine
+            + "\n\n[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]\n\n"
+            + "[CONTEXT COMPACTION 12:04]\nSummary follows."
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(92),
+                "role": .string("user"),
+                "_compressed_summary": .bool(true),
+                "content": .string(merged)
+            ])
+        ])
+
+        XCTAssertEqual(messages.map(\.content), [genuine])
+    }
+
+    func testBareDelimiterRecordWithEmptyPrefixIsOmitted() {
+        let merged = "\n\n[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]\n\n"
+            + "[CONTEXT SUMMARY]: Everything before this point.\n"
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(93),
+                "role": .string("user"),
+                "content": .string(merged)
+            ])
+        ])
+
+        XCTAssertTrue(messages.isEmpty)
+    }
+
+    func testDelimiterRecordWithoutWrapperKeepsGenuineContent() {
+        // The wrapper header is optional; the delimiter alone marks the merge.
+        let genuine = "Please rerun the migration tests."
+        let merged = genuine
+            + "\n\n[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]\n\n"
+            + "[CONTEXT COMPACTION 12:04]\nSummary follows."
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(95),
+                "role": .string("user"),
+                "content": .string(merged)
+            ])
+        ])
+
+        XCTAssertEqual(messages.map(\.content), [genuine])
+    }
+
+    func testQuotedWrapperInsideGenuineContentIsPreserved() {
+        // The wrapper is only stripped as a leading header; a copy the user
+        // quoted mid-message belongs to their message.
+        let genuine = "The transcript marker looks like this:\n"
+            + "[PRIOR CONTEXT — for reference only; not a new message]\n"
+            + "and then my question follows."
+        let merged = genuine
+            + "\n\n[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]\n\n"
+            + "[CONTEXT COMPACTION 12:04]\nSummary follows."
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(96),
+                "role": .string("user"),
+                "content": .string(merged)
+            ])
+        ])
+
+        XCTAssertEqual(messages.map(\.content), [genuine])
+    }
+
+    func testToolResultContainingCompactionDelimiterIsNotTruncated() {
+        // Compaction artifacts ride conversational roles; a tool output that
+        // merely prints the delimiter text must keep its full content.
+        let output = "grep results:\n[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]\nmatched 3 lines"
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(94),
+                "role": .string("tool"),
+                "tool_call_id": .string("call-9"),
+                "tool_name": .string("run_grep"),
+                "content": .string(output)
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .tool)
+        XCTAssertEqual(messages[0].tool?.output, output)
+    }
+
+    func testOrdinaryCompactionDiscussionIsNotHidden() {
+        let content = "Can you explain how context compaction works?"
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(88),
+                "role": .string("user"),
+                "content": .string(content)
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .user)
+        XCTAssertEqual(messages[0].content, content)
+    }
+
+    func testLargePersistedCompactionSummaryNeverReachesChatMessages() {
+        // A multi-megabyte summary must be dropped during normalization, not
+        // handed to the Markdown/UI rendering pipeline as a user bubble.
+        let hugeSummary = "[CONTEXT COMPACTION 12:04]\n"
+            + String(repeating: "The session covered implementation details and open questions. ", count: 30_000)
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(89),
+                "role": .string("user"),
+                "_compressed_summary": .bool(true),
+                "content": .string(hugeSummary)
+            ]),
+            .object([
+                "id": .number(90),
+                "role": .string("assistant"),
+                "content": .string("Still here after the summary was dropped.")
+            ])
+        ])
+
+        XCTAssertEqual(messages.map(\.role), [.assistant])
+        XCTAssertEqual(messages.first?.content, "Still here after the summary was dropped.")
+    }
+
     func testInterruptedIdenticalCorrectionDoesNotCreateASecondUserBubble() {
         let messages = MessageNormalizer.normalizeMessages([
             .object([


### PR DESCRIPTION
## Problem

When reopening/resuming a Hermes session, persisted context-compaction summaries come back in history with a normal conversational role (usually `user`). Conduit normalized them into visible chat bubbles — and because a summary can be megabytes large, the Markdown/UI rendering pipeline stalled on it.

## Fix

Filtering lives entirely at the history-normalization boundary in `MessageNormalizer` (`Conduit/Services/HermesClient.swift`) — the single point both resume paths already use (`session.resume` and the dashboard `/api/sessions/{id}/messages` prefetch). A new `visibleContentRemovingCompaction(from:content:isToolResult:)` runs right after raw-content extraction, before role/system/runtime normalization, so summary text can never reach a `ChatMessage` or the renderer. No view-layer changes.

Detection (role-independent):

- `_compressed_summary == true` — top-level or inside the record's `metadata` object
- content starts with `[CONTEXT COMPACTION` (current) or `[CONTEXT SUMMARY]:` (legacy), case-insensitive and start-anchored, checked against a bounded 32-char head so a summary-sized payload is never copied

Merged records containing `[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]`:

- keep only the genuine prompt before the delimiter
- strip the `[PRIOR CONTEXT — for reference only; not a new message]` wrapper only when it leads the retained text (a copy the user quoted mid-message survives)
- drop the record if the remainder is empty or is itself an older summary (double-compaction shape)
- the summary suffix is never passed into `ChatMessage`

Tool-result rows bypass the filter entirely: compaction artifacts only ride conversational roles, while a tool's own output may legitimately print the delimiter text.

## Tests

14 new tests in `MessageNormalizerTests`: all eight shapes from the issue (metadata-flagged user summary, current/legacy prefix without metadata, assistant-role summary, merged real-content + summary, merged with no genuine content, false-positive protection, large-summary regression) plus reviewer-driven edges (double-compaction prefix, flagged merged record keeps genuine content, bare delimiter, wrapper-absent merge, quoted-wrapper preservation, delimiter-printing tool output). Local runs green: 194/194 across `MessageNormalizerTests`, `AppStateChatResumeTests`, `ChatResumePolicyTests`, `SessionPresentationCacheTests`, `DashboardTicketBridgeTests`.

## Out of scope

- Legitimate extremely large user/assistant messages still render through synchronous Markdown parsing — separate performance concern.
- Dash/case-tolerant delimiter matching deliberately declined: Hermes emits exact programmatic constants, and tolerance widens the false-positive surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation transcript cleanup by removing internal context-compaction summaries.
  * Preserved genuine user messages, tool results, and ordinary discussion content.
  * Correctly handles legacy, merged, malformed, and summary-only transcript entries.
  * Omits records that contain no visible conversational content.
  * Improved handling of large summaries and varied formatting without affecting legitimate prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->