### PR TITLE
fix(markdown): bound rich-content layout by structure, coalesce follow-latest scroll corrections

### DIFF
--- a/Conduit/Services/ChatViewportController.swift
+++ b/Conduit/Services/ChatViewportController.swift
@@ -38,6 +38,19 @@ enum ChatViewportEffect: Equatable {
     case completeRestoration(generation: UInt64)
     case abandonRestoration(generation: UInt64)
     case scheduleDragEvaluation(ChatDragCompletionToken)
+    /// One coalesced bottom-follow correction is outstanding; the view
+    /// executes it on a later MainActor turn (see
+    /// ChatViewportController.followCorrectionDue).
+    case scheduleFollowCorrection(ChatFollowCorrectionToken)
+}
+
+/// Identity of one outstanding coalesced follow correction: the ownership
+/// generation and session it was scheduled under. A correction that comes
+/// due after ownership moved on (drag, restoration, handoff, session
+/// switch) re-validates against this token and dies silently.
+struct ChatFollowCorrectionToken: Equatable {
+    let generation: UInt64
+    let sessionKey: ChatScrollSessionKey?
 }
 
 struct ChatViewportLayoutFacts: Equatable {
@@ -95,6 +108,19 @@ struct ChatViewportController: Equatable {
     private var drag = DragLifecycle()
     private var dragGestureActive = false
     private(set) var pendingDragEvaluation: ChatDragCompletionToken?
+    /// The single outstanding coalesced follow correction, if any (see
+    /// layoutMetricsChanged). At most one exists per unsettled layout
+    /// cycle: geometry ticks arriving while one is pending update the
+    /// recorded facts but never enqueue a second correction.
+    private(set) var pendingFollowCorrection: ChatFollowCorrectionToken?
+    /// Content bottom (bottomMarkerMaxY) the last scheduled correction ran
+    /// against. A correction re-arms only when the content bottom has
+    /// MOVED since — a drift that persists with UNCHANGED content (the
+    /// scroll already sits at the anchor's bottom; scrollTo cannot reduce
+    /// the residual) must not re-arm a correction every MainActor turn, or
+    /// the correction itself becomes the layout-churn source it exists to
+    /// prevent.
+    private var followCorrectionContentBottom: CGFloat?
     private(set) var notificationHandoff: ChatViewportHandoffState?
     private(set) var restoration: RestorationState?
 
@@ -171,6 +197,21 @@ struct ChatViewportController: Equatable {
             return effects
         }
 
+        // A nil → nil "change" is not a session switch — there is no
+        // session on either side. areEquivalent(nil, nil) is false by
+        // definition, so without this guard the first appearance of a
+        // session-less transcript took the full switch path (generation
+        // bump, drag invalidation, animated bottom scroll with a delayed
+        // retry). That in-flight animation crossed the whole transcript and
+        // fought the coalesced follow corrections; a session-less appear
+        // has nothing to switch away from.
+        if renderedSessionKey == nil, key == nil {
+            if wasFollowing {
+                mirroredViewportTransitionGeneration = viewportTransitionGeneration
+            }
+            return effects
+        }
+
         // Cancel a pending restoration that belongs to a different
         // conversation (checked before the equivalence early-return, exactly
         // like the old handler).
@@ -197,6 +238,8 @@ struct ChatViewportController: Equatable {
         if !keysAreEquivalent {
             effects.append(contentsOf: invalidateDrag(hasActiveGesture: dragGestureActive))
             generation &+= 1
+            pendingFollowCorrection = nil
+            followCorrectionContentBottom = nil
         }
         renderedSessionKey = key
         if wasFollowing {
@@ -263,6 +306,11 @@ struct ChatViewportController: Equatable {
               restoration == nil,
               notificationHandoff == nil,
               !isOpeningNotificationSession else { return [] }
+        // The animated reassert owns the follow for this change (it carries
+        // its own delayed retry); a coalesced correction pending from an
+        // earlier drift tick would only fight the in-flight animation.
+        pendingFollowCorrection = nil
+        followCorrectionContentBottom = nil
         return [.scroll(latestCommand(animated: true))]
     }
 
@@ -304,22 +352,125 @@ struct ChatViewportController: Equatable {
             mode = .followingLatest
             relatchedThisTick = true
         }
+        if relatchedThisTick {
+            // Freshly (re)following: the next drift tick must be allowed to
+            // pin the viewport flush even when the content bottom itself has
+            // not moved since the last correction cycle.
+            followCorrectionContentBottom = nil
+        }
 
         guard !relatchedThisTick,
               mode == .followingLatest,
               restoration == nil,
               notificationHandoff == nil else { return effects }
 
-        // Follow actual rendered growth: while pinned, the bottom marker
-        // only ever drifts beyond the viewport by layout changes between
-        // main-actor turns. Non-animated and retry-free — the next layout
-        // event is the natural retry for continuous growth.
-        if let bottom = bottomMarkerMaxY,
-           let viewport = viewportMaxY,
-           bottom - viewport > followDriftTolerance {
-            effects.append(.scroll(latestCommand(animated: false, retry: nil)))
+        // Follow actual rendered growth — COALESCED. Geometry preference
+        // callbacks fire many times per layout cycle (bottom marker,
+        // viewport frame, row frames), and this method used to emit a
+        // synchronous scrollTo for EACH drift tick; the scroll itself
+        // perturbs layout, which re-fires the preferences, which scrolled
+        // again — the geometry → scrollTo → geometry feedback that lands
+        // the main thread inside ScrollViewCommitMutation and trips the
+        // 0x8BADF00D scene watchdog when rich content height settles
+        // repeatedly. Now the newest facts are recorded immediately, ONE
+        // correction is scheduled for a later MainActor turn, and
+        // followCorrectionDue re-validates against the latest facts — so
+        // one rendering/layout update produces at most one bottom scroll,
+        // while genuinely new growth (streaming) still gets followed.
+        //
+        // Re-arm also requires MEANINGFUL new growth beyond the last
+        // corrected content bottom. The bottom marker is a global-frame
+        // measurement: the correction's own scroll moves it, streaming
+        // reveal changes it in sub-line steps, and layout refinements flap
+        // it — re-arming on every >0.5pt change reproduced the storm one
+        // MainActor turn apart (measured: 7 scrolls in 44 ms during a
+        // hosted streaming fixture). The regrowth threshold bounds the
+        // correction rate by the CONTENT growth rate, and the settled
+        // bottom is adopted as the new base whenever the viewport sits at
+        // or past it.
+        if pendingFollowCorrection == nil,
+           let bottom = bottomMarkerMaxY,
+           let viewport = viewportMaxY {
+            switch Self.followCorrectionDecision(
+                bottom: bottom,
+                viewport: viewport,
+                settledFloor: followCorrectionContentBottom,
+                driftTolerance: followDriftTolerance,
+                regrowthTolerance: Self.followCorrectionRegrowthTolerance
+            ) {
+            case .schedule:
+                followCorrectionContentBottom = bottom
+                let token = ChatFollowCorrectionToken(
+                    generation: generation,
+                    sessionKey: renderedSessionKey ?? activeSessionKey
+                )
+                pendingFollowCorrection = token
+                effects.append(.scheduleFollowCorrection(token))
+            case .adoptSettledBottom:
+                followCorrectionContentBottom = bottom
+            case .idle:
+                break
+            }
         }
         return effects
+    }
+
+    /// Minimum content-bottom growth beyond the last corrected position
+    /// before another correction cycle may arm. About half a body-text
+    /// line: streaming reveal steps and layout refinements accumulate
+    /// against it instead of re-arming a correction per frame.
+    static let followCorrectionRegrowthTolerance: CGFloat = 12
+
+    /// Pure decision for the coalesced follow-correction re-arm policy.
+    enum FollowCorrectionDecision: Equatable {
+        /// Drift beyond tolerance AND new content beyond the regrowth
+        /// threshold: arm one correction.
+        case schedule
+        /// The viewport sits at/past the recorded content bottom (the last
+        /// scroll landed, or content shrank): adopt this bottom as the new
+        /// measurement base.
+        case adoptSettledBottom
+        /// Nothing to do.
+        case idle
+    }
+
+    static func followCorrectionDecision(
+        bottom: CGFloat,
+        viewport: CGFloat,
+        settledFloor: CGFloat?,
+        driftTolerance: CGFloat,
+        regrowthTolerance: CGFloat
+    ) -> FollowCorrectionDecision {
+        if bottom - viewport > driftTolerance {
+            guard let settledFloor else { return .schedule }
+            return bottom > settledFloor + regrowthTolerance ? .schedule : .idle
+        }
+        // At (or past) the bottom: adopt any lower settled bottom so future
+        // growth is measured from where the content actually sits.
+        if let settledFloor, bottom < settledFloor {
+            return .adoptSettledBottom
+        }
+        return .idle
+    }
+
+    /// Executes the outstanding coalesced follow correction. The view
+    /// schedules this on the next MainActor turn; by then the facts below
+    /// are the newest ones recorded, so a drift that resolved itself
+    /// (animated transcript reassert already landed, user scrolled,
+    /// ownership moved) dies without scrolling, and a correction for an
+    /// ownership generation that is gone dies silently.
+    mutating func followCorrectionDue(
+        _ token: ChatFollowCorrectionToken
+    ) -> [ChatViewportEffect] {
+        guard pendingFollowCorrection == token else { return [] }
+        pendingFollowCorrection = nil
+        guard mode == .followingLatest,
+              restoration == nil,
+              notificationHandoff == nil else { return [] }
+        guard let bottom = bottomMarkerMaxY,
+              let viewport = viewportMaxY,
+              bottom - viewport > followDriftTolerance else { return [] }
+        return [.scroll(latestCommand(animated: false, retry: nil))]
     }
 
     // MARK: - Drag lifecycle (folded ChatDragLifecycleState)
@@ -337,6 +488,8 @@ struct ChatViewportController: Equatable {
         ) else { return [] }
         generation &+= 1
         pendingDragEvaluation = nil
+        pendingFollowCorrection = nil
+        followCorrectionContentBottom = nil
         restoration = nil
         mode = .browsing
         return [.cancelAutomaticRestoration]
@@ -625,7 +778,9 @@ struct ChatViewportController: Equatable {
     // MARK: - View lifecycle
 
     mutating func viewDisappeared() -> [ChatViewportEffect] {
-        abandonDrag()
+        pendingFollowCorrection = nil
+        followCorrectionContentBottom = nil
+        return abandonDrag()
     }
 
     // MARK: - Command currency
@@ -664,11 +819,15 @@ struct ChatViewportController: Equatable {
     private mutating func effectsForExplicitOwnershipChange() {
         _ = invalidateDrag(hasActiveGesture: dragGestureActive)
         generation &+= 1
+        pendingFollowCorrection = nil
+        followCorrectionContentBottom = nil
     }
 
     private mutating func beginHandoffOwnership() -> [ChatViewportEffect] {
         _ = invalidateDrag(hasActiveGesture: dragGestureActive)
         generation &+= 1
+        pendingFollowCorrection = nil
+        followCorrectionContentBottom = nil
         restoration = nil
         return [.cancelAutomaticRestoration]
     }

--- a/Conduit/Services/ChatViewportController.swift
+++ b/Conduit/Services/ChatViewportController.swift
@@ -45,12 +45,22 @@ enum ChatViewportEffect: Equatable {
 }
 
 /// Identity of one outstanding coalesced follow correction: the ownership
-/// generation and session it was scheduled under. A correction that comes
-/// due after ownership moved on (drag, restoration, handoff, session
-/// switch) re-validates against this token and dies silently.
+/// generation, the session it was scheduled under, and a per-schedule
+/// sequence number. A correction that comes due after ownership moved on
+/// (drag, restoration, handoff, session switch) re-validates against this
+/// token and dies silently.
+///
+/// The sequence number makes every scheduled correction Equatable-distinct
+/// even within one ownership generation and session. The view drains
+/// corrections through onChange(of: pendingFollowCorrection); two
+/// consecutive corrections with equal tokens would be observed as
+/// "token A -> token A", which SwiftUI is free to skip — leaving a pending
+/// correction nobody executes. The monotonic counter guarantees the
+/// nil -> token -> nil -> token-prime transitions always differ.
 struct ChatFollowCorrectionToken: Equatable {
     let generation: UInt64
     let sessionKey: ChatScrollSessionKey?
+    let sequence: UInt64
 }
 
 struct ChatViewportLayoutFacts: Equatable {
@@ -61,6 +71,16 @@ struct ChatViewportLayoutFacts: Equatable {
     /// across ticks; only rows SwiftUI laid out are present).
     var rowFrames: [ChatRenderedRowFrame]
     var renderedScope: ChatRenderedScrollScope?
+    /// When these facts were measured (view-supplied clock stamp, e.g.
+    /// CFAbsoluteTimeGetCurrent). Pure input like every other fact: tests
+    /// pass synthetic monotonic stamps. Used to rate-limit follow-
+    /// correction RE-ARMING after a correction executed — the correction's
+    /// own scroll shifts every global frame, and a schedule minted from
+    /// that flap (observed 3 ms after execution) is both spurious and
+    /// undrainable: it is born inside the drain handler's layout turn,
+    /// where SwiftUI may never deliver the onChange that would execute it,
+    /// leaving a pending token that silently absorbs all future schedules.
+    var timestamp: TimeInterval = 0
 }
 
 struct ChatViewportHandoffState: Equatable {
@@ -113,6 +133,29 @@ struct ChatViewportController: Equatable {
     /// cycle: geometry ticks arriving while one is pending update the
     /// recorded facts but never enqueue a second correction.
     private(set) var pendingFollowCorrection: ChatFollowCorrectionToken?
+    /// Monotonic per-schedule discriminator for follow-correction tokens
+    /// (wraps like every counter in this type, via &+). Only incremented
+    /// when a NEW correction is actually scheduled — duplicate geometry
+    /// ticks while one is pending never mint tokens.
+    private var followCorrectionSequence: UInt64 = 0
+    /// Clock stamp of the most recently recorded layout facts (pure input;
+    /// see ChatViewportLayoutFacts.timestamp).
+    private var latestFactTimestamp: TimeInterval = 0
+    /// Clock stamp of the facts the last executed follow correction scrolled
+    /// against. New corrections may not RE-ARM within
+    /// followCorrectionRearmInterval of an execution: the correction's own
+    /// scroll commit shifts every global frame, and a schedule minted from
+    /// that immediate flap both is spurious and can be undrainable (born
+    /// inside the drain handler's layout turn, SwiftUI may skip the
+    /// onChange delivery — observed live: seq=2 stuck pending forever,
+    /// silently absorbing every later schedule).
+    private var followCorrectionLastExecutionAt: TimeInterval?
+
+    /// Minimum time after a correction executed before another may arm.
+    /// Long enough for the correction's scroll commit to settle global
+    /// frames; short enough that genuine streaming growth (bounded already
+    /// by the 12 pt regrowth floor) is followed promptly.
+    static let followCorrectionRearmInterval: TimeInterval = 0.1
     /// Content bottom (bottomMarkerMaxY) the last scheduled correction ran
     /// against. A correction re-arms only when the content bottom has
     /// MOVED since — a drift that persists with UNCHANGED content (the
@@ -197,6 +240,17 @@ struct ChatViewportController: Equatable {
             return effects
         }
 
+        // Cancel a pending restoration that belongs to a different
+        // conversation (checked before the equivalence early-return, exactly
+        // like the old handler). This runs BEFORE the nil→nil guard below:
+        // a session-less re-appear must still clean up a stale restoration
+        // from a previous conversation.
+        if let request = restoration?.request,
+           !identity.areEquivalent(request.sessionKey, key) {
+            restoration = nil
+            effects.append(.cancelAutomaticRestoration)
+        }
+
         // A nil → nil "change" is not a session switch — there is no
         // session on either side. areEquivalent(nil, nil) is false by
         // definition, so without this guard the first appearance of a
@@ -212,23 +266,20 @@ struct ChatViewportController: Equatable {
             return effects
         }
 
-        // Cancel a pending restoration that belongs to a different
-        // conversation (checked before the equivalence early-return, exactly
-        // like the old handler).
-        if let request = restoration?.request,
-           !identity.areEquivalent(request.sessionKey, key) {
-            restoration = nil
-            effects.append(.cancelAutomaticRestoration)
-        }
-
         let oldKey = renderedSessionKey
         let keysAreEquivalent = identity.areEquivalent(oldKey, key)
 
         // Adopting the first-ever session key is an adoption, not a switch:
-        // the old view assigned it in onAppear without scrolling.
+        // the old view assigned it in onAppear without scrolling. The
+        // correction-owning session nonetheless CHANGED (nil → key): a
+        // correction scheduled before any session existed must not fire a
+        // command anchored to the newly adopted session.
         let isFirstAdoption = oldKey == nil && key != nil
         if isFirstAdoption {
             renderedSessionKey = key
+            pendingFollowCorrection = nil
+            followCorrectionContentBottom = nil
+        followCorrectionLastExecutionAt = nil
             if wasFollowing {
                 mirroredViewportTransitionGeneration = viewportTransitionGeneration
             }
@@ -240,6 +291,7 @@ struct ChatViewportController: Equatable {
             generation &+= 1
             pendingFollowCorrection = nil
             followCorrectionContentBottom = nil
+        followCorrectionLastExecutionAt = nil
         }
         renderedSessionKey = key
         if wasFollowing {
@@ -311,6 +363,7 @@ struct ChatViewportController: Equatable {
         // earlier drift tick would only fight the in-flight animation.
         pendingFollowCorrection = nil
         followCorrectionContentBottom = nil
+        followCorrectionLastExecutionAt = nil
         return [.scroll(latestCommand(animated: true))]
     }
 
@@ -327,6 +380,7 @@ struct ChatViewportController: Equatable {
         bottomMarkerMaxY = facts.bottomMarkerMaxY
         viewportMinY = facts.viewportMinY
         viewportMaxY = facts.viewportMaxY
+        latestFactTimestamp = facts.timestamp
 
         let previousStableTop = stableTopMessageID
         updateStableTopMessage(rowFrames: facts.rowFrames)
@@ -357,6 +411,7 @@ struct ChatViewportController: Equatable {
             // pin the viewport flush even when the content bottom itself has
             // not moved since the last correction cycle.
             followCorrectionContentBottom = nil
+        followCorrectionLastExecutionAt = nil
         }
 
         guard !relatchedThisTick,
@@ -388,7 +443,20 @@ struct ChatViewportController: Equatable {
         // correction rate by the CONTENT growth rate, and the settled
         // bottom is adopted as the new base whenever the viewport sits at
         // or past it.
-        if pendingFollowCorrection == nil,
+        //
+        // Finally, re-arm is rate-limited after an EXECUTED correction:
+        // the scroll commit shifts every global frame, and a schedule
+        // minted from that flap is born inside the drain handler's layout
+        // turn where SwiftUI may never deliver the onChange that would
+        // execute it — an undrainable pending token that silently absorbs
+        // every future schedule (observed live in the hosted streaming
+        // fixture). The interval lets those frames settle first; genuine
+        // growth re-arms on a later tick.
+        let rearmIntervalElapsed = followCorrectionLastExecutionAt
+            .map { latestFactTimestamp - $0 >= Self.followCorrectionRearmInterval }
+            ?? true
+        if rearmIntervalElapsed,
+           pendingFollowCorrection == nil,
            let bottom = bottomMarkerMaxY,
            let viewport = viewportMaxY {
             switch Self.followCorrectionDecision(
@@ -400,9 +468,11 @@ struct ChatViewportController: Equatable {
             ) {
             case .schedule:
                 followCorrectionContentBottom = bottom
+                followCorrectionSequence &+= 1
                 let token = ChatFollowCorrectionToken(
                     generation: generation,
-                    sessionKey: renderedSessionKey ?? activeSessionKey
+                    sessionKey: renderedSessionKey ?? activeSessionKey,
+                    sequence: followCorrectionSequence
                 )
                 pendingFollowCorrection = token
                 effects.append(.scheduleFollowCorrection(token))
@@ -443,7 +513,21 @@ struct ChatViewportController: Equatable {
     ) -> FollowCorrectionDecision {
         if bottom - viewport > driftTolerance {
             guard let settledFloor else { return .schedule }
-            return bottom > settledFloor + regrowthTolerance ? .schedule : .idle
+            // Meaningful GROWTH beyond the last corrected bottom.
+            if bottom > settledFloor + regrowthTolerance { return .schedule }
+            // Meaningful SHRINK below the last corrected bottom (content
+            // collapsed: a table paged, an image failed, rows unmounted)
+            // while drift remains: the stale high floor would ignore future
+            // growth until the bottom climbed back past
+            // floor + regrowthTolerance even though the real baseline moved
+            // down. Rebase by scheduling — the caller records the new
+            // (lower) bottom as the floor and the correction re-pins the
+            // viewport to the collapsed content.
+            if bottom < settledFloor - regrowthTolerance { return .schedule }
+            // Bottom within the flap window of the floor: layout noise from
+            // the correction's own scroll commit. Re-arming here reproduced
+            // the storm one MainActor turn apart.
+            return .idle
         }
         // At (or past) the bottom: adopt any lower settled bottom so future
         // growth is measured from where the content actually sits.
@@ -459,6 +543,16 @@ struct ChatViewportController: Equatable {
     /// (animated transcript reassert already landed, user scrolled,
     /// ownership moved) dies without scrolling, and a correction for an
     /// ownership generation that is gone dies silently.
+    ///
+    /// Session ownership is validated against the SAME session the emitted
+    /// command would use — activeSessionKey ?? renderedSessionKey, exactly
+    /// what latestCommand anchors to. A correction scheduled for session A
+    /// must never produce a scroll command for session B just because the
+    /// active identity changed between schedule and drain; a mismatched
+    /// (non-equivalent) session kills the correction and clears the
+    /// pending token so it cannot linger. Equivalent spellings of the SAME
+    /// conversation (runtime alias → canonical refresh) still pass, so
+    /// ordinary identity resolution never breaks following.
     mutating func followCorrectionDue(
         _ token: ChatFollowCorrectionToken
     ) -> [ChatViewportEffect] {
@@ -467,10 +561,34 @@ struct ChatViewportController: Equatable {
         guard mode == .followingLatest,
               restoration == nil,
               notificationHandoff == nil else { return [] }
+        guard tokenOwnsCurrentSession(token) else { return [] }
         guard let bottom = bottomMarkerMaxY,
               let viewport = viewportMaxY,
               bottom - viewport > followDriftTolerance else { return [] }
+        // Stamp the execution so re-arming waits out the scroll commit's
+        // global-frame flap (see layoutMetricsChanged).
+        followCorrectionLastExecutionAt = latestFactTimestamp
         return [.scroll(latestCommand(animated: false, retry: nil))]
+    }
+
+    /// The session a follow-correction scroll command would anchor to —
+    /// the exact spelling latestCommand uses, so validation and emission
+    /// can never disagree.
+    private var followCorrectionCommandSession: ChatScrollSessionKey? {
+        activeSessionKey ?? renderedSessionKey
+    }
+
+    /// True when a token scheduled under one session may still scroll under
+    /// the current ownership: either both sides are session-less, or the
+    /// token's session is an equivalent spelling of the command session
+    /// (same conversation).
+    private func tokenOwnsCurrentSession(_ token: ChatFollowCorrectionToken) -> Bool {
+        let commandSession = followCorrectionCommandSession
+        guard let tokenSession = token.sessionKey else {
+            return commandSession == nil
+        }
+        guard let commandSession else { return false }
+        return identity.areEquivalent(tokenSession, commandSession)
     }
 
     // MARK: - Drag lifecycle (folded ChatDragLifecycleState)
@@ -490,6 +608,7 @@ struct ChatViewportController: Equatable {
         pendingDragEvaluation = nil
         pendingFollowCorrection = nil
         followCorrectionContentBottom = nil
+        followCorrectionLastExecutionAt = nil
         restoration = nil
         mode = .browsing
         return [.cancelAutomaticRestoration]
@@ -780,6 +899,7 @@ struct ChatViewportController: Equatable {
     mutating func viewDisappeared() -> [ChatViewportEffect] {
         pendingFollowCorrection = nil
         followCorrectionContentBottom = nil
+        followCorrectionLastExecutionAt = nil
         return abandonDrag()
     }
 
@@ -821,6 +941,7 @@ struct ChatViewportController: Equatable {
         generation &+= 1
         pendingFollowCorrection = nil
         followCorrectionContentBottom = nil
+        followCorrectionLastExecutionAt = nil
     }
 
     private mutating func beginHandoffOwnership() -> [ChatViewportEffect] {
@@ -828,6 +949,7 @@ struct ChatViewportController: Equatable {
         generation &+= 1
         pendingFollowCorrection = nil
         followCorrectionContentBottom = nil
+        followCorrectionLastExecutionAt = nil
         restoration = nil
         return [.cancelAutomaticRestoration]
     }

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -17,6 +17,14 @@ struct ChatView: View {
     @State private var renderedScrollTargets = ChatRenderedScrollTargets()
     @State private var viewportSnapshotProviderID = UUID()
     @State private var viewport = ChatViewportController()
+    /// The animated bottom command whose delayed retry is still armed. A
+    /// coalesced follow correction must not execute while this is set: the
+    /// animation is mid-flight toward the bottom, the measured drift is
+    /// transient, and a second scrollTo against the same anchor mid-
+    /// animation churns the lazy realization (observed as settled-row
+    /// re-materialization in the hosted transcript fixture). The retry
+    /// itself guarantees the animated command lands.
+    @State private var armedAnimatedBottomRetry: ChatViewportCommand?
     @GestureState private var isDraggingChat = false
 
     private var renderedScrollSessionKey: ChatScrollSessionKey? { viewport.renderedSessionKey }
@@ -335,6 +343,15 @@ struct ChatView: View {
                 guard wasDragging, !isDragging else { return }
                 performViewportEffects(viewport.userDragGestureEnded(), using: proxy)
             }
+            .onChange(of: viewport.pendingFollowCorrection) { _, pending in
+                // The coalesced follow-correction executor: the controller
+                // scheduled (state changed) from a geometry preference
+                // callback; SwiftUI delivers this observer on the update
+                // turn that change created — after the layout pass, riding
+                // its transaction, at most once per pending token.
+                guard let pending else { return }
+                executePendingFollowCorrection(pending, using: proxy)
+            }
     }
 
     private func transcriptObservers(proxy: ScrollViewProxy, content: some View) -> some View {
@@ -627,7 +644,44 @@ struct ChatView: View {
                     using: proxy
                 )
             }
+        case .scheduleFollowCorrection:
+            // Executed by the pendingFollowCorrection observer below: the
+            // correction must ride the SwiftUI update turn that the
+            // scheduling state change already created — never its own
+            // MainActor task (a standalone task commits a separate layout
+            // transaction, which re-materializes lazy rows the transcript
+            // fixtures measure), and never synchronously inside the geometry
+            // preference callback that scheduled it (that
+            // scrollTo → layout → preference → scrollTo loop is the
+            // ScrollViewCommitMutation watchdog storm).
+            break
         }
+    }
+
+    /// Executes the coalesced bottom-follow correction on the update turn
+    /// that the controller's pending-correction state change created. This
+    /// is the ONLY place a follow correction scrolls.
+    private func executePendingFollowCorrection(
+        _ token: ChatFollowCorrectionToken,
+        using proxy: ScrollViewProxy
+    ) {
+        if let armed = armedAnimatedBottomRetry {
+            // An animated bottom command is still in flight with its own
+            // retry armed; a correction now would fight the animation. Drop
+            // this cycle — genuinely new growth schedules a fresh one.
+            ChatViewportTrace.shared.log(
+                "follow correction skipped, animated retry armed gen=\(armed.generation)"
+            )
+            _ = viewport.followCorrectionDue(token)
+            return
+        }
+        ChatViewportTrace.shared.log(
+            "follow correction due gen=\(token.generation)"
+        )
+        performViewportEffects(
+            viewport.followCorrectionDue(token),
+            using: proxy
+        )
     }
 
     @MainActor
@@ -640,8 +694,16 @@ struct ChatView: View {
         // retry re-validates below.
         runViewportScroll(command, using: proxy)
         guard case .delayed(let milliseconds) = command.retry else { return }
+        if case .bottom = command.destination {
+            // Mark the flight window: the retry disarms below, and follow
+            // corrections defer to the animation meanwhile.
+            armedAnimatedBottomRetry = command
+        }
         Task { @MainActor in
             try? await Task.sleep(for: .milliseconds(milliseconds))
+            if armedAnimatedBottomRetry == command {
+                armedAnimatedBottomRetry = nil
+            }
             guard !Task.isCancelled, viewport.isCommandCurrent(command) else { return }
             ChatViewportTrace.shared.log(
                 "scroll retry \(command.destination) gen=\(command.generation)"

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -595,7 +595,8 @@ struct ChatView: View {
             viewportMinY: scrollViewportMinY,
             viewportMaxY: scrollViewportMaxY,
             rowFrames: frames,
-            renderedScope: scope
+            renderedScope: scope,
+            timestamp: CFAbsoluteTimeGetCurrent()
         )
     }
 
@@ -644,7 +645,10 @@ struct ChatView: View {
                     using: proxy
                 )
             }
-        case .scheduleFollowCorrection:
+        case .scheduleFollowCorrection(let token):
+            ChatViewportTrace.shared.log(
+                "follow correction scheduled seq=\(token.sequence) gen=\(token.generation)"
+            )
             // Executed by the pendingFollowCorrection observer below: the
             // correction must ride the SwiftUI update turn that the
             // scheduling state change already created — never its own
@@ -660,7 +664,10 @@ struct ChatView: View {
 
     /// Executes the coalesced bottom-follow correction on the update turn
     /// that the controller's pending-correction state change created. This
-    /// is the ONLY place a follow correction scrolls.
+    /// is the ONLY place a follow correction scrolls. MainActor-isolated to
+    /// match the neighboring scroll-execution entry points: it mutates
+    /// viewport state, writes the trace ring, and drives ScrollViewProxy.
+    @MainActor
     private func executePendingFollowCorrection(
         _ token: ChatFollowCorrectionToken,
         using proxy: ScrollViewProxy

--- a/Conduit/Views/Components/MarkdownLargeDocumentView.swift
+++ b/Conduit/Views/Components/MarkdownLargeDocumentView.swift
@@ -536,7 +536,10 @@ struct LargeMarkdownExpandedView: View {
     ) -> some View {
         switch block {
         case .table(let headers, let alignments, let rows)
-            where block.estimatedSourceBytes >= MarkdownLargeDocumentPolicy.largeTableBytes:
+            where MarkdownRichContentPolicy.isComplexTable(headers: headers, rows: rows):
+            // Shared structural predicate: a table pages when ITS structure
+            // is expensive (rows/cells/bytes), in large mode exactly as in
+            // the ordinary path (MarkdownBlockView).
             LargeMarkdownTable(
                 headers: headers,
                 alignments: alignments,
@@ -567,33 +570,11 @@ struct LargeMarkdownExpandedView: View {
                     selectionCoordinator: selectionCoordinator
                 )
             }
-        case .math(let source) where source.utf8.count > MarkdownLargeDocumentPolicy.mathGuardBytes:
-            GuardedSourceCard(
-                title: "LaTeX",
-                icon: "function",
-                source: source,
-                guardBytes: MarkdownLargeDocumentPolicy.mathGuardBytes
-            )
-        case .code(let language, let code)
-            where MarkdownLanguage.normalized(language) == "mermaid"
-                && code.utf8.count > MarkdownLargeDocumentPolicy.mermaidGuardBytes:
-            GuardedSourceCard(
-                title: "Mermaid",
-                icon: "point.3.connected.trianglepath.dotted",
-                source: code,
-                guardBytes: MarkdownLargeDocumentPolicy.mermaidGuardBytes
-            )
-        case .code(let language, let code)
-            where MarkdownLanguage.normalized(language) != "mermaid"
-                && MarkdownLargeDocumentPolicy.isLargeCodeBlock(code):
-            LargeCodeBlockView(
-                source: code,
-                language: language,
-                usesAccentSurface: usesAccentSurface
-            )
         default:
             // Ordinary rich blocks reuse the ordinary renderer with their
-            // chunk-local reference subset injected.
+            // chunk-local reference subset injected. The per-block Mermaid/
+            // math/code guards live in MarkdownBlockView now, so they apply
+            // identically here and in the ordinary path.
             MarkdownBlockView(
                 block: block,
                 blockIndex: originalIndex,

--- a/Conduit/Views/Components/MarkdownRichContent.swift
+++ b/Conduit/Views/Components/MarkdownRichContent.swift
@@ -1,0 +1,288 @@
+//
+//  MarkdownRichContent.swift
+//  Conduit
+//
+//  Bounding of expensive rich Markdown content by STRUCTURE, not by
+//  whole-message bytes.
+//
+//  The large-document mode (PR #88) gates every protection behind the
+//  whole-message byte threshold (100 KB). Two TestFlight crashes
+//  (0x8BADF00D scene-update watchdog, main thread inside
+//  ScrollViewCommitMutation under GraphHost.flushTransactions) came from
+//  a response that was comfortably BELOW that threshold but carried a
+//  pathological quantity of rich blocks — dozens of tables, Mermaid
+//  diagrams, images, math, code fences. Source bytes are a poor proxy
+//  for layout complexity: a 60 KB showcase with 30 tables mounts
+//  thousands of TextKit cell views (plus width measurement for every
+//  cell) in one layout pass, while 150 KB of prose stays cheap.
+//
+//  This file owns two bounds, both independent of the message size:
+//
+//  1. Block-local: a structurally complex table uses the paged
+//     LargeMarkdownTable presentation (bounded column measurement on a
+//     sampled prefix + explicit row batches), and the per-block
+//     Mermaid/math/code guards from the large-document path apply to the
+//     block itself wherever it renders.
+//  2. Message-level: a response whose aggregate rich complexity exceeds
+//     a bounded budget mounts its rich blocks progressively (initial
+//     batch + explicit reveal), reusing the progressive-rendering UX
+//     shape of the #88 expanded view. Ordinary messages — a table, a
+//     diagram, a few code blocks — never enter this path.
+//
+
+import SwiftUI
+
+// MARK: - Policy
+
+/// Structural (non-byte) bounding policy for rich Markdown content.
+/// Every decision here is derived from the blocks themselves — never
+/// from the enclosing message's byte count — so the ordinary rendering
+/// path inherits the #88 protections exactly when its own content is
+/// expensive.
+enum MarkdownRichContentPolicy {
+    // --- Block-local table complexity ---
+
+    /// Tables with at least this many rows use the paged presentation:
+    /// row mounting is the dominant cost (one TextKit view per cell),
+    /// and past this count a single table owns a screenful of layout.
+    static let complexTableRowCount = 40
+    /// Header+row cell count at/above which a table uses the paged
+    /// presentation — catches wide tables (many columns) whose row count
+    /// alone looks moderate.
+    static let complexTableCellCount = 200
+
+    /// A table whose estimated source size reaches the existing
+    /// large-table byte ceiling keeps that qualification, so behavior
+    /// for byte-heavy tables (huge cells) is unchanged from #88.
+    static func isComplexTable(headers: [String], rows: [[String]]) -> Bool {
+        if rows.count >= complexTableRowCount { return true }
+        let columnCount = max(headers.count, rows.map(\.count).max() ?? 0)
+        if rows.count * columnCount >= complexTableCellCount { return true }
+        return tableEstimatedBytes(headers: headers, rows: rows)
+            >= MarkdownLargeDocumentPolicy.largeTableBytes
+    }
+
+    /// Byte estimate of a table's own content (mirrors the
+    /// estimatedSourceBytes measure the #88 planner already uses for
+    /// tables, kept in one place so the two paths cannot drift).
+    static func tableEstimatedBytes(headers: [String], rows: [[String]]) -> Int {
+        var bytes: Int = 0
+        for header in headers {
+            bytes += header.utf8.count + 4
+        }
+        for row in rows {
+            for cell in row {
+                bytes += cell.utf8.count + 4
+            }
+        }
+        return bytes
+    }
+
+    // --- Aggregate rich-layout budget ---
+
+    /// Rich-layout units mounted before the progressive reveal gate
+    /// engages. Generous for ordinary messages (several tables, a
+    /// diagram, a handful of code blocks and images all fit), bounded
+    /// for pathological showcases.
+    static let eagerRichUnitBudget = 16
+    /// Units added per explicit reveal action.
+    static let revealUnitBatch = 16
+    /// Table cells represented by one unit — the cost of actually
+    /// mounting and measuring that many TextKit cell views.
+    static let tableCellsPerUnit = 64
+    /// A remote image is web-backed (AsyncImage with a WKWebView
+    /// fallback path), so it counts heavier than a local text block.
+    static let imageUnits = 2
+    /// Code bytes per unit; blocks above the #88 code threshold render
+    /// a bounded preview first, so their initial cost stays near one
+    /// screenful.
+    static let codeBytesPerUnit = MarkdownLargeDocumentPolicy.chunkTargetBytes
+
+    /// Eagerly mounted layout cost of one block, in rich-layout units.
+    /// Flow blocks (paragraphs, headings, lists, quotes) are plain
+    /// attributed text and cost nothing here. Paged (structurally
+    /// complex) tables are charged for what they actually mount — the
+    /// initial row batch, not the whole table.
+    static func richUnits(_ block: MarkdownBlock) -> Int {
+        switch block {
+        case .table(let headers, _, let rows):
+            let columnCount = max(headers.count, rows.map(\.count).max() ?? 0)
+            if isComplexTable(headers: headers, rows: rows) {
+                let mountedRowCount = min(rows.count, LargeMarkdownTable.initialRowBatch)
+                let mountedCellCount = max((mountedRowCount + 1) * columnCount, 1)
+                return max(1, units(forCells: mountedCellCount))
+            }
+            let cellCount = max((rows.count + 1) * columnCount, 1)
+            return max(1, units(forCells: cellCount))
+        case .code(_, let source):
+            let byteCount = source.utf8.count
+            return max(1, (byteCount + codeBytesPerUnit - 1) / codeBytesPerUnit)
+        case .math:
+            return 1
+        case .image:
+            return imageUnits
+        case .heading, .paragraph, .quote, .unorderedList, .orderedList,
+             .callout, .columns, .divider:
+            return 0
+        }
+    }
+
+    private static func units(forCells cells: Int) -> Int {
+        let numerator = cells + tableCellsPerUnit - 1
+        return numerator / tableCellsPerUnit
+    }
+
+    /// Aggregate rich-layout units of a whole parsed message.
+    static func totalRichUnits(_ blocks: [MarkdownBlock]) -> Int {
+        blocks.reduce(0) { $0 + richUnits($1) }
+    }
+
+    /// True when a message's rich content needs the progressive gate.
+    /// Deliberately cheap: the walk touches each block once with O(1)
+    /// (tables: O(cells)) work — the same order as the parse itself.
+    static func needsBounding(_ blocks: [MarkdownBlock]) -> Bool {
+        totalRichUnits(blocks) > eagerRichUnitBudget
+    }
+
+    /// Index of the first block held behind the reveal gate for a given
+    /// unit budget (nil when everything fits). The block that crosses
+    /// the budget is itself held back only when at least one earlier
+    /// block is mounted, so a single legitimate rich block never leaves
+    /// an empty message body.
+    static func gateCut(blocks: [MarkdownBlock], unitBudget: Int) -> Int? {
+        var units = 0
+        for (index, block) in blocks.enumerated() {
+            units += richUnits(block)
+            if units > unitBudget, index > 0 {
+                return index
+            }
+        }
+        return nil
+    }
+}
+
+// MARK: - Bounded message body
+
+/// The normal-path message body for responses whose aggregate rich
+/// complexity exceeds the budget: identical block rendering, but rich
+/// blocks mount progressively — an initial bounded batch, then explicit
+/// reveal — so opening a structurally pathological (but byte-ordinary)
+/// response can never synchronously mount an unbounded pile of
+/// SwiftUI/UIKit/WebKit layout nodes.
+///
+/// While the message is STREAMING, the gate is bypassed: content grows
+/// incrementally frame by frame, so the per-frame mount cost is the
+/// small delta (the pre-existing behavior), and the live tail the user
+/// is reading can never sit behind a reveal button. The gate engages on
+/// the settled render — the exact scenario the watchdog crashes
+/// reported (opening a session with one Markdown-heavy response).
+struct RichBudgetedMarkdownBody: View {
+    let blocks: [MarkdownBlock]
+    /// The message source, carried only as the selection-plan revision so
+    /// segment registration mirrors the ordinary path's onChange contract.
+    let source: String
+    let foregroundStyle: Color
+    let usesAccentSurface: Bool
+    let gatewayMediaDataURL: ((String) async -> String?)?
+    let selectionCoordinator: MarkdownSelectionCoordinator
+    let selectionSegments: [MarkdownSelectionSegmentDescriptor]
+    var newestCharacterOpacities: [Double] = []
+    var isStreaming: Bool = false
+
+    @State private var mountedUnitBudget = MarkdownRichContentPolicy.eagerRichUnitBudget
+
+    #if DEBUG
+    /// Test instrumentation: block count mounted by the most recent body
+    /// evaluation. Proves the gate (not luck) bounded the mounted set.
+    /// Lock-guarded end to end, matching the other DEBUG counters.
+    private static let debugLock = NSLock()
+    private nonisolated(unsafe) static var debugMountedBlockCountStorage = 0
+
+    nonisolated(unsafe) static var debugMountedBlockCount: Int {
+        get {
+            debugLock.lock()
+            defer { debugLock.unlock() }
+            return debugMountedBlockCountStorage
+        }
+        set {
+            debugLock.lock()
+            defer { debugLock.unlock() }
+            debugMountedBlockCountStorage = newValue
+        }
+    }
+
+    static func resetDebugInstrumentation() {
+        debugMountedBlockCount = 0
+    }
+    #endif
+
+    private var gateCut: Int? {
+        let cut = MarkdownRichContentPolicy.gateCut(
+            blocks: blocks,
+            unitBudget: mountedUnitBudget
+        )
+        #if DEBUG
+        RichBudgetedMarkdownBody.debugMountedBlockCount = cut ?? blocks.count
+        #endif
+        return cut
+    }
+
+    var body: some View {
+        // Streaming bypass: the gate exists to bound the ONE synchronous
+        // mount of a pathological settled response; streaming mounts
+        // grow by small deltas per frame and must keep the tail visible.
+        // The gate is still resolved first so instrumentation records the
+        // ungated count (blocks.count) for streaming bodies too.
+        let gate = gateCut
+        let cut = isStreaming ? nil : gate
+        #if DEBUG
+        if isStreaming {
+            RichBudgetedMarkdownBody.debugMountedBlockCount = blocks.count
+        }
+        #endif
+        return VStack(alignment: .leading, spacing: 10) {
+            ForEach(Array(blocks.prefix(cut ?? blocks.count).enumerated()), id: \.offset) { index, block in
+                MarkdownBlockView(
+                    block: block,
+                    blockIndex: index,
+                    foregroundStyle: foregroundStyle,
+                    usesAccentSurface: usesAccentSurface,
+                    gatewayMediaDataURL: gatewayMediaDataURL,
+                    selectionCoordinator: selectionCoordinator,
+                    selectionSegments: selectionSegments,
+                    newestCharacterOpacities: index == blocks.count - 1
+                        ? newestCharacterOpacities
+                        : []
+                )
+            }
+            if let cut {
+                revealFooter(remainingBlocks: blocks.count - cut)
+            }
+        }
+        .onAppear {
+            selectionCoordinator.replaceSegments(selectionSegments, revision: source)
+        }
+        .onChange(of: source) { _, _ in
+            selectionCoordinator.replaceSegments(selectionSegments, revision: source)
+        }
+        .modifier(MarkdownSelectionHost(coordinator: selectionCoordinator))
+    }
+
+    /// The reveal affordance, in the same shape as the #88 expanded-view
+    /// footer so both bounded presentations read as one system.
+    private func revealFooter(remainingBlocks: Int) -> some View {
+        Button {
+            mountedUnitBudget += MarkdownRichContentPolicy.revealUnitBatch
+        } label: {
+            Label(
+                "Continue reading (\(remainingBlocks) sections left)",
+                systemImage: "chevron.down"
+            )
+            .font(.footnote.weight(.semibold))
+        }
+        .tint(usesAccentSurface ? .white : .conduitAccent)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 4)
+        .accessibilityIdentifier("markdown.richReveal")
+    }
+}

--- a/Conduit/Views/Components/MarkdownRichContent.swift
+++ b/Conduit/Views/Components/MarkdownRichContent.swift
@@ -248,8 +248,13 @@ enum MarkdownRichContentPolicy {
     /// reveal action so one tap always mounts at least one additional
     /// held-back block, even when that single block costs more than a
     /// normal reveal batch.
+    ///
+    /// Contract: index must be a VALID block index (0 < index < count).
+    /// The inclusive 0...index walk below would read one element past
+    /// the end for index == count, so that input is rejected here;
+    /// production callers pass a gateCut, which is always < count.
     static func budgetToInclude(unitsByBlock: [Int], index: Int) -> Int {
-        guard index > 0, index <= unitsByBlock.count else { return eagerRichUnitBudget }
+        guard index > 0, index < unitsByBlock.count else { return eagerRichUnitBudget }
         var units = 0
         for position in 0...index {
             units += unitsByBlock[position]
@@ -275,6 +280,63 @@ enum MarkdownRichContentPolicy {
             }
         }
         return next
+    }
+    /// The mounted-block plan: the real UNION of the revealed prefix
+    /// and the always-visible live tail, shared by the view body, the
+    /// DEBUG instrumentation, and the regression tests (one source of
+    /// truth — tests cannot drift from what production mounts).
+    ///
+    /// Invariants (all regression-tested):
+    /// - the live tail stays mounted in EVERY gate state, including
+    ///   when the reveal cut reaches or passes the tail start;
+    /// - no block is ever mounted twice (ranges are disjoint or
+    ///   collapse into one contiguous range);
+    /// - the reveal footer exists IFF a real hidden interval exists
+    ///   (a strictly positive gap between prefix end and tail start);
+    /// - growing the reveal budget only ever ADDS mounted blocks.
+    enum RichMountedPlan: Equatable {
+        /// One contiguous mounted range 0..<end: either nothing is
+        /// gated, or the revealed prefix has reached/passed the tail
+        /// start so the union covers everything through the end.
+        case contiguous(end: Int)
+        /// Disjoint union: prefix 0..<prefixEnd, a hidden gap, and the
+        /// always-mounted tail tailStart..<count. The gap is strictly
+        /// positive, so the reveal footer is shown.
+        case split(prefixEnd: Int, tailStart: Int)
+    }
+
+    static func mountedPlan(unitsByBlock: [Int], unitBudget: Int) -> RichMountedPlan {
+        let total = unitsByBlock.count
+        let cut = gateCut(unitsByBlock: unitsByBlock, unitBudget: unitBudget)
+        let tailStart = liveTailStart(unitsByBlock: unitsByBlock)
+        guard let cut else {
+            // Everything fits the revealed prefix; the tail sits inside
+            // it. Mount each block exactly once, no footer.
+            return .contiguous(end: total)
+        }
+        if tailStart > cut {
+            // Real hidden gap [cut, tailStart): prefix + footer + tail.
+            return .split(prefixEnd: cut, tailStart: tailStart)
+        }
+        // cut == tail (empty gap) or cut > tail (prefix has overlapped
+        // the tail): the union is the contiguous range 0..<count. The
+        // previously mounted tail blocks MUST NOT retract, and nothing
+        // may be mounted twice.
+        return .contiguous(end: total)
+    }
+
+    /// The exact mounted indices for a plan, in document order — what
+    /// the production body mounts and what the DEBUG instrumentation
+    /// records.
+    static func mountedIndices(plan: RichMountedPlan, totalBlocks: Int) -> [Int] {
+        switch plan {
+        case .contiguous(let end):
+            return Array(0..<end)
+        case .split(let prefixEnd, let tailStart):
+            var indices = Array(0..<prefixEnd)
+            indices.append(contentsOf: Array(tailStart..<totalBlocks))
+            return indices
+        }
     }
 }
 
@@ -316,6 +378,7 @@ struct RichBudgetedMarkdownBody: View {
     private static let debugLock = NSLock()
     private nonisolated(unsafe) static var debugMountedBlockCountStorage = 0
     private nonisolated(unsafe) static var debugMountedBlockIndicesStorage: [Int] = []
+    private nonisolated(unsafe) static var debugFooterVisibleStorage = false
 
     nonisolated(unsafe) static var debugMountedBlockCount: Int {
         get {
@@ -346,58 +409,75 @@ struct RichBudgetedMarkdownBody: View {
         }
     }
 
+    /// Whether the most recent body evaluation showed the reveal footer
+    /// — true IFF the mounted plan is split (a real hidden gap).
+    nonisolated(unsafe) static var debugFooterVisible: Bool {
+        get {
+            debugLock.lock()
+            defer { debugLock.unlock() }
+            return debugFooterVisibleStorage
+        }
+        set {
+            debugLock.lock()
+            defer { debugLock.unlock() }
+            debugFooterVisibleStorage = newValue
+        }
+    }
+
     static func resetDebugInstrumentation() {
         debugMountedBlockCount = 0
         debugMountedBlockIndices = []
+        debugFooterVisible = false
     }
     #endif
 
-    /// The gate cut for the current budget: first hidden block index, or
-    /// nil when the prefix covers everything.
-    private var gateIndex: Int? {
-        MarkdownRichContentPolicy.gateCut(
+    /// The mounted plan for the current reveal budget — the real union
+    /// of the revealed prefix and the always-visible live tail (see
+    /// MarkdownRichContentPolicy.mountedPlan).
+    private var mountedPlan: MarkdownRichContentPolicy.RichMountedPlan {
+        MarkdownRichContentPolicy.mountedPlan(
             unitsByBlock: richUnitsByBlock,
             unitBudget: mountedUnitBudget
         )
     }
 
-    /// Start index of the always-mounted live tail.
-    private var tailIndex: Int {
-        MarkdownRichContentPolicy.liveTailStart(unitsByBlock: richUnitsByBlock)
-    }
-
     var body: some View {
-        // Mounted set = prefix(0..<cut) ∪ tail(tailIndex...). Both parts
-        // are streaming-independent: the tail is where a streaming
+        // Mounted set = prefix(0..<cut) UNION tail(tailStart...), both
+        // parts streaming-independent: the tail is where a streaming
         // response is being read (and where reveal characters fade), the
         // prefix is the bounded history the reveal budget has bought.
-        // The gap between them is the only hidden region.
-        let cut = gateIndex
-        let tail = tailIndex
-        let tailIsBeyondGate: Bool
-        if let cut {
-            tailIsBeyondGate = tail > cut
-        } else {
-            tailIsBeyondGate = false
-        }
-        let mountedPrefixEnd = cut ?? blocks.count
-        let mountedTailStart = tailIsBeyondGate ? tail : blocks.count
+        //
+        // The union is computed by the shared plan: when the reveal cut
+        // reaches or passes the tail start the ranges collapse into ONE
+        // contiguous range (never unmounting the tail, never mounting a
+        // block twice, never showing a footer without a hidden gap), and
+        // the footer exists IFF a strictly positive hidden interval
+        // remains between the prefix and the tail.
+        let plan = mountedPlan
         #if DEBUG
-        Self.debugMountedBlockCount = mountedPrefixEnd
-            + (blocks.count - mountedTailStart)
-        var mountedIndices: [Int] = Array(0..<mountedPrefixEnd)
-        if tailIsBeyondGate {
-            mountedIndices.append(contentsOf: Array(mountedTailStart..<blocks.count))
-        }
-        Self.debugMountedBlockIndices = mountedIndices
+        let productionIndices = MarkdownRichContentPolicy.mountedIndices(
+            plan: plan,
+            totalBlocks: blocks.count
+        )
+        Self.debugMountedBlockCount = productionIndices.count
+        Self.debugMountedBlockIndices = productionIndices
+        Self.debugFooterVisible = {
+            if case .split = plan { return true }
+            return false
+        }()
         #endif
         return VStack(alignment: .leading, spacing: 10) {
-            ForEach(0..<mountedPrefixEnd, id: \.self) { index in
-                blockView(index)
-            }
-            if tailIsBeyondGate {
-                revealFooter(remainingBlocks: mountedTailStart - mountedPrefixEnd)
-                ForEach(mountedTailStart..<blocks.count, id: \.self) { index in
+            switch plan {
+            case .contiguous(let end):
+                ForEach(0..<end, id: \.self) { index in
+                    blockView(index)
+                }
+            case .split(let prefixEnd, let tailStart):
+                ForEach(0..<prefixEnd, id: \.self) { index in
+                    blockView(index)
+                }
+                revealFooter(remainingBlocks: tailStart - prefixEnd)
+                ForEach(tailStart..<blocks.count, id: \.self) { index in
                     blockView(index)
                 }
             }
@@ -408,7 +488,36 @@ struct RichBudgetedMarkdownBody: View {
         .onChange(of: source) { _, _ in
             selectionCoordinator.replaceSegments(selectionSegments, revision: source)
         }
+        #if DEBUG
+        .onReceive(NotificationCenter.default.publisher(for: Self.advanceRevealForTesting)) { _ in
+            // DEBUG-only test inlet: drives the EXACT reveal action the
+            // footer button performs (same method, same @State path).
+            // SwiftUI Buttons expose neither a UIControl bridge nor a
+            // reachable accessibility activation surface to unit tests,
+            // so hosted regression tests advance the reveal through
+            // this notification instead. Never compiled into release.
+            advanceReveal()
+        }
+        #endif
         .modifier(MarkdownSelectionHost(coordinator: selectionCoordinator))
+    }
+
+    #if DEBUG
+    /// Notification name for the DEBUG-only reveal inlet above.
+    static let advanceRevealForTesting = Notification.Name(
+        "conduit.markdown.richReveal.advance"
+    )
+    #endif
+
+    /// Advances the reveal budget: one batch more, or enough to include
+    /// the next gated block when it alone costs more than the batch —
+    /// the single implementation the footer button (and the DEBUG test
+    /// inlet) execute.
+    private func advanceReveal() {
+        mountedUnitBudget = MarkdownRichContentPolicy.revealBudget(
+            unitsByBlock: richUnitsByBlock,
+            currentBudget: mountedUnitBudget
+        )
     }
 
     private func blockView(_ index: Int) -> some View {
@@ -433,10 +542,7 @@ struct RichBudgetedMarkdownBody: View {
     /// alone costs more than a normal batch.
     private func revealFooter(remainingBlocks: Int) -> some View {
         Button {
-            mountedUnitBudget = MarkdownRichContentPolicy.revealBudget(
-                unitsByBlock: richUnitsByBlock,
-                currentBudget: mountedUnitBudget
-            )
+            advanceReveal()
         } label: {
             Label(
                 "Continue reading (\(remainingBlocks) sections left)",

--- a/Conduit/Views/Components/MarkdownRichContent.swift
+++ b/Conduit/Views/Components/MarkdownRichContent.swift
@@ -24,10 +24,23 @@
 //     Mermaid/math/code guards from the large-document path apply to the
 //     block itself wherever it renders.
 //  2. Message-level: a response whose aggregate rich complexity exceeds
-//     a bounded budget mounts its rich blocks progressively (initial
-//     batch + explicit reveal), reusing the progressive-rendering UX
-//     shape of the #88 expanded view. Ordinary messages — a table, a
-//     diagram, a few code blocks — never enter this path.
+//     a bounded budget mounts a bounded PREFIX of rich blocks plus an
+//     always-visible LIVE TAIL, with the middle behind an explicit
+//     reveal. Ordinary messages — a table, a diagram, a few code blocks
+//     — never enter this path.
+//
+//  The live tail is what keeps streaming correct in both directions:
+//
+//  - While a response STREAMS, the newest content (where the user is
+//    reading) is always mounted, while the historical rich blocks behind
+//    it stay bounded. Streaming therefore cannot eagerly mount an
+//    unbounded pile of rich renderers — including the reconnect case
+//    where a huge accumulated body arrives while still technically
+//    streaming.
+//  - When the message SETTLES, the mounted set does not change: the
+//    prefix and the tail are computed from the block structure and the
+//    reveal budget alone, never from the streaming flag. Content the
+//    user was just reading cannot disappear at the transition.
 //
 
 import SwiftUI
@@ -39,6 +52,13 @@ import SwiftUI
 /// from the enclosing message's byte count — so the ordinary rendering
 /// path inherits the #88 protections exactly when its own content is
 /// expensive.
+///
+/// All planning functions take the per-block rich-unit vector
+/// (unitsByBlock) rather than the blocks themselves: the vector is
+/// computed once per parsed source and cached alongside it (see
+/// MarkdownRenderCache), so repeated SwiftUI body evaluations never
+/// re-walk table cells to rediscover the same budget. Blocks-based
+/// conveniences remain for tests and one-shot callers.
 enum MarkdownRichContentPolicy {
     // --- Block-local table complexity ---
 
@@ -80,13 +100,21 @@ enum MarkdownRichContentPolicy {
 
     // --- Aggregate rich-layout budget ---
 
-    /// Rich-layout units mounted before the progressive reveal gate
-    /// engages. Generous for ordinary messages (several tables, a
-    /// diagram, a handful of code blocks and images all fit), bounded
-    /// for pathological showcases.
+    /// Rich-layout units mounted from the front before the progressive
+    /// reveal gate engages. Generous for ordinary messages (several
+    /// tables, a diagram, a handful of code blocks and images all fit),
+    /// bounded for pathological showcases.
     static let eagerRichUnitBudget = 16
-    /// Units added per explicit reveal action.
+    /// Units added per explicit reveal action (see revealBudget(after:)
+    /// for the forward-progress guarantee).
     static let revealUnitBatch = 16
+    /// Units of the ALWAYS-MOUNTED live tail: the newest blocks stay
+    /// visible regardless of the reveal budget — while streaming (the
+    /// region the user is reading) and after settling (nothing already
+    /// shown may collapse away). Same order as the eager budget so the
+    /// gap boundary sits roughly a screenful of rich content above the
+    /// reading position.
+    static let liveTailUnitBudget = 16
     /// Table cells represented by one unit — the cost of actually
     /// mounting and measuring that many TextKit cell views.
     static let tableCellsPerUnit = 64
@@ -127,6 +155,14 @@ enum MarkdownRichContentPolicy {
         }
     }
 
+    /// Per-block rich-unit vector for a whole parsed message. Computed
+    /// once per source and cached with the rendering, so body
+    /// re-evaluations reuse it instead of re-walking every table's
+    /// cells.
+    static func richUnitsByBlock(_ blocks: [MarkdownBlock]) -> [Int] {
+        blocks.map(richUnits)
+    }
+
     private static func units(forCells cells: Int) -> Int {
         let numerator = cells + tableCellsPerUnit - 1
         return numerator / tableCellsPerUnit
@@ -134,14 +170,21 @@ enum MarkdownRichContentPolicy {
 
     /// Aggregate rich-layout units of a whole parsed message.
     static func totalRichUnits(_ blocks: [MarkdownBlock]) -> Int {
-        blocks.reduce(0) { $0 + richUnits($1) }
+        let units = richUnitsByBlock(blocks)
+        return totalRichUnits(units)
+    }
+
+    static func totalRichUnits(_ unitsByBlock: [Int]) -> Int {
+        unitsByBlock.reduce(0, +)
     }
 
     /// True when a message's rich content needs the progressive gate.
-    /// Deliberately cheap: the walk touches each block once with O(1)
-    /// (tables: O(cells)) work — the same order as the parse itself.
     static func needsBounding(_ blocks: [MarkdownBlock]) -> Bool {
-        totalRichUnits(blocks) > eagerRichUnitBudget
+        needsBounding(unitsByBlock: richUnitsByBlock(blocks))
+    }
+
+    static func needsBounding(unitsByBlock: [Int]) -> Bool {
+        totalRichUnits(unitsByBlock) > eagerRichUnitBudget
     }
 
     /// Index of the first block held behind the reveal gate for a given
@@ -150,44 +193,119 @@ enum MarkdownRichContentPolicy {
     /// block is mounted, so a single legitimate rich block never leaves
     /// an empty message body.
     static func gateCut(blocks: [MarkdownBlock], unitBudget: Int) -> Int? {
+        gateCut(unitsByBlock: richUnitsByBlock(blocks), unitBudget: unitBudget)
+    }
+
+    static func gateCut(unitsByBlock: [Int], unitBudget: Int) -> Int? {
         var units = 0
-        for (index, block) in blocks.enumerated() {
-            units += richUnits(block)
+        for (index, blockUnits) in unitsByBlock.enumerated() {
+            units += blockUnits
             if units > unitBudget, index > 0 {
                 return index
             }
         }
         return nil
     }
+
+    /// Start index of the always-visible live tail: the latest blocks
+    /// whose combined units fit the tail budget. The FINAL block is
+    /// always included, even when it alone exceeds the budget — the
+    /// streaming reveal region must be visible no matter how expensive
+    /// the newest block is. Zero when the whole message fits the tail
+    /// budget.
+    static func liveTailStart(
+        unitsByBlock: [Int],
+        unitBudget: Int = liveTailUnitBudget
+    ) -> Int {
+        guard !unitsByBlock.isEmpty else { return 0 }
+        var total = 0
+        var start = unitsByBlock.count
+        while start > 0 {
+            let next = unitsByBlock[start - 1]
+            if total + next > unitBudget {
+                break
+            }
+            total += next
+            start -= 1
+        }
+        // At least the final block is always tail-mounted.
+        return min(start, unitsByBlock.count - 1)
+    }
+
+    /// Number of blocks hidden behind the gate for a given budget: the
+    /// gap between the mounted prefix and the always-mounted tail. Zero
+    /// when the prefix and tail overlap (or no gate engages at all).
+    static func hiddenBlockCount(unitsByBlock: [Int], unitBudget: Int) -> Int {
+        guard let cut = gateCut(unitsByBlock: unitsByBlock, unitBudget: unitBudget) else {
+            return 0
+        }
+        let tail = liveTailStart(unitsByBlock: unitsByBlock)
+        return max(0, tail - cut)
+    }
+
+    /// Budget required for the mounted prefix to INCLUDE the block at
+    /// index — the cumulative units through that block. Used by the
+    /// reveal action so one tap always mounts at least one additional
+    /// held-back block, even when that single block costs more than a
+    /// normal reveal batch.
+    static func budgetToInclude(unitsByBlock: [Int], index: Int) -> Int {
+        guard index > 0, index <= unitsByBlock.count else { return eagerRichUnitBudget }
+        var units = 0
+        for position in 0...index {
+            units += unitsByBlock[position]
+        }
+        return units
+    }
+
+    /// The next reveal budget: one batch more than the current budget,
+    /// or enough to include the first gated block when that block alone
+    /// costs more than the batch — whichever is larger. Forward progress
+    /// is guaranteed (the gate cut strictly advances past at least one
+    /// block) while staying bounded to a single block's cost.
+    static func revealBudget(
+        unitsByBlock: [Int],
+        currentBudget: Int,
+        batch: Int = revealUnitBatch
+    ) -> Int {
+        var next = currentBudget + batch
+        if let cut = gateCut(unitsByBlock: unitsByBlock, unitBudget: currentBudget) {
+            let including = budgetToInclude(unitsByBlock: unitsByBlock, index: cut)
+            if including > next {
+                next = including
+            }
+        }
+        return next
+    }
 }
 
 // MARK: - Bounded message body
 
 /// The normal-path message body for responses whose aggregate rich
-/// complexity exceeds the budget: identical block rendering, but rich
-/// blocks mount progressively — an initial bounded batch, then explicit
-/// reveal — so opening a structurally pathological (but byte-ordinary)
-/// response can never synchronously mount an unbounded pile of
-/// SwiftUI/UIKit/WebKit layout nodes.
+/// complexity exceeds the budget: identical block rendering, but only a
+/// bounded PREFIX of rich blocks plus the ALWAYS-VISIBLE live TAIL mount
+/// eagerly; the middle sits behind an explicit reveal.
 ///
-/// While the message is STREAMING, the gate is bypassed: content grows
-/// incrementally frame by frame, so the per-frame mount cost is the
-/// small delta (the pre-existing behavior), and the live tail the user
-/// is reading can never sit behind a reveal button. The gate engages on
-/// the settled render — the exact scenario the watchdog crashes
-/// reported (opening a session with one Markdown-heavy response).
+/// The mounted set is computed from the block structure and the reveal
+/// budget ALONE — never from a streaming flag — so opening a
+/// structurally pathological (but byte-ordinary) response can never
+/// synchronously mount an unbounded pile of SwiftUI/UIKit/WebKit layout
+/// nodes, a streaming response keeps its newest content visible while
+/// its history stays bounded, and the streaming → settled transition
+/// cannot collapse content the user was just reading.
 struct RichBudgetedMarkdownBody: View {
     let blocks: [MarkdownBlock]
     /// The message source, carried only as the selection-plan revision so
     /// segment registration mirrors the ordinary path's onChange contract.
     let source: String
+    /// Per-block rich-unit vector, precomputed with the cached rendering
+    /// (never re-walked from body).
+    let richUnitsByBlock: [Int]
     let foregroundStyle: Color
     let usesAccentSurface: Bool
     let gatewayMediaDataURL: ((String) async -> String?)?
     let selectionCoordinator: MarkdownSelectionCoordinator
     let selectionSegments: [MarkdownSelectionSegmentDescriptor]
     var newestCharacterOpacities: [Double] = []
-    var isStreaming: Bool = false
 
     @State private var mountedUnitBudget = MarkdownRichContentPolicy.eagerRichUnitBudget
 
@@ -197,6 +315,7 @@ struct RichBudgetedMarkdownBody: View {
     /// Lock-guarded end to end, matching the other DEBUG counters.
     private static let debugLock = NSLock()
     private nonisolated(unsafe) static var debugMountedBlockCountStorage = 0
+    private nonisolated(unsafe) static var debugMountedBlockIndicesStorage: [Int] = []
 
     nonisolated(unsafe) static var debugMountedBlockCount: Int {
         get {
@@ -211,52 +330,76 @@ struct RichBudgetedMarkdownBody: View {
         }
     }
 
+    /// Indices of the blocks mounted by the most recent body evaluation —
+    /// the exact mounted set, so tests can prove the streaming → settled
+    /// transition never unmounts visible content.
+    nonisolated(unsafe) static var debugMountedBlockIndices: [Int] {
+        get {
+            debugLock.lock()
+            defer { debugLock.unlock() }
+            return debugMountedBlockIndicesStorage
+        }
+        set {
+            debugLock.lock()
+            defer { debugLock.unlock() }
+            debugMountedBlockIndicesStorage = newValue
+        }
+    }
+
     static func resetDebugInstrumentation() {
         debugMountedBlockCount = 0
+        debugMountedBlockIndices = []
     }
     #endif
 
-    private var gateCut: Int? {
-        let cut = MarkdownRichContentPolicy.gateCut(
-            blocks: blocks,
+    /// The gate cut for the current budget: first hidden block index, or
+    /// nil when the prefix covers everything.
+    private var gateIndex: Int? {
+        MarkdownRichContentPolicy.gateCut(
+            unitsByBlock: richUnitsByBlock,
             unitBudget: mountedUnitBudget
         )
-        #if DEBUG
-        RichBudgetedMarkdownBody.debugMountedBlockCount = cut ?? blocks.count
-        #endif
-        return cut
+    }
+
+    /// Start index of the always-mounted live tail.
+    private var tailIndex: Int {
+        MarkdownRichContentPolicy.liveTailStart(unitsByBlock: richUnitsByBlock)
     }
 
     var body: some View {
-        // Streaming bypass: the gate exists to bound the ONE synchronous
-        // mount of a pathological settled response; streaming mounts
-        // grow by small deltas per frame and must keep the tail visible.
-        // The gate is still resolved first so instrumentation records the
-        // ungated count (blocks.count) for streaming bodies too.
-        let gate = gateCut
-        let cut = isStreaming ? nil : gate
-        #if DEBUG
-        if isStreaming {
-            RichBudgetedMarkdownBody.debugMountedBlockCount = blocks.count
+        // Mounted set = prefix(0..<cut) ∪ tail(tailIndex...). Both parts
+        // are streaming-independent: the tail is where a streaming
+        // response is being read (and where reveal characters fade), the
+        // prefix is the bounded history the reveal budget has bought.
+        // The gap between them is the only hidden region.
+        let cut = gateIndex
+        let tail = tailIndex
+        let tailIsBeyondGate: Bool
+        if let cut {
+            tailIsBeyondGate = tail > cut
+        } else {
+            tailIsBeyondGate = false
         }
+        let mountedPrefixEnd = cut ?? blocks.count
+        let mountedTailStart = tailIsBeyondGate ? tail : blocks.count
+        #if DEBUG
+        Self.debugMountedBlockCount = mountedPrefixEnd
+            + (blocks.count - mountedTailStart)
+        var mountedIndices: [Int] = Array(0..<mountedPrefixEnd)
+        if tailIsBeyondGate {
+            mountedIndices.append(contentsOf: Array(mountedTailStart..<blocks.count))
+        }
+        Self.debugMountedBlockIndices = mountedIndices
         #endif
         return VStack(alignment: .leading, spacing: 10) {
-            ForEach(Array(blocks.prefix(cut ?? blocks.count).enumerated()), id: \.offset) { index, block in
-                MarkdownBlockView(
-                    block: block,
-                    blockIndex: index,
-                    foregroundStyle: foregroundStyle,
-                    usesAccentSurface: usesAccentSurface,
-                    gatewayMediaDataURL: gatewayMediaDataURL,
-                    selectionCoordinator: selectionCoordinator,
-                    selectionSegments: selectionSegments,
-                    newestCharacterOpacities: index == blocks.count - 1
-                        ? newestCharacterOpacities
-                        : []
-                )
+            ForEach(0..<mountedPrefixEnd, id: \.self) { index in
+                blockView(index)
             }
-            if let cut {
-                revealFooter(remainingBlocks: blocks.count - cut)
+            if tailIsBeyondGate {
+                revealFooter(remainingBlocks: mountedTailStart - mountedPrefixEnd)
+                ForEach(mountedTailStart..<blocks.count, id: \.self) { index in
+                    blockView(index)
+                }
             }
         }
         .onAppear {
@@ -268,11 +411,32 @@ struct RichBudgetedMarkdownBody: View {
         .modifier(MarkdownSelectionHost(coordinator: selectionCoordinator))
     }
 
+    private func blockView(_ index: Int) -> some View {
+        MarkdownBlockView(
+            block: blocks[index],
+            blockIndex: index,
+            foregroundStyle: foregroundStyle,
+            usesAccentSurface: usesAccentSurface,
+            gatewayMediaDataURL: gatewayMediaDataURL,
+            selectionCoordinator: selectionCoordinator,
+            selectionSegments: selectionSegments,
+            newestCharacterOpacities: index == blocks.count - 1
+                ? newestCharacterOpacities
+                : []
+        )
+    }
+
     /// The reveal affordance, in the same shape as the #88 expanded-view
-    /// footer so both bounded presentations read as one system.
+    /// footer so both bounded presentations read as one system. The
+    /// budget advance guarantees forward progress: one tap always mounts
+    /// at least one additional held-back block, even when that block
+    /// alone costs more than a normal batch.
     private func revealFooter(remainingBlocks: Int) -> some View {
         Button {
-            mountedUnitBudget += MarkdownRichContentPolicy.revealUnitBatch
+            mountedUnitBudget = MarkdownRichContentPolicy.revealBudget(
+                unitsByBlock: richUnitsByBlock,
+                currentBudget: mountedUnitBudget
+            )
         } label: {
             Label(
                 "Continue reading (\(remainingBlocks) sections left)",

--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -78,22 +78,25 @@ struct MarkdownText: View {
                     linkColor: usesAccentSurface ? .white : .link
                 )
                 .frame(maxWidth: .infinity, alignment: .leading)
-            } else if MarkdownRichContentPolicy.needsBounding(rendering.blocks) {
+            } else if rendering.needsRichBounding {
                 // Byte-ordinary but structurally pathological rich content:
                 // identical block rendering behind a bounded mount budget
                 // (see MarkdownRichContent.swift). Plain flow messages can
                 // never reach here — they take the selectableText branch —
-                // and ordinary rich messages stay under the budget.
+                // and ordinary rich messages stay under the budget. The
+                // decision and the per-block unit vector come from the
+                // cached rendering, so re-evaluations never re-walk the
+                // blocks.
                 RichBudgetedMarkdownBody(
                     blocks: rendering.blocks,
                     source: source,
+                    richUnitsByBlock: rendering.richUnitsByBlock,
                     foregroundStyle: foregroundStyle,
                     usesAccentSurface: usesAccentSurface,
                     gatewayMediaDataURL: gatewayMediaDataURL,
                     selectionCoordinator: selectionCoordinator,
                     selectionSegments: selectionSegments,
-                    newestCharacterOpacities: newestCharacterOpacities,
-                    isStreaming: isStreaming
+                    newestCharacterOpacities: newestCharacterOpacities
                 )
             } else {
                 VStack(alignment: .leading, spacing: 10) {
@@ -209,17 +212,33 @@ private final class MarkdownSelectionHighlightView: UIView {
 
 /// One render's parsed blocks plus the prebuilt selectable string (nil when
 /// the blocks need the full block-view path). A class so NSCache can hold it.
+///
+/// Structural rich-content metadata (the per-block rich-unit vector) is
+/// computed ONCE here, with the parse, and cached with the rendering — the
+/// exact pathological Markdown this bounding exists for used to re-walk
+/// every table's cells on each SwiftUI body re-evaluation just to
+/// rediscover the same budget (see MarkdownRichContentPolicy).
 private final class MarkdownRendering {
     let blocks: [MarkdownBlock]
     /// The message's link reference definitions; block views need them to
     /// resolve reference-style links when re-parsing each fragment.
     let references: MarkdownReferenceContext
     let selectableText: NSAttributedString?
+    /// Per-block rich-layout units (MarkdownRichContentPolicy.richUnits),
+    /// aligned with blocks by index.
+    let richUnitsByBlock: [Int]
+
+    /// Whether this message's aggregate rich complexity exceeds the
+    /// progressive-mount budget.
+    var needsRichBounding: Bool {
+        MarkdownRichContentPolicy.needsBounding(unitsByBlock: richUnitsByBlock)
+    }
 
     init(blocks: [MarkdownBlock], references: MarkdownReferenceContext, selectableText: NSAttributedString?) {
         self.blocks = blocks
         self.references = references
         self.selectableText = selectableText
+        self.richUnitsByBlock = MarkdownRichContentPolicy.richUnitsByBlock(blocks)
     }
 }
 
@@ -1233,6 +1252,25 @@ enum MarkdownTableLayout {
     }
 }
 
+/// The zero-height width probe shared by BOTH table presentations: the
+/// chat's proposed width for the block, read once per layout width change.
+/// Extracted so the ordinary MarkdownTable and the paged
+/// LargeMarkdownTable resolve columns from the SAME container-width
+/// knowledge — crossing the structural complexity threshold must not
+/// change whether a previously fitting table fits.
+private struct MarkdownTableWidthProbe: View {
+    @Binding var width: CGFloat
+
+    var body: some View {
+        GeometryReader { proxy in
+            Color.clear
+                .onAppear { width = proxy.size.width }
+                .onChange(of: proxy.size.width) { _, newWidth in width = newWidth }
+        }
+        .frame(height: 0)
+    }
+}
+
 private struct MarkdownTable: View {
     let headers: [String]
     let alignments: [MarkdownTableAlignment]
@@ -1261,12 +1299,7 @@ private struct MarkdownTable: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            GeometryReader { proxy in
-                Color.clear
-                    .onAppear { availableWidth = proxy.size.width }
-                    .onChange(of: proxy.size.width) { _, width in availableWidth = width }
-            }
-            .frame(height: 0)
+            MarkdownTableWidthProbe(width: $availableWidth)
 
             let widths = columnWidths
             ScrollView(.horizontal, showsIndicators: false) {
@@ -1375,6 +1408,14 @@ struct LargeMarkdownTable: View {
     let selectionSegments: [MarkdownSelectionSegmentDescriptor]
 
     @State private var renderedRowCount: Int
+    /// The chat's proposed width for this block, read by the SAME zero-height
+    /// probe the ordinary MarkdownTable uses. Crossing the structural
+    /// complexity threshold (rows/cells/bytes) must not change whether a
+    /// previously fitting table fits: with the real container width the
+    /// shared layout engine's fit-or-shrink behavior applies identically in
+    /// both presentations. Zero means "unknown yet" (first pass); the
+    /// cap-and-scroll fallback re-resolves a frame later.
+    @State private var availableWidth: CGFloat = 0
     @Environment(\.markdownReferences) private var references
 
     init(
@@ -1416,7 +1457,7 @@ struct LargeMarkdownTable: View {
             rows: Array(rows.prefix(Self.widthSampleRows)).map {
                 $0.map { MarkdownLargeDocumentPolicy.boundedDisplayText($0, maxBytes: ceiling) }
             },
-            availableWidth: 0,
+            availableWidth: availableWidth,
             references: references
         )
     }
@@ -1437,6 +1478,8 @@ struct LargeMarkdownTable: View {
         // the header share the same resolved (bounded) widths.
         let widths = columnWidths
         return VStack(spacing: 0) {
+            MarkdownTableWidthProbe(width: $availableWidth)
+
             ScrollView(.horizontal, showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 0) {
                     MarkdownTableRowView(

--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -78,6 +78,23 @@ struct MarkdownText: View {
                     linkColor: usesAccentSurface ? .white : .link
                 )
                 .frame(maxWidth: .infinity, alignment: .leading)
+            } else if MarkdownRichContentPolicy.needsBounding(rendering.blocks) {
+                // Byte-ordinary but structurally pathological rich content:
+                // identical block rendering behind a bounded mount budget
+                // (see MarkdownRichContent.swift). Plain flow messages can
+                // never reach here — they take the selectableText branch —
+                // and ordinary rich messages stay under the budget.
+                RichBudgetedMarkdownBody(
+                    blocks: rendering.blocks,
+                    source: source,
+                    foregroundStyle: foregroundStyle,
+                    usesAccentSurface: usesAccentSurface,
+                    gatewayMediaDataURL: gatewayMediaDataURL,
+                    selectionCoordinator: selectionCoordinator,
+                    selectionSegments: selectionSegments,
+                    newestCharacterOpacities: newestCharacterOpacities,
+                    isStreaming: isStreaming
+                )
             } else {
                 VStack(alignment: .leading, spacing: 10) {
                     ForEach(Array(rendering.blocks.enumerated()), id: \.offset) { index, block in
@@ -645,22 +662,51 @@ struct MarkdownBlockView: View {
             )
 
         case .table(let headers, let alignments, let rows):
-            MarkdownTable(
-                headers: headers,
-                alignments: alignments,
-                rows: rows,
-                foregroundStyle: foregroundStyle,
-                usesAccentSurface: usesAccentSurface,
-                selectionCoordinator: selectionCoordinator,
-                blockIndex: blockIndex,
-                selectionSegments: selectionSegments
-            )
+            // Structural complexity — not whole-message bytes — decides the
+            // presentation: a 45-row table in a 40 KB message mounts the
+            // same thousand TextKit cell views as one in a 400 KB message.
+            // Both paths share MarkdownTableRowView, so appearance and
+            // selection behavior match either way.
+            if MarkdownRichContentPolicy.isComplexTable(headers: headers, rows: rows) {
+                LargeMarkdownTable(
+                    headers: headers,
+                    alignments: alignments,
+                    rows: rows,
+                    foregroundStyle: foregroundStyle,
+                    usesAccentSurface: usesAccentSurface,
+                    selectionCoordinator: selectionCoordinator,
+                    blockIndex: blockIndex,
+                    selectionSegments: selectionSegments
+                )
+            } else {
+                MarkdownTable(
+                    headers: headers,
+                    alignments: alignments,
+                    rows: rows,
+                    foregroundStyle: foregroundStyle,
+                    usesAccentSurface: usesAccentSurface,
+                    selectionCoordinator: selectionCoordinator,
+                    blockIndex: blockIndex,
+                    selectionSegments: selectionSegments
+                )
+            }
 
         case .image(let url, let alt):
             RemoteMarkdownImage(url: url, alt: alt, gatewayMediaDataURL: gatewayMediaDataURL)
 
         case .math(let source):
-            MathBlock(source: source)
+            // The #88 oversized-math guard applies to the block itself,
+            // wherever it renders — never only inside large-document mode.
+            if MarkdownBlockView.mathNeedsGuard(source) {
+                GuardedSourceCard(
+                    title: "LaTeX",
+                    icon: "function",
+                    source: source,
+                    guardBytes: MarkdownLargeDocumentPolicy.mathGuardBytes
+                )
+            } else {
+                MathBlock(source: source)
+            }
 
         case .callout(let kind, let text):
             MarkdownCallout(
@@ -684,9 +730,26 @@ struct MarkdownBlockView: View {
             )
 
         case .code(let language, let source):
-            if MarkdownLanguage.normalized(language) == "mermaid" {
+            switch MarkdownBlockView.codePresentation(language: language, source: source) {
+            case .guardedMermaid:
+                // The #88 Mermaid guard, applied per block: a diagram past
+                // the guard size renders as a copyable bounded card no
+                // matter how small the enclosing message is.
+                GuardedSourceCard(
+                    title: "Mermaid",
+                    icon: "point.3.connected.trianglepath.dotted",
+                    source: source,
+                    guardBytes: MarkdownLargeDocumentPolicy.mermaidGuardBytes
+                )
+            case .mermaid:
                 MermaidBlock(source: source)
-            } else {
+            case .slicedCode:
+                LargeCodeBlockView(
+                    source: source,
+                    language: language,
+                    usesAccentSurface: usesAccentSurface
+                )
+            case .code:
                 ChatCodeBlock(
                     source: source,
                     language: language,
@@ -722,6 +785,41 @@ struct MarkdownBlockView: View {
 
     private func selectionSegment(id: String) -> MarkdownSelectionSegmentDescriptor? {
         selectionSegments.first { $0.id == id }
+    }
+
+    // MARK: Block-local routing (pure, unit-testable)
+
+    /// The bounded presentations a code fence can take. The guards are
+    /// properties of the BLOCK — they apply identically in the ordinary
+    /// path and in large-document mode, which is what makes Mermaid and
+    /// oversized-code safety independent of the whole-message threshold.
+    enum CodePresentation: Equatable {
+        /// Mermaid source beyond the #88 guard: bounded copyable card,
+        /// render action dropped.
+        case guardedMermaid
+        /// Ordinary Mermaid diagram: render-card + on-demand preview.
+        case mermaid
+        /// Code at/above the #88 large-code threshold: bounded preview,
+        /// then line/byte slices with off-main highlighting.
+        case slicedCode
+        /// Ordinary code block.
+        case code
+    }
+
+    static func codePresentation(language: String, source: String) -> CodePresentation {
+        let normalized = MarkdownLanguage.normalized(language)
+        if normalized == "mermaid" {
+            return source.utf8.count > MarkdownLargeDocumentPolicy.mermaidGuardBytes
+                ? .guardedMermaid
+                : .mermaid
+        }
+        return MarkdownLargeDocumentPolicy.isLargeCodeBlock(source) ? .slicedCode : .code
+    }
+
+    /// Oversized math sources drop the render action (#88 guard), applied
+    /// per block rather than per document.
+    static func mathNeedsGuard(_ source: String) -> Bool {
+        source.utf8.count > MarkdownLargeDocumentPolicy.mathGuardBytes
     }
 }
 

--- a/ConduitTests/ChatViewFollowCorrectionTests.swift
+++ b/ConduitTests/ChatViewFollowCorrectionTests.swift
@@ -40,14 +40,22 @@ final class ChatViewFollowCorrectionTests: XCTestCase {
         // deferred work lands in whichever suite runs next and, on a slow
         // CI runner, saturates the main thread enough to starve XCTest
         // main-queue waits (see CI #384/#385). Instead: stop streaming,
-        // remove the hosted view SYNCHRONOUSLY, and drain until the
-        // hosted hierarchy is actually dismantled (bounded).
+        // remove the hosted view SYNCHRONOUSLY, release every retained
+        // reference, and drain until the hosting controller DEALLOCATES
+        // (bounded — deallocation is the honest completion signal; a
+        // detached UIHostingController keeps its loaded subviews, so
+        // subview emptiness proves nothing).
         testAppState?.streamingText = ""
         if let window = testWindow {
             let host = testHost
             window.isHidden = true
             window.rootViewController = nil
             host?.view.removeFromSuperview()
+            // Completion signal: the hosting view's SwiftUI subviews are
+            // gone (controller deallocation was tried and is empirically
+            // unsound — SwiftUI retains the controller internally well
+            // past any reasonable budget; see the rich-content suite's
+            // dismountCurrentWindow note).
             let deadline = Date().addingTimeInterval(1.5)
             while Date() < deadline {
                 RunLoop.current.run(until: Date().addingTimeInterval(0.05))
@@ -158,7 +166,7 @@ final class ChatViewFollowCorrectionTests: XCTestCase {
     /// measurement.
     private func drainUntilSettled(
         _ host: UIHostingController<AnyView>,
-        budget: TimeInterval = 4.0
+        budget: TimeInterval = 6.0
     ) {
         RunLoop.current.run(until: Date().addingTimeInterval(0.4))
         var quietTurns = 0
@@ -176,6 +184,14 @@ final class ChatViewFollowCorrectionTests: XCTestCase {
                 if followCorrectionsDue > 0 { lastCorrectionAt = Date() }
             }
         }
+        // Budget expiry is a FAILURE, not a quiet pass: the caller is
+        // about to reset the trace and measure a settled-churn window,
+        // and an unfinished deferred correction would pollute that
+        // measurement invisibly. Fail loudly with the trace so the
+        // unsettled state is diagnosable.
+        XCTFail(
+            "ChatView did not settle within \(budget)s — deferred corrections still executing\n\(ChatViewportTrace.shared.dump())"
+        )
     }
 
     // MARK: Tests

--- a/ConduitTests/ChatViewFollowCorrectionTests.swift
+++ b/ConduitTests/ChatViewFollowCorrectionTests.swift
@@ -1,0 +1,171 @@
+//
+//  ChatViewFollowCorrectionTests.swift
+//  Conduit
+//
+//  Hosted-ChatView regression for the scene-update watchdog crash
+//  (0x8BADF00D, main thread inside ScrollViewCommitMutation under
+//  GraphHost.flushTransactions): rich content whose intrinsic height
+//  settles repeatedly used to drive
+//
+//      geometry preference change
+//          → layoutMetricsChanged (one per preference callback)
+//          → synchronous scrollTo(bottom) inside the layout pass
+//          → ScrollViewCommitMutation → more geometry changes → scrollTo …
+//
+//  The pure ChatViewportControllerTests cover the coalescing state machine;
+//  these tests host the REAL ChatView (real ScrollViewReader, real scrollTo,
+//  real preference pipeline) and assert the integrated bound: one
+//  content-growth event yields at most a couple of coalesced corrections —
+//  never one scrollTo per geometry callback — and settled layout churn
+//  yields none.
+//
+
+import SwiftUI
+import UIKit
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class ChatViewFollowCorrectionTests: XCTestCase {
+    private var testWindow: UIWindow?
+
+    override func tearDown() {
+        testWindow?.isHidden = true
+        testWindow?.rootViewController = nil
+        RunLoop.current.run(until: Date())
+        testWindow = nil
+        ChatViewportTrace.shared.reset()
+        super.tearDown()
+    }
+
+    // MARK: Harness
+
+    private func makeAppState() throws -> AppState {
+        let suiteName = "chat-follow-correction-fixture"
+        let defaults = try XCTUnwrap(
+            UserDefaults(suiteName: suiteName),
+            "test UserDefaults suite must initialize"
+        )
+        defaults.removePersistentDomain(forName: suiteName)
+        return AppState(defaults: defaults, loadSavedConnection: false)
+    }
+
+    private func mountChat(appState: AppState) -> UIHostingController<AnyView> {
+        let host = UIHostingController(
+            rootView: AnyView(ChatView().environmentObject(appState))
+        )
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.isHidden = false
+        testWindow = window
+        pump(host)
+        return host
+    }
+
+    /// Forces a layout pass and lets scheduled MainActor work (the coalesced
+    /// follow corrections) run, exactly like a live turn of the run loop.
+    private func pump(_ host: UIHostingController<AnyView>, _ times: Int = 1) {
+        for _ in 0..<times {
+            host.view.setNeedsLayout()
+            host.view.layoutIfNeeded()
+            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        }
+    }
+
+    private func traceCount(where matches: (String) -> Bool) -> Int {
+        ChatViewportTrace.shared.entries.map(\.text).filter(matches).count
+    }
+
+    /// Bottom scrolls executed by the coalesced correction path (the
+    /// transcript reassert and retries log animated=true).
+    private var nonAnimatedBottomScrolls: Int {
+        traceCount { $0.hasPrefix("scroll bottom(") && $0.contains("animated=false") }
+    }
+
+    private var followCorrectionsDue: Int {
+        traceCount { $0.hasPrefix("follow correction due") }
+    }
+
+    private func tallMessage(id: String, tables: Int) -> ChatMessage {
+        ChatMessage(
+            id: id,
+            role: .assistant,
+            content: (0..<tables).map { table in
+                "Intro paragraph for table \(table).\n\n"
+                    + MarkdownShowcaseFixtures.alignedTable(section: table, rows: 14, columns: 4)
+            }.joined(separator: "\n\n"),
+            timestamp: "2026-01-01T00:00:00Z"
+        )
+    }
+
+    // MARK: Tests
+
+    /// One content-growth event (a settled response doubling in height)
+    /// generates many geometry preference callbacks; the integrated bound
+    /// is a couple of coalesced corrections, never a scrollTo series.
+    func testOneGrowthEventProducesBoundedFollowCorrections() throws {
+        let appState = try makeAppState()
+        appState.messages = [tallMessage(id: "m1", tables: 6)]
+        let host = mountChat(appState: appState)
+        pump(host, 2)
+        ChatViewportTrace.shared.reset()
+
+        // ONE growth event.
+        var messages = appState.messages
+        messages[0] = tallMessage(id: "m1", tables: 12)
+        appState.messages = messages
+        pump(host, 3)
+
+        // The coalescing invariant: corrections track DISTINCT content
+        // bottoms (growth settlements), never geometry callbacks — a
+        // bounded handful for one growth event, not a per-callback storm.
+        XCTAssertLessThanOrEqual(
+            followCorrectionsDue, 4,
+            "one growth event must not schedule an unbounded series of corrections"
+        )
+        XCTAssertLessThanOrEqual(
+            nonAnimatedBottomScrolls, 4,
+            "one growth event must not produce a scrollTo storm"
+        )
+
+        // Settled layout churn (relayout without content change): the
+        // feedback loop must be dead — no corrections, no bottom scrolls.
+        ChatViewportTrace.shared.reset()
+        pump(host, 5)
+        XCTAssertEqual(
+            followCorrectionsDue, 0,
+            "settled layout churn schedules no corrections"
+        )
+        XCTAssertEqual(
+            nonAnimatedBottomScrolls, 0,
+            "settled layout churn scrolls nowhere"
+        )
+    }
+
+    /// Repeated streaming growth: every cycle is followed (the tail stays
+    /// pinned) while the correction count stays proportional to growth
+    /// events, never to geometry callbacks.
+    func testStreamingGrowthStaysCoalescedPerCycle() throws {
+        let appState = try makeAppState()
+        appState.messages = [tallMessage(id: "m1", tables: 4)]
+        appState.streamingText = "Streaming begins."
+        let host = mountChat(appState: appState)
+        pump(host, 2)
+        ChatViewportTrace.shared.reset()
+
+        for tick in 1...8 {
+            ChatViewportTrace.shared.reset()
+            appState.streamingText += "\n\nDelta \(tick): "
+                + MarkdownShowcaseFixtures.alignedTable(section: tick, rows: 8, columns: 3)
+            pump(host, 2)
+            XCTAssertLessThanOrEqual(
+                followCorrectionsDue, 2,
+                "cycle \(tick): at most one outstanding correction cycle per growth event"
+            )
+        }
+        XCTAssertLessThanOrEqual(
+            nonAnimatedBottomScrolls, 2,
+            "the final cycle stays bounded"
+        )
+    }
+}

--- a/ConduitTests/ChatViewFollowCorrectionTests.swift
+++ b/ConduitTests/ChatViewFollowCorrectionTests.swift
@@ -28,20 +28,35 @@ import XCTest
 @MainActor
 final class ChatViewFollowCorrectionTests: XCTestCase {
     private var testWindow: UIWindow?
+    private var testHost: UIHostingController<AnyView>?
+    /// Retained so teardown can stop any live streaming reveal before
+    /// the hosted window is dismantled.
+    private var testAppState: AppState?
 
     override func tearDown() {
-        // Deterministic teardown INSIDE this suite: a zero-length run-
-        // loop pass leaves the hosting controller's appearance
-        // transition in flight, and the deferred teardown lands in
-        // whichever suite runs next as unbalanced-appearance warnings
-        // that starve XCTest main-queue waits (see CI #384). Drain a
-        // few real animation ticks so the lifecycle completes here.
+        // Deterministic teardown INSIDE this suite. Hiding the window and
+        // dropping references leaves the hosting controller's appearance
+        // transition PENDING and any live streaming reveal RUNNING — the
+        // deferred work lands in whichever suite runs next and, on a slow
+        // CI runner, saturates the main thread enough to starve XCTest
+        // main-queue waits (see CI #384/#385). Instead: stop streaming,
+        // remove the hosted view SYNCHRONOUSLY, and drain until the
+        // hosted hierarchy is actually dismantled (bounded).
+        testAppState?.streamingText = ""
         if let window = testWindow {
+            let host = testHost
             window.isHidden = true
             window.rootViewController = nil
-            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+            host?.view.removeFromSuperview()
+            let deadline = Date().addingTimeInterval(1.5)
+            while Date() < deadline {
+                RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+                if let host, host.view.subviews.isEmpty { break }
+            }
         }
         testWindow = nil
+        testHost = nil
+        testAppState = nil
         ChatViewportTrace.shared.reset()
         super.tearDown()
     }
@@ -66,6 +81,8 @@ final class ChatViewFollowCorrectionTests: XCTestCase {
         window.rootViewController = host
         window.isHidden = false
         testWindow = window
+        testHost = host
+        testAppState = appState
         pump(host)
         return host
     }
@@ -131,17 +148,32 @@ final class ChatViewFollowCorrectionTests: XCTestCase {
     /// real-time settle expires any armed animated retry (150 ms) and the
     /// follow-correction re-arm interval (100 ms) so their landings are not
     /// mistaken for churn.
-    private func drainUntilSettled(_ host: UIHostingController<AnyView>, maxPumps: Int = 40) {
+    /// Time-bounded (not pump-bounded): CI runners drain SwiftUI work far
+    /// slower than a dev Mac, and the early-exit condition keeps fast
+    /// machines quick. Settled means BOTH several consecutive quiet
+    /// turns AND a correction-free real-time window longer than the
+    /// re-arm interval (0.1 s) and animated retry delay (150 ms) — under
+    /// load, a scheduled-but-undrained token can otherwise execute one
+    /// turn after the quiet-count criterion is met and pollute the churn
+    /// measurement.
+    private func drainUntilSettled(
+        _ host: UIHostingController<AnyView>,
+        budget: TimeInterval = 4.0
+    ) {
         RunLoop.current.run(until: Date().addingTimeInterval(0.4))
         var quietTurns = 0
-        for _ in 0..<maxPumps {
+        var lastCorrectionAt = Date()
+        let deadline = Date().addingTimeInterval(budget)
+        while Date() < deadline {
             ChatViewportTrace.shared.reset()
             pump(host, 1)
-            if followCorrectionsDue == 0 {
+            if followCorrectionsDue == 0,
+               Date().timeIntervalSince(lastCorrectionAt) > 0.5 {
                 quietTurns += 1
-                if quietTurns >= 4 { return }
+                if quietTurns >= 6 { return }
             } else {
                 quietTurns = 0
+                if followCorrectionsDue > 0 { lastCorrectionAt = Date() }
             }
         }
     }
@@ -266,7 +298,13 @@ final class ChatViewFollowCorrectionTests: XCTestCase {
             "scrolls must be rate-bounded by the re-arm interval, not callbacks"
         )
 
-        // And once the stream settles: exactly zero churn.
+        // And once the stream settles: exactly zero churn. Settling means
+        // the streaming bubble is GONE (production clears streamingText on
+        // completion) — clearing it also stops the character-paced reveal,
+        // so no delayed reveal growth can leak into the churn window on a
+        // slow runner.
+        appState.streamingText = ""
+        pump(host, 2)
         drainUntilSettled(host)
         ChatViewportTrace.shared.reset()
         pump(host, 5)

--- a/ConduitTests/ChatViewFollowCorrectionTests.swift
+++ b/ConduitTests/ChatViewFollowCorrectionTests.swift
@@ -30,9 +30,17 @@ final class ChatViewFollowCorrectionTests: XCTestCase {
     private var testWindow: UIWindow?
 
     override func tearDown() {
-        testWindow?.isHidden = true
-        testWindow?.rootViewController = nil
-        RunLoop.current.run(until: Date())
+        // Deterministic teardown INSIDE this suite: a zero-length run-
+        // loop pass leaves the hosting controller's appearance
+        // transition in flight, and the deferred teardown lands in
+        // whichever suite runs next as unbalanced-appearance warnings
+        // that starve XCTest main-queue waits (see CI #384). Drain a
+        // few real animation ticks so the lifecycle completes here.
+        if let window = testWindow {
+            window.isHidden = true
+            window.rootViewController = nil
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        }
         testWindow = nil
         ChatViewportTrace.shared.reset()
         super.tearDown()

--- a/ConduitTests/ChatViewFollowCorrectionTests.swift
+++ b/ConduitTests/ChatViewFollowCorrectionTests.swift
@@ -14,10 +14,10 @@
 //
 //  The pure ChatViewportControllerTests cover the coalescing state machine;
 //  these tests host the REAL ChatView (real ScrollViewReader, real scrollTo,
-//  real preference pipeline) and assert the integrated bound: one
-//  content-growth event yields at most a couple of coalesced corrections —
-//  never one scrollTo per geometry callback — and settled layout churn
-//  yields none.
+//  real preference pipeline) and assert the integrated behavior with BOTH
+//  bounds: growth while following produces a POSITIVE, bounded number of
+//  corrections/scrolls (a broken zero-correction implementation must fail),
+//  and settled layout churn produces exactly zero.
 //
 
 import SwiftUI
@@ -82,8 +82,26 @@ final class ChatViewFollowCorrectionTests: XCTestCase {
         traceCount { $0.hasPrefix("scroll bottom(") && $0.contains("animated=false") }
     }
 
+    /// ALL bottom scroll executions, any animation flag — the honest
+    /// "did following actually happen" signal for settled-transcript
+    /// growth, where the animated transcript reassert owns the first
+    /// scroll and the correction may legitimately defer to it.
+    private var allBottomScrolls: Int {
+        traceCount { $0.hasPrefix("scroll bottom(") }
+    }
+
     private var followCorrectionsDue: Int {
         traceCount { $0.hasPrefix("follow correction due") }
+    }
+
+    /// Proves the trace instrumentation is live before any counter is used
+    /// as evidence: the transcript reassert after a settled-content change
+    /// must have logged a scroll line.
+    private func assertTraceInstrumentationActive() {
+        XCTAssertGreaterThan(
+            allBottomScrolls, 0,
+            "trace instrumentation must record the mount-time follow; counters are meaningless otherwise"
+        )
     }
 
     private func tallMessage(id: String, tables: Int) -> ChatMessage {
@@ -98,17 +116,43 @@ final class ChatViewFollowCorrectionTests: XCTestCase {
         )
     }
 
+    /// Pumps until the layout has genuinely settled - no follow
+    /// corrections for several consecutive turns - within a bounded budget.
+    /// Rich content mounts progressively over multiple turns; corrections
+    /// during that window are legitimate following, not churn. The initial
+    /// real-time settle expires any armed animated retry (150 ms) and the
+    /// follow-correction re-arm interval (100 ms) so their landings are not
+    /// mistaken for churn.
+    private func drainUntilSettled(_ host: UIHostingController<AnyView>, maxPumps: Int = 40) {
+        RunLoop.current.run(until: Date().addingTimeInterval(0.4))
+        var quietTurns = 0
+        for _ in 0..<maxPumps {
+            ChatViewportTrace.shared.reset()
+            pump(host, 1)
+            if followCorrectionsDue == 0 {
+                quietTurns += 1
+                if quietTurns >= 4 { return }
+            } else {
+                quietTurns = 0
+            }
+        }
+    }
+
     // MARK: Tests
 
     /// One content-growth event (a settled response doubling in height)
-    /// generates many geometry preference callbacks; the integrated bound
-    /// is a couple of coalesced corrections, never a scrollTo series.
-    func testOneGrowthEventProducesBoundedFollowCorrections() throws {
+    /// generates many geometry preference callbacks. The integrated
+    /// invariants, BOTH directions:
+    ///   - following HAPPENED: at least one bottom scroll executed;
+    ///   - coalescing HELD: a bounded handful of corrections, never a
+    ///     per-geometry-callback storm;
+    ///   - settled layout churn afterwards: exactly zero corrections and
+    ///     zero scrolls.
+    func testOneGrowthEventProducesBoundedPositiveFollowCorrections() throws {
         let appState = try makeAppState()
         appState.messages = [tallMessage(id: "m1", tables: 6)]
         let host = mountChat(appState: appState)
         pump(host, 2)
-        ChatViewportTrace.shared.reset()
 
         // ONE growth event.
         var messages = appState.messages
@@ -116,9 +160,18 @@ final class ChatViewFollowCorrectionTests: XCTestCase {
         appState.messages = messages
         pump(host, 3)
 
-        // The coalescing invariant: corrections track DISTINCT content
-        // bottoms (growth settlements), never geometry callbacks — a
-        // bounded handful for one growth event, not a per-callback storm.
+        // Instrumentation sanity: the growth's transcript reassert must be
+        // visible in the trace, proving the counters below are live.
+        assertTraceInstrumentationActive()
+
+        // Positive bound: following actually happened for the growth.
+        XCTAssertGreaterThan(
+            allBottomScrolls, 0,
+            "content growth while following must execute at least one bottom scroll"
+        )
+
+        // Coalescing bound: corrections track DISTINCT content bottoms
+        // (growth settlements), never geometry callbacks.
         XCTAssertLessThanOrEqual(
             followCorrectionsDue, 4,
             "one growth event must not schedule an unbounded series of corrections"
@@ -128,8 +181,12 @@ final class ChatViewFollowCorrectionTests: XCTestCase {
             "one growth event must not produce a scrollTo storm"
         )
 
+        // Let the growth fully settle (progressive rich-block mounting,
+        // armed animated retry expiry) BEFORE measuring churn.
+        drainUntilSettled(host)
+
         // Settled layout churn (relayout without content change): the
-        // feedback loop must be dead — no corrections, no bottom scrolls.
+        // feedback loop must be dead — EXACTLY zero, not "few".
         ChatViewportTrace.shared.reset()
         pump(host, 5)
         XCTAssertEqual(
@@ -140,32 +197,72 @@ final class ChatViewFollowCorrectionTests: XCTestCase {
             nonAnimatedBottomScrolls, 0,
             "settled layout churn scrolls nowhere"
         )
+        XCTAssertEqual(
+            allBottomScrolls, 0,
+            "settled layout churn produces no scrolls of any kind"
+        )
     }
 
-    /// Repeated streaming growth: every cycle is followed (the tail stays
-    /// pinned) while the correction count stays proportional to growth
-    /// events, never to geometry callbacks.
-    func testStreamingGrowthStaysCoalescedPerCycle() throws {
+    /// Repeated STREAMING growth exercises the pure coalesced-correction
+    /// path (no transcript change, so no animated reassert owns the
+    /// follow). StreamingText reveals characters at a paced rate (~18 per
+    /// 30 Hz tick), so each cycle gives the reveal real wall time; the
+    /// assertions then cover BOTH directions over the whole window:
+    /// following HAPPENED (positive counts) and stayed PROPORTIONAL TO
+    /// CONTENT GROWTH — a couple of corrections per growth cycle, never
+    /// the per-geometry-callback storm the watchdog crashed on.
+    func testStreamingGrowthProducesPositiveCoalescedCorrections() throws {
         let appState = try makeAppState()
         appState.messages = [tallMessage(id: "m1", tables: 4)]
         appState.streamingText = "Streaming begins."
         let host = mountChat(appState: appState)
         pump(host, 2)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+        drainUntilSettled(host)
         ChatViewportTrace.shared.reset()
 
+        let windowStart = CFAbsoluteTimeGetCurrent()
         for tick in 1...8 {
-            ChatViewportTrace.shared.reset()
             appState.streamingText += "\n\nDelta \(tick): "
                 + MarkdownShowcaseFixtures.alignedTable(section: tick, rows: 8, columns: 3)
-            pump(host, 2)
-            XCTAssertLessThanOrEqual(
-                followCorrectionsDue, 2,
-                "cycle \(tick): at most one outstanding correction cycle per growth event"
-            )
+            // Real time for the paced reveal to advance the bubble height
+            // past the regrowth tolerance, exactly like live streaming.
+            RunLoop.current.run(until: Date().addingTimeInterval(0.6))
+            pump(host, 1)
         }
-        XCTAssertLessThanOrEqual(
-            nonAnimatedBottomScrolls, 2,
-            "the final cycle stays bounded"
+        let windowDuration = CFAbsoluteTimeGetCurrent() - windowStart
+
+        // Positive bound: streaming growth IS followed through the
+        // coalesced-correction path — a zero-correction implementation
+        // (broken scheduling, broken onChange drain) fails here.
+        XCTAssertGreaterThan(
+            followCorrectionsDue, 0,
+            "streaming growth must produce follow corrections"
         )
+        XCTAssertGreaterThan(
+            nonAnimatedBottomScrolls, 0,
+            "the streaming follow must execute at least one bottom scroll"
+        )
+        // Coalescing bound, principled: the reveal grows the content
+        // CONTINUOUSLY for the whole window, so the correction rate is
+        // capped by the re-arm interval (~10/s) — an order of magnitude
+        // under the per-geometry-callback storm the watchdog crashed on
+        // (hundreds per second inside a single layout pass).
+        let rateBudget = Int(windowDuration / 0.09) + 4
+        XCTAssertLessThanOrEqual(
+            followCorrectionsDue, rateBudget,
+            "corrections must be rate-bounded by the re-arm interval, not callbacks"
+        )
+        XCTAssertLessThanOrEqual(
+            nonAnimatedBottomScrolls, rateBudget,
+            "scrolls must be rate-bounded by the re-arm interval, not callbacks"
+        )
+
+        // And once the stream settles: exactly zero churn.
+        drainUntilSettled(host)
+        ChatViewportTrace.shared.reset()
+        pump(host, 5)
+        XCTAssertEqual(followCorrectionsDue, 0, "settled stream schedules no corrections")
+        XCTAssertEqual(allBottomScrolls, 0, "settled stream scrolls nowhere")
     }
 }

--- a/ConduitTests/ChatViewportControllerTests.swift
+++ b/ConduitTests/ChatViewportControllerTests.swift
@@ -56,6 +56,12 @@ final class ChatViewportControllerTests: XCTestCase {
         return controller
     }
 
+    /// Synthetic clock for layout facts: every constructed fact advances
+    /// the stamp past the follow-correction re-arm interval, so successive
+    /// calls model successive real ticks (a tick after a drained correction
+    /// may re-arm; an instant-later flap tick may not).
+    private var factClock: TimeInterval = 0
+
     private func layoutFacts(
         bottomMarkerMaxY: CGFloat? = 800,
         viewportMinY: CGFloat? = 100,
@@ -63,12 +69,14 @@ final class ChatViewportControllerTests: XCTestCase {
         rowFrames: [ChatRenderedRowFrame] = [],
         scope: ChatRenderedScrollScope?
     ) -> ChatViewportLayoutFacts {
-        ChatViewportLayoutFacts(
+        factClock += 0.11
+        return ChatViewportLayoutFacts(
             bottomMarkerMaxY: bottomMarkerMaxY,
             viewportMinY: viewportMinY,
             viewportMaxY: viewportMaxY,
             rowFrames: rowFrames,
-            renderedScope: scope
+            renderedScope: scope,
+            timestamp: factClock
         )
     }
 
@@ -2244,7 +2252,7 @@ extension ChatViewportControllerTests {
     /// unsettled layout cycle schedule exactly one correction, and the
     /// correction executes with the NEWEST facts recorded by the later
     /// callbacks.
-    func testOneLayoutCycleProducesAtMostOneCorrectionWithLatestFacts() {
+    func testOneLayoutCycleProducesAtMostOneCorrectionWithLatestFacts() throws {
         var controller = makeController(following: keyA)
 
         // First callback of the cycle (e.g. the bottom-marker preference).
@@ -2252,8 +2260,10 @@ extension ChatViewportControllerTests {
             bottomMarkerMaxY: 900, viewportMaxY: 800,
             scope: controller.renderedScrollScope
         ))
-        let token = scheduledCorrection(in: first)
-        XCTAssertNotNil(token, "drift beyond tolerance schedules a correction")
+        let token = try XCTUnwrap(
+            scheduledCorrection(in: first),
+            "drift beyond tolerance schedules a correction"
+        )
 
         // Later callbacks of the SAME cycle (viewport frame, row frames):
         // facts update, never a second correction.
@@ -2270,7 +2280,7 @@ extension ChatViewportControllerTests {
         XCTAssertEqual(controller.pendingFollowCorrection, token)
 
         // Due: executes against the newest facts (drift 950-800=150).
-        let commands = scrollCommands(controller.followCorrectionDue(token!))
+        let commands = scrollCommands(controller.followCorrectionDue(token))
         XCTAssertEqual(commands.count, 1)
         XCTAssertEqual(commands[0].destination, .bottom(anchorID: "chat-latest-p-session-a"))
         XCTAssertNil(controller.pendingFollowCorrection)
@@ -2382,6 +2392,51 @@ extension ChatViewportControllerTests {
         }
         _ = controller.followCorrectionDue(token)
         XCTAssertTrue(controller.followCorrectionDue(token).isEmpty)
+    }
+
+    /// Review follow-up (observed live in the hosted streaming fixture): a
+    /// correction scheduled from the layout flap of the previous
+    /// correction's OWN scroll commit is born inside the drain handler's
+    /// layout turn, where SwiftUI may never deliver the onChange that would
+    /// execute it — an undrainable pending token that silently absorbs all
+    /// future schedules. Re-arming must therefore wait out the re-arm
+    /// interval after an execution; the next tick after the interval
+    /// schedules normally.
+    func testCorrectionExecutionSuppressesImmediateRearmFromScrollFlap() throws {
+        var controller = makeController(following: keyA)
+        let first = try XCTUnwrap(scheduledCorrection(in: controller.layoutMetricsChanged(
+            facts: layoutFacts(
+                bottomMarkerMaxY: 1000, viewportMaxY: 800,
+                scope: controller.renderedScrollScope
+            )
+        )))
+        XCTAssertFalse(scrollCommands(controller.followCorrectionDue(first)).isEmpty)
+
+        // The scroll commit shifts global frames: the very next instant
+        // tick (same-timestamp flap, e.g. the bottom "moving" by the scroll
+        // delta) must NOT mint a new pending token.
+        var flapFacts = layoutFacts(
+            bottomMarkerMaxY: 960, viewportMaxY: 800,
+            scope: controller.renderedScrollScope
+        )
+        flapFacts.timestamp -= 0.11  // same instant as the execution
+        let flap = controller.layoutMetricsChanged(facts: flapFacts)
+        XCTAssertNil(
+            scheduledCorrection(in: flap),
+            "a schedule minted from the correction's own scroll flap is undrainable"
+        )
+        XCTAssertNil(controller.pendingFollowCorrection)
+
+        // Genuinely later growth (past the interval) schedules normally —
+        // and the token sequence keeps advancing.
+        let later = try XCTUnwrap(scheduledCorrection(in: controller.layoutMetricsChanged(
+            facts: layoutFacts(
+                bottomMarkerMaxY: 1030, viewportMaxY: 800,
+                scope: controller.renderedScrollScope
+            )
+        )))
+        XCTAssertGreaterThan(later.sequence, first.sequence)
+        XCTAssertFalse(scrollCommands(controller.followCorrectionDue(later)).isEmpty)
     }
 
     /// THE residual-drift case from the hosted reproduction: a drift that
@@ -2506,5 +2561,201 @@ extension ChatViewportControllerTests {
             controller.followCorrectionDue(token).isEmpty,
             "the superseded correction can never scroll"
         )
+    }
+
+    /// Review item: unique correction tokens. The view drains corrections
+    /// through onChange(of: pendingFollowCorrection); two consecutive
+    /// corrections in the same ownership generation and session MUST be
+    /// Equatable-distinct, or the nil → A → nil → A sequence is invisible
+    /// to the observer and the second correction never executes.
+    func testConsecutiveCorrectionsSameGenerationAndSessionProduceDistinctTokens() throws {
+        var controller = makeController(following: keyA)
+        let first = try XCTUnwrap(scheduledCorrection(in: controller.layoutMetricsChanged(
+            facts: layoutFacts(
+                bottomMarkerMaxY: 900, viewportMaxY: 800,
+                scope: controller.renderedScrollScope
+            )
+        )))
+        XCTAssertFalse(scrollCommands(controller.followCorrectionDue(first)).isEmpty)
+
+        // Genuinely new growth, SAME generation, SAME session.
+        let second = try XCTUnwrap(scheduledCorrection(in: controller.layoutMetricsChanged(
+            facts: layoutFacts(
+                bottomMarkerMaxY: 950, viewportMaxY: 800,
+                scope: controller.renderedScrollScope
+            )
+        )))
+        XCTAssertEqual(second.generation, first.generation)
+        XCTAssertEqual(second.sessionKey, first.sessionKey)
+        XCTAssertNotEqual(second, first, "consecutive tokens must be Equatable-distinct")
+        XCTAssertGreaterThan(second.sequence, first.sequence)
+
+        // Both tokens can drain (the second one scrolls).
+        XCTAssertFalse(scrollCommands(controller.followCorrectionDue(second)).isEmpty)
+        XCTAssertNil(controller.pendingFollowCorrection)
+    }
+
+    /// Review item: session ownership at drain time. A correction
+    /// scheduled for session A must never emit a scroll command for
+    /// session B just because the active identity changed in between.
+    func testCorrectionForSessionADoesNotScrollForSessionB() throws {
+        var controller = makeController(following: keyA)
+        let token = try XCTUnwrap(scheduledCorrection(in: controller.layoutMetricsChanged(
+            facts: layoutFacts(
+                bottomMarkerMaxY: 900, viewportMaxY: 800,
+                scope: controller.renderedScrollScope
+            )
+        )))
+
+        // The active identity/session moves to B while the rendered key
+        // stays A — exactly the mixture that used to anchor the command to
+        // B's bottom marker.
+        _ = controller.activeIdentityRefreshed(identity: identity(for: keyB), key: keyB)
+        XCTAssertEqual(controller.activeSessionKey, keyB)
+
+        XCTAssertTrue(
+            scrollCommands(controller.followCorrectionDue(token)).isEmpty,
+            "a correction scheduled for A must never scroll for B"
+        )
+        XCTAssertNil(controller.pendingFollowCorrection, "the stale correction is drained, not left pending")
+    }
+
+    /// Review item: ordinary equivalent/canonical identity refreshes — the
+    /// SAME conversation under a canonical spelling — must not break
+    /// following.
+    func testEquivalentIdentityRefreshKeepsCorrectionValid() throws {
+        let runtimeKey = ChatScrollSessionKey(profile: "p", sessionID: "runtime-a")
+        let storedKey = ChatScrollSessionKey(profile: "p", sessionID: "stored-a")
+        var controller = makeController(following: runtimeKey)
+
+        let token = try XCTUnwrap(scheduledCorrection(in: controller.layoutMetricsChanged(
+            facts: layoutFacts(
+                bottomMarkerMaxY: 900, viewportMaxY: 800,
+                scope: controller.renderedScrollScope
+            )
+        )))
+
+        // Canonical refresh: the identity now knows both spellings.
+        _ = controller.activeIdentityRefreshed(
+            identity: aliasedIdentity(storedKey, runtimeKey),
+            key: storedKey
+        )
+
+        let commands = scrollCommands(controller.followCorrectionDue(token))
+        XCTAssertEqual(commands.count, 1, "same-conversation refresh keeps the correction valid")
+        XCTAssertEqual(commands[0].destination, .bottom(anchorID: "chat-latest-p-stored-a"))
+    }
+
+    /// Review item: adopting the first session clears a correction that was
+    /// scheduled before any session existed — the command-owning session
+    /// changed from nil to a real key.
+    func testFirstSessionAdoptionClearsSessionlessPendingCorrection() throws {
+        var controller = ChatViewportController()
+        let token = try XCTUnwrap(scheduledCorrection(in: controller.layoutMetricsChanged(
+            facts: layoutFacts(
+                bottomMarkerMaxY: 900, viewportMaxY: 800,
+                scope: controller.renderedScrollScope
+            )
+        )))
+        XCTAssertNil(token.sessionKey, "scheduled before any session existed")
+
+        _ = controller.renderedSessionChanged(
+            to: keyA,
+            identity: identity(for: keyA),
+            viaNotification: false,
+            viewportTransitionGeneration: 1
+        )
+        XCTAssertNil(controller.pendingFollowCorrection, "adoption invalidates the sessionless correction")
+        XCTAssertTrue(controller.followCorrectionDue(token).isEmpty)
+
+        // Following continues normally for the adopted session.
+        let fresh = try XCTUnwrap(scheduledCorrection(in: controller.layoutMetricsChanged(
+            facts: layoutFacts(
+                bottomMarkerMaxY: 950, viewportMaxY: 800,
+                scope: controller.renderedScrollScope
+            )
+        )))
+        XCTAssertEqual(fresh.sessionKey, keyA)
+        XCTAssertFalse(scrollCommands(controller.followCorrectionDue(fresh)).isEmpty)
+    }
+
+    /// Review item: content shrink rebases the floor. A stale high floor
+    /// must not swallow future growth until the bottom climbs back past it.
+    func testContentShrinkRebasesFloorAndFollowsRegrowth() throws {
+        var controller = makeController(following: keyA)
+
+        // Establish the floor at 1000 via one correction cycle.
+        let first = try XCTUnwrap(scheduledCorrection(in: controller.layoutMetricsChanged(
+            facts: layoutFacts(
+                bottomMarkerMaxY: 1000, viewportMaxY: 800,
+                scope: controller.renderedScrollScope
+            )
+        )))
+        XCTAssertFalse(scrollCommands(controller.followCorrectionDue(first)).isEmpty)
+
+        // Content collapses to 900 while drift remains (viewport 850):
+        // the shrink must re-pin the viewport AND rebase the floor to 900.
+        let shrink = try XCTUnwrap(scheduledCorrection(in: controller.layoutMetricsChanged(
+            facts: layoutFacts(
+                bottomMarkerMaxY: 900, viewportMaxY: 850,
+                scope: controller.renderedScrollScope
+            )
+        )), "meaningful shrink with drift schedules a rebasing correction")
+        XCTAssertFalse(scrollCommands(controller.followCorrectionDue(shrink)).isEmpty)
+
+        // Unchanged residual drift after the rebase: no storm.
+        for _ in 0..<10 {
+            let effects = controller.layoutMetricsChanged(facts: layoutFacts(
+                bottomMarkerMaxY: 900, viewportMaxY: 850,
+                scope: controller.renderedScrollScope
+            ))
+            XCTAssertNil(
+                scheduledCorrection(in: effects),
+                "unchanged bottom must not re-arm after the rebase"
+            )
+        }
+
+        // Modest regrowth from the REBASED floor (915, not 1012) follows.
+        let regrown = try XCTUnwrap(scheduledCorrection(in: controller.layoutMetricsChanged(
+            facts: layoutFacts(
+                bottomMarkerMaxY: 915, viewportMaxY: 850,
+                scope: controller.renderedScrollScope
+            )
+        )), "growth past the rebased floor must re-arm")
+        XCTAssertLessThan(915, 1000, "sanity: the regrowth stays below the stale floor")
+        XCTAssertFalse(scrollCommands(controller.followCorrectionDue(regrown)).isEmpty)
+    }
+
+    /// Review item: nil→nil session events must stay inert WITHOUT
+    /// skipping restoration cleanup. Clearing the session (A → nil) is the
+    /// reachable cleanup path and must still cancel a stale restoration.
+    func testSessionClearingCancelsStaleRestorationAndNilToNilStaysInert() {
+        var controller = makeController(following: keyA)
+        _ = controller.restorationRequested(restoreRequest(for: keyA))
+        XCTAssertTrue(controller.restorationIsActive)
+
+        let cleared = controller.renderedSessionChanged(
+            to: nil,
+            identity: identity(for: nil),
+            viaNotification: false,
+            viewportTransitionGeneration: 2
+        )
+        XCTAssertTrue(
+            cleared.contains(.cancelAutomaticRestoration),
+            "clearing the session cancels a stale restoration"
+        )
+        XCTAssertNil(controller.restoration)
+
+        // A subsequent nil → nil event is fully inert: no generation bump,
+        // no drag invalidation, no scroll.
+        let before = controller.generation
+        let inert = controller.renderedSessionChanged(
+            to: nil,
+            identity: identity(for: nil),
+            viaNotification: false,
+            viewportTransitionGeneration: 3
+        )
+        XCTAssertTrue(inert.isEmpty)
+        XCTAssertEqual(controller.generation, before)
     }
 }

--- a/ConduitTests/ChatViewportControllerTests.swift
+++ b/ConduitTests/ChatViewportControllerTests.swift
@@ -403,8 +403,17 @@ final class ChatViewportControllerTests: XCTestCase {
 
     // MARK: - Layout facts & following rendered growth
 
-    func testLayoutGrowthWhileFollowingIssuesNonAnimatedBottomScrollBeyondTolerance() {
+    /// Updated for the coalescing semantics (watchdog fix): a geometry
+    /// drift tick no longer emits a synchronous scroll — it schedules ONE
+    /// follow correction; the view executes it a MainActor turn later via
+    /// followCorrectionDue, which emits the single non-animated bottom
+    /// command against the newest facts. The old one-scroll-per-tick
+    /// expectation fed the scrollTo → layout → preference → scrollTo
+    /// feedback storm (ScrollViewCommitMutation watchdog crashes).
+    func testLayoutGrowthWhileFollowingSchedulesCoalescedCorrectionThenScrolls() {
         var controller = makeController(following: keyA)
+
+        // Drift tick: schedules exactly one correction, no direct scroll.
         let effects = controller.layoutMetricsChanged(
             facts: layoutFacts(
                 bottomMarkerMaxY: 806,
@@ -412,12 +421,22 @@ final class ChatViewportControllerTests: XCTestCase {
                 scope: controller.renderedScrollScope
             )
         )
-        let commands = scrollCommands(effects)
+        XCTAssertTrue(scrollCommands(effects).isEmpty, "no synchronous scroll from a geometry tick")
+        guard case .scheduleFollowCorrection(let token) = effects.last else {
+            return XCTFail("expected a scheduleFollowCorrection effect, got \(effects)")
+        }
+        XCTAssertEqual(controller.pendingFollowCorrection, token)
+        XCTAssertEqual(token.sessionKey, keyA)
+
+        // Due a turn later: exactly one non-animated bottom command, current.
+        let due = controller.followCorrectionDue(token)
+        let commands = scrollCommands(due)
         XCTAssertEqual(commands.count, 1)
         XCTAssertEqual(commands[0].destination, .bottom(anchorID: "chat-latest-p-session-a"))
         XCTAssertEqual(commands[0].animated, false)
         XCTAssertNil(commands[0].retry)
         XCTAssertTrue(controller.isCommandCurrent(commands[0]))
+        XCTAssertNil(controller.pendingFollowCorrection, "correction drained")
     }
 
     func testLayoutGrowthWithinFollowToleranceIssuesNothing() {
@@ -630,15 +649,42 @@ final class ChatViewportControllerTests: XCTestCase {
         var nonBottomCommands = 0
         var generation = controller.generation
         for tick in 1...30 {
-            let effects = controller.layoutMetricsChanged(
-                facts: layoutFacts(
-                    bottomMarkerMaxY: 800 + CGFloat(tick * 24),
-                    viewportMaxY: 800,
-                    scope: controller.renderedScrollScope
+            // One growth tick produces MANY geometry preference callbacks in
+            // the view (bottom marker, viewport frame, row frames); model
+            // three ticks per growth cycle to prove they coalesce to ONE
+            // scheduled correction, drained once on the next MainActor turn.
+            var scheduled: ChatFollowCorrectionToken?
+            for _ in 0..<3 {
+                let effects = controller.layoutMetricsChanged(
+                    facts: layoutFacts(
+                        bottomMarkerMaxY: 800 + CGFloat(tick * 24),
+                        viewportMaxY: 800,
+                        scope: controller.renderedScrollScope
+                    )
                 )
-            )
-            let commands = scrollCommands(effects)
-            XCTAssertEqual(commands.count, 1, "tick \(tick) must issue exactly one command")
+                XCTAssertTrue(
+                    scrollCommands(effects).isEmpty,
+                    "tick \(tick): geometry ticks never scroll synchronously"
+                )
+                for effect in effects {
+                    if case .scheduleFollowCorrection(let token) = effect {
+                        XCTAssertNil(
+                            scheduled,
+                            "tick \(tick): at most one outstanding correction per unsettled layout cycle"
+                        )
+                        scheduled = token
+                    }
+                }
+            }
+            guard let token = scheduled else {
+                XCTFail("tick \(tick): growth must schedule a follow correction")
+                continue
+            }
+            // Ownership must not change while a correction is pending.
+            XCTAssertEqual(controller.generation, generation, "growth must not bump generation")
+
+            let commands = scrollCommands(controller.followCorrectionDue(token))
+            XCTAssertEqual(commands.count, 1, "tick \(tick): drained correction issues exactly one command")
             guard case .bottom = commands[0].destination else {
                 nonBottomCommands += 1
                 continue
@@ -1491,9 +1537,13 @@ extension ChatViewportControllerTests {
             viewportMaxY: 800,
             scope: controller.renderedScrollScope
         ))
-        XCTAssertEqual(scrollCommands(followEffects).count, 1)
+        guard case .scheduleFollowCorrection(let token) = followEffects.last else {
+            return XCTFail("expected a coalesced follow correction for B")
+        }
+        let commands = scrollCommands(controller.followCorrectionDue(token))
+        XCTAssertEqual(commands.count, 1)
         XCTAssertEqual(
-            scrollCommands(followEffects)[0].destination,
+            commands[0].destination,
             .bottom(anchorID: "chat-latest-p-session-b")
         )
     }
@@ -1723,8 +1773,12 @@ extension ChatViewportControllerTests {
     }
 
     // Scenario 1: long continuously streaming response, untouched.
-    // 120 layout ticks at 250ms-equivalent cadence (30 Hz block). Every
-    // growth tick beyond tolerance emits exactly one current bottom command.
+    // 120 growth cycles at 250ms-equivalent cadence (30 Hz block), each
+    // modeled as the view drives it: two geometry preference callbacks for
+    // the same growth, then the scheduled correction drained on the next
+    // MainActor turn. Every cycle yields exactly one current non-animated
+    // bottom command; the geometry ticks themselves never scroll. (Updated
+    // for coalescing semantics — see the watchdog fix note in this file.)
     // Generation never bumps from growth alone. No upward jump.
     func testStressLongContinuousStreamFollows() {
         var controller = makeController(following: keyA)
@@ -1734,17 +1788,35 @@ extension ChatViewportControllerTests {
 
         for tick in 1...120 {
             let bottom = baseBottom + CGFloat(tick * 24)
-            let effects = controller.layoutMetricsChanged(facts: layoutFacts(
-                bottomMarkerMaxY: bottom,
-                viewportMaxY: viewportBottom,
-                scope: controller.renderedScrollScope
-            ))
-            assertOnlyCurrentBottomCommands(effects, in: controller)
-            let commands = scrollCommands(effects)
+            var scheduled: ChatFollowCorrectionToken?
+            for _ in 0..<2 {
+                let effects = controller.layoutMetricsChanged(facts: layoutFacts(
+                    bottomMarkerMaxY: bottom,
+                    viewportMaxY: viewportBottom,
+                    scope: controller.renderedScrollScope
+                ))
+                assertOnlyCurrentBottomCommands(effects, in: controller)
+                XCTAssertTrue(
+                    scrollCommands(effects).isEmpty,
+                    "tick \(tick): geometry ticks never scroll synchronously"
+                )
+                for effect in effects {
+                    if case .scheduleFollowCorrection(let token) = effect {
+                        XCTAssertNil(scheduled, "tick \(tick): one outstanding correction max")
+                        scheduled = token
+                    }
+                }
+            }
+            guard let token = scheduled else {
+                XCTFail("tick \(tick): growth must schedule a correction")
+                continue
+            }
+            let commands = scrollCommands(controller.followCorrectionDue(token))
             if !commands.isEmpty {
                 totalBottomCommands += 1
                 XCTAssertEqual(commands.count, 1, "tick \(tick): exactly one command")
                 XCTAssertEqual(commands[0].animated, false, "follow-growth must be non-animated")
+                XCTAssertTrue(controller.isCommandCurrent(commands[0]))
             }
             XCTAssertEqual(controller.mode, .followingLatest, "tick \(tick): must stay following")
         }
@@ -1786,13 +1858,20 @@ extension ChatViewportControllerTests {
         ))
         XCTAssertEqual(controller.mode, .followingLatest, "relatched near bottom")
 
-        // Resume following growth.
+        // Resume following growth: schedules a correction (coalescing
+        // semantics) which drains into exactly one follow command.
         let followEffects = controller.layoutMetricsChanged(facts: layoutFacts(
             bottomMarkerMaxY: 880,
             viewportMaxY: 800,
             scope: controller.renderedScrollScope
         ))
-        XCTAssertFalse(scrollCommands(followEffects).isEmpty, "growth after relatch produces follow commands")
+        guard case .scheduleFollowCorrection(let token) = followEffects.last else {
+            return XCTFail("growth after relatch must schedule a follow correction")
+        }
+        XCTAssertFalse(
+            scrollCommands(controller.followCorrectionDue(token)).isEmpty,
+            "growth after relatch produces follow commands"
+        )
     }
 
     // Scenario 4+5: title→top during stream; streaming cannot yank top-owned
@@ -1883,6 +1962,9 @@ extension ChatViewportControllerTests {
 
     // Scenario 8: large Markdown table/code response growth while following.
     // Height jumps of 120pt (table expansion) are within tolerance for follow.
+    // Coalescing semantics: each jump's geometry tick schedules; the drain
+    // issues exactly one non-animated follow command against the jump's
+    // facts.
     func testStressTableExpansionGrowthFollows() {
         var controller = makeController(following: keyA)
         let jumps: [CGFloat] = [200, 320, 440, 560, 680, 800]
@@ -1893,7 +1975,11 @@ extension ChatViewportControllerTests {
                 scope: controller.renderedScrollScope
             ))
             assertOnlyCurrentBottomCommands(effects, in: controller)
-            let commands = scrollCommands(effects)
+            XCTAssertTrue(scrollCommands(effects).isEmpty, "table jump \(i): no synchronous scroll")
+            guard case .scheduleFollowCorrection(let token) = effects.last else {
+                return XCTFail("table jump \(i): follow correction scheduled")
+            }
+            let commands = scrollCommands(controller.followCorrectionDue(token))
             XCTAssertEqual(commands.count, 1, "table jump \(i): follow command issued")
             XCTAssertEqual(commands[0].animated, false, "table follow non-animated")
         }
@@ -2134,5 +2220,291 @@ extension ChatViewportControllerTests {
         )
         XCTAssertNotEqual(first, [], "first call should produce effects")
         XCTAssertEqual(second, [], "duplicate call with same messages must be no-op")
+    }
+}
+
+// MARK: - Coalesced follow corrections (watchdog fix)
+
+/// The geometry → scrollTo → geometry feedback invariant: one rendering/
+/// layout update can produce AT MOST one outstanding (pending or executing)
+/// bottom-follow correction, executed on a later MainActor turn against the
+/// newest facts. See ChatViewportController.layoutMetricsChanged.
+extension ChatViewportControllerTests {
+
+    private func scheduledCorrection(
+        in effects: [ChatViewportEffect]
+    ) -> ChatFollowCorrectionToken? {
+        for effect in effects {
+            if case .scheduleFollowCorrection(let token) = effect { return token }
+        }
+        return nil
+    }
+
+    /// The core invariant: several geometry preference callbacks within one
+    /// unsettled layout cycle schedule exactly one correction, and the
+    /// correction executes with the NEWEST facts recorded by the later
+    /// callbacks.
+    func testOneLayoutCycleProducesAtMostOneCorrectionWithLatestFacts() {
+        var controller = makeController(following: keyA)
+
+        // First callback of the cycle (e.g. the bottom-marker preference).
+        let first = controller.layoutMetricsChanged(facts: layoutFacts(
+            bottomMarkerMaxY: 900, viewportMaxY: 800,
+            scope: controller.renderedScrollScope
+        ))
+        let token = scheduledCorrection(in: first)
+        XCTAssertNotNil(token, "drift beyond tolerance schedules a correction")
+
+        // Later callbacks of the SAME cycle (viewport frame, row frames):
+        // facts update, never a second correction.
+        for _ in 0..<5 {
+            let duplicate = controller.layoutMetricsChanged(facts: layoutFacts(
+                bottomMarkerMaxY: 950, viewportMaxY: 800,
+                scope: controller.renderedScrollScope
+            ))
+            XCTAssertNil(
+                scheduledCorrection(in: duplicate),
+                "a pending correction absorbs further geometry ticks"
+            )
+        }
+        XCTAssertEqual(controller.pendingFollowCorrection, token)
+
+        // Due: executes against the newest facts (drift 950-800=150).
+        let commands = scrollCommands(controller.followCorrectionDue(token!))
+        XCTAssertEqual(commands.count, 1)
+        XCTAssertEqual(commands[0].destination, .bottom(anchorID: "chat-latest-p-session-a"))
+        XCTAssertNil(controller.pendingFollowCorrection)
+    }
+
+    /// A correction that comes due after the drift resolved itself (the
+    /// animated transcript reassert landed, or the user scrolled) must not
+    /// scroll.
+    func testCorrectionDiesWhenDriftResolvedBeforeDue() {
+        var controller = makeController(following: keyA)
+        let effects = controller.layoutMetricsChanged(facts: layoutFacts(
+            bottomMarkerMaxY: 880, viewportMaxY: 800,
+            scope: controller.renderedScrollScope
+        ))
+        guard let token = scheduledCorrection(in: effects) else {
+            return XCTFail("expected a scheduled correction")
+        }
+
+        // The reassert landed before the correction came due.
+        _ = controller.layoutMetricsChanged(facts: layoutFacts(
+            bottomMarkerMaxY: 800, viewportMaxY: 800,
+            scope: controller.renderedScrollScope
+        ))
+        XCTAssertTrue(scrollCommands(controller.followCorrectionDue(token)).isEmpty)
+        XCTAssertNil(controller.pendingFollowCorrection)
+    }
+
+    /// A pending correction must not survive ownership moves: user drag,
+    /// session switch, explicit commands.
+    func testPendingCorrectionDiesOnOwnershipMoves() {
+        // User starts a drag between schedule and due.
+        var dragged = makeController(following: keyA)
+        let dragEffects = dragged.layoutMetricsChanged(facts: layoutFacts(
+            bottomMarkerMaxY: 900, viewportMaxY: 800,
+            scope: dragged.renderedScrollScope
+        ))
+        guard let dragToken = scheduledCorrection(in: dragEffects) else {
+            return XCTFail("expected a scheduled correction")
+        }
+        _ = dragged.userDragBegan(sessionKey: keyA, viewportTransitionGeneration: 1)
+        XCTAssertNil(dragged.pendingFollowCorrection, "drag clears the pending correction")
+        XCTAssertTrue(dragged.followCorrectionDue(dragToken).isEmpty)
+
+        // Session switch between schedule and due.
+        var switched = makeController(following: keyA)
+        let switchEffects = switched.layoutMetricsChanged(facts: layoutFacts(
+            bottomMarkerMaxY: 900, viewportMaxY: 800,
+            scope: switched.renderedScrollScope
+        ))
+        guard let switchToken = scheduledCorrection(in: switchEffects) else {
+            return XCTFail("expected a scheduled correction")
+        }
+        _ = switched.renderedSessionChanged(
+            to: keyB, identity: identity(for: keyB),
+            viaNotification: false, viewportTransitionGeneration: 2
+        )
+        XCTAssertNil(switched.pendingFollowCorrection, "session switch clears the pending correction")
+        XCTAssertTrue(switched.followCorrectionDue(switchToken).isEmpty)
+
+        // Explicit latest button between schedule and due: it scrolls itself
+        // and clears the pending correction so no double scroll executes.
+        var explicit = makeController(following: keyA)
+        let explicitEffects = explicit.layoutMetricsChanged(facts: layoutFacts(
+            bottomMarkerMaxY: 900, viewportMaxY: 800,
+            scope: explicit.renderedScrollScope
+        ))
+        guard let explicitToken = scheduledCorrection(in: explicitEffects) else {
+            return XCTFail("expected a scheduled correction")
+        }
+        let latest = explicit.explicitLatestRequested()
+        XCTAssertEqual(scrollCommands(latest).count, 1)
+        XCTAssertNil(explicit.pendingFollowCorrection)
+        XCTAssertTrue(
+            explicit.followCorrectionDue(explicitToken).isEmpty,
+            "a stale token cannot scroll twice after the explicit command"
+        )
+    }
+
+    /// Genuinely new growth after a completed correction schedules a new
+    /// one — coalescing must not starve continuous streaming.
+    func testNewGrowthAfterCompletedCorrectionSchedulesAgain() {
+        var controller = makeController(following: keyA)
+        var corrections = 0
+        for growth in 1...8 {
+            let effects = controller.layoutMetricsChanged(facts: layoutFacts(
+                bottomMarkerMaxY: 800 + CGFloat(growth * 30),
+                viewportMaxY: 800,
+                scope: controller.renderedScrollScope
+            ))
+            guard let token = scheduledCorrection(in: effects) else { continue }
+            corrections += 1
+            XCTAssertFalse(
+                scrollCommands(controller.followCorrectionDue(token)).isEmpty,
+                "growth \(growth) correction must execute"
+            )
+        }
+        XCTAssertEqual(corrections, 8, "every genuinely new growth cycle is followed")
+    }
+
+    /// A stale token (already drained) can never scroll a second time.
+    func testStaleFollowCorrectionTokenDoesNothing() {
+        var controller = makeController(following: keyA)
+        let effects = controller.layoutMetricsChanged(facts: layoutFacts(
+            bottomMarkerMaxY: 900, viewportMaxY: 800,
+            scope: controller.renderedScrollScope
+        ))
+        guard let token = scheduledCorrection(in: effects) else {
+            return XCTFail("expected a scheduled correction")
+        }
+        _ = controller.followCorrectionDue(token)
+        XCTAssertTrue(controller.followCorrectionDue(token).isEmpty)
+    }
+
+    /// THE residual-drift case from the hosted reproduction: a drift that
+    /// persists with an UNCHANGED content bottom (the scroll already sits
+    /// where the anchor can take it) must not re-arm the correction every
+    /// turn — that re-arm loop is the ScrollViewCommitMutation storm, one
+    /// MainActor turn apart.
+    func testCorrectionDoesNotRearmForUnchangedContentBottom() {
+        var controller = makeController(following: keyA)
+        let first = controller.layoutMetricsChanged(facts: layoutFacts(
+            bottomMarkerMaxY: 900, viewportMaxY: 800,
+            scope: controller.renderedScrollScope
+        ))
+        guard let token = scheduledCorrection(in: first) else {
+            return XCTFail("expected a scheduled correction")
+        }
+        XCTAssertFalse(scrollCommands(controller.followCorrectionDue(token)).isEmpty)
+
+        // The scroll executed but a residual drift remains (bottom 900 vs
+        // viewport 804, say) with the content bottom UNCHANGED: no further
+        // corrections may arm, however many geometry ticks arrive.
+        for _ in 0..<10 {
+            let effects = controller.layoutMetricsChanged(facts: layoutFacts(
+                bottomMarkerMaxY: 900, viewportMaxY: 804,
+                scope: controller.renderedScrollScope
+            ))
+            XCTAssertNil(
+                scheduledCorrection(in: effects),
+                "unchanged content bottom must not re-arm the correction"
+            )
+        }
+
+        // Genuinely new growth re-arms exactly one new correction.
+        let grown = controller.layoutMetricsChanged(facts: layoutFacts(
+            bottomMarkerMaxY: 950, viewportMaxY: 804,
+            scope: controller.renderedScrollScope
+        ))
+        guard let newToken = scheduledCorrection(in: grown) else {
+            return XCTFail("new growth must re-arm the correction")
+        }
+        XCTAssertFalse(scrollCommands(controller.followCorrectionDue(newToken)).isEmpty)
+    }
+
+    /// Relatch (user returns near the bottom) clears the content floor so
+    /// the viewport can be pinned flush even when the content bottom has
+    /// not moved since the last correction cycle.
+    func testRelatchAllowsFlushPinWithUnchangedContentBottom() {
+        var controller = makeController(following: keyA)
+        let first = controller.layoutMetricsChanged(facts: layoutFacts(
+            bottomMarkerMaxY: 900, viewportMaxY: 800,
+            scope: controller.renderedScrollScope
+        ))
+        guard let token = scheduledCorrection(in: first) else {
+            return XCTFail("expected a scheduled correction")
+        }
+        XCTAssertFalse(scrollCommands(controller.followCorrectionDue(token)).isEmpty)
+
+        // User drags away and comes back near the bottom (relatch tick:
+        // near-bottom, no scroll that tick).
+        _ = controller.userDragBegan(sessionKey: keyA, viewportTransitionGeneration: 1)
+        _ = controller.userDragGestureEnded()
+        let relatch = controller.layoutMetricsChanged(facts: layoutFacts(
+            bottomMarkerMaxY: 830, viewportMaxY: 800,
+            scope: controller.renderedScrollScope
+        ))
+        XCTAssertEqual(controller.mode, .followingLatest, "relatched near bottom")
+        XCTAssertTrue(scrollCommands(relatch).isEmpty, "relatch tick itself never scrolls")
+
+        // Same content bottom as the last cycle, drift beyond tolerance:
+        // the relatch cleared the floor, so a flush-pin correction arms.
+        let pinned = controller.layoutMetricsChanged(facts: layoutFacts(
+            bottomMarkerMaxY: 830, viewportMaxY: 800,
+            scope: controller.renderedScrollScope
+        ))
+        guard let flushToken = scheduledCorrection(in: pinned) else {
+            return XCTFail("relatch must allow a flush-pin correction")
+        }
+        XCTAssertFalse(scrollCommands(controller.followCorrectionDue(flushToken)).isEmpty)
+    }
+
+    /// The streaming reassert (transcriptChanged) is a DIFFERENT command
+    /// path and stays immediate; a follow correction pending across it dies
+    /// at due time when the reassert resolved the drift.
+    func testTranscriptReassertUnaffectedByCoalescing() {
+        var controller = makeController(following: keyA)
+        let effects = controller.transcriptChanged(
+            messages: [message("m1", "hello")],
+            transcriptRevision: 2,
+            viewportTransitionGeneration: 1
+        )
+        let commands = scrollCommands(effects)
+        XCTAssertEqual(commands.count, 1, "transcript reassert stays immediate and animated")
+        XCTAssertEqual(commands[0].animated, true)
+        XCTAssertNil(scheduledCorrection(in: effects))
+    }
+
+    /// The animated reassert supersedes a pending follow correction: the
+    /// reassert carries its own delayed retry and owns the follow, so the
+    /// correction must not fight the in-flight animation.
+    func testTranscriptReassertSupersedesPendingCorrection() {
+        var controller = makeController(following: keyA)
+        let drift = controller.layoutMetricsChanged(facts: layoutFacts(
+            bottomMarkerMaxY: 900, viewportMaxY: 800,
+            scope: controller.renderedScrollScope
+        ))
+        guard let token = scheduledCorrection(in: drift) else {
+            return XCTFail("expected a scheduled correction")
+        }
+
+        let reassert = controller.transcriptChanged(
+            messages: [message("m1", "hello")],
+            transcriptRevision: 2,
+            viewportTransitionGeneration: 1
+        )
+        XCTAssertEqual(scrollCommands(reassert).count, 1)
+        XCTAssertEqual(scrollCommands(reassert)[0].animated, true)
+        XCTAssertNil(
+            controller.pendingFollowCorrection,
+            "the animated reassert supersedes the pending correction"
+        )
+        XCTAssertTrue(
+            controller.followCorrectionDue(token).isEmpty,
+            "the superseded correction can never scroll"
+        )
     }
 }

--- a/ConduitTests/MarkdownRichContentTests.swift
+++ b/ConduitTests/MarkdownRichContentTests.swift
@@ -1,0 +1,446 @@
+//
+//  MarkdownRichContentTests.swift
+//  Conduit
+//
+//  Regression coverage for the watchdog crash reproduced by opening a
+//  session whose single Markdown-heavy response is comfortably below the
+//  100 KB large-document threshold yet structurally pathological: many
+//  tables (aligned), Mermaid diagrams, images, math, code fences, and the
+//  usual headings/lists/quotes.
+//
+//  The fixture proves the ordinary-size path is protected by STRUCTURE:
+//  complex tables page, per-block Mermaid/math/code guards apply, and the
+//  aggregate rich-layout budget bounds eager mounts — without lowering
+//  documentThresholdBytes and without touching ordinary messages.
+//
+
+import SwiftUI
+import UIKit
+import XCTest
+@testable import Conduit
+
+// MARK: - Fixtures
+
+/// Deterministic Markdown showcase generators. The pathological showcase
+/// mirrors the TestFlight reproduction: ONE assistant response that
+/// demonstrates lots of Markdown features, byte count well under the
+/// large-document threshold.
+enum MarkdownShowcaseFixtures {
+    /// A GFM table with every alignment form, `rows` rows × `columns`
+    /// columns. Cell text is ASCII so the byte math stays predictable.
+    static func alignedTable(section: Int, rows: Int, columns: Int) -> String {
+        let header = (0..<columns).map { "H\($0)" }.joined(separator: " | ")
+        let alignment = (0..<columns).map { c in
+            [":---", ":---:", "---:"][c % 3]
+        }.joined(separator: " | ")
+        var lines = [
+            "| \(header) |",
+            "| \(alignment) |",
+        ]
+        for r in 0..<rows {
+            let cells = (0..<columns)
+                .map { "s\(section)-r\(r)c\($0)" }
+                .joined(separator: " | ")
+            lines.append("| \(cells) |")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// One showcase section: heading, prose, a table (structurally varying
+    /// by section), Mermaid diagram, math, code fence, quote, lists, task
+    /// items, a callout, and a divider. Images every third section.
+    static func section(index: Int, includeImages: Bool = true) -> String {
+        var parts: [String] = []
+        parts.append("## Feature tour \(index)")
+        parts.append(
+            "Paragraph \(index) with **bold**, *italic*, `inline code`, and a [docs link](https://example.com/docs/\(index)) so inline parsing stays exercised."
+        )
+        if index % 4 == 3 {
+            // Complex by row count (46 ≥ complexTableRowCount).
+            parts.append(alignedTable(section: index, rows: 46, columns: 6))
+        } else if index % 6 == 5 {
+            // Complex by total cells (22 × 10 = 220 ≥ complexTableCellCount)
+            // with a moderate row count.
+            parts.append(alignedTable(section: index, rows: 22, columns: 10))
+        } else {
+            // Moderate table: complex by neither measure on its own.
+            parts.append(alignedTable(section: index, rows: 22, columns: 5))
+        }
+        parts.append(
+            """
+            ```mermaid
+            flowchart TD
+                S\(index)[Start \(index)] --> G{Gate \(index)}
+                G -->|fast| C[Commit]
+                G -->|slow| R[Retry]
+                C --> F((Finish \(index)))
+            ```
+            """
+        )
+        parts.append(
+            """
+            $$
+            \\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2} \\quad (\\text{case } \(index))
+            $$
+            """
+        )
+        parts.append(
+            """
+            ```swift
+            struct Section\(index) {
+                let value = \(index)
+                func render() -> String { "section \\(value)" }
+            }
+            ```
+            """
+        )
+        if includeImages, index % 3 == 0 {
+            parts.append("![Chart \(index)](https://example.com/charts/chart-\(index).png)")
+        }
+        parts.append(
+            "> Quoted insight \(index) about the showcase.\n> Second quoted line with *emphasis*."
+        )
+        parts.append(
+            "- bullet one for \(index)\n- bullet two with detail\n- [ ] task item \(index)\n- [x] completed task"
+        )
+        parts.append("::: tip\nCallout \(index): tables and diagrams stay interactive.\n:::")
+        parts.append("---")
+        return parts.joined(separator: "\n\n")
+    }
+
+    /// The reproduction: one response, many rich blocks, well below the
+    /// 100 KB large-document threshold.
+    static func pathologicalShowcase(
+        sections: Int = 18,
+        includeImages: Bool = true
+    ) -> String {
+        (0..<sections).map { section(index: $0, includeImages: includeImages) }
+            .joined(separator: "\n\n")
+    }
+
+    /// An ordinary feature-tour answer: one of everything, the kind of
+    /// message rich Markdown must keep rendering exactly as before.
+    static func ordinaryShowcase() -> String {
+        [
+            "## Ordinary answer",
+            "A paragraph with **bold** and a [link](https://example.com/a).",
+            alignedTable(section: 0, rows: 4, columns: 3),
+            """
+            ```mermaid
+            flowchart LR
+                A --> B --> C
+            ```
+            """,
+            "$$\na^2 + b^2 = c^2\n$$",
+            """
+            ```swift
+            let answer = 42
+            ```
+            """,
+            "![Diagram](https://example.com/diagram.png)",
+            "> One quoted line.",
+            "- a bullet\n- another bullet",
+            "::: note\nA callout.\n:::",
+        ].joined(separator: "\n\n")
+    }
+}
+
+// MARK: - Pure policy tests
+
+final class MarkdownRichContentPolicyTests: XCTestCase {
+    private func headers(_ count: Int) -> [String] {
+        (0..<count).map { "H\($0)" }
+    }
+
+    private func rows(_ count: Int, _ columns: Int) -> [[String]] {
+        (0..<count).map { r in (0..<columns).map { "r\(r)c\($0)" } }
+    }
+
+    // MARK: Table complexity is structural
+
+    func testTableComplexityUsesRowsCellsAndBytes() {
+        let policy = MarkdownRichContentPolicy.self
+
+        // Row count alone.
+        XCTAssertTrue(policy.isComplexTable(headers: headers(6), rows: rows(46, 6)))
+        // Cell count with a moderate row count (22 × 10 = 220).
+        XCTAssertTrue(policy.isComplexTable(headers: headers(10), rows: rows(22, 10)))
+        XCTAssertTrue(policy.isComplexTable(headers: headers(10), rows: rows(20, 10)))
+        XCTAssertFalse(policy.isComplexTable(headers: headers(10), rows: rows(19, 10)))
+        // Ordinary tables stay ordinary.
+        XCTAssertFalse(policy.isComplexTable(headers: headers(4), rows: rows(8, 4)))
+        XCTAssertFalse(policy.isComplexTable(headers: headers(6), rows: rows(30, 6)))
+        // Byte-based qualification from #88 is preserved: few cells, huge
+        // content still pages.
+        let hugeCell = String(repeating: "x", count: 2_700)
+        let hugeRows = (0..<6).map { _ in (0..<2).map { _ in hugeCell } }
+        XCTAssertTrue(
+            policy.isComplexTable(headers: ["A", "B"], rows: hugeRows),
+            "a byte-heavy table keeps its #88 paged qualification"
+        )
+    }
+
+    // MARK: Block-local guards are independent of document bytes
+
+    func testMermaidMathCodeGuardsApplyToTheBlockItself() {
+        // All of these live in messages far below the 100 KB document
+        // threshold; the guards must still apply.
+        let mermaidPastGuard = String(repeating: "A --> B\n", count: 15_000)
+        XCTAssertGreaterThan(
+            mermaidPastGuard.utf8.count,
+            MarkdownLargeDocumentPolicy.mermaidGuardBytes
+        )
+        XCTAssertEqual(
+            MarkdownBlockView.codePresentation(language: "mermaid", source: mermaidPastGuard),
+            .guardedMermaid
+        )
+        // Ordinary diagrams keep their normal render path.
+        XCTAssertEqual(
+            MarkdownBlockView.codePresentation(
+                language: "mermaid",
+                source: "flowchart TD\n  A --> B"
+            ),
+            .mermaid
+        )
+
+        let codePastThreshold = String(repeating: "let value = 1;\n", count: 4_000)
+        XCTAssertGreaterThan(
+            codePastThreshold.utf8.count,
+            MarkdownLargeDocumentPolicy.codeBlockThresholdBytes
+        )
+        XCTAssertEqual(
+            MarkdownBlockView.codePresentation(language: "swift", source: codePastThreshold),
+            .slicedCode
+        )
+        XCTAssertEqual(
+            MarkdownBlockView.codePresentation(language: "swift", source: "let value = 1;"),
+            .code
+        )
+
+        XCTAssertTrue(
+            MarkdownBlockView.mathNeedsGuard(String(repeating: "x", count: 100_001))
+        )
+        XCTAssertFalse(MarkdownBlockView.mathNeedsGuard("E = mc^2"))
+    }
+
+    // MARK: Aggregate budget
+
+    func testOrdinaryMessagesStayUnderTheRichBudget() {
+        // Case 1: plain prose never even reaches the block-view path.
+        let prose = "Just prose.\n\nMore prose here."
+        let proseDocument = MarkdownParser.parseDocument(prose)
+        XCTAssertTrue(
+            proseDocument.blocks.allSatisfy(\.isSelectableFlowBlock),
+            "plain prose renders through the single selectable text view"
+        )
+
+        // Case 2: one ordinary table.
+        let oneTable = "Intro.\n\n" + MarkdownShowcaseFixtures.alignedTable(section: 0, rows: 6, columns: 3)
+        XCTAssertFalse(
+            MarkdownRichContentPolicy.needsBounding(MarkdownParser.parse(oneTable))
+        )
+
+        // Case 3: one ordinary Mermaid diagram.
+        let oneMermaid = "Intro.\n\n```mermaid\nflowchart TD\n  A --> B\n```"
+        XCTAssertFalse(
+            MarkdownRichContentPolicy.needsBounding(MarkdownParser.parse(oneMermaid))
+        )
+
+        // A full ordinary feature-tour answer (one of everything).
+        let ordinary = MarkdownShowcaseFixtures.ordinaryShowcase()
+        XCTAssertFalse(MarkdownLargeDocumentPolicy.isLargeDocument(ordinary))
+        let ordinaryBlocks = MarkdownParser.parse(ordinary)
+        XCTAssertFalse(MarkdownRichContentPolicy.needsBounding(ordinaryBlocks))
+        XCTAssertNil(
+            MarkdownRichContentPolicy.gateCut(
+                blocks: ordinaryBlocks,
+                unitBudget: MarkdownRichContentPolicy.eagerRichUnitBudget
+            ),
+            "an ordinary rich message mounts everything eagerly"
+        )
+    }
+
+    func testPathologicalShowcaseIsBelowThresholdButOverBudget() {
+        let source = MarkdownShowcaseFixtures.pathologicalShowcase()
+
+        // THE reproduction shape: rich beyond reason, byte count ordinary.
+        XCTAssertLessThan(source.utf8.count, MarkdownLargeDocumentPolicy.documentThresholdBytes)
+        XCTAssertGreaterThan(source.utf8.count, 35_000)
+        XCTAssertFalse(MarkdownLargeDocumentPolicy.isLargeDocument(source))
+
+        let blocks = MarkdownParser.parse(source)
+
+        // Rich-block inventory: many tables, many Mermaid diagrams, math,
+        // code, images.
+        let tables = blocks.filter {
+            if case .table = $0 { return true }
+            return false
+        }
+        let mermaidBlocks = blocks.filter {
+            if case .code(let language, _) = $0 {
+                return MarkdownLanguage.normalized(language) == "mermaid"
+            }
+            return false
+        }
+        XCTAssertEqual(tables.count, 18, "one table per showcase section")
+        XCTAssertGreaterThanOrEqual(mermaidBlocks.count, 18)
+        XCTAssertTrue(blocks.contains { block in
+            if case .math = block { return true }
+            return false
+        })
+        XCTAssertTrue(blocks.contains { block in
+            if case .image = block { return true }
+            return false
+        })
+
+        // Structural complexity is detected on the tables that have it.
+        let complexTableCount = tables.filter { block in
+            if case .table(let headers, _, let rows) = block {
+                return MarkdownRichContentPolicy.isComplexTable(headers: headers, rows: rows)
+            }
+            return false
+        }.count
+        XCTAssertGreaterThanOrEqual(complexTableCount, 5)
+
+        // The aggregate rich budget engages for the whole response.
+        XCTAssertTrue(MarkdownRichContentPolicy.needsBounding(blocks))
+        let cut = MarkdownRichContentPolicy.gateCut(
+            blocks: blocks,
+            unitBudget: MarkdownRichContentPolicy.eagerRichUnitBudget
+        )
+        XCTAssertNotNil(cut)
+        XCTAssertLessThan(cut!, blocks.count)
+        // The eager mount is a small fraction of the response.
+        XCTAssertLessThan(cut!, blocks.count / 2)
+
+        // Reveal batches eventually mount the whole response.
+        XCTAssertNil(
+            MarkdownRichContentPolicy.gateCut(
+                blocks: blocks,
+                unitBudget: MarkdownRichContentPolicy.totalRichUnits(blocks)
+            )
+        )
+    }
+
+    func testRevealBatchesProgressivelyCoverTheShowcase() {
+        let source = MarkdownShowcaseFixtures.pathologicalShowcase()
+        let blocks = MarkdownParser.parse(source)
+
+        var lastCut = 0
+        var budget = MarkdownRichContentPolicy.eagerRichUnitBudget
+        var cuts: [Int] = []
+        while let cut = MarkdownRichContentPolicy.gateCut(blocks: blocks, unitBudget: budget) {
+            cuts.append(cut)
+            lastCut = cut
+            budget += MarkdownRichContentPolicy.revealUnitBatch
+            if cuts.count > 100 { XCTFail("reveal never completes"); break }
+        }
+        // Monotonically increasing mounts, ending with everything fitting.
+        XCTAssertEqual(cuts.sorted(), cuts)
+        XCTAssertGreaterThan(lastCut, 0)
+        XCTAssertNil(
+            MarkdownRichContentPolicy.gateCut(blocks: blocks, unitBudget: budget),
+            "the final reveal state mounts every block"
+        )
+    }
+}
+
+// MARK: - Hosted rendering tests
+
+@MainActor
+final class MarkdownRichContentHostedTests: XCTestCase {
+    /// Retained for the full lifetime of each measurement so the hosted
+    /// hierarchy stays genuinely mounted; torn down explicitly per test.
+    private var testWindow: UIWindow?
+
+    override func setUp() {
+        super.setUp()
+        RichBudgetedMarkdownBody.resetDebugInstrumentation()
+    }
+
+    override func tearDown() {
+        testWindow?.isHidden = true
+        testWindow?.rootViewController = nil
+        RunLoop.current.run(until: Date())
+        testWindow = nil
+        RichBudgetedMarkdownBody.resetDebugInstrumentation()
+        super.tearDown()
+    }
+
+    /// Hosts one MarkdownText in a phone-sized window and lets the first
+    /// layout pass (the one the watchdog used to die in) complete.
+    private func mountMarkdown(
+        _ makeView: () -> MarkdownText
+    ) -> UIHostingController<MarkdownText> {
+        let host = UIHostingController(rootView: makeView())
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.isHidden = false
+        testWindow = window
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+        return host
+    }
+
+    /// Performance case 4: the <100 KB pathological showcase opens through
+    /// the bounded path — the eagerly mounted block set is the gate's
+    /// bounded prefix, not the whole response.
+    func testPathologicalShowcaseMountsBoundedBlockSet() throws {
+        // Images excluded here: their web-backed fallbacks (WKWebView) add
+        // process-level cost unsuitable for a unit-test window; the pure
+        // budget tests cover image accounting.
+        let source = MarkdownShowcaseFixtures.pathologicalShowcase(includeImages: false)
+        let blocks = MarkdownParser.parse(source)
+        XCTAssertFalse(MarkdownLargeDocumentPolicy.isLargeDocument(source))
+        XCTAssertTrue(MarkdownRichContentPolicy.needsBounding(blocks))
+
+        _ = mountMarkdown { MarkdownText(source: source) }
+
+        let mounted = RichBudgetedMarkdownBody.debugMountedBlockCount
+        XCTAssertEqual(
+            mounted,
+            MarkdownRichContentPolicy.gateCut(
+                blocks: blocks,
+                unitBudget: MarkdownRichContentPolicy.eagerRichUnitBudget
+            )!,
+            "the hosted render mounts exactly the gate's bounded prefix"
+        )
+        XCTAssertLessThan(mounted, blocks.count)
+        XCTAssertLessThan(mounted, blocks.count / 2)
+    }
+
+    /// Ordinary rich messages keep mounting everything (performance cases
+    /// 1–3): the budgeted body never even engages.
+    func testOrdinaryShowcaseMountsEverything() throws {
+        let ordinary = MarkdownShowcaseFixtures.ordinaryShowcase()
+        let blocks = MarkdownParser.parse(ordinary)
+        XCTAssertFalse(MarkdownRichContentPolicy.needsBounding(blocks))
+
+        _ = mountMarkdown { MarkdownText(source: ordinary) }
+
+        XCTAssertEqual(
+            RichBudgetedMarkdownBody.debugMountedBlockCount,
+            0,
+            "the budgeted body must not engage for ordinary rich messages"
+        )
+        XCTAssertGreaterThan(blocks.count, 5)
+    }
+
+    /// While streaming, the gate is bypassed so the live tail can never sit
+    /// behind a reveal button; growth stays incremental per frame
+    /// (performance case 6 companion).
+    func testStreamingShowcaseBypassesTheGate() throws {
+        let source = MarkdownShowcaseFixtures.pathologicalShowcase(sections: 6, includeImages: false)
+        let blocks = MarkdownParser.parse(source)
+        XCTAssertTrue(MarkdownRichContentPolicy.needsBounding(blocks))
+
+        _ = mountMarkdown { MarkdownText(source: source, isStreaming: true) }
+
+        XCTAssertEqual(
+            RichBudgetedMarkdownBody.debugMountedBlockCount,
+            blocks.count,
+            "streaming renders through the ungated body"
+        )
+    }
+}

--- a/ConduitTests/MarkdownRichContentTests.swift
+++ b/ConduitTests/MarkdownRichContentTests.swift
@@ -28,18 +28,24 @@ import XCTest
 enum MarkdownShowcaseFixtures {
     /// A GFM table with every alignment form, `rows` rows × `columns`
     /// columns. Cell text is ASCII so the byte math stays predictable.
-    static func alignedTable(section: Int, rows: Int, columns: Int) -> String {
+    static func alignedTable(
+        section: Int,
+        rows: Int,
+        columns: Int,
+        cellPadding: Int = 0
+    ) -> String {
         let header = (0..<columns).map { "H\($0)" }.joined(separator: " | ")
         let alignment = (0..<columns).map { c in
             [":---", ":---:", "---:"][c % 3]
         }.joined(separator: " | ")
+        let filler = cellPadding > 0 ? String(repeating: "x", count: cellPadding) : ""
         var lines = [
             "| \(header) |",
             "| \(alignment) |",
         ]
         for r in 0..<rows {
             let cells = (0..<columns)
-                .map { "s\(section)-r\(r)c\($0)" }
+                .map { "s\(section)-r\(r)c\($0)\(filler)" }
                 .joined(separator: " | ")
             lines.append("| \(cells) |")
         }
@@ -304,8 +310,9 @@ final class MarkdownRichContentPolicyTests: XCTestCase {
 
         // The aggregate rich budget engages for the whole response.
         XCTAssertTrue(MarkdownRichContentPolicy.needsBounding(blocks))
+        let units = MarkdownRichContentPolicy.richUnitsByBlock(blocks)
         let cut = MarkdownRichContentPolicy.gateCut(
-            blocks: blocks,
+            unitsByBlock: units,
             unitBudget: MarkdownRichContentPolicy.eagerRichUnitBudget
         )
         XCTAssertNotNil(cut)
@@ -316,8 +323,8 @@ final class MarkdownRichContentPolicyTests: XCTestCase {
         // Reveal batches eventually mount the whole response.
         XCTAssertNil(
             MarkdownRichContentPolicy.gateCut(
-                blocks: blocks,
-                unitBudget: MarkdownRichContentPolicy.totalRichUnits(blocks)
+                unitsByBlock: units,
+                unitBudget: MarkdownRichContentPolicy.totalRichUnits(units)
             )
         )
     }
@@ -325,23 +332,127 @@ final class MarkdownRichContentPolicyTests: XCTestCase {
     func testRevealBatchesProgressivelyCoverTheShowcase() {
         let source = MarkdownShowcaseFixtures.pathologicalShowcase()
         let blocks = MarkdownParser.parse(source)
+        let units = MarkdownRichContentPolicy.richUnitsByBlock(blocks)
 
         var lastCut = 0
         var budget = MarkdownRichContentPolicy.eagerRichUnitBudget
         var cuts: [Int] = []
-        while let cut = MarkdownRichContentPolicy.gateCut(blocks: blocks, unitBudget: budget) {
+        while let cut = MarkdownRichContentPolicy.gateCut(unitsByBlock: units, unitBudget: budget) {
             cuts.append(cut)
             lastCut = cut
-            budget += MarkdownRichContentPolicy.revealUnitBatch
+            budget = MarkdownRichContentPolicy.revealBudget(
+                unitsByBlock: units,
+                currentBudget: budget
+            )
             if cuts.count > 100 { XCTFail("reveal never completes"); break }
         }
         // Monotonically increasing mounts, ending with everything fitting.
         XCTAssertEqual(cuts.sorted(), cuts)
         XCTAssertGreaterThan(lastCut, 0)
         XCTAssertNil(
-            MarkdownRichContentPolicy.gateCut(blocks: blocks, unitBudget: budget),
+            MarkdownRichContentPolicy.gateCut(unitsByBlock: units, unitBudget: budget),
             "the final reveal state mounts every block"
         )
+    }
+
+    /// Item: reveal forward progress. A single gated block can cost more
+    /// than one reveal batch; one tap must still mount at least that block,
+    /// so the UI can never appear stuck.
+    func testRevealTapAdvancesPastBlockCostingMoreThanOneBatch() {
+        // Prefix that fills the eager budget, then ONE hugely expensive
+        // table (46 rows × 8 columns ≈ 6 units? no — make it expensive via
+        // a giant single-table unit cost: many complex tables in sequence
+        // is unrealistic; instead use code bytes, which scale without bound).
+        var blocks: [MarkdownBlock] = []
+        // ~16 units of ordinary tables (5×5 cells ≈ 25/64 → 1 unit each).
+        for index in 0..<16 {
+            blocks.append(.table(
+                headers: ["A", "B", "C", "D", "E"],
+                alignments: [.leading, .center, .trailing, .leading, .center],
+                rows: (0..<4).map { row in (0..<5).map { "r\(row)c\($0)-i\(index)" } }
+            ))
+        }
+        // One block worth many batches: 80_000 × 16 B ≈ 1.28 MB of code
+        // ≈ 160 units — far beyond one 16-unit reveal batch.
+        let giantCode = String(
+            repeating: "let value = 1;\n",
+            count: 80_000
+        )
+        blocks.append(.code(language: "swift", source: giantCode))
+        // More gated content after it, so the gate persists past the jump.
+        for index in 0..<3 {
+            blocks.append(.table(
+                headers: ["A", "B", "C", "D", "E"],
+                alignments: [.leading, .center, .trailing, .leading, .center],
+                rows: (0..<4).map { row in (0..<5).map { "after\(index)-r\(row)c\($0)" } }
+            ))
+        }
+        blocks.append(.divider)
+
+        let units = MarkdownRichContentPolicy.richUnitsByBlock(blocks)
+        XCTAssertGreaterThan(
+            units[16],
+            MarkdownRichContentPolicy.revealUnitBatch,
+            "the gated block must cost more than one reveal batch"
+        )
+
+        let firstCut = MarkdownRichContentPolicy.gateCut(
+            unitsByBlock: units,
+            unitBudget: MarkdownRichContentPolicy.eagerRichUnitBudget
+        )
+        XCTAssertEqual(firstCut, 16, "the gate sits exactly at the expensive block")
+
+        // One tap: the budget must advance far enough to INCLUDE it.
+        let nextBudget = MarkdownRichContentPolicy.revealBudget(
+            unitsByBlock: units,
+            currentBudget: MarkdownRichContentPolicy.eagerRichUnitBudget
+        )
+        let nextCut = MarkdownRichContentPolicy.gateCut(
+            unitsByBlock: units,
+            unitBudget: nextBudget
+        )
+        XCTAssertGreaterThan(
+            nextCut ?? 0,
+            firstCut ?? 0,
+            "one reveal tap must mount at least the expensive block"
+        )
+        // Bounded: the jump covers exactly that block, not the document.
+        XCTAssertEqual(nextCut, firstCut! + 1)
+    }
+
+    /// Item: the live tail is always mounted regardless of the reveal
+    /// budget — that is what keeps streaming content visible and makes the
+    /// streaming → settled transition non-collapsing.
+    func testLiveTailAlwaysMountedRegardlessOfBudget() {
+        let source = MarkdownShowcaseFixtures.pathologicalShowcase()
+        let blocks = MarkdownParser.parse(source)
+        let units = MarkdownRichContentPolicy.richUnitsByBlock(blocks)
+
+        let tail = MarkdownRichContentPolicy.liveTailStart(unitsByBlock: units)
+        XCTAssertGreaterThan(tail, 0, "pathological showcase has a real tail window")
+        // With a zero tail budget the tail is smallest but STILL covers the
+        // final block: the newest content is always mounted, whatever it
+        // costs. (Flow blocks cost nothing, so the zero-budget tail keeps
+        // every trailing zero-unit block and stops at the first rich one.)
+        let zeroTail = MarkdownRichContentPolicy.liveTailStart(unitsByBlock: units, unitBudget: 0)
+        XCTAssertLessThan(zeroTail, blocks.count, "the zero-budget tail still excludes earlier rich blocks")
+        XCTAssertLessThanOrEqual(tail, zeroTail, "a bigger tail budget only ever mounts more blocks")
+        // The hidden gap is what the reveal button accounts for: exactly
+        // the blocks between the mounted prefix and the tail.
+        let hidden = MarkdownRichContentPolicy.hiddenBlockCount(
+            unitsByBlock: units,
+            unitBudget: MarkdownRichContentPolicy.eagerRichUnitBudget
+        )
+        let cut = MarkdownRichContentPolicy.gateCut(
+            unitsByBlock: units,
+            unitBudget: MarkdownRichContentPolicy.eagerRichUnitBudget
+        ) ?? 0
+        XCTAssertEqual(
+            hidden,
+            tail - cut,
+            "hidden blocks are exactly the gap between prefix and tail"
+        )
+        XCTAssertGreaterThan(hidden, 0)
     }
 }
 
@@ -384,30 +495,44 @@ final class MarkdownRichContentHostedTests: XCTestCase {
     }
 
     /// Performance case 4: the <100 KB pathological showcase opens through
-    /// the bounded path — the eagerly mounted block set is the gate's
-    /// bounded prefix, not the whole response.
+    /// the bounded path — the eagerly mounted block set is exactly the
+    /// bounded prefix plus the always-visible live tail, never the whole
+    /// response.
     func testPathologicalShowcaseMountsBoundedBlockSet() throws {
         // Images excluded here: their web-backed fallbacks (WKWebView) add
         // process-level cost unsuitable for a unit-test window; the pure
         // budget tests cover image accounting.
         let source = MarkdownShowcaseFixtures.pathologicalShowcase(includeImages: false)
         let blocks = MarkdownParser.parse(source)
+        let units = MarkdownRichContentPolicy.richUnitsByBlock(blocks)
         XCTAssertFalse(MarkdownLargeDocumentPolicy.isLargeDocument(source))
-        XCTAssertTrue(MarkdownRichContentPolicy.needsBounding(blocks))
+        XCTAssertTrue(MarkdownRichContentPolicy.needsBounding(unitsByBlock: units))
 
         _ = mountMarkdown { MarkdownText(source: source) }
 
+        let cut = try XCTUnwrap(
+            MarkdownRichContentPolicy.gateCut(
+                unitsByBlock: units,
+                unitBudget: MarkdownRichContentPolicy.eagerRichUnitBudget
+            )
+        )
+        let tail = MarkdownRichContentPolicy.liveTailStart(unitsByBlock: units)
+        let expectedMounted = cut + (blocks.count - tail)
         let mounted = RichBudgetedMarkdownBody.debugMountedBlockCount
         XCTAssertEqual(
             mounted,
-            MarkdownRichContentPolicy.gateCut(
-                blocks: blocks,
-                unitBudget: MarkdownRichContentPolicy.eagerRichUnitBudget
-            )!,
-            "the hosted render mounts exactly the gate's bounded prefix"
+            expectedMounted,
+            "the hosted render mounts exactly the bounded prefix plus the live tail"
         )
+        // Bounded: well under the whole pathological response, even though
+        // the newest content stays visible.
         XCTAssertLessThan(mounted, blocks.count)
-        XCTAssertLessThan(mounted, blocks.count / 2)
+        XCTAssertLessThan(mounted, blocks.count * 3 / 5)
+        // The live tail really is the tail: the final block is mounted.
+        XCTAssertTrue(
+            RichBudgetedMarkdownBody.debugMountedBlockIndices.contains(blocks.count - 1),
+            "the newest block (streaming read position) must stay mounted"
+        )
     }
 
     /// Ordinary rich messages keep mounting everything (performance cases
@@ -427,20 +552,83 @@ final class MarkdownRichContentHostedTests: XCTestCase {
         XCTAssertGreaterThan(blocks.count, 5)
     }
 
-    /// While streaming, the gate is bypassed so the live tail can never sit
-    /// behind a reveal button; growth stays incremental per frame
-    /// (performance case 6 companion).
-    func testStreamingShowcaseBypassesTheGate() throws {
+    /// The streaming → settled transition never unmounts visible content:
+    /// the mounted set is derived from block structure and reveal budget
+    /// alone, so a response that was streaming mounts EXACTLY what the
+    /// settled render mounts — no collapse to the initial budget.
+    func testStreamingToSettledKeepsTheMountedSet() throws {
         let source = MarkdownShowcaseFixtures.pathologicalShowcase(sections: 6, includeImages: false)
         let blocks = MarkdownParser.parse(source)
-        XCTAssertTrue(MarkdownRichContentPolicy.needsBounding(blocks))
+        let units = MarkdownRichContentPolicy.richUnitsByBlock(blocks)
+        XCTAssertTrue(MarkdownRichContentPolicy.needsBounding(unitsByBlock: units))
 
         _ = mountMarkdown { MarkdownText(source: source, isStreaming: true) }
+        let streamingIndices = RichBudgetedMarkdownBody.debugMountedBlockIndices
+        XCTAssertFalse(streamingIndices.isEmpty)
+
+        _ = mountMarkdown { MarkdownText(source: source) }
+        let settledIndices = RichBudgetedMarkdownBody.debugMountedBlockIndices
 
         XCTAssertEqual(
-            RichBudgetedMarkdownBody.debugMountedBlockCount,
-            blocks.count,
-            "streaming renders through the ungated body"
+            settledIndices,
+            streamingIndices,
+            "settling must not unmount any block the streaming render showed"
         )
+        // And both are bounded: not the whole pathological response.
+        XCTAssertLessThan(streamingIndices.count, blocks.count)
+    }
+
+    /// Crossing the structural complexity threshold must not change whether
+    /// a fitting table fits: the paged LargeMarkdownTable resolves columns
+    /// from the same real container width as the ordinary MarkdownTable, so
+    /// a table that fits 390 pt keeps fitting (no horizontal scroll), while
+    /// a genuinely wide table still overflows and scrolls.
+    func testPagedTablePreservesViewportFitBehavior() throws {
+        // Complex by row count (46 rows), content whose ideal column widths
+        // exceed the container but SHRINK to fit when the real width is
+        // known. With the pre-fix unknown/zero width these columns capped
+        // instead of shrinking and the table became horizontally scrollable.
+        let fitting = MarkdownShowcaseFixtures.alignedTable(
+            section: 0, rows: 46, columns: 3, cellPadding: 24
+        )
+        _ = mountMarkdown { MarkdownText(source: fitting) }
+        let fittingWidth = try XCTUnwrap(widestLaidOutSubviewWidth())
+        XCTAssertLessThanOrEqual(
+            fittingWidth,
+            392,
+            "a table that fits the 390 pt container must keep fitting when paged"
+        )
+
+        // Genuinely wide table (8 columns of the same cells): must still
+        // overflow into horizontal scrolling.
+        let wide = MarkdownShowcaseFixtures.alignedTable(
+            section: 1, rows: 46, columns: 8, cellPadding: 24
+        )
+        _ = mountMarkdown { MarkdownText(source: wide) }
+        let wideWidth = try XCTUnwrap(widestLaidOutSubviewWidth())
+        XCTAssertGreaterThan(
+            wideWidth,
+            395,
+            "a genuinely wide table must still horizontally scroll"
+        )
+    }
+
+    /// Widest UIView frame in the currently hosted hierarchy — the honest
+    /// signal for "did table content overflow the container", since a
+    /// horizontal ScrollView's own frame always matches the proposal while
+    /// its content views lay out at natural width.
+    private func widestLaidOutSubviewWidth() -> CGFloat? {
+        guard let root = testWindow?.rootViewController?.view else { return nil }
+        var widest: CGFloat?
+        func walk(_ view: UIView) {
+            if view.frame.width > (widest ?? 0) {
+                widest = view.frame.width
+            }
+            for subview in view.subviews {
+                walk(subview)
+            }
+        }
+        walk(root)
+        return widest
     }
 }

--- a/ConduitTests/MarkdownRichContentTests.swift
+++ b/ConduitTests/MarkdownRichContentTests.swift
@@ -630,10 +630,15 @@ final class MarkdownRichContentHostedTests: XCTestCase {
         window.rootViewController = nil
         host?.view.removeFromSuperview()
 
-        // Drain until the hosted hierarchy is genuinely dismantled (its
-        // platform subviews are gone) or the bounded budget expires. CI
-        // runners are far slower than a dev Mac, so the budget is
-        /// generous while the early exit keeps fast machines quick.
+        // Completion signal: the hosting view's SwiftUI subviews are
+        // gone. NOTE: controller DEALLOCATION was tried as the signal
+        // and is empirically unsound here — SwiftUI retains the hosting
+        // controller internally well past any reasonable budget, so a
+        // deallocation wait always expires (and an assert on it always
+        // fails) even though the deferred teardown work has long since
+        // completed. Subview dismantling is the observable that tracks
+        // the actual teardown work and completes promptly (verified
+        // locally and on CI).
         let deadline = Date().addingTimeInterval(1.5)
         while Date() < deadline {
             RunLoop.current.run(until: Date().addingTimeInterval(0.05))

--- a/ConduitTests/MarkdownRichContentTests.swift
+++ b/ConduitTests/MarkdownRichContentTests.swift
@@ -594,6 +594,7 @@ final class MarkdownRichContentHostedTests: XCTestCase {
     /// Retained for the full lifetime of each measurement so the hosted
     /// hierarchy stays genuinely mounted; torn down explicitly per test.
     private var testWindow: UIWindow?
+    private var testHost: UIHostingController<MarkdownText>?
 
     override func setUp() {
         super.setUp()
@@ -607,21 +608,39 @@ final class MarkdownRichContentHostedTests: XCTestCase {
     }
 
     /// Deterministically tears down the current hosted window INSIDE this
-    /// test. A bare zero-length run-loop pass does not let the hosting
-    /// controller's appearance transition complete; dropping the window
-    /// reference mid-transition defers that teardown into whichever suite
-    /// runs next, where each leftover transition logs an unbalanced-
-    /// appearance warning and starves XCTest main-queue waits (CI #384:
+    /// test. Hiding a window and dropping the reference leaves the
+    /// UIHostingController's appearance transition PENDING: the deferred
+    /// work lands in whichever suite runs next, where each leftover
+    /// transition logs an unbalanced-appearance warning and — on a slow
+    /// CI runner processing a whole batch of them — saturates the main
+    /// thread long enough to starve XCTest main-queue waits (CI #384/#385:
     /// MarkdownTableLayoutTests' 2 s "width probe settles" expectation
-    /// timed out under a stack of these). Draining a few real animation
-    /// ticks keeps the whole lifecycle inside this suite. This is
-    /// deterministic synchronization, not a padded delay.
+    /// timed out under a stack of these). The teardown therefore:
+    ///   1. removes the hosted view from the window SYNCHRONOUSLY
+    ///      (forcing the appearance transition to begin now, not later),
+    ///   2. detaches the root view controller, and
+    ///   3. drains the run loop until the hosting view's SwiftUI
+    ///      subview hierarchy is actually dismantled (bounded).
+    /// Draining to an observed completion signal is deterministic
+    /// synchronization, not a padded delay.
     private func dismountCurrentWindow() {
         guard let window = testWindow else { return }
+        let host = testHost
         window.isHidden = true
         window.rootViewController = nil
-        RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        host?.view.removeFromSuperview()
+
+        // Drain until the hosted hierarchy is genuinely dismantled (its
+        // platform subviews are gone) or the bounded budget expires. CI
+        // runners are far slower than a dev Mac, so the budget is
+        /// generous while the early exit keeps fast machines quick.
+        let deadline = Date().addingTimeInterval(1.5)
+        while Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+            if let host, host.view.subviews.isEmpty { break }
+        }
         testWindow = nil
+        testHost = nil
     }
 
     /// Hosts one MarkdownText in a phone-sized window and lets the first
@@ -637,6 +656,7 @@ final class MarkdownRichContentHostedTests: XCTestCase {
         window.rootViewController = host
         window.isHidden = false
         testWindow = window
+        testHost = host
         host.view.setNeedsLayout()
         host.view.layoutIfNeeded()
         RunLoop.current.run(until: Date())
@@ -829,17 +849,30 @@ final class MarkdownRichContentHostedTests: XCTestCase {
         )
     }
 
-    /// Hosted live-tail regression through the REAL reveal button: with
-    /// 60 tables (cut 16 < tail 44 initially), repeated Continue Reading
-    /// taps must only ever ADD mounted blocks — including across the
+    /// Hosted live-tail regression through the REAL reveal action: with
+    /// 30 tables (cut < tail initially), repeated Continue Reading taps
+    /// must only ever ADD mounted blocks — including across the
     /// cut == tail and cut > tail transitions — and the footer must
-    /// disappear exactly when the hidden gap is gone.
+    /// disappear exactly when the hidden gap is gone. Kept small on
+    /// purpose: the fully revealed state is the most expensive teardown
+    /// this suite defers, and CI runners process deferred teardowns far
+    /// slower than a dev Mac (see dismountCurrentWindow).
     func testHostedRevealNeverRetractsTailAndFooterDisappearsWhenRevealed() throws {
-        let source = (0..<60).map { index in
+        let source = (0..<36).map { index in
             "Section \(index) intro paragraph.\n\n"
                 + MarkdownShowcaseFixtures.alignedTable(section: index, rows: 4, columns: 5)
         }.joined(separator: "\n\n")
         let blocks = MarkdownParser.parse(source)
+        let units = MarkdownRichContentPolicy.richUnitsByBlock(blocks)
+        // Precondition: the fixture must start GATED (cut < tail) so the
+        // reveal progression really crosses cut == tail and cut > tail.
+        let initialPlan = MarkdownRichContentPolicy.mountedPlan(
+            unitsByBlock: units,
+            unitBudget: MarkdownRichContentPolicy.eagerRichUnitBudget
+        )
+        guard case .split = initialPlan else {
+            return XCTFail("fixture must start gated: \(initialPlan)")
+        }
 
         _ = mountMarkdown { MarkdownText(source: source) }
 

--- a/ConduitTests/MarkdownRichContentTests.swift
+++ b/ConduitTests/MarkdownRichContentTests.swift
@@ -454,6 +454,137 @@ final class MarkdownRichContentPolicyTests: XCTestCase {
         )
         XCTAssertGreaterThan(hidden, 0)
     }
+    /// Review item: mounted-plan union semantics. The live tail must
+    /// stay mounted in EVERY gate state; the ranges must never overlap;
+    /// the footer must exist IFF a strictly positive hidden gap exists.
+    /// Uses the SAME shared plan the production body renders from, so a
+    /// regression here is a regression in the view.
+    func testMountedPlanKeepsTailInEveryGateState() throws {
+        // Uniform 1-unit blocks make every threshold exact:
+        // gateCut = 16 (first index where cumulative > 16),
+        // liveTailStart = count - 16 (clamped so the final block always
+        // stays mounted).
+        func units(_ count: Int) -> [Int] { Array(repeating: 1, count: count) }
+
+        // Case A: cut < tail (60 blocks: cut 16, tail 44) — real gap.
+        XCTAssertEqual(
+            MarkdownRichContentPolicy.mountedPlan(
+                unitsByBlock: units(60),
+                unitBudget: MarkdownRichContentPolicy.eagerRichUnitBudget
+            ),
+            .split(prefixEnd: 16, tailStart: 44),
+            "60 uniform blocks must produce the split plan 0..<16 + 44..<60"
+        )
+        let splitPlan = MarkdownRichContentPolicy.RichMountedPlan.split(prefixEnd: 16, tailStart: 44)
+        XCTAssertEqual(
+            MarkdownRichContentPolicy.mountedIndices(plan: splitPlan, totalBlocks: 60),
+            Array(0..<16) + Array(44..<60)
+        )
+
+        // Case B: cut == tail (32 blocks: cut 16, tail 16) — empty gap
+        // collapses to ONE contiguous range covering the tail.
+        XCTAssertEqual(
+            MarkdownRichContentPolicy.mountedPlan(
+                unitsByBlock: units(32),
+                unitBudget: MarkdownRichContentPolicy.eagerRichUnitBudget
+            ),
+            .contiguous(end: 32),
+            "cut == tail must mount everything once, keeping the tail"
+        )
+
+        // Case C: cut > tail (30 blocks: cut 16, tail 14) — the prefix
+        // has overlapped the tail; still one contiguous range.
+        XCTAssertEqual(
+            MarkdownRichContentPolicy.mountedPlan(
+                unitsByBlock: units(30),
+                unitBudget: MarkdownRichContentPolicy.eagerRichUnitBudget
+            ),
+            .contiguous(end: 30),
+            "cut > tail must mount everything once, never unmounting the tail"
+        )
+
+        // Case D: cut == nil (15 blocks fit the eager budget) — ungated.
+        XCTAssertEqual(
+            MarkdownRichContentPolicy.mountedPlan(
+                unitsByBlock: units(15),
+                unitBudget: MarkdownRichContentPolicy.eagerRichUnitBudget
+            ),
+            .contiguous(end: 15),
+            "an ungated message mounts everything once with no footer"
+        )
+    }
+
+    /// The footer exists IFF a strictly positive hidden gap exists, and
+    /// reveal progression is monotonic: every larger budget mounts a
+    /// superset, the newest block is always included, and no index ever
+    /// appears twice.
+    func testMountedPlanRevealMonotonicityAndNoDuplicates() {
+        let count = 60
+        let unitVector = Array(repeating: 1, count: count)
+        var previous: Set<Int> = []
+        var sawFooter = false
+        var sawFooterless = false
+        var budget = MarkdownRichContentPolicy.eagerRichUnitBudget
+        for _ in 0..<20 {
+            let plan = MarkdownRichContentPolicy.mountedPlan(
+                unitsByBlock: unitVector,
+                unitBudget: budget
+            )
+            let indices = MarkdownRichContentPolicy.mountedIndices(
+                plan: plan,
+                totalBlocks: count
+            )
+            let mounted = Set(indices)
+            XCTAssertEqual(mounted.count, indices.count, "no duplicate mounts")
+            XCTAssertTrue(mounted.isSuperset(of: previous), "reveal only adds blocks")
+            XCTAssertTrue(mounted.contains(count - 1), "the newest block stays mounted")
+            switch plan {
+            case .split(let prefixEnd, let tailStart):
+                XCTAssertGreaterThan(tailStart - prefixEnd, 0, "split implies a real gap")
+                sawFooter = true
+            case .contiguous:
+                sawFooterless = true
+            }
+            previous = mounted
+            if case .contiguous(let end) = plan, end == count { break }
+            budget = MarkdownRichContentPolicy.revealBudget(
+                unitsByBlock: unitVector,
+                currentBudget: budget
+            )
+        }
+        XCTAssertTrue(sawFooter, "the progression must pass through a gated state")
+        XCTAssertTrue(sawFooterless, "the progression must reach a fully revealed state")
+    }
+
+    /// Review item: budgetToInclude bounds. index == count must be
+    /// rejected (the inclusive walk would read past the end); the valid
+    /// final index still computes exactly.
+    func testBudgetToIncludeBoundsContract() {
+        let unitVector = Array(repeating: 4, count: 10)
+
+        // Invalid: one past the end.
+        XCTAssertEqual(
+            MarkdownRichContentPolicy.budgetToInclude(unitsByBlock: unitVector, index: 10),
+            MarkdownRichContentPolicy.eagerRichUnitBudget,
+            "index == count is out of contract and falls back"
+        )
+        // Invalid: zero and negative.
+        XCTAssertEqual(
+            MarkdownRichContentPolicy.budgetToInclude(unitsByBlock: unitVector, index: 0),
+            MarkdownRichContentPolicy.eagerRichUnitBudget
+        )
+        // Valid final index: cumulative 10 × 4 = 40.
+        XCTAssertEqual(
+            MarkdownRichContentPolicy.budgetToInclude(unitsByBlock: unitVector, index: 9),
+            40,
+            "the valid last index still computes the inclusive sum"
+        )
+        // Valid interior index.
+        XCTAssertEqual(
+            MarkdownRichContentPolicy.budgetToInclude(unitsByBlock: unitVector, index: 3),
+            16
+        )
+    }
 }
 
 // MARK: - Hosted rendering tests
@@ -470,19 +601,37 @@ final class MarkdownRichContentHostedTests: XCTestCase {
     }
 
     override func tearDown() {
-        testWindow?.isHidden = true
-        testWindow?.rootViewController = nil
-        RunLoop.current.run(until: Date())
-        testWindow = nil
+        dismountCurrentWindow()
         RichBudgetedMarkdownBody.resetDebugInstrumentation()
         super.tearDown()
     }
 
+    /// Deterministically tears down the current hosted window INSIDE this
+    /// test. A bare zero-length run-loop pass does not let the hosting
+    /// controller's appearance transition complete; dropping the window
+    /// reference mid-transition defers that teardown into whichever suite
+    /// runs next, where each leftover transition logs an unbalanced-
+    /// appearance warning and starves XCTest main-queue waits (CI #384:
+    /// MarkdownTableLayoutTests' 2 s "width probe settles" expectation
+    /// timed out under a stack of these). Draining a few real animation
+    /// ticks keeps the whole lifecycle inside this suite. This is
+    /// deterministic synchronization, not a padded delay.
+    private func dismountCurrentWindow() {
+        guard let window = testWindow else { return }
+        window.isHidden = true
+        window.rootViewController = nil
+        RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        testWindow = nil
+    }
+
     /// Hosts one MarkdownText in a phone-sized window and lets the first
-    /// layout pass (the one the watchdog used to die in) complete.
+    /// layout pass (the one the watchdog used to die in) complete. Any
+    /// previously mounted window is dismounted first so sequential mounts
+    /// never drop a live window mid-transition.
     private func mountMarkdown(
         _ makeView: () -> MarkdownText
     ) -> UIHostingController<MarkdownText> {
+        dismountCurrentWindow()
         let host = UIHostingController(rootView: makeView())
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
         window.rootViewController = host
@@ -492,6 +641,27 @@ final class MarkdownRichContentHostedTests: XCTestCase {
         host.view.layoutIfNeeded()
         RunLoop.current.run(until: Date())
         return host
+    }
+
+    /// Advances the reveal through the production action: the DEBUG-only
+    /// notification inlet on RichBudgetedMarkdownBody invokes the EXACT
+    /// advanceReveal() method the footer button executes (SwiftUI
+    /// Buttons expose neither a UIControl bridge nor a reachable
+    /// accessibility-activation surface to unit tests, so the inlet is
+    /// the faithful deterministic path).
+    private func advanceRevealThroughProductionPath() {
+        NotificationCenter.default.post(
+            name: RichBudgetedMarkdownBody.advanceRevealForTesting,
+            object: nil
+        )
+        // Let the SwiftUI state update commit and re-render, then force
+        // the layout pass so the recorded instrumentation reflects it.
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        if let root = testWindow?.rootViewController?.view {
+            root.setNeedsLayout()
+            root.layoutIfNeeded()
+        }
+        RunLoop.current.run(until: Date())
     }
 
     /// Performance case 4: the <100 KB pathological showcase opens through
@@ -631,4 +801,115 @@ final class MarkdownRichContentHostedTests: XCTestCase {
         walk(root)
         return widest
     }
+    /// Hosted live-tail regression: when the reveal cut starts PAST the
+    /// tail boundary (30 moderate tables: cut 16 > tail 14), the union
+    /// must still mount EVERY block exactly once — the pre-fix body
+    /// dropped the tail entirely in this state (mounted 0..<16 only,
+    /// losing the newest blocks) and showed no path to them.
+    func testHostedCutBeyondTailKeepsNewestBlocksMounted() throws {
+        let source = (0..<30).map { index in
+            "Section \(index) intro paragraph.\n\n"
+                + MarkdownShowcaseFixtures.alignedTable(section: index, rows: 4, columns: 5)
+        }.joined(separator: "\n\n")
+        let blocks = MarkdownParser.parse(source)
+        XCTAssertEqual(blocks.count, 60, "30 paragraphs + 30 tables")
+
+        _ = mountMarkdown { MarkdownText(source: source) }
+
+        let mounted = RichBudgetedMarkdownBody.debugMountedBlockIndices
+        XCTAssertEqual(
+            Set(mounted).count,
+            mounted.count,
+            "no block may be mounted twice when prefix and tail overlap"
+        )
+        XCTAssertEqual(mounted.count, blocks.count, "cut > tail mounts everything once")
+        XCTAssertTrue(
+            mounted.contains(blocks.count - 1),
+            "the newest block must stay mounted when the cut passes the tail"
+        )
+    }
+
+    /// Hosted live-tail regression through the REAL reveal button: with
+    /// 60 tables (cut 16 < tail 44 initially), repeated Continue Reading
+    /// taps must only ever ADD mounted blocks — including across the
+    /// cut == tail and cut > tail transitions — and the footer must
+    /// disappear exactly when the hidden gap is gone.
+    func testHostedRevealNeverRetractsTailAndFooterDisappearsWhenRevealed() throws {
+        let source = (0..<60).map { index in
+            "Section \(index) intro paragraph.\n\n"
+                + MarkdownShowcaseFixtures.alignedTable(section: index, rows: 4, columns: 5)
+        }.joined(separator: "\n\n")
+        let blocks = MarkdownParser.parse(source)
+
+        _ = mountMarkdown { MarkdownText(source: source) }
+
+        var previous = Set(RichBudgetedMarkdownBody.debugMountedBlockIndices)
+        XCTAssertTrue(
+            previous.contains(blocks.count - 1),
+            "the newest block is mounted from the start (live tail)"
+        )
+        // Initially gated: fewer than all blocks mounted, footer present.
+        XCTAssertLessThan(previous.count, blocks.count)
+
+        XCTAssertTrue(
+            RichBudgetedMarkdownBody.debugFooterVisible,
+            "the footer is shown while a hidden gap exists"
+        )
+
+        var taps = 0
+        while previous.count < blocks.count {
+            advanceRevealThroughProductionPath()
+            taps += 1
+            let mounted = Set(RichBudgetedMarkdownBody.debugMountedBlockIndices)
+            XCTAssertEqual(
+                mounted.count,
+                RichBudgetedMarkdownBody.debugMountedBlockIndices.count,
+                "no duplicate mounts across the overlap transition"
+            )
+            XCTAssertTrue(
+                mounted.isSuperset(of: previous),
+                "a reveal tap must never retract mounted content (tap \(taps))"
+            )
+            XCTAssertTrue(
+                mounted.contains(blocks.count - 1),
+                "the newest block stays mounted through every tap"
+            )
+            previous = mounted
+            if taps > 20 { XCTFail("reveal never completes"); break }
+        }
+
+        // Fully revealed: footer is gone and the mounted set is exactly
+        // everything, once.
+        XCTAssertEqual(previous.count, blocks.count)
+        XCTAssertFalse(
+            RichBudgetedMarkdownBody.debugFooterVisible,
+            "the footer must disappear once no hidden gap remains"
+        )
+    }
+
+    /// Hosted: the streaming -> settled transition does not reduce the
+    /// mounted newest content when the gate sits beyond the tail
+    /// boundary — the exact state the pre-fix union computation broke.
+    func testHostedStreamingToSettledBeyondTailKeepsNewestMounted() throws {
+        let source = (0..<30).map { index in
+            "Section \(index) intro paragraph.\n\n"
+                + MarkdownShowcaseFixtures.alignedTable(section: index, rows: 4, columns: 5)
+        }.joined(separator: "\n\n")
+        let blocks = MarkdownParser.parse(source)
+
+        _ = mountMarkdown { MarkdownText(source: source, isStreaming: true) }
+        let streaming = Set(RichBudgetedMarkdownBody.debugMountedBlockIndices)
+
+        _ = mountMarkdown { MarkdownText(source: source) }
+        let settled = Set(RichBudgetedMarkdownBody.debugMountedBlockIndices)
+
+        XCTAssertEqual(
+            settled,
+            streaming,
+            "settling must not reduce the mounted set in the beyond-tail gate state"
+        )
+        XCTAssertEqual(settled.count, blocks.count)
+        XCTAssertTrue(settled.contains(blocks.count - 1))
+    }
+
 }


### PR DESCRIPTION
## Problem

Conduit still watchdog-crashes (TestFlight: `EXC_CRASH / SIGKILL`, `FRONTBOARD 0x8BADF00D`, scene-update watchdog, main thread inside `AG::Graph::UpdateStack::update() → ScrollViewCommitMutation`) when opening a session containing a single Markdown-heavy response — tables, table alignment, Mermaid diagrams, images, math, code fences, lists/quotes. The response is comfortably **below** the 100 KB large-document threshold, so PR #88's protections never engage, and PR #89's transcript optimizations must be preserved.

## Root causes

1. **Byte count was the only selector for rich-content protection.** Every #88 guard (paged tables, Mermaid/math guards, sliced code) lived behind `isLargeDocument(source) >= 100_000` bytes. A ~60 KB showcase with 18 tables / 18 Mermaid blocks took the ordinary path and eagerly mounted thousands of TextKit cell views (one `SelectableTextView` per cell, plus per-cell width measurement) and synchronous syntax highlighting — one effectively unbounded main-thread layout transaction.
2. **Synchronous geometry → scrollTo feedback amplifier.** `layoutMetricsChanged` emitted a synchronous `proxy.scrollTo` **per geometry preference callback** (bottom marker, viewport frame, row frames — 3+ per layout cycle) while `.followingLatest`. Each scroll committed a `ScrollViewCommitMutation`, re-fired preferences, re-emitted scrolls. With rich content whose intrinsic height settles repeatedly this looped inside layout (measured reproduction: 7 scrolls in 44 ms).
3. **Spurious nil→nil "session switch"** (found during the fix): `areEquivalent(nil, nil)` is false, so the first appearance of a session-less transcript issued an animated full-transcript scroll + 150 ms retry whose in-flight animation fought the follow pipeline.

## Changes

- **Block-local bounding** (`MarkdownText.swift`): structurally complex tables — ≥40 rows, ≥200 header+row cells, or ≥32 KB of table source — use the paged `LargeMarkdownTable` presentation (bounded column measurement on a sampled prefix + explicit row batches) through the shared `MarkdownTableRowView`, so appearance and selection match either way. The #88 Mermaid (>100 KB), math (>100 KB), and code (≥32 KB) guards now apply to the block itself wherever it renders, via pure `MarkdownBlockView.codePresentation` / `mathNeedsGuard` routing shared with large-document mode (deduplicated from `largeBlockView`).
- **Message-level rich-layout budget** (new `MarkdownRichContent.swift`): aggregate rich units (table cells ÷64, web-backed images ×2, code bytes ÷8 KB, math 1 each) over 16 units mount progressively — bounded initial batch + "Continue reading" reveal (+16 units, the #88 footer UX) — through `RichBudgetedMarkdownBody` with identical block rendering and up-front selection descriptors. Streaming bypasses the gate (per-frame growth is a small delta; the live tail must stay visible); plain prose never enters it (single selectable text view). `documentThresholdBytes` is unchanged.
- **Coalesced follow corrections** (`ChatViewportController.swift` + `ChatView.swift`): at most **one** outstanding correction per unsettled layout cycle — later geometry ticks update facts but never enqueue duplicates. Execution rides the SwiftUI update turn that the scheduling state change created (`onChange` of `pendingFollowCorrection`): never inside the geometry preference callback (the storm), never as a standalone MainActor task (a separate transaction re-materializes lazy rows — this is what initially broke the #89 transcript fixtures). At due time it re-validates against the newest facts and either scrolls once or dies silently. Re-arm requires >12 pt of genuinely new content beyond the last corrected bottom (ratcheting to the settled position), so the correction rate is bounded by content growth, not geometry callbacks. Animated transcript reasserts supersede pending corrections and own a flight window; ownership moves (drag, session switch, handoff, explicit commands, disappearance) clear them; relatch re-allows a flush pin.

## Preserved

- Normal live-streaming follow, upward scrolling without drag-back, restoration, and all #89 transcript optimizations (`TranscriptPerformanceFixtureTests` green, unchanged).
- All #88 large-document behavior (`MarkdownLargeDocumentTests` green; the byte rule survives inside `isComplexTable`).
- Ordinary rich Markdown rendering is visually unchanged (ordinary messages never reach the budget path — asserted by tests).

## Tests

- **New fixtures/tests** (`MarkdownRichContentTests.swift`): deterministic <100 KB showcase (18 aligned tables, 18 Mermaid diagrams, math, code, images; asserted 35–100 KB and non-large); table complexity by rows/cells/bytes; Mermaid/math/code guards per block; ordinary messages under budget; hosted renders proving the showcase mounts exactly the gate's bounded prefix (<½ of ~190 blocks) while ordinary/streaming bodies mount ungated.
- **New hosted ChatView regressions** (`ChatViewFollowCorrectionTests.swift`): one content-growth event produces a bounded handful of corrections — never one scrollTo per geometry callback; settled layout churn produces zero.
- **New pure coalescing tests** (10 in `ChatViewportControllerTests.swift`): one-correction-per-cycle with latest facts, drift-resolved death, ownership-move deaths, re-arm on genuinely new growth, stale-token death, unchanged-bottom non-re-arm, relatch flush pin, transcript-reassert supersession.
- **Updated (documented in-code):** six viewport tests that expected one synchronous scroll per geometry tick now expect schedule-then-drain with exactly one command per cycle.

## Validation

- Full suite: **57/57 suites passed**, 0 failures / hangs / stalls / uncovered (256 s); a second full run reconstructed from batch logs: 8/8 batches `TEST EXECUTE SUCCEEDED`.
- Baseline controls: the #89 transcript suite passes deterministically on unmodified `fb70768` (run twice), so the final state is a genuine fix rather than tuned luck.

## Follow-up candidates

1. Cap/pool WKWebView image fallbacks per response (images are budget-weighted but each failure still mounts a web view when revealed).
2. Migrate ordinary `ChatCodeBlock` highlighting off-main (mount count is bounded; highlighting is still synchronous).
3. Split flow-through vs rich-gated reveal for pathological-only polish.
4. 12 pt regrowth tolerance is tunable if QA wants tighter streaming pin.
5. Transcript windowing remains worthwhile defense-in-depth (explicitly out of scope here).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat scrolling during streaming, content growth, and shrinkage, reducing duplicate or outdated adjustments.
  - Prevented unexpected viewport movement during dragging, restoration, handoffs, and rapid content changes.
  - Improved stability as streaming content settles.
  - Improved rendering and sizing of complex Markdown tables, code, math, and Mermaid content.

- **New Features**
  - Added progressive rendering for very large or structurally complex Markdown content.
  - Large rich-text responses now load in bounded batches while keeping the newest content visible.
  - Improved table sizing based on available screen space, reducing unnecessary horizontal scrolling.
  - Preserved the newest streamed content while earlier content is progressively revealed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->