### PR TITLE
perf(chat): bound transcript rendering work during streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ Package.resolved
 *.p8
 *.p12
 *.mobileprovision
+TestResults*.xcresult
+ci-logs/

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -333,6 +333,25 @@ final class AppState: ObservableObject {
     @Published var isConnecting = false
     @Published var profiles: [String] = []
     @Published private(set) var sessionFilterOrder: [SessionSource] = [.chat, .discord, .telegram, .api, .webhook, .other]
+    /// Stable per-profile gateway-media resolver for settled row content.
+    /// Created lazily on first read and reused while the active profile is
+    /// unchanged, so ChatView's first body pass already has a resolver
+    /// identity (no nil → resolver invalidation sweep over the settled
+    /// transcript) and rows' Equatable gates only open on genuine profile
+    /// changes. The resolver holds this AppState weakly, so caching it here
+    /// creates no retain cycle.
+    var gatewayMediaResolver: GatewayMediaDataURLResolver {
+        if let cached = cachedGatewayMediaResolver,
+           cached.profile == activeProfile {
+            return cached.resolver
+        }
+        let resolver = GatewayMediaDataURLResolver(appState: self, profile: activeProfile)
+        cachedGatewayMediaResolver = (activeProfile, resolver)
+        return resolver
+    }
+
+    private var cachedGatewayMediaResolver: (profile: String, resolver: GatewayMediaDataURLResolver)?
+
     @Published private(set) var activeProfile: String = "default" {
         didSet { refreshActiveChatScrollSessionIdentity() }
     }

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -101,12 +101,23 @@ struct ChatRenderedScrollContent: Equatable {
 /// Global-space frame of one rendered stable message row, scoped to the
 /// rendered scroll scope that produced it. Only rows SwiftUI actually laid
 /// out report frames; this is how the viewport controller learns which
-/// stable row intersects the viewport without .scrollPosition.
+/// stable row intersects the viewport without .scrollPosition. `order` is
+/// the row's position in the transcript target list, so consumers can pick
+/// the semantic first visible row from the rendered subset alone — no scan
+/// of the full transcript.
 struct ChatRenderedRowFrame: Equatable {
     let id: String        // ChatMessageScrollTarget.id == message.id
     let minY: CGFloat
     let maxY: CGFloat
+    let order: Int
     let scope: ChatRenderedScrollScope
+}
+
+/// Frame + transcript order carried per rendered row inside the
+/// preference payload dictionaries.
+struct ChatRenderedRowGeometry: Equatable {
+    let frame: CGRect
+    let order: Int
 }
 
 /// A preference payload emitted only by targets SwiftUI has instantiated.
@@ -115,16 +126,17 @@ struct ChatRenderedRowFrame: Equatable {
 struct ChatRenderedScrollTargets: Equatable {
     private(set) var rowsByScope: [ChatRenderedScrollScope: Set<String>] = [:]
     private(set) var bottomsByScope: [ChatRenderedScrollScope: Set<String>] = [:]
-    private(set) var framesByScope: [ChatRenderedScrollScope: [String: CGRect]] = [:]
+    private(set) var framesByScope: [ChatRenderedScrollScope: [String: ChatRenderedRowGeometry]] = [:]
 
     static func row(
         semanticID: String,
         scope: ChatRenderedScrollScope,
-        frame: CGRect? = nil
+        frame: CGRect? = nil,
+        order: Int = 0
     ) -> ChatRenderedScrollTargets {
         var targets = ChatRenderedScrollTargets(rowsByScope: [scope: [semanticID]])
         if let frame {
-            targets.framesByScope = [scope: [semanticID: frame]]
+            targets.framesByScope = [scope: [semanticID: ChatRenderedRowGeometry(frame: frame, order: order)]]
         }
         return targets
     }
@@ -165,9 +177,9 @@ struct ChatRenderedScrollTargets: Equatable {
         bottomsByScope[scope]?.contains(anchorID) == true
     }
 
-    /// Global frames of rendered stable rows for a scope (rows that reported
-    /// geometry this pass; offscreen lazy rows are absent).
-    func rowFrames(in scope: ChatRenderedScrollScope) -> [String: CGRect] {
+    /// Global frames + transcript order of rendered stable rows for a scope
+    /// (rows that reported geometry this pass; offscreen lazy rows are absent).
+    func rowFrames(in scope: ChatRenderedScrollScope) -> [String: ChatRenderedRowGeometry] {
         framesByScope[scope] ?? [:]
     }
 

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -61,6 +61,8 @@ struct ChatMessageScrollTargetCache: Equatable {
     @discardableResult
     mutating func update(for messages: [ChatMessage]) -> ChatMessageScrollTargetCacheUpdate {
         let updatedFingerprints = ChatMessageScrollTargets.fingerprints(for: messages)
+        TranscriptPerf.lastFingerprintedMessageCount = messages.count
+        TranscriptPerf.lastFingerprintedByteCount = messages.reduce(0) { $0 + $1.content.utf8.count + ($1.code?.utf8.count ?? 0) }
         if updatedFingerprints == fingerprints, targets.count == messages.count {
             guard targets.map(\.message) != messages else { return .unchanged }
             targets = zip(messages, targets).map { message, target in

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -60,22 +60,78 @@ struct ChatMessageScrollTargetCache: Equatable {
 
     @discardableResult
     mutating func update(for messages: [ChatMessage]) -> ChatMessageScrollTargetCacheUpdate {
-        let updatedFingerprints = ChatMessageScrollTargets.fingerprints(for: messages)
-        TranscriptPerf.lastFingerprintedMessageCount = messages.count
-        TranscriptPerf.lastFingerprintedByteCount = messages.reduce(0) { $0 + $1.content.utf8.count + ($1.code?.utf8.count ?? 0) }
-        if updatedFingerprints == fingerprints, targets.count == messages.count {
-            guard targets.map(\.message) != messages else { return .unchanged }
-            targets = zip(messages, targets).map { message, target in
+        // Longest common prefix of equal messages: plain value compares,
+        // no hashing, no intermediate allocations.
+        var commonPrefix = 0
+        while commonPrefix < targets.count,
+              commonPrefix < messages.count,
+              targets[commonPrefix].message == messages[commonPrefix] {
+            commonPrefix += 1
+        }
+
+        // Identical transcripts: no work at all.
+        if commonPrefix == targets.count, commonPrefix == messages.count {
+            TranscriptPerf.lastFingerprintedMessageCount = 0
+            TranscriptPerf.lastFingerprintedByteCount = 0
+            return .unchanged
+        }
+
+        // Hash only the changed suffix.
+        let suffixStart = commonPrefix
+        let suffixMessages = Array(messages[suffixStart...])
+        let suffixFingerprints = ChatMessageScrollTargets.fingerprints(for: suffixMessages)
+        TranscriptPerf.lastFingerprintedMessageCount = suffixMessages.count
+        TranscriptPerf.lastFingerprintedByteCount = Self.fingerprintedBytes(of: suffixMessages)
+
+        // Same length and identical suffix fingerprints: a rendering-only
+        // replacement (equal semantics, different message objects). Swap the
+        // message values in place; semantic IDs and restoration metadata are
+        // untouched, so duplicate semantics cannot shift.
+        if targets.count == messages.count,
+           suffixFingerprints.elementsEqual(fingerprints[suffixStart...]) {
+            let replacement = zip(suffixMessages, targets[suffixStart...]).map { message, target in
                 ChatMessageScrollTarget(
                     message: message,
                     semanticID: target.semanticID,
                     restorationMetadata: target.restorationMetadata
                 )
             }
+            targets.replaceSubrange(suffixStart..., with: replacement)
             renderingRevision &+= 1
             return .renderingChanged
         }
 
+        // Incremental semantic rebuild of the suffix is safe only when
+        // duplicate-count semantics are provably local to the suffix: no
+        // fingerprint may cross the prefix/suffix boundary in either
+        // direction (old or new), and the suffix itself must be
+        // duplicate-free. Otherwise fall back to a full rebuild — correctness
+        // over exotic incremental cases.
+        let prefixFingerprints = Set(fingerprints[..<suffixStart])
+        let oldSuffixFingerprints = fingerprints[suffixStart...]
+        let canRebuildSuffixIncrementally =
+            suffixFingerprints.allSatisfy { !prefixFingerprints.contains($0) }
+            && oldSuffixFingerprints.allSatisfy { !prefixFingerprints.contains($0) }
+            && Set(suffixFingerprints).count == suffixFingerprints.count
+
+        if canRebuildSuffixIncrementally {
+            let suffixTargets = ChatMessageScrollTargets.make(
+                for: suffixMessages,
+                fingerprints: suffixFingerprints
+            )
+            fingerprints.replaceSubrange(suffixStart..., with: suffixFingerprints)
+            targets.replaceSubrange(suffixStart..., with: suffixTargets)
+            renderingRevision &+= 1
+            return .semanticsChanged
+        }
+
+        // Full rebuild fallback: mutation could affect duplicate-count
+        // semantics anywhere in the transcript.
+        let updatedFingerprints = commonPrefix == 0
+            ? suffixFingerprints
+            : ChatMessageScrollTargets.fingerprints(for: messages)
+        TranscriptPerf.lastFingerprintedMessageCount = messages.count
+        TranscriptPerf.lastFingerprintedByteCount = Self.fingerprintedBytes(of: messages)
         fingerprints = updatedFingerprints
         targets = ChatMessageScrollTargets.make(
             for: messages,
@@ -83,6 +139,10 @@ struct ChatMessageScrollTargetCache: Equatable {
         )
         renderingRevision &+= 1
         return .semanticsChanged
+    }
+
+    private static func fingerprintedBytes(of messages: [ChatMessage]) -> Int {
+        messages.reduce(0) { $0 + $1.content.utf8.count + ($1.code?.utf8.count ?? 0) }
     }
 }
 

--- a/Conduit/Services/ChatViewportController.swift
+++ b/Conduit/Services/ChatViewportController.swift
@@ -712,21 +712,21 @@ struct ChatViewportController: Equatable {
         )
     }
 
+    /// Stable-top detection operates purely over the rendered frames the
+    /// layout pass supplied: filter to rows intersecting the viewport, then
+    /// take the smallest transcript order. Work is O(rendered rows) — never
+    /// a scan of the full transcript target list, which in a deep
+    /// conversation is hundreds of entries per geometry tick.
     private mutating func updateStableTopMessage(rowFrames: [ChatRenderedRowFrame]) {
         guard let viewportMinY, let viewportMaxY else {
             stableTopMessageID = nil
             return
         }
-        let framesByID = Dictionary(rowFrames.map { ($0.id, $0) }) { first, _ in first }
-        TranscriptPerf.stableTopScanTargetCount = targetCache.targets.count
-        for target in targetCache.targets {
-            guard let frame = framesByID[target.id] else { continue }
-            if frame.maxY > viewportMinY && frame.minY < viewportMaxY {
-                stableTopMessageID = target.id
-                return
-            }
-        }
-        stableTopMessageID = nil
+        TranscriptPerf.stableTopScanTargetCount = rowFrames.count
+        stableTopMessageID = rowFrames
+            .filter { $0.maxY > viewportMinY && $0.minY < viewportMaxY }
+            .min(by: { $0.order < $1.order })?
+            .id
     }
 
     private func resolveRestorationDestination(

--- a/Conduit/Services/ChatViewportController.swift
+++ b/Conduit/Services/ChatViewportController.swift
@@ -250,6 +250,7 @@ struct ChatViewportController: Equatable {
         activeSessionKey: ChatScrollSessionKey? = nil,
         isOpeningNotificationSession: Bool = false
     ) -> [ChatViewportEffect] {
+        TranscriptPerf.note(.transcriptChanged)
         if let activeSessionKey {
             self.activeSessionKey = activeSessionKey
         }
@@ -274,6 +275,7 @@ struct ChatViewportController: Equatable {
     mutating func layoutMetricsChanged(
         facts: ChatViewportLayoutFacts
     ) -> [ChatViewportEffect] {
+        TranscriptPerf.note(.layoutMetricsChanged)
         bottomMarkerMaxY = facts.bottomMarkerMaxY
         viewportMinY = facts.viewportMinY
         viewportMaxY = facts.viewportMaxY
@@ -716,6 +718,7 @@ struct ChatViewportController: Equatable {
             return
         }
         let framesByID = Dictionary(rowFrames.map { ($0.id, $0) }) { first, _ in first }
+        TranscriptPerf.stableTopScanTargetCount = targetCache.targets.count
         for target in targetCache.targets {
             guard let frame = framesByID[target.id] else { continue }
             if frame.maxY > viewportMinY && frame.minY < viewportMaxY {

--- a/Conduit/Services/TranscriptPerformanceInstrumentation.swift
+++ b/Conduit/Services/TranscriptPerformanceInstrumentation.swift
@@ -1,0 +1,148 @@
+//
+//  TranscriptPerformanceInstrumentation.swift
+//  Conduit
+//
+//  Deterministic counters for measuring transcript rendering work.
+//  Tests can reset and read counters to assert that expensive work was
+//  avoided. `note()` is `@inline(__always)` so the compiler can strip
+//  it in release builds when the body is empty.
+//
+
+import Foundation
+
+/// Lightweight counters that measure how much work a transcript operation
+/// caused, not how long it took. Every counter is a plain integer — no
+/// timers, no wall-clock thresholds.
+///
+/// Usage in tests:
+///   TranscriptPerf.reset()
+///   /* trigger operation */
+///   XCTAssertEqual(TranscriptPerf.settledMarkdownTextBodyEvaluations, 0)
+enum TranscriptPerf {
+    // MARK: - Event recording
+
+    /// Record a performance event. In release builds the body is empty
+    /// and the compiler can inline/remove the call.
+    @inline(__always)
+    static func note(_ event: Event) {
+        #if DEBUG
+        switch event {
+        case .settledBubbleBody: storage.settledBubbleBody += 1
+        case .settledMarkdownBody: storage.settledMarkdownBody += 1
+        case .selectableTextViewUpdate: storage.selectableTextViewUpdate += 1
+        case .selectableTextViewTextRebuild: storage.selectableTextViewTextRebuild += 1
+        case .textKitMeasurement: storage.textKitMeasurement += 1
+        case .rowFramePreferenceUpdate: storage.rowFramePreferenceUpdate += 1
+        case .layoutMetricsChanged: storage.layoutMetricsChanged += 1
+        case .transcriptChanged: storage.transcriptChanged += 1
+        }
+        #endif
+    }
+
+    enum Event {
+        case settledBubbleBody
+        case settledMarkdownBody
+        case selectableTextViewUpdate
+        case selectableTextViewTextRebuild
+        case textKitMeasurement
+        case rowFramePreferenceUpdate
+        case layoutMetricsChanged
+        case transcriptChanged
+    }
+
+    // MARK: - Counter accessors
+
+    static var settledMessageBubbleBodyEvaluations: Int {
+        get { read(\.settledBubbleBody) }
+    }
+
+    static var settledMarkdownTextBodyEvaluations: Int {
+        get { read(\.settledMarkdownBody) }
+    }
+
+    static var selectableTextViewUpdateCalls: Int {
+        get { read(\.selectableTextViewUpdate) }
+    }
+
+    static var selectableTextViewTextRebuilds: Int {
+        get { read(\.selectableTextViewTextRebuild) }
+    }
+
+    static var textKitMeasurementCalls: Int {
+        get { read(\.textKitMeasurement) }
+    }
+
+    static var rowFramePreferenceUpdates: Int {
+        get { read(\.rowFramePreferenceUpdate) }
+    }
+
+    static var layoutMetricsChangedCalls: Int {
+        get { read(\.layoutMetricsChanged) }
+    }
+
+    static var transcriptChangedCalls: Int {
+        get { read(\.transcriptChanged) }
+    }
+
+    /// Number of messages fingerprinted in the last
+    /// `ChatMessageScrollTargetCache.update` call.
+    static var lastFingerprintedMessageCount: Int {
+        get { read(\.lastFingerprintedMessageCount) }
+        set { write(\.lastFingerprintedMessageCount, newValue) }
+    }
+
+    /// Total bytes hashed in the last fingerprint update.
+    static var lastFingerprintedByteCount: Int {
+        get { read(\.lastFingerprintedByteCount) }
+        set { write(\.lastFingerprintedByteCount, newValue) }
+    }
+
+    /// Times `updateStableTopMessage` scanned targets.
+    static var stableTopScanTargetCount: Int {
+        get { read(\.stableTopScanTargetCount) }
+        set { write(\.stableTopScanTargetCount, newValue) }
+    }
+
+    // MARK: - Control
+
+    /// Reset all counters to zero.
+    static func reset() {
+        #if DEBUG
+        storage = Storage()
+        #endif
+    }
+
+    // MARK: - Private storage
+
+    #if DEBUG
+    private static var storage = Storage()
+
+    private struct Storage {
+        var settledBubbleBody = 0
+        var settledMarkdownBody = 0
+        var selectableTextViewUpdate = 0
+        var selectableTextViewTextRebuild = 0
+        var textKitMeasurement = 0
+        var rowFramePreferenceUpdate = 0
+        var layoutMetricsChanged = 0
+        var transcriptChanged = 0
+        var lastFingerprintedMessageCount = 0
+        var lastFingerprintedByteCount = 0
+        var stableTopScanTargetCount = 0
+    }
+    #endif
+
+    private static func read(_ keyPath: KeyPath<Storage, Int>) -> Int {
+        #if DEBUG
+        return storage[keyPath: keyPath]
+        #else
+        return 0
+        #endif
+    }
+
+    private static func write(_ keyPath: WritableKeyPath<Storage, Int>, _ value: Int) {
+        #if DEBUG
+        storage[keyPath: keyPath] = value
+        #endif
+    }
+}

--- a/Conduit/Services/TranscriptPerformanceInstrumentation.swift
+++ b/Conduit/Services/TranscriptPerformanceInstrumentation.swift
@@ -114,9 +114,10 @@ enum TranscriptPerf {
 
     // MARK: - Private storage
 
-    #if DEBUG
-    private static var storage = Storage()
-
+    /// The Storage TYPE must exist in every configuration so the
+    /// unconditional `read`/`write` helper signatures compile in Release;
+    /// only the stored instance is Debug-only. Release instrumentation is
+    /// therefore zero-cost: reads return 0 and writes are compiled out.
     private struct Storage {
         var settledBubbleBody = 0
         var settledMarkdownBody = 0
@@ -130,12 +131,16 @@ enum TranscriptPerf {
         var lastFingerprintedByteCount = 0
         var stableTopScanTargetCount = 0
     }
+
+    #if DEBUG
+    private static var storage = Storage()
     #endif
 
     private static func read(_ keyPath: KeyPath<Storage, Int>) -> Int {
         #if DEBUG
         return storage[keyPath: keyPath]
         #else
+        _ = keyPath
         return 0
         #endif
     }
@@ -143,6 +148,9 @@ enum TranscriptPerf {
     private static func write(_ keyPath: WritableKeyPath<Storage, Int>, _ value: Int) {
         #if DEBUG
         storage[keyPath: keyPath] = value
+        #else
+        _ = keyPath
+        _ = value
         #endif
     }
 }

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -349,18 +349,6 @@ struct ChatView: View {
                     using: proxy
                 )
             }
-            .onChange(of: appState.chatTranscriptRevision) { _, _ in
-                performViewportEffects(
-                    viewport.transcriptChanged(
-                        messages: appState.messages,
-                        transcriptRevision: appState.chatTranscriptRevision,
-                        viewportTransitionGeneration: appState.chatViewportTransitionGeneration,
-                        activeSessionKey: activeScrollSessionKey,
-                        isOpeningNotificationSession: appState.isOpeningNotificationSession
-                    ),
-                    using: proxy
-                )
-            }
             .onChange(of: appState.chatResumeRestorationRequest) { oldRequest, newRequest in
                 guard oldRequest != nil, newRequest == nil else { return }
                 // The published request disappeared on the AppState side

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -769,6 +769,7 @@ struct MessageBubble: View {
     @EnvironmentObject var appState: AppState
 
     var body: some View {
+        let _ = TranscriptPerf.note(.settledBubbleBody)
         switch message.role {
         case .user:
             UserBubble(message: message)

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -17,11 +17,6 @@ struct ChatView: View {
     @State private var renderedScrollTargets = ChatRenderedScrollTargets()
     @State private var viewportSnapshotProviderID = UUID()
     @State private var viewport = ChatViewportController()
-    /// Stable gateway-media resolver for settled row content. Recreated
-    /// only when the active profile changes; rows compare it by identity
-    /// inside their Equatable gates, so ordinary AppState publishes never
-    /// invalidate settled Markdown through it.
-    @State private var gatewayMediaResolver: GatewayMediaDataURLResolver?
     @GestureState private var isDraggingChat = false
 
     private var renderedScrollSessionKey: ChatScrollSessionKey? { viewport.renderedSessionKey }
@@ -148,7 +143,7 @@ struct ChatView: View {
                 }
 
                 ForEach(Array(chatMessageScrollTargets.enumerated()), id: \.element.id) { index, target in
-                    MessageBubble(message: target.message, gatewayResolver: gatewayMediaResolver)
+                    MessageBubble(message: target.message, gatewayResolver: appState.gatewayMediaResolver)
                         .id(target.id)
                         .background {
                             GeometryReader { geometry in
@@ -263,12 +258,6 @@ struct ChatView: View {
     private func lifecycleObservers(proxy: ScrollViewProxy, content: some View) -> some View {
         content
             .onAppear {
-                if gatewayMediaResolver == nil {
-                    gatewayMediaResolver = GatewayMediaDataURLResolver(
-                        appState: appState,
-                        profile: appState.activeProfile
-                    )
-                }
                 performViewportEffects(
                     viewport.renderedSessionChanged(
                         to: activeScrollSessionKey,
@@ -403,11 +392,7 @@ struct ChatView: View {
                     using: proxy
                 )
             }
-            .onChange(of: appState.activeProfile) { _, newProfile in
-                gatewayMediaResolver = GatewayMediaDataURLResolver(
-                    appState: appState,
-                    profile: newProfile
-                )
+            .onChange(of: appState.activeProfile) { _, _ in
                 ChatViewportTrace.shared.log(
                     "event profileChanged viaNotification=\(appState.isOpeningNotificationSession)"
                 )
@@ -826,12 +811,17 @@ struct MessageBubble: View {
 struct UserBubble: View {
     let message: ChatMessage
     let gatewayResolver: GatewayMediaDataURLResolver?
+    @Environment(\.sizeCategory) private var sizeCategory
 
     var body: some View {
         HStack {
             Spacer(minLength: 40)
             VStack(alignment: .trailing, spacing: 4) {
-                UserMessageContent(message: message, gatewayResolver: gatewayResolver)
+                UserMessageContent(
+                    message: message,
+                    gatewayResolver: gatewayResolver,
+                    sizeCategory: sizeCategory
+                )
                     .equatable()
 
                 MessageTimestampLabel(timestamp: message.timestamp)
@@ -848,11 +838,13 @@ struct UserBubble: View {
 private struct UserMessageContent: View, Equatable {
     let message: ChatMessage
     let gatewayResolver: GatewayMediaDataURLResolver?
-    @Environment(\.sizeCategory) private var sizeCategory
+    /// Explicit Dynamic Type input — see SettledAssistantMessageContent.
+    let sizeCategory: ContentSizeCategory
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.message == rhs.message
             && lhs.gatewayResolver === rhs.gatewayResolver
+            && lhs.sizeCategory == rhs.sizeCategory
     }
 
     var body: some View {
@@ -1093,13 +1085,21 @@ struct SettledAssistantMessageContent: View, Equatable {
     let displayName: String
     let avatarURL: URL?
     let gatewayResolver: GatewayMediaDataURLResolver?
-    @Environment(\.sizeCategory) private var sizeCategory
+    /// Explicit Dynamic Type input (read by the shell): equality describes
+    /// every visual input, so a category change re-opens the gate and
+    /// re-renders with fresh fonts (the Markdown render cache keys on the
+    /// content size category). Other presentation traits the subtree
+    /// consumes are render-time adaptive — color scheme resolves through
+    /// UIKit trait collections, layout direction through TextKit — and do
+    /// not require body re-evaluation.
+    let sizeCategory: ContentSizeCategory
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.message == rhs.message
             && lhs.displayName == rhs.displayName
             && lhs.avatarURL == rhs.avatarURL
             && lhs.gatewayResolver === rhs.gatewayResolver
+            && lhs.sizeCategory == rhs.sizeCategory
     }
 
     var body: some View {
@@ -1238,6 +1238,7 @@ struct AssistantBubble: View {
     let readAloudController: MessageReadAloudController
     let gatewayResolver: GatewayMediaDataURLResolver?
     @EnvironmentObject var appState: AppState
+    @Environment(\.sizeCategory) private var sizeCategory
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -1245,7 +1246,8 @@ struct AssistantBubble: View {
                 message: message,
                 displayName: appState.profileDisplayName(appState.activeProfile),
                 avatarURL: appState.profileAvatarURL(for: appState.activeProfile),
-                gatewayResolver: gatewayResolver
+                gatewayResolver: gatewayResolver,
+                sizeCategory: sizeCategory
             )
             .equatable()
 
@@ -1435,13 +1437,15 @@ private struct SettledThinkingCardContent: View, Equatable {
     let message: ChatMessage
     let displayName: String
     let avatarURL: URL?
+    /// Explicit Dynamic Type input — see SettledAssistantMessageContent.
+    let sizeCategory: ContentSizeCategory
     @State private var expanded = false
-    @Environment(\.sizeCategory) private var sizeCategory
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.message == rhs.message
             && lhs.displayName == rhs.displayName
             && lhs.avatarURL == rhs.avatarURL
+            && lhs.sizeCategory == rhs.sizeCategory
     }
 
     var body: some View {
@@ -1479,13 +1483,15 @@ private struct SettledThinkingCardContent: View, Equatable {
 struct ThinkingCard: View {
     let message: ChatMessage
     @EnvironmentObject var appState: AppState
+    @Environment(\.sizeCategory) private var sizeCategory
 
     var body: some View {
         if appState.displayPreferences.showReasoning, !message.content.isEmpty {
             SettledThinkingCardContent(
                 message: message,
                 displayName: appState.profileDisplayName(appState.activeProfile),
-                avatarURL: appState.profileAvatarURL(for: appState.activeProfile)
+                avatarURL: appState.profileAvatarURL(for: appState.activeProfile),
+                sizeCategory: sizeCategory
             )
             .equatable()
         }
@@ -1550,12 +1556,14 @@ enum MessageTimestampFormatter {
 private struct SettledToolCardContent: View, Equatable {
     let message: ChatMessage
     let expandToolsByDefault: Bool
+    /// Explicit Dynamic Type input — see SettledAssistantMessageContent.
+    let sizeCategory: ContentSizeCategory
     @State private var expanded = false
-    @Environment(\.sizeCategory) private var sizeCategory
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.message == rhs.message
             && lhs.expandToolsByDefault == rhs.expandToolsByDefault
+            && lhs.sizeCategory == rhs.sizeCategory
     }
 
     var body: some View {
@@ -1667,12 +1675,14 @@ private struct SettledToolCardContent: View, Equatable {
 struct ToolCard: View {
     let message: ChatMessage
     @EnvironmentObject var appState: AppState
+    @Environment(\.sizeCategory) private var sizeCategory
 
     var body: some View {
         if appState.displayPreferences.showToolProgress, message.tool != nil {
             SettledToolCardContent(
                 message: message,
-                expandToolsByDefault: appState.displayPreferences.expandToolsByDefault
+                expandToolsByDefault: appState.displayPreferences.expandToolsByDefault,
+                sizeCategory: sizeCategory
             )
             .equatable()
         }

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -17,6 +17,11 @@ struct ChatView: View {
     @State private var renderedScrollTargets = ChatRenderedScrollTargets()
     @State private var viewportSnapshotProviderID = UUID()
     @State private var viewport = ChatViewportController()
+    /// Stable gateway-media resolver for settled row content. Recreated
+    /// only when the active profile changes; rows compare it by identity
+    /// inside their Equatable gates, so ordinary AppState publishes never
+    /// invalidate settled Markdown through it.
+    @State private var gatewayMediaResolver: GatewayMediaDataURLResolver?
     @GestureState private var isDraggingChat = false
 
     private var renderedScrollSessionKey: ChatScrollSessionKey? { viewport.renderedSessionKey }
@@ -142,7 +147,7 @@ struct ChatView: View {
                 }
 
                 ForEach(chatMessageScrollTargets) { target in
-                    MessageBubble(message: target.message)
+                    MessageBubble(message: target.message, gatewayResolver: gatewayMediaResolver)
                         .id(target.id)
                         .background {
                             GeometryReader { geometry in
@@ -256,6 +261,12 @@ struct ChatView: View {
     private func lifecycleObservers(proxy: ScrollViewProxy, content: some View) -> some View {
         content
             .onAppear {
+                if gatewayMediaResolver == nil {
+                    gatewayMediaResolver = GatewayMediaDataURLResolver(
+                        appState: appState,
+                        profile: appState.activeProfile
+                    )
+                }
                 performViewportEffects(
                     viewport.renderedSessionChanged(
                         to: activeScrollSessionKey,
@@ -390,7 +401,11 @@ struct ChatView: View {
                     using: proxy
                 )
             }
-            .onChange(of: appState.activeProfile) { _, _ in
+            .onChange(of: appState.activeProfile) { _, newProfile in
+                gatewayMediaResolver = GatewayMediaDataURLResolver(
+                    appState: appState,
+                    profile: newProfile
+                )
                 ChatViewportTrace.shared.log(
                     "event profileChanged viaNotification=\(appState.isOpeningNotificationSession)"
                 )
@@ -752,19 +767,26 @@ private struct ChatRenderedScrollTargetsPreferenceKey: PreferenceKey {
 }
 // MARK: - Message Bubble
 
+/// Routes a transcript row to its presentation. The expensive settled
+/// content of each row type lives behind an Equatable gate (see
+/// SettledAssistantMessageContent and friends) so a streaming publish —
+/// which re-creates every mounted row through this switch — cannot force
+/// settled Markdown presentation to re-evaluate.
 struct MessageBubble: View {
     let message: ChatMessage
+    let gatewayResolver: GatewayMediaDataURLResolver?
     @EnvironmentObject var appState: AppState
 
     var body: some View {
         let _ = TranscriptPerf.note(.settledBubbleBody)
         switch message.role {
         case .user:
-            UserBubble(message: message)
+            UserBubble(message: message, gatewayResolver: gatewayResolver)
         case .assistant:
             AssistantBubble(
                 message: message,
-                readAloudController: appState.messageReadAloudController
+                readAloudController: appState.messageReadAloudController,
+                gatewayResolver: gatewayResolver
             )
         case .reasoning:
             ThinkingCard(message: message)
@@ -791,7 +813,8 @@ struct MessageBubble: View {
         case .partial:
             AssistantBubble(
                 message: message,
-                readAloudController: appState.messageReadAloudController
+                readAloudController: appState.messageReadAloudController,
+                gatewayResolver: gatewayResolver
             )
         }
     }
@@ -799,12 +822,14 @@ struct MessageBubble: View {
 
 struct UserBubble: View {
     let message: ChatMessage
+    let gatewayResolver: GatewayMediaDataURLResolver?
 
     var body: some View {
         HStack {
             Spacer(minLength: 40)
             VStack(alignment: .trailing, spacing: 4) {
-                UserMessageContent(message: message)
+                UserMessageContent(message: message, gatewayResolver: gatewayResolver)
+                    .equatable()
 
                 MessageTimestampLabel(timestamp: message.timestamp)
                     .frame(maxWidth: .infinity, alignment: .trailing)
@@ -813,8 +838,19 @@ struct UserBubble: View {
     }
 }
 
-private struct UserMessageContent: View {
+/// Settled user-row content: Markdown plus attachment previews. Equatable
+/// over the message and the stable gateway resolver so streaming publishes
+/// cannot re-evaluate it (same contract as
+/// SettledAssistantMessageContent).
+private struct UserMessageContent: View, Equatable {
     let message: ChatMessage
+    let gatewayResolver: GatewayMediaDataURLResolver?
+    @Environment(\.sizeCategory) private var sizeCategory
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.message == rhs.message
+            && lhs.gatewayResolver === rhs.gatewayResolver
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 9) {
@@ -825,7 +861,7 @@ private struct UserMessageContent: View {
             if let attachments = message.attachments {
                 ForEach(attachments) { attachment in
                     if attachment.kind == .image {
-                        UserImageAttachmentPreview(attachment: attachment)
+                        UserImageAttachmentPreview(attachment: attachment, gatewayResolver: gatewayResolver)
                     } else {
                         UserDocumentAttachmentChip(attachment: attachment)
                     }
@@ -853,7 +889,7 @@ private struct UserMessageContent: View {
 
 private struct UserImageAttachmentPreview: View {
     let attachment: Attachment
-    @EnvironmentObject private var appState: AppState
+    let gatewayResolver: GatewayMediaDataURLResolver?
     @State private var gatewayImage: UIImage?
     @State private var gatewayLoadFailed = false
     @State private var localPreview: UIImage?
@@ -953,7 +989,7 @@ private struct UserImageAttachmentPreview: View {
                 .background(Color.white.opacity(0.13), in: Capsule())
             }
         }
-        .task(id: "\(attachment.uri)|\(appState.activeProfile)") {
+        .task(id: "\(attachment.uri)|\(gatewayResolver?.profile ?? "")") {
             // Local file: cache hits are already shown by `body` on the first
             // frame via `cachedLocalImage`, so only misses reach here. Decode
             // off the MainActor so a large photo can't hitch scrolling.
@@ -974,13 +1010,10 @@ private struct UserImageAttachmentPreview: View {
                 // returns above, so a local URI never reaches here — which also
                 // removes the old `localImage == nil` check that decoded local
                 // files on the MainActor before short-circuiting.
-            } else if isGatewayImage {
+            } else if isGatewayImage, let gatewayResolver {
                 gatewayImage = nil
                 gatewayLoadFailed = false
-                guard let dataURL = await appState.gatewayMediaDataURL(
-                    for: attachment.uri,
-                    profile: appState.activeProfile
-                ),
+                guard let dataURL = await gatewayResolver.dataURL(for: attachment.uri),
                 !Task.isCancelled,
                 let image = image(fromDataURL: dataURL) else {
                     guard !Task.isCancelled else { return }
@@ -1047,15 +1080,23 @@ private struct UserDocumentAttachmentChip: View {
     }
 }
 
-struct AssistantBubble: View {
+/// The settled half of an assistant row: identity header, Markdown body,
+/// and code block. Equatable over immutable message presentation inputs so
+/// a streaming publish re-creating this view is a no-op (`.equatable()`
+/// skips body evaluation when inputs compare equal). Dynamic Type changes
+/// still invalidate through the `\.sizeCategory` environment read.
+struct SettledAssistantMessageContent: View, Equatable {
     let message: ChatMessage
-    @EnvironmentObject var appState: AppState
-    @ObservedObject private var readAloudController: MessageReadAloudController
-    @State private var copied = false
+    let displayName: String
+    let avatarURL: URL?
+    let gatewayResolver: GatewayMediaDataURLResolver?
+    @Environment(\.sizeCategory) private var sizeCategory
 
-    init(message: ChatMessage, readAloudController: MessageReadAloudController) {
-        self.message = message
-        self.readAloudController = readAloudController
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.message == rhs.message
+            && lhs.displayName == rhs.displayName
+            && lhs.avatarURL == rhs.avatarURL
+            && lhs.gatewayResolver === rhs.gatewayResolver
     }
 
     var body: some View {
@@ -1064,11 +1105,11 @@ struct AssistantBubble: View {
             // the full reading column instead of inheriting the avatar indent.
             HStack(spacing: 8) {
                 ConduitAgentMark(
-                    avatarURL: appState.profileAvatarURL(for: appState.activeProfile),
-                    displayName: appState.profileDisplayName(appState.activeProfile)
+                    avatarURL: avatarURL,
+                    displayName: displayName
                 )
 
-                Text(appState.profileDisplayName(appState.activeProfile))
+                Text(displayName)
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
 
@@ -1079,8 +1120,8 @@ struct AssistantBubble: View {
             if !message.content.isEmpty {
                 MarkdownText(
                     source: message.content,
-                    gatewayMediaDataURL: { path in
-                        await appState.gatewayMediaDataURL(for: path, profile: appState.activeProfile)
+                    gatewayMediaDataURL: gatewayResolver.map { resolver in
+                        { path in await resolver.dataURL(for: path) }
                     }
                 )
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -1090,73 +1131,43 @@ struct AssistantBubble: View {
                 ChatCodeBlock(source: code)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
-
-            HStack(spacing: 4) {
-                Spacer(minLength: 0)
-
-                Button {
-                    copyResponse()
-                } label: {
-                    Image(systemName: copied ? "checkmark" : "doc.on.doc")
-                        .font(.subheadline.weight(.semibold))
-                        .frame(width: 34, height: 34)
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(copied ? Color.conduitAccent : Color.secondary)
-                .accessibilityLabel(copied ? "Response copied" : "Copy response")
-
-                Button {
-                    Haptics.medium()
-                    Task { await appState.branchFromAssistantMessage(message.id) }
-                } label: {
-                    Image(systemName: "arrow.triangle.branch")
-                        .font(.subheadline.weight(.semibold))
-                        .frame(width: 34, height: 34)
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(.secondary)
-                .disabled(appState.isBusy || appState.isBranchingChat)
-                .opacity(appState.isBusy || appState.isBranchingChat ? 0.45 : 1)
-                .accessibilityLabel("Branch from this response")
-
-                if message.role == .assistant {
-                    Button {
-                        if readAloudIsActive {
-                            Haptics.medium()
-                        } else {
-                            Haptics.light()
-                        }
-                        appState.toggleReadAloud(message: message)
-                    } label: {
-                        Group {
-                            if case .preparing(let id) = readAloudController.state, id == message.id {
-                                ProgressView()
-                                    .controlSize(.small)
-                            } else {
-                                Image(systemName: readAloudIsActive ? "stop.fill" : "speaker.wave.2")
-                            }
-                        }
-                        .font(.subheadline.weight(.semibold))
-                        .frame(width: 34, height: 34)
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(readAloudIsActive ? Color.conduitAccent : Color.secondary)
-                    .disabled(readAloudUnavailable && !readAloudIsActive)
-                    .opacity(readAloudUnavailable && !readAloudIsActive ? 0.45 : 1)
-                    .accessibilityLabel(readAloudIsActive ? "Stop reading response" : "Read response aloud")
-                }
-            }
-            .padding(.top, 2)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
+}
 
-    private var readAloudIsActive: Bool {
-        readAloudController.isActiveMessage(message.id)
-    }
+/// The dynamic half of an assistant row: copy/branch controls that depend
+/// on busy state, kept small so their per-publish re-evaluation is cheap.
+struct AssistantMessageActions: View {
+    let message: ChatMessage
+    @EnvironmentObject private var appState: AppState
+    @State private var copied = false
 
-    private var readAloudUnavailable: Bool {
-        appState.readAloudUnavailableReason != nil
+    var body: some View {
+        Button {
+            copyResponse()
+        } label: {
+            Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                .font(.subheadline.weight(.semibold))
+                .frame(width: 34, height: 34)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(copied ? Color.conduitAccent : Color.secondary)
+        .accessibilityLabel(copied ? "Response copied" : "Copy response")
+
+        Button {
+            Haptics.medium()
+            Task { await appState.branchFromAssistantMessage(message.id) }
+        } label: {
+            Image(systemName: "arrow.triangle.branch")
+                .font(.subheadline.weight(.semibold))
+                .frame(width: 34, height: 34)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.secondary)
+        .disabled(appState.isBusy || appState.isBranchingChat)
+        .opacity(appState.isBusy || appState.isBranchingChat ? 0.45 : 1)
+        .accessibilityLabel("Branch from this response")
     }
 
     private func copyResponse() {
@@ -1168,6 +1179,84 @@ struct AssistantBubble: View {
             guard !Task.isCancelled else { return }
             copied = false
         }
+    }
+}
+
+/// The read-aloud control surface. This is deliberately the ONLY part of
+/// an assistant row that observes the shared read-aloud controller, so a
+/// playback state transition re-renders a 34pt button instead of every
+/// response's Markdown in the transcript.
+struct ReadAloudButton: View {
+    let message: ChatMessage
+    @ObservedObject var controller: MessageReadAloudController
+    @EnvironmentObject private var appState: AppState
+
+    private var isActive: Bool {
+        controller.isActiveMessage(message.id)
+    }
+
+    private var unavailable: Bool {
+        appState.readAloudUnavailableReason != nil
+    }
+
+    var body: some View {
+        Button {
+            if isActive {
+                Haptics.medium()
+            } else {
+                Haptics.light()
+            }
+            appState.toggleReadAloud(message: message)
+        } label: {
+            Group {
+                if case .preparing(let id) = controller.state, id == message.id {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Image(systemName: isActive ? "stop.fill" : "speaker.wave.2")
+                }
+            }
+            .font(.subheadline.weight(.semibold))
+            .frame(width: 34, height: 34)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(isActive ? Color.conduitAccent : Color.secondary)
+        .disabled(unavailable && !isActive)
+        .opacity(unavailable && !isActive ? 0.45 : 1)
+        .accessibilityLabel(isActive ? "Stop reading response" : "Read response aloud")
+    }
+}
+
+struct AssistantBubble: View {
+    let message: ChatMessage
+    /// Held as a plain reference (not @ObservedObject): forwarding a
+    /// controller instance must not subscribe this whole bubble to every
+    /// read-aloud state transition. Only ReadAloudButton observes it.
+    let readAloudController: MessageReadAloudController
+    let gatewayResolver: GatewayMediaDataURLResolver?
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            SettledAssistantMessageContent(
+                message: message,
+                displayName: appState.profileDisplayName(appState.activeProfile),
+                avatarURL: appState.profileAvatarURL(for: appState.activeProfile),
+                gatewayResolver: gatewayResolver
+            )
+            .equatable()
+
+            HStack(spacing: 4) {
+                Spacer(minLength: 0)
+                AssistantMessageActions(message: message)
+
+                if message.role == .assistant {
+                    ReadAloudButton(message: message, controller: readAloudController)
+                }
+            }
+            .padding(.top, 2)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
@@ -1336,41 +1425,66 @@ private struct ModelChangeSummaryCard: View {
     }
 }
 
+/// Settled reasoning-row content, gated the same way as assistant/user
+/// content: identical presentation inputs skip body evaluation during
+/// unrelated AppState publishes.
+private struct SettledThinkingCardContent: View, Equatable {
+    let message: ChatMessage
+    let displayName: String
+    let avatarURL: URL?
+    @State private var expanded = false
+    @Environment(\.sizeCategory) private var sizeCategory
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.message == rhs.message
+            && lhs.displayName == rhs.displayName
+            && lhs.avatarURL == rhs.avatarURL
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            ConduitAgentMark(
+                avatarURL: avatarURL,
+                displayName: displayName
+            )
+
+            DisclosureGroup(isExpanded: $expanded) {
+                SelectableTextView(
+                    text: message.content,
+                    font: .preferredFont(forTextStyle: .callout),
+                    textColor: .secondaryLabel
+                )
+                    .padding(.top, 4)
+            } label: {
+                HStack(spacing: 6) {
+                    Label("Thinking", systemImage: "brain.head.profile")
+                    MessageTimestampLabel(timestamp: message.timestamp)
+                }
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            }
+            .tint(.conduitAccent)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .conduitGlassSurface(cornerRadius: 16, tint: .conduitAccent.opacity(0.06))
+
+            Spacer(minLength: 28)
+        }
+    }
+}
+
 struct ThinkingCard: View {
     let message: ChatMessage
     @EnvironmentObject var appState: AppState
-    @State private var expanded = false
 
     var body: some View {
         if appState.displayPreferences.showReasoning, !message.content.isEmpty {
-            HStack(alignment: .top, spacing: 10) {
-                ConduitAgentMark(
-                    avatarURL: appState.profileAvatarURL(for: appState.activeProfile),
-                    displayName: appState.profileDisplayName(appState.activeProfile)
-                )
-
-                DisclosureGroup(isExpanded: $expanded) {
-                    SelectableTextView(
-                        text: message.content,
-                        font: .preferredFont(forTextStyle: .callout),
-                        textColor: .secondaryLabel
-                    )
-                        .padding(.top, 4)
-                } label: {
-                    HStack(spacing: 6) {
-                        Label("Thinking", systemImage: "brain.head.profile")
-                        MessageTimestampLabel(timestamp: message.timestamp)
-                    }
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                }
-                .tint(.conduitAccent)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
-                .conduitGlassSurface(cornerRadius: 16, tint: .conduitAccent.opacity(0.06))
-
-                Spacer(minLength: 28)
-            }
+            SettledThinkingCardContent(
+                message: message,
+                displayName: appState.profileDisplayName(appState.activeProfile),
+                avatarURL: appState.profileAvatarURL(for: appState.activeProfile)
+            )
+            .equatable()
         }
     }
 }
@@ -1428,13 +1542,21 @@ enum MessageTimestampFormatter {
 
 // MARK: - Tool Card
 
-struct ToolCard: View {
+/// Settled tool-row content, gated on the message and expansion default so
+/// streaming publishes skip its SelectableTextView measurement work.
+private struct SettledToolCardContent: View, Equatable {
     let message: ChatMessage
+    let expandToolsByDefault: Bool
     @State private var expanded = false
-    @EnvironmentObject var appState: AppState
+    @Environment(\.sizeCategory) private var sizeCategory
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.message == rhs.message
+            && lhs.expandToolsByDefault == rhs.expandToolsByDefault
+    }
 
     var body: some View {
-        if appState.displayPreferences.showToolProgress, let tool = message.tool {
+        if let tool = message.tool {
             VStack(alignment: .leading, spacing: 0) {
                 Button {
                     withAnimation(ConduitMotion.response) {
@@ -1493,7 +1615,7 @@ struct ToolCard: View {
                                     .font(.caption2.bold())
                                     .foregroundStyle(.tertiary)
                                 SelectableTextView(
-                                    text: Self.truncateForDisplay(input, maxLines: 500),
+                                    text: ToolCard.truncateForDisplay(input, maxLines: 500),
                                     font: .monospacedSystemFont(ofSize: UIFont.preferredFont(forTextStyle: .caption1).pointSize, weight: .regular),
                                     textColor: .secondaryLabel,
                                     maximumNumberOfLines: 0
@@ -1507,7 +1629,7 @@ struct ToolCard: View {
                                     .font(.caption2.bold())
                                     .foregroundStyle(.tertiary)
                                 SelectableTextView(
-                                    text: Self.truncateForDisplay(output, maxLines: 500),
+                                    text: ToolCard.truncateForDisplay(output, maxLines: 500),
                                     font: .monospacedSystemFont(ofSize: UIFont.preferredFont(forTextStyle: .caption1).pointSize, weight: .regular),
                                     textColor: .secondaryLabel,
                                     maximumNumberOfLines: 0
@@ -1523,7 +1645,7 @@ struct ToolCard: View {
             }
             .conduitGlassSurface(cornerRadius: 18, tint: tool.status == .running ? .conduitAccent.opacity(0.10) : .clear)
             .onAppear {
-                if appState.displayPreferences.expandToolsByDefault {
+                if expandToolsByDefault {
                     expanded = true
                 }
             }
@@ -1536,6 +1658,21 @@ struct ToolCard: View {
             .replacingOccurrences(of: "\n", with: " ")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return preview.isEmpty ? nil : preview
+    }
+}
+
+struct ToolCard: View {
+    let message: ChatMessage
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        if appState.displayPreferences.showToolProgress, message.tool != nil {
+            SettledToolCardContent(
+                message: message,
+                expandToolsByDefault: appState.displayPreferences.expandToolsByDefault
+            )
+            .equatable()
+        }
     }
 
     /// Limits tool output rendered in the non-scrolling SelectableTextView to

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -80,10 +80,11 @@ struct ChatView: View {
         appState.chatResumeRestorationRequest != nil
     }
 
-    /// Latest global frames of rendered stable rows for the current scope.
-    /// Only message rows report frames (streaming/typing/markers never do),
-    /// so ephemeral identifiers cannot enter stable-top observation.
-    private var renderedRowFrames: [String: CGRect] {
+    /// Latest global frames + transcript order of rendered stable rows for
+    /// the current scope. Only message rows report frames (streaming/typing/
+    /// markers never do), so ephemeral identifiers cannot enter stable-top
+    /// observation.
+    private var renderedRowFrames: [String: ChatRenderedRowGeometry] {
         guard let scope = renderedScrollScope else { return [:] }
         return renderedScrollTargets.rowFrames(in: scope)
     }
@@ -146,7 +147,7 @@ struct ChatView: View {
                     EmptyChatState().padding(.top, 60)
                 }
 
-                ForEach(chatMessageScrollTargets) { target in
+                ForEach(Array(chatMessageScrollTargets.enumerated()), id: \.element.id) { index, target in
                     MessageBubble(message: target.message, gatewayResolver: gatewayMediaResolver)
                         .id(target.id)
                         .background {
@@ -157,7 +158,8 @@ struct ChatView: View {
                                         ChatRenderedScrollTargets.row(
                                             semanticID: target.id,
                                             scope: $0,
-                                            frame: geometry.frame(in: .global)
+                                            frame: geometry.frame(in: .global),
+                                            order: index
                                         )
                                     } ?? ChatRenderedScrollTargets()
                                 )
@@ -571,11 +573,12 @@ struct ChatView: View {
 
     private func currentLayoutFacts() -> ChatViewportLayoutFacts {
         let scope = renderedScrollScope
-        let frames = renderedRowFrames.map { id, frame in
+        let frames = renderedRowFrames.map { id, geometry in
             ChatRenderedRowFrame(
                 id: id,
-                minY: frame.minY,
-                maxY: frame.maxY,
+                minY: geometry.frame.minY,
+                maxY: geometry.frame.maxY,
+                order: geometry.order,
                 scope: scope ?? ChatRenderedScrollScope(
                     sessionKey: activeOrFallbackScrollSessionKey,
                     cacheRevision: 0,

--- a/Conduit/Views/Components/GatewayMediaDataURLResolver.swift
+++ b/Conduit/Views/Components/GatewayMediaDataURLResolver.swift
@@ -14,10 +14,17 @@
 //  reference, compare it by identity, and build the per-call closure
 //  inside their own body.
 //
+//  AppState owns the canonical instance (see
+//  `AppState.gatewayMediaResolver`) so ChatView's FIRST body pass already
+//  has a resolver — no nil → resolver invalidation pass over the settled
+//  transcript after appear. The appState reference is weak because the
+//  AppState-cached resolver would otherwise retain its owner in a cycle;
+//  AppState outlives every view that holds the resolver.
+//
 
 @MainActor
 final class GatewayMediaDataURLResolver {
-    private let appState: AppState
+    private weak var appState: AppState?
     let profile: String
 
     init(appState: AppState, profile: String) {
@@ -26,6 +33,7 @@ final class GatewayMediaDataURLResolver {
     }
 
     func dataURL(for path: String) async -> String? {
-        await appState.gatewayMediaDataURL(for: path, profile: profile)
+        guard let appState else { return nil }
+        return await appState.gatewayMediaDataURL(for: path, profile: profile)
     }
 }

--- a/Conduit/Views/Components/GatewayMediaDataURLResolver.swift
+++ b/Conduit/Views/Components/GatewayMediaDataURLResolver.swift
@@ -1,0 +1,31 @@
+//
+//  GatewayMediaDataURLResolver.swift
+//  Conduit
+//
+//  A stable presentation dependency for gateway `MEDIA:` resolution.
+//
+//  Assistant/user Markdown content needs `AppState.gatewayMediaDataURL`
+//  for gateway-hosted images, but capturing AppState (or building a fresh
+//  closure each body evaluation) inside a settled row would either
+//  subscribe the row to every AppState publish — invalidating hundreds of
+//  settled rows on each streaming tick — or defeat SwiftUI's Equatable
+//  gating because closures never compare equal. This resolver is a small
+//  object with a stable identity per profile: rows hold it as a plain
+//  reference, compare it by identity, and build the per-call closure
+//  inside their own body.
+//
+
+@MainActor
+final class GatewayMediaDataURLResolver {
+    private let appState: AppState
+    let profile: String
+
+    init(appState: AppState, profile: String) {
+        self.appState = appState
+        self.profile = profile
+    }
+
+    func dataURL(for path: String) async -> String? {
+        await appState.gatewayMediaDataURL(for: path, profile: profile)
+    }
+}

--- a/Conduit/Views/Components/MarkdownSelectionCoordinator.swift
+++ b/Conduit/Views/Components/MarkdownSelectionCoordinator.swift
@@ -233,6 +233,12 @@ final class MarkdownSelectionCoordinator: ObservableObject {
         publishIfVisibleSelectionChanged(from: before)
     }
 
+    /// Whether a segment currently has a mounted text view registered —
+    /// the behavior-level query for registration lifecycle tests.
+    func isSegmentRegistered(_ segmentID: String) -> Bool {
+        recordsByID[segmentID]?.textView != nil
+    }
+
     func register(descriptor: MarkdownSelectionSegmentDescriptor, textView: UITextView) {
         let existingRecord = recordsByID[descriptor.id]
         let registrationChanged = existingRecord?.descriptor != descriptor || existingRecord?.textView !== textView

--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -52,6 +52,7 @@ struct MarkdownText: View {
 
     @ViewBuilder
     private var normalBody: some View {
+        let _ = isStreaming ? () : TranscriptPerf.note(.settledMarkdownBody)
         let rendering = MarkdownRenderCache.rendering(
             source: source,
             recognizesGatewayMedia: gatewayMediaDataURL != nil,

--- a/Conduit/Views/Components/SelectableTextView.swift
+++ b/Conduit/Views/Components/SelectableTextView.swift
@@ -172,8 +172,18 @@ struct SelectableTextView: UIViewRepresentable {
             replacementTextView.attributedText = uiView.mountedTextView.attributedText
             replacementTextView.selectedRange = uiView.mountedTextView.selectedRange
             uiView.setMountedTextView(replacementTextView)
-            // The mounted text view instance changed: metrics derived from it
-            // must not be served from cache.
+            // The mounted text view instance changed. The replacement only
+            // inherits attributedText/selection — font, colors, line limits,
+            // wrapping, container sizing, and link attributes are applied by
+            // `configure` alone, so the presentation gate must not skip it:
+            // clear the applied presentation (and cached metrics derived
+            // from the previous instance) so the gate below configures this
+            // fresh view exactly once. Attributed content is still preserved:
+            // configure's isEqual guard skips replacement when the copied
+            // text already matches, so a selection-only swap does not
+            // regenerate content.
+            coordinator.appliedPresentation = nil
+            coordinator.cachedMeasurement = nil
             coordinator.presentationGeneration &+= 1
         }
 

--- a/Conduit/Views/Components/SelectableTextView.swift
+++ b/Conduit/Views/Components/SelectableTextView.swift
@@ -172,12 +172,29 @@ struct SelectableTextView: UIViewRepresentable {
             replacementTextView.attributedText = uiView.mountedTextView.attributedText
             replacementTextView.selectedRange = uiView.mountedTextView.selectedRange
             uiView.setMountedTextView(replacementTextView)
+            // The mounted text view instance changed: metrics derived from it
+            // must not be served from cache.
+            coordinator.presentationGeneration &+= 1
         }
 
         let textView = uiView.mountedTextView
         textView.delegate = coordinator
         configureSelectionBridge(for: textView, coordinator: coordinator)
-        configure(textView)
+
+        // Presentation identity: when every input that materially affects
+        // text styling/layout is unchanged, `configure` is a no-op-by-rebuild
+        // (styled copy, attribute enumeration, container mutation, intrinsic
+        // invalidation) — skip it entirely. Selection registration below is
+        // deliberately NOT part of the gate: coordinator/segment changes must
+        // keep flowing without forcing text restyling.
+        let presentation = Coordinator.Presentation(view: self)
+        let presentationIsUnchanged = coordinator.appliedPresentation == presentation
+        if !presentationIsUnchanged {
+            configure(textView)
+            coordinator.appliedPresentation = presentation
+            coordinator.presentationGeneration &+= 1
+        }
+
         registerSelectionIfNeeded(for: textView, coordinator: coordinator)
         uiView.mountedSelectionCoordinator = coordinator.selectionCoordinator
         uiView.mountedSelectionSegment = coordinator.selectionSegment
@@ -214,7 +231,73 @@ struct SelectableTextView: UIViewRepresentable {
     }
 
     func sizeThatFits(_ proposal: ProposedViewSize, uiView: SelectableTextViewHostView, context: Context) -> CGSize? {
-        measuredSize(proposalWidth: proposal.width, textView: uiView.mountedTextView)
+        measuredSizeCached(
+            proposalWidth: proposal.width,
+            textView: uiView.mountedTextView,
+            coordinator: context.coordinator
+        )
+    }
+
+    /// Cached measurement entry for the SwiftUI sizing hook: an unchanged
+    /// presentation measured at the same effective width returns the cached
+    /// CGSize without asking TextKit to lay the text out again. Any change
+    /// that can alter geometry bumps `presentationGeneration` in
+    /// `updateUIViewForTests`, invalidating the entry; the cache lives on
+    /// the coordinator and dies with the mounted view.
+    @MainActor
+    func measuredSizeCached(
+        proposalWidth: CGFloat?,
+        textView: UITextView,
+        coordinator: Coordinator
+    ) -> CGSize? {
+        let key: Coordinator.MeasurementKey
+        switch effectiveMeasurementMode(proposalWidth: proposalWidth) {
+        case .none:
+            return nil
+        case .nonWrapping:
+            key = .nonWrapping
+        case .selfSizing:
+            key = .selfSizing
+        case .wrapping(let width):
+            key = .wrapping(width: width)
+        }
+
+        if let cached = coordinator.cachedMeasurement,
+           cached.generation == coordinator.presentationGeneration,
+           cached.key == key {
+            return cached.size
+        }
+        guard let size = measuredSize(proposalWidth: proposalWidth, textView: textView) else {
+            return nil
+        }
+        coordinator.cachedMeasurement = Coordinator.CachedMeasurement(
+            generation: coordinator.presentationGeneration,
+            key: key,
+            size: size
+        )
+        return size
+    }
+
+    /// The measurement mode derived from the view's configuration and the
+    /// proposal — mirrors the branching in `measuredSize(proposalWidth:textView:)`.
+    private enum MeasurementMode {
+        case none
+        case nonWrapping
+        case selfSizing
+        case wrapping(width: CGFloat)
+    }
+
+    private func effectiveMeasurementMode(proposalWidth: CGFloat?) -> MeasurementMode {
+        if !wrapsLines {
+            return .nonWrapping
+        }
+        if selfSizingWidthRange != nil {
+            return .selfSizing
+        }
+        guard let width = proposalWidth, width > 0, width.isFinite else {
+            return .none
+        }
+        return .wrapping(width: width)
     }
 
     /// Extracted sizing logic so `sizeThatFits` and unit tests share one
@@ -438,9 +521,62 @@ struct SelectableTextView: UIViewRepresentable {
     }
 
     final class Coordinator: NSObject, UITextViewDelegate {
+        /// Every input that materially affects text presentation. When an
+        /// incoming update's presentation equals the applied one, text
+        /// configuration is skipped. `NSAttributedString` equality is
+        /// content equality, so a stable object from the Markdown render
+        /// cache compares equal cheaply while a genuinely changed value
+        /// correctly invalidates.
+        struct Presentation: Equatable {
+            let attributedText: NSAttributedString
+            let font: UIFont
+            let textColor: UIColor
+            let lineSpacing: CGFloat
+            let maximumNumberOfLines: Int
+            let wrapsLines: Bool
+            let linkColor: UIColor
+            let textAlignment: NSTextAlignment
+            let selfSizingWidthRange: ClosedRange<CGFloat>?
+
+            init(view: SelectableTextView) {
+                self.attributedText = view.attributedText
+                self.font = view.font
+                self.textColor = view.textColor
+                self.lineSpacing = view.lineSpacing
+                self.maximumNumberOfLines = view.maximumNumberOfLines
+                self.wrapsLines = view.wrapsLines
+                self.linkColor = view.linkColor
+                self.textAlignment = view.textAlignment
+                self.selfSizingWidthRange = view.selfSizingWidthRange
+            }
+        }
+
+        /// Identifies the effective measurement inputs for the sizing cache.
+        /// The presentation generation (bumped whenever styling is applied or
+        /// the mounted text view is swapped) covers content/font/spacing/
+        /// alignment/limits; the key covers the width regime.
+        enum MeasurementKey: Equatable {
+            case nonWrapping
+            case selfSizing
+            case wrapping(width: CGFloat)
+        }
+
+        struct CachedMeasurement {
+            let generation: UInt64
+            let key: MeasurementKey
+            let size: CGSize
+        }
+
         var linkColor: UIColor
         weak var selectionCoordinator: MarkdownSelectionCoordinator?
         var selectionSegment: MarkdownSelectionSegmentDescriptor?
+
+        var appliedPresentation: Presentation?
+        var presentationGeneration: UInt64 = 0
+        /// One-entry measurement cache scoped to the current presentation
+        /// generation. Invalidated by any generation bump; lives and dies
+        /// with the coordinator (i.e. the mounted view).
+        var cachedMeasurement: CachedMeasurement?
 
         init(
             linkColor: UIColor,

--- a/Conduit/Views/Components/SelectableTextView.swift
+++ b/Conduit/Views/Components/SelectableTextView.swift
@@ -159,6 +159,7 @@ struct SelectableTextView: UIViewRepresentable {
 
     @MainActor
     func updateUIViewForTests(_ uiView: SelectableTextViewHostView, coordinator: Coordinator) {
+        TranscriptPerf.note(.selectableTextViewUpdate)
         coordinator.linkColor = linkColor
         coordinator.selectionCoordinator = selectionCoordinator
         coordinator.selectionSegment = selectionSegment
@@ -248,6 +249,7 @@ struct SelectableTextView: UIViewRepresentable {
     /// (TextKit 2) the proposed width drives wrapping independent of the
     /// text container's stored size, so no container mutation is needed.
     static func measuredWrappingHeight(of textView: UITextView, at width: CGFloat) -> CGFloat {
+        TranscriptPerf.note(.textKitMeasurement)
         let measured = textView.sizeThatFits(CGSize(width: width, height: CGFloat.greatestFiniteMagnitude))
         return ceil(measured.height)
     }
@@ -296,6 +298,7 @@ struct SelectableTextView: UIViewRepresentable {
 
         let selectedRange = textView.selectedRange
         if !textView.attributedText.isEqual(to: styledText) {
+            TranscriptPerf.note(.selectableTextViewTextRebuild)
             textView.attributedText = styledText
             let selectedLocation = min(selectedRange.location, styledText.length)
             let selectedEnd = min(NSMaxRange(selectedRange), styledText.length)

--- a/ConduitTests/ChatMessageScrollTargetCacheIncrementalTests.swift
+++ b/ConduitTests/ChatMessageScrollTargetCacheIncrementalTests.swift
@@ -1,0 +1,229 @@
+import XCTest
+@testable import Conduit
+
+/// Regression tests for incremental target-cache fingerprinting (Fix 5):
+/// appending or replacing a transcript tail must hash only the changed
+/// suffix, and every incremental result must be identical to the existing
+/// full-rebuild reference. Deterministic via TranscriptPerf counters.
+final class ChatMessageScrollTargetCacheIncrementalTests: XCTestCase {
+
+    private func message(_ id: String, _ content: String, role: MessageRole = .assistant) -> ChatMessage {
+        ChatMessage(
+            id: id,
+            role: role,
+            content: content,
+            timestamp: "2026-01-01T00:00:00Z"
+        )
+    }
+
+    /// The full-rebuild reference: exactly what the pre-incremental
+    /// implementation produced for any transcript.
+    private func referenceTargets(for messages: [ChatMessage]) -> [ChatMessageScrollTarget] {
+        ChatMessageScrollTargets.make(for: messages)
+    }
+
+    /// Drives the incremental cache through a sequence of transcripts and
+    /// asserts each result equals the full-rebuild reference.
+    private func assertSequence(
+        _ transcripts: [[ChatMessage]],
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        var cache = ChatMessageScrollTargetCache()
+        for messages in transcripts {
+            let result = cache.update(for: messages)
+            XCTAssertNotEqual(
+                result, .unchanged,
+                "a real transcript change must not report unchanged",
+                file: file, line: line
+            )
+            XCTAssertEqual(
+                cache.targets, referenceTargets(for: messages),
+                "incremental result must equal the full-rebuild reference",
+                file: file, line: line
+            )
+        }
+    }
+
+    private func prime(_ messages: [ChatMessage]) -> ChatMessageScrollTargetCache {
+        var cache = ChatMessageScrollTargetCache()
+        _ = cache.update(for: messages)
+        return cache
+    }
+
+    // MARK: - Incremental work bounds (counters)
+
+    func testAppendHashesOnlyTheAppendedMessage() {
+        let base = (0..<200).map { message("m\($0)", "settled content \($0) with some length") }
+        var cache = prime(base)
+
+        TranscriptPerf.reset()
+        _ = cache.update(for: base + [message("m200", "the new final message")])
+
+        XCTAssertEqual(
+            TranscriptPerf.lastFingerprintedMessageCount, 1,
+            "an append must fingerprint only the appended message"
+        )
+    }
+
+    func testTailReplacementHashesOnlyTheChangedTail() {
+        let base = (0..<200).map { message("m\($0)", "settled content \($0) with some length") }
+        var cache = prime(base)
+
+        var replaced = base
+        replaced[199] = message("m199", "edited final message")
+
+        TranscriptPerf.reset()
+        _ = cache.update(for: replaced)
+
+        XCTAssertEqual(
+            TranscriptPerf.lastFingerprintedMessageCount, 1,
+            "a tail replacement must fingerprint only the changed tail"
+        )
+    }
+
+    func testUnchangedTranscriptHashesNothing() {
+        let base = (0..<50).map { message("m\($0)", "content \($0)") }
+        var cache = prime(base)
+
+        TranscriptPerf.reset()
+        let result = cache.update(for: base)
+        XCTAssertEqual(result, .unchanged)
+        XCTAssertEqual(TranscriptPerf.lastFingerprintedMessageCount, 0)
+    }
+
+    // MARK: - Incremental equivalence vs full rebuild
+
+    func testAppendResultMatchesFullRebuild() {
+        assertSequence([
+            [message("a", "one")],
+            [message("a", "one"), message("b", "two")],
+            [message("a", "one"), message("b", "two"), message("c", "three")],
+        ])
+    }
+
+    func testTailReplacementResultMatchesFullRebuild() {
+        assertSequence([
+            [message("a", "one"), message("b", "two"), message("c", "three"), message("d", "four")],
+            [message("a", "one"), message("b", "two"), message("c", "three"), message("d", "EDITED")],
+        ])
+    }
+
+    func testRenderingOnlyReplacementPreservesSemanticIDsAndReportsRenderingChanged() {
+        var cache = prime([message("a", "one"), message("b", "two")])
+        let originalIDs = cache.targets.map(\.semanticID)
+
+        // Same fingerprints (same content), different message object (e.g.
+        // normalized attachment metadata elsewhere on the value).
+        let reprojected = [
+            ChatMessage(id: "a", role: .assistant, content: "one", timestamp: "2026-01-02T00:00:00Z"),
+            ChatMessage(id: "b", role: .assistant, content: "two", timestamp: "2026-01-02T00:00:00Z"),
+        ]
+
+        TranscriptPerf.reset()
+        let result = cache.update(for: reprojected)
+        XCTAssertEqual(result, .renderingChanged)
+        XCTAssertEqual(cache.targets.map(\.semanticID), originalIDs)
+        XCTAssertEqual(cache.targets, referenceTargets(for: reprojected))
+        // Fingerprinting still hashes only the diverging suffix (timestamp
+        // differs from the first element, so the whole array is the suffix
+        // here — but the reference comparison above proves correctness).
+        XCTAssertGreaterThan(TranscriptPerf.lastFingerprintedMessageCount, 0)
+    }
+
+    func testDuplicateContentsFallBackToFullRebuildAndMatchReference() {
+        // Appending a duplicate of an existing fingerprint must not take an
+        // incremental path that would mis-number occurrences.
+        let a1 = message("a1", "identical body")
+        let a2 = message("a2", "identical body")
+        let b = message("b", "different body")
+
+        var cache = prime([a1, a2, b])
+        XCTAssertEqual(cache.targets.map(\.semanticID), referenceTargets(for: [a1, a2, b]).map(\.semanticID))
+
+        TranscriptPerf.reset()
+        _ = cache.update(for: [a1, a2, b, message("a3", "identical body")])
+
+        XCTAssertEqual(
+            cache.targets, referenceTargets(for: [a1, a2, b, message("a3", "identical body")]),
+            "duplicate-crossing append must still match the full-rebuild reference"
+        )
+        XCTAssertEqual(
+            TranscriptPerf.lastFingerprintedMessageCount, 4,
+            "duplicate-crossing mutations must fall back to a full rebuild"
+        )
+    }
+
+    func testMiddleInsertionMatchesFullRebuild() {
+        assertSequence([
+            [message("a", "one"), message("c", "three")],
+            [message("a", "one"), message("b", "inserted"), message("c", "three")],
+        ])
+    }
+
+    func testDeletionMatchesFullRebuild() {
+        assertSequence([
+            [message("a", "one"), message("b", "two"), message("c", "three"), message("d", "four")],
+            [message("a", "one"), message("b", "two"), message("d", "four")],
+        ])
+    }
+
+    func testReorderFallsBackToFullRebuildAndMatchesReference() {
+        assertSequence([
+            [message("a", "one"), message("b", "two"), message("c", "three")],
+            [message("c", "three"), message("a", "one"), message("b", "two")],
+        ])
+    }
+
+    func testFullReplacementMatchesFullRebuild() {
+        assertSequence([
+            [message("a", "one"), message("b", "two")],
+            [message("x", "completely"), message("y", "different"), message("z", "transcript")],
+        ])
+    }
+
+    /// Property-style sweep: randomized mutations over a transcript with a
+    /// colliding fingerprint pool, incremental vs reference, always equal.
+    func testRandomizedMutationsAlwaysMatchFullRebuild() {
+        var messages = (0..<40).map { message("m\($0)", "body \($0 % 7) of message \($0)") }
+        var cache = prime(messages)
+        XCTAssertEqual(cache.targets, referenceTargets(for: messages))
+
+        // Deterministic pseudo-random sequence: seeded LCG.
+        var seed: UInt64 = 0x9E3779B97F4A7C15
+        func next() -> UInt64 {
+            seed = seed &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+            return seed
+        }
+
+        for step in 0..<60 {
+            switch next() % 5 {
+            case 0: // append
+                messages.append(message("s\(step)-append", "body \(next() % 9) appended"))
+            case 1: // delete
+                guard messages.count > 1 else { break }
+                messages.remove(at: Int(next() % UInt64(messages.count)))
+            case 2: // insert middle
+                messages.insert(
+                    message("s\(step)-insert", "body \(next() % 9) inserted"),
+                    at: Int(next() % UInt64(messages.count))
+                )
+            case 3: // edit tail
+                if !messages.isEmpty {
+                    let idx = messages.count - 1 - Int(next() % 3)
+                    messages[idx] = message(messages[idx].id, "body \(next() % 9) edited")
+                }
+            default: // duplicate an existing body
+                if !messages.isEmpty {
+                    let source = messages[Int(next() % UInt64(messages.count))]
+                    messages.append(message("s\(step)-dup", source.content))
+                }
+            }
+            _ = cache.update(for: messages)
+            XCTAssertEqual(
+                cache.targets, referenceTargets(for: messages),
+                "step \(step): incremental result diverged from the full-rebuild reference"
+            )
+        }
+    }
+}

--- a/ConduitTests/ChatMessageScrollTargetCacheIncrementalTests.swift
+++ b/ConduitTests/ChatMessageScrollTargetCacheIncrementalTests.swift
@@ -208,9 +208,9 @@ final class ChatMessageScrollTargetCacheIncrementalTests: XCTestCase {
                     message("s\(step)-insert", "body \(next() % 9) inserted"),
                     at: Int(next() % UInt64(messages.count))
                 )
-            case 3: // edit tail
+            case 3: // edit near the tail (clamped to valid indices)
                 if !messages.isEmpty {
-                    let idx = messages.count - 1 - Int(next() % 3)
+                    let idx = max(0, messages.count - 1 - Int(next() % 3))
                     messages[idx] = message(messages[idx].id, "body \(next() % 9) edited")
                 }
             default: // duplicate an existing body

--- a/ConduitTests/ChatScrollStateTests.swift
+++ b/ConduitTests/ChatScrollStateTests.swift
@@ -855,6 +855,6 @@ extension ChatScrollStateTests {
                 semanticID: "m2", scope: scope, frame: CGRect(x: 0, y: 999, width: 300, height: 240)
             )
         )
-        XCTAssertEqual(pass3.rowFrames(in: scope)["m2"]?.minY, 999)
+        XCTAssertEqual(pass3.rowFrames(in: scope)["m2"]?.frame.minY, 999)
     }
 }

--- a/ConduitTests/ChatViewportControllerTests.swift
+++ b/ConduitTests/ChatViewportControllerTests.swift
@@ -2054,4 +2054,40 @@ extension ChatViewportControllerTests {
         XCTAssertTrue(tickEffects.isEmpty,
                       "no restoration state means the tick is a no-op")
     }
+
+    // MARK: - Duplicate transcript-change regression
+
+    func testSingleTranscriptMutationCausesOneTranscriptChangedCall() {
+        var controller = makeController(following: keyA)
+        let msgs = [message("m1", "hello")]
+
+        TranscriptPerf.reset()
+        _ = controller.transcriptChanged(
+            messages: msgs,
+            transcriptRevision: 1,
+            viewportTransitionGeneration: 1
+        )
+        XCTAssertEqual(TranscriptPerf.transcriptChangedCalls, 1,
+                       "one mutation must cause exactly one transcriptChanged call")
+    }
+
+    func testDuplicateTranscriptChangedIsIdempotent() {
+        var controller = makeController(following: keyA)
+        let msgs = [message("m1", "hello")]
+
+        // First call: semantic change
+        let first = controller.transcriptChanged(
+            messages: msgs,
+            transcriptRevision: 1,
+            viewportTransitionGeneration: 1
+        )
+        // Second call with identical messages: should be .unchanged
+        let second = controller.transcriptChanged(
+            messages: msgs,
+            transcriptRevision: 1,
+            viewportTransitionGeneration: 1
+        )
+        XCTAssertNotEqual(first, [], "first call should produce effects")
+        XCTAssertEqual(second, [], "duplicate call with same messages must be no-op")
+    }
 }

--- a/ConduitTests/ChatViewportControllerTests.swift
+++ b/ConduitTests/ChatViewportControllerTests.swift
@@ -923,8 +923,8 @@ final class ChatViewportControllerTests: XCTestCase {
             viewportMinY: 100,
             viewportMaxY: 800,
             rowFrames: [
-                ChatRenderedRowFrame(id: "m1", minY: 40, maxY: 140, scope: scope),
-                ChatRenderedRowFrame(id: "m2", minY: 160, maxY: 400, scope: scope),
+                ChatRenderedRowFrame(id: "m1", minY: 40, maxY: 140, order: 0, scope: scope),
+                ChatRenderedRowFrame(id: "m2", minY: 160, maxY: 400, order: 1, scope: scope),
             ],
             scope: scope
         ))
@@ -956,8 +956,8 @@ final class ChatViewportControllerTests: XCTestCase {
             viewportMinY: 100,
             viewportMaxY: 800,
             rowFrames: [
-                ChatRenderedRowFrame(id: "m2", minY: 120, maxY: 300, scope: scope),
-                ChatRenderedRowFrame(id: "m3", minY: 320, maxY: 500, scope: scope),
+                ChatRenderedRowFrame(id: "m2", minY: 120, maxY: 300, order: 1, scope: scope),
+                ChatRenderedRowFrame(id: "m3", minY: 320, maxY: 500, order: 2, scope: scope),
             ],
             scope: scope
         ))
@@ -970,12 +970,57 @@ final class ChatViewportControllerTests: XCTestCase {
             viewportMinY: 100,
             viewportMaxY: 800,
             rowFrames: [
-                ChatRenderedRowFrame(id: "m1", minY: 40, maxY: 140, scope: scope),
-                ChatRenderedRowFrame(id: "m2", minY: 160, maxY: 340, scope: scope),
+                ChatRenderedRowFrame(id: "m1", minY: 40, maxY: 140, order: 0, scope: scope),
+                ChatRenderedRowFrame(id: "m2", minY: 160, maxY: 340, order: 1, scope: scope),
             ],
             scope: scope
         ))
         XCTAssertEqual(controller.stableTopMessageID, "m1")
+    }
+
+    /// Fix 4 regression: with a deep transcript (hundreds of targets) but only
+    /// a handful of rendered frames, stable-top detection must process only
+    /// the rendered frames — deterministic via the stable-top scan counter —
+    /// and still pick the first visible row in transcript order.
+    func testStableTopDetectionScalesWithRenderedRowsNotTranscriptLength() {
+        var controller = makeController(following: keyA)
+        // 500-message transcript.
+        let deepTranscript = (0..<500).map { message("deep-\($0)", "content \($0)") }
+        _ = controller.transcriptChanged(
+            messages: deepTranscript,
+            transcriptRevision: 1,
+            viewportTransitionGeneration: 1
+        )
+        XCTAssertEqual(controller.targets.count, 500)
+        guard let scope = controller.renderedScrollScope else {
+            return XCTFail("expected a scope")
+        }
+
+        // Only three rows actually rendered near the viewport (lazy layout),
+        // reported out of order to prove the min-by-order selection.
+        TranscriptPerf.reset()
+        _ = controller.layoutMetricsChanged(facts: layoutFacts(
+            bottomMarkerMaxY: 900,
+            viewportMinY: 100,
+            viewportMaxY: 800,
+            rowFrames: [
+                ChatRenderedRowFrame(id: "deep-301", minY: 500, maxY: 700, order: 301, scope: scope),
+                ChatRenderedRowFrame(id: "deep-300", minY: 300, maxY: 480, order: 300, scope: scope),
+                ChatRenderedRowFrame(id: "deep-299", minY: 120, maxY: 280, order: 299, scope: scope),
+            ],
+            scope: scope
+        ))
+
+        XCTAssertEqual(controller.stableTopMessageID, "deep-299",
+                       "must pick the lowest-order visible rendered row")
+        XCTAssertEqual(
+            TranscriptPerf.stableTopScanTargetCount, 3,
+            "work must scale with rendered frames, not total transcript length"
+        )
+        XCTAssertNotEqual(
+            TranscriptPerf.stableTopScanTargetCount, controller.targets.count,
+            "the full transcript target list must not be scanned"
+        )
     }
 }
 
@@ -1590,9 +1635,9 @@ extension ChatViewportControllerTests {
             viewportMinY: 100,
             viewportMaxY: 800,
             rowFrames: [
-                ChatRenderedRowFrame(id: "m1", minY: 40, maxY: 140, scope: scope),
-                ChatRenderedRowFrame(id: "m2", minY: 160, maxY: 400, scope: scope),
-                ChatRenderedRowFrame(id: "m3", minY: 420, maxY: 700, scope: scope),
+                ChatRenderedRowFrame(id: "m1", minY: 40, maxY: 140, order: 0, scope: scope),
+                ChatRenderedRowFrame(id: "m2", minY: 160, maxY: 400, order: 1, scope: scope),
+                ChatRenderedRowFrame(id: "m3", minY: 420, maxY: 700, order: 2, scope: scope),
             ],
             scope: scope
         ))
@@ -1607,8 +1652,8 @@ extension ChatViewportControllerTests {
             viewportMinY: 100,
             viewportMaxY: 800,
             rowFrames: [
-                ChatRenderedRowFrame(id: "m2", minY: 120, maxY: 360, scope: scope),
-                ChatRenderedRowFrame(id: "m3", minY: 380, maxY: 660, scope: scope),
+                ChatRenderedRowFrame(id: "m2", minY: 120, maxY: 360, order: 1, scope: scope),
+                ChatRenderedRowFrame(id: "m3", minY: 380, maxY: 660, order: 2, scope: scope),
             ],
             scope: scope
         ))

--- a/ConduitTests/ComposerPasteTextViewTests.swift
+++ b/ConduitTests/ComposerPasteTextViewTests.swift
@@ -8,93 +8,105 @@ import XCTest
 
 @MainActor
 final class ComposerPasteTextViewTests: XCTestCase {
-    private var savedPasteboardItems: [[String: Any]] = []
-
-    override func setUp() {
-        super.setUp()
-        // Snapshot the system pasteboard so tearDown can restore it instead of
-        // clobbering a real clipboard (relevant when the suite runs on a device).
-        savedPasteboardItems = UIPasteboard.general.items
-    }
-
-    override func tearDown() {
-        UIPasteboard.general.items = savedPasteboardItems
-        super.tearDown()
-    }
+    // Tests that mutate UIPasteboard.general wrap their body in
+    // withClearedGeneralPasteboard so they start from a known-empty clipboard
+    // and leave nothing behind. A suite-wide setUp()/tearDown()
+    // used to round-trip UIPasteboard.general.items around every test —
+    // including the purely in-memory NSItemProvider tests below — and the
+    // .items getter is the dangerous half: it materializes whatever the
+    // simulator clipboard holds (content this app did not write), which can
+    // block indefinitely on CI simulators. XCTest logs "Test Case ... started"
+    // before setUp() returns, so the stall presents as a stuck first test
+    // rather than a hung pasteboard read. Writes and clears are safe, so
+    // isolation here uses clears only — never an unsolicited read.
 
     func testPasteboardContainsImageTrueForImagePasteboard() {
-        let view = ImagePasteTextView()
-        UIPasteboard.general.image = Self.fixtureImage()
+        withClearedGeneralPasteboard {
+            let view = ImagePasteTextView()
+            UIPasteboard.general.image = Self.fixtureImage()
 
-        XCTAssertTrue(view.pasteboardContainsImage())
+            XCTAssertTrue(view.pasteboardContainsImage())
+        }
     }
 
     func testPasteboardContainsImageFalseForTextPasteboard() {
-        let view = ImagePasteTextView()
-        UIPasteboard.general.string = "just text"
+        withClearedGeneralPasteboard {
+            let view = ImagePasteTextView()
+            UIPasteboard.general.string = "just text"
 
-        XCTAssertFalse(view.pasteboardContainsImage())
+            XCTAssertFalse(view.pasteboardContainsImage())
+        }
     }
 
     func testCanPerformActionOffersPasteForImagePasteboard() {
-        let view = ImagePasteTextView()
-        view.isEditable = true
-        UIPasteboard.general.image = Self.fixtureImage()
+        withClearedGeneralPasteboard {
+            let view = ImagePasteTextView()
+            view.isEditable = true
+            UIPasteboard.general.image = Self.fixtureImage()
 
-        // Regression: UITextView drops "Paste" for an image-only pasteboard, so
-        // the long-press edit menu only offered system items like "Autofill".
-        // canPerformAction must surface paste: so the existing paste(_:) path
-        // becomes reachable from the menu.
-        XCTAssertTrue(view.canPerformAction(#selector(UIResponder.paste(_:)), withSender: nil))
+            // Regression: UITextView drops "Paste" for an image-only pasteboard, so
+            // the long-press edit menu only offered system items like "Autofill".
+            // canPerformAction must surface paste: so the existing paste(_:) path
+            // becomes reachable from the menu.
+            XCTAssertTrue(view.canPerformAction(#selector(UIResponder.paste(_:)), withSender: nil))
+        }
     }
 
     func testShouldOfferImagePasteTrueForImagePasteboard() {
-        let view = ImagePasteTextView()
-        view.isEditable = true
-        UIPasteboard.general.image = Self.fixtureImage()
+        withClearedGeneralPasteboard {
+            let view = ImagePasteTextView()
+            view.isEditable = true
+            UIPasteboard.general.image = Self.fixtureImage()
 
-        XCTAssertTrue(view.shouldOfferImagePaste())
+            XCTAssertTrue(view.shouldOfferImagePaste())
+        }
     }
 
     func testShouldOfferImagePasteFalseWhenNotEditable() {
-        let view = ImagePasteTextView()
-        view.isEditable = false
-        UIPasteboard.general.image = Self.fixtureImage()
+        withClearedGeneralPasteboard {
+            let view = ImagePasteTextView()
+            view.isEditable = false
+            UIPasteboard.general.image = Self.fixtureImage()
 
-        // A disabled composer must not offer image paste even with an image on
-        // the pasteboard.
-        XCTAssertFalse(view.shouldOfferImagePaste())
+            // A disabled composer must not offer image paste even with an image on
+            // the pasteboard.
+            XCTAssertFalse(view.shouldOfferImagePaste())
+        }
     }
 
     func testShouldOfferImagePasteFalseForTextOnlyPasteboard() {
-        let view = ImagePasteTextView()
-        view.isEditable = true
-        UIPasteboard.general.string = "just text"
+        withClearedGeneralPasteboard {
+            let view = ImagePasteTextView()
+            view.isEditable = true
+            UIPasteboard.general.string = "just text"
 
-        // Text-only content must not be treated as an image paste.
-        XCTAssertFalse(view.shouldOfferImagePaste())
+            // Text-only content must not be treated as an image paste.
+            XCTAssertFalse(view.shouldOfferImagePaste())
+        }
     }
 
     func testPasteSelectorDeliversImageFromPasteboard() async {
         // End-to-end check of the exact path a menu tap now dispatches: the
         // legacy paste(_:) selector reads UIPasteboard.general and fires
         // onPastedImage. This is independent of the canPerformAction gate.
-        let view = ImagePasteTextView()
-        UIPasteboard.general.image = Self.fixtureImage()
+        await withClearedGeneralPasteboard {
+            let view = ImagePasteTextView()
+            UIPasteboard.general.image = Self.fixtureImage()
 
-        let callback = expectation(description: "paste(_:) delivered image")
-        view.onPastedImage = { pastedImage in
-            XCTAssertFalse(pastedImage.data.isEmpty)
-            XCTAssertEqual(pastedImage.typeIdentifier, UTType.png.identifier)
-            callback.fulfill()
+            let callback = expectation(description: "paste(_:) delivered image")
+            view.onPastedImage = { pastedImage in
+                XCTAssertFalse(pastedImage.data.isEmpty)
+                XCTAssertEqual(pastedImage.typeIdentifier, UTType.png.identifier)
+                callback.fulfill()
+            }
+            view.onPastedImageError = { message in
+                XCTFail("paste(_:) should deliver the image, got: \(message)")
+            }
+
+            view.paste(nil as Any?)
+
+            await fulfillment(of: [callback], timeout: 5.0)
         }
-        view.onPastedImageError = { message in
-            XCTFail("paste(_:) should deliver the image, got: \(message)")
-        }
-
-        view.paste(nil as Any?)
-
-        await fulfillment(of: [callback], timeout: 5.0)
     }
 
     func testProgrammaticTextApplicationDoesNotPublishAsUserEditing() {
@@ -390,6 +402,29 @@ final class ComposerPasteTextViewTests: XCTestCase {
             ComposerBar.pastedImageErrorMessage("The image provider failed."),
             "Could not paste image: The image provider failed."
         )
+    }
+
+    /// Clears the general pasteboard, runs `body`, then clears it again.
+    /// Scoped to the tests that actually write to UIPasteboard.general so
+    /// every other test in this suite stays off the global pasteboard service
+    /// entirely. Deliberately performs NO read of `items`: materializing
+    /// existing clipboard content is what wedges CI simulators, while clears
+    /// and writes stay safe. The trailing clear also keeps image payloads from
+    /// leaking into later suites.
+    private func withClearedGeneralPasteboard(_ body: () throws -> Void) rethrows {
+        let pasteboard = UIPasteboard.general
+        pasteboard.items = []
+        defer { pasteboard.items = [] }
+        try body()
+    }
+
+    /// Async counterpart for tests that await while their mutated pasteboard
+    /// content is live (e.g. waiting on a paste callback expectation).
+    private func withClearedGeneralPasteboard(_ body: () async throws -> Void) async rethrows {
+        let pasteboard = UIPasteboard.general
+        pasteboard.items = []
+        defer { pasteboard.items = [] }
+        try await body()
     }
 
     private static func fixtureImage() -> UIImage {

--- a/ConduitTests/SelectableTextViewPresentationCacheTests.swift
+++ b/ConduitTests/SelectableTextViewPresentationCacheTests.swift
@@ -1,0 +1,240 @@
+import XCTest
+import UIKit
+@testable import Conduit
+
+/// Regression tests for SelectableTextView presentation memoization (Fix 3):
+/// an identical settled presentation must return from updateUIView without
+/// rebuilding/styling/replacing text, and repeated measurement at the same
+/// width must not ask TextKit to lay the text out again. Deterministic via
+/// TranscriptPerf counters — no wall-clock assertions.
+@MainActor
+final class SelectableTextViewPresentationCacheTests: XCTestCase {
+
+    private func makeView(
+        text: String = "A settled paragraph of selectable text.",
+        font: UIFont = .preferredFont(forTextStyle: .body),
+        maximumNumberOfLines: Int = 0,
+        wrapsLines: Bool = true,
+        selfSizingWidthRange: ClosedRange<CGFloat>? = nil,
+        selectionCoordinator: MarkdownSelectionCoordinator? = nil,
+        selectionSegment: MarkdownSelectionSegmentDescriptor? = nil
+    ) -> SelectableTextView {
+        SelectableTextView(
+            text: text,
+            font: font,
+            textColor: .label,
+            lineSpacing: 4,
+            maximumNumberOfLines: maximumNumberOfLines,
+            wrapsLines: wrapsLines,
+            selfSizingWidthRange: selfSizingWidthRange,
+            selectionCoordinator: selectionCoordinator,
+            selectionSegment: selectionSegment
+        )
+    }
+
+    /// 1. Identical presentation + repeated update: no attributed-text rebuild.
+    func testIdenticalPresentationUpdatePerformsNoTextRebuild() {
+        let view = makeView()
+        let coordinator = view.makeCoordinator()
+        let host = view.makeUIViewForTests(coordinator: coordinator)
+
+        let rebuildsAfterFirst = TranscriptPerf.selectableTextViewTextRebuilds
+
+        // Identical inputs: the presentation token must short-circuit configure.
+        let identical = makeView()
+        let rebuildsBefore = TranscriptPerf.selectableTextViewTextRebuilds
+        identical.updateUIViewForTests(host, coordinator: coordinator)
+
+        XCTAssertEqual(
+            TranscriptPerf.selectableTextViewTextRebuilds, rebuildsBefore,
+            "identical presentation must not rebuild attributed text"
+        )
+        XCTAssertGreaterThan(rebuildsAfterFirst, 0, "sanity: first apply did rebuild")
+    }
+
+    /// 1b. Repeated measurement at the same width avoids TextKit.
+    func testRepeatedMeasurementAtSameWidthAvoidsTextKit() {
+        let view = makeView()
+        let coordinator = view.makeCoordinator()
+        let host = view.makeUIViewForTests(coordinator: coordinator)
+        let textView = host.mountedTextView
+
+        let first = view.measuredSizeCached(
+            proposalWidth: 320, textView: textView, coordinator: coordinator
+        )
+        XCTAssertNotNil(first)
+
+        TranscriptPerf.reset()
+        let second = view.measuredSizeCached(
+            proposalWidth: 320, textView: textView, coordinator: coordinator
+        )
+        XCTAssertEqual(second, first, "cached measurement must return the same size")
+        XCTAssertEqual(
+            TranscriptPerf.textKitMeasurementCalls, 0,
+            "identical presentation at the same width must not invoke TextKit measurement"
+        )
+    }
+
+    /// 2. Content change invalidates the presentation gate and the cache.
+    func testContentChangeInvalidates() {
+        let view = makeView()
+        let coordinator = view.makeCoordinator()
+        let host = view.makeUIViewForTests(coordinator: coordinator)
+
+        _ = view.measuredSizeCached(
+            proposalWidth: 320, textView: host.mountedTextView, coordinator: coordinator
+        )
+
+        let changed = makeView(text: "A settled paragraph of selectable text. Now changed.")
+        let rebuildsBefore = TranscriptPerf.selectableTextViewTextRebuilds
+        changed.updateUIViewForTests(host, coordinator: coordinator)
+        XCTAssertGreaterThan(
+            TranscriptPerf.selectableTextViewTextRebuilds, rebuildsBefore,
+            "changed content must rebuild attributed text"
+        )
+
+        TranscriptPerf.reset()
+        let size = changed.measuredSizeCached(
+            proposalWidth: 320, textView: host.mountedTextView, coordinator: coordinator
+        )
+        XCTAssertNotNil(size)
+        XCTAssertGreaterThan(
+            TranscriptPerf.textKitMeasurementCalls, 0,
+            "changed content must re-measure through TextKit"
+        )
+    }
+
+    /// 3. Width change invalidates the measurement cache.
+    func testWidthChangeInvalidatesMeasurement() {
+        let view = makeView()
+        let coordinator = view.makeCoordinator()
+        let host = view.makeUIViewForTests(coordinator: coordinator)
+
+        _ = view.measuredSizeCached(
+            proposalWidth: 320, textView: host.mountedTextView, coordinator: coordinator
+        )
+
+        TranscriptPerf.reset()
+        _ = view.measuredSizeCached(
+            proposalWidth: 200, textView: host.mountedTextView, coordinator: coordinator
+        )
+        XCTAssertGreaterThan(
+            TranscriptPerf.textKitMeasurementCalls, 0,
+            "a different proposed width must re-measure through TextKit"
+        )
+    }
+
+    /// 4. Font change (Dynamic Type) invalidates the presentation gate.
+    ///    A font-only change may apply through the text view's font property
+    ///    (which UIKit applies to the mounted text) rather than the
+    ///    attributed-string replacement branch, so the deterministic signal
+    ///    is the presentation generation bump plus the mounted font.
+    func testFontChangeInvalidates() {
+        let view = makeView()
+        let coordinator = view.makeCoordinator()
+        let host = view.makeUIViewForTests(coordinator: coordinator)
+        let generationBefore = coordinator.presentationGeneration
+
+        let bigger = makeView(font: .preferredFont(forTextStyle: .title1))
+        bigger.updateUIViewForTests(host, coordinator: coordinator)
+
+        XCTAssertGreaterThan(
+            coordinator.presentationGeneration, generationBefore,
+            "a font change must open the presentation gate (run configure)"
+        )
+        let mountedFont = host.mountedTextView.attributedText.attribute(
+            .font, at: 0, effectiveRange: nil
+        ) as? UIFont
+        XCTAssertEqual(
+            mountedFont, bigger.font,
+            "the new font must actually apply to the mounted text"
+        )
+    }
+
+    /// 5. Selection-coordinator changes still register/unregister correctly
+    ///    without forcing text restyling.
+    func testSelectionChangeRegistersWithoutTextRestyle() {
+        let view = makeView()
+        let coordinator = view.makeCoordinator()
+        let host = view.makeUIViewForTests(coordinator: coordinator)
+        XCTAssertFalse(host.isUsingCoordinatedTextView, "plain mount starts uncoordinated")
+
+        let markdownCoordinator = MarkdownSelectionCoordinator()
+        let segment = MarkdownSelectionSegmentDescriptor(
+            id: "block-0", order: 0, separatorBefore: ""
+        )
+        let coordinated = makeView(
+            selectionCoordinator: markdownCoordinator,
+            selectionSegment: segment
+        )
+
+        let rebuildsBefore = TranscriptPerf.selectableTextViewTextRebuilds
+        coordinated.updateUIViewForTests(host, coordinator: coordinator)
+
+        XCTAssertTrue(
+            host.isUsingCoordinatedTextView,
+            "selection coordinator + segment must mount the coordinated text view"
+        )
+        XCTAssertTrue(
+            markdownCoordinator.isSegmentRegistered(segment.id),
+            "the selection segment must be registered"
+        )
+        XCTAssertEqual(
+            TranscriptPerf.selectableTextViewTextRebuilds, rebuildsBefore,
+            "a selection-only change must not rebuild attributed text"
+        )
+
+        // Removing the coordinator unregisters and returns to the plain view.
+        let plain = makeView()
+        plain.updateUIViewForTests(host, coordinator: coordinator)
+        XCTAssertFalse(host.isUsingCoordinatedTextView)
+        XCTAssertFalse(
+            markdownCoordinator.isSegmentRegistered(segment.id),
+            "the selection segment must be unregistered when coordination ends"
+        )
+    }
+
+    /// 6. Table self-sizing and non-wrapping behavior remain correct.
+    func testSelfSizingAndNonWrappingMeasurementsRemainCorrect() {
+        // Self-sizing (table cell): deterministic width within the range,
+        // cached by presentation generation without a width key.
+        let cell = makeView(selfSizingWidthRange: 80...220)
+        let cellCoordinator = cell.makeCoordinator()
+        let cellHost = cell.makeUIViewForTests(coordinator: cellCoordinator)
+
+        let first = cell.measuredSizeCached(
+            proposalWidth: nil, textView: cellHost.mountedTextView, coordinator: cellCoordinator
+        )
+        XCTAssertNotNil(first)
+
+        TranscriptPerf.reset()
+        let second = cell.measuredSizeCached(
+            proposalWidth: nil, textView: cellHost.mountedTextView, coordinator: cellCoordinator
+        )
+        XCTAssertEqual(second, first, "self-sizing measurement must be stable")
+        XCTAssertEqual(
+            TranscriptPerf.textKitMeasurementCalls, 0,
+            "self-sizing re-measurement must be cached"
+        )
+        if let size = first {
+            XCTAssertTrue((80...220).contains(size.width), "self-sizing width must be clamped to the range")
+        }
+
+        // Non-wrapping: single-fragment width, height at least one line.
+        let nonWrapping = makeView(text: "no wrapping here", wrapsLines: false)
+        let nwCoordinator = nonWrapping.makeCoordinator()
+        let nwHost = nonWrapping.makeUIViewForTests(coordinator: nwCoordinator)
+
+        let nwFirst = nonWrapping.measuredSizeCached(
+            proposalWidth: nil, textView: nwHost.mountedTextView, coordinator: nwCoordinator
+        )
+        XCTAssertNotNil(nwFirst)
+
+        TranscriptPerf.reset()
+        let nwSecond = nonWrapping.measuredSizeCached(
+            proposalWidth: nil, textView: nwHost.mountedTextView, coordinator: nwCoordinator
+        )
+        XCTAssertEqual(nwSecond, nwFirst, "non-wrapping measurement must be cached")
+        XCTAssertEqual(TranscriptPerf.textKitMeasurementCalls, 0)
+    }
+}

--- a/ConduitTests/SelectableTextViewPresentationCacheTests.swift
+++ b/ConduitTests/SelectableTextViewPresentationCacheTests.swift
@@ -10,6 +10,11 @@ import UIKit
 @MainActor
 final class SelectableTextViewPresentationCacheTests: XCTestCase {
 
+    override func setUp() {
+        super.setUp()
+        TranscriptPerf.reset()
+    }
+
     private func makeView(
         text: String = "A settled paragraph of selectable text.",
         font: UIFont = .preferredFont(forTextStyle: .body),
@@ -33,23 +38,26 @@ final class SelectableTextViewPresentationCacheTests: XCTestCase {
     }
 
     /// 1. Identical presentation + repeated update: no attributed-text rebuild.
+    ///    The per-test reset makes the sanity assertion prove THIS view
+    ///    instance performed the first-apply rebuild.
     func testIdenticalPresentationUpdatePerformsNoTextRebuild() {
         let view = makeView()
         let coordinator = view.makeCoordinator()
-        let host = view.makeUIViewForTests(coordinator: coordinator)
 
-        let rebuildsAfterFirst = TranscriptPerf.selectableTextViewTextRebuilds
+        TranscriptPerf.reset()
+        let host = view.makeUIViewForTests(coordinator: coordinator)
+        XCTAssertEqual(
+            TranscriptPerf.selectableTextViewTextRebuilds, 1,
+            "sanity: the initial mount of this instance performed exactly one rebuild"
+        )
 
         // Identical inputs: the presentation token must short-circuit configure.
         let identical = makeView()
-        let rebuildsBefore = TranscriptPerf.selectableTextViewTextRebuilds
         identical.updateUIViewForTests(host, coordinator: coordinator)
-
         XCTAssertEqual(
-            TranscriptPerf.selectableTextViewTextRebuilds, rebuildsBefore,
+            TranscriptPerf.selectableTextViewTextRebuilds, 1,
             "identical presentation must not rebuild attributed text"
         )
-        XCTAssertGreaterThan(rebuildsAfterFirst, 0, "sanity: first apply did rebuild")
     }
 
     /// 1b. Repeated measurement at the same width avoids TextKit.
@@ -151,10 +159,14 @@ final class SelectableTextViewPresentationCacheTests: XCTestCase {
         )
     }
 
-    /// 5. Selection-coordinator changes still register/unregister correctly
-    ///    without forcing text restyling.
-    func testSelectionChangeRegistersWithoutTextRestyle() {
-        let view = makeView()
+    /// 5. Selection transitions in both directions still register/unregister
+    ///    correctly, do not regenerate attributed content, and fully
+    ///    configure the swapped-in text view (font, colors, line limits,
+    ///    wrapping, container, link attributes — everything `configure`
+    ///    owns, which the copied attributedText alone does not carry).
+    func testSelectionSwapRegistersAndFullyConfiguresReplacementTextView() {
+        // A finite line limit makes configuration loss observable.
+        let view = makeView(text: "A limited settled paragraph.", maximumNumberOfLines: 2)
         let coordinator = view.makeCoordinator()
         let host = view.makeUIViewForTests(coordinator: coordinator)
         XCTAssertFalse(host.isUsingCoordinatedTextView, "plain mount starts uncoordinated")
@@ -164,11 +176,18 @@ final class SelectableTextViewPresentationCacheTests: XCTestCase {
             id: "block-0", order: 0, separatorBefore: ""
         )
         let coordinated = makeView(
+            text: "A limited settled paragraph.",
+            maximumNumberOfLines: 2,
             selectionCoordinator: markdownCoordinator,
             selectionSegment: segment
         )
 
-        let rebuildsBefore = TranscriptPerf.selectableTextViewTextRebuilds
+        // Plain → coordinated. The copied attributedText already carries the
+        // full styling from the previous view's configure pass, so the
+        // isEqual guard needs no re-apply — the fresh view still receives
+        // every view-level setting (font, colors, limits, container, link
+        // attributes) because configure runs unconditionally on it.
+        TranscriptPerf.reset()
         coordinated.updateUIViewForTests(host, coordinator: coordinator)
 
         XCTAssertTrue(
@@ -180,17 +199,80 @@ final class SelectableTextViewPresentationCacheTests: XCTestCase {
             "the selection segment must be registered"
         )
         XCTAssertEqual(
-            TranscriptPerf.selectableTextViewTextRebuilds, rebuildsBefore,
-            "a selection-only change must not rebuild attributed text"
+            TranscriptPerf.selectableTextViewTextRebuilds, 0,
+            "a swap must not regenerate attributed content (copied text is already styled)"
         )
+        XCTAssertEqual(
+            host.mountedTextView.attributedText.string,
+            coordinated.attributedText.string,
+            "a selection-only swap must not regenerate content"
+        )
+        assertFullyConfigured(host.mountedTextView, like: coordinated)
 
-        // Removing the coordinator unregisters and returns to the plain view.
-        let plain = makeView()
+        // Coordinated → plain (same presentation otherwise).
+        TranscriptPerf.reset()
+        let plain = makeView(text: "A limited settled paragraph.", maximumNumberOfLines: 2)
         plain.updateUIViewForTests(host, coordinator: coordinator)
-        XCTAssertFalse(host.isUsingCoordinatedTextView)
+
+        XCTAssertFalse(
+            host.isUsingCoordinatedTextView,
+            "removing coordination must return to the plain text view"
+        )
         XCTAssertFalse(
             markdownCoordinator.isSegmentRegistered(segment.id),
             "the selection segment must be unregistered when coordination ends"
+        )
+        XCTAssertEqual(
+            TranscriptPerf.selectableTextViewTextRebuilds, 0,
+            "the reverse swap must not regenerate attributed content either"
+        )
+        XCTAssertEqual(
+            host.mountedTextView.attributedText.string,
+            plain.attributedText.string,
+            "the reverse swap must not regenerate content"
+        )
+        assertFullyConfigured(host.mountedTextView, like: plain)
+    }
+
+    /// The full set of view-level configuration `configure` applies — every
+    /// item a freshly swapped-in UITextView would otherwise miss.
+    private func assertFullyConfigured(
+        _ textView: UITextView,
+        like view: SelectableTextView,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(textView.font, view.font, file: file, line: line)
+        XCTAssertEqual(textView.textColor, view.textColor, file: file, line: line)
+        XCTAssertEqual(
+            textView.textContainer.maximumNumberOfLines,
+            view.maximumNumberOfLines,
+            "line limits must survive the text-view swap", file: file, line: line
+        )
+        XCTAssertTrue(
+            textView.textContainer.widthTracksTextView == view.wrapsLines,
+            "wrapping configuration must survive the swap", file: file, line: line
+        )
+        let expectedBreak: NSLineBreakMode = view.maximumNumberOfLines > 0
+            ? .byTruncatingTail
+            : (view.wrapsLines ? .byWordWrapping : .byClipping)
+        XCTAssertEqual(
+            textView.textContainer.lineBreakMode,
+            expectedBreak,
+            "line-break mode must survive the swap", file: file, line: line
+        )
+        XCTAssertEqual(
+            (textView.linkTextAttributes[.foregroundColor] as? UIColor),
+            view.linkColor,
+            "link attributes must survive the swap", file: file, line: line
+        )
+        let paragraph = textView.attributedText.attribute(
+            .paragraphStyle, at: 0, effectiveRange: nil
+        ) as? NSParagraphStyle
+        XCTAssertEqual(
+            paragraph?.lineSpacing,
+            view.lineSpacing,
+            "paragraph line spacing must survive the swap", file: file, line: line
         )
     }
 

--- a/ConduitTests/SettledMessageIsolationTests.swift
+++ b/ConduitTests/SettledMessageIsolationTests.swift
@@ -13,9 +13,34 @@ import SwiftUI
 @MainActor
 final class SettledMessageIsolationTests: XCTestCase {
 
-    private func makeAppState() -> AppState {
-        let defaults = UserDefaults(suiteName: "settled-isolation-tests")!
-        defaults.removePersistentDomain(forName: "settled-isolation-tests")
+    /// Retained for the full lifetime of each measurement so the hosted
+    /// hierarchy stays genuinely mounted; torn down explicitly per test.
+    private var testWindow: UIWindow?
+
+    override func setUp() {
+        super.setUp()
+        TranscriptPerf.reset()
+    }
+
+    override func tearDown() {
+        // Detach the window first so dismantle work is triggered, flush the
+        // run loop so it completes within THIS test, then reset counters —
+        // the next test starts from zero with no pending teardown updates.
+        testWindow?.isHidden = true
+        testWindow?.rootViewController = nil
+        RunLoop.current.run(until: Date())
+        testWindow = nil
+        TranscriptPerf.reset()
+        super.tearDown()
+    }
+
+    private func makeAppState() throws -> AppState {
+        let suiteName = "settled-isolation-tests"
+        let defaults = try XCTUnwrap(
+            UserDefaults(suiteName: suiteName),
+            "test UserDefaults suite must initialize"
+        )
+        defaults.removePersistentDomain(forName: suiteName)
         return AppState(defaults: defaults, loadSavedConnection: false)
     }
 
@@ -39,12 +64,12 @@ final class SettledMessageIsolationTests: XCTestCase {
         )
     }
 
-    /// Hosts an AssistantBubble row and returns the hosting controller.
+    /// Hosts an AssistantBubble row in a retained, live window.
     private func mountRow(
         message: ChatMessage,
         appState: AppState,
         resolver: GatewayMediaDataURLResolver?
-    ) -> (UIHostingController<AnyView>, UIWindow) {
+    ) -> UIHostingController<AnyView> {
         let row = AnyView(AssistantBubble(
             message: message,
             readAloudController: appState.messageReadAloudController,
@@ -55,17 +80,19 @@ final class SettledMessageIsolationTests: XCTestCase {
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
         window.rootViewController = host
         window.isHidden = false
+        testWindow = window
         host.view.setNeedsLayout()
         host.view.layoutIfNeeded()
-        return (host, window)
+        RunLoop.current.run(until: Date())
+        return host
     }
 
-    func testIdenticalRowRecreationSkipsSettledMarkdownPresentation() {
-        let appState = makeAppState()
+    func testIdenticalRowRecreationSkipsSettledMarkdownPresentation() throws {
+        let appState = try makeAppState()
         let resolver = GatewayMediaDataURLResolver(appState: appState, profile: "default")
         let message = markdownMessage()
 
-        let (host, _) = mountRow(message: message, appState: appState, resolver: resolver)
+        let host = mountRow(message: message, appState: appState, resolver: resolver)
 
         // Baseline: the initial mount performed the expensive work.
         let initialMarkdownBodies = TranscriptPerf.settledMarkdownTextBodyEvaluations
@@ -96,11 +123,11 @@ final class SettledMessageIsolationTests: XCTestCase {
         _ = initialSTVUpdates
     }
 
-    func testContentChangeStillReRendersSettledContent() {
-        let appState = makeAppState()
+    func testContentChangeStillReRendersSettledContent() throws {
+        let appState = try makeAppState()
         let resolver = GatewayMediaDataURLResolver(appState: appState, profile: "default")
 
-        let (host, _) = mountRow(message: markdownMessage(), appState: appState, resolver: resolver)
+        let host = mountRow(message: markdownMessage(), appState: appState, resolver: resolver)
 
         // A genuinely changed message must open the gate. The content must
         // actually differ (not just the id) so the selectable text view
@@ -128,12 +155,12 @@ final class SettledMessageIsolationTests: XCTestCase {
         )
     }
 
-    func testResolverChangeStillReRendersSettledContent() {
-        let appState = makeAppState()
+    func testResolverChangeStillReRendersSettledContent() throws {
+        let appState = try makeAppState()
         let resolverA = GatewayMediaDataURLResolver(appState: appState, profile: "default")
         let resolverB = GatewayMediaDataURLResolver(appState: appState, profile: "other")
 
-        let (host, _) = mountRow(message: markdownMessage(), appState: appState, resolver: resolverA)
+        let host = mountRow(message: markdownMessage(), appState: appState, resolver: resolverA)
 
         // A different resolver identity (profile switch) must open the gate.
         TranscriptPerf.reset()
@@ -153,8 +180,8 @@ final class SettledMessageIsolationTests: XCTestCase {
         )
     }
 
-    func testEquatableConformanceComparesMessageAndResolverIdentity() {
-        let appState = makeAppState()
+    func testEquatableConformanceComparesMessageAndResolverIdentity() throws {
+        let appState = try makeAppState()
         let resolver = GatewayMediaDataURLResolver(appState: appState, profile: "default")
         let otherResolver = GatewayMediaDataURLResolver(appState: appState, profile: "default")
 
@@ -162,29 +189,123 @@ final class SettledMessageIsolationTests: XCTestCase {
             message: markdownMessage(),
             displayName: "Hermes",
             avatarURL: nil,
-            gatewayResolver: resolver
+            gatewayResolver: resolver,
+            sizeCategory: .large
         )
         let sameInputs = SettledAssistantMessageContent(
             message: markdownMessage(),
             displayName: "Hermes",
             avatarURL: nil,
-            gatewayResolver: resolver
+            gatewayResolver: resolver,
+            sizeCategory: .large
         )
         let differentResolver = SettledAssistantMessageContent(
             message: markdownMessage(),
             displayName: "Hermes",
             avatarURL: nil,
-            gatewayResolver: otherResolver
+            gatewayResolver: otherResolver,
+            sizeCategory: .large
         )
         let differentMessage = SettledAssistantMessageContent(
             message: markdownMessage(id: "m2"),
             displayName: "Hermes",
             avatarURL: nil,
-            gatewayResolver: resolver
+            gatewayResolver: resolver,
+            sizeCategory: .large
+        )
+        let differentSizeCategory = SettledAssistantMessageContent(
+            message: markdownMessage(),
+            displayName: "Hermes",
+            avatarURL: nil,
+            gatewayResolver: resolver,
+            sizeCategory: .extraExtraLarge
         )
 
         XCTAssertEqual(a, sameInputs, "equal message + same resolver identity must compare equal")
         XCTAssertNotEqual(a, differentResolver, "different resolver instance must compare unequal even with equal contents")
         XCTAssertNotEqual(a, differentMessage, "different message must compare unequal")
+        XCTAssertNotEqual(a, differentSizeCategory, "a Dynamic Type change must compare unequal and re-open the gate")
+    }
+
+    /// Dynamic Type invalidation (#4): a size-category change must re-open
+    /// the settled-content gate, re-evaluate the Markdown body, and deliver
+    /// a changed font to the mounted text view — while an ordinary
+    /// re-creation at the SAME category (streaming-tick shape) stays dormant.
+    func testDynamicTypeChangeReOpensSettledGateAndUpdatesFonts() throws {
+        let appState = try makeAppState()
+        let resolver = GatewayMediaDataURLResolver(appState: appState, profile: "default")
+        let message = markdownMessage()
+
+        func row(_ category: ContentSizeCategory) -> AnyView {
+            AnyView(
+                AssistantBubble(
+                    message: message,
+                    readAloudController: appState.messageReadAloudController,
+                    gatewayResolver: resolver
+                )
+                .environmentObject(appState)
+                .environment(\.sizeCategory, category)
+            )
+        }
+
+        let host = UIHostingController(rootView: row(.large))
+        testWindow = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        testWindow?.rootViewController = host
+        testWindow?.isHidden = false
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+
+        // Capture the mounted font at the initial category.
+        let fontAtLarge = firstTextViewFont(in: host.view)
+
+        // Same-category re-creation (streaming-tick shape): must stay dormant.
+        TranscriptPerf.reset()
+        host.rootView = row(.large)
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+        XCTAssertEqual(
+            TranscriptPerf.settledMarkdownTextBodyEvaluations, 0,
+            "a same-category re-creation must not wake settled content"
+        )
+
+        // Category change: the gate re-opens and the settled Markdown body
+        // re-evaluates. Downstream font resolution follows UIApplication's
+        // preferredContentSizeCategory (the system setting), which moves
+        // together with the SwiftUI environment value in production but
+        // cannot be changed from inside the test process — so with only the
+        // environment value changed, the re-rendered content is identical
+        // and SelectableTextView is correctly skipped by SwiftUI's own
+        // equality check. The gate mechanics are additionally covered by
+        // testEquatableConformanceComparesMessageAndResolverIdentity.
+        TranscriptPerf.reset()
+        host.rootView = row(.extraExtraLarge)
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+
+        XCTAssertGreaterThan(
+            TranscriptPerf.settledMarkdownTextBodyEvaluations, 0,
+            "a Dynamic Type change must re-evaluate settled content"
+        )
+        _ = fontAtLarge
+    }
+
+    private func firstTextViewFont(in view: UIView) -> UIFont? {
+        var found: UIFont?
+        enumerateSubviews(of: view) { subview in
+            if found == nil, let textView = subview as? UITextView {
+                found = textView.font
+            }
+        }
+        return found
+    }
+
+    private func enumerateSubviews(of view: UIView, visit: (UIView) -> Void) {
+        for subview in view.subviews {
+            visit(subview)
+            enumerateSubviews(of: subview, visit: visit)
+        }
     }
 }

--- a/ConduitTests/SettledMessageIsolationTests.swift
+++ b/ConduitTests/SettledMessageIsolationTests.swift
@@ -1,0 +1,190 @@
+import XCTest
+import SwiftUI
+@testable import Conduit
+
+/// Regression tests for settled-row isolation (Fix 2): publishing unrelated
+/// live state must not re-evaluate settled Markdown presentation. These use
+/// the deterministic TranscriptPerf counters, not wall-clock timing.
+///
+/// The streaming-tick simulation re-assigns the hosting root view with an
+/// equal-value row — exactly what ChatView's ForEach does to every mounted
+/// row on each AppState publish — and asserts the Equatable gate skipped
+/// the expensive settled subtree.
+@MainActor
+final class SettledMessageIsolationTests: XCTestCase {
+
+    private func makeAppState() -> AppState {
+        let defaults = UserDefaults(suiteName: "settled-isolation-tests")!
+        defaults.removePersistentDomain(forName: "settled-isolation-tests")
+        return AppState(defaults: defaults, loadSavedConnection: false)
+    }
+
+    private func markdownMessage(id: String = "m1") -> ChatMessage {
+        ChatMessage(
+            id: id,
+            role: .assistant,
+            content: """
+            ## Heading one
+
+            A settled paragraph with **bold**, *italic*, and `code` runs.
+
+            - list item one
+            - list item two
+
+            > A quoted line for coverage.
+
+            [A link](https://example.com)
+            """,
+            timestamp: "2026-01-01T00:00:00Z"
+        )
+    }
+
+    /// Hosts an AssistantBubble row and returns the hosting controller.
+    private func mountRow(
+        message: ChatMessage,
+        appState: AppState,
+        resolver: GatewayMediaDataURLResolver?
+    ) -> (UIHostingController<AnyView>, UIWindow) {
+        let row = AnyView(AssistantBubble(
+            message: message,
+            readAloudController: appState.messageReadAloudController,
+            gatewayResolver: resolver
+        )
+        .environmentObject(appState))
+        let host = UIHostingController(rootView: row)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.isHidden = false
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+        return (host, window)
+    }
+
+    func testIdenticalRowRecreationSkipsSettledMarkdownPresentation() {
+        let appState = makeAppState()
+        let resolver = GatewayMediaDataURLResolver(appState: appState, profile: "default")
+        let message = markdownMessage()
+
+        let (host, _) = mountRow(message: message, appState: appState, resolver: resolver)
+
+        // Baseline: the initial mount performed the expensive work.
+        let initialMarkdownBodies = TranscriptPerf.settledMarkdownTextBodyEvaluations
+        let initialSTVUpdates = TranscriptPerf.selectableTextViewUpdateCalls
+        XCTAssertGreaterThan(initialMarkdownBodies, 0, "initial mount must render the markdown")
+
+        // Simulate a streaming tick: the parent re-creates the row with
+        // IDENTICAL inputs (equal message value, same resolver identity).
+        TranscriptPerf.reset()
+        host.rootView = AnyView(AssistantBubble(
+            message: message,
+            readAloudController: appState.messageReadAloudController,
+            gatewayResolver: resolver
+        )
+        .environmentObject(appState))
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+
+        XCTAssertEqual(
+            TranscriptPerf.settledMarkdownTextBodyEvaluations, 0,
+            "a streaming publish re-creating an identical settled row must not re-evaluate its Markdown"
+        )
+        XCTAssertEqual(
+            TranscriptPerf.selectableTextViewUpdateCalls, 0,
+            "a streaming publish re-creating an identical settled row must not touch SelectableTextView"
+        )
+        _ = initialSTVUpdates
+    }
+
+    func testContentChangeStillReRendersSettledContent() {
+        let appState = makeAppState()
+        let resolver = GatewayMediaDataURLResolver(appState: appState, profile: "default")
+
+        let (host, _) = mountRow(message: markdownMessage(), appState: appState, resolver: resolver)
+
+        // A genuinely changed message must open the gate. The content must
+        // actually differ (not just the id) so the selectable text view
+        // receives a new attributed string.
+        TranscriptPerf.reset()
+        var changed = markdownMessage(id: "m2")
+        changed.content += "\n\nA second paragraph with different content."
+        host.rootView = AnyView(AssistantBubble(
+            message: changed,
+            readAloudController: appState.messageReadAloudController,
+            gatewayResolver: resolver
+        )
+        .environmentObject(appState))
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+
+        XCTAssertGreaterThan(
+            TranscriptPerf.settledMarkdownTextBodyEvaluations, 0,
+            "changed content must re-evaluate settled presentation"
+        )
+        XCTAssertGreaterThan(
+            TranscriptPerf.selectableTextViewUpdateCalls, 0,
+            "changed content must update the selectable text view"
+        )
+    }
+
+    func testResolverChangeStillReRendersSettledContent() {
+        let appState = makeAppState()
+        let resolverA = GatewayMediaDataURLResolver(appState: appState, profile: "default")
+        let resolverB = GatewayMediaDataURLResolver(appState: appState, profile: "other")
+
+        let (host, _) = mountRow(message: markdownMessage(), appState: appState, resolver: resolverA)
+
+        // A different resolver identity (profile switch) must open the gate.
+        TranscriptPerf.reset()
+        host.rootView = AnyView(AssistantBubble(
+            message: markdownMessage(),
+            readAloudController: appState.messageReadAloudController,
+            gatewayResolver: resolverB
+        )
+        .environmentObject(appState))
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+
+        XCTAssertGreaterThan(
+            TranscriptPerf.settledMarkdownTextBodyEvaluations, 0,
+            "resolver identity change (profile switch) must re-evaluate settled presentation"
+        )
+    }
+
+    func testEquatableConformanceComparesMessageAndResolverIdentity() {
+        let appState = makeAppState()
+        let resolver = GatewayMediaDataURLResolver(appState: appState, profile: "default")
+        let otherResolver = GatewayMediaDataURLResolver(appState: appState, profile: "default")
+
+        let a = SettledAssistantMessageContent(
+            message: markdownMessage(),
+            displayName: "Hermes",
+            avatarURL: nil,
+            gatewayResolver: resolver
+        )
+        let sameInputs = SettledAssistantMessageContent(
+            message: markdownMessage(),
+            displayName: "Hermes",
+            avatarURL: nil,
+            gatewayResolver: resolver
+        )
+        let differentResolver = SettledAssistantMessageContent(
+            message: markdownMessage(),
+            displayName: "Hermes",
+            avatarURL: nil,
+            gatewayResolver: otherResolver
+        )
+        let differentMessage = SettledAssistantMessageContent(
+            message: markdownMessage(id: "m2"),
+            displayName: "Hermes",
+            avatarURL: nil,
+            gatewayResolver: resolver
+        )
+
+        XCTAssertEqual(a, sameInputs, "equal message + same resolver identity must compare equal")
+        XCTAssertNotEqual(a, differentResolver, "different resolver instance must compare unequal even with equal contents")
+        XCTAssertNotEqual(a, differentMessage, "different message must compare unequal")
+    }
+}

--- a/ConduitTests/SettledMessageIsolationTests.swift
+++ b/ConduitTests/SettledMessageIsolationTests.swift
@@ -228,84 +228,95 @@ final class SettledMessageIsolationTests: XCTestCase {
     }
 
     /// Dynamic Type invalidation (#4): a size-category change must re-open
-    /// the settled-content gate, re-evaluate the Markdown body, and deliver
-    /// a changed font to the mounted text view — while an ordinary
-    /// re-creation at the SAME category (streaming-tick shape) stays dormant.
-    func testDynamicTypeChangeReOpensSettledGateAndUpdatesFonts() throws {
+    /// the settled-content gate so the settled Markdown body re-evaluates.
+    ///
+    /// Same-category dormancy (the streaming-tick shape) has dedicated
+    /// coverage in
+    /// testIdenticalRowRecreationSkipsSettledMarkdownPresentation; this test
+    /// exercises only the gate-reopening half.
+    ///
+    /// Structurally deterministic: after each mutation the run loop is
+    /// drained until the asserted condition holds or a bounded deadline
+    /// expires. SwiftUI hosting commits are driven by display links, which
+    /// need real elapsed time — a zero-interval `RunLoop.run(until: Date())`
+    /// tick observes only whatever flushed synchronously and made the
+    /// previous version of this test flaky on slower CI runners (a late
+    /// transaction from the initial mount landed inside the measurement
+    /// window). Actual font delivery cannot be asserted in-process:
+    /// UIFontMetrics resolve against UIApplication's
+    /// preferredContentSizeCategory, which is process-global. The Equatable
+    /// input contract (including sizeCategory) is covered directly by
+    /// testEquatableConformanceComparesMessageAndResolverIdentity.
+    func testDynamicTypeChangeReOpensSettledContentGate() throws {
         let appState = try makeAppState()
         let resolver = GatewayMediaDataURLResolver(appState: appState, profile: "default")
         let message = markdownMessage()
 
-        func row(_ category: ContentSizeCategory) -> AnyView {
-            AnyView(
-                AssistantBubble(
-                    message: message,
-                    readAloudController: appState.messageReadAloudController,
-                    gatewayResolver: resolver
-                )
-                .environmentObject(appState)
-                .environment(\.sizeCategory, category)
+        func harness(_ category: ContentSizeCategory) -> SettledGateHarnessRow {
+            SettledGateHarnessRow(
+                message: message,
+                readAloudController: appState.messageReadAloudController,
+                gatewayResolver: resolver,
+                appState: appState,
+                sizeCategory: category
             )
         }
 
-        let host = UIHostingController(rootView: row(.large))
+        let host = UIHostingController(rootView: harness(.large))
         testWindow = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
         testWindow?.rootViewController = host
         testWindow?.isHidden = false
         host.view.setNeedsLayout()
         host.view.layoutIfNeeded()
-        RunLoop.current.run(until: Date())
+        // Let the initial mount fully settle — including trait-sync follow-up
+        // transactions — before arming the measurement window.
+        drainUntil(2.0) { TranscriptPerf.settledMarkdownTextBodyEvaluations > 0 }
 
-        // Capture the mounted font at the initial category.
-        let fontAtLarge = firstTextViewFont(in: host.view)
-
-        // Same-category re-creation (streaming-tick shape): must stay dormant.
         TranscriptPerf.reset()
-        host.rootView = row(.large)
+        host.rootView = harness(.extraExtraLarge)
         host.view.setNeedsLayout()
         host.view.layoutIfNeeded()
-        RunLoop.current.run(until: Date())
-        XCTAssertEqual(
-            TranscriptPerf.settledMarkdownTextBodyEvaluations, 0,
-            "a same-category re-creation must not wake settled content"
-        )
-
-        // Category change: the gate re-opens and the settled Markdown body
-        // re-evaluates. Downstream font resolution follows UIApplication's
-        // preferredContentSizeCategory (the system setting), which moves
-        // together with the SwiftUI environment value in production but
-        // cannot be changed from inside the test process — so with only the
-        // environment value changed, the re-rendered content is identical
-        // and SelectableTextView is correctly skipped by SwiftUI's own
-        // equality check. The gate mechanics are additionally covered by
-        // testEquatableConformanceComparesMessageAndResolverIdentity.
-        TranscriptPerf.reset()
-        host.rootView = row(.extraExtraLarge)
-        host.view.setNeedsLayout()
-        host.view.layoutIfNeeded()
-        RunLoop.current.run(until: Date())
+        drainUntil(2.0) { TranscriptPerf.settledMarkdownTextBodyEvaluations > 0 }
 
         XCTAssertGreaterThan(
             TranscriptPerf.settledMarkdownTextBodyEvaluations, 0,
-            "a Dynamic Type change must re-evaluate settled content"
+            "a Dynamic Type change must re-open the settled-content gate and re-evaluate settled content"
         )
-        _ = fontAtLarge
     }
 
-    private func firstTextViewFont(in view: UIView) -> UIFont? {
-        var found: UIFont?
-        enumerateSubviews(of: view) { subview in
-            if found == nil, let textView = subview as? UITextView {
-                found = textView.font
-            }
+    /// Drains the run loop in short real intervals until `condition` holds or
+    /// the bounded deadline passes. Display-link-driven SwiftUI commits need
+    /// elapsed time to fire, so draining until the observable state is
+    /// reached is deterministic where a fixed zero-interval tick is not: it
+    /// exits as early as possible and fails only when the state genuinely
+    /// never arrives.
+    private func drainUntil(_ seconds: TimeInterval, _ condition: () -> Bool) {
+        let deadline = Date().addingTimeInterval(seconds)
+        while Date() < deadline {
+            if condition() { return }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
         }
-        return found
     }
+}
 
-    private func enumerateSubviews(of view: UIView, visit: (UIView) -> Void) {
-        for subview in view.subviews {
-            visit(subview)
-            enumerateSubviews(of: subview, visit: visit)
-        }
+/// Concrete hosted root for the Dynamic Type gate test. A stable concrete
+/// type (instead of an erased AnyView) gives UIHostingController direct value
+/// diffing: changing `sizeCategory` is a first-class rootView value change,
+/// and the environment write happens inside `body` exactly once per value.
+private struct SettledGateHarnessRow: View {
+    let message: ChatMessage
+    let readAloudController: MessageReadAloudController
+    let gatewayResolver: GatewayMediaDataURLResolver?
+    let appState: AppState
+    let sizeCategory: ContentSizeCategory
+
+    var body: some View {
+        AssistantBubble(
+            message: message,
+            readAloudController: readAloudController,
+            gatewayResolver: gatewayResolver
+        )
+        .environmentObject(appState)
+        .environment(\.sizeCategory, sizeCategory)
     }
 }

--- a/ConduitTests/TranscriptPerformanceFixtureTests.swift
+++ b/ConduitTests/TranscriptPerformanceFixtureTests.swift
@@ -18,9 +18,34 @@ import SwiftUI
 @MainActor
 final class TranscriptPerformanceFixtureTests: XCTestCase {
 
-    private func makeAppState() -> AppState {
-        let defaults = UserDefaults(suiteName: "transcript-perf-fixture")!
-        defaults.removePersistentDomain(forName: "transcript-perf-fixture")
+    /// Retained for the full lifetime of each measurement so the hosted
+    /// hierarchy stays genuinely mounted; torn down explicitly per test.
+    private var testWindow: UIWindow?
+
+    override func setUp() {
+        super.setUp()
+        TranscriptPerf.reset()
+    }
+
+    override func tearDown() {
+        // Detach the window first so dismantle work is triggered, flush the
+        // run loop so it completes within THIS test, then reset counters —
+        // the next test starts from zero with no pending teardown updates.
+        testWindow?.isHidden = true
+        testWindow?.rootViewController = nil
+        RunLoop.current.run(until: Date())
+        testWindow = nil
+        TranscriptPerf.reset()
+        super.tearDown()
+    }
+
+    private func makeAppState() throws -> AppState {
+        let suiteName = "transcript-perf-fixture"
+        let defaults = try XCTUnwrap(
+            UserDefaults(suiteName: suiteName),
+            "test UserDefaults suite must initialize"
+        )
+        defaults.removePersistentDomain(forName: suiteName)
         return AppState(defaults: defaults, loadSavedConnection: false)
     }
 
@@ -122,17 +147,17 @@ final class TranscriptPerformanceFixtureTests: XCTestCase {
 
     // MARK: - Harness
 
-    /// Drains pending SwiftUI updates (including any left over from the
-    /// previous test's host window teardown) so counter windows measure
-    /// only this test's work.
-    private func drainRunLoop() {
+    /// Lets SwiftUI updates that belong to THIS test (e.g. the settle tick
+    /// below) complete before the next counter window opens.
+    private func settleCurrentTestUpdates() {
         RunLoop.current.run(until: Date().addingTimeInterval(0.15))
     }
 
+    /// Hosts the full ChatView in a retained, live window.
     private func mountChat(
         appState: AppState,
         streaming: String
-    ) -> (UIHostingController<AnyView>, UIWindow) {
+    ) -> UIHostingController<AnyView> {
         appState.streamingText = streaming
         let host = UIHostingController(
             rootView: AnyView(ChatView().environmentObject(appState))
@@ -140,10 +165,11 @@ final class TranscriptPerformanceFixtureTests: XCTestCase {
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
         window.rootViewController = host
         window.isHidden = false
+        testWindow = window
         host.view.setNeedsLayout()
         host.view.layoutIfNeeded()
-        drainRunLoop()
-        return (host, window)
+        RunLoop.current.run(until: Date())
+        return host
     }
 
     /// Drives `ticks` streaming publishes at the production ~30 Hz cadence,
@@ -167,10 +193,10 @@ final class TranscriptPerformanceFixtureTests: XCTestCase {
     // MARK: - Fixtures
 
     func testStreamingTicksLeaveSettledMarkdownDormant_MarkdownTranscript() throws {
-        let appState = makeAppState()
+        let appState = try makeAppState()
         appState.messages = Self.markdownTranscript()
 
-        let (host, _) = mountChat(appState: appState, streaming: "Initial streaming frame")
+        let host = mountChat(appState: appState, streaming: "Initial streaming frame")
 
         // Sanity: the settled transcript actually mounted and rendered.
         let settledMarkdownAtRest = TranscriptPerf.settledMarkdownTextBodyEvaluations
@@ -183,7 +209,7 @@ final class TranscriptPerformanceFixtureTests: XCTestCase {
         // additional lazy row as layout adjusts. Steady-state work is what
         // the acceptance criterion bounds, so measure from the second tick.
         streamTicks(1, appState: appState, host: host)
-        drainRunLoop()
+        settleCurrentTestUpdates()
 
         TranscriptPerf.reset()
         streamTicks(10, appState: appState, host: host)
@@ -211,12 +237,12 @@ final class TranscriptPerformanceFixtureTests: XCTestCase {
     }
 
     func testStreamingTicksLeaveSettledMarkdownDormant_PlainTextTranscript() throws {
-        let appState = makeAppState()
+        let appState = try makeAppState()
         appState.messages = Self.plainTextTranscript()
 
-        let (host, _) = mountChat(appState: appState, streaming: "Initial streaming frame")
+        let host = mountChat(appState: appState, streaming: "Initial streaming frame")
         streamTicks(1, appState: appState, host: host)
-        drainRunLoop()
+        settleCurrentTestUpdates()
 
         TranscriptPerf.reset()
         streamTicks(10, appState: appState, host: host)
@@ -228,15 +254,58 @@ final class TranscriptPerformanceFixtureTests: XCTestCase {
         XCTAssertLessThanOrEqual(TranscriptPerf.textKitMeasurementCalls, 30)
     }
 
+    /// First-render gateway resolver (#5): settled Markdown must render
+    /// exactly once on first appearance — no nil → resolver invalidation
+    /// sweep. The resolver identity must be stable for the profile and the
+    /// settled evaluation count must not grow after the initial layout.
+    func testFirstAppearanceRendersSettledMarkdownOnce() throws {
+        let appState = try makeAppState()
+        appState.messages = Self.markdownTranscript()
+
+        // Stable identity per profile, available from the first body pass.
+        let first = appState.gatewayMediaResolver
+        XCTAssertIdentical(
+            appState.gatewayMediaResolver, first,
+            "the resolver must be identity-stable while the profile is unchanged"
+        )
+
+        let host = mountChat(appState: appState, streaming: "Initial frame")
+        // Let lazy mounting fully settle: the first pass mounts the visible
+        // screenful and LazyVStack prefetches neighbor rows on subsequent
+        // turns — each a legitimate FIRST render of a new row, not a
+        // re-render of an existing one.
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+        let initialEvaluations = TranscriptPerf.settledMarkdownTextBodyEvaluations
+        XCTAssertGreaterThan(
+            initialEvaluations, 0,
+            "settled Markdown must render on first appearance"
+        )
+
+        // Re-layout and pump with no state change: the count must be stable.
+        // The pre-fix nil → resolver transition re-evaluated every mounted
+        // settled row here (and repopulated the render cache under a new
+        // gateway-recognition key).
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+
+        XCTAssertEqual(
+            TranscriptPerf.settledMarkdownTextBodyEvaluations, initialEvaluations,
+            "no second settled render pass may occur after first appearance"
+        )
+    }
+
     /// The settled transcript itself still renders through the normal path
     /// when it genuinely changes: appending a message re-renders exactly the
     /// new content, and the fingerprint bound stays O(append).
     func testGenuineAppendRendersNewMessageAndFingerprintsBounded() throws {
-        let appState = makeAppState()
+        let appState = try makeAppState()
         var messages = Self.markdownTranscript(count: 100)
         appState.messages = messages
 
-        let (host, _) = mountChat(appState: appState, streaming: "")
+        let host = mountChat(appState: appState, streaming: "")
         appState.streamingText = ""  // StreamingBubble unmounts
 
         TranscriptPerf.reset()

--- a/ConduitTests/TranscriptPerformanceFixtureTests.swift
+++ b/ConduitTests/TranscriptPerformanceFixtureTests.swift
@@ -1,0 +1,269 @@
+import XCTest
+import SwiftUI
+@testable import Conduit
+
+/// Performance fixture (spec: 250 settled Markdown-heavy messages + one
+/// active streaming response, every message below the 100 KB large-document
+/// threshold, plus a plain-text counterpart). Asserts the architectural
+/// acceptance criterion with deterministic counters, never wall-clock:
+///
+///   one streaming publish
+///       → only the live StreamingBubble changes
+///       settled Markdown presentation rebuilds ≈ 0
+///       settled TextKit measurements ≈ 0
+///
+/// The fixture hosts the real ChatView (real ForEach, real gating, real
+/// StreamingBubble) so the measured cascade is the production one. The
+/// LazyVStack mounts the visible subset of rows, exactly as on a device.
+@MainActor
+final class TranscriptPerformanceFixtureTests: XCTestCase {
+
+    private func makeAppState() -> AppState {
+        let defaults = UserDefaults(suiteName: "transcript-perf-fixture")!
+        defaults.removePersistentDomain(forName: "transcript-perf-fixture")
+        return AppState(defaults: defaults, loadSavedConnection: false)
+    }
+
+    // MARK: - Fixture transcripts
+
+    /// Markdown-heavy settled messages covering paragraphs, headings,
+    /// lists, quotes, links, and moderate code blocks. Diverse from the
+    /// first message onward — the LazyVStack mounts roughly the first
+    /// screenful, so the mounted subset must exercise every block shape.
+    static func markdownTranscript(count: Int = 250) -> [ChatMessage] {
+        (0..<count).map { index in
+            ChatMessage(
+                id: "fixture-\(index)",
+                role: index % 2 == 0 ? .assistant : .user,
+                content: markdownBody(index: index),
+                timestamp: "2026-01-01T00:00:00Z"
+            )
+        }
+    }
+
+    private static func markdownBody(index: Int) -> String {
+        switch index % 6 {
+        case 0:
+            return """
+            ### Section heading \(index)
+
+            A settled paragraph with **bold**, *italic*, and `inline code` —
+            message \(index) of the cumulative-transcript fixture. It repeats
+            enough prose to resemble a real assistant answer, and carries a
+            [reference link](https://example.com/item/\(index)) for coverage.
+
+            - first list item with some detail
+            - second list item
+            - third list item with a trailing note
+            """
+        case 1:
+            return """
+            Message \(index) asks a settled question with _emphasis_ and a
+            [link](https://example.com/q/\(index)); the answer follows in the
+            next turn. Ordinary paragraphs keep the reading column busy.
+            """
+        case 2:
+            return """
+            > A quoted passage for message \(index).
+            > Quotes render through the selectable flow path with italic runs.
+
+            Follow-up paragraph after the quote, long enough to wrap across
+            two or three display lines in the fixture viewport.
+            """
+        case 3:
+            return """
+            #### Code-bearing answer \(index)
+
+            ```swift
+            func settled\(index)() -> String {
+                let value = "message \\(index)"
+                return value
+            }
+            ```
+
+            A short paragraph after the code block for coverage.
+            """
+        case 4:
+            return """
+            1. Ordered first step for message \(index)
+            2. Ordered second step
+            3. Ordered third step with a [docs link](https://example.com/docs/\(index))
+
+            Closing paragraph.
+            """
+        default:
+            return """
+            ## Heading \(index)
+
+            Mixed content: a paragraph, then a list, then a quote.
+
+            - bullet one
+            - bullet two
+
+            > quoted line
+            """
+        }
+    }
+
+    /// Plain-text counterpart: no Markdown structure, same volume.
+    static func plainTextTranscript(count: Int = 250) -> [ChatMessage] {
+        (0..<count).map { index in
+            ChatMessage(
+                id: "plain-\(index)",
+                role: index % 2 == 0 ? .assistant : .user,
+                content: String(
+                    repeating: "Plain settled message \(index) body text. ",
+                    count: 24
+                ),
+                timestamp: "2026-01-01T00:00:00Z"
+            )
+        }
+    }
+
+    // MARK: - Harness
+
+    /// Drains pending SwiftUI updates (including any left over from the
+    /// previous test's host window teardown) so counter windows measure
+    /// only this test's work.
+    private func drainRunLoop() {
+        RunLoop.current.run(until: Date().addingTimeInterval(0.15))
+    }
+
+    private func mountChat(
+        appState: AppState,
+        streaming: String
+    ) -> (UIHostingController<AnyView>, UIWindow) {
+        appState.streamingText = streaming
+        let host = UIHostingController(
+            rootView: AnyView(ChatView().environmentObject(appState))
+        )
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.isHidden = false
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+        drainRunLoop()
+        return (host, window)
+    }
+
+    /// Drives `ticks` streaming publishes at the production ~30 Hz cadence,
+    /// pumping layout each tick (see the SwiftUI async-commit pitfall:
+    /// state set from async contexts needs a forced layout pass per pump).
+    private func streamTicks(
+        _ ticks: Int,
+        appState: AppState,
+        host: UIHostingController<AnyView>
+    ) {
+        for tick in 0..<ticks {
+            appState.streamingText =
+                "Live streaming delta \(tick) — the only view that should change. "
+                + String(repeating: "Growing body \(tick). ", count: tick + 1)
+            host.view.setNeedsLayout()
+            host.view.layoutIfNeeded()
+            RunLoop.current.run(until: Date())
+        }
+    }
+
+    // MARK: - Fixtures
+
+    func testStreamingTicksLeaveSettledMarkdownDormant_MarkdownTranscript() throws {
+        let appState = makeAppState()
+        appState.messages = Self.markdownTranscript()
+
+        let (host, _) = mountChat(appState: appState, streaming: "Initial streaming frame")
+
+        // Sanity: the settled transcript actually mounted and rendered.
+        let settledMarkdownAtRest = TranscriptPerf.settledMarkdownTextBodyEvaluations
+        XCTAssertGreaterThan(
+            settledMarkdownAtRest, 0,
+            "fixture must mount settled Markdown rows before streaming starts"
+        )
+
+        // Settle tick: the first streaming delta can legitimately mount one
+        // additional lazy row as layout adjusts. Steady-state work is what
+        // the acceptance criterion bounds, so measure from the second tick.
+        streamTicks(1, appState: appState, host: host)
+        drainRunLoop()
+
+        TranscriptPerf.reset()
+        streamTicks(10, appState: appState, host: host)
+
+        XCTAssertEqual(
+            TranscriptPerf.settledMarkdownTextBodyEvaluations, 0,
+            "10 streaming publishes must not re-evaluate any settled Markdown body"
+        )
+        // The live streaming row legitimately updates, rebuilds, and measures
+        // its own few block text views each tick (~2-3 SelectableTextViews).
+        // The bounds below allow only that live-row work: under the pre-fix
+        // cascade every mounted settled row joined these counts per tick.
+        XCTAssertLessThanOrEqual(
+            TranscriptPerf.selectableTextViewUpdateCalls, 30,
+            "SelectableTextView work must be bounded to the live row (~3/tick)"
+        )
+        XCTAssertLessThanOrEqual(
+            TranscriptPerf.textKitMeasurementCalls, 30,
+            "TextKit measurement must be bounded to the live row, not the settled transcript"
+        )
+        XCTAssertLessThanOrEqual(
+            TranscriptPerf.selectableTextViewTextRebuilds, 20,
+            "attributed-text rebuilds must be bounded to the live row's changed content (~2/tick)"
+        )
+    }
+
+    func testStreamingTicksLeaveSettledMarkdownDormant_PlainTextTranscript() throws {
+        let appState = makeAppState()
+        appState.messages = Self.plainTextTranscript()
+
+        let (host, _) = mountChat(appState: appState, streaming: "Initial streaming frame")
+        streamTicks(1, appState: appState, host: host)
+        drainRunLoop()
+
+        TranscriptPerf.reset()
+        streamTicks(10, appState: appState, host: host)
+
+        XCTAssertEqual(
+            TranscriptPerf.settledMarkdownTextBodyEvaluations, 0,
+            "plain-text transcript: streaming must not re-evaluate settled Markdown"
+        )
+        XCTAssertLessThanOrEqual(TranscriptPerf.textKitMeasurementCalls, 30)
+    }
+
+    /// The settled transcript itself still renders through the normal path
+    /// when it genuinely changes: appending a message re-renders exactly the
+    /// new content, and the fingerprint bound stays O(append).
+    func testGenuineAppendRendersNewMessageAndFingerprintsBounded() throws {
+        let appState = makeAppState()
+        var messages = Self.markdownTranscript(count: 100)
+        appState.messages = messages
+
+        let (host, _) = mountChat(appState: appState, streaming: "")
+        appState.streamingText = ""  // StreamingBubble unmounts
+
+        TranscriptPerf.reset()
+        messages.append(
+            ChatMessage(
+                id: "fixture-new",
+                role: .assistant,
+                content: "## A genuinely new message\n\nWith a paragraph and a [link](https://example.com/new).",
+                timestamp: "2026-01-02T00:00:00Z"
+            )
+        )
+        appState.messages = messages
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+
+        XCTAssertEqual(
+            TranscriptPerf.lastFingerprintedMessageCount, 1,
+            "appending to a 100-message transcript must fingerprint exactly the appended message"
+        )
+        XCTAssertGreaterThan(
+            TranscriptPerf.settledMarkdownTextBodyEvaluations, 0,
+            "the genuinely new message must render"
+        )
+        XCTAssertEqual(
+            TranscriptPerf.transcriptChangedCalls, 1,
+            "one messages mutation must cause exactly one transcriptChanged call"
+        )
+    }
+}

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -18,6 +18,11 @@
 #     retry loop exactly like a test failure.
 #   - The simulator is explicitly booted (shutdown → boot → bootstatus) before
 #     EVERY attempt, including the first.
+#   - After a TIMED-OUT attempt the retry erases the dedicated simulator before
+#     rebooting: the deadline kill removes xcodebuild's process group, but
+#     services inside the simulator (e.g. the pasteboard daemon) can stay
+#     wedged in ways a plain reboot does not clear. Ordinary failures keep the
+#     fast shutdown→boot reset.
 #   - Raw xcodebuild logs land in ci-logs/ and stream into the step log; any
 #     partial .xcresult bundles are left on disk for the artifact upload.
 #
@@ -43,13 +48,26 @@ fi
 LOG_DIR="ci-logs"
 mkdir -p "$LOG_DIR"
 
+# Headless CI has no clipboard UI. App-level UIPasteboard access participates
+# in the Mac<->simulator automatic clipboard sync, a recurring hang source on
+# fresh runners (observed as a unit-test suite stalling forever inside its
+# first pasteboard touch). The pasteboard-mutating unit tests only need the
+# device-local pasteboard, so keep Simulator.app out of the path entirely.
+defaults write com.apple.iphonesimulator PasteboardAutomaticSync -bool false
+
 # Boot the simulator to a known-clean state. All failures are tolerated: on a
 # fresh runner the device may already be shut down (or booted), and a wedged
 # device is exactly what this reset is here to clear. bootstatus is bounded
 # by -t; shutdown/boot themselves can in principle stall on a wedged
 # CoreSimulatorService — the job-level timeout is the backstop for that.
 reset_and_boot_simulator() {
+  # $1 = 1 erases the device before booting (used after a timed-out attempt).
+  local erase="${1:-0}"
   xcrun simctl shutdown "$SIMULATOR" >/dev/null 2>&1 || true
+  if [ "$erase" -eq 1 ]; then
+    echo "::warning::previous attempt timed out — erasing simulator $SIMULATOR before retry"
+    xcrun simctl erase "$SIMULATOR" >/dev/null 2>&1 || true
+  fi
   sleep 3
   xcrun simctl boot "$SIMULATOR" 2>/dev/null || true
   # Wait for a complete boot before handing the device to xcodebuild; a
@@ -154,6 +172,7 @@ run_attempt() {
   wait "$runner"
 }
 
+erase_before_retry=0
 for attempt in $(seq 1 "$ATTEMPTS"); do
   if [ "$attempt" -eq 1 ]; then
     bundle="TestResults.xcresult"
@@ -162,9 +181,10 @@ for attempt in $(seq 1 "$ATTEMPTS"); do
   fi
 
   # A wedged or half-booted simulator is the one failure mode in-test retries
-  # cannot clear; reset it before every attempt, including the first.
+  # cannot clear; reset it before every attempt, including the first. After a
+  # timed-out attempt the reset escalates to an erase (see below).
   echo "Booting simulator $SIMULATOR for attempt $attempt"
-  reset_and_boot_simulator
+  reset_and_boot_simulator "$erase_before_retry"
 
   echo "::group::Test attempt $attempt (budget ${ATTEMPT_TIMEOUT_SECS}s)"
   status=0
@@ -176,6 +196,11 @@ for attempt in $(seq 1 "$ATTEMPTS"); do
     exit 0
   fi
   echo "tests failed on attempt $attempt (exit status $status)"
+  # Only a deadline kill (124) escalates the next reset to an erase; ordinary
+  # test failures keep the fast shutdown→boot path.
+  if [ "$status" -eq 124 ]; then
+    erase_before_retry=1
+  fi
 done
 
 echo "all $ATTEMPTS test attempts failed"


### PR DESCRIPTION
## Why

TestFlight `.ips` reports show `0x8BADF00D` scene-update watchdog terminations with the main thread inside SwiftUI (`ForEachState.estimatedCount` → `LazyStack.sizeThatFits`) — **with PR #88 already present**. #88 bounds pathological *individual* messages; the remaining failure mode is **cumulative transcript-level work**: with hundreds of settled Markdown messages and one active response, every streaming publish (~30 Hz) re-evaluated every mounted settled row through Markdown → SelectableTextView → TextKit, and several per-tick paths scaled with total transcript length or bytes.

This is a focused stabilization pass — no chat UX, Markdown architecture, viewport-controller, or protocol changes.

## The invariant

> Work caused by one streaming/layout tick must be proportional to the live/visible change — not to total transcript length or total transcript bytes.

## Changes (one commit per fix, reviewable in order)

| Commit | Fix |
|---|---|
| `c6d801b` | **Instrumentation** — DEBUG-only deterministic `TranscriptPerf` counters (settled Markdown/bubble body evals, STV updates/rebuilds, TextKit measurements, layout/transcript-change calls, stable-top scan size, fingerprinted messages/bytes). Zero-cost in Release. |
| `5c87460` | **Fix 1 — duplicate transcript reconciliation.** `ChatView` observed both `messages` and `chatTranscriptRevision`; `messages.didSet` publishes both, so every mutation ran `viewport.transcriptChanged` (and its fingerprint work) twice. The `messages` observer is now the single trigger; the revision stays in `AppState` for the settle handshake and rendered-scope versioning. |
| `6b400ee` | **Fix 2 — isolate settled presentation (highest value).** Settled content of every row type now lives behind `.equatable()` gates over immutable inputs (`message` + presentation values), so a streaming publish re-creating an identical row skips its body entirely. Read-aloud observation moved from every `AssistantBubble` to a 34pt `ReadAloudButton`; busy-state controls into `AssistantMessageActions`. Gateway `MEDIA:` resolution moved from a per-body-eval closure capturing `AppState` to a stable per-profile `GatewayMediaDataURLResolver` compared by identity. |
| `a79f009` | **Fix 3 — SelectableTextView memoization.** A presentation token (attributed content, font, color, spacing, line limit, wrapping, alignment, link color, self-sizing range) skips `configure()` entirely when unchanged — no styled copy, attribute enumeration, container mutation, or intrinsic invalidation. A `(presentation generation, width regime) → CGSize` cache on the coordinator skips TextKit `sizeThatFits` at unchanged width. Selection registration/unregistration and the coordinated-text-view swap stay on the fast path. |
| `5de803a` | **Fix 4 — stable-top O(rendered rows).** Rendered frames now carry their transcript order; stable-top picks the min-order frame intersecting the viewport instead of walking the full target list per geometry tick. Semantic ordering preserved exactly (min order, not `minY`). |
| `f19a623` | **Fix 5 — incremental fingerprints.** `ChatMessageScrollTargetCache.update` finds the longest common prefix of equal messages (value compares only), hashes only the changed suffix, and takes the incremental path only when duplicate-count semantics are provably local (no fingerprint crosses the prefix/suffix boundary in either direction; suffix internally duplicate-free). Duplicate-crossing appends, reorders, and full replacements fall back to the full rebuild. |
| `5a62cc2` | **Fixture** — 250 Markdown-heavy messages (headings, lists, quotes, links, moderate code; each well under the 100 KB threshold) + plain-text counterpart, hosting the real `ChatView`, driven by real `streamingText` publishes. Counters only, no wall-clock. |
| `605207f` | **Hardening pass** (review follow-ups, each verified before applying): Release-build compile fix (`Storage` type out of `#if DEBUG`; explicit Release build verified); text-view swap now fully configures the fresh `UITextView` (font/colors/line limits/wrapping/container/link attributes — previously skipped when the presentation gate held) with bidirectional swap tests; fixture `UIWindow` retained for the full measurement (was discarded — detached hierarchy) with explicit teardown; Dynamic Type is an explicit Equatable input fed by environment-reading shells (no unread-`@Environment` reliance) with a hosted regression test; the gateway resolver is `AppState`-owned and available from the first body pass, eliminating the nil → resolver double render; harness determinism (per-test counter resets, detach-then-flush teardown, index clamp, `XCTUnwrap`). |

## Measured result (deterministic counters, real ChatView hosted in a retained live window)

250 settled Markdown-heavy messages + one active streaming response, 10 streaming publishes:

| Path | Before (structural) | After (measured, live window) |
|---|---|---|
| Settled Markdown body evals | every mounted settled row × 10 (~60–80) | **0** |
| SelectableTextView updates | every mounted settled row per tick | **3** total (live row only) |
| Attributed-text rebuilds | every mounted settled row per tick | **1** total (live row only) |
| TextKit measurements | every revisited row | **1** total (measurement cache) |
| Stable-top scan per geometry tick | O(total messages) | **O(rendered frames)** (proven: 3 vs 500) |
| Fingerprints for append to 200-message transcript | 200 | **1** (tail edit: 1; unchanged: 0) |
| `transcriptChanged` per messages mutation | 2 | **1** |
| Settled renders on first appearance | 2 passes (nil → resolver sweep) | **1** |

Plain-text counterpart: same assertions green.

## Tests

- **34 new deterministic tests**: duplicate-trigger regression (2), settled isolation incl. gate-open cases + Dynamic Type regression (6), STV presentation/measurement cache incl. bidirectional swap configuration (7), stable-top bound (1), incremental-vs-full-rebuild reference incl. randomized 60-step seeded sweep (12), 250-message fixtures incl. first-appearance single-render (4) — plus `MarkdownSelectionCoordinator.isSegmentRegistered` as a behavior-level test accessor.
- **Full unit suite: 934 passed, 0 failed, 0 skipped** (single complete run on the final head).
- **Release configuration build verified green** (the instrumentation file could not compile in Release before `605207f`; CI Debug runs did not catch it).
- Focused suites on the final head: markdown rendering/selection/coordinator/table/reference/large-document/fallback 175/175; viewport/scroll/title/resume/incremental/reasoning 142/142; STV cache + settled isolation + fixture 16/16.

## Remaining transcript-size-dependent paths (all cheap value work, no parse/layout/measure)

- `Array(targets.enumerated())` allocation per `ChatView` body eval — O(count) struct copies.
- Common-prefix equality scan per mutation — O(prefix) compares, no hashing.
- `.equatable()` full-message compare per mounted row per tick — CoW-shared, bounded by the mounted subset.

Transcript windowing remains the documented next safety net if field reports persist on multi-thousand-message transcripts; the corrected live-window evidence says it is not needed for the reported failure mode.

## Manual validation

The automatable behaviors above are covered by hosted tests; a human pass on simulator/device before the next TestFlight is recommended (cold open of a long Markdown-heavy conversation, streaming while scrolling, cross-block selection, read aloud, Dynamic Type change with a settled transcript visible, profile switching, gateway `MEDIA:` images, row expand/collapse, background/foreground).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved chat transcript updates, scrolling, and layout handling for large conversations.
  * Reduced unnecessary re-rendering during streaming, text updates, and app-state changes.
  * Improved selectable-text measurement and presentation through smarter caching.
  * Optimized incremental updates so new or changed messages require less processing.
  * Added performance tracking for transcript rendering and layout activity.

* **Reliability**
  * Improved media preview handling and gateway-hosted images.
  * Preserved stable scroll positioning during transcript changes.
  * Added safeguards for message edits, reordering, and duplicate content.
  * Ensured settled message content updates correctly when Dynamic Type settings change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->