### PR TITLE
Coalesce live reasoning publication to defuse scene-update watchdog

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -1553,7 +1553,7 @@ final class AppState: ObservableObject {
         activeSessionTitle = "New conversation"
         messages = []
         clearStreamingText()
-        resetReasoningStream()
+        resetReasoningTurn()
         activeSessionTitlesByProfile = [:]
         pinnedSessionIDsByProfile = [:]
         pinnedSessionIDs = []
@@ -1992,7 +1992,7 @@ final class AppState: ObservableObject {
         messages = []
         setActiveSessionState(id: nil, title: "New conversation")
         clearStreamingText()
-        resetReasoningStream()
+        resetReasoningTurn()
         turnState = .idle
         defaults.removeObject(forKey: activeSessionTitlesByProfileKey)
         defaults.removeObject(forKey: pinnedSessionIDsByProfileKey)
@@ -2848,7 +2848,7 @@ final class AppState: ObservableObject {
             noteChatViewportTranscriptReplacement()
             clearStreamingText()
             activeAssistantMessageId = nil
-            resetReasoningStream()
+            resetReasoningTurn()
             turnState = .idle
             errorMessage = nil
             // A fresh conversation has no per-session override and no
@@ -3045,7 +3045,7 @@ final class AppState: ObservableObject {
             streamingText = recoveredText
         }
         activeAssistantMessageId = nil
-        resetReasoningStream()
+        resetReasoningTurn()
         applyRuntime(
             result.snapshot,
             for: result.sessionId
@@ -4285,7 +4285,7 @@ final class AppState: ObservableObject {
         messages = []
         clearStreamingText()
         activeAssistantMessageId = nil
-        resetReasoningStream()
+        resetReasoningTurn()
         turnState = .idle
         finishChatViewportTransition(generation: transitionGeneration)
     }
@@ -4363,7 +4363,7 @@ final class AppState: ObservableObject {
         messages = []
         clearStreamingText()
         activeAssistantMessageId = nil
-        resetReasoningStream()
+        resetReasoningTurn()
         updateActiveSessionTitle(for: sessionId)
         let reconciled = await reconcile(
             sessionId: sessionId,
@@ -7238,7 +7238,7 @@ final class AppState: ObservableObject {
             // A new turn ends any live reasoning card; flush first so the
             // previous segment keeps its exact buffered text.
             flushReasoningPublish()
-            resetReasoningStream()
+            resetReasoningTurn()
             setRunning(true)
             notifyVoiceAssistant(.started(sessionID: streamSessionId))
 
@@ -7266,7 +7266,7 @@ final class AppState: ObservableObject {
 
         case .messageError(_, let message):
             flushReasoningPublish()
-            resetReasoningStream()
+            resetReasoningTurn()
             clearStreamingText()
             errorMessage = message
             setRunning(false)
@@ -7274,7 +7274,7 @@ final class AppState: ObservableObject {
 
         case .messageInterrupted:
             flushReasoningPublish()
-            resetReasoningStream()
+            resetReasoningTurn()
             clearStreamingText()
             setRunning(false)
             notifyVoiceAssistant(.interrupted(sessionID: streamSessionId))
@@ -7309,8 +7309,10 @@ final class AppState: ObservableObject {
             if name.lowercased() == "clarify" { break }
             // The tool card must land after a complete reasoning card; flush
             // the coalesced buffer before the boundary reorders the transcript.
+            // A tool ends the reasoning SEGMENT only — the turn flag survives
+            // so completion-carried reasoning cannot duplicate this segment.
             flushReasoningPublish()
-            resetReasoningStream()
+            resetReasoningSegment()
             flushStreamingPartial()
             messages.append(ChatMessage(
                 id: "tool-start-\(Date().timeIntervalSince1970)",
@@ -7323,7 +7325,7 @@ final class AppState: ObservableObject {
         case .toolComplete(_, let name, let output):
             if name.lowercased() == "clarify" { break }
             flushReasoningPublish()
-            resetReasoningStream()
+            resetReasoningSegment()
             // Update the matching running tool card in place instead of
             // appending a duplicate. This keeps input + output together in
             // one chronological entry, matching how the HTTP API returns
@@ -7544,17 +7546,26 @@ final class AppState: ObservableObject {
         publishReasoningBuffer(liveCardID: activeReasoningMessageId)
     }
 
-    /// Restore the ENTIRE per-turn reasoning state machine to its initial
-    /// condition. The transcript is being replaced (session open/resume/new
-    /// conversation/disconnect), so the old card must not receive further
-    /// updates — including from an in-flight publish — and the next turn's
-    /// completion-carried reasoning must not look already-streamed.
-    private func resetReasoningStream() {
+    /// End the active reasoning SEGMENT without publishing. Used at tool
+    /// boundaries: the tool card ends the current thinking card, but the
+    /// assistant TURN continues — reasoning may resume in a fresh segment, and
+    /// reasoning already streamed this turn still counts at completion.
+    private func resetReasoningSegment() {
         reasoningPublishTask?.cancel()
         reasoningPublishTask = nil
         hasScheduledReasoningPublish = false
         reasoningBuffer = ""
         activeReasoningMessageId = nil
+    }
+
+    /// Restore the ENTIRE per-turn reasoning state machine to its initial
+    /// condition. Used when the turn or transcript itself is being replaced
+    /// (message boundaries, completion, disconnect, session switch): the old
+    /// card must not receive further updates — including from an in-flight
+    /// publish — and the next turn's completion-carried reasoning must not
+    /// look already-streamed.
+    private func resetReasoningTurn() {
+        resetReasoningSegment()
         receivedReasoningForCurrentTurn = false
     }
 
@@ -8376,7 +8387,7 @@ final class AppState: ObservableObject {
 
         clearStreamingText()
         activeAssistantMessageId = nil
-        resetReasoningStream()
+        resetReasoningTurn()
         setRunning(false)
         // Cancel any pending coalesced flush and write immediately — the
         // turn is complete so all messages are in their final state.

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -465,13 +465,19 @@ final class AppState: ObservableObject {
                 streamingPublishTask?.cancel()
                 streamingPublishTask = nil
                 hasScheduledStreamingPublish = false
-            } else if !streamingBuffer.isEmpty {
-                lastStreamingPublishBurst = max(
-                    streamingBuffer.count - streamingText.count,
-                    0
-                )
-                lastStreamingPublishDate = Date()
-                streamingText = streamingBuffer
+                reasoningPublishTask?.cancel()
+                reasoningPublishTask = nil
+                hasScheduledReasoningPublish = false
+            } else {
+                if !streamingBuffer.isEmpty {
+                    lastStreamingPublishBurst = max(
+                        streamingBuffer.count - streamingText.count,
+                        0
+                    )
+                    lastStreamingPublishDate = Date()
+                    streamingText = streamingBuffer
+                }
+                flushReasoningPublish()
             }
         }
     }
@@ -585,6 +591,13 @@ final class AppState: ObservableObject {
     private var activeAssistantMessageId: String?
     private var activeReasoningMessageId: String?
     private var receivedReasoningForCurrentTurn = false
+    /// Authoritative merged reasoning for the live thinking card. Raw deltas
+    /// merge into this buffer immediately; the published transcript is only
+    /// republished at a coalesced cadence so an expanded ThinkingCard cannot
+    /// monopolize main-actor layout work during a live reasoning stream.
+    private var reasoningBuffer = ""
+    private var reasoningPublishTask: Task<Void, Never>?
+    private var hasScheduledReasoningPublish = false
     private var streamingBuffer = ""
     /// Gateway deltas can arrive much faster than SwiftUI can lay out a chat
     /// transcript. Keep the authoritative buffer intact, but publish at a
@@ -1540,6 +1553,7 @@ final class AppState: ObservableObject {
         activeSessionTitle = "New conversation"
         messages = []
         clearStreamingText()
+        resetReasoningStream()
         activeSessionTitlesByProfile = [:]
         pinnedSessionIDsByProfile = [:]
         pinnedSessionIDs = []
@@ -1978,6 +1992,7 @@ final class AppState: ObservableObject {
         messages = []
         setActiveSessionState(id: nil, title: "New conversation")
         clearStreamingText()
+        resetReasoningStream()
         turnState = .idle
         defaults.removeObject(forKey: activeSessionTitlesByProfileKey)
         defaults.removeObject(forKey: pinnedSessionIDsByProfileKey)
@@ -2833,7 +2848,7 @@ final class AppState: ObservableObject {
             noteChatViewportTranscriptReplacement()
             clearStreamingText()
             activeAssistantMessageId = nil
-            activeReasoningMessageId = nil
+            resetReasoningStream()
             receivedReasoningForCurrentTurn = false
             turnState = .idle
             errorMessage = nil
@@ -3031,7 +3046,7 @@ final class AppState: ObservableObject {
             streamingText = recoveredText
         }
         activeAssistantMessageId = nil
-        activeReasoningMessageId = nil
+        resetReasoningStream()
         receivedReasoningForCurrentTurn = false
         applyRuntime(
             result.snapshot,
@@ -4272,7 +4287,7 @@ final class AppState: ObservableObject {
         messages = []
         clearStreamingText()
         activeAssistantMessageId = nil
-        activeReasoningMessageId = nil
+        resetReasoningStream()
         receivedReasoningForCurrentTurn = false
         turnState = .idle
         finishChatViewportTransition(generation: transitionGeneration)
@@ -4351,7 +4366,7 @@ final class AppState: ObservableObject {
         messages = []
         clearStreamingText()
         activeAssistantMessageId = nil
-        activeReasoningMessageId = nil
+        resetReasoningStream()
         updateActiveSessionTitle(for: sessionId)
         let reconciled = await reconcile(
             sessionId: sessionId,
@@ -7223,7 +7238,10 @@ final class AppState: ObservableObject {
         switch event {
         case .messageStart:
             finalizePendingStreamingCompletion()
-            activeReasoningMessageId = nil
+            // A new turn ends any live reasoning card; flush first so the
+            // previous segment keeps its exact buffered text.
+            flushReasoningPublish()
+            resetReasoningStream()
             receivedReasoningForCurrentTurn = false
             setRunning(true)
             notifyVoiceAssistant(.started(sessionID: streamSessionId))
@@ -7251,15 +7269,17 @@ final class AppState: ObservableObject {
             notifyVoiceAssistant(.completed(sessionID: streamSessionId, content: content))
 
         case .messageError(_, let message):
+            flushReasoningPublish()
+            resetReasoningStream()
             clearStreamingText()
-            activeReasoningMessageId = nil
             errorMessage = message
             setRunning(false)
             notifyVoiceAssistant(.failed(sessionID: streamSessionId, message: message))
 
         case .messageInterrupted:
+            flushReasoningPublish()
+            resetReasoningStream()
             clearStreamingText()
-            activeReasoningMessageId = nil
             setRunning(false)
             notifyVoiceAssistant(.interrupted(sessionID: streamSessionId))
 
@@ -7291,7 +7311,10 @@ final class AppState: ObservableObject {
 
         case .toolStart(_, let name, let input):
             if name.lowercased() == "clarify" { break }
-            activeReasoningMessageId = nil
+            // The tool card must land after a complete reasoning card; flush
+            // the coalesced buffer before the boundary reorders the transcript.
+            flushReasoningPublish()
+            resetReasoningStream()
             flushStreamingPartial()
             messages.append(ChatMessage(
                 id: "tool-start-\(Date().timeIntervalSince1970)",
@@ -7303,7 +7326,8 @@ final class AppState: ObservableObject {
 
         case .toolComplete(_, let name, let output):
             if name.lowercased() == "clarify" { break }
-            activeReasoningMessageId = nil
+            flushReasoningPublish()
+            resetReasoningStream()
             // Update the matching running tool card in place instead of
             // appending a duplicate. This keeps input + output together in
             // one chronological entry, matching how the HTTP API returns
@@ -7454,27 +7478,85 @@ final class AppState: ObservableObject {
 
     /// A reasoning delta belongs exactly where Hermes emitted it. Gateways can
     /// send either deltas or repeated cumulative snapshots, so merge both into
-    /// one live card rather than creating duplicate thinking boxes.
+    /// one live card rather than creating duplicate thinking boxes. The first
+    /// delta of a segment mounts the card immediately so the thinking box
+    /// appears promptly; every later delta coalesces through
+    /// `reasoningBuffer` and republishes at display cadence.
     private func appendReasoning(_ text: String) {
         guard !text.isEmpty else { return }
-        if let id = activeReasoningMessageId,
-           let index = messages.firstIndex(where: { $0.id == id }) {
-            messages[index].content = mergedReasoning(
-                existing: messages[index].content,
-                incoming: text
-            )
+        reasoningBuffer = mergedReasoning(
+            existing: reasoningBuffer,
+            incoming: text
+        )
+        guard activeReasoningMessageId != nil else {
+            let id = "reasoning-\(Date().timeIntervalSince1970)"
+            messages.append(ChatMessage(
+                id: id,
+                role: .reasoning,
+                content: reasoningBuffer,
+                timestamp: Self.localTimestamp(),
+                author: activeProfile
+            ))
+            activeReasoningMessageId = id
             return
         }
+        scheduleReasoningPublish()
+    }
 
-        let id = "reasoning-\(Date().timeIntervalSince1970)"
-        messages.append(ChatMessage(
-            id: id,
-            role: .reasoning,
-            content: text,
-            timestamp: Self.localTimestamp(),
-            author: activeProfile
-        ))
-        activeReasoningMessageId = id
+    private func scheduleReasoningPublish() {
+        guard !showSidebar, !hasScheduledReasoningPublish else { return }
+        hasScheduledReasoningPublish = true
+        let cardID = activeReasoningMessageId
+
+        reasoningPublishTask = Task { [weak self] in
+            do {
+                // Reasoning updates mutate the published transcript, which is
+                // heavier than the streaming-text projection: an expanded
+                // ThinkingCard restyles its attributed text and remeasures a
+                // growing height on every commit. ~20 fps keeps the stream
+                // readable while leaving the main actor free between layout
+                // passes.
+                try await Task.sleep(for: .milliseconds(50))
+            } catch {
+                return
+            }
+
+            guard !Task.isCancelled, let self else { return }
+            self.hasScheduledReasoningPublish = false
+            self.reasoningPublishTask = nil
+            self.publishReasoningBuffer(liveCardID: cardID)
+        }
+    }
+
+    /// Stale publish tasks are structurally inert: once a boundary or session
+    /// switch has ended the live card, the captured id no longer matches, so
+    /// nothing can mutate a finalized or replaced transcript.
+    private func publishReasoningBuffer(liveCardID: String?) {
+        guard let liveCardID, liveCardID == activeReasoningMessageId,
+              let index = messages.firstIndex(where: { $0.id == liveCardID }),
+              messages[index].content != reasoningBuffer else { return }
+        messages[index].content = reasoningBuffer
+    }
+
+    /// Publish any coalesced reasoning immediately so the live card is exact
+    /// before a semantic boundary (completion, tool, error, interruption,
+    /// next turn) reads or reorders the transcript.
+    private func flushReasoningPublish() {
+        reasoningPublishTask?.cancel()
+        reasoningPublishTask = nil
+        hasScheduledReasoningPublish = false
+        publishReasoningBuffer(liveCardID: activeReasoningMessageId)
+    }
+
+    /// Drop all live reasoning state without publishing. The transcript is
+    /// being replaced (session open/resume/new conversation), so the old card
+    /// must not receive further updates — including from an in-flight publish.
+    private func resetReasoningStream() {
+        reasoningPublishTask?.cancel()
+        reasoningPublishTask = nil
+        hasScheduledReasoningPublish = false
+        reasoningBuffer = ""
+        activeReasoningMessageId = nil
     }
 
     private func mergedReasoning(existing: String, incoming: String) -> String {
@@ -8183,6 +8265,9 @@ final class AppState: ObservableObject {
         content: String?,
         reasoning: String?
     ) {
+        // messageComplete is a semantic boundary: the thinking card must show
+        // its full buffered reasoning immediately, not one cadence later.
+        flushReasoningPublish()
         streamingCompletionTask?.cancel()
         streamingPublishTask?.cancel()
         streamingPublishTask = nil
@@ -8258,6 +8343,9 @@ final class AppState: ObservableObject {
         finalContent: String,
         reasoning: String?
     ) {
+        // Reasoning that raced the drain window must not be discarded when
+        // the pending completion finalizes.
+        flushReasoningPublish()
         removeAllPartials()
         // Some gateways repeat the full trace in completion after already
         // emitting reasoning events. Use it only when streaming supplied no
@@ -8289,7 +8377,7 @@ final class AppState: ObservableObject {
 
         clearStreamingText()
         activeAssistantMessageId = nil
-        activeReasoningMessageId = nil
+        resetReasoningStream()
         receivedReasoningForCurrentTurn = false
         setRunning(false)
         // Cancel any pending coalesced flush and write immediately — the

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2849,7 +2849,6 @@ final class AppState: ObservableObject {
             clearStreamingText()
             activeAssistantMessageId = nil
             resetReasoningStream()
-            receivedReasoningForCurrentTurn = false
             turnState = .idle
             errorMessage = nil
             // A fresh conversation has no per-session override and no
@@ -3047,7 +3046,6 @@ final class AppState: ObservableObject {
         }
         activeAssistantMessageId = nil
         resetReasoningStream()
-        receivedReasoningForCurrentTurn = false
         applyRuntime(
             result.snapshot,
             for: result.sessionId
@@ -4288,7 +4286,6 @@ final class AppState: ObservableObject {
         clearStreamingText()
         activeAssistantMessageId = nil
         resetReasoningStream()
-        receivedReasoningForCurrentTurn = false
         turnState = .idle
         finishChatViewportTransition(generation: transitionGeneration)
     }
@@ -7242,7 +7239,6 @@ final class AppState: ObservableObject {
             // previous segment keeps its exact buffered text.
             flushReasoningPublish()
             resetReasoningStream()
-            receivedReasoningForCurrentTurn = false
             setRunning(true)
             notifyVoiceAssistant(.started(sessionID: streamSessionId))
 
@@ -7548,15 +7544,18 @@ final class AppState: ObservableObject {
         publishReasoningBuffer(liveCardID: activeReasoningMessageId)
     }
 
-    /// Drop all live reasoning state without publishing. The transcript is
-    /// being replaced (session open/resume/new conversation), so the old card
-    /// must not receive further updates — including from an in-flight publish.
+    /// Restore the ENTIRE per-turn reasoning state machine to its initial
+    /// condition. The transcript is being replaced (session open/resume/new
+    /// conversation/disconnect), so the old card must not receive further
+    /// updates — including from an in-flight publish — and the next turn's
+    /// completion-carried reasoning must not look already-streamed.
     private func resetReasoningStream() {
         reasoningPublishTask?.cancel()
         reasoningPublishTask = nil
         hasScheduledReasoningPublish = false
         reasoningBuffer = ""
         activeReasoningMessageId = nil
+        receivedReasoningForCurrentTurn = false
     }
 
     private func mergedReasoning(existing: String, incoming: String) -> String {
@@ -8378,7 +8377,6 @@ final class AppState: ObservableObject {
         clearStreamingText()
         activeAssistantMessageId = nil
         resetReasoningStream()
-        receivedReasoningForCurrentTurn = false
         setRunning(false)
         // Cancel any pending coalesced flush and write immediately — the
         // turn is complete so all messages are in their final state.

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -7508,7 +7508,7 @@ final class AppState: ObservableObject {
         hasScheduledReasoningPublish = true
         let cardID = activeReasoningMessageId
 
-        reasoningPublishTask = Task { [weak self] in
+        reasoningPublishTask = Task { @MainActor [weak self] in
             do {
                 // Reasoning updates mutate the published transcript, which is
                 // heavier than the streaming-text projection: an expanded

--- a/ConduitTests/AppStateReasoningStreamTests.swift
+++ b/ConduitTests/AppStateReasoningStreamTests.swift
@@ -367,6 +367,41 @@ final class AppStateReasoningStreamTests: XCTestCase {
         )
     }
 
+    func testCompletionOnlyReasoningSurvivesFullReasoningStateReset() {
+        let state = makeAppState()
+        installActiveSession(state, id: "stored-a")
+
+        // Turn one streamed reasoning: receivedReasoningForCurrentTurn == true.
+        feedReasoning(["prior turn reasoning "], sessionId: "stored-a", state: state)
+        XCTAssertEqual(reasoningCards(in: state).count, 1)
+
+        // A full state reset (disconnect) must restore the ENTIRE per-turn
+        // reasoning state machine — a stale turn flag would make the next
+        // session's completion-carried reasoning look already-streamed and
+        // silently discard it.
+        state.disconnect()
+        installActiveSession(state, id: "stored-b")
+
+        state.handleStreamEvent(
+            .messageComplete(
+                sessionId: "stored-b",
+                messageId: "assistant-b",
+                content: "Answer",
+                reasoning: "completion-only reasoning"
+            )
+        )
+        // Force the drained completion synchronously.
+        state.handleStreamEvent(.messageStart(sessionId: "stored-b"))
+
+        let cards = reasoningCards(in: state)
+        XCTAssertEqual(cards.count, 1)
+        XCTAssertEqual(cards.first?.content, "completion-only reasoning")
+        XCTAssertFalse(
+            state.messages.contains { $0.content.contains("prior turn") },
+            "Session A reasoning must not leak into session B's transcript"
+        )
+    }
+
     func testSessionSwitchDiscardsPendingReasoningPublishForNewSession() async {
         let replacementMessages = [
             ChatMessage(id: "new-1", role: .assistant, content: "Other session", timestamp: "1")

--- a/ConduitTests/AppStateReasoningStreamTests.swift
+++ b/ConduitTests/AppStateReasoningStreamTests.swift
@@ -1,0 +1,411 @@
+import Combine
+import XCTest
+@testable import Conduit
+
+/// Live reasoning must publish through the same display-cadence discipline as
+/// assistant streaming: raw gateway deltas merge into an authoritative buffer
+/// immediately, but the published transcript only republishes at a coalesced
+/// cadence so an expanded ThinkingCard cannot saturate main-actor layout work
+/// (0x8BADF00D scene-update watchdog during active reasoning streams).
+@MainActor
+final class AppStateReasoningStreamTests: XCTestCase {
+
+    // MARK: - Harness
+
+    private func makeAppState(
+        lifecycleOperations: ChatResumeLifecycleOperations = .live
+    ) -> AppState {
+        let suite = "AppStateReasoningStreamTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Failed to create test UserDefaults suite")
+        }
+        addTeardownBlock { defaults.removePersistentDomain(forName: suite) }
+        return AppState(
+            defaults: defaults,
+            loadSavedConnection: false,
+            chatResumeLifecycleOperations: lifecycleOperations
+        )
+    }
+
+    private func installActiveSession(_ state: AppState, id: String) {
+        let summary = SessionSummary(
+            id: id,
+            alternateIds: [],
+            title: id,
+            model: "Hermes",
+            updatedLabel: "now",
+            profile: "default",
+            source: .chat,
+            isActive: false,
+            isArchived: false,
+            lineageRootId: nil
+        )
+        state.sessions = [summary]
+        state.activeSessionId = id
+    }
+
+    /// The sidebar drawer suppresses streaming publications while open and
+    /// force-publishes the authoritative buffers when it closes. Toggling it
+    /// gives tests a synchronous flush without sleeping on the publish cadence.
+    private func forceFlushPendingReasoning(on state: AppState) {
+        state.showSidebar = true
+        state.showSidebar = false
+    }
+
+    private func feedReasoning(
+        _ chunks: [String],
+        sessionId: String,
+        state: AppState
+    ) {
+        chunks.forEach {
+            state.handleStreamEvent(.reasoningDelta(sessionId: sessionId, text: $0))
+        }
+    }
+
+    private func reasoningCards(in state: AppState) -> [ChatMessage] {
+        state.messages.filter { $0.role == .reasoning }
+    }
+
+    // MARK: - Coalescing
+
+    func testRapidReasoningDeltasCoalesceTranscriptPublications() {
+        let state = makeAppState()
+        installActiveSession(state, id: "stored-a")
+        let chunks = (0..<75).map { "reasoning-line-\($0) " }
+        let expectedTotal = chunks.joined()
+
+        var burstPublications = 0
+        let cancellable = state.$messages.dropFirst().sink { _ in burstPublications += 1 }
+        feedReasoning(chunks, sessionId: "stored-a", state: state)
+        cancellable.cancel()
+
+        // One publication creates the thinking card; every raw delta after
+        // that must merge into the authoritative buffer without republishing.
+        XCTAssertEqual(burstPublications, 1)
+        XCTAssertEqual(reasoningCards(in: state).count, 1)
+        XCTAssertEqual(reasoningCards(in: state).first?.content, chunks.first)
+
+        forceFlushPendingReasoning(on: state)
+        XCTAssertEqual(reasoningCards(in: state).first?.content, expectedTotal)
+    }
+
+    func testReasoningCardIdentityIsStableAcrossCoalescedPublications() {
+        let state = makeAppState()
+        installActiveSession(state, id: "stored-a")
+
+        feedReasoning(["first segment "], sessionId: "stored-a", state: state)
+        forceFlushPendingReasoning(on: state)
+        let firstCardID = reasoningCards(in: state).first?.id
+
+        feedReasoning(["continues to stream "], sessionId: "stored-a", state: state)
+        forceFlushPendingReasoning(on: state)
+
+        XCTAssertEqual(reasoningCards(in: state).count, 1)
+        XCTAssertEqual(reasoningCards(in: state).first?.id, firstCardID)
+        XCTAssertEqual(
+            reasoningCards(in: state).first?.content,
+            "first segment continues to stream "
+        )
+    }
+
+    // MARK: - Gateway delta shapes
+
+    func testCumulativeReasoningSnapshotsDoNotDuplicate() {
+        let state = makeAppState()
+        installActiveSession(state, id: "stored-a")
+
+        feedReasoning(
+            ["abc", "abcdef", "abcdefgh"],
+            sessionId: "stored-a",
+            state: state
+        )
+        forceFlushPendingReasoning(on: state)
+
+        XCTAssertEqual(reasoningCards(in: state).first?.content, "abcdefgh")
+    }
+
+    func testIncrementalReasoningDeltasConcatenateExactly() {
+        let state = makeAppState()
+        installActiveSession(state, id: "stored-a")
+
+        feedReasoning(["abc", "def", "ghi"], sessionId: "stored-a", state: state)
+        forceFlushPendingReasoning(on: state)
+
+        XCTAssertEqual(reasoningCards(in: state).first?.content, "abcdefghi")
+    }
+
+    // MARK: - Boundary flushes
+
+    func testMessageCompleteFlushesPendingReasoningSynchronously() {
+        let state = makeAppState()
+        installActiveSession(state, id: "stored-a")
+
+        feedReasoning(
+            ["partial thought ", "still buffering"],
+            sessionId: "stored-a",
+            state: state
+        )
+        state.handleStreamEvent(
+            .messageComplete(
+                sessionId: "stored-a",
+                messageId: "assistant-1",
+                content: "Final answer",
+                reasoning: nil
+            )
+        )
+
+        XCTAssertEqual(
+            reasoningCards(in: state).first?.content,
+            "partial thought still buffering"
+        )
+
+        // Force the drained completion so the final assistant message lands
+        // synchronously; the reasoning card must stay complete and ordered
+        // before it.
+        state.handleStreamEvent(.messageStart(sessionId: "stored-a"))
+        guard let reasoningIndex = state.messages.firstIndex(where: { $0.role == .reasoning }),
+              let assistantIndex = state.messages.firstIndex(where: { $0.id == "assistant-1" })
+        else {
+            return XCTFail("Expected finalized reasoning card and assistant message")
+        }
+        XCTAssertEqual(state.messages[reasoningIndex].content, "partial thought still buffering")
+        XCTAssertLessThan(reasoningIndex, assistantIndex)
+    }
+
+    func testToolStartFlushesPendingReasoningAndPreservesOrdering() {
+        let state = makeAppState()
+        installActiveSession(state, id: "stored-a")
+
+        feedReasoning(
+            ["deciding which file to inspect ", "before the tool runs"],
+            sessionId: "stored-a",
+            state: state
+        )
+        state.handleStreamEvent(
+            .toolStart(sessionId: "stored-a", toolName: "read_file", toolInput: nil)
+        )
+
+        XCTAssertEqual(
+            reasoningCards(in: state).first?.content,
+            "deciding which file to inspect before the tool runs"
+        )
+        XCTAssertEqual(state.messages.last?.role, .tool)
+        guard let reasoningIndex = state.messages.firstIndex(where: { $0.role == .reasoning }),
+              let toolIndex = state.messages.firstIndex(where: { $0.role == .tool })
+        else {
+            return XCTFail("Expected reasoning card followed by tool card")
+        }
+        XCTAssertLessThan(reasoningIndex, toolIndex)
+
+        // Reasoning that resumes after a tool belongs to a fresh card, never
+        // the finalized one.
+        feedReasoning(["post-tool thinking "], sessionId: "stored-a", state: state)
+        forceFlushPendingReasoning(on: state)
+        XCTAssertEqual(reasoningCards(in: state).count, 2)
+        XCTAssertEqual(reasoningCards(in: state).last?.content, "post-tool thinking ")
+    }
+
+    func testMessageErrorFlushesPendingReasoningWithoutStaleDelayedPublish() async throws {
+        let state = makeAppState()
+        installActiveSession(state, id: "stored-a")
+
+        // Two chunks guarantee a coalesced publish is actually pending when
+        // the boundary arrives; one chunk would mount the card fully and
+        // make the flush assertion trivially pass.
+        feedReasoning(
+            ["mid-flight reasoning ", "still open"],
+            sessionId: "stored-a",
+            state: state
+        )
+        state.handleStreamEvent(
+            .messageError(sessionId: "stored-a", message: "gateway exploded")
+        )
+
+        XCTAssertEqual(
+            reasoningCards(in: state).first?.content,
+            "mid-flight reasoning still open"
+        )
+        XCTAssertEqual(state.errorMessage, "gateway exploded")
+
+        // No coalesced publish may fire after the boundary: not the
+        // transcript equality, and not even a single republication.
+        var postBoundaryPublications = 0
+        let cancellable = state.$messages.dropFirst().sink { _ in
+            postBoundaryPublications += 1
+        }
+        try await Task.sleep(for: .milliseconds(250))
+        cancellable.cancel()
+        XCTAssertEqual(postBoundaryPublications, 0)
+        XCTAssertEqual(
+            reasoningCards(in: state).first?.content,
+            "mid-flight reasoning still open"
+        )
+    }
+
+    func testMessageInterruptedFlushesPendingReasoningWithoutStaleDelayedPublish() async throws {
+        let state = makeAppState()
+        installActiveSession(state, id: "stored-a")
+
+        feedReasoning(
+            ["about to be ", "interrupted"],
+            sessionId: "stored-a",
+            state: state
+        )
+        state.handleStreamEvent(.messageInterrupted(sessionId: "stored-a"))
+
+        XCTAssertEqual(
+            reasoningCards(in: state).first?.content,
+            "about to be interrupted"
+        )
+
+        var postBoundaryPublications = 0
+        let cancellable = state.$messages.dropFirst().sink { _ in
+            postBoundaryPublications += 1
+        }
+        try await Task.sleep(for: .milliseconds(250))
+        cancellable.cancel()
+        XCTAssertEqual(postBoundaryPublications, 0)
+        XCTAssertEqual(
+            reasoningCards(in: state).first?.content,
+            "about to be interrupted"
+        )
+    }
+
+    func testShowSidebarSuppressesReasoningPublishUntilClosed() {
+        let state = makeAppState()
+        installActiveSession(state, id: "stored-a")
+
+        feedReasoning(["visible "], sessionId: "stored-a", state: state)
+        XCTAssertEqual(reasoningCards(in: state).first?.content, "visible ")
+
+        // The drawer suppresses coalesced reasoning publications while it is
+        // animating; the buffer stays authoritative.
+        state.showSidebar = true
+        feedReasoning(["hidden ", "while draining"], sessionId: "stored-a", state: state)
+        XCTAssertEqual(reasoningCards(in: state).first?.content, "visible ")
+
+        state.showSidebar = false
+        XCTAssertEqual(
+            reasoningCards(in: state).first?.content,
+            "visible hidden while draining"
+        )
+    }
+
+    func testReasoningDeltaDuringCompletionDrainMountsFreshCardAfterAssistant() {
+        let state = makeAppState()
+        installActiveSession(state, id: "stored-a")
+
+        feedReasoning(["pre-complete "], sessionId: "stored-a", state: state)
+        state.handleStreamEvent(
+            .messageComplete(
+                sessionId: "stored-a",
+                messageId: "assistant-1",
+                content: "Final answer",
+                reasoning: nil
+            )
+        )
+        // A delta racing the drain window finalizes the pending completion
+        // first, then mounts a fresh card — the pre-fix behavior, with no
+        // buffered text lost.
+        state.handleStreamEvent(
+            .reasoningDelta(sessionId: "stored-a", text: "late thought")
+        )
+
+        let cards = reasoningCards(in: state)
+        XCTAssertEqual(cards.count, 2)
+        XCTAssertEqual(cards.first?.content, "pre-complete ")
+        XCTAssertEqual(cards.last?.content, "late thought")
+        XCTAssertEqual(state.messages.map(\.role), [.reasoning, .assistant, .reasoning])
+    }
+
+    func testCompletionReasoningTraceDoesNotDuplicateStreamedCard() {
+        let state = makeAppState()
+        installActiveSession(state, id: "stored-a")
+
+        feedReasoning(
+            ["streamed so far ", "still streaming"],
+            sessionId: "stored-a",
+            state: state
+        )
+        state.handleStreamEvent(
+            .messageComplete(
+                sessionId: "stored-a",
+                messageId: "assistant-1",
+                content: "Final answer",
+                reasoning: "full trace"
+            )
+        )
+        state.handleStreamEvent(.messageStart(sessionId: "stored-a"))
+
+        // Completion repeating the trace after streamed reasoning keeps the
+        // streamed card; it must not append a duplicate thinking box.
+        XCTAssertEqual(reasoningCards(in: state).count, 1)
+        XCTAssertEqual(
+            reasoningCards(in: state).first?.content,
+            "streamed so far still streaming"
+        )
+    }
+
+    func testSessionSwitchDiscardsPendingReasoningPublishForNewSession() async {
+        let replacementMessages = [
+            ChatMessage(id: "new-1", role: .assistant, content: "Other session", timestamp: "1")
+        ]
+        let state = makeAppState(lifecycleOperations: ChatResumeLifecycleOperations(
+            openSession: { _, sessionID in
+                SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: replacementMessages,
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            refreshContext: { _, _ in }
+        ))
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        state.connection = connection
+        state.client = HermesClient(connection: connection, profile: "default")
+        let origin = SessionSummary(
+            id: "stored-a",
+            alternateIds: [],
+            title: "stored-a",
+            model: "Hermes",
+            updatedLabel: "now",
+            profile: "default",
+            source: .chat,
+            isActive: false,
+            isArchived: false,
+            lineageRootId: nil
+        )
+        let destination = SessionSummary(
+            id: "stored-b",
+            alternateIds: [],
+            title: "stored-b",
+            model: "Hermes",
+            updatedLabel: "now",
+            profile: "default",
+            source: .chat,
+            isActive: false,
+            isArchived: false,
+            lineageRootId: nil
+        )
+        state.sessions = [origin, destination]
+        state.activeSessionId = origin.id
+
+        feedReasoning(
+            ["stale reasoning ", "that must not leak"],
+            sessionId: origin.id,
+            state: state
+        )
+        let opened = await state.openSession(destination.id)
+        XCTAssertTrue(opened)
+
+        XCTAssertEqual(state.activeSessionId, destination.id)
+        XCTAssertTrue(reasoningCards(in: state).isEmpty)
+        XCTAssertEqual(state.messages, replacementMessages)
+
+        // Even a forced flush of any surviving pending state must not
+        // reproduce the old session's reasoning inside the new transcript.
+        forceFlushPendingReasoning(on: state)
+        XCTAssertTrue(reasoningCards(in: state).isEmpty)
+        XCTAssertEqual(state.messages, replacementMessages)
+    }
+}

--- a/ConduitTests/AppStateReasoningStreamTests.swift
+++ b/ConduitTests/AppStateReasoningStreamTests.swift
@@ -402,6 +402,79 @@ final class AppStateReasoningStreamTests: XCTestCase {
         )
     }
 
+    func testToolBoundaryDoesNotEraseTurnReasoningFlagAtCompletion() {
+        let state = makeAppState()
+        installActiveSession(state, id: "stored-a")
+
+        feedReasoning(["pre-tool reasoning"], sessionId: "stored-a", state: state)
+        state.handleStreamEvent(
+            .toolStart(sessionId: "stored-a", toolName: "read_file", toolInput: nil)
+        )
+        state.handleStreamEvent(
+            .toolComplete(sessionId: "stored-a", toolName: "read_file", toolOutput: "result")
+        )
+        state.handleStreamEvent(
+            .messageComplete(
+                sessionId: "stored-a",
+                messageId: "assistant-1",
+                content: "Final answer",
+                reasoning: "full completion trace"
+            )
+        )
+        // Force the drained completion synchronously.
+        state.handleStreamEvent(.messageStart(sessionId: "stored-a"))
+
+        // A tool boundary ends the reasoning SEGMENT, not the turn: reasoning
+        // streamed before the tool still counts as this turn's reasoning, so
+        // the completion-carried trace must not mount a duplicate card.
+        let cards = reasoningCards(in: state)
+        XCTAssertEqual(cards.count, 1)
+        XCTAssertEqual(cards.first?.content, "pre-tool reasoning")
+
+        guard let reasoningIndex = state.messages.firstIndex(where: { $0.role == .reasoning }),
+              let toolIndex = state.messages.firstIndex(where: { $0.role == .tool }),
+              let assistantIndex = state.messages.firstIndex(where: { $0.id == "assistant-1" })
+        else {
+            return XCTFail("Expected reasoning, tool, and assistant messages")
+        }
+        XCTAssertLessThan(reasoningIndex, toolIndex)
+        XCTAssertLessThan(toolIndex, assistantIndex)
+        XCTAssertEqual(state.messages[assistantIndex].content, "Final answer")
+        XCTAssertEqual(state.messages[toolIndex].tool?.status, .complete)
+    }
+
+    func testMultiSegmentTurnKeepsBothSegmentsAndSkipsCompletionTrace() {
+        let state = makeAppState()
+        installActiveSession(state, id: "stored-a")
+
+        // Two reasoning segments separated by tools inside ONE turn. Both
+        // segment cards must survive to completion, and the completion-carried
+        // trace must not append a third.
+        feedReasoning(["first segment "], sessionId: "stored-a", state: state)
+        state.handleStreamEvent(
+            .toolStart(sessionId: "stored-a", toolName: "read_file", toolInput: nil)
+        )
+        feedReasoning(["second segment"], sessionId: "stored-a", state: state)
+        state.handleStreamEvent(
+            .toolComplete(sessionId: "stored-a", toolName: "read_file", toolOutput: "result")
+        )
+        state.handleStreamEvent(
+            .messageComplete(
+                sessionId: "stored-a",
+                messageId: "assistant-1",
+                content: "Final answer",
+                reasoning: "full completion trace"
+            )
+        )
+        state.handleStreamEvent(.messageStart(sessionId: "stored-a"))
+
+        let cards = reasoningCards(in: state)
+        XCTAssertEqual(cards.count, 2)
+        XCTAssertEqual(cards.first?.content, "first segment ")
+        XCTAssertEqual(cards.last?.content, "second segment")
+        XCTAssertEqual(state.messages.last?.id, "assistant-1")
+    }
+
     func testSessionSwitchDiscardsPendingReasoningPublishForNewSession() async {
         let replacementMessages = [
             ChatMessage(id: "new-1", role: .assistant, content: "Other session", timestamp: "1")
@@ -461,6 +534,12 @@ final class AppStateReasoningStreamTests: XCTestCase {
         // Even a forced flush of any surviving pending state must not
         // reproduce the old session's reasoning inside the new transcript.
         forceFlushPendingReasoning(on: state)
+        XCTAssertTrue(reasoningCards(in: state).isEmpty)
+        XCTAssertEqual(state.messages, replacementMessages)
+
+        // Five 50 ms cadence periods: proves that after the session switch no
+        // stale publish (guarded or not) can mutate the replacement transcript.
+        try? await Task.sleep(for: .milliseconds(250))
         XCTAssertTrue(reasoningCards(in: state).isEmpty)
         XCTAssertEqual(state.messages, replacementMessages)
     }

--- a/ConduitTests/AppStateReasoningStreamTests.swift
+++ b/ConduitTests/AppStateReasoningStreamTests.swift
@@ -89,6 +89,27 @@ final class AppStateReasoningStreamTests: XCTestCase {
         XCTAssertEqual(reasoningCards(in: state).first?.content, expectedTotal)
     }
 
+    func testScheduledReasoningPublishFiresWithoutForcedFlush() async throws {
+        let state = makeAppState()
+        installActiveSession(state, id: "stored-a")
+
+        feedReasoning(
+            ["coalesced chunk one ", "coalesced chunk two"],
+            sessionId: "stored-a",
+            state: state
+        )
+        XCTAssertEqual(reasoningCards(in: state).first?.content, "coalesced chunk one ")
+
+        // The scheduled 50 ms publish must land on its own — no sidebar
+        // force-flush, no boundary event. The wait only needs to clear the
+        // cadence interval, so generous slack keeps it stable on CI runners.
+        try await Task.sleep(for: .milliseconds(500))
+        XCTAssertEqual(
+            reasoningCards(in: state).first?.content,
+            "coalesced chunk one coalesced chunk two"
+        )
+    }
+
     func testReasoningCardIdentityIsStableAcrossCoalescedPublications() {
         let state = makeAppState()
         installActiveSession(state, id: "stored-a")


### PR DESCRIPTION
## Problem

TestFlight build 135 hit reproducible **0x8BADF00D scene-update watchdog SIGKILLs** (iOS 27 beta) when the user expanded the live "Thinking" card while reasoning was still streaming.

## Root cause

`.reasoningDelta` mutated the published `messages` array on **every raw WebSocket frame**. Assistant streaming already coalesces publication (`scheduleStreamingPublish`, 33 ms) precisely to avoid main-actor saturation — reasoning bypassed that machinery entirely. With the card expanded (kept mounted across updates since PR #33's stable row identity), every delta drove the full loop: `SelectableTextView` attributed-text restyle → `UITextView` intrinsic-size invalidation → `sizeThatFits` measurement → `LazyVStack`/`ScrollView` relayout → next delta. Main thread pinned in AttributeGraph/ScrollView layout until the 10-second scene-update allowance expired.

## Fix (AppState.swift only)

Mirror the assistant-streaming discipline with one clearly-owned reasoning state machine:

- **`reasoningBuffer`** — authoritative merged trace; every raw delta merges immediately via the unchanged `mergedReasoning(existing:incoming:)` (handles incremental deltas *and* cumulative snapshots).
- **First delta mounts the card immediately** so the thinking box appears promptly; subsequent content republishes at a **50 ms cadence (~20 fps)** — reasoning card updates mutate the transcript, which is heavier than the `streamingText` projection, so the cadence is relaxed vs streaming's 33 ms.
- **`flushReasoningPublish()`** at every semantic boundary: `messageComplete` (at `scheduleStreamingCompletion` entry), `toolStart`, `toolComplete`, `messageError`, `messageInterrupted`, `messageStart`, and `finalizeStreamingCompletion` (covers deltas racing the completion drain window). No buffered text is lost at any boundary.
- **`resetReasoningStream()`** at every transcript replacement: `openSession`, resume apply, `clearActiveSessionIfNeeded`, new-conversation create, plus `prepareChatResumeForConnection` and `disconnect` (found in local review — two `messages = []` sites the original audit missed).
- **Stale publishes are inert by construction**: the publish task captures the card id at schedule time and validates it against the live card before mutating, so nothing can write into a finalized or replaced transcript.
- **Sidebar drawer parity**: opening cancels the pending publish; closing force-flushes — same suppression discipline as streaming text.
- `activeReasoningMessageId` stays stable within a segment (ThinkingCard expansion state preserved); a segment after a tool boundary still mounts a fresh card, matching pre-fix behavior.

## Tests (`AppStateReasoningStreamTests`, 12 cases)

- 75 rapid deltas → exactly **1** transcript publication (was 75), exact final content after flush
- cumulative snapshots (`abc`→`abcdefgh`) and incremental deltas — no duplication
- stable card id across coalesced publications
- `messageComplete` / `toolStart` / `messageError` / `messageInterrupted` flush pending reasoning synchronously, keep ordering, and emit **zero** post-boundary publications
- reasoning delta racing the completion drain mounts a fresh card after the assistant message (pre-fix behavior, nothing lost)
- completion-carried trace does not duplicate a streamed card
- session switch discards pending reasoning; a forced flush cannot leak it into the new transcript
- sidebar suppression + close-flush

Verified RED→GREEN on the coalescing test; full local pass on AppStateChatResume / BufferedEventDeduplication / SessionYolo / ResponseHaptic / SessionPresentationCache / TurnState suites.

## Deliberately out of scope

- `SelectableTextView` rewrite (per-frame attributed-string rebuild remains, but now runs at 20 fps max instead of per-frame)
- `ChatView`'s dual observation of `appState.messages` + `chatTranscriptRevision` (secondary amplifier, separate PR)
- ThinkingCard redesign

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Live reasoning updates now appear more smoothly and consistently during responses.
  * Reasoning content is flushed promptly before responses complete or transition to tools, errors, interruptions, and other conversation boundaries.
  * Opening the sidebar immediately preserves the latest reasoning content while avoiding delayed or duplicate updates.

* **Bug Fixes**
  * Prevented duplicate reasoning content after tool transitions or completed responses.
  * Pending reasoning is cleared when switching conversations, preventing content from appearing in the wrong session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->