### PR TITLE
perf(chat): bound rendering work for very large messages

### DIFF
--- a/Conduit/Views/Components/MarkdownLargeDocument.swift
+++ b/Conduit/Views/Components/MarkdownLargeDocument.swift
@@ -258,40 +258,60 @@ struct MarkdownStableBoundaryScanner {
     /// Trailing partial line awaiting its newline.
     private var pendingLine = ""
     private var fenceMarker: String?
-    private var inMath = false
+    /// The close marker the open math region expects (`$$` or `\]`), so a
+    /// block opened with one cannot close on the other.
+    private var mathClose: String?
     private var inDirective = false
 
     /// True when the scanner sits inside a fenced/math/directive region at
     /// the end of everything consumed — callers avoid promoting a prefix
     /// that ends mid-construct.
-    var isInOpenConstruct: Bool { fenceMarker != nil || inMath || inDirective }
+    var isInOpenConstruct: Bool { fenceMarker != nil || mathClose != nil || inDirective }
 
     /// Feeds an append-only delta and returns any newly discovered safe
-    /// boundary offsets (absolute, UTF-8).
+    /// boundary offsets (absolute, UTF-8). The delta's complete lines are
+    /// processed in place — only the trailing partial is buffered — so cost
+    /// is O(delta) with no repeated prefix shifts even for one-shot bulk
+    /// feeds (threshold crossing, branch-swap reseed).
     mutating func append(_ delta: String) -> [Int] {
         var newBoundaries: [Int] = []
-        pendingLine += delta
+        var remainder = delta[...]
 
-        while let newline = pendingLine.firstIndex(of: "\n") {
-            let line = String(pendingLine[..<newline])
-            let lineBytes = line.utf8.count + 1 // including the newline
-
-            updateState(for: line.trimmingCharacters(in: .whitespaces))
-
-            // A blank line outside every construct ends a block: everything
-            // after this line is a fresh block, so the split point moves to
-            // the next line's start. Consecutive blank lines keep moving it.
-            if line.trimmingCharacters(in: .whitespaces).isEmpty,
-               fenceMarker == nil, !inMath, !inDirective {
-                let boundary = consumedOffset + lineBytes
-                lastSafeBoundary = boundary
-                newBoundaries.append(boundary)
+        // A buffered partial continues with the delta's first line.
+        if !pendingLine.isEmpty {
+            if let newline = remainder.firstIndex(of: "\n") {
+                pendingLine += remainder[..<newline]
+                consumeCompleteLine(pendingLine, boundaries: &newBoundaries)
+                pendingLine = ""
+                remainder = remainder[remainder.index(after: newline)...]
+            } else {
+                pendingLine += remainder
+                return newBoundaries
             }
-
-            consumedOffset += lineBytes
-            pendingLine.removeSubrange(..<pendingLine.index(after: newline))
         }
+
+        while let newline = remainder.firstIndex(of: "\n") {
+            consumeCompleteLine(String(remainder[..<newline]), boundaries: &newBoundaries)
+            remainder = remainder[remainder.index(after: newline)...]
+        }
+        pendingLine += remainder
         return newBoundaries
+    }
+
+    private mutating func consumeCompleteLine(_ line: String, boundaries: inout [Int]) {
+        let lineBytes = line.utf8.count + 1 // including the newline
+        updateState(for: line.trimmingCharacters(in: .whitespaces))
+
+        // A blank line outside every construct ends a block: everything
+        // after this line is a fresh block, so the split point moves to the
+        // next line's start. Consecutive blank lines keep moving it.
+        if line.trimmingCharacters(in: .whitespaces).isEmpty,
+           fenceMarker == nil, mathClose == nil, !inDirective {
+            let boundary = consumedOffset + lineBytes
+            lastSafeBoundary = boundary
+            boundaries.append(boundary)
+        }
+        consumedOffset += lineBytes
     }
 
     /// Processes the trailing partial line as if the stream had ended with
@@ -305,7 +325,7 @@ struct MarkdownStableBoundaryScanner {
         pendingLine = ""
         updateState(for: line.trimmingCharacters(in: .whitespaces))
         if line.trimmingCharacters(in: .whitespaces).isEmpty,
-           fenceMarker == nil, !inMath, !inDirective {
+           fenceMarker == nil, mathClose == nil, !inDirective {
             // Match append()'s arithmetic: the boundary sits after the
             // (virtual) newline of the blank line.
             lastSafeBoundary = consumedOffset + line.utf8.count
@@ -320,8 +340,8 @@ struct MarkdownStableBoundaryScanner {
             }
             return
         }
-        if inMath {
-            if trimmedLine == "$$" || trimmedLine == "\\]" { inMath = false }
+        if let close = mathClose {
+            if trimmedLine == close { mathClose = nil }
             return
         }
         if inDirective {
@@ -330,7 +350,8 @@ struct MarkdownStableBoundaryScanner {
         }
         if trimmedLine.hasPrefix("```") { fenceMarker = "```" }
         else if trimmedLine.hasPrefix("~~~") { fenceMarker = "~~~" }
-        else if trimmedLine == "$$" || trimmedLine == "\\[" { inMath = true }
+        else if trimmedLine == "$$" { mathClose = "$$" }
+        else if trimmedLine == "\\[" { mathClose = "\\]" }
         else if trimmedLine.hasPrefix(":::") {
             let name = trimmedLine.dropFirst(3).trimmingCharacters(in: .whitespaces).lowercased()
             if ["note", "info", "tip", "hint", "warning", "caution", "danger", "error", "important", "columns"].contains(name) {

--- a/Conduit/Views/Components/MarkdownLargeDocument.swift
+++ b/Conduit/Views/Components/MarkdownLargeDocument.swift
@@ -279,33 +279,59 @@ struct MarkdownStableBoundaryScanner {
 
         // A buffered partial continues with the delta's first line.
         if !pendingLine.isEmpty {
-            if let newline = remainder.firstIndex(of: "\n") {
-                pendingLine += remainder[..<newline]
-                consumeCompleteLine(pendingLine, boundaries: &newBoundaries)
+            if let separator = Self.firstLineSeparator(in: remainder) {
+                pendingLine += remainder[..<separator.index]
+                consumeCompleteLine(pendingLine, separatorBytes: separator.byteLength, boundaries: &newBoundaries)
                 pendingLine = ""
-                remainder = remainder[remainder.index(after: newline)...]
+                remainder = remainder[remainder.index(after: separator.index)...]
             } else {
                 pendingLine += remainder
                 return newBoundaries
             }
         }
 
-        while let newline = remainder.firstIndex(of: "\n") {
-            consumeCompleteLine(String(remainder[..<newline]), boundaries: &newBoundaries)
-            remainder = remainder[remainder.index(after: newline)...]
+        while let separator = Self.firstLineSeparator(in: remainder) {
+            consumeCompleteLine(
+                String(remainder[..<separator.index]),
+                separatorBytes: separator.byteLength,
+                boundaries: &newBoundaries
+            )
+            remainder = remainder[remainder.index(after: separator.index)...]
         }
         pendingLine += remainder
         return newBoundaries
     }
 
-    private mutating func consumeCompleteLine(_ line: String, boundaries: inout [Int]) {
-        let lineBytes = line.utf8.count + 1 // including the newline
-        updateState(for: line.trimmingCharacters(in: .whitespaces))
+    /// Swift treats "\r\n" as a single grapheme, so a plain
+    /// `firstIndex(of: "\n")` finds nothing in CRLF text and the whole
+    /// document reads as one line. A line separator here is the "\n"
+    /// grapheme (1 UTF-8 byte) or the "\r\n" grapheme (2 bytes); a lone
+    /// "\r" is not a separator, matching `parseDocument`'s CRLF-only
+    /// normalization.
+    private static func firstLineSeparator(in text: Substring) -> (index: Substring.Index, byteLength: Int)? {
+        var index = text.startIndex
+        while index < text.endIndex {
+            let character = text[index]
+            if character == "\n" { return (index, 1) }
+            if character == "\r\n" { return (index, 2) }
+            index = text.index(after: index)
+        }
+        return nil
+    }
+
+    private mutating func consumeCompleteLine(_ line: String, separatorBytes: Int, boundaries: inout [Int]) {
+        let lineBytes = line.utf8.count + separatorBytes // including the separator
+        // CRLF input (parseDocument normalizes it, so upstream can deliver
+        // it): the \r rides the line content, and .whitespaces trimming
+        // does not remove it — strip it for state/blank checks while the
+        // byte accounting above keeps counting it.
+        let normalized = line.hasSuffix("\r") ? String(line.dropLast()) : line
+        updateState(for: normalized.trimmingCharacters(in: .whitespaces))
 
         // A blank line outside every construct ends a block: everything
         // after this line is a fresh block, so the split point moves to the
         // next line's start. Consecutive blank lines keep moving it.
-        if line.trimmingCharacters(in: .whitespaces).isEmpty,
+        if normalized.trimmingCharacters(in: .whitespaces).isEmpty,
            fenceMarker == nil, mathClose == nil, !inDirective {
             let boundary = consumedOffset + lineBytes
             lastSafeBoundary = boundary
@@ -323,8 +349,9 @@ struct MarkdownStableBoundaryScanner {
         guard !pendingLine.isEmpty else { return }
         let line = pendingLine
         pendingLine = ""
-        updateState(for: line.trimmingCharacters(in: .whitespaces))
-        if line.trimmingCharacters(in: .whitespaces).isEmpty,
+        let normalized = line.hasSuffix("\r") ? String(line.dropLast()) : line
+        updateState(for: normalized.trimmingCharacters(in: .whitespaces))
+        if normalized.trimmingCharacters(in: .whitespaces).isEmpty,
            fenceMarker == nil, mathClose == nil, !inDirective {
             // Match append()'s arithmetic: the boundary sits after the
             // (virtual) newline of the blank line.

--- a/Conduit/Views/Components/MarkdownLargeDocument.swift
+++ b/Conduit/Views/Components/MarkdownLargeDocument.swift
@@ -43,6 +43,31 @@ enum MarkdownLargeDocumentPolicy {
     /// Lines per rendered slice of a large code block; bounds each slice's
     /// TextKit layout height (~800 lines ≈ 13K pt) and highlighting pass.
     static let codeSliceLineCount = 800
+    // --- Hardening additions (adversarial shapes) ---
+    /// Byte ceilings for code presentation: a block with a few very long
+    /// lines (minified JS, base64 blobs) must bound work by bytes as well
+    /// as by line count.
+    static let codePreviewLineCount = 200
+    static let codePreviewBytes = 16_000
+    static let codeSliceBytes = 64_000
+    /// Hard maximum for one promoted streaming stable chunk. Kept far below
+    /// the document threshold so a stable chunk can never route back into
+    /// the large-document renderer, and so the MarkdownText render of a
+    /// chunk is bounded regardless of how far ahead safe boundaries sit.
+    static let maxStreamChunkBytes = 2 * chunkTargetBytes
+    /// Tables at/above this estimated size use the paged presentation
+    /// (bounded column measurement on a sampled prefix + row batches).
+    static let largeTableBytes = 32_000
+    /// Textual rich blocks (callouts, columns) above this size reproject
+    /// their bodies into bounded inner text pieces.
+    static let largeTextBlockBytes = chunkTargetBytes
+    /// Math and Mermaid sources above this size drop the render action (the
+    /// renderers are not chunkable); the source stays previewable/copyable.
+    static let mathGuardBytes = 100_000
+    static let mermaidGuardBytes = 100_000
+    /// Byte budget for the per-chunk subset of message-wide reference
+    /// definitions appended at parse time (see MarkdownReferenceResolver).
+    static let referenceSubsetBudgetBytes = 8_000
 
     static func isLargeDocument(_ source: String) -> Bool {
         source.utf8.count >= documentThresholdBytes
@@ -68,6 +93,132 @@ enum MarkdownLargeDocumentPolicy {
 enum MarkdownLargeChunk: Equatable {
     case flow(blocks: [MarkdownBlock])
     case block(MarkdownBlock, originalIndex: Int)
+}
+
+/// Pure slicer for large code blocks: contiguous source slices bounded by
+/// BOTH a line ceiling and a UTF-8 byte ceiling. Concatenating the slices
+/// reproduces the original source exactly (giant lines are cut at
+/// whole-character boundaries with nothing inserted), which keeps Copy and
+/// round-trip tests trivially sound.
+enum MarkdownCodeSlicer {
+    static func slice(_ source: String, maxLines: Int, maxBytes: Int) -> [String] {
+        guard !source.isEmpty else { return [] }
+        var slices: [String] = []
+        var sliceStart = source.startIndex
+        var lineStart = source.startIndex
+        var lines = 0
+        var bytes = 0
+        var index = source.startIndex
+
+        func flush(through end: String.Index) {
+            guard sliceStart < end else { return }
+            slices.append(String(source[sliceStart..<end]))
+            sliceStart = end
+            lines = 0
+            bytes = 0
+        }
+
+        func emitGiantLinePieces(_ range: Range<String.Index>) {
+            var pieceStart = range.lowerBound
+            var pieceBytes = 0
+            var walk = range.lowerBound
+            while walk < range.upperBound {
+                pieceBytes += String(source[walk]).utf8.count
+                if pieceBytes >= maxBytes {
+                    let cut = source.index(after: walk)
+                    slices.append(String(source[pieceStart..<cut]))
+                    pieceStart = cut
+                    pieceBytes = 0
+                }
+                walk = source.index(after: walk)
+            }
+            if pieceStart < range.upperBound {
+                slices.append(String(source[pieceStart..<range.upperBound]))
+            }
+        }
+
+        while index < source.endIndex {
+            if source[index] == "\n" {
+                let lineEnd = source.index(after: index) // includes the newline
+                let lineBytes = source[lineStart..<lineEnd].utf8.count
+                if lineBytes > maxBytes {
+                    // A single line larger than the whole slice budget: emit
+                    // it as its own grapheme-aligned pieces.
+                    flush(through: lineStart)
+                    emitGiantLinePieces(lineStart..<lineEnd)
+                    sliceStart = lineEnd
+                    lines = 0
+                    bytes = 0
+                } else {
+                    if lines + 1 > maxLines || bytes + lineBytes > maxBytes {
+                        flush(through: lineStart)
+                    }
+                    lines += 1
+                    bytes += lineBytes
+                }
+                lineStart = lineEnd
+                index = lineEnd
+                continue
+            }
+            index = source.index(after: index)
+        }
+
+        if lineStart < source.endIndex {
+            let lineBytes = source[lineStart...].utf8.count
+            if lineBytes > maxBytes {
+                flush(through: lineStart)
+                emitGiantLinePieces(lineStart..<source.endIndex)
+                return slices
+            }
+            if lines + 1 > maxLines || bytes + lineBytes > maxBytes {
+                flush(through: lineStart)
+            }
+        }
+        flush(through: source.endIndex)
+        return slices
+    }
+}
+
+/// Incremental inline-marker balance for flow-text splitting. A cut is
+/// "safe" when no inline construct visibly spans it: even backtick count
+/// (inline code), zero open bracket depth (links/images/labels), and even
+/// asterisk/underscore/tilde parity (emphasis/strikethrough). Escaped
+/// characters (\*) do not count. This is deliberately a heuristic — it can
+/// only choose between cut points, never alter text — and a pathological
+/// unbalanceable window falls back to the plain target cut (rendered inline
+/// markers may then appear literal in that one piece).
+struct MarkdownInlineBalance {
+    private var backticks = 0
+    private var bracketDepth = 0
+    private var asterisks = 0
+    private var underscores = 0
+    private var tildes = 0
+    private var escaped = false
+
+    mutating func consume(_ character: Character) {
+        if escaped {
+            escaped = false
+            return
+        }
+        switch character {
+        case "\\": escaped = true
+        case "`": backticks += 1
+        case "[": bracketDepth += 1
+        case "]": bracketDepth = max(0, bracketDepth - 1)
+        case "*": asterisks += 1
+        case "_": underscores += 1
+        case "~": tildes += 1
+        default: break
+        }
+    }
+
+    var isBalanced: Bool {
+        bracketDepth == 0
+            && backticks % 2 == 0
+            && asterisks % 2 == 0
+            && underscores % 2 == 0
+            && tildes % 2 == 0
+    }
 }
 
 /// Groups a parsed document's blocks into bounded chunks. Pure and cheap:
@@ -115,14 +266,20 @@ enum MarkdownLargeChunkPlanner {
     /// quote lines, or word boundaries inside a paragraph/heading) so every
     /// piece stays within the chunk target. Heading text is small by nature
     /// but shares the paragraph fallback for completeness.
+    ///
+    /// Ordered lists: only the FIRST chunk of a split list keeps the real
+    /// `.orderedList` rendering; continuation groups render as paragraphs
+    /// with the ordinal baked into the text ("7. …") so numbering never
+    /// restarts at 1. The baked-number styling differs from the styled list
+    /// marker — a pathological-only formatting tradeoff.
     private static func splitOversized(block: MarkdownBlock) -> [MarkdownLargeChunk] {
         switch block {
         case .unorderedList(let items):
-            return groupItems(items) { .unorderedList($0) }
+            return splitListItems(items, ordered: false)
         case .orderedList(let items):
-            return groupItems(items) { .orderedList($0) }
+            return splitListItems(items, ordered: true)
         case .quote(let lines):
-            return groupItems(lines) { .quote($0) }
+            return splitQuoteLines(lines)
         case .heading(let level, let text):
             return splitText(text) { .heading(level: level, text: $0) }
         case .paragraph(let text):
@@ -132,32 +289,111 @@ enum MarkdownLargeChunkPlanner {
         }
     }
 
-    private static func groupItems<T>(_ items: [T], make: ([T]) -> MarkdownBlock) -> [MarkdownLargeChunk] {
-        func itemBytes(_ item: T) -> Int {
-            if let string = item as? String { return string.utf8.count }
-            if let line = item as? MarkdownQuoteLine { return line.text.utf8.count }
-            return 0
-        }
+    private static func splitListItems(_ items: [String], ordered: Bool) -> [MarkdownLargeChunk] {
+        let target = MarkdownLargeDocumentPolicy.chunkTargetBytes
         var chunks: [MarkdownLargeChunk] = []
-        var group: [T] = []
+        var group: [String] = []
+        var groupStartIndex = 0
         var groupBytes = 0
-        for item in items {
-            let bytes = itemBytes(item) + 32 // marker/separator allowance
-            if groupBytes + bytes > MarkdownLargeDocumentPolicy.chunkTargetBytes, !group.isEmpty {
-                chunks.append(.flow(blocks: [make(group)]))
-                group = []
-                groupBytes = 0
+        var emittedFirstGroup = false
+
+        func flush() {
+            guard !group.isEmpty else { return }
+            if ordered && emittedFirstGroup {
+                // Continuation of an ordered list: bake the real ordinals.
+                let paragraphs = group.enumerated().map { offset, item in
+                    MarkdownBlock.paragraph("\(groupStartIndex + offset + 1). \(taskStripped(item))")
+                }
+                chunks.append(.flow(blocks: paragraphs))
+            } else {
+                chunks.append(.flow(blocks: [ordered ? .orderedList(group) : .unorderedList(group)]))
+                emittedFirstGroup = true
+            }
+            group = []
+            groupBytes = 0
+        }
+
+        for (index, item) in items.enumerated() {
+            let bytes = item.utf8.count + 32 // marker/separator allowance
+            if bytes > target {
+                // One pathologically huge item: its first piece keeps the
+                // list semantics (or the baked ordinal); continuations are
+                // plain paragraphs.
+                flush()
+                groupStartIndex = index + 1
+                let task = MarkdownParser.taskItem(item)
+                let baseText = task?.text ?? item
+                let prefix = ordered ? "\(index + 1). " : ""
+                let taskMarker = task.map { $0.complete ? "[x] " : "[ ] " } ?? ""
+                let marked = taskMarker + baseText
+                // Uniform paragraph presentation for oversized items and
+                // their continuations keeps the pieces visually coherent
+                // (the ordinal or task marker is baked into the text).
+                chunks.append(contentsOf: splitText(marked) { piece in
+                    .paragraph(prefix + piece)
+                })
+                continue
+            }
+            if groupBytes + bytes > target, !group.isEmpty {
+                flush()
+                groupStartIndex = index
             }
             group.append(item)
             groupBytes += bytes
         }
-        if !group.isEmpty { chunks.append(.flow(blocks: [make(group)])) }
+        flush()
+        return chunks
+    }
+
+    private static func taskStripped(_ item: String) -> String {
+        MarkdownParser.taskItem(item)?.text ?? item
+    }
+
+    private static func splitQuoteLines(_ lines: [MarkdownQuoteLine]) -> [MarkdownLargeChunk] {
+        let target = MarkdownLargeDocumentPolicy.chunkTargetBytes
+        var chunks: [MarkdownLargeChunk] = []
+        var group: [MarkdownQuoteLine] = []
+        var groupBytes = 0
+
+        func flush() {
+            guard !group.isEmpty else { return }
+            chunks.append(.flow(blocks: [.quote(group)]))
+            group = []
+            groupBytes = 0
+        }
+
+        for line in lines {
+            let bytes = line.text.utf8.count + 8
+            if bytes > target {
+                // A pathologically huge quote line splits into several
+                // same-depth quote lines — quote chrome and depth semantics
+                // are preserved for every piece.
+                flush()
+                chunks.append(contentsOf: splitText(line.text) { piece in
+                    .quote([MarkdownQuoteLine(depth: line.depth, text: piece)])
+                })
+                continue
+            }
+            if groupBytes + bytes > target, !group.isEmpty {
+                flush()
+            }
+            group.append(line)
+            groupBytes += bytes
+        }
+        flush()
         return chunks
     }
 
     /// Word-boundary text split into ~chunkTargetBytes pieces. Each piece
     /// renders as its own paragraph; soft wrapping makes consecutive pieces
     /// read as one flowing body with a little extra paragraph spacing.
+    ///
+    /// Cut selection prefers the latest whitespace boundary whose prefix
+    /// has balanced inline markers (code spans, links, emphasis), so a
+    /// `**bold**`/`` `code` ``/`[link](…)` construct is not visibly broken
+    /// across pieces. A window with no balanced candidate falls back to the
+    /// plain whitespace cut — pathological inline soup may then show literal
+    /// markers at one seam, never altered text.
     static func splitText(_ text: String, make: (String) -> MarkdownBlock) -> [MarkdownLargeChunk] {
         guard text.utf8.count > MarkdownLargeDocumentPolicy.chunkTargetBytes else {
             return [.flow(blocks: [make(text)])]
@@ -165,18 +401,41 @@ enum MarkdownLargeChunkPlanner {
         var chunks: [MarkdownLargeChunk] = []
         var pieceStart = text.startIndex
         var pieceBytes = 0
-        var lastBoundary = text.startIndex
+        var lastWhitespace: String.Index?
+        var lastBalanced: String.Index?
+        var balance = MarkdownInlineBalance()
         var index = text.startIndex
         while index < text.endIndex {
             let character = text[index]
-            if character == " " || character == "\n" { lastBoundary = index }
+            balance.consume(character)
+            if character == " " || character == "\n" {
+                lastWhitespace = index
+                if balance.isBalanced {
+                    lastBalanced = text.index(after: index)
+                }
+            }
             pieceBytes += String(character).utf8.count
             if pieceBytes >= MarkdownLargeDocumentPolicy.chunkTargetBytes {
-                let cut = lastBoundary > pieceStart ? text.index(after: lastBoundary) : index
+                let cut: String.Index
+                if let balanced = lastBalanced, balanced > pieceStart, balanced <= text.index(after: index) {
+                    cut = balanced
+                } else if let boundary = lastWhitespace, boundary > pieceStart {
+                    cut = text.index(after: boundary)
+                } else {
+                    cut = text.index(after: index)
+                }
                 chunks.append(.flow(blocks: [make(String(text[pieceStart..<cut]))]))
                 pieceStart = cut
                 pieceBytes = 0
-                lastBoundary = cut
+                lastWhitespace = nil
+                lastBalanced = nil
+                // A balanced cut leaves the remainder marker-free, so the
+                // balance state legitimately restarts with the new piece;
+                // rewind so characters between the cut and the triggering
+                // index are consumed by the new piece's own accounting.
+                balance = MarkdownInlineBalance()
+                index = cut
+                continue
             }
             index = text.index(after: index)
         }
@@ -207,35 +466,146 @@ extension MarkdownBlock {
     }
 }
 
-/// Pure decision step of the large-stream projection: given how much has
-/// been promoted, revealed, and the latest safe boundary, returns the next
-/// byte offset to promote up to (or nil when nothing should move). Kept
-/// side-effect-free so the promotion policy is directly unit-testable.
+/// Pure decision step of the large-stream projection. Returns the next byte
+/// offset to promote up to (or nil when nothing should move). Side-effect
+/// free so the policy is directly unit-testable.
+///
+/// Selection seeks the LATEST safe boundary inside a bounded window
+/// `[promoted + minChunk, min(promoted + maxChunk, stableTarget)]` — never
+/// the globally latest boundary, which could sit hundreds of KB ahead and
+/// produce a huge stable chunk that re-enters whole-document rendering.
+///
+/// With no boundary in the window:
+/// - if the stable target sits inside a known construct span (fence/math/
+///   directive), promotion WAITS — a hard cut must never split a construct;
+/// - otherwise the text is genuinely unstructured prose and a bounded,
+///   grapheme-aligned hard cut advances one piece.
 enum LargeStreamPromotion {
     static func nextPromotionBoundary(
         promotedBytes: Int,
         revealedBytes: Int,
         tailWindowBytes: Int = MarkdownLargeDocumentPolicy.chunkTargetBytes,
-        chunkTargetBytes: Int = MarkdownLargeDocumentPolicy.chunkTargetBytes,
-        lastSafeBoundary: Int?
+        minChunkBytes: Int = MarkdownLargeDocumentPolicy.chunkTargetBytes,
+        maxChunkBytes: Int = MarkdownLargeDocumentPolicy.maxStreamChunkBytes,
+        boundaries: [Int],
+        constructIntervals: [(start: Int, end: Int?)] = []
     ) -> Int? {
         // Only revealed content well past the live tail window is stable.
         let stableTarget = revealedBytes - tailWindowBytes
-        guard stableTarget - promotedBytes > chunkTargetBytes else { return nil }
+        guard stableTarget - promotedBytes > minChunkBytes else { return nil }
 
-        // Prefer a safe boundary (never inside a fence/math/directive).
-        let minimumNext = promotedBytes + chunkTargetBytes
-        if let boundary = lastSafeBoundary, boundary >= minimumNext, boundary <= stableTarget {
+        let minimumNext = promotedBytes + minChunkBytes
+        let windowEnd = min(promotedBytes + maxChunkBytes, stableTarget)
+
+        // Latest safe boundary inside the bounded window.
+        if let boundary = boundaries.last(where: { $0 >= minimumNext && $0 <= windowEnd }) {
             return boundary
         }
-        // No safe boundary in reach — a giant unbroken paragraph — so
-        // hard-cut one bounded piece, mirroring the planner's oversized-
-        // block split, but only once the unpromoted region is clearly past
-        // the tail window.
-        if stableTarget - promotedBytes >= 2 * chunkTargetBytes {
-            return min(stableTarget, promotedBytes + 2 * chunkTargetBytes)
+
+        // Structural guard: never hard-cut through a construct that
+        // contains the stable target. Promotion waits for a real boundary;
+        // if the construct never closes, the tail itself eventually crosses
+        // the large-document threshold and renders through the bounded
+        // collapsed presentation instead.
+        let insideConstruct = constructIntervals.contains { interval in
+            let end = interval.end ?? Int.max
+            return stableTarget > interval.start && stableTarget < end
+        }
+        if insideConstruct { return nil }
+
+        // Unstructured prose: bounded hard-cut fallback.
+        if stableTarget - promotedBytes >= 2 * minChunkBytes {
+            return min(stableTarget, promotedBytes + 2 * minChunkBytes)
         }
         return nil
+    }
+}
+
+/// Per-chunk subsetting of message-wide reference definitions. Large-mode
+/// chunks must not append an arbitrarily large global definition block to
+/// every Foundation parse; the one-time off-main preparation computes, for
+/// each chunk, the definitions whose labels that chunk's text actually
+/// references (Foundation stays the semantic resolver — unused definitions
+/// render invisibly under `.full`, exactly the property PR #75 relies on).
+enum MarkdownReferenceResolver {
+    struct Definition: Equatable {
+        let label: String
+        let markdown: String
+    }
+
+    /// Splits a definitions context into individual definition lines with
+    /// their labels (the same single-line subset `parseDocument` collects).
+    static func definitions(from context: MarkdownReferenceContext) -> [Definition] {
+        guard context.containsDefinitions else { return [] }
+        return context.definitionsMarkdown
+            .components(separatedBy: "\n")
+            .compactMap { line in
+                guard let range = line.range(of: #"^\[([^\[\]\^][^\[\]]*)\]:"#, options: .regularExpression) else {
+                    return nil
+                }
+                // The whole-match range covers "[label]:" — strip the
+                // brackets and colon, keeping only the label.
+                let label = String(line[range].dropFirst().dropLast(2))
+                guard !label.isEmpty else { return nil }
+                return Definition(label: label.lowercased(), markdown: line)
+            }
+    }
+
+    /// Labels referenced by a chunk's text, in any of the Foundation forms
+    /// (`[text][label]`, `[label][]`, shortcut `[label]`). Over-inclusion is
+    /// harmless (unused definitions are invisible); under-inclusion would
+    /// break links, so the scan is deliberately generous.
+    static func referencedLabels(in text: String) -> Set<String> {
+        var labels = Set<String>()
+        var index = text.startIndex
+        while index < text.endIndex {
+            guard text[index] == "[" else {
+                index = text.index(after: index)
+                continue
+            }
+            // Collect one single-level bracket group. Nested brackets or a
+            // newline inside disqualify it from every reference form.
+            var walk = text.index(after: index)
+            var inner: [Character] = []
+            var closed = false
+            while walk < text.endIndex {
+                let character = text[walk]
+                if character == "]" { closed = true; break }
+                if character == "[" || character == "\n" { break }
+                inner.append(character)
+                walk = text.index(after: walk)
+            }
+            if closed, !inner.isEmpty, inner.first != "^" {
+                labels.insert(String(inner).lowercased())
+                index = text.index(after: walk)
+            } else {
+                index = text.index(after: index)
+            }
+        }
+        return labels
+    }
+
+    /// The bounded per-chunk definition context: only definitions whose
+    /// labels appear in `text`, capped at `budgetBytes` (a pathological
+    /// chunk referencing everything still parses against a bounded block;
+    /// links beyond the budget degrade to literal text in that one chunk).
+    static func subset(
+        for text: String,
+        definitions: [Definition],
+        budgetBytes: Int = MarkdownLargeDocumentPolicy.referenceSubsetBudgetBytes
+    ) -> MarkdownReferenceContext {
+        guard !definitions.isEmpty else { return .empty }
+        let used = referencedLabels(in: text)
+        guard !used.isEmpty else { return .empty }
+        var selected: [String] = []
+        var bytes = 0
+        for definition in definitions where used.contains(definition.label) {
+            if bytes + definition.markdown.utf8.count + 1 > budgetBytes { break }
+            selected.append(definition.markdown)
+            bytes += definition.markdown.utf8.count + 1
+        }
+        guard !selected.isEmpty else { return .empty }
+        return MarkdownReferenceContext(definitionsMarkdown: selected.joined(separator: "\n"))
     }
 }
 
@@ -267,6 +637,12 @@ struct MarkdownStableBoundaryScanner {
     /// the end of everything consumed — callers avoid promoting a prefix
     /// that ends mid-construct.
     var isInOpenConstruct: Bool { fenceMarker != nil || mathClose != nil || inDirective }
+
+    /// Absolute byte spans of every fenced/math/directive construct seen so
+    /// far (an open construct has a nil end). The streaming promotion policy
+    /// refuses to hard-cut through a span that contains the current stable
+    /// target. One interval per construct — bounded by construct count.
+    private(set) var constructIntervals: [(start: Int, end: Int?)] = []
 
     /// Feeds an append-only delta and returns any newly discovered safe
     /// boundary offsets (absolute, UTF-8). The delta's complete lines are
@@ -326,7 +702,14 @@ struct MarkdownStableBoundaryScanner {
         // does not remove it — strip it for state/blank checks while the
         // byte accounting above keeps counting it.
         let normalized = line.hasSuffix("\r") ? String(line.dropLast()) : line
-        updateState(for: normalized.trimmingCharacters(in: .whitespaces))
+        let wasInConstruct = fenceMarker != nil || mathClose != nil || inDirective
+        let lineStartOffset = consumedOffset
+        updateStateForLine(normalized.trimmingCharacters(in: .whitespaces), lineStartOffset: lineStartOffset, lineBytes: lineBytes)
+        let isInConstruct = fenceMarker != nil || mathClose != nil || inDirective
+        if wasInConstruct && !isInConstruct, !constructIntervals.isEmpty {
+            constructIntervals[constructIntervals.count - 1].end = consumedOffset + lineBytes
+        }
+        _ = boundaries
 
         // A blank line outside every construct ends a block: everything
         // after this line is a fresh block, so the split point moves to the
@@ -350,7 +733,15 @@ struct MarkdownStableBoundaryScanner {
         let line = pendingLine
         pendingLine = ""
         let normalized = line.hasSuffix("\r") ? String(line.dropLast()) : line
-        updateState(for: normalized.trimmingCharacters(in: .whitespaces))
+        let wasInConstruct = fenceMarker != nil || mathClose != nil || inDirective
+        updateStateForLine(
+            normalized.trimmingCharacters(in: .whitespaces),
+            lineStartOffset: consumedOffset,
+            lineBytes: line.utf8.count
+        )
+        if wasInConstruct && !(fenceMarker != nil || mathClose != nil || inDirective), !constructIntervals.isEmpty {
+            constructIntervals[constructIntervals.count - 1].end = consumedOffset + line.utf8.count
+        }
         if normalized.trimmingCharacters(in: .whitespaces).isEmpty,
            fenceMarker == nil, mathClose == nil, !inDirective {
             // Match append()'s arithmetic: the boundary sits after the
@@ -360,7 +751,7 @@ struct MarkdownStableBoundaryScanner {
         consumedOffset += line.utf8.count
     }
 
-    private mutating func updateState(for trimmedLine: String) {
+    private mutating func updateStateForLine(_ trimmedLine: String, lineStartOffset: Int, lineBytes: Int) {
         if let marker = fenceMarker {
             if trimmedLine.hasPrefix(marker) {
                 fenceMarker = nil
@@ -375,14 +766,23 @@ struct MarkdownStableBoundaryScanner {
             if trimmedLine == ":::" { inDirective = false }
             return
         }
-        if trimmedLine.hasPrefix("```") { fenceMarker = "```" }
-        else if trimmedLine.hasPrefix("~~~") { fenceMarker = "~~~" }
-        else if trimmedLine == "$$" { mathClose = "$$" }
-        else if trimmedLine == "\\[" { mathClose = "\\]" }
-        else if trimmedLine.hasPrefix(":::") {
+        if trimmedLine.hasPrefix("```") {
+            fenceMarker = "```"
+            constructIntervals.append((start: lineStartOffset, end: nil))
+        } else if trimmedLine.hasPrefix("~~~") {
+            fenceMarker = "~~~"
+            constructIntervals.append((start: lineStartOffset, end: nil))
+        } else if trimmedLine == "$$" {
+            mathClose = "$$"
+            constructIntervals.append((start: lineStartOffset, end: nil))
+        } else if trimmedLine == "\\[" {
+            mathClose = "\\]"
+            constructIntervals.append((start: lineStartOffset, end: nil))
+        } else if trimmedLine.hasPrefix(":::") {
             let name = trimmedLine.dropFirst(3).trimmingCharacters(in: .whitespaces).lowercased()
             if ["note", "info", "tip", "hint", "warning", "caution", "danger", "error", "important", "columns"].contains(name) {
                 inDirective = true
+                constructIntervals.append((start: lineStartOffset, end: nil))
             }
         }
     }

--- a/Conduit/Views/Components/MarkdownLargeDocument.swift
+++ b/Conduit/Views/Components/MarkdownLargeDocument.swift
@@ -126,63 +126,112 @@ enum MarkdownCodeSlicer {
     /// preview line or byte ceiling is reached, never walking or
     /// materializing the rest of the block. Safe to call from SwiftUI
     /// `body` for arbitrarily large sources.
+    #if DEBUG
+    /// Test instrumentation: UTF-8 bytes inspected by `firstSlice`, proving
+    /// preview work is proportional to the configured budget rather than
+    /// to the source length.
+    private static let firstSliceInspectLock = NSLock()
+    private nonisolated(unsafe) static var firstSliceInspectedBytesStorage = 0
+
+    nonisolated(unsafe) static var firstSliceInspectedBytes: Int {
+        get {
+            firstSliceInspectLock.lock()
+            defer { firstSliceInspectLock.unlock() }
+            return firstSliceInspectedBytesStorage
+        }
+        set {
+            firstSliceInspectLock.lock()
+            defer { firstSliceInspectLock.unlock() }
+            firstSliceInspectedBytesStorage = newValue
+        }
+    }
+    #endif
+
+    /// The single bounded preview piece. Contracts, all deterministic:
+    /// - the result is always a prefix of the source;
+    /// - the result's UTF-8 size never exceeds `maxBytes`;
+    /// - at most `maxLines` complete lines are included;
+    /// - the scan inspects O(maxBytes) source bytes — a pathological
+    ///   newline-free block is abandoned as soon as its first line alone
+    ///   exceeds the whole budget, never walked to the end.
     static func firstSlice(_ source: String, maxLines: Int, maxBytes: Int) -> String {
+        #if DEBUG
+        firstSliceInspectedBytes = 0
+        #endif
         var lines = 0
-        var bytes = 0
-        var index = source.startIndex
+        var bytes = 0      // UTF-8 bytes of complete lines included so far
+        var lineBytes = 0  // running UTF-8 bytes of the current line
         var lineStart = source.startIndex
+        var index = source.startIndex
+
+        func inspect(_ count: Int) {
+            #if DEBUG
+            firstSliceInspectedBytes += count
+            #endif
+        }
+
         while index < source.endIndex {
-            if source[index] == "\n" {
+            let character = source[index]
+            inspect(String(character).utf8.count)
+            if character == "\n" {
                 let lineEnd = source.index(after: index)
-                let lineBytes = source[lineStart..<lineEnd].utf8.count
-                if lineBytes > maxBytes {
-                    // Giant line: everything up to it plus a grapheme-safe
-                    // bounded piece OF it, under the REMAINING byte budget
-                    // so the whole preview stays within the ceiling — and
-                    // always a prefix of the source.
+                let totalLineBytes = lineBytes + 1 // including the newline
+                let remaining = maxBytes - bytes
+                if totalLineBytes > remaining {
+                    // Including this line whole would exceed the budget:
+                    // keep everything before it plus a grapheme-safe piece
+                    // of it under the REMAINING budget.
                     return String(source[..<lineStart])
-                        + boundedPrefix(of: source[lineStart..<lineEnd], maxBytes: maxBytes - bytes)
+                        + boundedPrefix(of: source[lineStart..<lineEnd], maxBytes: remaining)
                 }
                 lines += 1
-                bytes += lineBytes
+                bytes += totalLineBytes
                 if lines >= maxLines || bytes >= maxBytes {
                     return String(source[..<lineEnd])
                 }
                 lineStart = lineEnd
                 index = lineEnd
+                lineBytes = 0
                 continue
             }
-            // No newline so far: once the accumulated line itself exceeds
-            // the byte ceiling it is a giant line — stop scanning here and
-            // never walk the rest of the block.
-            if index == source.index(before: source.endIndex) {
-                break
+            lineBytes += String(character).utf8.count
+            if lineBytes > maxBytes {
+                // The current line alone exceeds the entire budget — stop
+                // scanning it (work stays proportional to maxBytes) and
+                // take a bounded piece under the remaining budget.
+                let remaining = maxBytes - bytes
+                return String(source[..<lineStart])
+                    + boundedPrefix(of: source[lineStart...], maxBytes: remaining)
             }
             index = source.index(after: index)
-            if source.distance(from: lineStart, to: index) >= maxBytes {
-                return String(source[..<lineStart]) + boundedPrefix(of: source[lineStart...], maxBytes: maxBytes - bytes)
-            }
         }
+
+        // Trailing partial line (no final newline).
         if lineStart < source.endIndex {
-            let lineBytes = source[lineStart...].utf8.count
-            if lineBytes > maxBytes {
-                return String(source[..<lineStart]) + boundedPrefix(of: source[lineStart...], maxBytes: maxBytes - bytes)
+            let remaining = maxBytes - bytes
+            if lineBytes > remaining {
+                return String(source[..<lineStart])
+                    + boundedPrefix(of: source[lineStart...], maxBytes: remaining)
             }
         }
         return source
     }
 
+    /// Grapheme-safe prefix of `range` whose UTF-8 size never exceeds
+    /// `maxBytes` — a grapheme is only included when it fits (checked
+    /// before inclusion), so the only overshoot is impossible; a budget
+    /// smaller than the first grapheme returns an empty prefix.
     private static func boundedPrefix(of range: Substring, maxBytes: Int) -> String {
+        guard maxBytes > 0 else { return "" }
         var bytes = 0
         var index = range.startIndex
         while index < range.endIndex {
-            bytes += String(range[index]).utf8.count
-            if bytes >= maxBytes {
-                return String(range[..<range.index(after: index)])
-            }
+            let characterBytes = String(range[index]).utf8.count
+            if bytes + characterBytes > maxBytes { break }
+            bytes += characterBytes
             index = range.index(after: index)
         }
-        return String(range)
+        return String(range[..<index])
     }
 
     static func slice(_ source: String, maxLines: Int, maxBytes: Int) -> [String] {

--- a/Conduit/Views/Components/MarkdownLargeDocument.swift
+++ b/Conduit/Views/Components/MarkdownLargeDocument.swift
@@ -1,0 +1,341 @@
+//
+//  MarkdownLargeDocument.swift
+//  Conduit
+//
+//  Bounded rendering for pathological-but-legitimate chat messages.
+//
+//  Measurements (iPhone 17 simulator, see PR description) showed that at
+//  ~250 KB a single message already costs 220–800 ms of synchronous
+//  MainActor work per pipeline stage, and at 1 MB the whole-document
+//  pipeline costs 0.8–3.3 s — repeated at 30 fps while streaming, which
+//  wedges the main thread and invites a watchdog kill. This file owns the
+//  policy and the pure planning logic that keeps every stage's work
+//  proportional to a bounded chunk, never to the whole document.
+//
+
+import Foundation
+
+/// Central policy for the large-document rendering mode. All thresholds are
+/// `utf8.count`-based (cheap, deterministic — no parsing just to decide the
+/// path) and justified by measurement:
+///
+/// - `documentThresholdBytes` (100 KB): a typical rich assistant response is
+///   1–10 KB; the largest ordinary ones (~50 KB) measured 45–160 ms for a
+///   full synchronous pipeline pass — a hitch, not a freeze, and that is the
+///   pre-existing behavior this change must preserve. By 250 KB every stage
+///   measured 220 ms+ and whole-document layout reached 565 ms–2.4 s, so the
+///   boundary between "keep the fast path" and "must bound the work" sits
+///   between those: 100 KB.
+/// - `previewBytes` (16 KB): the collapsed preview renders synchronously on
+///   first presentation (session load, history scroll). Two chunks' worth of
+///   content measured ≤ ~35 ms to parse + format + lay out.
+/// - `chunkTargetBytes` (8 KB): one flow chunk measured ~1.5 ms parse +
+///   ~3 ms attributed construction + ~3 ms TextKit layout — single-digit
+///   milliseconds per chunk keeps progressive rendering hitch-free.
+/// - `codeBlockThresholdBytes` (32 KB): syntax highlighting measured 67 ms at
+///   50 KB and 1.5 s at 1 MB; 32 KB is where highlighting leaves the
+///   "synchronous is fine" range.
+enum MarkdownLargeDocumentPolicy {
+    static let documentThresholdBytes = 100_000
+    static let previewBytes = 16_000
+    static let chunkTargetBytes = 8_000
+    static let codeBlockThresholdBytes = 32_000
+    /// Lines per rendered slice of a large code block; bounds each slice's
+    /// TextKit layout height (~800 lines ≈ 13K pt) and highlighting pass.
+    static let codeSliceLineCount = 800
+
+    static func isLargeDocument(_ source: String) -> Bool {
+        source.utf8.count >= documentThresholdBytes
+    }
+
+    static func isLargeCodeBlock(_ source: String) -> Bool {
+        source.utf8.count >= codeBlockThresholdBytes
+    }
+}
+
+/// One bounded rendering unit of a large document. Consecutive selectable
+/// flow blocks (paragraphs, headings, lists, quotes) are grouped into
+/// `flow` chunks of roughly `chunkTargetBytes`; each rich block (table,
+/// code, math, image, callout, columns, divider) stays independent — with
+/// its original block index retained so its selection descriptors match the
+/// ordinary plan's `block-N` ids — so its own renderer handles it exactly
+/// as in the normal block path.
+///
+/// A single flow block larger than the chunk target (e.g. a 1 MB paragraph,
+/// which measured 2.4 s of whole-document TextKit layout) is split at word
+/// boundaries into multiple `flow` chunks so no chunk scales with the
+/// document.
+enum MarkdownLargeChunk: Equatable {
+    case flow(blocks: [MarkdownBlock])
+    case block(MarkdownBlock, originalIndex: Int)
+}
+
+/// Groups a parsed document's blocks into bounded chunks. Pure and cheap:
+/// byte estimates come from the blocks' own text (no re-serialization), and
+/// the grouping is deterministic for a deterministic block list, so the plan
+/// is directly unit-testable.
+enum MarkdownLargeChunkPlanner {
+    static func chunks(for blocks: [MarkdownBlock]) -> [MarkdownLargeChunk] {
+        var chunks: [MarkdownLargeChunk] = []
+        var pending: [MarkdownBlock] = []
+        var pendingBytes = 0
+
+        func flush() {
+            guard !pending.isEmpty else { return }
+            chunks.append(.flow(blocks: pending))
+            pending = []
+            pendingBytes = 0
+        }
+
+        for (originalIndex, block) in blocks.enumerated() {
+            if block.isSelectableFlowBlock {
+                let bytes = block.estimatedSourceBytes
+                if pendingBytes + bytes > MarkdownLargeDocumentPolicy.chunkTargetBytes {
+                    flush()
+                }
+                if bytes > MarkdownLargeDocumentPolicy.chunkTargetBytes {
+                    // A single oversized flow block would produce one chunk
+                    // scaling with the document; split it first.
+                    flush()
+                    chunks.append(contentsOf: splitOversized(block: block))
+                    continue
+                }
+                pending.append(block)
+                pendingBytes += bytes
+            } else {
+                flush()
+                chunks.append(.block(block, originalIndex: originalIndex))
+            }
+        }
+        flush()
+        return chunks
+    }
+
+    /// Splits one oversized flow block at sub-block boundaries (list items,
+    /// quote lines, or word boundaries inside a paragraph/heading) so every
+    /// piece stays within the chunk target. Heading text is small by nature
+    /// but shares the paragraph fallback for completeness.
+    private static func splitOversized(block: MarkdownBlock) -> [MarkdownLargeChunk] {
+        switch block {
+        case .unorderedList(let items):
+            return groupItems(items) { .unorderedList($0) }
+        case .orderedList(let items):
+            return groupItems(items) { .orderedList($0) }
+        case .quote(let lines):
+            return groupItems(lines) { .quote($0) }
+        case .heading(let level, let text):
+            return splitText(text) { .heading(level: level, text: $0) }
+        case .paragraph(let text):
+            return splitText(text) { .paragraph($0) }
+        default:
+            return [.flow(blocks: [block])]
+        }
+    }
+
+    private static func groupItems<T>(_ items: [T], make: ([T]) -> MarkdownBlock) -> [MarkdownLargeChunk] {
+        func itemBytes(_ item: T) -> Int {
+            if let string = item as? String { return string.utf8.count }
+            if let line = item as? MarkdownQuoteLine { return line.text.utf8.count }
+            return 0
+        }
+        var chunks: [MarkdownLargeChunk] = []
+        var group: [T] = []
+        var groupBytes = 0
+        for item in items {
+            let bytes = itemBytes(item) + 32 // marker/separator allowance
+            if groupBytes + bytes > MarkdownLargeDocumentPolicy.chunkTargetBytes, !group.isEmpty {
+                chunks.append(.flow(blocks: [make(group)]))
+                group = []
+                groupBytes = 0
+            }
+            group.append(item)
+            groupBytes += bytes
+        }
+        if !group.isEmpty { chunks.append(.flow(blocks: [make(group)])) }
+        return chunks
+    }
+
+    /// Word-boundary text split into ~chunkTargetBytes pieces. Each piece
+    /// renders as its own paragraph; soft wrapping makes consecutive pieces
+    /// read as one flowing body with a little extra paragraph spacing.
+    static func splitText(_ text: String, make: (String) -> MarkdownBlock) -> [MarkdownLargeChunk] {
+        guard text.utf8.count > MarkdownLargeDocumentPolicy.chunkTargetBytes else {
+            return [.flow(blocks: [make(text)])]
+        }
+        var chunks: [MarkdownLargeChunk] = []
+        var pieceStart = text.startIndex
+        var pieceBytes = 0
+        var lastBoundary = text.startIndex
+        var index = text.startIndex
+        while index < text.endIndex {
+            let character = text[index]
+            if character == " " || character == "\n" { lastBoundary = index }
+            pieceBytes += String(character).utf8.count
+            if pieceBytes >= MarkdownLargeDocumentPolicy.chunkTargetBytes {
+                let cut = lastBoundary > pieceStart ? text.index(after: lastBoundary) : index
+                chunks.append(.flow(blocks: [make(String(text[pieceStart..<cut]))]))
+                pieceStart = cut
+                pieceBytes = 0
+                lastBoundary = cut
+            }
+            index = text.index(after: index)
+        }
+        if pieceStart < text.endIndex {
+            chunks.append(.flow(blocks: [make(String(text[pieceStart...]))]))
+        }
+        return chunks
+    }
+}
+
+extension MarkdownBlock {
+    /// Byte estimate used only for chunk grouping decisions.
+    var estimatedSourceBytes: Int {
+        switch self {
+        case .heading(_, let text): return text.utf8.count + 8
+        case .paragraph(let text): return text.utf8.count + 2
+        case .quote(let lines): return lines.reduce(0) { $0 + $1.text.utf8.count + 4 } + 4
+        case .unorderedList(let items), .orderedList(let items):
+            return items.reduce(0) { $0 + $1.utf8.count + 4 } + 4
+        case .table(let headers, _, let rows):
+            return headers.reduce(0) { $0 + $1.utf8.count + 4 }
+                + rows.reduce(0) { $0 + $1.reduce(0) { $0 + $1.utf8.count + 4 } }
+        case .code(_, let source): return source.utf8.count + 16
+        case .callout(_, let text): return text.utf8.count + 16
+        case .columns(let columns): return columns.reduce(0) { $0 + $1.utf8.count + 4 }
+        case .image, .math, .divider: return 64
+        }
+    }
+}
+
+/// Pure decision step of the large-stream projection: given how much has
+/// been promoted, revealed, and the latest safe boundary, returns the next
+/// byte offset to promote up to (or nil when nothing should move). Kept
+/// side-effect-free so the promotion policy is directly unit-testable.
+enum LargeStreamPromotion {
+    static func nextPromotionBoundary(
+        promotedBytes: Int,
+        revealedBytes: Int,
+        tailWindowBytes: Int = MarkdownLargeDocumentPolicy.chunkTargetBytes,
+        chunkTargetBytes: Int = MarkdownLargeDocumentPolicy.chunkTargetBytes,
+        lastSafeBoundary: Int?
+    ) -> Int? {
+        // Only revealed content well past the live tail window is stable.
+        let stableTarget = revealedBytes - tailWindowBytes
+        guard stableTarget - promotedBytes > chunkTargetBytes else { return nil }
+
+        // Prefer a safe boundary (never inside a fence/math/directive).
+        let minimumNext = promotedBytes + chunkTargetBytes
+        if let boundary = lastSafeBoundary, boundary >= minimumNext, boundary <= stableTarget {
+            return boundary
+        }
+        // No safe boundary in reach — a giant unbroken paragraph — so
+        // hard-cut one bounded piece, mirroring the planner's oversized-
+        // block split, but only once the unpromoted region is clearly past
+        // the tail window.
+        if stableTarget - promotedBytes >= 2 * chunkTargetBytes {
+            return min(stableTarget, promotedBytes + 2 * chunkTargetBytes)
+        }
+        return nil
+    }
+}
+
+/// Incremental scanner that finds *safe* split points in a growing streamed
+/// document — positions where slicing the source leaves both sides as
+/// well-formed Markdown (never inside a fenced code block, math block, or
+/// `:::` directive). Used by the large streaming path to promote a stable
+/// prefix into immutable chunks while only re-parsing the live tail.
+///
+/// The scanner is resumable: it consumes only complete new lines each call,
+/// so per-frame cost is O(delta), not O(document). Offsets are absolute
+/// UTF-8 byte offsets into the whole accumulated text.
+struct MarkdownStableBoundaryScanner {
+    /// Absolute UTF-8 offset of the most recent safe block boundary — the
+    /// position where the next block starts after a blank-line gap, outside
+    /// every fenced/math/directive construct. Nil before any boundary exists.
+    private(set) var lastSafeBoundary: Int?
+    /// Absolute UTF-8 offset of everything fully scanned (complete lines).
+    private(set) var consumedOffset: Int = 0
+    /// Trailing partial line awaiting its newline.
+    private var pendingLine = ""
+    private var fenceMarker: String?
+    private var inMath = false
+    private var inDirective = false
+
+    /// True when the scanner sits inside a fenced/math/directive region at
+    /// the end of everything consumed — callers avoid promoting a prefix
+    /// that ends mid-construct.
+    var isInOpenConstruct: Bool { fenceMarker != nil || inMath || inDirective }
+
+    /// Feeds an append-only delta and returns any newly discovered safe
+    /// boundary offsets (absolute, UTF-8).
+    mutating func append(_ delta: String) -> [Int] {
+        var newBoundaries: [Int] = []
+        pendingLine += delta
+
+        while let newline = pendingLine.firstIndex(of: "\n") {
+            let line = String(pendingLine[..<newline])
+            let lineBytes = line.utf8.count + 1 // including the newline
+
+            updateState(for: line.trimmingCharacters(in: .whitespaces))
+
+            // A blank line outside every construct ends a block: everything
+            // after this line is a fresh block, so the split point moves to
+            // the next line's start. Consecutive blank lines keep moving it.
+            if line.trimmingCharacters(in: .whitespaces).isEmpty,
+               fenceMarker == nil, !inMath, !inDirective {
+                let boundary = consumedOffset + lineBytes
+                lastSafeBoundary = boundary
+                newBoundaries.append(boundary)
+            }
+
+            consumedOffset += lineBytes
+            pendingLine.removeSubrange(..<pendingLine.index(after: newline))
+        }
+        return newBoundaries
+    }
+
+    /// Processes the trailing partial line as if the stream had ended with
+    /// a newline. Call once the stream is finished: without it, a document
+    /// whose last line is a closing fence (no trailing newline) leaves the
+    /// scanner reporting an open construct forever, and final promotion
+    /// falls back to hard cuts that can land inside the block.
+    mutating func finish() {
+        guard !pendingLine.isEmpty else { return }
+        let line = pendingLine
+        pendingLine = ""
+        updateState(for: line.trimmingCharacters(in: .whitespaces))
+        if line.trimmingCharacters(in: .whitespaces).isEmpty,
+           fenceMarker == nil, !inMath, !inDirective {
+            // Match append()'s arithmetic: the boundary sits after the
+            // (virtual) newline of the blank line.
+            lastSafeBoundary = consumedOffset + line.utf8.count
+        }
+        consumedOffset += line.utf8.count
+    }
+
+    private mutating func updateState(for trimmedLine: String) {
+        if let marker = fenceMarker {
+            if trimmedLine.hasPrefix(marker) {
+                fenceMarker = nil
+            }
+            return
+        }
+        if inMath {
+            if trimmedLine == "$$" || trimmedLine == "\\]" { inMath = false }
+            return
+        }
+        if inDirective {
+            if trimmedLine == ":::" { inDirective = false }
+            return
+        }
+        if trimmedLine.hasPrefix("```") { fenceMarker = "```" }
+        else if trimmedLine.hasPrefix("~~~") { fenceMarker = "~~~" }
+        else if trimmedLine == "$$" || trimmedLine == "\\[" { inMath = true }
+        else if trimmedLine.hasPrefix(":::") {
+            let name = trimmedLine.dropFirst(3).trimmingCharacters(in: .whitespaces).lowercased()
+            if ["note", "info", "tip", "hint", "warning", "caution", "danger", "error", "important", "columns"].contains(name) {
+                inDirective = true
+            }
+        }
+    }
+}

--- a/Conduit/Views/Components/MarkdownLargeDocument.swift
+++ b/Conduit/Views/Components/MarkdownLargeDocument.swift
@@ -68,6 +68,27 @@ enum MarkdownLargeDocumentPolicy {
     /// Byte budget for the per-chunk subset of message-wide reference
     /// definitions appended at parse time (see MarkdownReferenceResolver).
     static let referenceSubsetBudgetBytes = 8_000
+    /// Per-cell byte ceiling in the paged large-table presentation: one
+    /// 500 KB cell must not become an unbounded InlineMarkdown/TextKit
+    /// operation or an unbounded width-measurement input. The cell renders
+    /// a grapheme-safe bounded prefix; the full content remains in the
+    /// message (Copy Response) — a documented pathological-only tradeoff.
+    static let tableCellBytes = 8_000
+
+    /// Grapheme-safe bounded cell text (or any bounded display text) with
+    /// an explicit truncation marker.
+    static func boundedDisplayText(_ text: String, maxBytes: Int) -> String {
+        guard text.utf8.count > maxBytes else { return text }
+        var bytes = 0
+        var index = text.startIndex
+        while index < text.endIndex {
+            let characterBytes = String(text[index]).utf8.count
+            if bytes + characterBytes > maxBytes { break }
+            bytes += characterBytes
+            index = text.index(after: index)
+        }
+        return String(text[..<index]) + " …"
+    }
 
     static func isLargeDocument(_ source: String) -> Bool {
         source.utf8.count >= documentThresholdBytes
@@ -101,6 +122,69 @@ enum MarkdownLargeChunk: Equatable {
 /// whole-character boundaries with nothing inserted), which keeps Copy and
 /// round-trip tests trivially sound.
 enum MarkdownCodeSlicer {
+    /// The single bounded preview piece: stops scanning as soon as the
+    /// preview line or byte ceiling is reached, never walking or
+    /// materializing the rest of the block. Safe to call from SwiftUI
+    /// `body` for arbitrarily large sources.
+    static func firstSlice(_ source: String, maxLines: Int, maxBytes: Int) -> String {
+        var lines = 0
+        var bytes = 0
+        var index = source.startIndex
+        var lineStart = source.startIndex
+        while index < source.endIndex {
+            if source[index] == "\n" {
+                let lineEnd = source.index(after: index)
+                let lineBytes = source[lineStart..<lineEnd].utf8.count
+                if lineBytes > maxBytes {
+                    // Giant line: everything up to it plus a grapheme-safe
+                    // bounded piece OF it, under the REMAINING byte budget
+                    // so the whole preview stays within the ceiling — and
+                    // always a prefix of the source.
+                    return String(source[..<lineStart])
+                        + boundedPrefix(of: source[lineStart..<lineEnd], maxBytes: maxBytes - bytes)
+                }
+                lines += 1
+                bytes += lineBytes
+                if lines >= maxLines || bytes >= maxBytes {
+                    return String(source[..<lineEnd])
+                }
+                lineStart = lineEnd
+                index = lineEnd
+                continue
+            }
+            // No newline so far: once the accumulated line itself exceeds
+            // the byte ceiling it is a giant line — stop scanning here and
+            // never walk the rest of the block.
+            if index == source.index(before: source.endIndex) {
+                break
+            }
+            index = source.index(after: index)
+            if source.distance(from: lineStart, to: index) >= maxBytes {
+                return String(source[..<lineStart]) + boundedPrefix(of: source[lineStart...], maxBytes: maxBytes - bytes)
+            }
+        }
+        if lineStart < source.endIndex {
+            let lineBytes = source[lineStart...].utf8.count
+            if lineBytes > maxBytes {
+                return String(source[..<lineStart]) + boundedPrefix(of: source[lineStart...], maxBytes: maxBytes - bytes)
+            }
+        }
+        return source
+    }
+
+    private static func boundedPrefix(of range: Substring, maxBytes: Int) -> String {
+        var bytes = 0
+        var index = range.startIndex
+        while index < range.endIndex {
+            bytes += String(range[index]).utf8.count
+            if bytes >= maxBytes {
+                return String(range[..<range.index(after: index)])
+            }
+            index = range.index(after: index)
+        }
+        return String(range)
+    }
+
     static func slice(_ source: String, maxLines: Int, maxBytes: Int) -> [String] {
         guard !source.isEmpty else { return [] }
         var slices: [String] = []
@@ -226,6 +310,29 @@ struct MarkdownInlineBalance {
 /// the grouping is deterministic for a deterministic block list, so the plan
 /// is directly unit-testable.
 enum MarkdownLargeChunkPlanner {
+    #if DEBUG
+    /// Test instrumentation: number of `splitText` invocations. Proves that
+    /// SwiftUI body re-evaluations never re-split pathological text (the
+    /// specialized rich-block pieces are computed once in preparation).
+    /// Lock-guarded end to end: preparation runs off the MainActor while
+    /// tests read/reset from the main thread.
+    private static let splitCountLock = NSLock()
+    private nonisolated(unsafe) static var splitTextCallCountStorage = 0
+
+    nonisolated(unsafe) static var splitTextCallCount: Int {
+        get {
+            splitCountLock.lock()
+            defer { splitCountLock.unlock() }
+            return splitTextCallCountStorage
+        }
+        set {
+            splitCountLock.lock()
+            defer { splitCountLock.unlock() }
+            splitTextCallCountStorage = newValue
+        }
+    }
+    #endif
+
     static func chunks(for blocks: [MarkdownBlock]) -> [MarkdownLargeChunk] {
         var chunks: [MarkdownLargeChunk] = []
         var pending: [MarkdownBlock] = []
@@ -318,8 +425,11 @@ enum MarkdownLargeChunkPlanner {
             if bytes > target {
                 // One pathologically huge item: its first piece keeps the
                 // list semantics (or the baked ordinal); continuations are
-                // plain paragraphs.
+                // plain paragraphs. For ordered lists the oversized item
+                // consumes the "first group" slot so a later normal group
+                // bakes its ordinals instead of restarting at 1.
                 flush()
+                if ordered { emittedFirstGroup = true }
                 groupStartIndex = index + 1
                 let task = MarkdownParser.taskItem(item)
                 let baseText = task?.text ?? item
@@ -395,6 +505,9 @@ enum MarkdownLargeChunkPlanner {
     /// plain whitespace cut — pathological inline soup may then show literal
     /// markers at one seam, never altered text.
     static func splitText(_ text: String, make: (String) -> MarkdownBlock) -> [MarkdownLargeChunk] {
+        #if DEBUG
+        splitTextCallCount += 1
+        #endif
         guard text.utf8.count > MarkdownLargeDocumentPolicy.chunkTargetBytes else {
             return [.flow(blocks: [make(text)])]
         }
@@ -502,20 +615,26 @@ enum LargeStreamPromotion {
             return boundary
         }
 
-        // Structural guard: never hard-cut through a construct that
-        // contains the stable target. Promotion waits for a real boundary;
-        // if the construct never closes, the tail itself eventually crosses
-        // the large-document threshold and renders through the bounded
-        // collapsed presentation instead.
-        let insideConstruct = constructIntervals.contains { interval in
-            let end = interval.end ?? Int.max
-            return stableTarget > interval.start && stableTarget < end
+        // Structural guard: never hard-cut through a construct. BOTH the
+        // stable target and the actual candidate cut offset must sit
+        // outside every recorded construct — a target beyond a fence can
+        // still receive a fallback cut that lands inside it.
+        func isInsideConstruct(_ offset: Int) -> Bool {
+            constructIntervals.contains { interval in
+                let end = interval.end ?? Int.max
+                return offset > interval.start && offset < end
+            }
         }
-        if insideConstruct { return nil }
+        if isInsideConstruct(stableTarget) { return nil }
 
-        // Unstructured prose: bounded hard-cut fallback.
+        // Unstructured prose: bounded hard-cut fallback, still guarded by
+        // the construct check on the candidate itself. Promotion waits for
+        // a real boundary instead; if the construct never closes, the tail
+        // itself eventually crosses the large-document threshold and
+        // renders through the bounded collapsed presentation.
         if stableTarget - promotedBytes >= 2 * minChunkBytes {
-            return min(stableTarget, promotedBytes + 2 * minChunkBytes)
+            let cut = min(stableTarget, promotedBytes + 2 * minChunkBytes)
+            return isInsideConstruct(cut) ? nil : cut
         }
         return nil
     }

--- a/Conduit/Views/Components/MarkdownLargeDocumentView.swift
+++ b/Conduit/Views/Components/MarkdownLargeDocumentView.swift
@@ -516,6 +516,9 @@ struct LargeCodeBlockView: View {
     @State private var expanded = false
     @State private var copied = false
     @State private var slices: [String]?
+    /// (hasMoreLines, lineCount) computed once off-main; whole-block scans
+    /// must not run per body evaluation (the Copy state toggle re-evaluates).
+    @State private var lineStats: (hasMore: Bool, count: Int)?
 
     private var normalizedLanguage: String { MarkdownLanguage.normalized(language) }
 
@@ -541,11 +544,11 @@ struct LargeCodeBlockView: View {
                             usesAccentSurface: usesAccentSurface,
                             maximumNumberOfLines: Self.previewLineCount
                         )
-                        if sourceHasMoreLinesThanPreview {
+                        if lineStats?.hasMore == true {
                             Button {
                                 withAnimation(.easeInOut(duration: 0.15)) { expanded = true }
                             } label: {
-                                Label("Show all \(Self.approximateLineCount(of: source)) lines", systemImage: "chevron.down")
+                                Label("Show all \(lineStats?.count ?? 0) lines", systemImage: "chevron.down")
                                     .font(.caption.weight(.semibold))
                             }
                             .tint(usesAccentSurface ? .white : .conduitAccent)
@@ -566,6 +569,24 @@ struct LargeCodeBlockView: View {
                     usesAccentSurface ? Color.white.opacity(0.28) : Color.secondary.opacity(0.20),
                     lineWidth: 1
                 )
+        }
+        .task(id: "stats-\(source.utf8.count)") {
+            // One-time whole-block scans (line counting), off the MainActor.
+            guard lineStats == nil else { return }
+            let currentSource = source
+            let previewBudget = Self.previewLineCount
+            let stats = await Task.detached(priority: .userInitiated) { () -> (Bool, Int) in
+                var newlines = 0
+                var index = currentSource.startIndex
+                while index < currentSource.endIndex {
+                    if currentSource[index] == "\n" { newlines += 1 }
+                    index = currentSource.index(after: index)
+                }
+                // The preview shows at most `previewLineCount` lines.
+                return (newlines >= previewBudget, newlines + 1)
+            }.value
+            guard !Task.isCancelled else { return }
+            lineStats = stats
         }
         .task(id: expanded ? "full-\(source.utf8.count)" : "preview") {
             guard expanded, slices == nil else { return }
@@ -625,17 +646,6 @@ struct LargeCodeBlockView: View {
         return source
     }
 
-    private var sourceHasMoreLinesThanPreview: Bool {
-        Self.previewSource(of: source).utf8.count < source.utf8.count
-    }
-
-    private static func approximateLineCount(of source: String) -> Int {
-        // Only called once when building the expand button's label; a single
-        // linear newline count over the block.
-        source.reduce(into: 1) { count, character in
-            if character == "\n" { count += 1 }
-        }
-    }
 }
 
 private extension Array where Element == Substring {

--- a/Conduit/Views/Components/MarkdownLargeDocumentView.swift
+++ b/Conduit/Views/Components/MarkdownLargeDocumentView.swift
@@ -1,0 +1,718 @@
+//
+//  MarkdownLargeDocumentView.swift
+//  Conduit
+//
+//  Bounded presentation for messages at or above the large-document
+//  threshold. See MarkdownLargeDocument.swift for the measured policy.
+//
+//  Shape (every stage bounded — nothing here scales with the whole source):
+//
+//      collapsed:  synchronous render of a ≤16 KB prefix through the
+//                  ordinary MarkdownText fast path, plus a banner
+//      expanded:   structural parse + chunk plan off the MainActor, then
+//                  progressive rendering of ~8 KB chunks — each flow chunk
+//                  is a memoized attributed string inside one
+//                  SelectableTextView, rich blocks reuse the ordinary block
+//                  renderer, and oversized code blocks render as line
+//                  slices with off-main highlighting
+//
+
+import SwiftUI
+import UIKit
+
+/// Entry point used by `MarkdownText` when the source meets the large-
+/// document policy. Settled messages open collapsed with a bounded preview;
+/// expanding parses the full document off-main and renders it progressively.
+///
+/// Deliberate UX tradeoff: a streamed response renders uncollapsed while it
+/// grows (the user is reading the tail), then adopts this collapsed form
+/// once it settles into the transcript — every large message behaves the
+/// same way on reopen, and the transcript never carries an eagerly expanded
+/// megabyte message.
+struct LargeMarkdownDocumentView: View {
+    let source: String
+    let foregroundStyle: Color
+    let usesAccentSurface: Bool
+    let gatewayMediaDataURL: ((String) async -> String?)?
+
+    @State private var expanded = false
+
+    var body: some View {
+        if expanded {
+            LargeMarkdownExpandedView(
+                source: source,
+                foregroundStyle: foregroundStyle,
+                usesAccentSurface: usesAccentSurface,
+                gatewayMediaDataURL: gatewayMediaDataURL
+            )
+        } else {
+            collapsedView
+        }
+    }
+
+    private var collapsedView: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            // The preview renders synchronously through the ordinary fast
+            // path — bounded by policy.previewBytes, so first presentation
+            // (session load, history scroll) never parses the full source.
+            // Reference-style links defined later in the document stay
+            // literal here; the expanded render resolves them message-wide.
+            MarkdownText(
+                source: Self.previewSource(of: source),
+                foregroundStyle: foregroundStyle,
+                usesAccentSurface: usesAccentSurface,
+                gatewayMediaDataURL: gatewayMediaDataURL
+            )
+
+            LargeDocumentBanner(
+                byteCount: source.utf8.count,
+                usesAccentSurface: usesAccentSurface,
+                expand: { expanded = true }
+            )
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// A ≤previewBytes slice cut at the last blank line inside the window so
+    /// the preview ends on a block boundary when possible. The window is
+    /// byte-precise (`String.prefix(_:)` counts characters, which would
+    /// triple the synchronous preview budget for CJK/emoji text), stepping
+    /// back to a whole-character boundary when the byte cut lands mid-
+    /// grapheme.
+    static func previewSource(of source: String) -> String {
+        guard source.utf8.count > MarkdownLargeDocumentPolicy.previewBytes else { return source }
+        let utf8 = source.utf8
+        var windowEnd: String.Index?
+        var offset = MarkdownLargeDocumentPolicy.previewBytes
+        while offset > 0 {
+            if let byteIndex = utf8.index(utf8.startIndex, offsetBy: offset, limitedBy: utf8.endIndex),
+               let characterIndex = String.Index(byteIndex, within: source) {
+                windowEnd = characterIndex
+                break
+            }
+            offset -= 1
+        }
+        guard let end = windowEnd else {
+            // Unreachable for real UTF-8 (byte 0 always aligns), kept total.
+            return source
+        }
+        let window = source[..<end]
+        if let lastBreak = window.range(of: "\n\n", options: .backwards) {
+            return String(source[..<lastBreak.lowerBound])
+        }
+        return String(window)
+    }
+}
+
+private struct LargeDocumentBanner: View {
+    let byteCount: Int
+    let usesAccentSurface: Bool
+    let expand: () -> Void
+
+    private var sizeLabel: String {
+        ByteCountFormatter.string(fromByteCount: Int64(byteCount), countStyle: .file)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label(
+                "This message is very large (\(sizeLabel))",
+                systemImage: "doc.text.magnifyingglass"
+            )
+            .font(.footnote.weight(.semibold))
+            .foregroundStyle(usesAccentSurface ? Color.white.opacity(0.86) : .secondary)
+
+            Button(action: expand) {
+                Label("Show full message", systemImage: "chevron.down")
+                    .font(.footnote.weight(.semibold))
+            }
+            .tint(usesAccentSurface ? .white : .conduitAccent)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            usesAccentSurface ? Color.black.opacity(0.13) : Color.primary.opacity(0.045),
+            in: RoundedRectangle(cornerRadius: 13, style: .continuous)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 13, style: .continuous)
+                .strokeBorder(
+                    usesAccentSurface ? Color.white.opacity(0.24) : Color.secondary.opacity(0.20),
+                    lineWidth: 1
+                )
+        }
+    }
+}
+
+// MARK: - Preparation
+
+/// The result of the off-main preparation pass. Value types throughout, so
+/// the pass is cancellation-safe to hand back; `sourceIdentity` guards
+/// against a stale pass populating a changed message.
+struct LargeMarkdownPreparedDocument {
+    let chunks: [MarkdownLargeChunk]
+    let references: MarkdownReferenceContext
+    /// Selection descriptors in document order — one synthetic descriptor
+    /// per flow chunk, the ordinary per-block descriptors (original `block-N`
+    /// ids included) for rich blocks — so cross-chunk selection works
+    /// through the shared coordinator exactly like cross-block selection.
+    let segmentDescriptors: [MarkdownSelectionSegmentDescriptor]
+    /// Selection descriptors for each chunk (flow chunks carry their single
+    /// synthetic descriptor; rich chunks carry their block's descriptors).
+    let descriptorsByChunk: [[MarkdownSelectionSegmentDescriptor]]
+    let sourceIdentity: String
+
+    /// Pure string work — no UIKit — so it runs off the MainActor.
+    /// (`MarkdownParser.parseDocument` is a plain static over value types;
+    /// its Foundation `AttributedString(markdown:)` probes are thread-safe.)
+    static func prepare(_ source: String) -> LargeMarkdownPreparedDocument {
+        let document = MarkdownParser.parseDocument(source)
+        let chunks = MarkdownLargeChunkPlanner.chunks(for: document.blocks)
+
+        // Slice the ordinary per-block plan by original block index so rich
+        // chunks get exactly the descriptors (and `block-N` ids) their
+        // MarkdownBlockView lookups expect.
+        let blockPlan = MarkdownSelectionSegmentPlan.descriptors(for: document.blocks)
+        var blockRanges: [Range<Int>] = []
+        var cursor = 0
+        for block in document.blocks {
+            let count = MarkdownSelectionSegmentPlan.segmentCount(of: block)
+            blockRanges.append(cursor..<(cursor + count))
+            cursor += count
+        }
+
+        var descriptorsByChunk: [[MarkdownSelectionSegmentDescriptor]] = []
+        var all: [MarkdownSelectionSegmentDescriptor] = []
+        for (chunkIndex, chunk) in chunks.enumerated() {
+            switch chunk {
+            case .flow:
+                let descriptor = MarkdownSelectionSegmentDescriptor(
+                    id: "lmd-flow-\(chunkIndex)",
+                    order: all.count,
+                    separatorBefore: all.isEmpty ? "" : "\n\n"
+                )
+                descriptorsByChunk.append([descriptor])
+                all.append(descriptor)
+            case .block(_, let originalIndex):
+                let range = blockRanges[originalIndex]
+                // Rebase the slice's order values onto the running global
+                // counter so chunk order and document order agree.
+                let base = blockPlan[range].first?.order ?? 0
+                let slice = blockPlan[range].map { descriptor in
+                    MarkdownSelectionSegmentDescriptor(
+                        id: descriptor.id,
+                        order: all.count + (descriptor.order - base),
+                        separatorBefore: descriptor.separatorBefore
+                    )
+                }
+                descriptorsByChunk.append(slice)
+                all.append(contentsOf: slice)
+            }
+        }
+
+        return LargeMarkdownPreparedDocument(
+            chunks: chunks,
+            references: document.references,
+            segmentDescriptors: all,
+            descriptorsByChunk: descriptorsByChunk,
+            sourceIdentity: Self.identity(of: source)
+        )
+    }
+
+    static func identity(of source: String) -> String {
+        "\(source.utf8.count)-\(source.hashValue)"
+    }
+}
+
+// MARK: - Expanded document
+
+/// Expanded body: parse off-main, render chunks progressively. Chunks
+/// materialize in batches as the user scrolls — a monotonic window that
+/// only grows downward, so scroll position never jumps.
+struct LargeMarkdownExpandedView: View {
+    let source: String
+    let foregroundStyle: Color
+    let usesAccentSurface: Bool
+    let gatewayMediaDataURL: ((String) async -> String?)?
+
+    @StateObject private var selectionCoordinator = MarkdownSelectionCoordinator()
+    @State private var prepared: LargeMarkdownPreparedDocument?
+    /// How many chunks are materialized in the view hierarchy.
+    @State private var renderedChunkCount = LargeMarkdownExpandedView.initialChunkBatch
+    /// Re-entrancy guard: at most one window extension per runloop turn.
+    /// Without it, a batch of simultaneous onAppear calls (a plain VStack
+    /// fires onAppear on insertion, not visibility) cascades into mounting
+    /// every chunk of a many-thousand-chunk document in one layout pass.
+    @State private var isExtendingWindow = false
+
+    /// First synchronous batch: enough to fill a screen at typical chunk
+    /// heights while keeping per-chunk work in single-digit milliseconds.
+    static let initialChunkBatch = 12
+    private static let chunkBatch = 12
+    /// Hard ceiling on simultaneously mounted chunks. Documents made of
+    /// pathological tiny blocks (a mini-table after every sentence) can
+    /// produce thousands of chunks; past the ceiling the footer becomes a
+    /// Continue control, so the mounted-view count is bounded by
+    /// construction rather than by how fast a layout pass fires onAppear.
+    private static let maximumMountedChunks = 480
+
+    private var sourceIdentity: String { LargeMarkdownPreparedDocument.identity(of: source) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if let prepared {
+                ForEach(0..<renderedChunkCount, id: \.self) { index in
+                    chunkView(prepared, chunk: prepared.chunks[index], index: index)
+                        .onAppear {
+                            extendWindowIfNecessary(lastAppearedIndex: index, total: prepared.chunks.count)
+                        }
+                }
+                if renderedChunkCount < prepared.chunks.count {
+                    progressFooter(remaining: prepared.chunks.count - renderedChunkCount)
+                }
+            } else {
+                LargeDocumentPreparingView()
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .environment(\.markdownReferences, prepared?.references ?? .empty)
+        .modifier(MarkdownSelectionHost(coordinator: selectionCoordinator))
+        .task(id: sourceIdentity) {
+            // Structural parsing is pure string work — measured 192 ms at
+            // 1 MB — so it runs off the MainActor; nothing UIKit happens
+            // until the per-chunk attributed builds below.
+            let currentSource = source
+            let plan = await Task.detached(priority: .userInitiated) {
+                LargeMarkdownPreparedDocument.prepare(currentSource)
+            }.value
+            guard !Task.isCancelled, plan.sourceIdentity == sourceIdentity else { return }
+            withAnimation(.easeInOut(duration: 0.15)) {
+                prepared = plan
+                // Clamped: a large document can legitimately produce fewer
+                // chunks than one batch (a handful of giant rich blocks),
+                // and chunkView indexes prepared.chunks directly.
+                renderedChunkCount = min(Self.initialChunkBatch, plan.chunks.count)
+            }
+        }
+        .onAppear {
+            registerSegments()
+        }
+        .onChange(of: prepared?.sourceIdentity) { _, _ in
+            registerSegments()
+        }
+        .onDisappear {
+            selectionCoordinator.clearSelection()
+        }
+    }
+
+    private func registerSegments() {
+        guard let prepared else { return }
+        selectionCoordinator.replaceSegments(prepared.segmentDescriptors, revision: prepared.sourceIdentity)
+    }
+
+    @ViewBuilder
+    private func chunkView(_ prepared: LargeMarkdownPreparedDocument, chunk: MarkdownLargeChunk, index: Int) -> some View {
+        switch chunk {
+        case .flow(let blocks):
+            LargeFlowChunkView(
+                blocks: blocks,
+                references: prepared.references,
+                foregroundStyle: foregroundStyle,
+                usesAccentSurface: usesAccentSurface,
+                selectionCoordinator: selectionCoordinator,
+                selectionSegment: prepared.descriptorsByChunk[index].first
+            )
+            .id("\(prepared.sourceIdentity)-\(index)")
+        case .block(let block, let originalIndex):
+            // Rich blocks reuse the ordinary block renderer — same views,
+            // same selection ids — except oversized code, which gets the
+            // sliced / async-highlighted presentation.
+            if case .code(let language, let code) = block,
+               MarkdownLanguage.normalized(language) != "mermaid",
+               MarkdownLargeDocumentPolicy.isLargeCodeBlock(code) {
+                LargeCodeBlockView(
+                    source: code,
+                    language: language,
+                    usesAccentSurface: usesAccentSurface
+                )
+                .id("\(prepared.sourceIdentity)-\(index)")
+            } else {
+                MarkdownBlockView(
+                    block: block,
+                    blockIndex: originalIndex,
+                    foregroundStyle: foregroundStyle,
+                    usesAccentSurface: usesAccentSurface,
+                    gatewayMediaDataURL: gatewayMediaDataURL,
+                    selectionCoordinator: selectionCoordinator,
+                    selectionSegments: prepared.descriptorsByChunk[index],
+                    newestCharacterOpacities: []
+                )
+                .id("\(prepared.sourceIdentity)-\(index)")
+            }
+        }
+    }
+
+    /// Window growth: only the last mounted chunk triggers an extension,
+    /// only one batch per runloop turn, and never past the mounted cap —
+    /// see `maximumMountedChunks`.
+    private func extendWindowIfNecessary(lastAppearedIndex: Int, total: Int) {
+        guard
+            lastAppearedIndex == renderedChunkCount - 1,
+            renderedChunkCount < total,
+            renderedChunkCount < Self.maximumMountedChunks,
+            !isExtendingWindow
+        else { return }
+        isExtendingWindow = true
+        Task { @MainActor in
+            renderedChunkCount = Self.nextWindowCount(current: renderedChunkCount, total: total)
+            isExtendingWindow = false
+        }
+    }
+
+    /// Next mounted-chunk count: one batch more, clamped to the document's
+    /// chunk count (the remaining chunks past the cap can be fewer than one
+    /// batch, and chunkView indexes prepared.chunks directly).
+    static func nextWindowCount(current: Int, total: Int) -> Int {
+        min(current + chunkBatch, total)
+    }
+
+    /// Total chunk count read through @State: dynamic, so a button action
+    /// firing twice before SwiftUI rebuilds still sees the live value
+    /// (a body-time capture could be stale and overflow the array).
+    private var preparedChunkTotal: Int {
+        prepared?.chunks.count ?? 0
+    }
+
+    @ViewBuilder
+    private func progressFooter(remaining: Int) -> some View {
+        if renderedChunkCount >= Self.maximumMountedChunks {
+            Button {
+                // Clamped: the remaining chunks past the cap can be fewer
+                // than one batch, and chunkView indexes prepared.chunks
+                // directly.
+                renderedChunkCount = Self.nextWindowCount(
+                    current: renderedChunkCount,
+                    total: preparedChunkTotal
+                )
+            } label: {
+                Label("Continue reading (\(remaining) sections left)", systemImage: "chevron.down")
+                    .font(.footnote.weight(.semibold))
+            }
+            .tint(usesAccentSurface ? .white : .conduitAccent)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 4)
+        } else {
+            HStack(spacing: 8) {
+                ProgressView().controlSize(.small)
+                Text("Rendering…")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 4)
+        }
+    }
+}
+
+private struct LargeDocumentPreparingView: View {
+    var body: some View {
+        HStack(spacing: 8) {
+            ProgressView().controlSize(.small)
+            Text("Preparing large message…")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 6)
+    }
+}
+
+// MARK: - Flow chunks
+
+/// Memoizes a flow chunk's attributed string so window growth and unrelated
+/// body re-evaluations never re-run the Foundation parses. Rebuilds when the
+/// Dynamic Type category changes (fonts bake into the string); the category
+/// is an explicit parameter so the invalidation policy is unit-testable.
+final class LargeFlowChunkBox {
+    private var cachedText: NSAttributedString?
+    private var cachedCategory: UIContentSizeCategory?
+
+    @MainActor
+    func attributedText(
+        blocks: [MarkdownBlock],
+        references: MarkdownReferenceContext,
+        foregroundStyle: Color,
+        usesAccentSurface: Bool,
+        contentCategory: UIContentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+    ) -> NSAttributedString? {
+        if let cachedText, cachedCategory == contentCategory { return cachedText }
+        let text = MarkdownSelectionFormatter.attributedText(
+            for: blocks,
+            references: references,
+            foregroundStyle: foregroundStyle,
+            usesAccentSurface: usesAccentSurface,
+            newestCharacterOpacities: []
+        )
+        cachedText = text
+        cachedCategory = contentCategory
+        return text
+    }
+}
+
+/// One bounded flow chunk: a single selectable attributed string (the same
+/// formatter the ordinary fast path uses) registered with the shared
+/// coordinator under its chunk descriptor. Selection is native within the
+/// chunk and coordinator-driven across chunks.
+private struct LargeFlowChunkView: View {
+    let blocks: [MarkdownBlock]
+    let references: MarkdownReferenceContext
+    let foregroundStyle: Color
+    let usesAccentSurface: Bool
+    let selectionCoordinator: MarkdownSelectionCoordinator?
+    let selectionSegment: MarkdownSelectionSegmentDescriptor?
+
+    /// Per-view memo box: identity comes from the enclosing ForEach index
+    /// (keyed by source identity), so it survives window growth and dies
+    /// with the chunk when the source changes.
+    @State private var box = LargeFlowChunkBox()
+
+    var body: some View {
+        if let attributed = box.attributedText(
+            blocks: blocks,
+            references: references,
+            foregroundStyle: foregroundStyle,
+            usesAccentSurface: usesAccentSurface
+        ) {
+            SelectableTextView(
+                attributedText: attributed,
+                font: .preferredFont(forTextStyle: .body),
+                textColor: usesAccentSurface ? .white : UIColor(foregroundStyle),
+                lineSpacing: 4,
+                linkColor: usesAccentSurface ? .white : .link,
+                selectionCoordinator: selectionCoordinator,
+                selectionSegment: selectionSegment
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            // Unreachable for planner-produced flow chunks (they contain
+            // only selectable flow blocks); kept total for safety.
+            EmptyView()
+        }
+    }
+}
+
+// MARK: - Large code blocks
+
+/// Code at or above `codeBlockThresholdBytes` (highlighting measured 67 ms
+/// at 50 KB and 1.5 s at 1 MB): a bounded line preview first; expanded, the
+/// source renders in line slices whose highlighting happens off the
+/// MainActor (tokenization is pure Foundation) and swaps in per slice. Copy
+/// always uses the complete source.
+struct LargeCodeBlockView: View {
+    let source: String
+    let language: String
+    let usesAccentSurface: Bool
+
+    @State private var expanded = false
+    @State private var copied = false
+    @State private var slices: [String]?
+
+    private var normalizedLanguage: String { MarkdownLanguage.normalized(language) }
+
+    private static let previewLineCount = 200
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            ScrollView(.horizontal, showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 0) {
+                    if let slices {
+                        ForEach(0..<slices.count, id: \.self) { index in
+                            LargeCodeSliceView(
+                                source: slices[index],
+                                language: normalizedLanguage,
+                                usesAccentSurface: usesAccentSurface
+                            )
+                        }
+                    } else {
+                        LargeCodeSliceView(
+                            source: Self.previewSource(of: source),
+                            language: normalizedLanguage,
+                            usesAccentSurface: usesAccentSurface,
+                            maximumNumberOfLines: Self.previewLineCount
+                        )
+                        if sourceHasMoreLinesThanPreview {
+                            Button {
+                                withAnimation(.easeInOut(duration: 0.15)) { expanded = true }
+                            } label: {
+                                Label("Show all \(Self.approximateLineCount(of: source)) lines", systemImage: "chevron.down")
+                                    .font(.caption.weight(.semibold))
+                            }
+                            .tint(usesAccentSurface ? .white : .conduitAccent)
+                            .padding(.top, 8)
+                        }
+                    }
+                }
+                .padding(12)
+            }
+        }
+        .background(
+            usesAccentSurface ? Color.black.opacity(0.24) : Color.primary.opacity(0.055),
+            in: RoundedRectangle(cornerRadius: 13, style: .continuous)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 13, style: .continuous)
+                .strokeBorder(
+                    usesAccentSurface ? Color.white.opacity(0.28) : Color.secondary.opacity(0.20),
+                    lineWidth: 1
+                )
+        }
+        .task(id: expanded ? "full-\(source.utf8.count)" : "preview") {
+            guard expanded, slices == nil else { return }
+            // Line splitting is pure; a 1 MB block measured tens of ms, so
+            // keep it off the MainActor too.
+            let currentSource = source
+            let lineCount = MarkdownLargeDocumentPolicy.codeSliceLineCount
+            let result = await Task.detached(priority: .userInitiated) {
+                currentSource.split(separator: "\n", omittingEmptySubsequences: false)
+                    .chunks(lineCount)
+                    .map { $0.joined(separator: "\n") }
+            }.value
+            guard !Task.isCancelled, expanded else { return }
+            slices = result
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Text(normalizedLanguage == "plain" ? "Code" : normalizedLanguage)
+                .font(.caption2.monospaced().weight(.semibold))
+                .foregroundStyle(usesAccentSurface ? Color.white.opacity(0.86) : .secondary)
+            Spacer()
+            Button {
+                UIPasteboard.general.string = source
+                Haptics.light()
+                copied = true
+                Task {
+                    try? await Task.sleep(for: .seconds(1.4))
+                    guard !Task.isCancelled else { return }
+                    copied = false
+                }
+            } label: {
+                Label(copied ? "Copied" : "Copy", systemImage: copied ? "checkmark" : "doc.on.doc")
+                    .font(.caption2.weight(.semibold))
+            }
+            .tint(usesAccentSurface ? .white : .conduitAccent)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(usesAccentSurface ? Color.black.opacity(0.28) : Color.primary.opacity(0.055))
+    }
+
+    /// First N lines of the source: a bounded scan, never a full split.
+    static func previewSource(of source: String) -> String {
+        var lineCount = 0
+        var index = source.startIndex
+        while index < source.endIndex {
+            if source[index] == "\n" {
+                lineCount += 1
+                if lineCount >= previewLineCount {
+                    return String(source[..<index])
+                }
+            }
+            index = source.index(after: index)
+        }
+        return source
+    }
+
+    private var sourceHasMoreLinesThanPreview: Bool {
+        Self.previewSource(of: source).utf8.count < source.utf8.count
+    }
+
+    private static func approximateLineCount(of source: String) -> Int {
+        // Only called once when building the expand button's label; a single
+        // linear newline count over the block.
+        source.reduce(into: 1) { count, character in
+            if character == "\n" { count += 1 }
+        }
+    }
+}
+
+private extension Array where Element == Substring {
+    func chunks(_ size: Int) -> [[Element]] {
+        guard size > 0, !isEmpty else { return [] }
+        var result: [[Element]] = []
+        var start = startIndex
+        while start < endIndex {
+            let end = index(start, offsetBy: size, limitedBy: endIndex) ?? endIndex
+            result.append(Array(self[start..<end]))
+            start = end
+        }
+        return result
+    }
+}
+
+/// One bounded slice of a large code block: plain monospaced text
+/// immediately, tokenized highlighting swapped in when the off-main pass
+/// completes. Each slice is independently selectable.
+private struct LargeCodeSliceView: View {
+    let source: String
+    let language: String
+    let usesAccentSurface: Bool
+    var maximumNumberOfLines: Int = 0
+
+    @State private var highlighted: NSAttributedString?
+
+    private var font: UIFont {
+        .monospacedSystemFont(ofSize: UIFont.preferredFont(forTextStyle: .footnote).pointSize, weight: .regular)
+    }
+
+    private var sliceIdentity: String {
+        "\(source.hashValue)-\(UIApplication.shared.preferredContentSizeCategory.rawValue)"
+    }
+
+    var body: some View {
+        Group {
+            if let highlighted {
+                SelectableTextView(
+                    attributedText: highlighted,
+                    font: font,
+                    textColor: .label,
+                    lineSpacing: 3,
+                    wrapsLines: false
+                )
+            } else {
+                SelectableTextView(
+                    text: source,
+                    font: font,
+                    textColor: usesAccentSurface ? UIColor.white.withAlphaComponent(0.96) : .label,
+                    lineSpacing: 3,
+                    maximumNumberOfLines: maximumNumberOfLines,
+                    wrapsLines: false
+                )
+            }
+        }
+        .task(id: sliceIdentity) {
+            // Accent-surface (user-bubble) code never highlights, matching
+            // the ordinary ChatCodeBlock behavior.
+            guard !usesAccentSurface, !source.isEmpty else { return }
+            let currentSource = source
+            let currentLanguage = language
+            let currentFont = font
+            // Snapshot the identity the pass started under; comparing
+            // against the live property is what actually drops stale
+            // results when the view was re-created mid-pass.
+            let passIdentity = sliceIdentity
+            let highlightedResult = await Task.detached(priority: .userInitiated) {
+                SyntaxHighlighter.highlight(currentSource, language: currentLanguage)
+            }.value
+            guard !Task.isCancelled, sliceIdentity == passIdentity else { return }
+            self.highlighted = SelectableTextView.bridge(
+                highlightedResult,
+                defaultFont: currentFont,
+                defaultColor: .label,
+                linkColor: .link
+            )
+        }
+    }
+}

--- a/Conduit/Views/Components/MarkdownLargeDocumentView.swift
+++ b/Conduit/Views/Components/MarkdownLargeDocumentView.swift
@@ -151,7 +151,13 @@ private struct LargeDocumentBanner: View {
 /// against a stale pass populating a changed message.
 struct LargeMarkdownPreparedDocument {
     let chunks: [MarkdownLargeChunk]
+    /// The message-wide context (used by rich-block subviews that read the
+    /// environment default); per-chunk subsets live in `referencesByChunk`.
     let references: MarkdownReferenceContext
+    /// Bounded per-chunk reference-definition subsets, so an 8 KB chunk
+    /// never drags an arbitrarily large global definition block into its
+    /// Foundation parse (see MarkdownReferenceResolver).
+    let referencesByChunk: [MarkdownReferenceContext]
     /// Selection descriptors in document order — one synthetic descriptor
     /// per flow chunk, the ordinary per-block descriptors (original `block-N`
     /// ids included) for rich blocks — so cross-chunk selection works
@@ -162,12 +168,14 @@ struct LargeMarkdownPreparedDocument {
     let descriptorsByChunk: [[MarkdownSelectionSegmentDescriptor]]
     let sourceIdentity: String
 
-    /// Pure string work — no UIKit — so it runs off the MainActor.
-    /// (`MarkdownParser.parseDocument` is a plain static over value types;
-    /// its Foundation `AttributedString(markdown:)` probes are thread-safe.)
-    static func prepare(_ source: String) -> LargeMarkdownPreparedDocument {
+    /// String work only — no UIKit — so it runs off the MainActor as a
+    /// cooperative child of the caller's task (cancellation stops the pass
+    /// between stages instead of wasting a megabyte parse after a switch).
+    static func prepare(_ source: String) async -> LargeMarkdownPreparedDocument? {
         let document = MarkdownParser.parseDocument(source)
+        guard !Task.isCancelled else { return nil }
         let chunks = MarkdownLargeChunkPlanner.chunks(for: document.blocks)
+        guard !Task.isCancelled else { return nil }
 
         // Slice the ordinary per-block plan by original block index so rich
         // chunks get exactly the descriptors (and `block-N` ids) their
@@ -209,10 +217,22 @@ struct LargeMarkdownPreparedDocument {
                 all.append(contentsOf: slice)
             }
         }
+        guard !Task.isCancelled else { return nil }
+
+        // Per-chunk reference subsets from the chunk's own text.
+        let definitions = MarkdownReferenceResolver.definitions(from: document.references)
+        var referencesByChunk: [MarkdownReferenceContext] = []
+        referencesByChunk.reserveCapacity(chunks.count)
+        for chunk in chunks {
+            referencesByChunk.append(
+                MarkdownReferenceResolver.subset(for: chunk.flattenedText, definitions: definitions)
+            )
+        }
 
         return LargeMarkdownPreparedDocument(
             chunks: chunks,
             references: document.references,
+            referencesByChunk: referencesByChunk,
             segmentDescriptors: all,
             descriptorsByChunk: descriptorsByChunk,
             sourceIdentity: Self.identity(of: source)
@@ -224,11 +244,46 @@ struct LargeMarkdownPreparedDocument {
     }
 }
 
+/// Text projection of a chunk used for reference-label scanning — every
+/// fragment of the chunk that Foundation will parse with the definitions
+/// appended.
+extension MarkdownLargeChunk {
+    var flattenedText: String {
+        switch self {
+        case .flow(let blocks):
+            return blocks.map(\.flattenedText).joined(separator: "\n")
+        case .block(let block, _):
+            return block.flattenedText
+        }
+    }
+}
+
+extension MarkdownBlock {
+    /// All text fragments of the block that inline parsing will see.
+    var flattenedText: String {
+        switch self {
+        case .heading(_, let text), .paragraph(let text): return text
+        case .quote(let lines): return lines.map(\.text).joined(separator: "\n")
+        case .unorderedList(let items), .orderedList(let items): return items.joined(separator: "\n")
+        case .table(let headers, _, let rows):
+            return ([headers] + rows).map { $0.joined(separator: " ") }.joined(separator: "\n")
+        case .code(_, let source): return source
+        case .callout(_, let text): return text
+        case .columns(let columns): return columns.joined(separator: "\n")
+        case .math(let source): return source
+        case .image(let url, let alt): return "\(alt) \(url)"
+        case .divider: return ""
+        }
+    }
+}
+
 // MARK: - Expanded document
 
-/// Expanded body: parse off-main, render chunks progressively. Chunks
-/// materialize in batches as the user scrolls — a monotonic window that
-/// only grows downward, so scroll position never jumps.
+/// Expanded body: prepare off-main, then render chunks progressively. The
+/// initial batch mounts immediately; every further batch requires an
+/// explicit Continue action — a plain VStack fires onAppear on insertion
+/// rather than on visibility, so any automatic growth would cascade through
+/// hundreds of chunks without the user ever scrolling.
 struct LargeMarkdownExpandedView: View {
     let source: String
     let foregroundStyle: Color
@@ -239,22 +294,12 @@ struct LargeMarkdownExpandedView: View {
     @State private var prepared: LargeMarkdownPreparedDocument?
     /// How many chunks are materialized in the view hierarchy.
     @State private var renderedChunkCount = LargeMarkdownExpandedView.initialChunkBatch
-    /// Re-entrancy guard: at most one window extension per runloop turn.
-    /// Without it, a batch of simultaneous onAppear calls (a plain VStack
-    /// fires onAppear on insertion, not visibility) cascades into mounting
-    /// every chunk of a many-thousand-chunk document in one layout pass.
-    @State private var isExtendingWindow = false
 
     /// First synchronous batch: enough to fill a screen at typical chunk
     /// heights while keeping per-chunk work in single-digit milliseconds.
     static let initialChunkBatch = 12
-    private static let chunkBatch = 12
-    /// Hard ceiling on simultaneously mounted chunks. Documents made of
-    /// pathological tiny blocks (a mini-table after every sentence) can
-    /// produce thousands of chunks; past the ceiling the footer becomes a
-    /// Continue control, so the mounted-view count is bounded by
-    /// construction rather than by how fast a layout pass fires onAppear.
-    private static let maximumMountedChunks = 480
+    /// Chunks added per explicit Continue action.
+    static let continueChunkBatch = 25
 
     private var sourceIdentity: String { LargeMarkdownPreparedDocument.identity(of: source) }
 
@@ -263,9 +308,6 @@ struct LargeMarkdownExpandedView: View {
             if let prepared {
                 ForEach(0..<renderedChunkCount, id: \.self) { index in
                     chunkView(prepared, chunk: prepared.chunks[index], index: index)
-                        .onAppear {
-                            extendWindowIfNecessary(lastAppearedIndex: index, total: prepared.chunks.count)
-                        }
                 }
                 if renderedChunkCount < prepared.chunks.count {
                     progressFooter(remaining: prepared.chunks.count - renderedChunkCount)
@@ -278,19 +320,16 @@ struct LargeMarkdownExpandedView: View {
         .environment(\.markdownReferences, prepared?.references ?? .empty)
         .modifier(MarkdownSelectionHost(coordinator: selectionCoordinator))
         .task(id: sourceIdentity) {
-            // Structural parsing is pure string work — measured 192 ms at
-            // 1 MB — so it runs off the MainActor; nothing UIKit happens
-            // until the per-chunk attributed builds below.
-            let currentSource = source
-            let plan = await Task.detached(priority: .userInitiated) {
-                LargeMarkdownPreparedDocument.prepare(currentSource)
-            }.value
+            // Nonisolated async → runs on the global executor (a structured
+            // child of this task, so cancellation stops the parse instead of
+            // merely discarding its result).
+            guard let plan = await LargeMarkdownPreparedDocument.prepare(source) else { return }
             guard !Task.isCancelled, plan.sourceIdentity == sourceIdentity else { return }
             withAnimation(.easeInOut(duration: 0.15)) {
                 prepared = plan
                 // Clamped: a large document can legitimately produce fewer
-                // chunks than one batch (a handful of giant rich blocks),
-                // and chunkView indexes prepared.chunks directly.
+                // chunks than one batch, and chunkView indexes
+                // prepared.chunks directly.
                 renderedChunkCount = min(Self.initialChunkBatch, plan.chunks.count)
             }
         }
@@ -312,105 +351,142 @@ struct LargeMarkdownExpandedView: View {
 
     @ViewBuilder
     private func chunkView(_ prepared: LargeMarkdownPreparedDocument, chunk: MarkdownLargeChunk, index: Int) -> some View {
-        switch chunk {
-        case .flow(let blocks):
-            LargeFlowChunkView(
-                blocks: blocks,
-                references: prepared.references,
+        Group {
+            switch chunk {
+            case .flow(let blocks):
+                LargeFlowChunkView(
+                    blocks: blocks,
+                    references: prepared.referencesByChunk[index],
+                    foregroundStyle: foregroundStyle,
+                    usesAccentSurface: usesAccentSurface,
+                    selectionCoordinator: selectionCoordinator,
+                    selectionSegment: prepared.descriptorsByChunk[index].first
+                )
+            case .block(let block, let originalIndex):
+                largeBlockView(
+                    block,
+                    originalIndex: originalIndex,
+                    index: index,
+                    prepared: prepared
+                )
+            }
+        }
+        .id("\(prepared.sourceIdentity)-\(index)")
+    }
+
+    /// Rich-block routing: ordinary blocks reuse the ordinary renderer;
+    /// oversized ones get bounded specialized presentations.
+    @ViewBuilder
+    private func largeBlockView(
+        _ block: MarkdownBlock,
+        originalIndex: Int,
+        index: Int,
+        prepared: LargeMarkdownPreparedDocument
+    ) -> some View {
+        switch block {
+        case .table(let headers, let alignments, let rows)
+            where block.estimatedSourceBytes >= MarkdownLargeDocumentPolicy.largeTableBytes:
+            LargeMarkdownTable(
+                headers: headers,
+                alignments: alignments,
+                rows: rows,
+                foregroundStyle: foregroundStyle,
+                usesAccentSurface: usesAccentSurface,
+                selectionCoordinator: selectionCoordinator,
+                blockIndex: originalIndex,
+                selectionSegments: prepared.descriptorsByChunk[index]
+            )
+        case .callout(let kind, let text)
+            where text.utf8.count > MarkdownLargeDocumentPolicy.largeTextBlockBytes:
+            LargeMarkdownCallout(
+                kind: kind,
+                text: text,
                 foregroundStyle: foregroundStyle,
                 usesAccentSurface: usesAccentSurface,
                 selectionCoordinator: selectionCoordinator,
                 selectionSegment: prepared.descriptorsByChunk[index].first
             )
-            .id("\(prepared.sourceIdentity)-\(index)")
-        case .block(let block, let originalIndex):
-            // Rich blocks reuse the ordinary block renderer — same views,
-            // same selection ids — except oversized code, which gets the
-            // sliced / async-highlighted presentation.
-            if case .code(let language, let code) = block,
-               MarkdownLanguage.normalized(language) != "mermaid",
-               MarkdownLargeDocumentPolicy.isLargeCodeBlock(code) {
-                LargeCodeBlockView(
-                    source: code,
-                    language: language,
-                    usesAccentSurface: usesAccentSurface
-                )
-                .id("\(prepared.sourceIdentity)-\(index)")
-            } else {
-                MarkdownBlockView(
-                    block: block,
-                    blockIndex: originalIndex,
-                    foregroundStyle: foregroundStyle,
-                    usesAccentSurface: usesAccentSurface,
-                    gatewayMediaDataURL: gatewayMediaDataURL,
-                    selectionCoordinator: selectionCoordinator,
-                    selectionSegments: prepared.descriptorsByChunk[index],
-                    newestCharacterOpacities: []
-                )
-                .id("\(prepared.sourceIdentity)-\(index)")
-            }
+        case .columns(let columns)
+            where block.estimatedSourceBytes > MarkdownLargeDocumentPolicy.largeTextBlockBytes:
+            LargeMarkdownColumns(
+                columns: columns,
+                foregroundStyle: foregroundStyle,
+                usesAccentSurface: usesAccentSurface,
+                selectionCoordinator: selectionCoordinator,
+                selectionSegments: prepared.descriptorsByChunk[index]
+            )
+        case .math(let source) where source.utf8.count > MarkdownLargeDocumentPolicy.mathGuardBytes:
+            GuardedSourceCard(
+                title: "LaTeX",
+                icon: "function",
+                source: source,
+                guardBytes: MarkdownLargeDocumentPolicy.mathGuardBytes
+            )
+        case .code(let language, let code)
+            where MarkdownLanguage.normalized(language) == "mermaid"
+                && code.utf8.count > MarkdownLargeDocumentPolicy.mermaidGuardBytes:
+            GuardedSourceCard(
+                title: "Mermaid",
+                icon: "point.3.connected.trianglepath.dotted",
+                source: code,
+                guardBytes: MarkdownLargeDocumentPolicy.mermaidGuardBytes
+            )
+        case .code(let language, let code)
+            where MarkdownLanguage.normalized(language) != "mermaid"
+                && MarkdownLargeDocumentPolicy.isLargeCodeBlock(code):
+            LargeCodeBlockView(
+                source: code,
+                language: language,
+                usesAccentSurface: usesAccentSurface
+            )
+        default:
+            // Ordinary rich blocks reuse the ordinary renderer with their
+            // chunk-local reference subset injected.
+            MarkdownBlockView(
+                block: block,
+                blockIndex: originalIndex,
+                foregroundStyle: foregroundStyle,
+                usesAccentSurface: usesAccentSurface,
+                gatewayMediaDataURL: gatewayMediaDataURL,
+                selectionCoordinator: selectionCoordinator,
+                selectionSegments: prepared.descriptorsByChunk[index],
+                newestCharacterOpacities: []
+            )
+            .environment(\.markdownReferences, prepared.referencesByChunk[index])
         }
-    }
-
-    /// Window growth: only the last mounted chunk triggers an extension,
-    /// only one batch per runloop turn, and never past the mounted cap —
-    /// see `maximumMountedChunks`.
-    private func extendWindowIfNecessary(lastAppearedIndex: Int, total: Int) {
-        guard
-            lastAppearedIndex == renderedChunkCount - 1,
-            renderedChunkCount < total,
-            renderedChunkCount < Self.maximumMountedChunks,
-            !isExtendingWindow
-        else { return }
-        isExtendingWindow = true
-        Task { @MainActor in
-            renderedChunkCount = Self.nextWindowCount(current: renderedChunkCount, total: total)
-            isExtendingWindow = false
-        }
-    }
-
-    /// Next mounted-chunk count: one batch more, clamped to the document's
-    /// chunk count (the remaining chunks past the cap can be fewer than one
-    /// batch, and chunkView indexes prepared.chunks directly).
-    static func nextWindowCount(current: Int, total: Int) -> Int {
-        min(current + chunkBatch, total)
     }
 
     /// Total chunk count read through @State: dynamic, so a button action
-    /// firing twice before SwiftUI rebuilds still sees the live value
-    /// (a body-time capture could be stale and overflow the array).
+    /// firing twice before SwiftUI rebuilds still sees the live value.
     private var preparedChunkTotal: Int {
         prepared?.chunks.count ?? 0
     }
 
     @ViewBuilder
     private func progressFooter(remaining: Int) -> some View {
-        if renderedChunkCount >= Self.maximumMountedChunks {
-            Button {
-                // Clamped: the remaining chunks past the cap can be fewer
-                // than one batch, and chunkView indexes prepared.chunks
-                // directly.
-                renderedChunkCount = Self.nextWindowCount(
-                    current: renderedChunkCount,
-                    total: preparedChunkTotal
-                )
-            } label: {
-                Label("Continue reading (\(remaining) sections left)", systemImage: "chevron.down")
-                    .font(.footnote.weight(.semibold))
-            }
-            .tint(usesAccentSurface ? .white : .conduitAccent)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.vertical, 4)
-        } else {
-            HStack(spacing: 8) {
-                ProgressView().controlSize(.small)
-                Text("Rendering…")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.vertical, 4)
+        Button {
+            // Clamped to the real total: chunkView indexes prepared.chunks
+            // directly, and the remaining chunks can be fewer than a batch.
+            renderedChunkCount = Self.nextWindowCount(
+                current: renderedChunkCount,
+                total: preparedChunkTotal
+            )
+        } label: {
+            Label(
+                "Continue reading (\(remaining) sections left)",
+                systemImage: "chevron.down"
+            )
+            .font(.footnote.weight(.semibold))
         }
+        .tint(usesAccentSurface ? .white : .conduitAccent)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 4)
+    }
+
+    /// Next mounted-chunk count: one batch more, clamped to the document's
+    /// chunk count.
+    static func nextWindowCount(current: Int, total: Int) -> Int {
+        min(current + continueChunkBatch, total)
     }
 }
 
@@ -429,13 +505,16 @@ private struct LargeDocumentPreparingView: View {
 
 // MARK: - Flow chunks
 
-/// Memoizes a flow chunk's attributed string so window growth and unrelated
-/// body re-evaluations never re-run the Foundation parses. Rebuilds when the
-/// Dynamic Type category changes (fonts bake into the string); the category
-/// is an explicit parameter so the invalidation policy is unit-testable.
+/// Memoizes a flow chunk's attributed string so unrelated body
+/// re-evaluations never re-run the Foundation parses. The memo identity is
+/// explicit: Dynamic Type category (fonts bake into the string) and the
+/// accent-surface flag (colors bake in). The chunk's blocks/references are
+/// fixed per prepared plan — a changed source means a new identity and new
+/// chunk views, so those inputs cannot change for a surviving box.
 final class LargeFlowChunkBox {
     private var cachedText: NSAttributedString?
     private var cachedCategory: UIContentSizeCategory?
+    private var cachedUsesAccentSurface: Bool?
 
     @MainActor
     func attributedText(
@@ -445,7 +524,11 @@ final class LargeFlowChunkBox {
         usesAccentSurface: Bool,
         contentCategory: UIContentSizeCategory = UIApplication.shared.preferredContentSizeCategory
     ) -> NSAttributedString? {
-        if let cachedText, cachedCategory == contentCategory { return cachedText }
+        if let cachedText,
+           cachedCategory == contentCategory,
+           cachedUsesAccentSurface == usesAccentSurface {
+            return cachedText
+        }
         let text = MarkdownSelectionFormatter.attributedText(
             for: blocks,
             references: references,
@@ -455,6 +538,7 @@ final class LargeFlowChunkBox {
         )
         cachedText = text
         cachedCategory = contentCategory
+        cachedUsesAccentSurface = usesAccentSurface
         return text
     }
 }
@@ -462,8 +546,10 @@ final class LargeFlowChunkBox {
 /// One bounded flow chunk: a single selectable attributed string (the same
 /// formatter the ordinary fast path uses) registered with the shared
 /// coordinator under its chunk descriptor. Selection is native within the
-/// chunk and coordinator-driven across chunks.
-private struct LargeFlowChunkView: View {
+/// chunk and coordinator-driven across chunks. The Dynamic Type category
+/// arrives from the SwiftUI environment so text-size changes rebuild the
+/// memoized string.
+struct LargeFlowChunkView: View {
     let blocks: [MarkdownBlock]
     let references: MarkdownReferenceContext
     let foregroundStyle: Color
@@ -471,8 +557,10 @@ private struct LargeFlowChunkView: View {
     let selectionCoordinator: MarkdownSelectionCoordinator?
     let selectionSegment: MarkdownSelectionSegmentDescriptor?
 
+    @Environment(\.sizeCategory) private var sizeCategory
+
     /// Per-view memo box: identity comes from the enclosing ForEach index
-    /// (keyed by source identity), so it survives window growth and dies
+    /// (keyed by source identity), so it survives re-evaluations and dies
     /// with the chunk when the source changes.
     @State private var box = LargeFlowChunkBox()
 
@@ -481,7 +569,8 @@ private struct LargeFlowChunkView: View {
             blocks: blocks,
             references: references,
             foregroundStyle: foregroundStyle,
-            usesAccentSurface: usesAccentSurface
+            usesAccentSurface: usesAccentSurface,
+            contentCategory: UIContentSizeCategory(sizeCategory)
         ) {
             SelectableTextView(
                 attributedText: attributed,
@@ -501,13 +590,115 @@ private struct LargeFlowChunkView: View {
     }
 }
 
+// MARK: - Large textual rich blocks
+
+/// A callout whose body exceeds the text-block budget, reprojected into
+/// bounded inner pieces (each ≤ the chunk target) rendered inside the same
+/// callout chrome. Every piece is selectable and Copy Response still uses
+/// the complete message.
+private struct LargeMarkdownCallout: View {
+    let kind: String
+    let text: String
+    let foregroundStyle: Color
+    let usesAccentSurface: Bool
+    let selectionCoordinator: MarkdownSelectionCoordinator?
+    let selectionSegment: MarkdownSelectionSegmentDescriptor?
+
+    private var detail: (title: String, icon: String, color: Color) {
+        switch kind.lowercased() {
+        case "tip", "hint": ("Tip", "lightbulb.fill", .green)
+        case "warning", "caution": ("Warning", "exclamationmark.triangle.fill", .orange)
+        case "danger", "error": ("Important", "exclamationmark.octagon.fill", .red)
+        case "important": ("Important", "exclamationmark.circle.fill", .purple)
+        default: ("Note", "info.circle.fill", .blue)
+        }
+    }
+
+    var body: some View {
+        // The pieces are flow text below the document threshold; rendering
+        // each through the ordinary MarkdownText path reuses its cache and
+        // selection machinery instead of a second inline implementation.
+        let pieces = MarkdownLargeChunkPlanner.splitText(text) { .paragraph($0) }
+        VStack(alignment: .leading, spacing: 6) {
+            Label(detail.title, systemImage: detail.icon)
+                .font(.caption.weight(.bold))
+                .foregroundStyle(detail.color)
+            ForEach(Array(pieces.enumerated()), id: \.offset) { _, piece in
+                if case .flow(let blocks) = piece {
+                    LargeFlowChunkView(
+                        blocks: blocks,
+                        references: .empty,
+                        foregroundStyle: foregroundStyle,
+                        usesAccentSurface: usesAccentSurface,
+                        selectionCoordinator: nil,
+                        selectionSegment: nil
+                    )
+                }
+            }
+        }
+        .padding(12)
+        .background(detail.color.opacity(0.10), in: RoundedRectangle(cornerRadius: 13, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 13, style: .continuous)
+                .strokeBorder(detail.color.opacity(0.28), lineWidth: 1)
+        }
+    }
+}
+
+/// Columns whose combined size exceeds the text-block budget, reprojected
+/// per column into bounded pieces. The HStack chrome is preserved; each
+/// piece renders through the ordinary small path.
+private struct LargeMarkdownColumns: View {
+    let columns: [String]
+    let foregroundStyle: Color
+    let usesAccentSurface: Bool
+    let selectionCoordinator: MarkdownSelectionCoordinator?
+    let selectionSegments: [MarkdownSelectionSegmentDescriptor]
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 0) {
+            ForEach(Array(columns.enumerated()), id: \.offset) { index, column in
+                let pieces = MarkdownLargeChunkPlanner.splitText(column) { .paragraph($0) }
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(Array(pieces.enumerated()), id: \.offset) { _, piece in
+                        if case .flow(let blocks) = piece {
+                            LargeFlowChunkView(
+                                blocks: blocks,
+                                references: .empty,
+                                foregroundStyle: foregroundStyle,
+                                usesAccentSurface: usesAccentSurface,
+                                selectionCoordinator: selectionCoordinator,
+                                selectionSegment: nil
+                            )
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(12)
+                if index < columns.count - 1 {
+                    Divider().overlay(usesAccentSurface ? Color.white.opacity(0.24) : Color.secondary.opacity(0.20))
+                }
+            }
+        }
+        .background(
+            usesAccentSurface ? Color.black.opacity(0.13) : Color.primary.opacity(0.04),
+            in: RoundedRectangle(cornerRadius: 13, style: .continuous)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 13, style: .continuous)
+                .strokeBorder(usesAccentSurface ? Color.white.opacity(0.26) : Color.secondary.opacity(0.20), lineWidth: 1)
+        }
+    }
+}
+
 // MARK: - Large code blocks
 
 /// Code at or above `codeBlockThresholdBytes` (highlighting measured 67 ms
-/// at 50 KB and 1.5 s at 1 MB): a bounded line preview first; expanded, the
-/// source renders in line slices whose highlighting happens off the
-/// MainActor (tokenization is pure Foundation) and swaps in per slice. Copy
-/// always uses the complete source.
+/// at 50 KB and 1.5 s at 1 MB): a bounded preview first; expanded, the
+/// source renders as slices bounded by BOTH a line ceiling and a UTF-8 byte
+/// ceiling (a 1 MB single-line blob is as pathological as 25 K normal
+/// lines), with highlighting computed off the MainActor and swapped in per
+/// slice. Copy always uses the complete source.
 struct LargeCodeBlockView: View {
     let source: String
     let language: String
@@ -517,12 +708,10 @@ struct LargeCodeBlockView: View {
     @State private var copied = false
     @State private var slices: [String]?
     /// (hasMoreLines, lineCount) computed once off-main; whole-block scans
-    /// must not run per body evaluation (the Copy state toggle re-evaluates).
+    /// must not run per body evaluation.
     @State private var lineStats: (hasMore: Bool, count: Int)?
 
     private var normalizedLanguage: String { MarkdownLanguage.normalized(language) }
-
-    private static let previewLineCount = 200
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -538,12 +727,21 @@ struct LargeCodeBlockView: View {
                             )
                         }
                     } else {
-                        LargeCodeSliceView(
-                            source: Self.previewSource(of: source),
-                            language: normalizedLanguage,
-                            usesAccentSurface: usesAccentSurface,
-                            maximumNumberOfLines: Self.previewLineCount
-                        )
+                        // The preview renders ONE bounded slice — up to
+                        // `codePreviewLineCount` lines AND `codePreviewBytes`
+                        // bytes; a 1 MB single-line blob previews as its
+                        // first 16 KB piece.
+                        ForEach(Array(MarkdownCodeSlicer.slice(
+                            source,
+                            maxLines: MarkdownLargeDocumentPolicy.codePreviewLineCount,
+                            maxBytes: MarkdownLargeDocumentPolicy.codePreviewBytes
+                        ).prefix(1).enumerated()), id: \.offset) { _, piece in
+                            LargeCodeSliceView(
+                                source: piece,
+                                language: normalizedLanguage,
+                                usesAccentSurface: usesAccentSurface
+                            )
+                        }
                         if lineStats?.hasMore == true {
                             Button {
                                 withAnimation(.easeInOut(duration: 0.15)) { expanded = true }
@@ -571,35 +769,29 @@ struct LargeCodeBlockView: View {
                 )
         }
         .task(id: "stats-\(source.utf8.count)") {
-            // One-time whole-block scans (line counting), off the MainActor.
+            // One-time whole-block scans, off the MainActor and cancellation
+            // cooperative with this view's lifecycle.
             guard lineStats == nil else { return }
             let currentSource = source
-            let previewBudget = Self.previewLineCount
-            let stats = await Task.detached(priority: .userInitiated) { () -> (Bool, Int) in
-                var newlines = 0
-                var index = currentSource.startIndex
-                while index < currentSource.endIndex {
-                    if currentSource[index] == "\n" { newlines += 1 }
-                    index = currentSource.index(after: index)
-                }
-                // The preview shows at most `previewLineCount` lines.
-                return (newlines >= previewBudget, newlines + 1)
-            }.value
+            let stats = await MarkdownCodeSlicer.lineStats(
+                source: currentSource,
+                previewLineBudget: MarkdownLargeDocumentPolicy.codePreviewLineCount,
+                previewByteBudget: MarkdownLargeDocumentPolicy.codePreviewBytes
+            )
             guard !Task.isCancelled else { return }
             lineStats = stats
         }
         .task(id: expanded ? "full-\(source.utf8.count)" : "preview") {
             guard expanded, slices == nil else { return }
-            // Line splitting is pure; a 1 MB block measured tens of ms, so
-            // keep it off the MainActor too.
             let currentSource = source
-            let lineCount = MarkdownLargeDocumentPolicy.codeSliceLineCount
-            let result = await Task.detached(priority: .userInitiated) {
-                currentSource.split(separator: "\n", omittingEmptySubsequences: false)
-                    .chunks(lineCount)
-                    .map { $0.joined(separator: "\n") }
-            }.value
-            guard !Task.isCancelled, expanded else { return }
+            let maxLines = MarkdownLargeDocumentPolicy.codeSliceLineCount
+            let maxBytes = MarkdownLargeDocumentPolicy.codeSliceBytes
+            let result = await MarkdownCodeSlicer.sliceAsync(
+                currentSource,
+                maxLines: maxLines,
+                maxBytes: maxBytes
+            )
+            guard !Task.isCancelled, expanded, let result else { return }
             slices = result
         }
     }
@@ -629,37 +821,6 @@ struct LargeCodeBlockView: View {
         .padding(.vertical, 8)
         .background(usesAccentSurface ? Color.black.opacity(0.28) : Color.primary.opacity(0.055))
     }
-
-    /// First N lines of the source: a bounded scan, never a full split.
-    static func previewSource(of source: String) -> String {
-        var lineCount = 0
-        var index = source.startIndex
-        while index < source.endIndex {
-            if source[index] == "\n" {
-                lineCount += 1
-                if lineCount >= previewLineCount {
-                    return String(source[..<index])
-                }
-            }
-            index = source.index(after: index)
-        }
-        return source
-    }
-
-}
-
-private extension Array where Element == Substring {
-    func chunks(_ size: Int) -> [[Element]] {
-        guard size > 0, !isEmpty else { return [] }
-        var result: [[Element]] = []
-        var start = startIndex
-        while start < endIndex {
-            let end = index(start, offsetBy: size, limitedBy: endIndex) ?? endIndex
-            result.append(Array(self[start..<end]))
-            start = end
-        }
-        return result
-    }
 }
 
 /// One bounded slice of a large code block: plain monospaced text
@@ -672,13 +833,14 @@ private struct LargeCodeSliceView: View {
     var maximumNumberOfLines: Int = 0
 
     @State private var highlighted: NSAttributedString?
+    @Environment(\.sizeCategory) private var sizeCategory
 
     private var font: UIFont {
         .monospacedSystemFont(ofSize: UIFont.preferredFont(forTextStyle: .footnote).pointSize, weight: .regular)
     }
 
     private var sliceIdentity: String {
-        "\(source.hashValue)-\(UIApplication.shared.preferredContentSizeCategory.rawValue)"
+        "\(source.hashValue)-\(sizeCategory)"
     }
 
     var body: some View {
@@ -713,9 +875,10 @@ private struct LargeCodeSliceView: View {
             // against the live property is what actually drops stale
             // results when the view was re-created mid-pass.
             let passIdentity = sliceIdentity
-            let highlightedResult = await Task.detached(priority: .userInitiated) {
-                SyntaxHighlighter.highlight(currentSource, language: currentLanguage)
-            }.value
+            let highlightedResult = await SyntaxHighlighter.highlightAsync(
+                currentSource,
+                language: currentLanguage
+            )
             guard !Task.isCancelled, sliceIdentity == passIdentity else { return }
             self.highlighted = SelectableTextView.bridge(
                 highlightedResult,
@@ -724,5 +887,44 @@ private struct LargeCodeSliceView: View {
                 linkColor: .link
             )
         }
+    }
+}
+
+// MARK: - Off-main helpers
+
+extension MarkdownCodeSlicer {
+    /// Cancellation-cooperative slicing for the expanded presentation: runs
+    /// off the MainActor as a structured child of the caller and returns
+    /// nil when cancelled mid-walk.
+    static func sliceAsync(_ source: String, maxLines: Int, maxBytes: Int) async -> [String]? {
+        await Task.yield()
+        guard !Task.isCancelled else { return nil }
+        // The synchronous walk over a megabyte is tens of milliseconds —
+        // bounded — so a start-check plus the yield is proportionate; the
+        // result is discarded anyway if the caller was cancelled.
+        return slice(source, maxLines: maxLines, maxBytes: maxBytes)
+    }
+
+    /// One-time line statistics for the preview affordance. `hasMore` is
+    /// true when either ceiling (lines or bytes) leaves content unpreviewed.
+    static func lineStats(source: String, previewLineBudget: Int, previewByteBudget: Int) async -> (hasMore: Bool, count: Int) {
+        await Task.yield()
+        var newlines = 0
+        var index = source.startIndex
+        while index < source.endIndex {
+            if source[index] == "\n" { newlines += 1 }
+            index = source.index(after: index)
+        }
+        let hasMore = newlines >= previewLineBudget || source.utf8.count > previewByteBudget
+        return (hasMore, newlines + 1)
+    }
+}
+
+extension SyntaxHighlighter {
+    /// Off-main, cancellation-checked entry for large-slice highlighting.
+    static func highlightAsync(_ source: String, language: String) async -> AttributedString {
+        await Task.yield()
+        guard !Task.isCancelled else { return AttributedString(source) }
+        return highlight(source, language: language)
     }
 }

--- a/Conduit/Views/Components/MarkdownLargeDocumentView.swift
+++ b/Conduit/Views/Components/MarkdownLargeDocumentView.swift
@@ -166,7 +166,31 @@ struct LargeMarkdownPreparedDocument {
     /// Selection descriptors for each chunk (flow chunks carry their single
     /// synthetic descriptor; rich chunks carry their block's descriptors).
     let descriptorsByChunk: [[MarkdownSelectionSegmentDescriptor]]
+    /// Precomputed bounded pieces for specialized rich blocks (oversized
+    /// callouts/columns), keyed by chunk index: the pieces, their per-piece
+    /// bounded reference subsets, and their registered selection
+    /// descriptors — so no pathological text is ever re-split from `body`,
+    /// every piece participates in coordinated selection, and reference
+    /// links keep resolving under the bounded-definition policy.
+    let specializedByChunk: [Int: LargeSpecializedRichContent]
     let sourceIdentity: String
+
+    /// Routing predicates shared by preparation and the expanded view so a
+    /// chunk is specialized in exactly one place.
+    static func isSpecializedCallout(_ block: MarkdownBlock) -> Bool {
+        if case .callout(_, let text) = block {
+            return text.utf8.count > MarkdownLargeDocumentPolicy.largeTextBlockBytes
+        }
+        return false
+    }
+
+    static func isSpecializedColumns(_ block: MarkdownBlock) -> Bool {
+        if case .columns(let columns) = block {
+            let bytes = columns.reduce(0) { $0 + $1.utf8.count + 4 }
+            return bytes > MarkdownLargeDocumentPolicy.largeTextBlockBytes
+        }
+        return false
+    }
 
     /// String work only — no UIKit — so it runs off the MainActor as a
     /// cooperative child of the caller's task (cancellation stops the pass
@@ -189,8 +213,11 @@ struct LargeMarkdownPreparedDocument {
             cursor += count
         }
 
+        let definitions = MarkdownReferenceResolver.definitions(from: document.references)
+
         var descriptorsByChunk: [[MarkdownSelectionSegmentDescriptor]] = []
         var all: [MarkdownSelectionSegmentDescriptor] = []
+        var specializedByChunk: [Int: LargeSpecializedRichContent] = [:]
         for (chunkIndex, chunk) in chunks.enumerated() {
             switch chunk {
             case .flow:
@@ -201,7 +228,82 @@ struct LargeMarkdownPreparedDocument {
                 )
                 descriptorsByChunk.append([descriptor])
                 all.append(descriptor)
-            case .block(_, let originalIndex):
+            case .block(let block, let originalIndex):
+                // Specialized oversized callouts/columns: precompute the
+                // bounded pieces once, with per-piece descriptors that
+                // REPLACE the block's own descriptors so registered ids and
+                // mounted text views always correspond. Continuation pieces
+                // join with an empty separator: the split consumes the
+                // whitespace at the cut, so pieces concatenate to the
+                // original text exactly.
+                if Self.isSpecializedCallout(block), case .callout(let kind, let text) = block {
+                    let pieces = MarkdownLargeChunkPlanner.splitText(text) { .paragraph($0) }
+                    var pieceBlocks: [[MarkdownBlock]] = []
+                    var pieceReferences: [MarkdownReferenceContext] = []
+                    var pieceDescriptors: [MarkdownSelectionSegmentDescriptor] = []
+                    let originalSeparator = blockPlan[blockRanges[originalIndex]].first?.separatorBefore ?? "\n\n"
+                    for (pieceIndex, piece) in pieces.enumerated() {
+                        guard case .flow(let blocks) = piece else { continue }
+                        pieceBlocks.append(blocks)
+                        pieceReferences.append(
+                            MarkdownReferenceResolver.subset(for: blocks.map(\.flattenedText).joined(), definitions: definitions)
+                        )
+                        pieceDescriptors.append(MarkdownSelectionSegmentDescriptor(
+                            id: "lmd-callout-\(chunkIndex)-p\(pieceIndex)",
+                            order: all.count,
+                            separatorBefore: pieceIndex == 0 ? originalSeparator : ""
+                        ))
+                        all.append(pieceDescriptors[pieceDescriptors.count - 1])
+                    }
+                    let content = LargeSpecializedRichContent(
+                        kind: .callout(kind: kind),
+                        pieceBlocks: pieceBlocks,
+                        pieceReferences: pieceReferences,
+                        pieceDescriptors: pieceDescriptors
+                    )
+                    specializedByChunk[chunkIndex] = content
+                    descriptorsByChunk.append(pieceDescriptors)
+                    continue
+                }
+                if Self.isSpecializedColumns(block), case .columns(let columns) = block {
+                    let originalSeparators = blockPlan[blockRanges[originalIndex]].map(\.separatorBefore)
+                    var pieceBlocks: [[MarkdownBlock]] = []
+                    var pieceReferences: [MarkdownReferenceContext] = []
+                    var pieceDescriptors: [MarkdownSelectionSegmentDescriptor] = []
+                    var columnRanges: [Range<Int>] = []
+                    for (columnIndex, column) in columns.enumerated() {
+                        let pieces = MarkdownLargeChunkPlanner.splitText(column) { .paragraph($0) }
+                        let columnSeparator = originalSeparators.indices.contains(columnIndex)
+                            ? originalSeparators[columnIndex]
+                            : (columnIndex == 0 ? "\n\n" : " | ")
+                        let columnStart = pieceBlocks.count
+                        for (pieceIndex, piece) in pieces.enumerated() {
+                            guard case .flow(let blocks) = piece else { continue }
+                            pieceBlocks.append(blocks)
+                            pieceReferences.append(
+                                MarkdownReferenceResolver.subset(for: blocks.map(\.flattenedText).joined(), definitions: definitions)
+                            )
+                            pieceDescriptors.append(MarkdownSelectionSegmentDescriptor(
+                                id: "lmd-columns-\(chunkIndex)-c\(columnIndex)-p\(pieceIndex)",
+                                order: all.count,
+                                separatorBefore: pieceIndex == 0 ? columnSeparator : ""
+                            ))
+                            all.append(pieceDescriptors[pieceDescriptors.count - 1])
+                        }
+                        columnRanges.append(columnStart..<pieceBlocks.count)
+                    }
+                    let content = LargeSpecializedRichContent(
+                        kind: .columns(count: columns.count),
+                        pieceBlocks: pieceBlocks,
+                        pieceReferences: pieceReferences,
+                        pieceDescriptors: pieceDescriptors,
+                        columnPieceRanges: columnRanges
+                    )
+                    specializedByChunk[chunkIndex] = content
+                    descriptorsByChunk.append(pieceDescriptors)
+                    continue
+                }
+
                 let range = blockRanges[originalIndex]
                 // Rebase the slice's order values onto the running global
                 // counter so chunk order and document order agree.
@@ -220,7 +322,6 @@ struct LargeMarkdownPreparedDocument {
         guard !Task.isCancelled else { return nil }
 
         // Per-chunk reference subsets from the chunk's own text.
-        let definitions = MarkdownReferenceResolver.definitions(from: document.references)
         var referencesByChunk: [MarkdownReferenceContext] = []
         referencesByChunk.reserveCapacity(chunks.count)
         for chunk in chunks {
@@ -235,6 +336,7 @@ struct LargeMarkdownPreparedDocument {
             referencesByChunk: referencesByChunk,
             segmentDescriptors: all,
             descriptorsByChunk: descriptorsByChunk,
+            specializedByChunk: specializedByChunk,
             sourceIdentity: Self.identity(of: source)
         )
     }
@@ -274,6 +376,47 @@ extension MarkdownBlock {
         case .image(let url, let alt): return "\(alt) \(url)"
         case .divider: return ""
         }
+    }
+}
+
+/// Precomputed bounded pieces for a specialized rich block (oversized
+/// callout or columns): the piece blocks, per-piece bounded reference
+/// subsets, and per-piece selection descriptors — all computed once during
+/// the off-main preparation, never from `body`.
+struct LargeSpecializedRichContent {
+    enum Kind {
+        case callout(kind: String)
+        case columns(count: Int)
+    }
+    let kind: Kind
+    let pieceBlocks: [[MarkdownBlock]]
+    let pieceReferences: [MarkdownReferenceContext]
+    let pieceDescriptors: [MarkdownSelectionSegmentDescriptor]
+    /// For columns: the flat piece arrays sliced per original column.
+    let columnPieceRanges: [Range<Int>]?
+
+    var calloutKind: String {
+        if case .callout(let kind) = kind { return kind }
+        return "note"
+    }
+
+    var columnCount: Int {
+        if case .columns(let count) = kind { return count }
+        return 1
+    }
+
+    init(
+        kind: Kind,
+        pieceBlocks: [[MarkdownBlock]],
+        pieceReferences: [MarkdownReferenceContext],
+        pieceDescriptors: [MarkdownSelectionSegmentDescriptor],
+        columnPieceRanges: [Range<Int>]? = nil
+    ) {
+        self.kind = kind
+        self.pieceBlocks = pieceBlocks
+        self.pieceReferences = pieceReferences
+        self.pieceDescriptors = pieceDescriptors
+        self.columnPieceRanges = columnPieceRanges
     }
 }
 
@@ -320,6 +463,14 @@ struct LargeMarkdownExpandedView: View {
         .environment(\.markdownReferences, prepared?.references ?? .empty)
         .modifier(MarkdownSelectionHost(coordinator: selectionCoordinator))
         .task(id: sourceIdentity) {
+            // A changed source must not keep displaying the old prepared
+            // document while the replacement prepares: clear state, reset
+            // the window, drop any coordinated selection, show Preparing.
+            if prepared != nil {
+                prepared = nil
+                renderedChunkCount = Self.initialChunkBatch
+                selectionCoordinator.clearSelection()
+            }
             // Nonisolated async → runs on the global executor (a structured
             // child of this task, so cancellation stops the parse instead of
             // merely discarding its result).
@@ -396,25 +547,26 @@ struct LargeMarkdownExpandedView: View {
                 blockIndex: originalIndex,
                 selectionSegments: prepared.descriptorsByChunk[index]
             )
-        case .callout(let kind, let text)
-            where text.utf8.count > MarkdownLargeDocumentPolicy.largeTextBlockBytes:
-            LargeMarkdownCallout(
-                kind: kind,
-                text: text,
-                foregroundStyle: foregroundStyle,
-                usesAccentSurface: usesAccentSurface,
-                selectionCoordinator: selectionCoordinator,
-                selectionSegment: prepared.descriptorsByChunk[index].first
-            )
-        case .columns(let columns)
-            where block.estimatedSourceBytes > MarkdownLargeDocumentPolicy.largeTextBlockBytes:
-            LargeMarkdownColumns(
-                columns: columns,
-                foregroundStyle: foregroundStyle,
-                usesAccentSurface: usesAccentSurface,
-                selectionCoordinator: selectionCoordinator,
-                selectionSegments: prepared.descriptorsByChunk[index]
-            )
+        case .callout where LargeMarkdownPreparedDocument.isSpecializedCallout(block):
+            if let content = prepared.specializedByChunk[index] {
+                LargeMarkdownCallout(
+                    content: content,
+                    calloutKind: content.calloutKind,
+                    foregroundStyle: foregroundStyle,
+                    usesAccentSurface: usesAccentSurface,
+                    selectionCoordinator: selectionCoordinator
+                )
+            }
+        case .columns where LargeMarkdownPreparedDocument.isSpecializedColumns(block):
+            if let content = prepared.specializedByChunk[index] {
+                LargeMarkdownColumns(
+                    content: content,
+                    columnCount: content.columnCount,
+                    foregroundStyle: foregroundStyle,
+                    usesAccentSurface: usesAccentSurface,
+                    selectionCoordinator: selectionCoordinator
+                )
+            }
         case .math(let source) where source.utf8.count > MarkdownLargeDocumentPolicy.mathGuardBytes:
             GuardedSourceCard(
                 title: "LaTeX",
@@ -508,9 +660,15 @@ private struct LargeDocumentPreparingView: View {
 /// Memoizes a flow chunk's attributed string so unrelated body
 /// re-evaluations never re-run the Foundation parses. The memo identity is
 /// explicit: Dynamic Type category (fonts bake into the string) and the
-/// accent-surface flag (colors bake in). The chunk's blocks/references are
-/// fixed per prepared plan — a changed source means a new identity and new
-/// chunk views, so those inputs cannot change for a surviving box.
+/// accent-surface flag (colors bake in).
+///
+/// Invariant for the remaining inputs: `foregroundStyle` is tied 1:1 to
+/// `usesAccentSurface` at every call site (`.primary`/`false` and
+/// `.white`/`true` — the same pairing `MarkdownRenderCache` asserts), and
+/// the per-chunk reference subset is fixed by the prepared plan. A changed
+/// source means a new source identity and therefore new chunk-view ids and
+/// fresh boxes, so neither input can change for a surviving box. Large
+/// structures are never hashed or serialized on body evaluation.
 final class LargeFlowChunkBox {
     private var cachedText: NSAttributedString?
     private var cachedCategory: UIContentSizeCategory?
@@ -596,16 +754,17 @@ struct LargeFlowChunkView: View {
 /// bounded inner pieces (each ≤ the chunk target) rendered inside the same
 /// callout chrome. Every piece is selectable and Copy Response still uses
 /// the complete message.
-private struct LargeMarkdownCallout: View {
-    let kind: String
-    let text: String
+struct LargeMarkdownCallout: View {
+    /// Precomputed pieces — never re-split from `body` (the preparation
+    /// stage owns that work).
+    let content: LargeSpecializedRichContent
+    let calloutKind: String
     let foregroundStyle: Color
     let usesAccentSurface: Bool
     let selectionCoordinator: MarkdownSelectionCoordinator?
-    let selectionSegment: MarkdownSelectionSegmentDescriptor?
 
     private var detail: (title: String, icon: String, color: Color) {
-        switch kind.lowercased() {
+        switch calloutKind.lowercased() {
         case "tip", "hint": ("Tip", "lightbulb.fill", .green)
         case "warning", "caution": ("Warning", "exclamationmark.triangle.fill", .orange)
         case "danger", "error": ("Important", "exclamationmark.octagon.fill", .red)
@@ -615,25 +774,19 @@ private struct LargeMarkdownCallout: View {
     }
 
     var body: some View {
-        // The pieces are flow text below the document threshold; rendering
-        // each through the ordinary MarkdownText path reuses its cache and
-        // selection machinery instead of a second inline implementation.
-        let pieces = MarkdownLargeChunkPlanner.splitText(text) { .paragraph($0) }
         VStack(alignment: .leading, spacing: 6) {
             Label(detail.title, systemImage: detail.icon)
                 .font(.caption.weight(.bold))
                 .foregroundStyle(detail.color)
-            ForEach(Array(pieces.enumerated()), id: \.offset) { _, piece in
-                if case .flow(let blocks) = piece {
-                    LargeFlowChunkView(
-                        blocks: blocks,
-                        references: .empty,
-                        foregroundStyle: foregroundStyle,
-                        usesAccentSurface: usesAccentSurface,
-                        selectionCoordinator: nil,
-                        selectionSegment: nil
-                    )
-                }
+            ForEach(Array(content.pieceBlocks.enumerated()), id: \.offset) { index, blocks in
+                LargeFlowChunkView(
+                    blocks: blocks,
+                    references: content.pieceReferences[index],
+                    foregroundStyle: foregroundStyle,
+                    usesAccentSurface: usesAccentSurface,
+                    selectionCoordinator: selectionCoordinator,
+                    selectionSegment: content.pieceDescriptors[index]
+                )
             }
         }
         .padding(12)
@@ -648,34 +801,37 @@ private struct LargeMarkdownCallout: View {
 /// Columns whose combined size exceeds the text-block budget, reprojected
 /// per column into bounded pieces. The HStack chrome is preserved; each
 /// piece renders through the ordinary small path.
-private struct LargeMarkdownColumns: View {
-    let columns: [String]
+struct LargeMarkdownColumns: View {
+    /// Precomputed column-major pieces — never re-split from `body`.
+    let content: LargeSpecializedRichContent
+    let columnCount: Int
     let foregroundStyle: Color
     let usesAccentSurface: Bool
     let selectionCoordinator: MarkdownSelectionCoordinator?
-    let selectionSegments: [MarkdownSelectionSegmentDescriptor]
 
     var body: some View {
         HStack(alignment: .top, spacing: 0) {
-            ForEach(Array(columns.enumerated()), id: \.offset) { index, column in
-                let pieces = MarkdownLargeChunkPlanner.splitText(column) { .paragraph($0) }
+            ForEach(0..<columnCount, id: \.self) { column in
                 VStack(alignment: .leading, spacing: 6) {
-                    ForEach(Array(pieces.enumerated()), id: \.offset) { _, piece in
-                        if case .flow(let blocks) = piece {
-                            LargeFlowChunkView(
-                                blocks: blocks,
-                                references: .empty,
-                                foregroundStyle: foregroundStyle,
-                                usesAccentSurface: usesAccentSurface,
-                                selectionCoordinator: selectionCoordinator,
-                                selectionSegment: nil
-                            )
-                        }
+                    // The flat prepared pieces are column-major; each column
+                    // renders exactly its own slice.
+                    let pieceRange = content.columnPieceRanges?.indices.contains(column) == true
+                        ? content.columnPieceRanges![column]
+                        : 0..<content.pieceBlocks.count
+                    ForEach(Array(pieceRange), id: \.self) { index in
+                        LargeFlowChunkView(
+                            blocks: content.pieceBlocks[index],
+                            references: content.pieceReferences[index],
+                            foregroundStyle: foregroundStyle,
+                            usesAccentSurface: usesAccentSurface,
+                            selectionCoordinator: selectionCoordinator,
+                            selectionSegment: content.pieceDescriptors[index]
+                        )
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(12)
-                if index < columns.count - 1 {
+                if column < columnCount - 1 {
                     Divider().overlay(usesAccentSurface ? Color.white.opacity(0.24) : Color.secondary.opacity(0.20))
                 }
             }
@@ -727,21 +883,19 @@ struct LargeCodeBlockView: View {
                             )
                         }
                     } else {
-                        // The preview renders ONE bounded slice — up to
+                        // The preview renders ONE bounded piece — up to
                         // `codePreviewLineCount` lines AND `codePreviewBytes`
-                        // bytes; a 1 MB single-line blob previews as its
-                        // first 16 KB piece.
-                        ForEach(Array(MarkdownCodeSlicer.slice(
-                            source,
-                            maxLines: MarkdownLargeDocumentPolicy.codePreviewLineCount,
-                            maxBytes: MarkdownLargeDocumentPolicy.codePreviewBytes
-                        ).prefix(1).enumerated()), id: \.offset) { _, piece in
-                            LargeCodeSliceView(
-                                source: piece,
-                                language: normalizedLanguage,
-                                usesAccentSurface: usesAccentSurface
-                            )
-                        }
+                        // bytes — via the early-exiting preview slicer, so
+                        // `body` never walks the whole block.
+                        LargeCodeSliceView(
+                            source: MarkdownCodeSlicer.firstSlice(
+                                source,
+                                maxLines: MarkdownLargeDocumentPolicy.codePreviewLineCount,
+                                maxBytes: MarkdownLargeDocumentPolicy.codePreviewBytes
+                            ),
+                            language: normalizedLanguage,
+                            usesAccentSurface: usesAccentSurface
+                        )
                         if lineStats?.hasMore == true {
                             Button {
                                 withAnimation(.easeInOut(duration: 0.15)) { expanded = true }

--- a/Conduit/Views/Components/MarkdownSelectionCoordinator.swift
+++ b/Conduit/Views/Components/MarkdownSelectionCoordinator.swift
@@ -109,6 +109,30 @@ enum MarkdownSelectionSegmentPlan {
 
         return descriptors
     }
+
+    /// Number of plan descriptors a block contributes. Must mirror
+    /// `descriptors(for:)` exactly — the large-document preparation slices
+    /// the plan per block using these counts, so any drift would misassign
+    /// a block's selection segments.
+    static func segmentCount(of block: MarkdownBlock) -> Int {
+        switch block {
+        case .heading, .paragraph, .callout:
+            return 1
+        case .quote(let lines):
+            if let first = lines.first, MarkdownParser.calloutMarker(first.text) != nil { return 1 }
+            return lines.count
+        case .unorderedList(let items), .orderedList(let items):
+            return items.count
+        case .table(let headers, _, let rows):
+            return ([headers] + rows).reduce(0) { $0 + $1.count }
+        case .columns(let columns):
+            return columns.count
+        case .code(let language, _):
+            return MarkdownLanguage.normalized(language) == "mermaid" ? 0 : 1
+        case .image, .math, .divider:
+            return 0
+        }
+    }
 }
 
 @MainActor

--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -1191,6 +1191,42 @@ private struct MarkdownTable: View {
     }
 
     private func tableRow(_ cells: [String], rowIndex: Int, isHeader: Bool, widths: [CGFloat]) -> some View {
+        MarkdownTableRowView(
+            cells: cells,
+            isHeader: isHeader,
+            widths: widths,
+            alignments: alignments,
+            foregroundStyle: foregroundStyle,
+            usesAccentSurface: usesAccentSurface,
+            selectionCoordinator: selectionCoordinator,
+            segmentFor: { selectionSegment(row: rowIndex, column: $0) }
+        )
+    }
+
+    private func alignment(at index: Int) -> MarkdownTableAlignment {
+        alignments.indices.contains(index) ? alignments[index] : .leading
+    }
+
+    private func selectionSegment(row: Int, column: Int) -> MarkdownSelectionSegmentDescriptor? {
+        let id = "block-\(blockIndex)-table-r\(row)-c\(column)"
+        return selectionSegments.first { $0.id == id }
+    }
+}
+
+/// The table row rendering shared by `MarkdownTable` and the paged
+/// `LargeMarkdownTable` so dividers, fonts, alignment, selection, and the
+/// deterministic single-width sizing behave identically in both paths.
+struct MarkdownTableRowView: View {
+    let cells: [String]
+    let isHeader: Bool
+    let widths: [CGFloat]
+    let alignments: [MarkdownTableAlignment]
+    let foregroundStyle: Color
+    let usesAccentSurface: Bool
+    let selectionCoordinator: MarkdownSelectionCoordinator?
+    let segmentFor: (Int) -> MarkdownSelectionSegmentDescriptor?
+
+    var body: some View {
         HStack(spacing: 0) {
             ForEach(Array(cells.enumerated()), id: \.offset) { index, cell in
                 let width = widths.indices.contains(index)
@@ -1203,14 +1239,14 @@ private struct MarkdownTable: View {
                     font: isHeader
                         ? UIFont.preferredFont(forTextStyle: .caption1).withTraits(.traitBold)
                         : UIFont.preferredFont(forTextStyle: .footnote),
-                    textAlignment: alignment(at: index).nsText,
+                    textAlignment: alignments.indices.contains(index) ? alignments[index].nsText : .natural,
                     // The exact shared column width — a single-value range keeps
                     // the cell's measured/committed height deterministic from the
                     // first layout pass, and .frame(width:) below pins the
                     // displayed width so every row's dividers align.
                     selfSizingWidthRange: width...width,
                     selectionCoordinator: selectionCoordinator,
-                    selectionSegment: selectionSegment(row: rowIndex, column: index)
+                    selectionSegment: segmentFor(index)
                 )
                     .frame(width: width)
                     .padding(.horizontal, 10)
@@ -1221,14 +1257,148 @@ private struct MarkdownTable: View {
             }
         }
     }
+}
 
-    private func alignment(at index: Int) -> MarkdownTableAlignment {
-        alignments.indices.contains(index) ? alignments[index] : .leading
+/// Paged presentation for very large tables: column widths are computed
+/// once from a bounded sample of leading rows (measuring every cell of a
+/// 1 MB table would itself be unbounded work), and rows mount in explicit
+/// batches — never all at once. Cell selection ids keep the ordinary
+/// `block-N-table-rX-cY` shape, so coordinator selection behaves like any
+/// other table.
+struct LargeMarkdownTable: View {
+    let headers: [String]
+    let alignments: [MarkdownTableAlignment]
+    let rows: [[String]]
+    let foregroundStyle: Color
+    let usesAccentSurface: Bool
+    let selectionCoordinator: MarkdownSelectionCoordinator?
+    let blockIndex: Int
+    let selectionSegments: [MarkdownSelectionSegmentDescriptor]
+
+    @State private var renderedRowCount = LargeMarkdownTable.initialRowBatch
+    @Environment(\.markdownReferences) private var references
+
+    /// Rows whose cells feed the shared width measurement. Widths computed
+    /// from a bounded prefix can differ from whole-table widths for wildly
+    /// varying columns — a documented pathological-only tradeoff that keeps
+    /// the expensive measurement bounded.
+    static let widthSampleRows = 100
+    static let initialRowBatch = 25
+    static let rowBatch = 100
+
+    private var columnWidths: [CGFloat] {
+        MarkdownTableLayout.columnWidths(
+            headers: headers,
+            rows: Array(rows.prefix(Self.widthSampleRows)),
+            availableWidth: 0,
+            references: references
+        )
     }
 
-    private func selectionSegment(row: Int, column: Int) -> MarkdownSelectionSegmentDescriptor? {
+    private func segmentDescriptor(row: Int, column: Int) -> MarkdownSelectionSegmentDescriptor? {
         let id = "block-\(blockIndex)-table-r\(row)-c\(column)"
         return selectionSegments.first { $0.id == id }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 0) {
+                    MarkdownTableRowView(
+                        cells: headers,
+                        isHeader: true,
+                        widths: columnWidths,
+                        alignments: alignments,
+                        foregroundStyle: foregroundStyle,
+                        usesAccentSurface: usesAccentSurface,
+                        selectionCoordinator: selectionCoordinator,
+                        segmentFor: { segmentDescriptor(row: 0, column: $0) }
+                    )
+                    ForEach(0..<renderedRowCount, id: \.self) { rowOffset in
+                        Divider().overlay(usesAccentSurface ? Color.white.opacity(0.22) : Color.secondary.opacity(0.18))
+                        MarkdownTableRowView(
+                            cells: rows[rowOffset],
+                            isHeader: false,
+                            widths: columnWidths,
+                            alignments: alignments,
+                            foregroundStyle: foregroundStyle,
+                            usesAccentSurface: usesAccentSurface,
+                            selectionCoordinator: selectionCoordinator,
+                            segmentFor: { segmentDescriptor(row: rowOffset + 1, column: $0) }
+                        )
+                    }
+                }
+                .background(
+                    usesAccentSurface ? Color.black.opacity(0.13) : Color.primary.opacity(0.035),
+                    in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+                )
+                .overlay {
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .strokeBorder(usesAccentSurface ? Color.white.opacity(0.26) : Color.secondary.opacity(0.20), lineWidth: 1)
+                }
+            }
+            if renderedRowCount < rows.count {
+                Button {
+                    renderedRowCount = min(renderedRowCount + Self.rowBatch, rows.count)
+                } label: {
+                    Label("Show \(min(Self.rowBatch, rows.count - renderedRowCount)) more rows (\(rows.count - renderedRowCount) of \(rows.count) left)", systemImage: "chevron.down")
+                        .font(.caption.weight(.semibold))
+                }
+                .tint(usesAccentSurface ? .white : .conduitAccent)
+                .padding(.vertical, 8)
+            }
+        }
+    }
+}
+
+/// Fallback card for oversized math/Mermaid sources: the dedicated
+/// renderers are not chunkable, so past the guard size the presentation is
+/// a bounded source preview plus Copy (the render action is dropped).
+struct GuardedSourceCard: View {
+    let title: String
+    let icon: String
+    let source: String
+    let guardBytes: Int
+
+    @State private var copied = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Label(title, systemImage: icon)
+                    .font(.caption2.monospaced().weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("Too large to render")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            SelectableTextView(
+                text: String(source.prefix(2_000)),
+                font: .monospacedSystemFont(ofSize: UIFont.preferredFont(forTextStyle: .caption1).pointSize, weight: .regular),
+                textColor: .label,
+                maximumNumberOfLines: 5
+            )
+            Button {
+                UIPasteboard.general.string = source
+                Haptics.light()
+                copied = true
+                Task {
+                    try? await Task.sleep(for: .seconds(1.4))
+                    guard !Task.isCancelled else { return }
+                    copied = false
+                }
+            } label: {
+                Label(copied ? "Copied" : "Copy full source", systemImage: copied ? "checkmark" : "doc.on.doc")
+                    .font(.caption.weight(.semibold))
+            }
+            .tint(.conduitAccent)
+        }
+        .padding(12)
+        .background(Color.primary.opacity(0.055), in: RoundedRectangle(cornerRadius: 13, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 13, style: .continuous).strokeBorder(Color.secondary.opacity(0.20), lineWidth: 1)
+        }
     }
 }
 

--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -34,6 +34,24 @@ struct MarkdownText: View {
     var isStreaming: Bool = false
 
     var body: some View {
+        // Path fork is centralized here: ordinary messages keep the exact
+        // fast cached path below; pathological ones (see
+        // MarkdownLargeDocumentPolicy) get the bounded presentation so no
+        // stage of parse/format/layout scales with the whole source.
+        if MarkdownLargeDocumentPolicy.isLargeDocument(source) {
+            LargeMarkdownDocumentView(
+                source: source,
+                foregroundStyle: foregroundStyle,
+                usesAccentSurface: usesAccentSurface,
+                gatewayMediaDataURL: gatewayMediaDataURL
+            )
+        } else {
+            normalBody
+        }
+    }
+
+    @ViewBuilder
+    private var normalBody: some View {
         let rendering = MarkdownRenderCache.rendering(
             source: source,
             recognizesGatewayMedia: gatewayMediaDataURL != nil,
@@ -520,7 +538,7 @@ enum MarkdownSelectionFormatter {
     }
 }
 
-private extension MarkdownBlock {
+extension MarkdownBlock {
     var isSelectableFlowBlock: Bool {
         switch self {
         case .heading, .paragraph, .quote, .unorderedList, .orderedList:
@@ -558,7 +576,7 @@ enum MarkdownHeading {
     }
 }
 
-private struct MarkdownBlockView: View {
+struct MarkdownBlockView: View {
     let block: MarkdownBlock
     let blockIndex: Int
     let foregroundStyle: Color
@@ -710,11 +728,11 @@ private struct MarkdownBlockView: View {
 /// `MarkdownText` injects its parsed context; every `InlineMarkdown` in the
 /// subtree reads it. The default keeps `InlineMarkdown` renderable in
 /// isolation (no references), which matches pre-reference behavior.
-private struct MarkdownReferencesKey: EnvironmentKey {
+struct MarkdownReferencesKey: EnvironmentKey {
     static let defaultValue = MarkdownReferenceContext.empty
 }
 
-private extension EnvironmentValues {
+extension EnvironmentValues {
     var markdownReferences: MarkdownReferenceContext {
         get { self[MarkdownReferencesKey.self] }
         set { self[MarkdownReferencesKey.self] = newValue }
@@ -1809,6 +1827,14 @@ enum MarkupHTML {
 }
 
 enum MarkdownParser {
+    #if DEBUG
+    /// Test instrumentation: sizes (utf8 bytes) of every source handed to
+    /// `parseDocument`. Lets regression tests assert that pathological
+    /// streaming/rendering paths never re-parse the whole document per frame
+    /// — a bound on work, not a fragile wall-clock threshold.
+    nonisolated(unsafe) static var parseSourceSizes: [Int] = []
+    #endif
+
     /// Compatibility wrapper for callers that only need the visible blocks.
     /// Reference definitions are already stripped from them; call
     /// `parseDocument` when the render context needs those definitions.
@@ -1824,6 +1850,9 @@ enum MarkdownParser {
     /// neighboring paragraphs don't merge) and re-fed to Foundation with each
     /// fragment at render time; see `MarkdownReferenceContext`.
     static func parseDocument(_ source: String, recognizesGatewayMedia: Bool = false) -> MarkdownParsedDocument {
+        #if DEBUG
+        parseSourceSizes.append(source.utf8.count)
+        #endif
         let lines = source.replacingOccurrences(of: "\r\n", with: "\n").components(separatedBy: "\n")
         var visibleLines: [String] = []
         var definitions: [String] = []
@@ -2156,7 +2185,7 @@ private final class HighlightedCode {
     init(_ value: AttributedString) { self.value = value }
 }
 
-private enum SyntaxHighlighter {
+enum SyntaxHighlighter {
     /// Settled code blocks across the transcript re-render at streaming frame
     /// rate; tokenizing is linear but allocation-heavy, so memoize by content.
     ///

--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -1275,8 +1275,32 @@ struct LargeMarkdownTable: View {
     let blockIndex: Int
     let selectionSegments: [MarkdownSelectionSegmentDescriptor]
 
-    @State private var renderedRowCount = LargeMarkdownTable.initialRowBatch
+    @State private var renderedRowCount: Int
     @Environment(\.markdownReferences) private var references
+
+    init(
+        headers: [String],
+        alignments: [MarkdownTableAlignment],
+        rows: [[String]],
+        foregroundStyle: Color,
+        usesAccentSurface: Bool,
+        selectionCoordinator: MarkdownSelectionCoordinator?,
+        blockIndex: Int,
+        selectionSegments: [MarkdownSelectionSegmentDescriptor]
+    ) {
+        self.headers = headers
+        self.alignments = alignments
+        self.rows = rows
+        self.foregroundStyle = foregroundStyle
+        self.usesAccentSurface = usesAccentSurface
+        self.selectionCoordinator = selectionCoordinator
+        self.blockIndex = blockIndex
+        self.selectionSegments = selectionSegments
+        // A table qualifies as large because of total estimated bytes — a
+        // few rows with enormous cells also qualify, so the mounted count
+        // must clamp to the actual row count from the start.
+        _renderedRowCount = State(initialValue: min(LargeMarkdownTable.initialRowBatch, rows.count))
+    }
 
     /// Rows whose cells feed the shared width measurement. Widths computed
     /// from a bounded prefix can differ from whole-table widths for wildly
@@ -1287,12 +1311,21 @@ struct LargeMarkdownTable: View {
     static let rowBatch = 100
 
     private var columnWidths: [CGFloat] {
-        MarkdownTableLayout.columnWidths(
-            headers: headers,
-            rows: Array(rows.prefix(Self.widthSampleRows)),
+        let ceiling = MarkdownLargeDocumentPolicy.tableCellBytes
+        return MarkdownTableLayout.columnWidths(
+            headers: headers.map { MarkdownLargeDocumentPolicy.boundedDisplayText($0, maxBytes: ceiling) },
+            rows: Array(rows.prefix(Self.widthSampleRows)).map {
+                $0.map { MarkdownLargeDocumentPolicy.boundedDisplayText($0, maxBytes: ceiling) }
+            },
             availableWidth: 0,
             references: references
         )
+    }
+
+    /// Cell display text under the pathological-cell ceiling; keeps both
+    /// width measurement and text layout bounded per cell.
+    private func boundedCell(_ text: String) -> String {
+        MarkdownLargeDocumentPolicy.boundedDisplayText(text, maxBytes: MarkdownLargeDocumentPolicy.tableCellBytes)
     }
 
     private func segmentDescriptor(row: Int, column: Int) -> MarkdownSelectionSegmentDescriptor? {
@@ -1301,13 +1334,16 @@ struct LargeMarkdownTable: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
+        // One width computation per body evaluation — every mounted row and
+        // the header share the same resolved (bounded) widths.
+        let widths = columnWidths
+        return VStack(spacing: 0) {
             ScrollView(.horizontal, showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 0) {
                     MarkdownTableRowView(
-                        cells: headers,
+                        cells: headers.map(boundedCell),
                         isHeader: true,
-                        widths: columnWidths,
+                        widths: widths,
                         alignments: alignments,
                         foregroundStyle: foregroundStyle,
                         usesAccentSurface: usesAccentSurface,
@@ -1317,9 +1353,9 @@ struct LargeMarkdownTable: View {
                     ForEach(0..<renderedRowCount, id: \.self) { rowOffset in
                         Divider().overlay(usesAccentSurface ? Color.white.opacity(0.22) : Color.secondary.opacity(0.18))
                         MarkdownTableRowView(
-                            cells: rows[rowOffset],
+                            cells: rows[rowOffset].map(boundedCell),
                             isHeader: false,
-                            widths: columnWidths,
+                            widths: widths,
                             alignments: alignments,
                             foregroundStyle: foregroundStyle,
                             usesAccentSurface: usesAccentSurface,

--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -1831,8 +1831,30 @@ enum MarkdownParser {
     /// Test instrumentation: sizes (utf8 bytes) of every source handed to
     /// `parseDocument`. Lets regression tests assert that pathological
     /// streaming/rendering paths never re-parse the whole document per frame
-    /// — a bound on work, not a fragile wall-clock threshold.
-    nonisolated(unsafe) static var parseSourceSizes: [Int] = []
+    /// — a bound on work, not a fragile wall-clock threshold. Lock-guarded
+    /// because `parseDocument` runs on the MainActor (rendering) and inside
+    /// off-main preparation passes concurrently.
+    private static let parseSizeLock = NSLock()
+    private nonisolated(unsafe) static var parseSizes: [Int] = []
+
+    nonisolated(unsafe) static var parseSourceSizes: [Int] {
+        get {
+            parseSizeLock.lock()
+            defer { parseSizeLock.unlock() }
+            return parseSizes
+        }
+        set {
+            parseSizeLock.lock()
+            defer { parseSizeLock.unlock() }
+            parseSizes = newValue
+        }
+    }
+
+    nonisolated(unsafe) private static func recordParseSize(_ bytes: Int) {
+        parseSizeLock.lock()
+        defer { parseSizeLock.unlock() }
+        parseSizes.append(bytes)
+    }
     #endif
 
     /// Compatibility wrapper for callers that only need the visible blocks.
@@ -1851,7 +1873,7 @@ enum MarkdownParser {
     /// fragment at render time; see `MarkdownReferenceContext`.
     static func parseDocument(_ source: String, recognizesGatewayMedia: Bool = false) -> MarkdownParsedDocument {
         #if DEBUG
-        parseSourceSizes.append(source.utf8.count)
+        recordParseSize(source.utf8.count)
         #endif
         let lines = source.replacingOccurrences(of: "\r\n", with: "\n").components(separatedBy: "\n")
         var visibleLines: [String] = []

--- a/Conduit/Views/Components/StreamingText.swift
+++ b/Conduit/Views/Components/StreamingText.swift
@@ -63,6 +63,15 @@ struct StreamingText: View {
     @State private var largeStableChunks: [String] = []
     /// Incremental safe-boundary scanner over `largeAccumulated`.
     @State private var largeScanner = MarkdownStableBoundaryScanner()
+    /// Ascending safe-boundary offsets still ahead of the promoted prefix.
+    /// Keeping the history (not just the latest boundary) lets promotion
+    /// pick the latest boundary inside its bounded window when the newest
+    /// boundaries sit beyond the window — e.g. reveal still inside a fence
+    /// while the scanner has already processed past it. Pruned to the
+    /// promoted prefix and hard-capped so adversarial blank-line floods
+    /// cannot grow it unboundedly.
+    @State private var largeBoundaries: [Int] = []
+    private static let maximumRetainedBoundaries = 4_096
 
     private let timer = Timer.publish(every: 1.0 / 30.0, on: .main, in: .common).autoconnect()
     private let fadeDuration = 0.18
@@ -266,7 +275,7 @@ struct StreamingText: View {
         largeScanner = MarkdownStableBoundaryScanner()
         // The scanner needs the full history to know fence state from any
         // later promotion point onward.
-        _ = largeScanner.append(fullText)
+        largeBoundaries = largeScanner.append(fullText)
         isLargeStream = true
         targetCharacters = []
         visibleCharacters = []
@@ -289,6 +298,7 @@ struct StreamingText: View {
 
         let delta = String(newText.dropFirst(largeAccumulatedChars))
         guard !delta.isEmpty else { return }
+
         largeAccumulated = newText
         largeAccumulatedChars += delta.count
         // String.Index is only valid for the instance it was created from;
@@ -305,7 +315,10 @@ struct StreamingText: View {
             revealAllLargeImmediately()
             return
         }
-        _ = largeScanner.append(delta)
+        largeBoundaries.append(contentsOf: largeScanner.append(delta))
+        if largeBoundaries.count > Self.maximumRetainedBoundaries {
+            largeBoundaries.removeFirst(largeBoundaries.count - Self.maximumRetainedBoundaries)
+        }
 
         if reduceMotion {
             // Everything already arrived is shown instantly; per-tick reveal
@@ -368,7 +381,8 @@ struct StreamingText: View {
             promotedBytes: largePromotedBytes,
             revealedBytes: largeRevealedBytes,
             tailWindowBytes: Self.largeTailWindowBytes,
-            lastSafeBoundary: largeScanner.lastSafeBoundary
+            boundaries: largeBoundaries,
+            constructIntervals: largeScanner.constructIntervals
         ) {
             // Index conversion is linear in the accumulated string, but
             // promotions happen only every few KB of growth, so this stays
@@ -383,6 +397,7 @@ struct StreamingText: View {
 
             largeStableChunks.append(String(largeAccumulated[start..<end]))
             largePromotedBytes = next
+            largeBoundaries.removeAll { $0 <= next }
         }
     }
 

--- a/Conduit/Views/Components/StreamingText.swift
+++ b/Conduit/Views/Components/StreamingText.swift
@@ -9,6 +9,13 @@
 //  steady, adaptive pace and retain individual reveal timestamps, allowing
 //  the Markdown renderer to fade the newest glyphs independently.
 //
+//  Once the accumulated text crosses the large-document threshold, the
+//  component switches to a bounded mode: everything behind the live tail is
+//  promoted into immutable chunks (rendered once through the ordinary
+//  cached path) and only the tail — a window of a few KB — keeps
+//  re-rendering per tick. Without this, a 1 MB stream re-parses and
+//  re-lays-out the whole document at 30 fps (measured 0.8–3.3 s per frame).
+//
 
 import SwiftUI
 
@@ -21,15 +28,64 @@ struct StreamingText: View {
     var gatewayMediaDataURL: ((String) async -> String?)? = nil
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    // MARK: Small-stream state (existing behavior)
+
     @State private var targetCharacters: [Character] = []
     @State private var visibleCharacters: [Character] = []
     @State private var revealDates: [Date] = []
     @State private var isAnimating = false
 
+    // MARK: Large-stream state
+    //
+    // Bookkeeping is scalar-first (character/byte counts updated by O(delta)
+    // arithmetic) so a tick never walks the accumulated megabytes; index
+    // math happens only at promotion boundaries, which are rare.
+
+    /// True once the accumulated text has crossed the large-document
+    /// threshold; the component never switches back mid-stream (a message
+    /// only grows while streaming).
+    @State private var isLargeStream = false
+    /// The accumulated target text (append-only while the stream grows).
+    @State private var largeAccumulated = ""
+    /// Character count of `largeAccumulated`, tracked incrementally.
+    @State private var largeAccumulatedChars = 0
+    /// Index into `largeAccumulated` up to which characters are revealed.
+    @State private var largeRevealedEnd: String.Index?
+    /// Character count of the revealed prefix, tracked incrementally.
+    @State private var largeRevealedChars = 0
+    /// UTF-8 offset of the revealed prefix, tracked incrementally.
+    @State private var largeRevealedBytes = 0
+    /// UTF-8 offset of the prefix already promoted into stable chunks.
+    @State private var largePromotedBytes = 0
+    /// Source slices of promoted chunks; each renders once through the
+    /// ordinary (cached) MarkdownText path and never re-parses.
+    @State private var largeStableChunks: [String] = []
+    /// Incremental safe-boundary scanner over `largeAccumulated`.
+    @State private var largeScanner = MarkdownStableBoundaryScanner()
+
     private let timer = Timer.publish(every: 1.0 / 30.0, on: .main, in: .common).autoconnect()
     private let fadeDuration = 0.18
 
+    /// Tail window: the live region kept out of the stable chunks so it can
+    /// keep re-parsing per tick. Same order as the chunk target, so a tick's
+    /// whole-document work stays bounded by ~2 chunks.
+    private static let largeTailWindowBytes = MarkdownLargeDocumentPolicy.chunkTargetBytes
+
     var body: some View {
+        if isLargeStream {
+            largeBody
+                .onAppear { updateTarget(text) }
+                .onChange(of: text) { _, newText in updateTarget(newText) }
+                .onReceive(timer) { date in largeReveal(at: date) }
+        } else {
+            smallBody
+        }
+    }
+
+    // MARK: Small stream
+
+    private var smallBody: some View {
         TimelineView(
             .animation(
                 minimumInterval: 1.0 / 30.0,
@@ -64,6 +120,20 @@ struct StreamingText: View {
     }
 
     private func updateTarget(_ newText: String) {
+        if isLargeStream {
+            updateLargeTarget(newText)
+            return
+        }
+
+        // Cross into large mode instead of growing the per-character
+        // machinery past the threshold: seed the large state with everything
+        // accumulated so far (revealed wholesale — the animation that
+        // matters is the tail that keeps streaming).
+        if MarkdownLargeDocumentPolicy.isLargeDocument(newText) {
+            enterLargeMode(with: newText)
+            return
+        }
+
         let newTarget = Array(newText)
         if newTarget.count < visibleCharacters.count ||
             !newTarget.starts(with: visibleCharacters) {
@@ -131,5 +201,189 @@ struct StreamingText: View {
             let progress = date.timeIntervalSince(revealDate) / fadeDuration
             return min(max(progress, 0.04), 1)
         }
+    }
+
+    // MARK: Large stream
+
+    private var largeBody: some View {
+        TimelineView(
+            .animation(
+                minimumInterval: 1.0 / 30.0,
+                paused: reduceMotion || !isAnimating
+            )
+        ) { timeline in
+            VStack(alignment: .leading, spacing: 10) {
+                // Chunks and the tail parse in isolation, so reference
+                // definitions elsewhere in the stream do not resolve while
+                // streaming — they render literally until the message
+                // settles, at which point the settled view parses the whole
+                // message and resolves them message-wide.
+                ForEach(Array(largeStableChunks.enumerated()), id: \.offset) { _, chunk in
+                    MarkdownText(
+                        source: chunk,
+                        gatewayMediaDataURL: gatewayMediaDataURL,
+                        isStreaming: false
+                    )
+                }
+                MarkdownText(
+                    source: largeTailSource,
+                    gatewayMediaDataURL: gatewayMediaDataURL,
+                    newestCharacterOpacities: characterOpacities(at: timeline.date),
+                    isStreaming: true
+                )
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .onChange(of: reduceMotion) { _, shouldReduceMotion in
+            if shouldReduceMotion {
+                revealAllLargeImmediately()
+            }
+        }
+    }
+
+    /// The not-yet-promoted remainder of the revealed prefix — the only part
+    /// that re-renders per tick.
+    private var largeTailSource: String {
+        guard let revealedEnd = largeRevealedEnd else { return "" }
+        return String(largeAccumulated[revealedEnd...])
+    }
+
+    /// (Re)seeds large mode from `fullText`. Used on first crossing and on a
+    /// non-append target (branch swap / regeneration), which resets
+    /// everything — matching the small-mode reset semantics.
+    private func enterLargeMode(with fullText: String) {
+        largeAccumulated = fullText
+        largeAccumulatedChars = fullText.count
+        largeRevealedEnd = fullText.endIndex
+        largeRevealedChars = fullText.count
+        largeRevealedBytes = fullText.utf8.count
+        largePromotedBytes = 0
+        largeStableChunks = []
+        largeScanner = MarkdownStableBoundaryScanner()
+        // The scanner needs the full history to know fence state from any
+        // later promotion point onward.
+        _ = largeScanner.append(fullText)
+        isLargeStream = true
+        targetCharacters = []
+        visibleCharacters = []
+        revealDates = []
+
+        if reduceMotion {
+            revealAllLargeImmediately()
+        } else {
+            promoteLargeChunks()
+        }
+    }
+
+    private func updateLargeTarget(_ newText: String) {
+        // A lazily-recreated view (scrolling far away and back) reseeds; a
+        // non-append target resets.
+        guard largeRevealedEnd != nil, newText.hasPrefix(largeAccumulated) else {
+            enterLargeMode(with: newText)
+            return
+        }
+
+        let delta = String(newText.dropFirst(largeAccumulatedChars))
+        guard !delta.isEmpty else { return }
+        largeAccumulated = newText
+        largeAccumulatedChars += delta.count
+        // String.Index is only valid for the instance it was created from;
+        // re-derive the reveal cursor in the replaced string from its
+        // tracked UTF-8 offset (whole-character aligned by construction).
+        let utf8 = largeAccumulated.utf8
+        if largeRevealedBytes <= utf8.count,
+           let offsetIndex = utf8.index(utf8.startIndex, offsetBy: largeRevealedBytes, limitedBy: utf8.endIndex),
+           let revealed = String.Index(offsetIndex, within: largeAccumulated) {
+            largeRevealedEnd = revealed
+        }
+        _ = largeScanner.append(delta)
+
+        if reduceMotion {
+            // Everything already arrived is shown instantly; per-tick reveal
+            // is disabled under reduce motion.
+            largeRevealedEnd = newText.endIndex
+            largeRevealedChars = largeAccumulatedChars
+            largeRevealedBytes = newText.utf8.count
+            revealAllLargeImmediately()
+        }
+    }
+
+    private func largeReveal(at date: Date) {
+        guard !reduceMotion else { return }
+
+        revealDates.removeAll {
+            date.timeIntervalSince($0) >= fadeDuration
+        }
+
+        guard var revealedEnd = largeRevealedEnd else { return }
+        let remaining = largeAccumulatedChars - largeRevealedChars
+        if remaining <= 0 {
+            let shouldAnimate = !revealDates.isEmpty
+            if isAnimating != shouldAnimate { isAnimating = shouldAnimate }
+            if !active {
+                // The stream is finished and fully revealed: drain the
+                // scanner's trailing partial line so a document ending in a
+                // closing fence (without a final newline) still promotes at
+                // real boundaries instead of hard-cutting inside the block.
+                largeScanner.finish()
+            }
+            promoteLargeChunks()
+            return
+        }
+
+        let batchSize = revealBatchSize(for: remaining)
+        let revealCount = min(batchSize, remaining)
+        let baseDate = max(date, revealDates.last ?? date)
+        let stagger = min(0.012, 0.028 / Double(revealCount))
+
+        // Walk only the batch: O(revealCount) per tick regardless of how
+        // large the accumulated document has become.
+        for offset in 0..<revealCount {
+            let current = revealedEnd
+            revealedEnd = largeAccumulated.index(after: revealedEnd)
+            largeRevealedBytes += String(largeAccumulated[current]).utf8.count
+            revealDates.append(baseDate.addingTimeInterval(Double(offset) * stagger))
+        }
+        largeRevealedEnd = revealedEnd
+        largeRevealedChars += revealCount
+        isAnimating = true
+        promoteLargeChunks()
+    }
+
+    /// Promotes revealed-but-stable content into immutable chunks whenever
+    /// more than the tail window of it has accumulated. Boundary selection
+    /// (safe scanner boundary, with hard-cut fallback for unbroken blocks)
+    /// lives in the pure, unit-tested `LargeStreamPromotion`.
+    private func promoteLargeChunks() {
+        while let next = LargeStreamPromotion.nextPromotionBoundary(
+            promotedBytes: largePromotedBytes,
+            revealedBytes: largeRevealedBytes,
+            tailWindowBytes: Self.largeTailWindowBytes,
+            lastSafeBoundary: largeScanner.lastSafeBoundary
+        ) {
+            // Index conversion is linear in the accumulated string, but
+            // promotions happen only every few KB of growth, so this stays
+            // amortized O(delta).
+            let utf8 = largeAccumulated.utf8
+            guard
+                let startUTF8 = utf8.index(utf8.startIndex, offsetBy: largePromotedBytes, limitedBy: utf8.endIndex),
+                let endUTF8 = utf8.index(utf8.startIndex, offsetBy: next, limitedBy: utf8.endIndex),
+                let start = String.Index(startUTF8, within: largeAccumulated),
+                let end = String.Index(endUTF8, within: largeAccumulated),
+                start < end
+            else { return }
+
+            largeStableChunks.append(String(largeAccumulated[start..<end]))
+            largePromotedBytes = next
+        }
+    }
+
+    private func revealAllLargeImmediately() {
+        largeRevealedChars = largeAccumulatedChars
+        largeRevealedBytes = largeAccumulated.utf8.count
+        largeRevealedEnd = largeAccumulated.endIndex
+        revealDates = []
+        isAnimating = false
+        promoteLargeChunks()
     }
 }

--- a/Conduit/Views/Components/StreamingText.swift
+++ b/Conduit/Views/Components/StreamingText.swift
@@ -289,14 +289,14 @@ struct StreamingText: View {
     }
 
     private func updateLargeTarget(_ newText: String) {
-        // A lazily-recreated view (scrolling far away and back) reseeds; a
-        // non-append target resets.
-        guard largeRevealedEnd != nil, newText.hasPrefix(largeAccumulated) else {
+        // A lazily-recreated view (scrolling far away and back), a non-append
+        // target, or a grapheme merging across the append boundary all
+        // reseed from the complete new string (see largeAppendDelta).
+        guard let delta = Self.largeAppendDelta(old: largeAccumulated, new: newText), largeRevealedEnd != nil else {
             enterLargeMode(with: newText)
             return
         }
 
-        let delta = String(newText.dropFirst(largeAccumulatedChars))
         guard !delta.isEmpty else { return }
 
         largeAccumulated = newText
@@ -359,15 +359,26 @@ struct StreamingText: View {
         let stagger = min(0.012, 0.028 / Double(revealCount))
 
         // Walk only the batch: O(revealCount) per tick regardless of how
-        // large the accumulated document has become.
+        // large the accumulated document has become. The bounds guard is
+        // defense in depth: correct bookkeeping never reaches it, but the
+        // loop must never trap on inconsistent state — it stops and
+        // reconciles the counters instead.
+        var revealedInBatch = 0
         for offset in 0..<revealCount {
+            guard revealedEnd < largeAccumulated.endIndex else { break }
             let current = revealedEnd
             revealedEnd = largeAccumulated.index(after: revealedEnd)
             largeRevealedBytes += String(largeAccumulated[current]).utf8.count
             revealDates.append(baseDate.addingTimeInterval(Double(offset) * stagger))
+            revealedInBatch += 1
         }
         largeRevealedEnd = revealedEnd
-        largeRevealedChars += revealCount
+        largeRevealedChars += revealedInBatch
+        if revealedInBatch < revealCount, revealedEnd >= largeAccumulated.endIndex {
+            // Reconcile the scalar counters with the clamped cursor.
+            largeRevealedChars = largeAccumulatedChars
+            largeRevealedBytes = largeAccumulated.utf8.count
+        }
         isAnimating = true
         promoteLargeChunks()
     }
@@ -410,6 +421,28 @@ struct StreamingText: View {
             }
             largeBoundaries.removeAll { $0 <= largePromotedBytes }
         }
+    }
+
+    /// Pure append-delta derivation. Returns nil when the projection must
+    /// reseed from the complete new string: a non-append target (Character
+    /// prefix check failed), or a grapheme that merged across the append
+    /// boundary — a combining mark, ZWJ sequence, variation selector, or
+    /// regional-indicator pair can absorb the old string's final grapheme,
+    /// making the old UTF-8 length a non-boundary in the new string. In
+    /// both cases incremental bookkeeping (cursor, counters, scanner,
+    /// promoted prefix) cannot be nudged; correctness re-establishes every
+    /// invariant together. Byte-based so the derivation never depends on
+    /// Character-count subtleties.
+    static func largeAppendDelta(old: String, new: String) -> String? {
+        guard !old.isEmpty, new.hasPrefix(old) else { return nil }
+        let oldBytes = old.utf8.count
+        let utf8 = new.utf8
+        guard oldBytes <= utf8.count,
+              let boundaryUTF8 = utf8.index(utf8.startIndex, offsetBy: oldBytes, limitedBy: utf8.endIndex),
+              let boundary = String.Index(boundaryUTF8, within: new) else {
+            return nil
+        }
+        return String(new[boundary...])
     }
 
     /// Pure slicing step for the live tail: the byte window

--- a/Conduit/Views/Components/StreamingText.swift
+++ b/Conduit/Views/Components/StreamingText.swift
@@ -395,9 +395,20 @@ struct StreamingText: View {
                 start < end
             else { return }
 
-            largeStableChunks.append(String(largeAccumulated[start..<end]))
-            largePromotedBytes = next
-            largeBoundaries.removeAll { $0 <= next }
+            let slice = String(largeAccumulated[start..<end])
+            largeStableChunks.append(slice)
+            // Store the byte offset of the ACTUAL aligned end index so the
+            // scalar bookkeeping and the rendered boundary describe the
+            // same position; a hard-cut offset that landed inside a
+            // multibyte grapheme steps back, and the difference must not
+            // accumulate across promotions.
+            let utf8 = largeAccumulated.utf8
+            if let alignedEnd = end.samePosition(in: utf8) {
+                largePromotedBytes = utf8.distance(from: utf8.startIndex, to: alignedEnd)
+            } else {
+                largePromotedBytes = next
+            }
+            largeBoundaries.removeAll { $0 <= largePromotedBytes }
         }
     }
 

--- a/Conduit/Views/Components/StreamingText.swift
+++ b/Conduit/Views/Components/StreamingText.swift
@@ -241,11 +241,15 @@ struct StreamingText: View {
         }
     }
 
-    /// The not-yet-promoted remainder of the revealed prefix — the only part
-    /// that re-renders per tick.
+    /// The revealed-but-unpromoted window — the only part that re-renders
+    /// per tick. Text beyond the reveal cursor is deliberately NOT rendered
+    /// (character pacing must hold in large mode exactly as in small mode).
     private var largeTailSource: String {
-        guard let revealedEnd = largeRevealedEnd else { return "" }
-        return String(largeAccumulated[revealedEnd...])
+        Self.tailSource(
+            accumulated: largeAccumulated,
+            promotedBytes: largePromotedBytes,
+            revealedEnd: largeRevealedEnd
+        ) ?? ""
     }
 
     /// (Re)seeds large mode from `fullText`. Used on first crossing and on a
@@ -290,11 +294,16 @@ struct StreamingText: View {
         // String.Index is only valid for the instance it was created from;
         // re-derive the reveal cursor in the replaced string from its
         // tracked UTF-8 offset (whole-character aligned by construction).
+        // If alignment ever failed, reveal everything rather than retain an
+        // index into the discarded string.
         let utf8 = largeAccumulated.utf8
         if largeRevealedBytes <= utf8.count,
            let offsetIndex = utf8.index(utf8.startIndex, offsetBy: largeRevealedBytes, limitedBy: utf8.endIndex),
            let revealed = String.Index(offsetIndex, within: largeAccumulated) {
             largeRevealedEnd = revealed
+        } else {
+            revealAllLargeImmediately()
+            return
         }
         _ = largeScanner.append(delta)
 
@@ -363,19 +372,45 @@ struct StreamingText: View {
         ) {
             // Index conversion is linear in the accumulated string, but
             // promotions happen only every few KB of growth, so this stays
-            // amortized O(delta).
-            let utf8 = largeAccumulated.utf8
+            // amortized O(delta). Hard-cut offsets are pure arithmetic and
+            // can land mid-grapheme (CJK/emoji); step back to the previous
+            // whole-character boundary rather than stalling promotion.
             guard
-                let startUTF8 = utf8.index(utf8.startIndex, offsetBy: largePromotedBytes, limitedBy: utf8.endIndex),
-                let endUTF8 = utf8.index(utf8.startIndex, offsetBy: next, limitedBy: utf8.endIndex),
-                let start = String.Index(startUTF8, within: largeAccumulated),
-                let end = String.Index(endUTF8, within: largeAccumulated),
+                let start = Self.alignedIndex(utf8Offset: largePromotedBytes, in: largeAccumulated),
+                let end = Self.alignedIndex(utf8Offset: next, in: largeAccumulated),
                 start < end
             else { return }
 
             largeStableChunks.append(String(largeAccumulated[start..<end]))
             largePromotedBytes = next
         }
+    }
+
+    /// Pure slicing step for the live tail: the byte window
+    /// [promotedBytes, revealedEnd). Returns nil when nothing revealed is
+    /// unpromoted (or the view has not seeded yet).
+    static func tailSource(accumulated: String, promotedBytes: Int, revealedEnd: String.Index?) -> String? {
+        guard let revealedEnd else { return nil }
+        guard let start = alignedIndex(utf8Offset: promotedBytes, in: accumulated), start < revealedEnd else {
+            return nil
+        }
+        return String(accumulated[start..<revealedEnd])
+    }
+
+    /// Converts a UTF-8 byte offset to a character-aligned `String.Index`,
+    /// stepping back at most a few bytes when the offset lands inside a
+    /// grapheme's UTF-8 sequence. Nil only for offsets past the end.
+    static func alignedIndex(utf8Offset: Int, in string: String) -> String.Index? {
+        let utf8 = string.utf8
+        var offset = utf8Offset
+        while offset >= 0 {
+            if let byteIndex = utf8.index(utf8.startIndex, offsetBy: offset, limitedBy: utf8.endIndex),
+               let characterIndex = String.Index(byteIndex, within: string) {
+                return characterIndex
+            }
+            offset -= 1
+        }
+        return nil
     }
 
     private func revealAllLargeImmediately() {

--- a/ConduitTests/MarkdownLargeDocumentTests.swift
+++ b/ConduitTests/MarkdownLargeDocumentTests.swift
@@ -1,0 +1,828 @@
+//
+//  MarkdownLargeDocumentTests.swift
+//  Conduit
+//
+//  Regression coverage for the large-document rendering mode: threshold
+//  policy, chunking determinism/bounds, content preservation, reference
+//  links, selection-plan slicing, streaming promotion invariants, and the
+//  memoization/Dynamic Type invalidation of chunk rendering.
+//
+//  These are work-count/bound assertions rather than wall-clock timings, so
+//  they stay deterministic on any runner.
+//
+
+import SwiftUI
+import UIKit
+import XCTest
+@testable import Conduit
+
+final class MarkdownLargeDocumentTests: XCTestCase {
+    private let chunkTarget = MarkdownLargeDocumentPolicy.chunkTargetBytes
+
+    // MARK: Corpus helpers
+
+    private func paragraphSoup(targetBytes: Int) -> String {
+        // Stops shy of the target so the +2 separators never push the result
+        // past a threshold the caller is testing against.
+        var parts: [String] = []
+        var total = 0
+        var index = 0
+        while total < targetBytes - 512 {
+            let part = "Paragraph \(index) with some words and **bold** plus a [link\(index)](https://example.com/\(index)) to give it ordinary inline structure."
+            parts.append(part)
+            total += part.utf8.count + 2
+            index += 1
+        }
+        return parts.joined(separator: "\n\n")
+    }
+
+    private func mixedSoup(targetBytes: Int) -> String {
+        var parts: [String] = []
+        var total = 0
+        var index = 0
+        while total < targetBytes {
+            // Realistic density: a substantial paragraph per unit with the
+            // rich blocks riding along, rather than pathological
+            // table-after-every-sentence micro blocks.
+            let filler = (0..<30).map { word in "Section \(index) point \(word) carries ordinary explanatory prose that wraps at chat widths and a reference use [docs\(index % 4)][ref\(word % 4)] when \(word % 4) == \(index % 4)." }.joined(separator: " ")
+            let unit = """
+            \(filler)
+
+            | A | B |
+            |---|---|
+            | 1 | 2 |
+
+            ```swift
+            let value\(index) = \(index)
+            ```
+            """
+            parts.append(unit)
+            total += unit.utf8.count + 2
+            index += 1
+        }
+        return parts.joined(separator: "\n\n") + "\n\n" + (0..<4)
+            .map { "[ref\($0)]: https://example.com/docs/\($0)" }
+            .joined(separator: "\n")
+    }
+
+    private func stripped(_ text: String) -> String {
+        text.filter { !$0.isWhitespace }
+    }
+
+    // MARK: 1. Ordinary messages take the normal path
+
+    func testOrdinaryMessagesStayBelowLargeThreshold() {
+        XCTAssertFalse(MarkdownLargeDocumentPolicy.isLargeDocument("Hello, world!"))
+        XCTAssertFalse(MarkdownLargeDocumentPolicy.isLargeDocument(paragraphSoup(targetBytes: 8_000)))
+        XCTAssertFalse(MarkdownLargeDocumentPolicy.isLargeDocument(paragraphSoup(targetBytes: MarkdownLargeDocumentPolicy.documentThresholdBytes - 1)))
+
+        // The generator stops shy of its target (see the comment there), so
+        // crossing the threshold needs a target a margin above it.
+        XCTAssertTrue(MarkdownLargeDocumentPolicy.isLargeDocument(
+            paragraphSoup(targetBytes: MarkdownLargeDocumentPolicy.documentThresholdBytes + 1_024)
+        ))
+
+        // The threshold is byte-based, not character-based: multibyte text
+        // counts its UTF-8 bytes.
+        let multibyte = String(repeating: "é", count: MarkdownLargeDocumentPolicy.documentThresholdBytes / 2)
+        XCTAssertEqual(multibyte.utf8.count, MarkdownLargeDocumentPolicy.documentThresholdBytes)
+        XCTAssertTrue(MarkdownLargeDocumentPolicy.isLargeDocument(multibyte))
+    }
+
+    // MARK: 2/3. Initial presentation is bounded
+
+    func testPreviewSourceIsBoundedPrefix() {
+        let large = paragraphSoup(targetBytes: 400_000)
+        let preview = LargeMarkdownDocumentView.previewSource(of: large)
+
+        XCTAssertLessThanOrEqual(preview.utf8.count, MarkdownLargeDocumentPolicy.previewBytes)
+        XCTAssertTrue(large.hasPrefix(preview))
+        XCTAssertFalse(preview.isEmpty)
+
+        // Ends on a block boundary when one exists in the window.
+        XCTAssertFalse(preview.hasSuffix("\n\n"))
+
+        // A document with no blank line in the window falls back to a hard
+        // cut that is still bounded and still a prefix.
+        let giantSingleParagraph = String(repeating: "word ", count: 60_000)
+        let hardCut = LargeMarkdownDocumentView.previewSource(of: giantSingleParagraph)
+        XCTAssertLessThanOrEqual(hardCut.utf8.count, MarkdownLargeDocumentPolicy.previewBytes)
+        XCTAssertTrue(giantSingleParagraph.hasPrefix(hardCut))
+
+        // Small sources pass through untouched.
+        let small = "Just a normal message."
+        XCTAssertEqual(LargeMarkdownDocumentView.previewSource(of: small), small)
+    }
+
+    func testLargeCodePreviewIsBoundedInLines() {
+        let lines = (0..<2_000).map { "line \($0) of a very long code block" }
+        let source = lines.joined(separator: "\n")
+        let preview = LargeCodeBlockView.previewSource(of: source)
+
+        XCTAssertLessThanOrEqual(preview.components(separatedBy: "\n").count, 200)
+        XCTAssertTrue(source.hasPrefix(preview))
+    }
+
+    // MARK: 4/5. Expansion is chunked and preserves all content
+
+    func testChunkPlanBoundsEveryFlowChunk() {
+        let source = paragraphSoup(targetBytes: 300_000)
+        let prepared = LargeMarkdownPreparedDocument.prepare(source)
+
+        XCTAssertGreaterThan(prepared.chunks.count, 10)
+        for chunk in prepared.chunks {
+            guard case .flow(let blocks) = chunk else { continue }
+            let bytes = blocks.reduce(0) { $0 + $1.estimatedSourceBytes }
+            // Word-boundary splitting lets a piece overshoot by at most one
+            // word; grouping alone never exceeds the target.
+            XCTAssertLessThanOrEqual(bytes, chunkTarget + 128, "flow chunk exceeded the bound: \(bytes)")
+        }
+    }
+
+    func testOversizedSingleParagraphIsSplit() {
+        // One 1 MB paragraph measured 2.4 s of TextKit layout as a single
+        // selectable document; the plan must not produce it whole.
+        let giant = String(repeating: "word ", count: 200_000)
+        let prepared = LargeMarkdownPreparedDocument.prepare(giant)
+
+        XCTAssertGreaterThan(prepared.chunks.count, 10)
+        for chunk in prepared.chunks {
+            guard case .flow(let blocks) = chunk else { continue }
+            let bytes = blocks.reduce(0) { $0 + $1.estimatedSourceBytes }
+            XCTAssertLessThanOrEqual(bytes, chunkTarget + 128)
+        }
+    }
+
+    func testChunkPlanIsDeterministic() {
+        let source = mixedSoup(targetBytes: 200_000)
+        let first = LargeMarkdownPreparedDocument.prepare(source)
+        let second = LargeMarkdownPreparedDocument.prepare(source)
+        XCTAssertEqual(first.chunks, second.chunks)
+    }
+
+    func testPreparedDocumentPreservesAllContent() {
+        let source = mixedSoup(targetBytes: 200_000)
+        let document = MarkdownParser.parseDocument(source)
+        let prepared = LargeMarkdownPreparedDocument.prepare(source)
+
+        // Both sides flatten the SAME full-document parse, so the comparison
+        // isolates chunking: nothing the parser produced may be dropped or
+        // invented by grouping/splitting. (Reference definitions live in the
+        // references context by design — PR #75 — and are asserted in
+        // testPreparedDocumentCarriesReferenceDefinitions.)
+        var renderedText = ""
+        for chunk in prepared.chunks {
+            switch chunk {
+            case .flow(let blocks):
+                renderedText += blocks.map(\.textForTesting).joined(separator: "\n\n") + "\n\n"
+            case .block(let block, _):
+                renderedText += block.textForTesting + "\n\n"
+            }
+        }
+        let documentText = document.blocks.map(\.textForTesting).joined(separator: "\n\n")
+
+        XCTAssertEqual(stripped(renderedText), stripped(documentText))
+    }
+
+    // MARK: 7. Reference links resolve in large mode
+
+    func testPreparedDocumentCarriesReferenceDefinitions() {
+        let source = mixedSoup(targetBytes: 150_000)
+        let prepared = LargeMarkdownPreparedDocument.prepare(source)
+
+        XCTAssertTrue(prepared.references.containsDefinitions)
+
+        // The chunk containing a reference use renders it as a real link
+        // through the same formatter the ordinary fast path uses.
+        let firstChunk = prepared.chunks.first
+        guard case .flow(let blocks) = firstChunk else {
+            return XCTFail("expected the mixed corpus to open with a flow chunk")
+        }
+        let attributed = MarkdownSelectionFormatter.attributedText(
+            for: blocks,
+            references: prepared.references,
+            foregroundStyle: .primary,
+            usesAccentSurface: false,
+            newestCharacterOpacities: []
+        )
+        XCTAssertNotNil(attributed)
+        let hasLink = attributed != nil && (attributed!.attribute(.link, at: 0, effectiveRange: nil) != nil
+            || attributed!.length > 0 && (0..<attributed!.length).contains { offset in
+                attributed!.attribute(.link, at: offset, effectiveRange: nil) != nil
+            })
+        XCTAssertTrue(hasLink, "reference-style link did not resolve in large mode")
+    }
+
+    // MARK: 8. Tables and code blocks stay whole
+
+    func testRichBlocksRemainUnsplitWithOriginalIndexes() {
+        let source = mixedSoup(targetBytes: 200_000)
+        let document = MarkdownParser.parseDocument(source)
+        let prepared = LargeMarkdownPreparedDocument.prepare(source)
+
+        let originalTables = document.blocks.enumerated().filter { if case .table = $0.element { return true }; return false }
+        let chunkTables = prepared.chunks.filter { if case .block(.table, _) = $0 { return true }; return false }
+        XCTAssertEqual(chunkTables.count, originalTables.count)
+
+        let originalCode = document.blocks.enumerated().filter { if case .code = $0.element { return true }; return false }
+        let chunkCode = prepared.chunks.filter { if case .block(.code, _) = $0 { return true }; return false }
+        XCTAssertEqual(chunkCode.count, originalCode.count)
+
+        // Rich chunks keep their original block index so their selection
+        // descriptors match the ordinary plan's `block-N` ids.
+        var richIndexes: [Int] = []
+        for chunk in prepared.chunks {
+            if case .block(_, let originalIndex) = chunk { richIndexes.append(originalIndex) }
+        }
+        XCTAssertEqual(richIndexes, richIndexes.sorted())
+        for index in richIndexes {
+            XCTAssertLessThan(index, document.blocks.count)
+        }
+    }
+
+    func testSegmentSlicingMatchesOrdinaryPlan() {
+        let source = mixedSoup(targetBytes: 150_000)
+        let document = MarkdownParser.parseDocument(source)
+        let plan = MarkdownSelectionSegmentPlan.descriptors(for: document.blocks)
+        let prepared = LargeMarkdownPreparedDocument.prepare(source)
+
+        // The slicing invariant: segmentCount(of:) sums to the plan's length.
+        let summed = document.blocks.reduce(0) { $0 + MarkdownSelectionSegmentPlan.segmentCount(of: $1) }
+        XCTAssertEqual(summed, plan.count)
+
+        // Every rich chunk's descriptors are exactly its block's slice of
+        // the ordinary plan (same ids, same relative order), and every flow
+        // chunk contributes one synthetic descriptor. Orders are globally
+        // monotonic. Flow blocks' own plan descriptors are replaced by the
+        // synthetic chunk descriptor (one selectable view per chunk).
+        var blockRanges: [Range<Int>] = []
+        var rangeCursor = 0
+        for block in document.blocks {
+            let count = MarkdownSelectionSegmentPlan.segmentCount(of: block)
+            blockRanges.append(rangeCursor..<(rangeCursor + count))
+            rangeCursor += count
+        }
+
+        var syntheticIDs = Set<String>()
+        var previousOrder = -1
+        for (chunkIndex, chunk) in prepared.chunks.enumerated() {
+            let descriptors = prepared.descriptorsByChunk[chunkIndex]
+            switch chunk {
+            case .flow:
+                XCTAssertEqual(descriptors.count, 1)
+                XCTAssertEqual(descriptors.first?.id, "lmd-flow-\(chunkIndex)")
+                syntheticIDs.insert(descriptors.first!.id)
+            case .block(let block, let originalIndex):
+                let expectedCount = MarkdownSelectionSegmentPlan.segmentCount(of: block)
+                XCTAssertEqual(descriptors.count, expectedCount)
+                let expected = plan[blockRanges[originalIndex]]
+                XCTAssertEqual(descriptors.map(\.id), expected.map(\.id))
+                let orders = descriptors.map(\.order)
+                XCTAssertEqual(orders, orders.sorted())
+            }
+            for descriptor in descriptors {
+                XCTAssertGreaterThan(descriptor.order, previousOrder)
+                previousOrder = descriptor.order
+            }
+        }
+        XCTAssertFalse(syntheticIDs.isEmpty)
+    }
+
+    // MARK: 11. Stale async results cannot populate the wrong message
+
+    func testSourceIdentityDistinguishesSources() {
+        let base = paragraphSoup(targetBytes: 120_000)
+        let extended = base + "\n\nOne more paragraph."
+
+        XCTAssertNotEqual(
+            LargeMarkdownPreparedDocument.identity(of: base),
+            LargeMarkdownPreparedDocument.identity(of: extended)
+        )
+        XCTAssertEqual(
+            LargeMarkdownPreparedDocument.identity(of: base),
+            LargeMarkdownPreparedDocument.identity(of: String(base))
+        )
+    }
+
+    // MARK: 12. Dynamic Type invalidation
+
+    @MainActor
+    func testFlowChunkBoxMemoizesAndInvalidatesOnDynamicTypeChange() {
+        let box = LargeFlowChunkBox()
+        let blocks: [MarkdownBlock] = [.paragraph("Hello **world** with [a link](https://example.com).")]
+
+        let first = box.attributedText(
+            blocks: blocks,
+            references: .empty,
+            foregroundStyle: .primary,
+            usesAccentSurface: false,
+            contentCategory: .large
+        )
+        let cached = box.attributedText(
+            blocks: blocks,
+            references: .empty,
+            foregroundStyle: .primary,
+            usesAccentSurface: false,
+            contentCategory: .large
+        )
+        XCTAssertTrue(first === cached, "same Dynamic Type category must reuse the memoized string")
+
+        let rebuilt = box.attributedText(
+            blocks: blocks,
+            references: .empty,
+            foregroundStyle: .primary,
+            usesAccentSurface: false,
+            contentCategory: .extraLarge
+        )
+        XCTAssertFalse(first === rebuilt, "a Dynamic Type change must rebuild the attributed string")
+        // (Font sizes themselves resolve from the process-wide setting, which
+        // the view always passes as the category — the identity checks above
+        // are the memoization/invalidation contract.)
+    }
+
+    // MARK: Streaming: scanner + promotion invariants (scenario 10)
+
+    func testScannerFindsBoundariesOutsideConstructs() {
+        let text = "para one\n\npara two\n\n```python\nx = 1\n\ny = 2\n```\n\nafter fence\n"
+        var scanner = MarkdownStableBoundaryScanner()
+        let boundaries = scanner.append(text)
+
+        func offset(of marker: String) -> Int {
+            text.utf8.distance(from: text.utf8.startIndex, to: text.utf8.firstRange(of: marker.utf8)!.lowerBound)
+        }
+
+        let afterParaOne = offset(of: "para two")
+        let afterParaTwo = offset(of: "```python")
+        let afterFence = offset(of: "after fence")
+
+        XCTAssertTrue(boundaries.contains(afterParaOne))
+        XCTAssertTrue(boundaries.contains(afterParaTwo))
+        XCTAssertTrue(boundaries.contains(afterFence))
+
+        // The blank line *inside* the fence must not be a boundary.
+        let insideFence = offset(of: "y = 2")
+        XCTAssertFalse(boundaries.contains(insideFence))
+        XCTAssertEqual(scanner.lastSafeBoundary, afterFence)
+        XCTAssertFalse(scanner.isInOpenConstruct)
+    }
+
+    func testScannerReportsOpenConstructState() {
+        var scanner = MarkdownStableBoundaryScanner()
+        _ = scanner.append("text\n\n```python\nprint(1)\n")
+        XCTAssertTrue(scanner.isInOpenConstruct)
+
+        _ = scanner.append("print(2)\n```\n\ndone\n")
+        XCTAssertFalse(scanner.isInOpenConstruct)
+
+        var mathScanner = MarkdownStableBoundaryScanner()
+        _ = mathScanner.append("intro\n\n$$\nx = 1\n")
+        XCTAssertTrue(mathScanner.isInOpenConstruct)
+        _ = mathScanner.append("$$\n\nout\n")
+        XCTAssertFalse(mathScanner.isInOpenConstruct)
+    }
+
+    func testScannerIsResumableAcrossArbitraryDeltas() {
+        let text = paragraphSoup(targetBytes: 40_000)
+            + "\n\n```swift\nlet a = 1\n\nlet b = 2\n```\n\n"
+            + paragraphSoup(targetBytes: 10_000)
+
+        var oneShot = MarkdownStableBoundaryScanner()
+        let oneShotBoundaries = oneShot.append(text)
+
+        var incremental = MarkdownStableBoundaryScanner()
+        var incrementalBoundaries: [Int] = []
+        var index = text.startIndex
+        let step = 37
+        while index < text.endIndex {
+            let end = min(text.index(index, offsetBy: step, limitedBy: text.endIndex) ?? text.endIndex, text.endIndex)
+            incrementalBoundaries.append(contentsOf: incremental.append(String(text[index..<end])))
+            index = end
+        }
+
+        XCTAssertEqual(incrementalBoundaries, oneShotBoundaries)
+        XCTAssertEqual(incremental.lastSafeBoundary, oneShot.lastSafeBoundary)
+        XCTAssertEqual(incremental.consumedOffset, oneShot.consumedOffset)
+        XCTAssertEqual(incremental.isInOpenConstruct, oneShot.isInOpenConstruct)
+    }
+
+    func testPromotionPolicyAdvancesInBoundedSteps() {
+        let chunk = MarkdownLargeDocumentPolicy.chunkTargetBytes
+        let tail = chunk
+
+        // Not enough stable content yet.
+        XCTAssertNil(LargeStreamPromotion.nextPromotionBoundary(
+            promotedBytes: 0, revealedBytes: tail + chunk - 1, tailWindowBytes: tail, lastSafeBoundary: nil
+        ))
+
+        // Safe boundary in range wins.
+        XCTAssertEqual(
+            LargeStreamPromotion.nextPromotionBoundary(
+                promotedBytes: 0, revealedBytes: tail + 3 * chunk, tailWindowBytes: tail, lastSafeBoundary: tail + 2 * chunk
+            ),
+            tail + 2 * chunk
+        )
+
+        // A safe boundary behind the minimum chunk step is not used.
+        XCTAssertNil(LargeStreamPromotion.nextPromotionBoundary(
+            promotedBytes: 0, revealedBytes: tail + chunk + 100, tailWindowBytes: tail, lastSafeBoundary: tail - 5
+        ))
+
+        // No boundary at all: the hard cut engages only with two chunks of
+        // stable content, and never promotes into the tail window.
+        let hardCut = LargeStreamPromotion.nextPromotionBoundary(
+            promotedBytes: 0, revealedBytes: tail + 4 * chunk, tailWindowBytes: tail, lastSafeBoundary: nil
+        )
+        XCTAssertEqual(hardCut, 2 * chunk)
+        let noHardCut = LargeStreamPromotion.nextPromotionBoundary(
+            promotedBytes: 0, revealedBytes: tail + chunk + 100, tailWindowBytes: tail, lastSafeBoundary: nil
+        )
+        XCTAssertNil(noHardCut)
+    }
+
+    @MainActor
+    func testFewerChunksThanOneBatchRendersWithoutOverflow() throws {
+        // A large document can legitimately produce fewer chunks than the
+        // initial batch (a handful of giant rich blocks): the expanded view
+        // must clamp its initial window instead of indexing past the array.
+        let giantTableRows = (0..<2_000).map { "row \($0) with some cell content" }
+        let table = "| A | B |\n|---|---|\n" + giantTableRows
+            .map { "| \($0) | \($0.reversed()) |" }
+            .joined(separator: "\n")
+        let source = "Intro paragraph.\n\n" + table + "\n\n```swift\n" + String(repeating: "let a = 1\n", count: 4_000) + "\n```"
+        guard MarkdownLargeDocumentPolicy.isLargeDocument(source) else {
+            return XCTFail("corpus must exceed the large-document threshold")
+        }
+        let prepared = LargeMarkdownPreparedDocument.prepare(source)
+        XCTAssertLessThan(prepared.chunks.count, LargeMarkdownExpandedView.initialChunkBatch,
+                          "corpus should produce fewer chunks than one batch")
+
+        // The view-level invariant: the initial window never exceeds the
+        // chunk count.
+        XCTAssertLessThanOrEqual(min(12, prepared.chunks.count), prepared.chunks.count)
+
+        // Render end-to-end to prove no out-of-bounds during layout.
+        MarkdownParser.parseSourceSizes = []
+        let host = UIHostingController(
+            rootView: LargeMarkdownExpandedView(
+                source: source,
+                foregroundStyle: .primary,
+                usesAccentSurface: false,
+                gatewayMediaDataURL: nil
+            )
+        )
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        host.view.layoutIfNeeded()
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline,
+              !host.view.recursiveSubviewsForTests.contains(where: { ($0 as? UITextView)?.attributedText?.length ?? 0 > 0 }) {
+            pumpForSwiftUICommit(host: host)
+        }
+        XCTAssertTrue(
+            host.view.recursiveSubviewsForTests.contains { ($0 as? UITextView)?.attributedText?.length ?? 0 > 0 },
+            "content must render without an out-of-bounds crash"
+        )
+    }
+
+    func testPreviewBudgetIsBytePreciseForMultibyteText() {
+        // CJK characters are 3 UTF-8 bytes each: a character-based window
+        // would triple the synchronous preview budget.
+        let multibyte = String(repeating: "漢", count: 20_000) // 60 KB
+        let preview = LargeMarkdownDocumentView.previewSource(of: multibyte)
+        XCTAssertLessThanOrEqual(
+            preview.utf8.count,
+            MarkdownLargeDocumentPolicy.previewBytes,
+            "preview must respect the byte budget for multibyte text (got \(preview.utf8.count))"
+        )
+        XCTAssertTrue(multibyte.hasPrefix(preview))
+
+        // Mixed content with a blank-line boundary inside the byte window.
+        let mixed = String(repeating: "漢字テキスト", count: 2_000) + "\n\n" + String(repeating: " trailing", count: 2_000)
+        let mixedPreview = LargeMarkdownDocumentView.previewSource(of: mixed)
+        XCTAssertLessThanOrEqual(mixedPreview.utf8.count, MarkdownLargeDocumentPolicy.previewBytes)
+        XCTAssertTrue(mixed.hasPrefix(mixedPreview))
+    }
+
+    func testScannerFinishDrainsTrailingPartialLine() {
+        // A stream ending in a closing fence with no trailing newline must
+        // not leave the scanner stuck in an open construct.
+        var scanner = MarkdownStableBoundaryScanner()
+        _ = scanner.append("intro\n\n```swift\nlet a = 1\n```")
+        XCTAssertTrue(scanner.isInOpenConstruct, "fence without trailing newline is still open before finish")
+        scanner.finish()
+        XCTAssertFalse(scanner.isInOpenConstruct, "finish must close the construct")
+
+        // A blank trailing partial line yields one more safe boundary.
+        var blank = MarkdownStableBoundaryScanner()
+        _ = blank.append("one\n\ntwo\n\n")
+        blank.finish()
+        XCTAssertNotNil(blank.lastSafeBoundary)
+    }
+
+    func testContinueReadingWindowCountNeverOverflows() {
+        // Fewer remaining chunks than one batch past the cap: the next
+        // window count must clamp to the total, since chunkView indexes
+        // prepared.chunks directly.
+        XCTAssertEqual(LargeMarkdownExpandedView.nextWindowCount(current: 480, total: 485), 485)
+        XCTAssertEqual(LargeMarkdownExpandedView.nextWindowCount(current: 480, total: 600), 492)
+        XCTAssertEqual(LargeMarkdownExpandedView.nextWindowCount(current: 0, total: 5), 5)
+    }
+
+    func testSimulatedStreamKeepsTailBoundedAndContentIntact() {
+        // Simulates the large streaming loop over a 200 KB stream with dense
+        // paragraph boundaries: reveal advances in batches, promotion runs to
+        // a fixpoint after each step, and the invariant holds — the live tail
+        // (the only part re-parsed per tick) stays bounded, and promoted
+        // slices concatenated equal the revealed prefix.
+        let source = paragraphSoup(targetBytes: 200_000)
+        let totalBytes = source.utf8.count
+        var scanner = MarkdownStableBoundaryScanner()
+        var promotedSlices: [String] = []
+        var promotedBytes = 0
+        var revealedBytes = 0
+        let tail = MarkdownLargeDocumentPolicy.chunkTargetBytes
+        let maximumTail = tail + 2 * MarkdownLargeDocumentPolicy.chunkTargetBytes
+
+        var consumedBytes = 0
+        while consumedBytes < totalBytes {
+            let next = min(consumedBytes + 1_024, totalBytes)
+            let start = source.utf8.index(source.utf8.startIndex, offsetBy: consumedBytes)
+            let end = source.utf8.index(source.utf8.startIndex, offsetBy: next)
+            _ = scanner.append(String(source[start..<end]))
+            consumedBytes = next
+
+            // Reveal lags arrival a little; promotion only uses revealed bytes.
+            revealedBytes = min(revealedBytes + 2_048, consumedBytes)
+
+            while let boundary = LargeStreamPromotion.nextPromotionBoundary(
+                promotedBytes: promotedBytes,
+                revealedBytes: revealedBytes,
+                tailWindowBytes: tail,
+                lastSafeBoundary: scanner.lastSafeBoundary
+            ) {
+                let sliceStart = source.utf8.index(source.utf8.startIndex, offsetBy: promotedBytes)
+                let sliceEnd = source.utf8.index(source.utf8.startIndex, offsetBy: boundary)
+                promotedSlices.append(String(source[sliceStart..<sliceEnd]))
+                promotedBytes = boundary
+            }
+
+            XCTAssertLessThanOrEqual(revealedBytes - promotedBytes, maximumTail)
+        }
+
+        // Drain the reveal and promote the remainder.
+        revealedBytes = totalBytes
+        while let boundary = LargeStreamPromotion.nextPromotionBoundary(
+            promotedBytes: promotedBytes,
+            revealedBytes: revealedBytes,
+            tailWindowBytes: tail,
+            lastSafeBoundary: scanner.lastSafeBoundary
+        ) {
+            let sliceStart = source.utf8.index(source.utf8.startIndex, offsetBy: promotedBytes)
+            let sliceEnd = source.utf8.index(source.utf8.startIndex, offsetBy: boundary)
+            promotedSlices.append(String(source[sliceStart..<sliceEnd]))
+            promotedBytes = boundary
+        }
+
+        let promotedContent = promotedSlices.joined()
+        XCTAssertEqual(promotedContent.utf8.count, promotedBytes)
+        // The promoted slices concatenate to exactly the revealed prefix.
+        let expectedPrefix = String(decoding: source.utf8.prefix(promotedBytes), as: UTF8.self)
+        XCTAssertEqual(promotedContent, expectedPrefix)
+    }
+
+    // MARK: 2/4/10. View-level work bounds (parse-counter based)
+
+    /// Requirement: a huge message — user or assistant — must not
+    /// synchronously build the heavy whole-document representation before
+    /// initial presentation. Deterministic form: hosting a huge source at
+    /// its collapsed presentation never invokes `parseDocument` with the
+    /// whole source; every parse is bounded by the preview budget.
+    @MainActor
+    func testCollapsedPresentationNeverParsesWholeSource() throws {
+        let source = mixedSoup(targetBytes: 250_000)
+        guard MarkdownLargeDocumentPolicy.isLargeDocument(source) else {
+            return XCTFail("corpus must exceed the large-document threshold")
+        }
+
+        MarkdownParser.parseSourceSizes = []
+        let host = UIHostingController(
+            rootView: MarkdownText(
+                source: source,
+                foregroundStyle: .white,
+                usesAccentSurface: true
+            )
+        )
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        host.view.layoutIfNeeded()
+        let collapsedDeadline = Date().addingTimeInterval(0.5)
+        while Date() < collapsedDeadline {
+            pumpForSwiftUICommit(host: host)
+        }
+
+        XCTAssertGreaterThan(MarkdownParser.parseSourceSizes.count, 0, "the preview must have rendered")
+        for size in MarkdownParser.parseSourceSizes {
+            XCTAssertLessThanOrEqual(
+                size,
+                MarkdownLargeDocumentPolicy.previewBytes,
+                "collapsed presentation must only parse the bounded preview (saw \(size) bytes)"
+            )
+        }
+    }
+
+    /// Requirement: expanding must not revert to the unsafe whole-document
+    /// synchronous path. Deterministic form: the whole source is parsed
+    /// exactly once (the off-main preparation), and nothing else ever
+    /// touches the whole source again — chunks format from parsed blocks,
+    /// not by re-parsing.
+    @MainActor
+    func testExpansionParsesWholeSourceExactlyOnce() throws {
+        let source = mixedSoup(targetBytes: 250_000)
+        guard MarkdownLargeDocumentPolicy.isLargeDocument(source) else {
+            return XCTFail("corpus must exceed the large-document threshold")
+        }
+
+        MarkdownParser.parseSourceSizes = []
+        let host = UIHostingController(
+            rootView: LargeMarkdownExpandedView(
+                source: source,
+                foregroundStyle: .primary,
+                usesAccentSurface: false,
+                gatewayMediaDataURL: nil
+            )
+        )
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        host.view.layoutIfNeeded()
+
+        // Wait until the detached preparation has landed and rendered.
+        let deadline = Date().addingTimeInterval(5)
+        var rendered = false
+        while Date() < deadline {
+            pumpForSwiftUICommit(host: host)
+            let wholeParses = MarkdownParser.parseSourceSizes.filter {
+                $0 >= MarkdownLargeDocumentPolicy.documentThresholdBytes
+            }
+            if wholeParses.count >= 1, host.view.recursiveSubviewsForTests.contains(where: { view in
+                (view as? UITextView)?.attributedText?.length ?? 0 > 0
+            }) {
+                rendered = true
+                break
+            }
+        }
+
+        let wholeParses = MarkdownParser.parseSourceSizes.filter {
+            $0 >= MarkdownLargeDocumentPolicy.documentThresholdBytes
+        }
+        XCTAssertEqual(wholeParses.count, 1, "the whole source must be parsed exactly once (preparation)")
+        XCTAssertTrue(rendered, "chunks must have rendered after preparation")
+        for size in MarkdownParser.parseSourceSizes where size < MarkdownLargeDocumentPolicy.documentThresholdBytes {
+            XCTAssertLessThanOrEqual(
+                size,
+                MarkdownLargeDocumentPolicy.previewBytes,
+                "no per-chunk re-parse may exceed the preview budget (saw \(size))"
+            )
+        }
+    }
+
+    /// Requirement: a large streaming response must not perform unbounded
+    /// whole-source Markdown work on published frames. Deterministic form:
+    /// hosting a large stream renders only bounded chunk/tail sources —
+    /// `parseDocument` never sees anything near the whole document.
+    @MainActor
+    func testLargeStreamRenderingParsesOnlyBoundedSources() throws {
+        let source = mixedSoup(targetBytes: 250_000)
+        guard MarkdownLargeDocumentPolicy.isLargeDocument(source) else {
+            return XCTFail("corpus must exceed the large-document threshold")
+        }
+
+        MarkdownParser.parseSourceSizes = []
+        let host = UIHostingController(rootView: StreamingText(text: source, active: true))
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        host.view.layoutIfNeeded()
+        let streamDeadline = Date().addingTimeInterval(1.0)
+        while Date() < streamDeadline {
+            pumpForSwiftUICommit(host: host)
+        }
+
+        XCTAssertGreaterThan(MarkdownParser.parseSourceSizes.count, 0, "stream content must have rendered")
+        for size in MarkdownParser.parseSourceSizes {
+            XCTAssertLessThan(
+                size,
+                MarkdownLargeDocumentPolicy.documentThresholdBytes,
+                "large-stream rendering must only parse bounded sources (saw \(size))"
+            )
+        }
+    }
+
+    /// Requirement: switching sources mid-flight cannot let a stale async
+    /// preparation populate the wrong message. The identity guard drops
+    /// mismatched results; assert the visible end state matches the new
+    /// source, not the old one.
+    @MainActor
+    func testSourceSwapDropsStalePreparation() throws {
+        // Two large sources with distinctive first-chunk markers.
+        let sourceA = "oldmarker " + String(repeating: "OLD", count: 15)
+            + "\n\n" + paragraphSoup(targetBytes: 120_000)
+        let sourceB = "newmarker " + String(repeating: "NEW", count: 15)
+            + "\n\n" + paragraphSoup(targetBytes: 120_000)
+
+        let state = SourceSwapHostState(source: sourceA)
+        let host = UIHostingController(rootView: SourceSwapHostView(state: state))
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        host.view.layoutIfNeeded()
+
+        func renderedSummary() -> String {
+            host.view.recursiveSubviewsForTests
+                .compactMap { ($0 as? UITextView)?.attributedText?.string ?? nil }
+                .map { String($0.prefix(20)) }
+                .joined(separator: " | ")
+        }
+
+        // Phase A: initial preparation must land and render.
+        let deadlineA = Date().addingTimeInterval(5)
+        while Date() < deadlineA, !renderedSummary().contains("oldmarker") {
+            pumpForSwiftUICommit(host: host)
+        }
+        XCTAssertTrue(
+            renderedSummary().contains("oldmarker"),
+            "initial source must render; rendered: \(renderedSummary())"
+        )
+
+        // Swap under the same identity: the stale preparation for A must be
+        // dropped and B must render.
+        state.source = sourceB
+        let deadlineB = Date().addingTimeInterval(5)
+        while Date() < deadlineB, !renderedSummary().contains("newmarker") {
+            pumpForSwiftUICommit(host: host)
+        }
+        let final = renderedSummary()
+        XCTAssertTrue(final.contains("newmarker"), "new source must render; rendered: \(final)")
+        XCTAssertFalse(final.contains("OLDOLDOLDOLDOLDOLDOLD"), "stale preparation from the old source must not appear; rendered: \(final)")
+    }
+}
+
+@MainActor
+private final class SourceSwapHostState: ObservableObject {
+    @Published var source: String
+    init(source: String) { self.source = source }
+}
+
+private struct SourceSwapHostView: View {
+    @ObservedObject var state: SourceSwapHostState
+
+    var body: some View {
+        LargeMarkdownExpandedView(
+            source: state.source,
+            foregroundStyle: .primary,
+            usesAccentSurface: false,
+            gatewayMediaDataURL: nil
+        )
+    }
+}
+
+
+/// Runs the main run loop briefly and forces a UIKit layout pass: the
+/// XCTest runloop emulation does not always drive SwiftUI's asynchronous
+/// attribute commit on its own, which would leave representables from
+/// pending transactions orphaned instead of mounted.
+@MainActor
+private func pumpForSwiftUICommit(host: UIHostingController<some View>) {
+    RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+    host.view.setNeedsLayout()
+    host.view.layoutIfNeeded()
+}
+
+private extension UIView {
+    var recursiveSubviewsForTests: [UIView] {
+        subviews + subviews.flatMap(\.recursiveSubviewsForTests)
+    }
+}
+
+// MARK: - Test-only projections
+
+extension MarkdownBlock {
+    /// Flattened text projection for content-preservation comparisons.
+    var textForTesting: String {
+        switch self {
+        case .heading(_, let text), .paragraph(let text): return text
+        case .quote(let lines): return lines.map(\.text).joined(separator: "\n")
+        case .unorderedList(let items), .orderedList(let items): return items.joined(separator: "\n")
+        case .table(let headers, _, let rows):
+            return ([headers] + rows).map { $0.joined(separator: "|") }.joined(separator: "\n")
+        case .code(_, let source): return source
+        case .callout(_, let text): return text
+        case .columns(let columns): return columns.joined(separator: "\n")
+        case .math(let source): return source
+        case .image(let url, let alt): return "\(alt)\(url)"
+        case .divider: return "---"
+        }
+    }
+}

--- a/ConduitTests/MarkdownLargeDocumentTests.swift
+++ b/ConduitTests/MarkdownLargeDocumentTests.swift
@@ -1065,11 +1065,17 @@ extension MarkdownLargeDocumentTests {
                 }
             }
         }
-        // Continuation ordinals must continue from where the list chunk
-        // stopped, never restart at 1.
+        // Continuation ordinals MUST exist (the test cannot silently pass
+        // when the planner never bakes any) and must continue from where
+        // the list chunk stopped, never restarting at 1.
+        XCTAssertFalse(bakedOrdinals.isEmpty, "split ordered lists must bake continuation ordinals")
         if let first = bakedOrdinals.first {
             XCTAssertGreaterThan(first, 1, "continuation numbering must not restart at 1")
         }
+        // Ordinals are strictly increasing across continuation chunks (no
+        // duplicates either — sorted-equality alone would accept "2, 2, 3").
+        XCTAssertEqual(bakedOrdinals, Array(Set(bakedOrdinals)).sorted())
+        XCTAssertEqual(bakedOrdinals.count, Set(bakedOrdinals).count, "ordinals must not repeat")
     }
 
     // Case 4: many/large reference definitions -> per-chunk parse input
@@ -1181,7 +1187,7 @@ extension MarkdownLargeDocumentTests {
         // Promote with the stable target inside the recorded interval: the
         // policy must use a boundary BEFORE the fence or wait.
         let fenceStart = interval.start
-        let target = fenceStart + 1_000
+        let target = fenceStart + 9_000 // past promoted+minChunk so the window logic runs
         let inFence = LargeStreamPromotion.nextPromotionBoundary(
             promotedBytes: 0,
             revealedBytes: target + MarkdownLargeDocumentPolicy.chunkTargetBytes,
@@ -1363,6 +1369,427 @@ private struct DynamicTypeProbeView: View {
             selectionCoordinator: nil,
             selectionSegment: nil
         )
+    }
+}
+
+
+// MARK: - Pre-merge hardening battery
+
+extension MarkdownLargeDocumentTests {
+    // Case 1: a large table with only 3 rows (giant cells) must not crash
+    // the initial row window.
+    @MainActor
+    func testLargeTableWithFewGiantRowsDoesNotCrash() {
+        let giantCell = String(repeating: "cell ", count: 8_000) // 40 KB per cell
+        let rows = (0..<3).map { [String(repeating: "a", count: 40), "row \($0) \(giantCell)"] }
+        let table = MarkdownBlock.table(headers: ["A", "B"], alignments: [.leading, .leading], rows: rows)
+        XCTAssertGreaterThanOrEqual(table.estimatedSourceBytes, MarkdownLargeDocumentPolicy.largeTableBytes)
+
+        let host = UIHostingController(
+            rootView: LargeMarkdownTable(
+                headers: ["A", "B"],
+                alignments: [.leading, .leading],
+                rows: rows,
+                foregroundStyle: .primary,
+                usesAccentSurface: false,
+                selectionCoordinator: nil,
+                blockIndex: 0,
+                selectionSegments: []
+            )
+        )
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        host.view.layoutIfNeeded()
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline { pumpForSwiftUICommit(host: host) }
+        let textViews = host.view.recursiveSubviewsForTests.compactMap { $0 as? UITextView }
+        // Header (2 cells) + 3 rows × 2 cells, every cell byte-bounded.
+        XCTAssertLessThanOrEqual(textViews.count, 8, "mounted cells must match the clamped row window")
+        XCTAssertGreaterThan(textViews.count, 0)
+    }
+
+    // Case 2: a single 500 KB cell is bounded for measurement and render.
+    func testGiantTableCellIsBounded() {
+        let giant = String(repeating: "漢", count: 170_000) // ~510 KB
+        let bounded = MarkdownLargeDocumentPolicy.boundedDisplayText(giant, maxBytes: MarkdownLargeDocumentPolicy.tableCellBytes)
+        XCTAssertLessThanOrEqual(bounded.utf8.count, MarkdownLargeDocumentPolicy.tableCellBytes + 4, "grapheme-safe cut at the ceiling + ellipsis marker")
+        XCTAssertTrue(giant.hasPrefix(String(bounded.dropLast(2))), "bounded cell is a grapheme-safe prefix")
+    }
+
+    // Case 3 + 13: a fallback cut that would land inside a CLOSED fence is
+    // refused even though the stable target lies beyond the fence.
+    func testHardCutInsideClosedFenceIsRefused() {
+        let chunk = MarkdownLargeDocumentPolicy.chunkTargetBytes
+        let fenceStart = chunk              // 8 KB
+        let fenceEnd = 4 * chunk            // 32 KB
+        let stableTarget = 7 * chunk        // 56 KB, beyond the fence
+        let revealed = stableTarget + chunk
+
+        let boundary = LargeStreamPromotion.nextPromotionBoundary(
+            promotedBytes: 0,
+            revealedBytes: revealed,
+            tailWindowBytes: chunk,
+            boundaries: [fenceEnd + chunk], // only a boundary beyond the window
+            constructIntervals: [(start: fenceStart, end: fenceEnd)]
+        )
+        // The default fallback cut (16 KB) would land inside the fence —
+        // promotion must wait (nil), never split the construct.
+        XCTAssertNil(boundary)
+
+        // With a usable boundary BEFORE the fence, promotion uses it.
+        let early = LargeStreamPromotion.nextPromotionBoundary(
+            promotedBytes: 0,
+            revealedBytes: revealed,
+            tailWindowBytes: chunk,
+            boundaries: [chunk, fenceEnd + chunk],
+            constructIntervals: [(start: fenceStart, end: fenceEnd)]
+        )
+        XCTAssertEqual(early, chunk)
+
+        // Exhaustive sweep: no accepted cut ever lands strictly inside any
+        // recorded construct.
+        let intervals: [(start: Int, end: Int?)] = [
+            (start: 5 * chunk, end: 9 * chunk),
+            (start: 20 * chunk, end: nil)
+        ]
+        // Fallback hard cuts (no safe boundary available) must never land
+        // inside any recorded construct. Scanner-provided boundaries are
+        // trusted inputs — the scanner never emits one inside a construct.
+        for promoted in stride(from: 0, through: 60 * chunk, by: chunk / 2) {
+            let result = LargeStreamPromotion.nextPromotionBoundary(
+                promotedBytes: promoted,
+                revealedBytes: promoted + 30 * chunk,
+                tailWindowBytes: chunk,
+                boundaries: [],
+                constructIntervals: intervals
+            )
+            if let cut = result {
+                for interval in intervals {
+                    let end = interval.end ?? Int.max
+                    XCTAssertFalse(cut > interval.start && cut < end,
+                                   "cut \(cut) landed inside construct [\(interval.start), \(interval.end ?? -1))")
+                }
+            }
+        }
+    }
+
+    // Case 4: the code preview performs only bounded-prefix work.
+    func testCodePreviewIsBoundedPrefixWork() {
+        let blob = String(repeating: "ab", count: 500_000) // 1 MB single line
+        let preview = MarkdownCodeSlicer.firstSlice(
+            blob,
+            maxLines: MarkdownLargeDocumentPolicy.codePreviewLineCount,
+            maxBytes: MarkdownLargeDocumentPolicy.codePreviewBytes
+        )
+        XCTAssertLessThanOrEqual(preview.utf8.count, MarkdownLargeDocumentPolicy.codePreviewBytes + 8)
+        XCTAssertTrue(blob.hasPrefix(preview))
+
+        // A giant line following normal lines: the result must still be a
+        // PREFIX of the source (everything before it plus a bounded piece
+        // of it), not just the giant line's prefix.
+        let mixed = (0..<10).map { "normal \($0)" }.joined(separator: "\n")
+            + "\n" + String(repeating: "z", count: 200_000) + "\ntrailing"
+        let mixedPreview = MarkdownCodeSlicer.firstSlice(
+            mixed,
+            maxLines: MarkdownLargeDocumentPolicy.codePreviewLineCount,
+            maxBytes: MarkdownLargeDocumentPolicy.codePreviewBytes
+        )
+        XCTAssertTrue(mixed.hasPrefix(mixedPreview), "preview must remain a source prefix when a giant line follows normal lines")
+        XCTAssertTrue(mixedPreview.hasPrefix("normal 0"), "content before the giant line must be included")
+        XCTAssertLessThanOrEqual(mixedPreview.utf8.count, MarkdownLargeDocumentPolicy.codePreviewBytes + 16)
+
+        let tall = (0..<50_000).map { "line \($0)" }.joined(separator: "\n")
+        let tallPreview = MarkdownCodeSlicer.firstSlice(
+            tall,
+            maxLines: MarkdownLargeDocumentPolicy.codePreviewLineCount,
+            maxBytes: MarkdownLargeDocumentPolicy.codePreviewBytes
+        )
+        XCTAssertLessThanOrEqual(
+            tallPreview.components(separatedBy: "\n").count,
+            MarkdownLargeDocumentPolicy.codePreviewLineCount + 1
+        )
+        XCTAssertTrue(tall.hasPrefix(tallPreview))
+    }
+
+    // Cases 5 + 6: body re-evaluation never re-splits giant callouts or
+    // columns (pieces are precomputed during preparation).
+    @MainActor
+    func testSpecializedRichBlockBodiesDoNotResplit() async throws {
+        let giantCalloutBody = String(repeating: "callout prose with ordinary words. ", count: 1_200) // ~42 KB
+        let giantColumn = String(repeating: "column prose continues here. ", count: 1_200)
+        let source = "opening paragraph\n\n::: note\n\(giantCalloutBody)\n:::\n\nfinal paragraph"
+        let columnsSource = "intro\n\n::: columns\n::: column\n\(giantColumn)\n::: column\n\(giantColumn)\n:::"
+
+        MarkdownLargeChunkPlanner.splitTextCallCount = 0
+        guard let prepared = await LargeMarkdownPreparedDocument.prepare(source) else {
+            return XCTFail("preparation failed")
+        }
+        let splitsAfterPrepare = MarkdownLargeChunkPlanner.splitTextCallCount
+        XCTAssertGreaterThan(splitsAfterPrepare, 0, "the giant callout must be split during preparation")
+
+        guard let columnsPrepared = await LargeMarkdownPreparedDocument.prepare(columnsSource) else {
+            return XCTFail("columns preparation failed")
+        }
+        let splitsAfterBoth = MarkdownLargeChunkPlanner.splitTextCallCount
+
+        // Render both expanded views and pump — re-evaluations must not add
+        // a single further split.
+        for plan in [prepared, columnsPrepared] {
+            let host = UIHostingController(
+                rootView: LargeExpandedProbeView(plan: plan)
+            )
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+            window.rootViewController = host
+            window.makeKeyAndVisible()
+            host.view.layoutIfNeeded()
+            let deadline = Date().addingTimeInterval(1.5)
+            while Date() < deadline { pumpForSwiftUICommit(host: host) }
+        }
+        XCTAssertEqual(
+            MarkdownLargeChunkPlanner.splitTextCallCount, splitsAfterBoth,
+            "SwiftUI body re-evaluations must not re-split specialized rich blocks"
+        )
+    }
+
+    // Cases 7 + 8: selection/copy across a specialized block participates
+    // through registered per-piece descriptors in document order.
+    @MainActor
+    func testCopyAcrossSpecializedCalloutPiecesIncludesContent() async throws {
+        let giantCalloutBody = String(repeating: "callout prose with ordinary words. ", count: 1_200)
+        let source = "opening paragraph\n\n::: note\n\(giantCalloutBody)\n:::\n\nfinal paragraph"
+        guard let prepared = await LargeMarkdownPreparedDocument.prepare(source) else {
+            return XCTFail("preparation failed")
+        }
+
+        // The callout chunk's descriptors are per-piece, ordered, and every
+        // id is unique across the whole plan.
+        let calloutChunkIndex = prepared.chunks.firstIndex { chunk in
+            if case .block(let block, _) = chunk { return LargeMarkdownPreparedDocument.isSpecializedCallout(block) }
+            return false
+        }
+        guard let index = calloutChunkIndex else { return XCTFail("callout chunk missing") }
+        let descriptors = prepared.descriptorsByChunk[index]
+        XCTAssertGreaterThan(descriptors.count, 1, "giant callout must have several piece descriptors")
+        XCTAssertEqual(descriptors.map(\.order), descriptors.map(\.order).sorted())
+
+        // Coordinated copy across pieces joins the content in order.
+        let coordinator = MarkdownSelectionCoordinator()
+        coordinator.replaceSegments(prepared.segmentDescriptors, revision: prepared.sourceIdentity)
+        for descriptor in descriptors {
+            let textView = SelectableTextView.makeTextView()
+            textView.attributedText = NSAttributedString(
+                string: "PIECE-\(descriptor.id)-",
+                attributes: [.font: UIFont.preferredFont(forTextStyle: .body)]
+            )
+            coordinator.register(descriptor: descriptor, textView: textView)
+        }
+        let first = try XCTUnwrap(descriptors.first)
+        let last = try XCTUnwrap(descriptors.last)
+        let copied = coordinator.copiedAttributedText(
+            from: MarkdownSelectionEndpoint(segmentID: first.id, offset: 0),
+            to: MarkdownSelectionEndpoint(segmentID: last.id, offset: coordinator.text(for: last.id)?.utf16.count ?? 0)
+        )
+        XCTAssertTrue(copied.string.contains("PIECE-\(first.id)"), "copy must start with the first piece")
+        XCTAssertTrue(copied.string.contains("PIECE-\(last.id)"), "copy must include through the last piece")
+    }
+
+    // Case 9: reference-style links inside oversized callout pieces still
+    // resolve under the bounded per-piece subsets.
+    func testReferenceLinksInsideOversizedCalloutResolve() async throws {
+        let calloutBody = "uses [the guide][ref0] early. " + String(repeating: "ordinary callout prose. ", count: 1_400)
+        let source = "opening\n\n::: note\n\(calloutBody)\n:::\n\n\n[ref0]: https://example.com/guide/0"
+        guard let prepared = await LargeMarkdownPreparedDocument.prepare(source) else {
+            return XCTFail("preparation failed")
+        }
+        guard let index = prepared.chunks.firstIndex(where: { chunk in
+            if case .block(let block, _) = chunk { return LargeMarkdownPreparedDocument.isSpecializedCallout(block) }
+            return false
+        }) else { return XCTFail("callout chunk missing") }
+        guard let content = prepared.specializedByChunk[index] else {
+            return XCTFail("specialized content missing")
+        }
+
+        var resolved = false
+        for (pieceIndex, blocks) in content.pieceBlocks.enumerated() {
+            let subset = content.pieceReferences[pieceIndex]
+            XCTAssertLessThanOrEqual(subset.definitionsMarkdown.utf8.count,
+                                     MarkdownLargeDocumentPolicy.referenceSubsetBudgetBytes)
+            if let attributed = MarkdownSelectionFormatter.attributedText(
+                for: blocks, references: subset, foregroundStyle: .primary,
+                usesAccentSurface: false, newestCharacterOpacities: []
+            ), attributed.length > 0 {
+                var links = 0
+                attributed.enumerateAttribute(.link, in: NSRange(location: 0, length: attributed.length)) { value, _, _ in
+                    if value != nil { links += 1 }
+                }
+                if blocks.map(\.flattenedText).joined().contains("ref0") {
+                    XCTAssertGreaterThan(links, 0, "the piece containing the use must resolve its link")
+                    resolved = true
+                }
+            }
+        }
+        XCTAssertTrue(resolved, "the reference-using piece must exist and resolve")
+    }
+
+    // Case 10: oversized FIRST ordered item then normal items — numbering
+    // must not restart.
+    func testOversizedFirstOrderedItemThenNormalItems() async {
+        let huge = String(repeating: "item prose ", count: 900) // ~10 KB
+        let source = "1. \(huge)\n2. normal one\n3. normal two"
+        let document = MarkdownParser.parseDocument(source)
+        guard case .orderedList(let items)? = document.blocks.first else {
+            return XCTFail("expected ordered list")
+        }
+        let chunks = MarkdownLargeChunkPlanner.chunks(for: [.orderedList(items)])
+        XCTAssertGreaterThan(chunks.count, 1)
+
+        var orderedListBlocks = 0
+        var bakedOrdinals: [Int] = []
+        for chunk in chunks {
+            guard case .flow(let blocks) = chunk else { continue }
+            for block in blocks {
+                if case .orderedList = block { orderedListBlocks += 1 }
+                if case .paragraph(let text) = block,
+                   let ordinal = Int(text.prefix { $0.isNumber }) {
+                    bakedOrdinals.append(ordinal)
+                }
+            }
+        }
+        XCTAssertEqual(orderedListBlocks, 0,
+                       "an oversized FIRST item consumes the list slot; continuations must bake ordinals")
+        XCTAssertFalse(bakedOrdinals.isEmpty, "continuation ordinals must be baked")
+        XCTAssertEqual(bakedOrdinals.first, 1, "the first item keeps its ordinal")
+        XCTAssertTrue(bakedOrdinals.contains(2) && bakedOrdinals.contains(3),
+                      "normal following items continue numbering (got \(bakedOrdinals))")
+    }
+
+    // Case 11: a source swap clears stale prepared content immediately.
+    @MainActor
+    func testSourceSwapClearsStaleContentImmediately() {
+        let state = SourceSwapHostState(
+            source: "oldmarker " + paragraphSoup(targetBytes: 120_000)
+        )
+        let host = UIHostingController(rootView: SourceSwapHostView(state: state))
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        host.view.layoutIfNeeded()
+        let first = Date().addingTimeInterval(5)
+        while Date() < first,
+              !host.view.recursiveSubviewsForTests.contains(where: { ($0 as? UITextView)?.attributedText?.string.contains("oldmarker") == true }) {
+            pumpForSwiftUICommit(host: host)
+        }
+
+        XCTAssertTrue(
+            host.view.recursiveSubviewsForTests.contains { ($0 as? UITextView)?.attributedText?.string.contains("oldmarker") == true },
+            "precondition: the old source must have rendered before the swap"
+        )
+        state.source = "newmarker " + paragraphSoup(targetBytes: 120_000)
+        // One pump after the swap: old content must already be gone, even
+        // before the replacement preparation lands.
+        pumpForSwiftUICommit(host: host)
+        let rendered = host.view.recursiveSubviewsForTests
+            .compactMap { ($0 as? UITextView)?.attributedText?.string ?? nil }
+            .joined()
+        XCTAssertFalse(rendered.contains("oldmarker"), "stale content must not remain visible during preparation")
+    }
+
+    // Case 12: exact CJK/emoji streaming reconstruction — no missing or
+    // duplicated characters across aligned hard cuts.
+    func testStreamingReconstructionExactForCJKAndEmoji() {
+        // Mixed multibyte text with NO blank lines: every promotion is a
+        // grapheme-stepped hard cut.
+        let emoji = "👩‍👩‍👧‍👦"
+        let corpus = String(repeating: "漢字🎉\(emoji)テキスト", count: 9_000)
+        let total = corpus.utf8.count
+        XCTAssertGreaterThan(total, 300_000)
+
+        let chunk = MarkdownLargeDocumentPolicy.chunkTargetBytes
+        var promoted = 0
+        var pieces: [String] = []
+        while let next = LargeStreamPromotion.nextPromotionBoundary(
+            promotedBytes: promoted,
+            revealedBytes: total,
+            tailWindowBytes: chunk,
+            boundaries: [],
+            constructIntervals: []
+        ) {
+            guard let end = StreamingText.alignedIndex(utf8Offset: next, in: corpus) else {
+                return XCTFail("alignment failed at \(next)")
+            }
+            let start: String.Index
+            if promoted == 0 {
+                start = corpus.startIndex
+            } else if let aligned = StreamingText.alignedIndex(utf8Offset: promoted, in: corpus) {
+                start = aligned
+            } else {
+                return XCTFail("start alignment failed at \(promoted)")
+            }
+            pieces.append(String(corpus[start..<end]))
+            // Normalized offset (mirrors StreamingText's bookkeeping).
+            let utf8 = corpus.utf8
+            promoted = utf8.distance(from: utf8.startIndex, to: end.samePosition(in: utf8)!)
+        }
+        guard let tailStart = StreamingText.alignedIndex(utf8Offset: promoted, in: corpus) else {
+            return XCTFail("tail alignment failed at \(promoted)")
+        }
+        let tail = String(corpus[tailStart...])
+
+        XCTAssertEqual(pieces.joined() + tail, corpus,
+                       "promoted chunks plus the live tail must reconstruct the stream exactly")
+        XCTAssertGreaterThan(pieces.count, 10)
+    }
+}
+
+/// Hosts an already-prepared plan without re-running preparation, so tests
+/// can pump re-evaluations deterministically.
+private struct LargeExpandedProbeView: View {
+    let plan: LargeMarkdownPreparedDocument
+
+    var body: some View {
+        LargeMarkdownPreparedPlanHost(plan: plan)
+    }
+}
+
+private struct LargeMarkdownPreparedPlanHost: View {
+    let plan: LargeMarkdownPreparedDocument
+    @StateObject private var selectionCoordinator = MarkdownSelectionCoordinator()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(0..<plan.chunks.count, id: \.self) { index in
+                SpecializedChunkProbe(plan: plan, index: index, coordinator: selectionCoordinator)
+            }
+        }
+    }
+}
+
+private struct SpecializedChunkProbe: View {
+    let plan: LargeMarkdownPreparedDocument
+    let index: Int
+    let coordinator: MarkdownSelectionCoordinator
+
+    var body: some View {
+        if let content = plan.specializedByChunk[index] {
+            if case .callout = content.kind {
+                LargeMarkdownCallout(
+                    content: content,
+                    calloutKind: content.calloutKind,
+                    foregroundStyle: .primary,
+                    usesAccentSurface: false,
+                    selectionCoordinator: coordinator
+                )
+            } else {
+                LargeMarkdownColumns(
+                    content: content,
+                    columnCount: content.columnCount,
+                    foregroundStyle: .primary,
+                    usesAccentSurface: false,
+                    selectionCoordinator: coordinator
+                )
+            }
+        }
     }
 }
 

--- a/ConduitTests/MarkdownLargeDocumentTests.swift
+++ b/ConduitTests/MarkdownLargeDocumentTests.swift
@@ -114,20 +114,31 @@ final class MarkdownLargeDocumentTests: XCTestCase {
         XCTAssertEqual(LargeMarkdownDocumentView.previewSource(of: small), small)
     }
 
-    func testLargeCodePreviewIsBoundedInLines() {
+    func testLargeCodePreviewIsBoundedInLines() throws {
         let lines = (0..<2_000).map { "line \($0) of a very long code block" }
         let source = lines.joined(separator: "\n")
-        let preview = LargeCodeBlockView.previewSource(of: source)
+        let previewPieces = MarkdownCodeSlicer.slice(
+            source,
+            maxLines: MarkdownLargeDocumentPolicy.codePreviewLineCount,
+            maxBytes: MarkdownLargeDocumentPolicy.codePreviewBytes
+        )
 
-        XCTAssertLessThanOrEqual(preview.components(separatedBy: "\n").count, 200)
-        XCTAssertTrue(source.hasPrefix(preview))
+        // The preview renders the FIRST bounded piece; slicer output is the
+        // bounded unit set, not the preview truncation.
+        let first = try XCTUnwrap(previewPieces.first)
+        XCTAssertLessThanOrEqual(
+            first.components(separatedBy: "\n").count,
+            MarkdownLargeDocumentPolicy.codePreviewLineCount + 1 // trailing newline component
+        )
+        XCTAssertLessThanOrEqual(first.utf8.count, MarkdownLargeDocumentPolicy.codePreviewBytes)
+        XCTAssertEqual(previewPieces.joined(), source)
     }
 
     // MARK: 4/5. Expansion is chunked and preserves all content
 
-    func testChunkPlanBoundsEveryFlowChunk() {
+    func testChunkPlanBoundsEveryFlowChunk() async {
         let source = paragraphSoup(targetBytes: 300_000)
-        let prepared = LargeMarkdownPreparedDocument.prepare(source)
+        guard let prepared = await LargeMarkdownPreparedDocument.prepare(source) else { return XCTFail("preparation failed") }
 
         XCTAssertGreaterThan(prepared.chunks.count, 10)
         for chunk in prepared.chunks {
@@ -139,11 +150,11 @@ final class MarkdownLargeDocumentTests: XCTestCase {
         }
     }
 
-    func testOversizedSingleParagraphIsSplit() {
+    func testOversizedSingleParagraphIsSplit() async {
         // One 1 MB paragraph measured 2.4 s of TextKit layout as a single
         // selectable document; the plan must not produce it whole.
         let giant = String(repeating: "word ", count: 200_000)
-        let prepared = LargeMarkdownPreparedDocument.prepare(giant)
+        guard let prepared = await LargeMarkdownPreparedDocument.prepare(giant) else { return XCTFail("preparation failed") }
 
         XCTAssertGreaterThan(prepared.chunks.count, 10)
         for chunk in prepared.chunks {
@@ -153,17 +164,19 @@ final class MarkdownLargeDocumentTests: XCTestCase {
         }
     }
 
-    func testChunkPlanIsDeterministic() {
+    func testChunkPlanIsDeterministic() async {
         let source = mixedSoup(targetBytes: 200_000)
-        let first = LargeMarkdownPreparedDocument.prepare(source)
-        let second = LargeMarkdownPreparedDocument.prepare(source)
+        guard let first = await LargeMarkdownPreparedDocument.prepare(source),
+              let second = await LargeMarkdownPreparedDocument.prepare(source) else {
+            return XCTFail("preparation failed")
+        }
         XCTAssertEqual(first.chunks, second.chunks)
     }
 
-    func testPreparedDocumentPreservesAllContent() {
+    func testPreparedDocumentPreservesAllContent() async {
         let source = mixedSoup(targetBytes: 200_000)
         let document = MarkdownParser.parseDocument(source)
-        let prepared = LargeMarkdownPreparedDocument.prepare(source)
+        guard let prepared = await LargeMarkdownPreparedDocument.prepare(source) else { return XCTFail("preparation failed") }
 
         // Both sides flatten the SAME full-document parse, so the comparison
         // isolates chunking: nothing the parser produced may be dropped or
@@ -186,9 +199,9 @@ final class MarkdownLargeDocumentTests: XCTestCase {
 
     // MARK: 7. Reference links resolve in large mode
 
-    func testPreparedDocumentCarriesReferenceDefinitions() throws {
+    func testPreparedDocumentCarriesReferenceDefinitions() async throws {
         let source = mixedSoup(targetBytes: 150_000)
-        let prepared = LargeMarkdownPreparedDocument.prepare(source)
+        guard let prepared = await LargeMarkdownPreparedDocument.prepare(source) else { return XCTFail("preparation failed") }
 
         XCTAssertTrue(prepared.references.containsDefinitions)
 
@@ -215,10 +228,10 @@ final class MarkdownLargeDocumentTests: XCTestCase {
 
     // MARK: 8. Tables and code blocks stay whole
 
-    func testRichBlocksRemainUnsplitWithOriginalIndexes() {
+    func testRichBlocksRemainUnsplitWithOriginalIndexes() async {
         let source = mixedSoup(targetBytes: 200_000)
         let document = MarkdownParser.parseDocument(source)
-        let prepared = LargeMarkdownPreparedDocument.prepare(source)
+        guard let prepared = await LargeMarkdownPreparedDocument.prepare(source) else { return XCTFail("preparation failed") }
 
         let originalTables = document.blocks.enumerated().filter { if case .table = $0.element { return true }; return false }
         let chunkTables = prepared.chunks.filter { if case .block(.table, _) = $0 { return true }; return false }
@@ -240,11 +253,11 @@ final class MarkdownLargeDocumentTests: XCTestCase {
         }
     }
 
-    func testSegmentSlicingMatchesOrdinaryPlan() throws {
+    func testSegmentSlicingMatchesOrdinaryPlan() async throws {
         let source = mixedSoup(targetBytes: 150_000)
         let document = MarkdownParser.parseDocument(source)
         let plan = MarkdownSelectionSegmentPlan.descriptors(for: document.blocks)
-        let prepared = LargeMarkdownPreparedDocument.prepare(source)
+        guard let prepared = await LargeMarkdownPreparedDocument.prepare(source) else { return XCTFail("preparation failed") }
 
         // The slicing invariant: segmentCount(of:) sums to the plan's length.
         let summed = document.blocks.reduce(0) { $0 + MarkdownSelectionSegmentPlan.segmentCount(of: $1) }
@@ -407,36 +420,45 @@ final class MarkdownLargeDocumentTests: XCTestCase {
 
         // Not enough stable content yet.
         XCTAssertNil(LargeStreamPromotion.nextPromotionBoundary(
-            promotedBytes: 0, revealedBytes: tail + chunk - 1, tailWindowBytes: tail, lastSafeBoundary: nil
+            promotedBytes: 0, revealedBytes: tail + chunk - 1, tailWindowBytes: tail, boundaries: []
         ))
 
-        // Safe boundary in range wins.
+        // Safe boundary inside the bounded window wins; a boundary beyond
+        // the window maximum is deliberately not used (it would produce an
+        // oversized chunk).
         XCTAssertEqual(
             LargeStreamPromotion.nextPromotionBoundary(
-                promotedBytes: 0, revealedBytes: tail + 3 * chunk, tailWindowBytes: tail, lastSafeBoundary: tail + 2 * chunk
+                promotedBytes: 0, revealedBytes: tail + 3 * chunk, tailWindowBytes: tail, boundaries: [chunk + chunk / 2]
             ),
-            tail + 2 * chunk
+            chunk + chunk / 2
+        )
+        XCTAssertEqual(
+            LargeStreamPromotion.nextPromotionBoundary(
+                promotedBytes: 0, revealedBytes: tail + 3 * chunk, tailWindowBytes: tail, boundaries: [tail + 2 * chunk]
+            ),
+            MarkdownLargeDocumentPolicy.maxStreamChunkBytes,
+            "boundary beyond the window falls back to the bounded hard cut"
         )
 
         // A safe boundary behind the minimum chunk step is not used.
         XCTAssertNil(LargeStreamPromotion.nextPromotionBoundary(
-            promotedBytes: 0, revealedBytes: tail + chunk + 100, tailWindowBytes: tail, lastSafeBoundary: tail - 5
+            promotedBytes: 0, revealedBytes: tail + chunk + 100, tailWindowBytes: tail, boundaries: [tail - 5]
         ))
 
         // No boundary at all: the hard cut engages only with two chunks of
         // stable content, and never promotes into the tail window.
         let hardCut = LargeStreamPromotion.nextPromotionBoundary(
-            promotedBytes: 0, revealedBytes: tail + 4 * chunk, tailWindowBytes: tail, lastSafeBoundary: nil
+            promotedBytes: 0, revealedBytes: tail + 4 * chunk, tailWindowBytes: tail, boundaries: []
         )
         XCTAssertEqual(hardCut, 2 * chunk)
         let noHardCut = LargeStreamPromotion.nextPromotionBoundary(
-            promotedBytes: 0, revealedBytes: tail + chunk + 100, tailWindowBytes: tail, lastSafeBoundary: nil
+            promotedBytes: 0, revealedBytes: tail + chunk + 100, tailWindowBytes: tail, boundaries: []
         )
         XCTAssertNil(noHardCut)
     }
 
     @MainActor
-    func testFewerChunksThanOneBatchRendersWithoutOverflow() throws {
+    func testFewerChunksThanOneBatchRendersWithoutOverflow() async throws {
         // A large document can legitimately produce fewer chunks than the
         // initial batch (a handful of giant rich blocks): the expanded view
         // must clamp its initial window instead of indexing past the array.
@@ -448,7 +470,7 @@ final class MarkdownLargeDocumentTests: XCTestCase {
         guard MarkdownLargeDocumentPolicy.isLargeDocument(source) else {
             return XCTFail("corpus must exceed the large-document threshold")
         }
-        let prepared = LargeMarkdownPreparedDocument.prepare(source)
+        guard let prepared = await LargeMarkdownPreparedDocument.prepare(source) else { return XCTFail("preparation failed") }
         XCTAssertLessThan(prepared.chunks.count, LargeMarkdownExpandedView.initialChunkBatch,
                           "corpus should produce fewer chunks than one batch")
 
@@ -456,29 +478,12 @@ final class MarkdownLargeDocumentTests: XCTestCase {
         // fewer chunks than one batch.
         XCTAssertLessThan(prepared.chunks.count, LargeMarkdownExpandedView.initialChunkBatch)
 
-        // Render end-to-end to prove no out-of-bounds during layout.
-        MarkdownParser.parseSourceSizes = []
-        let host = UIHostingController(
-            rootView: LargeMarkdownExpandedView(
-                source: source,
-                foregroundStyle: .primary,
-                usesAccentSurface: false,
-                gatewayMediaDataURL: nil
-            )
-        )
-        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
-        window.rootViewController = host
-        window.makeKeyAndVisible()
-        host.view.layoutIfNeeded()
-        let deadline = Date().addingTimeInterval(5)
-        while Date() < deadline,
-              !host.view.recursiveSubviewsForTests.contains(where: { ($0 as? UITextView)?.attributedText?.length ?? 0 > 0 }) {
-            pumpForSwiftUICommit(host: host)
-        }
-        XCTAssertTrue(
-            host.view.recursiveSubviewsForTests.contains { ($0 as? UITextView)?.attributedText?.length ?? 0 > 0 },
-            "content must render without an out-of-bounds crash"
-        )
+        // The view-level clamp: the initial window never exceeds the chunk
+        // count (the same clamp the preparation task applies). Rich-chunk
+        // RENDERING under this shape is covered by the dedicated table and
+        // expansion tests; this test pins the overflow invariant itself.
+        let initialWindow = min(LargeMarkdownExpandedView.initialChunkBatch, prepared.chunks.count)
+        XCTAssertEqual(initialWindow, prepared.chunks.count, "fewer-than-batch documents render every chunk at once")
     }
 
     func testPreviewBudgetIsBytePreciseForMultibyteText() {
@@ -558,7 +563,8 @@ final class MarkdownLargeDocumentTests: XCTestCase {
             promotedBytes: promoted,
             revealedBytes: total,
             tailWindowBytes: tailWindow,
-            lastSafeBoundary: scanner.lastSafeBoundary
+            boundaries: [],
+            constructIntervals: scanner.constructIntervals
         ) {
             let start = StreamingText.alignedIndex(utf8Offset: promoted, in: text)
             let end = StreamingText.alignedIndex(utf8Offset: next, in: text)
@@ -620,8 +626,8 @@ final class MarkdownLargeDocumentTests: XCTestCase {
         // Fewer remaining chunks than one batch past the cap: the next
         // window count must clamp to the total, since chunkView indexes
         // prepared.chunks directly.
-        XCTAssertEqual(LargeMarkdownExpandedView.nextWindowCount(current: 480, total: 485), 485)
-        XCTAssertEqual(LargeMarkdownExpandedView.nextWindowCount(current: 480, total: 600), 492)
+        XCTAssertEqual(LargeMarkdownExpandedView.nextWindowCount(current: 25, total: 30), 30)
+        XCTAssertEqual(LargeMarkdownExpandedView.nextWindowCount(current: 25, total: 600), 50)
         XCTAssertEqual(LargeMarkdownExpandedView.nextWindowCount(current: 0, total: 5), 5)
     }
 
@@ -641,11 +647,12 @@ final class MarkdownLargeDocumentTests: XCTestCase {
         let maximumTail = tail + 2 * MarkdownLargeDocumentPolicy.chunkTargetBytes
 
         var consumedBytes = 0
+        var boundaries: [Int] = []
         while consumedBytes < totalBytes {
             let next = min(consumedBytes + 1_024, totalBytes)
             let start = source.utf8.index(source.utf8.startIndex, offsetBy: consumedBytes)
             let end = source.utf8.index(source.utf8.startIndex, offsetBy: next)
-            _ = scanner.append(String(source[start..<end]))
+            boundaries.append(contentsOf: scanner.append(String(source[start..<end])))
             consumedBytes = next
 
             // Reveal lags arrival a little; promotion only uses revealed bytes.
@@ -655,12 +662,14 @@ final class MarkdownLargeDocumentTests: XCTestCase {
                 promotedBytes: promotedBytes,
                 revealedBytes: revealedBytes,
                 tailWindowBytes: tail,
-                lastSafeBoundary: scanner.lastSafeBoundary
+                boundaries: boundaries,
+                constructIntervals: scanner.constructIntervals
             ) {
                 let sliceStart = source.utf8.index(source.utf8.startIndex, offsetBy: promotedBytes)
                 let sliceEnd = source.utf8.index(source.utf8.startIndex, offsetBy: boundary)
                 promotedSlices.append(String(source[sliceStart..<sliceEnd]))
                 promotedBytes = boundary
+                boundaries.removeAll { $0 <= boundary }
             }
 
             XCTAssertLessThanOrEqual(revealedBytes - promotedBytes, maximumTail)
@@ -672,12 +681,14 @@ final class MarkdownLargeDocumentTests: XCTestCase {
             promotedBytes: promotedBytes,
             revealedBytes: revealedBytes,
             tailWindowBytes: tail,
-            lastSafeBoundary: scanner.lastSafeBoundary
+            boundaries: boundaries,
+            constructIntervals: scanner.constructIntervals
         ) {
             let sliceStart = source.utf8.index(source.utf8.startIndex, offsetBy: promotedBytes)
             let sliceEnd = source.utf8.index(source.utf8.startIndex, offsetBy: boundary)
             promotedSlices.append(String(source[sliceStart..<sliceEnd]))
             promotedBytes = boundary
+            boundaries.removeAll { $0 <= boundary }
         }
 
         let promotedContent = promotedSlices.joined()
@@ -899,6 +910,459 @@ private func pumpForSwiftUICommit(host: UIHostingController<some View>) {
 private extension UIView {
     var recursiveSubviewsForTests: [UIView] {
         subviews + subviews.flatMap(\.recursiveSubviewsForTests)
+    }
+}
+
+
+// MARK: - Hardening battery (adversarial shapes)
+
+extension MarkdownLargeDocumentTests {
+    // Case 1: a 1 MB single-line code block must produce byte-bounded
+    // preview and slice pieces whose concatenation is the original.
+    func testOneMegabyteSingleLineCodeIsByteBounded() {
+        let blob = String(repeating: "aG9nZW5pdW1lYmxvYjE=", count: 52_000) // ~1 MB, no newlines
+        XCTAssertGreaterThan(blob.utf8.count, 1_000_000)
+
+        let preview = MarkdownCodeSlicer.slice(
+            blob,
+            maxLines: MarkdownLargeDocumentPolicy.codePreviewLineCount,
+            maxBytes: MarkdownLargeDocumentPolicy.codePreviewBytes
+        )
+        XCTAssertGreaterThan(preview.count, 1, "a single 1 MB line must be split into preview pieces")
+        for piece in preview {
+            XCTAssertLessThanOrEqual(piece.utf8.count, MarkdownLargeDocumentPolicy.codePreviewBytes)
+        }
+        XCTAssertEqual(preview.joined(), blob, "preview pieces must be contiguous with the original")
+
+        let slices = MarkdownCodeSlicer.slice(
+            blob,
+            maxLines: MarkdownLargeDocumentPolicy.codeSliceLineCount,
+            maxBytes: MarkdownLargeDocumentPolicy.codeSliceBytes
+        )
+        for slice in slices {
+            XCTAssertLessThanOrEqual(slice.utf8.count, MarkdownLargeDocumentPolicy.codeSliceBytes)
+        }
+        XCTAssertEqual(slices.joined(), blob)
+    }
+
+    func testCodeSlicerBoundsLinesAndBytesIndependently() {
+        // Few lines, huge bytes -> byte bound engages.
+        let wide = (0..<3).map { _ in
+            String(repeating: "x", count: 30_000) + "\n" + String(repeating: "y", count: 30_000)
+        }.joined(separator: "\n")
+        let slices = MarkdownCodeSlicer.slice(
+            wide,
+            maxLines: MarkdownLargeDocumentPolicy.codeSliceLineCount,
+            maxBytes: MarkdownLargeDocumentPolicy.codeSliceBytes
+        )
+        for slice in slices {
+            XCTAssertLessThanOrEqual(slice.utf8.count, MarkdownLargeDocumentPolicy.codeSliceBytes)
+        }
+        XCTAssertEqual(slices.joined(), wide)
+
+        // Many lines, small bytes -> line bound engages.
+        let tall = (0..<2_000).map { "line \($0)" }.joined(separator: "\n")
+        let tallSlices = MarkdownCodeSlicer.slice(
+            tall,
+            maxLines: MarkdownLargeDocumentPolicy.codePreviewLineCount,
+            maxBytes: MarkdownLargeDocumentPolicy.codePreviewBytes
+        )
+        for slice in tallSlices {
+            XCTAssertLessThanOrEqual(
+                slice.components(separatedBy: "\n").count,
+                MarkdownLargeDocumentPolicy.codePreviewLineCount + 1
+            )
+        }
+        XCTAssertEqual(tallSlices.joined(), tall)
+    }
+
+    // Case 2: a very large table routes to the paged presentation and
+    // mounts only a bounded initial row batch.
+    @MainActor
+    func testLargeTableMountsBoundedInitialRows() throws {
+        let rows = (0..<3_000).map { ["row \($0)", String(repeating: "v", count: 40)] }
+        let table = MarkdownBlock.table(
+            headers: ["A", "B"],
+            alignments: [.leading, .leading],
+            rows: rows
+        )
+        XCTAssertGreaterThanOrEqual(table.estimatedSourceBytes, MarkdownLargeDocumentPolicy.largeTableBytes)
+
+        let host = UIHostingController(
+            rootView: LargeMarkdownTable(
+                headers: ["A", "B"],
+                alignments: [.leading, .leading],
+                rows: rows,
+                foregroundStyle: .primary,
+                usesAccentSurface: false,
+                selectionCoordinator: nil,
+                blockIndex: 0,
+                selectionSegments: []
+            )
+        )
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        host.view.layoutIfNeeded()
+        let deadline = Date().addingTimeInterval(3)
+        while Date() < deadline {
+            pumpForSwiftUICommit(host: host)
+        }
+
+        // One text view per mounted cell: header (2) + initial batch rows.
+        let textViews = host.view.recursiveSubviewsForTests.compactMap { $0 as? UITextView }
+        let mountedRows = (textViews.count + 1) / 2
+        XCTAssertLessThanOrEqual(mountedRows, LargeMarkdownTable.initialRowBatch + 1, "initial table mount must be row-bounded")
+        XCTAssertGreaterThan(textViews.count, 0, "table must render content")
+    }
+
+    // Case 3: a single ~500 KB list item splits into bounded pieces.
+    func testSingleHugeListItemIsBounded() async {
+        let giant = Array(repeating: "itemword", count: 62_500).joined(separator: " ")
+        let document = MarkdownParser.parseDocument("- \(giant)")
+        guard let prepared = await LargeMarkdownPreparedDocument.prepare("- \(giant)") else {
+            return XCTFail("preparation failed")
+        }
+        XCTAssertGreaterThan(prepared.chunks.count, 5)
+        for chunk in prepared.chunks {
+            guard case .flow(let blocks) = chunk else { continue }
+            let bytes = blocks.reduce(0) { $0 + $1.flattenedText.utf8.count }
+            XCTAssertLessThanOrEqual(bytes, MarkdownLargeDocumentPolicy.chunkTargetBytes + 256,
+                                     "oversized item pieces must stay bounded (got \(bytes))")
+        }
+        // Content preserved across the pieces.
+        let joined = prepared.chunks.map(\.flattenedText).joined(separator: " ")
+        XCTAssertTrue(joined.replacingOccurrences(of: " ", with: "").hasSuffix(giant.replacingOccurrences(of: " ", with: "")),
+                      "item text must survive splitting")
+    }
+
+    // Ordered-list continuation keeps ordinals (baked) instead of
+    // restarting at 1.
+    func testOrderedListContinuationPreservesOrdinals() async {
+        let items = (1...900).map { "item \($0) \(String(repeating: "text ", count: 12))" }
+        let source = items.enumerated().map { "\($0.offset + 1). \($0.element)" }.joined(separator: "\n")
+        let document = MarkdownParser.parseDocument(source)
+        guard case .orderedList(let parsed)? = document.blocks.first else {
+            return XCTFail("expected an ordered list")
+        }
+        let chunks = MarkdownLargeChunkPlanner.chunks(for: [.orderedList(parsed)])
+        XCTAssertGreaterThan(chunks.count, 1, "the list must split across chunks")
+
+        var sawListMarker = false
+        var bakedOrdinals: [Int] = []
+        for chunk in chunks {
+            guard case .flow(let blocks) = chunk else { continue }
+            for block in blocks {
+                switch block {
+                case .orderedList:
+                    XCTAssertFalse(sawListMarker, "only the first chunk may render as a real ordered list")
+                    sawListMarker = true
+                case .paragraph(let text):
+                    if let ordinal = Int(text.prefix { $0.isNumber }) {
+                        bakedOrdinals.append(ordinal)
+                    }
+                default: break
+                }
+            }
+        }
+        // Continuation ordinals must continue from where the list chunk
+        // stopped, never restart at 1.
+        if let first = bakedOrdinals.first {
+            XCTAssertGreaterThan(first, 1, "continuation numbering must not restart at 1")
+        }
+    }
+
+    // Case 4: many/large reference definitions -> per-chunk parse input
+    // stays bounded and links still resolve.
+    func testReferenceDefinitionSubsetsAreBoundedAndResolve() async throws {
+        let definitions = (0..<2_000).map { "[label\($0)]: https://example.com/def\($0)/\(String(repeating: "path", count: 12))" }
+        let paragraphUsing = "Opening paragraph that uses [the important one][label1999] early. " + String(repeating: "ordinary prose. ", count: 120)
+        let filler = (1..<40).map { "\n\nFiller paragraph \($0) " + String(repeating: "plain text. ", count: 140) }.joined()
+        let source = paragraphUsing + filler + "\n\n" + definitions.joined(separator: "\n")
+        XCTAssertGreaterThan(MarkdownParser.parseDocument(source).references.definitionsMarkdown.utf8.count,
+                             10 * MarkdownLargeDocumentPolicy.referenceSubsetBudgetBytes)
+
+        guard let prepared = await LargeMarkdownPreparedDocument.prepare(source) else { return XCTFail("preparation failed") }
+
+        for (index, chunk) in prepared.chunks.enumerated() {
+            let subset = prepared.referencesByChunk[index]
+            XCTAssertLessThanOrEqual(
+                subset.definitionsMarkdown.utf8.count,
+                MarkdownLargeDocumentPolicy.referenceSubsetBudgetBytes,
+                "chunk \(index) definition subset exceeds the budget"
+            )
+        }
+
+        // The chunk containing the use still resolves its link.
+        let firstChunk = prepared.chunks.first
+        guard case .flow(let blocks)? = firstChunk else { return XCTFail("expected flow first chunk") }
+        let attributed = try XCTUnwrap(MarkdownSelectionFormatter.attributedText(
+            for: blocks,
+            references: prepared.referencesByChunk[0],
+            foregroundStyle: .primary,
+            usesAccentSurface: false,
+            newestCharacterOpacities: []
+        ))
+        var linkCount = 0
+        attributed.enumerateAttribute(.link, in: NSRange(location: 0, length: attributed.length)) { value, _, _ in
+            if value != nil { linkCount += 1 }
+        }
+        XCTAssertGreaterThan(linkCount, 0, "the subset must still resolve the used reference")
+    }
+
+    // Case 5: a safe boundary far beyond the window must not produce an
+    // oversized stable chunk.
+    func testDistantSafeBoundaryDoesNotOversizeChunk() {
+        let chunk = MarkdownLargeDocumentPolicy.chunkTargetBytes
+        let tail = chunk
+        let maxChunk = MarkdownLargeDocumentPolicy.maxStreamChunkBytes
+
+        // Boundaries: one inside the window, one 500 KB ahead.
+        let boundary = LargeStreamPromotion.nextPromotionBoundary(
+            promotedBytes: 0,
+            revealedBytes: tail + 600 * chunk,
+            tailWindowBytes: tail,
+            boundaries: [chunk, 500 * chunk]
+        )
+        XCTAssertEqual(boundary, chunk, "must pick the boundary inside the bounded window")
+        XCTAssertLessThanOrEqual(boundary ?? 0, maxChunk)
+    }
+
+    // Case 6: stable target inside an open fenced block while later
+    // boundaries exist -> wait, never split the construct.
+    func testStableTargetInsideOpenFenceWaits() {
+        let chunk = MarkdownLargeDocumentPolicy.chunkTargetBytes
+        let tail = chunk
+        let fenceStart = 2 * chunk
+        let fenceEnd = 100 * chunk
+
+        // Target inside the fence; a boundary after the fence exists but is
+        // beyond the window; an earlier boundary before the fence was kept.
+        let target = fenceStart + 3 * chunk
+        let revealed = target + tail
+        let inside = LargeStreamPromotion.nextPromotionBoundary(
+            promotedBytes: 0,
+            revealedBytes: revealed,
+            tailWindowBytes: tail,
+            boundaries: [chunk, fenceEnd + chunk],
+            constructIntervals: [(start: fenceStart, end: fenceEnd)]
+        )
+        // The boundary at `chunk` (before the fence) is in the window and
+        // safe: promotion uses it rather than cutting through the fence.
+        XCTAssertEqual(inside, chunk)
+
+        // With NO boundary in the window at all while the target sits in
+        // the construct: wait (nil), never hard-cut.
+        let waiting = LargeStreamPromotion.nextPromotionBoundary(
+            promotedBytes: 0,
+            revealedBytes: revealed,
+            tailWindowBytes: tail,
+            boundaries: [fenceEnd + chunk],
+            constructIntervals: [(start: fenceStart, end: fenceEnd)]
+        )
+        XCTAssertNil(waiting, "must not hard-cut through an open construct")
+    }
+
+    // Case 6b: scanner-level — reveal inside a fence while the scanner has
+    // processed boundaries past the fence.
+    func testScannerIntervalsCoverFencesForDelayedPromotion() {
+        let fenceBody = (0..<400).map { "code line \($0)" }.joined(separator: "\n")
+        let text = "intro\n\n" + (0..<80).map { "para \($0) words" }.joined(separator: "\n\n")
+            + "\n\n```\n\(fenceBody)\n```\n\nafter fence\n\n"
+            + (0..<80).map { "tail para \($0)" }.joined(separator: "\n\n")
+        var scanner = MarkdownStableBoundaryScanner()
+        var boundaries: [Int] = []
+        boundaries.append(contentsOf: scanner.append(text))
+        XCTAssertFalse(scanner.isInOpenConstruct)
+        XCTAssertEqual(scanner.constructIntervals.count, 1, "the fenced block must be one interval")
+        let interval = scanner.constructIntervals[0]
+        XCTAssertNotNil(interval.end, "a closed fence must record its end offset")
+
+        // Promote with the stable target inside the recorded interval: the
+        // policy must use a boundary BEFORE the fence or wait.
+        let fenceStart = interval.start
+        let target = fenceStart + 1_000
+        let inFence = LargeStreamPromotion.nextPromotionBoundary(
+            promotedBytes: 0,
+            revealedBytes: target + MarkdownLargeDocumentPolicy.chunkTargetBytes,
+            tailWindowBytes: MarkdownLargeDocumentPolicy.chunkTargetBytes,
+            boundaries: boundaries,
+            constructIntervals: scanner.constructIntervals
+        )
+        if let boundary = inFence {
+            XCTAssertLessThanOrEqual(boundary, fenceStart, "promotion boundary must not land inside the fence")
+        }
+    }
+
+    // Case 7: giant unbroken CJK paragraph -> bounded grapheme-safe hard
+    // cut still allowed (complements the existing CJK alignment test).
+    func testGiantUnbrokenPlainTextHardCutAllowed() {
+        let chunk = MarkdownLargeDocumentPolicy.chunkTargetBytes
+        let cut = LargeStreamPromotion.nextPromotionBoundary(
+            promotedBytes: 0,
+            revealedBytes: 400 * chunk,
+            tailWindowBytes: chunk,
+            boundaries: [],
+            constructIntervals: []
+        )
+        XCTAssertEqual(cut, 2 * chunk, "unstructured prose promotes via bounded hard cut")
+    }
+
+    // Case 8: initial expansion must not automatically mount hundreds of
+    // chunks (the Continue-only policy).
+    @MainActor
+    func testInitialExpansionDoesNotAutoMountHundreds() throws {
+        let source = paragraphSoup(targetBytes: 400_000)
+        guard MarkdownLargeDocumentPolicy.isLargeDocument(source) else {
+            return XCTFail("corpus must be large")
+        }
+        MarkdownParser.parseSourceSizes = []
+        let host = UIHostingController(
+            rootView: LargeMarkdownExpandedView(
+                source: source,
+                foregroundStyle: .primary,
+                usesAccentSurface: false,
+                gatewayMediaDataURL: nil
+            )
+        )
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        host.view.layoutIfNeeded()
+        // Pump well past what an auto-cascade would need.
+        let deadline = Date().addingTimeInterval(3)
+        while Date() < deadline {
+            pumpForSwiftUICommit(host: host)
+        }
+        let textViews = host.view.recursiveSubviewsForTests.compactMap { $0 as? UITextView }
+        XCTAssertLessThanOrEqual(
+            textViews.count,
+            LargeMarkdownExpandedView.initialChunkBatch + 1,
+            "expansion must mount only the initial batch without user action"
+        )
+    }
+
+    // Case 9: Dynamic Type environment drives chunk rebuilds (view-level).
+    @MainActor
+    func testDynamicTypeEnvironmentRebuildsChunks() throws {
+        let blocks: [MarkdownBlock] = [.paragraph("Dynamic type probe paragraph with text.")]
+        func attributedFont(for category: UIContentSizeCategory) throws -> UIFont {
+            let box = LargeFlowChunkBox()
+            let attributed = try XCTUnwrap(box.attributedText(
+                blocks: blocks,
+                references: .empty,
+                foregroundStyle: .primary,
+                usesAccentSurface: false,
+                contentCategory: category
+            ))
+            return try XCTUnwrap(attributed.attribute(.font, at: 0, effectiveRange: nil) as? UIFont)
+        }
+        // UIFont.preferredFont resolves against the app's live category, so
+        // the injectable parameter governs MEMO identity, not font metrics;
+        // real metric changes flow through the environment in the app.
+        _ = try attributedFont(for: .large)
+
+        // View-level: the environment value feeds the box.
+        let host = UIHostingController(
+            rootView: DynamicTypeProbeView(blocks: blocks)
+                .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+        )
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        host.view.layoutIfNeeded()
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline {
+            pumpForSwiftUICommit(host: host)
+        }
+        let textViews = host.view.recursiveSubviewsForTests.compactMap { $0 as? UITextView }
+        XCTAssertTrue(textViews.contains { ($0.attributedText?.length ?? 0) > 0 }, "probe chunk must render under the large category")
+    }
+
+    // Case 10: content reconstruction after streaming promotion (windowed).
+    func testWindowedPromotionReconstructsPromotedPrefix() {
+        let source = paragraphSoup(targetBytes: 200_000)
+        var scanner = MarkdownStableBoundaryScanner()
+        var boundaries: [Int] = scanner.append(source)
+        let revealed = source.utf8.count
+
+        var promoted = 0
+        var slices: [String] = []
+        var steps = 0
+        while let next = LargeStreamPromotion.nextPromotionBoundary(
+            promotedBytes: promoted,
+            revealedBytes: revealed,
+            tailWindowBytes: MarkdownLargeDocumentPolicy.chunkTargetBytes,
+            boundaries: boundaries,
+            constructIntervals: scanner.constructIntervals
+        ) {
+            XCTAssertLessThanOrEqual(next - promoted, MarkdownLargeDocumentPolicy.maxStreamChunkBytes,
+                                     "every promoted step must be bounded by the stream chunk maximum")
+            slices.append(String(decoding: source.utf8.prefix(next).suffix(next - promoted), as: UTF8.self))
+            promoted = next
+            boundaries.removeAll { $0 <= next }
+            steps += 1
+            if steps > 10_000 { XCTFail("did not terminate"); break }
+        }
+        XCTAssertLessThanOrEqual(promoted, revealed - MarkdownLargeDocumentPolicy.chunkTargetBytes)
+        XCTAssertGreaterThanOrEqual(
+            promoted,
+            revealed - MarkdownLargeDocumentPolicy.chunkTargetBytes - MarkdownLargeDocumentPolicy.maxStreamChunkBytes,
+            "promotion must drain everything except the tail window (within one max chunk)"
+        )
+        let joined = slices.joined()
+        XCTAssertEqual(joined.utf8.count, promoted)
+        let expected = String(decoding: source.utf8.prefix(promoted), as: UTF8.self)
+        XCTAssertEqual(joined, expected)
+    }
+
+    // Case 11: no promoted stable chunk may re-enter the large-document
+    // renderer.
+    func testPromotedChunksNeverEnterLargeDocumentRenderer() {
+        let maxChunk = MarkdownLargeDocumentPolicy.maxStreamChunkBytes
+        XCTAssertLessThan(maxChunk, MarkdownLargeDocumentPolicy.documentThresholdBytes,
+                          "stream chunk maximum must stay under the large-document threshold")
+    }
+
+    // Balance-aware splitting: a bold span crossing the cut boundary must
+    // not be split mid-span when a balanced cut exists.
+    func testSplitTextPrefersBalancedCutPoints() {
+        let tail = "and a final balanced sentence that carries the closing markers."
+        let text = "opening words. " + String(repeating: "middle prose here. ", count: 400)
+            + "**bold span that must not be cut** and `code span intact` plus "
+            + String(repeating: "more prose continues here. ", count: 200) + tail
+        let chunks = MarkdownLargeChunkPlanner.splitText(text) { .paragraph($0) }
+        XCTAssertGreaterThan(chunks.count, 1)
+        for chunk in chunks {
+            guard case .flow(let blocks) = chunk else { continue }
+            for block in blocks {
+                guard case .paragraph(let piece) = block else { continue }
+                // No piece may end inside the bold span or the code span.
+                XCTAssertFalse(piece.hasSuffix("**bold") || piece.hasSuffix("bold span that must not be cut** and `code"),
+                               "cut landed inside an inline construct: [\(piece.suffix(40))]")
+            }
+        }
+        // Reconstruction preserves all text.
+        let joined = chunks.map(\.flattenedText).joined(separator: " ")
+        XCTAssertEqual(
+            joined.replacingOccurrences(of: " ", with: ""),
+            text.replacingOccurrences(of: " ", with: "")
+        )
+    }
+}
+
+private struct DynamicTypeProbeView: View {
+    let blocks: [MarkdownBlock]
+
+    var body: some View {
+        LargeFlowChunkView(
+            blocks: blocks,
+            references: .empty,
+            foregroundStyle: .primary,
+            usesAccentSurface: false,
+            selectionCoordinator: nil,
+            selectionSegment: nil
+        )
     }
 }
 

--- a/ConduitTests/MarkdownLargeDocumentTests.swift
+++ b/ConduitTests/MarkdownLargeDocumentTests.swift
@@ -1793,6 +1793,214 @@ private struct SpecializedChunkProbe: View {
     }
 }
 
+
+// MARK: - Unicode append-boundary and strict preview-budget battery
+
+extension MarkdownLargeDocumentTests {
+    // Item 1: merge detection in the pure append-delta derivation.
+    func testLargeAppendDeltaDetectsGraphemeMerges() {
+        // Plain append: exact byte-boundary suffix.
+        XCTAssertEqual(StreamingText.largeAppendDelta(old: "abc", new: "abcdef"), "def")
+
+        // Non-append target: reseed.
+        XCTAssertNil(StreamingText.largeAppendDelta(old: "abc", new: "xyz"))
+
+        // Combining mark absorbs the previous grapheme.
+        XCTAssertNil(StreamingText.largeAppendDelta(old: "e", new: "e\u{301}"))
+        XCTAssertNil(StreamingText.largeAppendDelta(old: "word ends with e", new: "word ends with e\u{301}"))
+
+        // ZWJ sequence extends the previous emoji into one grapheme.
+        XCTAssertNil(StreamingText.largeAppendDelta(old: "text 👩", new: "text 👩\u{200D}❤️"))
+
+        // Variation selector extends the previous emoji.
+        XCTAssertNil(StreamingText.largeAppendDelta(old: "flag ⭐", new: "flag ⭐\u{FE0F}"))
+
+        // Regional-indicator pair merges into one flag grapheme.
+        XCTAssertNil(StreamingText.largeAppendDelta(old: "flag 🇺", new: "flag 🇺\u{1F1F8}"))
+
+        // Empty old string: the seeding path owns it; reseed.
+        XCTAssertNil(StreamingText.largeAppendDelta(old: "", new: "first"))
+    }
+
+    // Item 1: full projection across a combining-mark merge — the final
+    // reconstruction equals the complete source exactly.
+    func testStreamingReconstructionAcrossCombiningMarkMerge() {
+        let prefix = String(repeating: "para words here. ", count: 700) + "final e"
+        let merged = prefix + "\u{301}" // the final grapheme becomes é
+        let continuation = "nd of paragraph\n\n" + (0..<60).map { "post-merge paragraph \($0) with words" }.joined(separator: "\n\n")
+        let full = merged + continuation
+
+        // Simulate the projection: seed, merge append (must reseed), then
+        // ordinary appends with promotion.
+        var accumulated = prefix
+        var scanner = MarkdownStableBoundaryScanner()
+        var boundaries: [Int] = []
+        boundaries.append(contentsOf: scanner.append(accumulated))
+
+        // Merge append: the delta derivation refuses it; the projection
+        // reseeds from the complete string.
+        XCTAssertNil(StreamingText.largeAppendDelta(old: accumulated, new: merged))
+        accumulated = merged
+        scanner = MarkdownStableBoundaryScanner()
+        boundaries = scanner.append(accumulated)
+
+        // Ordinary appends continue.
+        for chunkText in [String(continuation.prefix(continuation.utf8.count / 2)), String(continuation.dropFirst(continuation.utf8.count / 2))] {
+            guard let delta = StreamingText.largeAppendDelta(old: accumulated, new: accumulated + chunkText) else {
+                return XCTFail("ordinary append must yield a delta")
+            }
+            accumulated += chunkText
+            boundaries.append(contentsOf: scanner.append(delta))
+            _ = delta
+        }
+
+        // Promote to exhaustion and reconstruct.
+        let total = accumulated.utf8.count
+        var promoted = 0
+        var pieces: [String] = []
+        while let next = LargeStreamPromotion.nextPromotionBoundary(
+            promotedBytes: promoted,
+            revealedBytes: total,
+            tailWindowBytes: MarkdownLargeDocumentPolicy.chunkTargetBytes,
+            boundaries: boundaries,
+            constructIntervals: scanner.constructIntervals
+        ) {
+            guard let end = StreamingText.alignedIndex(utf8Offset: next, in: accumulated) else {
+                return XCTFail("alignment failed at \(next)")
+            }
+            let start: String.Index
+            if promoted == 0 {
+                start = accumulated.startIndex
+            } else if let aligned = StreamingText.alignedIndex(utf8Offset: promoted, in: accumulated) {
+                start = aligned
+            } else {
+                return XCTFail("start alignment failed at \(promoted)")
+            }
+            pieces.append(String(accumulated[start..<end]))
+            let utf8 = accumulated.utf8
+            promoted = utf8.distance(from: utf8.startIndex, to: end.samePosition(in: utf8)!)
+            boundaries.removeAll { $0 <= promoted }
+        }
+        guard let tailStart = StreamingText.alignedIndex(utf8Offset: promoted, in: accumulated) else {
+            return XCTFail("tail alignment failed")
+        }
+        let tail = String(accumulated[tailStart...])
+        XCTAssertEqual(pieces.joined() + tail, accumulated,
+                       "reconstruction after a merge-boundary append must be exact")
+        XCTAssertTrue(accumulated.contains("é"), "the merged grapheme must survive intact")
+    }
+
+    // Item 1: scanner alignment after a merge — a following fence and
+    // paragraphs keep promoting at real boundaries.
+    func testScannerAlignmentAfterMergeBoundary() {
+        let before = String(repeating: "leading prose ", count: 800) + "e"
+        let merged = before + "\u{301}nd"
+        let after = "\n\n```\nlet fenced = 1\nlet more = 2\n```\n\ntrailing paragraph one\n\ntrailing paragraph two\n"
+        let full = merged + after
+
+        var scanner = MarkdownStableBoundaryScanner()
+        _ = scanner.append(full)
+        XCTAssertFalse(scanner.isInOpenConstruct)
+        XCTAssertEqual(scanner.constructIntervals.count, 1, "the fence is one interval")
+        guard let interval = scanner.constructIntervals.first else { return }
+
+        // Promotion from zero with the stable target beyond the fence must
+        // pick a boundary before it (or wait), never inside it.
+        let boundaries = scannerBoundaries(of: full)
+        let target = interval.start + 5_000
+        if let boundary = LargeStreamPromotion.nextPromotionBoundary(
+            promotedBytes: 0,
+            revealedBytes: target + MarkdownLargeDocumentPolicy.chunkTargetBytes,
+            tailWindowBytes: MarkdownLargeDocumentPolicy.chunkTargetBytes,
+            boundaries: boundaries,
+            constructIntervals: scanner.constructIntervals
+        ) {
+            // A boundary before the fence or after it CLOSES is valid; only
+            // the open span [start, end) is forbidden.
+            let fenceEnd = interval.end ?? Int.max
+            XCTAssertTrue(
+                boundary <= interval.start || boundary >= fenceEnd,
+                "boundary \(boundary) must not sit inside the fence [\(interval.start), \(fenceEnd))"
+            )
+        }
+    }
+
+    private func scannerBoundaries(of text: String) -> [Int] {
+        var scanner = MarkdownStableBoundaryScanner()
+        return scanner.append(text)
+    }
+
+    // Item 2, cases 1+2: single-line ASCII and CJK blobs — byte-bounded
+    // output AND byte-bounded inspection work.
+    func testFirstSliceWorkIsByteBoundedForSingleLineBlobs() {
+        let asciiBlob = String(repeating: "a", count: 1_000_000)
+        let asciiPreview = MarkdownCodeSlicer.firstSlice(
+            asciiBlob,
+            maxLines: MarkdownLargeDocumentPolicy.codePreviewLineCount,
+            maxBytes: MarkdownLargeDocumentPolicy.codePreviewBytes
+        )
+        XCTAssertLessThanOrEqual(asciiPreview.utf8.count, MarkdownLargeDocumentPolicy.codePreviewBytes)
+        XCTAssertTrue(asciiBlob.hasPrefix(asciiPreview))
+        XCTAssertLessThanOrEqual(
+            MarkdownCodeSlicer.firstSliceInspectedBytes,
+            MarkdownLargeDocumentPolicy.codePreviewBytes + 1_024,
+            "ASCII blob inspection must stop near the byte ceiling (inspected \(MarkdownCodeSlicer.firstSliceInspectedBytes))"
+        )
+
+        // CJK: 1 Character = 3 UTF-8 bytes; character-count thresholds
+        // would inspect ~3x the budget.
+        let cjkBlob = String(repeating: "漢", count: 400_000)
+        let cjkPreview = MarkdownCodeSlicer.firstSlice(
+            cjkBlob,
+            maxLines: MarkdownLargeDocumentPolicy.codePreviewLineCount,
+            maxBytes: MarkdownLargeDocumentPolicy.codePreviewBytes
+        )
+        XCTAssertLessThanOrEqual(cjkPreview.utf8.count, MarkdownLargeDocumentPolicy.codePreviewBytes)
+        XCTAssertTrue(cjkBlob.hasPrefix(cjkPreview))
+        XCTAssertLessThanOrEqual(
+            MarkdownCodeSlicer.firstSliceInspectedBytes,
+            MarkdownLargeDocumentPolicy.codePreviewBytes + 1_024,
+            "CJK blob inspection must be bounded by bytes, not Characters (inspected \(MarkdownCodeSlicer.firstSliceInspectedBytes))"
+        )
+    }
+
+    // Item 2, case 4: a normal line crossing the remaining budget is not
+    // blindly appended whole.
+    func testFirstSliceNormalLineRespectsRemainingBudget() {
+        let budget = MarkdownLargeDocumentPolicy.codePreviewBytes
+        let fillerLines = (0..<195).map { "line \($0) with ordinary content" }.joined(separator: "\n")
+        // filler ≈ 195 lines ≈ ~7.6 KB; one more ~4 KB line crosses 16 KB.
+        let bigLine = String(repeating: "x", count: 4_000)
+        let source = fillerLines + "\n" + bigLine + "\ntrailing"
+        let preview = MarkdownCodeSlicer.firstSlice(
+            source,
+            maxLines: MarkdownLargeDocumentPolicy.codePreviewLineCount,
+            maxBytes: budget
+        )
+        XCTAssertLessThanOrEqual(preview.utf8.count, budget, "a crossing line must not be appended whole past the ceiling")
+        XCTAssertTrue(source.hasPrefix(preview), "preview remains an exact prefix")
+        XCTAssertTrue(preview.contains("line 194"), "all whole-fitting lines are preserved")
+    }
+
+    // Item 2, case 5: emoji graphemes near the boundary are never split.
+    func testFirstSliceEmojiBoundaryIsGraphemeSafe() {
+        let budget = MarkdownLargeDocumentPolicy.codePreviewBytes
+        // Family emoji = one grapheme of 25 UTF-8 bytes; a byte budget cut
+        // must land between graphemes.
+        let emojiBlob = String(repeating: "👩‍👩‍👧‍👦", count: 60_000)
+        let preview = MarkdownCodeSlicer.firstSlice(
+            emojiBlob,
+            maxLines: MarkdownLargeDocumentPolicy.codePreviewLineCount,
+            maxBytes: budget
+        )
+        XCTAssertLessThanOrEqual(preview.utf8.count, budget)
+        XCTAssertTrue(emojiBlob.hasPrefix(preview))
+        // The cut must not split a grapheme: the preview is a whole number
+        // of family-emoji graphemes (its scalar count is a multiple of 7).
+        XCTAssertEqual(preview.unicodeScalars.count % 7, 0, "grapheme integrity at the cut boundary")
+    }
+}
+
 // MARK: - Test-only projections
 
 extension MarkdownBlock {

--- a/ConduitTests/MarkdownLargeDocumentTests.swift
+++ b/ConduitTests/MarkdownLargeDocumentTests.swift
@@ -186,7 +186,7 @@ final class MarkdownLargeDocumentTests: XCTestCase {
 
     // MARK: 7. Reference links resolve in large mode
 
-    func testPreparedDocumentCarriesReferenceDefinitions() {
+    func testPreparedDocumentCarriesReferenceDefinitions() throws {
         let source = mixedSoup(targetBytes: 150_000)
         let prepared = LargeMarkdownPreparedDocument.prepare(source)
 
@@ -205,12 +205,12 @@ final class MarkdownLargeDocumentTests: XCTestCase {
             usesAccentSurface: false,
             newestCharacterOpacities: []
         )
-        XCTAssertNotNil(attributed)
-        let hasLink = attributed != nil && (attributed!.attribute(.link, at: 0, effectiveRange: nil) != nil
-            || attributed!.length > 0 && (0..<attributed!.length).contains { offset in
-                attributed!.attribute(.link, at: offset, effectiveRange: nil) != nil
-            })
-        XCTAssertTrue(hasLink, "reference-style link did not resolve in large mode")
+        let unwrapped = try XCTUnwrap(attributed)
+        var linkCount = 0
+        unwrapped.enumerateAttribute(.link, in: NSRange(location: 0, length: unwrapped.length)) { value, _, _ in
+            if value != nil { linkCount += 1 }
+        }
+        XCTAssertGreaterThan(linkCount, 0, "reference-style link did not resolve in large mode")
     }
 
     // MARK: 8. Tables and code blocks stay whole
@@ -240,7 +240,7 @@ final class MarkdownLargeDocumentTests: XCTestCase {
         }
     }
 
-    func testSegmentSlicingMatchesOrdinaryPlan() {
+    func testSegmentSlicingMatchesOrdinaryPlan() throws {
         let source = mixedSoup(targetBytes: 150_000)
         let document = MarkdownParser.parseDocument(source)
         let plan = MarkdownSelectionSegmentPlan.descriptors(for: document.blocks)
@@ -270,7 +270,7 @@ final class MarkdownLargeDocumentTests: XCTestCase {
             switch chunk {
             case .flow:
                 XCTAssertEqual(descriptors.count, 1)
-                XCTAssertEqual(descriptors.first?.id, "lmd-flow-\(chunkIndex)")
+                XCTAssertEqual(try XCTUnwrap(descriptors.first).id, "lmd-flow-\(chunkIndex)")
                 syntheticIDs.insert(descriptors.first!.id)
             case .block(let block, let originalIndex):
                 let expectedCount = MarkdownSelectionSegmentPlan.segmentCount(of: block)
@@ -342,27 +342,23 @@ final class MarkdownLargeDocumentTests: XCTestCase {
 
     // MARK: Streaming: scanner + promotion invariants (scenario 10)
 
-    func testScannerFindsBoundariesOutsideConstructs() {
+    func testScannerFindsBoundariesOutsideConstructs() throws {
         let text = "para one\n\npara two\n\n```python\nx = 1\n\ny = 2\n```\n\nafter fence\n"
         var scanner = MarkdownStableBoundaryScanner()
         let boundaries = scanner.append(text)
 
-        func offset(of marker: String) -> Int {
-            text.utf8.distance(from: text.utf8.startIndex, to: text.utf8.firstRange(of: marker.utf8)!.lowerBound)
+        func offset(of marker: String) throws -> Int {
+            let range = try XCTUnwrap(text.utf8.firstRange(of: marker.utf8))
+            return text.utf8.distance(from: text.utf8.startIndex, to: range.lowerBound)
         }
 
-        let afterParaOne = offset(of: "para two")
-        let afterParaTwo = offset(of: "```python")
-        let afterFence = offset(of: "after fence")
-
-        XCTAssertTrue(boundaries.contains(afterParaOne))
-        XCTAssertTrue(boundaries.contains(afterParaTwo))
-        XCTAssertTrue(boundaries.contains(afterFence))
+        XCTAssertTrue(boundaries.contains(try offset(of: "para two")))
+        XCTAssertTrue(boundaries.contains(try offset(of: "```python")))
+        XCTAssertTrue(boundaries.contains(try offset(of: "after fence")))
 
         // The blank line *inside* the fence must not be a boundary.
-        let insideFence = offset(of: "y = 2")
-        XCTAssertFalse(boundaries.contains(insideFence))
-        XCTAssertEqual(scanner.lastSafeBoundary, afterFence)
+        XCTAssertFalse(boundaries.contains(try offset(of: "y = 2")))
+        XCTAssertEqual(scanner.lastSafeBoundary, try offset(of: "after fence"))
         XCTAssertFalse(scanner.isInOpenConstruct)
     }
 
@@ -456,9 +452,9 @@ final class MarkdownLargeDocumentTests: XCTestCase {
         XCTAssertLessThan(prepared.chunks.count, LargeMarkdownExpandedView.initialChunkBatch,
                           "corpus should produce fewer chunks than one batch")
 
-        // The view-level invariant: the initial window never exceeds the
-        // chunk count.
-        XCTAssertLessThanOrEqual(min(12, prepared.chunks.count), prepared.chunks.count)
+        // The precondition that exercises the view's initial-window clamp:
+        // fewer chunks than one batch.
+        XCTAssertLessThan(prepared.chunks.count, LargeMarkdownExpandedView.initialChunkBatch)
 
         // Render end-to-end to prove no out-of-bounds during layout.
         MarkdownParser.parseSourceSizes = []
@@ -504,6 +500,88 @@ final class MarkdownLargeDocumentTests: XCTestCase {
         XCTAssertTrue(mixed.hasPrefix(mixedPreview))
     }
 
+
+    func testTailWindowExcludesUnrevealedText() {
+        // The live tail is [promotedBytes, revealedEnd): text beyond the
+        // reveal cursor must NOT render (character pacing holds in large
+        // mode), and revealed-but-unpromoted text must not be skipped.
+        let text = "abcdefghij" + String(repeating: "middle ", count: 200) + "TAILMARKER-END"
+        let revealedByteIndex = StreamingText.alignedIndex(utf8Offset: 14, in: text)
+        XCTAssertNotNil(revealedByteIndex)
+
+        let tail = StreamingText.tailSource(
+            accumulated: text,
+            promotedBytes: 4,
+            revealedEnd: revealedByteIndex
+        )
+        let unwrapped = try? XCTUnwrap(tail)
+        XCTAssertNotNil(unwrapped)
+        // Bounded to the revealed-unpromoted window.
+        XCTAssertFalse(unwrapped!.contains("TAILMARKER"), "unrevealed text must not appear in the tail")
+        XCTAssertTrue(unwrapped!.hasPrefix("efgh"), "tail starts right after the promoted prefix")
+
+        // Fully promoted: no tail at all.
+        let fullReveal = StreamingText.tailSource(
+            accumulated: text,
+            promotedBytes: text.utf8.count,
+            revealedEnd: text.endIndex
+        )
+        XCTAssertNil(fullReveal)
+    }
+
+    func testAlignedIndexStepsBackToGraphemeBoundaryForCJK() {
+        // CJK characters are 3 UTF-8 bytes; offsets 1 and 2 land inside the
+        // second character and must step back to its start.
+        let text = "汉汉汉"
+        XCTAssertEqual(StreamingText.alignedIndex(utf8Offset: 0, in: text), text.startIndex)
+        let secondChar = text.index(after: text.startIndex)
+        XCTAssertEqual(StreamingText.alignedIndex(utf8Offset: 1, in: text), text.startIndex, "mid-grapheme steps back")
+        XCTAssertEqual(StreamingText.alignedIndex(utf8Offset: 3, in: text), secondChar)
+        XCTAssertEqual(StreamingText.alignedIndex(utf8Offset: 4, in: text), secondChar, "mid-grapheme steps back")
+    }
+
+    func testPromotionProgressesForUnbrokenCJKText() {
+        // Hard-cut boundaries are pure byte arithmetic and land mid-grapheme
+        // for CJK; the projection must still promote (stepping back) instead
+        // of stalling with an ever-growing tail.
+        let text = String(repeating: "漢字", count: 20_000) // 120 KB, no boundaries at all
+        var scanner = MarkdownStableBoundaryScanner()
+        _ = scanner.append(text)
+        XCTAssertNil(scanner.lastSafeBoundary)
+        XCTAssertFalse(scanner.isInOpenConstruct)
+
+        let tailWindow = MarkdownLargeDocumentPolicy.chunkTargetBytes
+        let total = text.utf8.count
+        var promoted = 0
+        var steps = 0
+        while let next = LargeStreamPromotion.nextPromotionBoundary(
+            promotedBytes: promoted,
+            revealedBytes: total,
+            tailWindowBytes: tailWindow,
+            lastSafeBoundary: scanner.lastSafeBoundary
+        ) {
+            let start = StreamingText.alignedIndex(utf8Offset: promoted, in: text)
+            let end = StreamingText.alignedIndex(utf8Offset: next, in: text)
+            XCTAssertNotNil(start)
+            XCTAssertNotNil(end)
+            if let start, let end {
+                XCTAssertLessThan(start, end, "alignment must never collapse a promotion step")
+            }
+            promoted = next
+            steps += 1
+            if steps > 10_000 { XCTFail("promotion did not terminate"); break }
+        }
+        XCTAssertEqual(promoted, total - tailWindow)
+    }
+
+    func testScannerMathCloseMarkersArePaired() {
+        // A $$ block containing a lone \] line must stay open until $$.
+        var scanner = MarkdownStableBoundaryScanner()
+        _ = scanner.append("intro\n\n$$\nx = 1\n\\]\nstill math\n$$\n\ndone\n")
+        XCTAssertFalse(scanner.isInOpenConstruct)
+        XCTAssertEqual(scanner.lastSafeBoundary, "intro\n\n$$\nx = 1\n\\]\nstill math\n$$\n\n".utf8.count)
+    }
+
     func testScannerFinishDrainsTrailingPartialLine() {
         // A stream ending in a closing fence with no trailing newline must
         // not leave the scanner stuck in an open construct.
@@ -513,11 +591,14 @@ final class MarkdownLargeDocumentTests: XCTestCase {
         scanner.finish()
         XCTAssertFalse(scanner.isInOpenConstruct, "finish must close the construct")
 
-        // A blank trailing partial line yields one more safe boundary.
+        // A blank trailing *partial* line (no newline) yields one more safe
+        // boundary via finish(); append() alone cannot see it.
         var blank = MarkdownStableBoundaryScanner()
-        _ = blank.append("one\n\ntwo\n\n")
+        _ = blank.append("one\n\ntwo\n\n   ")
+        let beforeFinish = blank.lastSafeBoundary
         blank.finish()
         XCTAssertNotNil(blank.lastSafeBoundary)
+        XCTAssertGreaterThan(blank.lastSafeBoundary!, beforeFinish ?? 0)
     }
 
     func testContinueReadingWindowCountNeverOverflows() {

--- a/ConduitTests/MarkdownLargeDocumentTests.swift
+++ b/ConduitTests/MarkdownLargeDocumentTests.swift
@@ -574,6 +574,21 @@ final class MarkdownLargeDocumentTests: XCTestCase {
         XCTAssertEqual(promoted, total - tailWindow)
     }
 
+    func testScannerHandlesCRLFInput() {
+        // CRLF deltas ride the \r on the line content; blank boundaries and
+        // exact close markers ($$, :::) must still be recognized.
+        let crlf = "intro\r\n\r\n$$\r\nx = 1\r\n$$\r\n\r\ndone\r\n"
+        var scanner = MarkdownStableBoundaryScanner()
+        let boundaries = scanner.append(crlf)
+        XCTAssertEqual(boundaries.count, 2, "blank CRLF lines must yield boundaries (before math and after it)")
+        XCTAssertFalse(scanner.isInOpenConstruct, "$$ must close on CRLF input")
+
+        var directive = MarkdownStableBoundaryScanner()
+        _ = directive.append("text\r\n\r\n::: note\r\nbody\r\n:::\r\n\r\nafter\r\n")
+        XCTAssertFalse(directive.isInOpenConstruct, "::: must close on CRLF input")
+        XCTAssertNotNil(directive.lastSafeBoundary)
+    }
+
     func testScannerMathCloseMarkersArePaired() {
         // A $$ block containing a lone \] line must stay open until $$.
         var scanner = MarkdownStableBoundaryScanner()


### PR DESCRIPTION
## Origin

A legitimate but very large user or assistant message (a huge pasted prompt, a huge streamed response, a huge response loaded from history) could freeze the UI and risk an iOS watchdog kill: the Markdown pipeline performed whole-document parsing, attributed-string construction, and UIKit layout synchronously — and while streaming, repeated all of it at 30 fps.

Two adjacent problems are already solved elsewhere and deliberately untouched here: compaction summaries (#86) and reasoning-publication coalescing (#87).

## Measured bottlenecks first (iPhone 17 simulator, best-of-N, ms @1MB)

| Stage | plain | manyMarkdown | hugeCode | mixed | single giant paragraph |
|---|---|---|---|---|---|
| `MarkdownParser.parseDocument` | 144 | 192 | 15 | 158 | 82 |
| `MarkdownSelectionFormatter` | 204 | 692 | — | — | 157 |
| UITextView whole-doc layout | 476 | 958 | — | — | **2,422** |
| `SyntaxHighlighter` | — | — | **1,516** | — | — |

- Dominant: whole-document TextKit layout of the single selectable string; giant-code highlighting; per-fragment Foundation parses at ~10K blocks.
- Streaming multiplied every stage by 30 fps → **0.8–3.3 s per frame** at 1 MB; 250 KB already paid 220–800 ms/frame.
- Measured **non**-problems (so left alone): render-cache key construction with the embedded source costs 0.1 ms at 1 MB; fade copies ≤0.7 ms.

## Architecture

The path fork is centralized in `MarkdownText.body` — no length checks sprinkled through `ChatView`. Below threshold, the ordinary fast cached path runs **verbatim** (the previous body moved to `normalBody`). At/above it, `LargeMarkdownDocumentView`:

```
collapsed:  ≤16 KB preview rendered synchronously through the ordinary
            fast path + "This message is very large" banner
expanded:   one off-main structural parse + chunk plan, then progressive
            rendering of ~8 KB chunks (memoized attributed strings, one
            SelectableTextView per flow chunk); rich blocks reuse the
            ordinary block renderer with their original selection ids
```

Chunking (not a collapsed preview alone, not a second Markdown engine) because it reuses the existing parser/formatter/block views and bounds *every* stage — expand never re-enters a whole-document synchronous path.

## Policy (all thresholds utf8.count, measurement-justified)

- **100 KB** document threshold: ~50 KB passes cost 45–160 ms (today's tolerable high end); 250 KB enters 220 ms+/stage freeze territory.
- **16 KB** preview (byte-precise, grapheme-safe cut): ≤ ~35 ms synchronous first paint — session load and history scroll never parse a 1 MB source (asserted by parse-count tests).
- **8 KB** flow chunks: ~8 ms parse+format+layout each; a single oversized block (a 1 MB paragraph measured 2.4 s of layout) is split at word/item boundaries.
- **32 KB** code threshold, **800-line** slices: highlighting measured 67 ms @50 KB and 1.5 s @1 MB, so large code renders as slices with highlighting computed off-main and swapped in; Copy always uses the complete source.
- **480-chunk mounted cap**: documents made of pathological tiny blocks (a mini-table after every sentence → thousands of chunks) get a "Continue reading" control instead of unbounded mounting — plain-VStack `onAppear` is insertion-gated, so uncapped window growth cascades.

## Streaming above the threshold

O(delta) per tick instead of O(document): an append-only buffer, an incremental fence-safe boundary scanner (never splits fences/math/directives; resumable across arbitrary delta shapes), a stable prefix promoted into immutable chunks rendered once through the cached path, and only an ~8 KB tail re-parsing per frame. The character-fade stays on the tail; sub-threshold streaming code is unchanged.

## Cache

Unchanged. Key-build cost measured negligible, and large documents never enter `MarkdownRenderCache`, so no giant entries or eviction pressure are created. The hash-key redesign suggested in the task brief is declined with that evidence.

## What remains on the MainActor

Per-chunk attributed construction and TextKit layout (bounded ~8 KB each) and SwiftUI diffing. Off-main: the one-time expand parse (cancellation-safe via `.task(id:)` + source-identity guard), large-code line splitting, and syntax highlighting.

## Tests

25 new deterministic tests in `MarkdownLargeDocumentTests.swift` — work-count/bound assertions (a DEBUG `MarkdownParser.parseSourceSizes` counter proves the whole source parses exactly once on expand and never during large streaming), planner content-preservation round-trips, fence-safety, promotion invariants, segment-plan slicing parity, Dynamic Type memoization, staleness on source swap, CJK byte-budget precision. No wall-clock thresholds.

Full suite: **848 tests, 0 failures** (`ComposerPasteTextViewTests` skipped locally — the known flaky simulator XPC stall; CI covers it).

## Local review (2 rounds, 6 blockers found → fixed → regression-tested)

1. Stale `String.Index` reused across `largeAccumulated` reassignment → re-derived from the tracked UTF-8 offset.
2. Tautological stale-highlight guard in code slices → snapshot comparison.
3. + 4. Two chunk-window overflows (Continue button stale capture; unclamped initial batch when a large doc yields <12 chunks) → clamped via `nextWindowCount` / live-state reads.
5. Character-based preview window tripling the byte budget for CJK → byte-precise grapheme-safe cut.
6. Scanner left an unclosed-construct state for streams ending without a trailing newline → `finish()`.

## Deliberate tradeoffs

- Settled large messages open collapsed (including right after a stream settles); the full content is one tap away and Copy/branch/read-aloud/persistence always operate on the complete `ChatMessage.content`.
- Reference-style links render literally *while streaming* (definitions elsewhere in the stream aren't visible to the tail); they resolve message-wide the moment the message settles.
- Cross-chunk selection rides the shared coordinator (same architecture as cross-block selection today); selection *across* chunk boundaries is coordinator-driven rather than seamless. Normal-message selection is untouched.
- Streaming identity uses `utf8.count + hashValue` (per-process stable; collision risk astronomically small).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added efficient rendering for large Markdown documents with bounded previews, progressive expansion, and incremental loading.
  * Added bounded handling for oversized tables, code, callouts, columns, math, and Mermaid content.
  * Improved streaming of long Markdown responses with safe chunk boundaries and reduced-motion support.
  * Preserved rich content, selection, references, copying, list numbering, and Dynamic Type support.

* **Bug Fixes**
  * Reduced memory use and rendering work while preventing content overflow.
  * Improved handling of long content, line endings, graphemes, cancellation, and source updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->