### PR TITLE
feat: add native Kanban support

### DIFF
--- a/Conduit/Models/KanbanModels.swift
+++ b/Conduit/Models/KanbanModels.swift
@@ -12,7 +12,12 @@ private extension KeyedDecodingContainer {
 
     func decodeLossyInt(forKey key: Key) -> Int? {
         if let value = try? decode(Int.self, forKey: key) { return value }
-        if let value = try? decode(Double.self, forKey: key) { return Int(value) }
+        // Doubles must be finite and exactly representable; a fractional or
+        // huge value decodes as nil instead of silently truncating (or
+        // crashing on architectures where the cast traps).
+        if let value = try? decode(Double.self, forKey: key), value.isFinite, let exact = Int(exactly: value.rounded(.towardZero)) {
+            return exact
+        }
         if let value = try? decode(String.self, forKey: key) { return Int(value) }
         return nil
     }

--- a/Conduit/Models/KanbanModels.swift
+++ b/Conduit/Models/KanbanModels.swift
@@ -15,7 +15,10 @@ private extension KeyedDecodingContainer {
         // Doubles must be finite and exactly representable; a fractional or
         // huge value decodes as nil instead of silently truncating (or
         // crashing on architectures where the cast traps).
-        if let value = try? decode(Double.self, forKey: key), value.isFinite, let exact = Int(exactly: value.rounded(.towardZero)) {
+        if let value = try? decode(Double.self, forKey: key) {
+            // Exact integers only: finite AND integral. Fractional values
+            // (2.5), NaN, and overflow decode as nil instead of truncating.
+            guard value.isFinite, let exact = Int(exactly: value) else { return nil }
             return exact
         }
         if let value = try? decode(String.self, forKey: key) { return Int(value) }
@@ -233,7 +236,11 @@ struct KanbanColumn: Codable, Equatable, Identifiable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         name = (try? container.decode(String.self, forKey: .name)) ?? "unknown"
-        tasks = (try? container.decode([KanbanTask].self, forKey: .tasks)) ?? []
+        // Lossily decode every row, but DROP rows without an identity: two
+        // id-less tasks would collide on "" inside SwiftUI ForEach and the
+        // service rejects empty IDs anyway, so they can never be actionable.
+        let rawTasks = (try? container.decodeIfPresent([KanbanTask].self, forKey: .tasks)) ?? []
+        tasks = rawTasks.filter { !$0.id.isEmpty }
     }
 }
 

--- a/Conduit/Models/KanbanModels.swift
+++ b/Conduit/Models/KanbanModels.swift
@@ -1,0 +1,765 @@
+import Foundation
+
+// MARK: - Defensive JSON helpers
+
+private extension KeyedDecodingContainer {
+    func decodeLossyString(forKey key: Key) -> String? {
+        if let value = try? decode(String.self, forKey: key) { return value }
+        if let value = try? decode(Int.self, forKey: key) { return String(value) }
+        if let value = try? decode(Double.self, forKey: key) { return String(value) }
+        return nil
+    }
+
+    func decodeLossyInt(forKey key: Key) -> Int? {
+        if let value = try? decode(Int.self, forKey: key) { return value }
+        if let value = try? decode(Double.self, forKey: key) { return Int(value) }
+        if let value = try? decode(String.self, forKey: key) { return Int(value) }
+        return nil
+    }
+}
+
+// MARK: - Board and task models
+
+struct KanbanTaskWarnings: Codable, Equatable {
+    var count: Int = 0
+    var highestSeverity: String?
+
+    enum CodingKeys: String, CodingKey {
+        case count
+        case highestSeverity = "highest_severity"
+    }
+}
+
+struct KanbanLinkCounts: Codable, Equatable {
+    var parents: Int = 0
+    var children: Int = 0
+}
+
+struct KanbanProgress: Codable, Equatable {
+    var done: Int = 0
+    var total: Int = 0
+}
+
+struct KanbanDiagnosticAction: Codable, Equatable {
+    var kind: String
+    var label: String
+    var payload: [String: AnyCodable]?
+    var suggested: Bool?
+}
+
+struct KanbanDiagnostic: Codable, Equatable {
+    var kind: String
+    var severity: String
+    var title: String
+    var detail: String
+    var actions: [KanbanDiagnosticAction]
+    var count: Int
+    var lastSeenAt: Int?
+    var data: [String: AnyCodable]?
+
+    enum CodingKeys: String, CodingKey {
+        case kind, severity, title, detail, actions, count, data
+        case lastSeenAt = "last_seen_at"
+    }
+}
+
+/// The small, UI-facing slice of a Kanban task returned by the backend.
+/// Unknown backend fields are intentionally ignored so schema additions remain safe.
+struct KanbanTask: Codable, Identifiable, Equatable {
+    let id: String
+    var title: String
+    var body: String?
+    var status: String
+    var assignee: String?
+    var priority: Int?
+    var tenant: String?
+    var createdAt: Int?
+    var latestSummary: String?
+    var commentCount: Int?
+    var linkCounts: KanbanLinkCounts?
+    var progress: KanbanProgress?
+    var warnings: KanbanTaskWarnings?
+    var startedAt: Int?
+    var workerPid: Int?
+    var lastHeartbeatAt: Int?
+
+    // Detail-only fields. Keeping them on the same value type lets the board
+    // and drawer share one decoder while preserving the backend's flat shape.
+    var result: String?
+    var createdBy: String?
+    var modelOverride: String?
+    var providerOverride: String?
+    var reasoningEffort: String?
+    var completedAt: Int?
+    var lastFailureError: String?
+    var workspaceKind: String?
+    var workspacePath: String?
+    var branchName: String?
+    var consecutiveFailures: Int?
+    var diagnostics: [KanbanDiagnostic]?
+
+    enum CodingKeys: String, CodingKey {
+        case id, title, body, status, assignee, priority, tenant
+        case createdAt = "created_at"
+        case latestSummary = "latest_summary"
+        case commentCount = "comment_count"
+        case linkCounts = "link_counts"
+        case progress, warnings
+        case startedAt = "started_at"
+        case workerPid = "worker_pid"
+        case lastHeartbeatAt = "last_heartbeat_at"
+        case result
+        case createdBy = "created_by"
+        case modelOverride = "model_override"
+        case providerOverride = "provider_override"
+        case reasoningEffort = "reasoning_effort"
+        case completedAt = "completed_at"
+        case lastFailureError = "last_failure_error"
+        case workspaceKind = "workspace_kind"
+        case workspacePath = "workspace_path"
+        case branchName = "branch_name"
+        case consecutiveFailures = "consecutive_failures"
+        case diagnostics
+    }
+
+    init(
+        id: String,
+        title: String,
+        body: String? = nil,
+        status: String,
+        assignee: String? = nil,
+        priority: Int? = nil,
+        tenant: String? = nil,
+        createdAt: Int? = nil,
+        latestSummary: String? = nil,
+        commentCount: Int? = nil,
+        linkCounts: KanbanLinkCounts? = nil,
+        progress: KanbanProgress? = nil,
+        warnings: KanbanTaskWarnings? = nil,
+        startedAt: Int? = nil,
+        workerPid: Int? = nil,
+        lastHeartbeatAt: Int? = nil,
+        result: String? = nil,
+        createdBy: String? = nil,
+        modelOverride: String? = nil,
+        providerOverride: String? = nil,
+        reasoningEffort: String? = nil,
+        completedAt: Int? = nil,
+        lastFailureError: String? = nil,
+        workspaceKind: String? = nil,
+        workspacePath: String? = nil,
+        branchName: String? = nil,
+        consecutiveFailures: Int? = nil,
+        diagnostics: [KanbanDiagnostic]? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.body = body
+        self.status = status
+        self.assignee = assignee
+        self.priority = priority
+        self.tenant = tenant
+        self.createdAt = createdAt
+        self.latestSummary = latestSummary
+        self.commentCount = commentCount
+        self.linkCounts = linkCounts
+        self.progress = progress
+        self.warnings = warnings
+        self.startedAt = startedAt
+        self.workerPid = workerPid
+        self.lastHeartbeatAt = lastHeartbeatAt
+        self.result = result
+        self.createdBy = createdBy
+        self.modelOverride = modelOverride
+        self.providerOverride = providerOverride
+        self.reasoningEffort = reasoningEffort
+        self.completedAt = completedAt
+        self.lastFailureError = lastFailureError
+        self.workspaceKind = workspaceKind
+        self.workspacePath = workspacePath
+        self.branchName = branchName
+        self.consecutiveFailures = consecutiveFailures
+        self.diagnostics = diagnostics
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = container.decodeLossyString(forKey: .id) ?? ""
+        title = (try? container.decode(String.self, forKey: .title)) ?? "Untitled task"
+        body = try? container.decodeIfPresent(String.self, forKey: .body)
+        status = (try? container.decode(String.self, forKey: .status)) ?? "todo"
+        assignee = try? container.decodeIfPresent(String.self, forKey: .assignee)
+        priority = container.decodeLossyInt(forKey: .priority)
+        tenant = try? container.decodeIfPresent(String.self, forKey: .tenant)
+        createdAt = container.decodeLossyInt(forKey: .createdAt)
+        latestSummary = try? container.decodeIfPresent(String.self, forKey: .latestSummary)
+        commentCount = container.decodeLossyInt(forKey: .commentCount)
+        linkCounts = try? container.decodeIfPresent(KanbanLinkCounts.self, forKey: .linkCounts)
+        progress = try? container.decodeIfPresent(KanbanProgress.self, forKey: .progress)
+        warnings = try? container.decodeIfPresent(KanbanTaskWarnings.self, forKey: .warnings)
+        startedAt = container.decodeLossyInt(forKey: .startedAt)
+        workerPid = container.decodeLossyInt(forKey: .workerPid)
+        lastHeartbeatAt = container.decodeLossyInt(forKey: .lastHeartbeatAt)
+        result = try? container.decodeIfPresent(String.self, forKey: .result)
+        createdBy = try? container.decodeIfPresent(String.self, forKey: .createdBy)
+        modelOverride = try? container.decodeIfPresent(String.self, forKey: .modelOverride)
+        providerOverride = try? container.decodeIfPresent(String.self, forKey: .providerOverride)
+        reasoningEffort = try? container.decodeIfPresent(String.self, forKey: .reasoningEffort)
+        completedAt = container.decodeLossyInt(forKey: .completedAt)
+        lastFailureError = try? container.decodeIfPresent(String.self, forKey: .lastFailureError)
+        workspaceKind = try? container.decodeIfPresent(String.self, forKey: .workspaceKind)
+        workspacePath = try? container.decodeIfPresent(String.self, forKey: .workspacePath)
+        branchName = try? container.decodeIfPresent(String.self, forKey: .branchName)
+        consecutiveFailures = container.decodeLossyInt(forKey: .consecutiveFailures)
+        diagnostics = try? container.decodeIfPresent([KanbanDiagnostic].self, forKey: .diagnostics)
+    }
+}
+
+struct KanbanColumn: Codable, Equatable, Identifiable {
+    var name: String
+    var tasks: [KanbanTask]
+    var id: String { name }
+
+    init(name: String, tasks: [KanbanTask] = []) {
+        self.name = name
+        self.tasks = tasks
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = (try? container.decode(String.self, forKey: .name)) ?? "unknown"
+        tasks = (try? container.decode([KanbanTask].self, forKey: .tasks)) ?? []
+    }
+}
+
+struct KanbanBoard: Codable, Equatable {
+    var columns: [KanbanColumn]
+    var tenants: [String]
+    var assignees: [String]
+    var latestEventID: Int?
+    var now: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case columns, tenants, assignees
+        case latestEventID = "latest_event_id"
+        case now
+    }
+
+    init(columns: [KanbanColumn], tenants: [String] = [], assignees: [String] = [], latestEventID: Int? = nil, now: Int? = nil) {
+        self.columns = columns
+        self.tenants = tenants
+        self.assignees = assignees
+        self.latestEventID = latestEventID
+        self.now = now
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        columns = (try? container.decode([KanbanColumn].self, forKey: .columns)) ?? []
+        tenants = (try? container.decode([String].self, forKey: .tenants)) ?? []
+        assignees = (try? container.decode([String].self, forKey: .assignees)) ?? []
+        latestEventID = container.decodeLossyInt(forKey: .latestEventID)
+        now = container.decodeLossyInt(forKey: .now)
+    }
+}
+
+struct KanbanBoardMetadata: Codable, Identifiable, Equatable {
+    let slug: String
+    var name: String?
+    var description: String?
+    var isCurrent: Bool?
+    var total: Int?
+    var defaultWorkdir: String?
+    var defaultWorkspaceKind: String?
+    var projectID: String?
+    var projectName: String?
+
+    var id: String { slug }
+
+    enum CodingKeys: String, CodingKey {
+        case slug, name, description
+        case isCurrent = "is_current"
+        case total
+        case defaultWorkdir = "default_workdir"
+        case defaultWorkspaceKind = "default_workspace_kind"
+        case projectID = "project_id"
+        case projectName = "project_name"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        slug = container.decodeLossyString(forKey: .slug) ?? "default"
+        name = try? container.decodeIfPresent(String.self, forKey: .name)
+        description = try? container.decodeIfPresent(String.self, forKey: .description)
+        isCurrent = try? container.decodeIfPresent(Bool.self, forKey: .isCurrent)
+        total = container.decodeLossyInt(forKey: .total)
+        defaultWorkdir = try? container.decodeIfPresent(String.self, forKey: .defaultWorkdir)
+        defaultWorkspaceKind = try? container.decodeIfPresent(String.self, forKey: .defaultWorkspaceKind)
+        projectID = try? container.decodeIfPresent(String.self, forKey: .projectID)
+        projectName = try? container.decodeIfPresent(String.self, forKey: .projectName)
+    }
+
+    init(slug: String, name: String? = nil, description: String? = nil, isCurrent: Bool? = nil, total: Int? = nil, defaultWorkdir: String? = nil, defaultWorkspaceKind: String? = nil, projectID: String? = nil, projectName: String? = nil) {
+        self.slug = slug
+        self.name = name
+        self.description = description
+        self.isCurrent = isCurrent
+        self.total = total
+        self.defaultWorkdir = defaultWorkdir
+        self.defaultWorkspaceKind = defaultWorkspaceKind
+        self.projectID = projectID
+        self.projectName = projectName
+    }
+}
+
+struct KanbanBoardsResponse: Codable, Equatable {
+    var boards: [KanbanBoardMetadata]
+    var current: String
+
+    init(boards: [KanbanBoardMetadata] = [], current: String = "default") {
+        self.boards = boards
+        self.current = current
+    }
+}
+
+// MARK: - Detail collections
+
+struct KanbanComment: Codable, Identifiable, Equatable {
+    let id: String
+    var taskID: String?
+    var author: String
+    var body: String
+    var createdAt: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case taskID = "task_id"
+        case author, body
+        case createdAt = "created_at"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = container.decodeLossyString(forKey: .id) ?? UUID().uuidString
+        taskID = try? container.decodeIfPresent(String.self, forKey: .taskID)
+        author = (try? container.decode(String.self, forKey: .author)) ?? "Hermes"
+        body = (try? container.decode(String.self, forKey: .body)) ?? ""
+        createdAt = container.decodeLossyInt(forKey: .createdAt)
+    }
+}
+
+struct KanbanEvent: Codable, Identifiable, Equatable {
+    let id: String
+    var taskID: String?
+    var kind: String
+    var payload: AnyCodable?
+    var createdAt: Int?
+    var runID: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case taskID = "task_id"
+        case kind, payload
+        case createdAt = "created_at"
+        case runID = "run_id"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = container.decodeLossyString(forKey: .id) ?? UUID().uuidString
+        taskID = try? container.decodeIfPresent(String.self, forKey: .taskID)
+        kind = (try? container.decode(String.self, forKey: .kind)) ?? "event"
+        payload = try? container.decodeIfPresent(AnyCodable.self, forKey: .payload)
+        createdAt = container.decodeLossyInt(forKey: .createdAt)
+        runID = container.decodeLossyString(forKey: .runID)
+    }
+}
+
+struct KanbanAttachment: Codable, Identifiable, Equatable {
+    let id: String
+    var taskID: String?
+    var filename: String
+    var contentType: String?
+    var size: Int?
+    var uploadedBy: String?
+    var createdAt: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case taskID = "task_id"
+        case filename
+        case contentType = "content_type"
+        case size
+        case uploadedBy = "uploaded_by"
+        case createdAt = "created_at"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = container.decodeLossyString(forKey: .id) ?? UUID().uuidString
+        taskID = try? container.decodeIfPresent(String.self, forKey: .taskID)
+        filename = (try? container.decode(String.self, forKey: .filename)) ?? "Attachment"
+        contentType = try? container.decodeIfPresent(String.self, forKey: .contentType)
+        size = container.decodeLossyInt(forKey: .size)
+        uploadedBy = try? container.decodeIfPresent(String.self, forKey: .uploadedBy)
+        createdAt = container.decodeLossyInt(forKey: .createdAt)
+    }
+}
+
+struct KanbanRun: Codable, Identifiable, Equatable {
+    let id: String
+    var taskID: String?
+    var profile: String?
+    var stepKey: String?
+    var status: String
+    var outcome: String?
+    var summary: String?
+    var error: String?
+    var metadata: AnyCodable?
+    var workerPID: Int?
+    var startedAt: Int?
+    var endedAt: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case taskID = "task_id"
+        case profile
+        case stepKey = "step_key"
+        case status, outcome, summary, error, metadata
+        case workerPID = "worker_pid"
+        case startedAt = "started_at"
+        case endedAt = "ended_at"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = container.decodeLossyString(forKey: .id) ?? UUID().uuidString
+        taskID = container.decodeLossyString(forKey: .taskID)
+        profile = try? container.decodeIfPresent(String.self, forKey: .profile)
+        stepKey = try? container.decodeIfPresent(String.self, forKey: .stepKey)
+        status = (try? container.decode(String.self, forKey: .status)) ?? "unknown"
+        outcome = try? container.decodeIfPresent(String.self, forKey: .outcome)
+        summary = try? container.decodeIfPresent(String.self, forKey: .summary)
+        error = try? container.decodeIfPresent(String.self, forKey: .error)
+        metadata = try? container.decodeIfPresent(AnyCodable.self, forKey: .metadata)
+        workerPID = container.decodeLossyInt(forKey: .workerPID)
+        startedAt = container.decodeLossyInt(forKey: .startedAt)
+        endedAt = container.decodeLossyInt(forKey: .endedAt)
+    }
+}
+
+struct KanbanTaskDetail: Codable, Equatable {
+    var task: KanbanTask
+    var comments: [KanbanComment]
+    var events: [KanbanEvent]
+    var attachments: [KanbanAttachment]
+    var links: KanbanTaskLinks
+    var childResults: [KanbanChildResult]
+    var runs: [KanbanRun]
+
+    init(task: KanbanTask, comments: [KanbanComment] = [], events: [KanbanEvent] = [], attachments: [KanbanAttachment] = [], links: KanbanTaskLinks = KanbanTaskLinks(), childResults: [KanbanChildResult] = [], runs: [KanbanRun] = []) {
+        self.task = task
+        self.comments = comments
+        self.events = events
+        self.attachments = attachments
+        self.links = links
+        self.childResults = childResults
+        self.runs = runs
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case task, comments, events, attachments, links
+        case childResults = "child_results"
+        case runs
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        task = (try? container.decode(KanbanTask.self, forKey: .task)) ?? KanbanTask(id: "", title: "Untitled task", status: "todo")
+        comments = (try? container.decode([KanbanComment].self, forKey: .comments)) ?? []
+        events = (try? container.decode([KanbanEvent].self, forKey: .events)) ?? []
+        attachments = (try? container.decode([KanbanAttachment].self, forKey: .attachments)) ?? []
+        links = (try? container.decode(KanbanTaskLinks.self, forKey: .links)) ?? KanbanTaskLinks()
+        childResults = (try? container.decode([KanbanChildResult].self, forKey: .childResults)) ?? []
+        runs = (try? container.decode([KanbanRun].self, forKey: .runs)) ?? []
+    }
+}
+
+struct KanbanTaskLinks: Codable, Equatable {
+    var parents: [String]
+    var children: [String]
+    init(parents: [String] = [], children: [String] = []) {
+        self.parents = parents
+        self.children = children
+    }
+}
+
+struct KanbanChildResult: Codable, Equatable, Identifiable {
+    let id: String
+    var title: String?
+    var status: String?
+    var latestSummary: String?
+    var result: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, title, status
+        case latestSummary = "latest_summary"
+        case result
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = container.decodeLossyString(forKey: .id) ?? UUID().uuidString
+        title = try? container.decodeIfPresent(String.self, forKey: .title)
+        status = try? container.decodeIfPresent(String.self, forKey: .status)
+        latestSummary = try? container.decodeIfPresent(String.self, forKey: .latestSummary)
+        result = try? container.decodeIfPresent(String.self, forKey: .result)
+    }
+}
+
+// MARK: - Auxiliary board data
+
+struct KanbanProfile: Codable, Identifiable, Equatable {
+    var name: String
+    var isDefault: Bool
+    var description: String
+    var descriptionAuto: Bool
+    var model: String?
+    var provider: String?
+    var skillCount: Int?
+    var id: String { name }
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case isDefault = "is_default"
+        case description
+        case descriptionAuto = "description_auto"
+        case model, provider
+        case skillCount = "skill_count"
+    }
+}
+
+struct KanbanProject: Codable, Identifiable, Equatable {
+    var id: String
+    var slug: String
+    var name: String
+    var primaryPath: String?
+    var icon: String?
+    var color: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, slug, name, icon, color
+        case primaryPath = "primary_path"
+    }
+}
+
+struct KanbanOrchestrationSettings: Codable, Equatable {
+    var orchestratorProfile: String
+    var defaultAssignee: String
+    var autoDecompose: Bool
+    var autoPromoteChildren: Bool?
+    var resolvedOrchestratorProfile: String
+    var resolvedDefaultAssignee: String
+
+    enum CodingKeys: String, CodingKey {
+        case orchestratorProfile = "orchestrator_profile"
+        case defaultAssignee = "default_assignee"
+        case autoDecompose = "auto_decompose"
+        case autoPromoteChildren = "auto_promote_children"
+        case resolvedOrchestratorProfile = "resolved_orchestrator_profile"
+        case resolvedDefaultAssignee = "resolved_default_assignee"
+    }
+}
+
+struct KanbanTaskEstimate: Codable, Equatable {
+    var ok: Bool
+    var reason: String?
+    var estimatedTokens: Int?
+    var complexity: String?
+    var rationale: String?
+    var model: String?
+
+    enum CodingKeys: String, CodingKey {
+        case ok, reason
+        case estimatedTokens = "est_tokens"
+        case complexity, rationale, model
+    }
+}
+
+struct KanbanWorkerLog: Codable, Equatable {
+    var exists: Bool
+    var sizeBytes: Int
+    var content: String
+    var truncated: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case exists
+        case sizeBytes = "size_bytes"
+        case content, truncated
+    }
+}
+
+// MARK: - Request bodies
+
+struct KanbanCreateTaskRequest: Encodable, Equatable {
+    var title: String
+    var body: String?
+    var assignee: String?
+    var tenant: String?
+    var priority: Int
+    var workspaceKind: String
+    var workspacePath: String?
+    var parents: [String]
+    var triage: Bool
+    var idempotencyKey: String?
+    var maxRuntimeSeconds: Int?
+    var skills: [String]?
+    var goalMode: Bool
+    var goalMaxTurns: Int?
+    var modelOverride: String?
+    var providerOverride: String?
+    var reasoningEffort: String?
+    var projectID: String?
+
+    enum CodingKeys: String, CodingKey {
+        case title, body, assignee, tenant, priority
+        case workspaceKind = "workspace_kind"
+        case workspacePath = "workspace_path"
+        case parents, triage
+        case idempotencyKey = "idempotency_key"
+        case maxRuntimeSeconds = "max_runtime_seconds"
+        case skills
+        case goalMode = "goal_mode"
+        case goalMaxTurns = "goal_max_turns"
+        case modelOverride = "model_override"
+        case providerOverride = "provider_override"
+        case reasoningEffort = "reasoning_effort"
+        case projectID = "project_id"
+    }
+
+    init(title: String, body: String? = nil, assignee: String? = nil, tenant: String? = nil, priority: Int = 0, workspaceKind: String = "scratch", workspacePath: String? = nil, parents: [String] = [], triage: Bool = false, idempotencyKey: String? = nil, maxRuntimeSeconds: Int? = nil, skills: [String]? = nil, goalMode: Bool = false, goalMaxTurns: Int? = nil, modelOverride: String? = nil, providerOverride: String? = nil, reasoningEffort: String? = nil, projectID: String? = nil) {
+        self.title = title
+        self.body = body
+        self.assignee = assignee
+        self.tenant = tenant
+        self.priority = priority
+        self.workspaceKind = workspaceKind
+        self.workspacePath = workspacePath
+        self.parents = parents
+        self.triage = triage
+        self.idempotencyKey = idempotencyKey
+        self.maxRuntimeSeconds = maxRuntimeSeconds
+        self.skills = skills
+        self.goalMode = goalMode
+        self.goalMaxTurns = goalMaxTurns
+        self.modelOverride = modelOverride
+        self.providerOverride = providerOverride
+        self.reasoningEffort = reasoningEffort
+        self.projectID = projectID
+    }
+}
+
+struct KanbanTaskPatch: Encodable, Equatable {
+    var status: String?
+    var assignee: String?
+    var priority: Int?
+    var title: String?
+    var body: String?
+    var result: String?
+    var blockReason: String?
+    var summary: String?
+    var metadata: [String: AnyCodable]?
+    var modelOverride: String?
+    var providerOverride: String?
+    var clearModelOverride: Bool
+    var reasoningEffort: String?
+    var clearReasoningEffort: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case status, assignee, priority, title, body, result
+        case blockReason = "block_reason"
+        case summary, metadata
+        case modelOverride = "model_override"
+        case providerOverride = "provider_override"
+        case clearModelOverride = "clear_model_override"
+        case reasoningEffort = "reasoning_effort"
+        case clearReasoningEffort = "clear_reasoning_effort"
+    }
+
+    init(status: String? = nil, assignee: String? = nil, priority: Int? = nil, title: String? = nil, body: String? = nil, result: String? = nil, blockReason: String? = nil, summary: String? = nil, metadata: [String: AnyCodable]? = nil, modelOverride: String? = nil, providerOverride: String? = nil, clearModelOverride: Bool = false, reasoningEffort: String? = nil, clearReasoningEffort: Bool = false) {
+        self.status = status
+        self.assignee = assignee
+        self.priority = priority
+        self.title = title
+        self.body = body
+        self.result = result
+        self.blockReason = blockReason
+        self.summary = summary
+        self.metadata = metadata
+        self.modelOverride = modelOverride
+        self.providerOverride = providerOverride
+        self.clearModelOverride = clearModelOverride
+        self.reasoningEffort = reasoningEffort
+        self.clearReasoningEffort = clearReasoningEffort
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(status, forKey: .status)
+        try container.encodeIfPresent(assignee, forKey: .assignee)
+        try container.encodeIfPresent(priority, forKey: .priority)
+        try container.encodeIfPresent(title, forKey: .title)
+        try container.encodeIfPresent(body, forKey: .body)
+        try container.encodeIfPresent(result, forKey: .result)
+        try container.encodeIfPresent(blockReason, forKey: .blockReason)
+        try container.encodeIfPresent(summary, forKey: .summary)
+        try container.encodeIfPresent(metadata, forKey: .metadata)
+        try container.encodeIfPresent(modelOverride, forKey: .modelOverride)
+        try container.encodeIfPresent(providerOverride, forKey: .providerOverride)
+        if clearModelOverride { try container.encode(true, forKey: .clearModelOverride) }
+        try container.encodeIfPresent(reasoningEffort, forKey: .reasoningEffort)
+        if clearReasoningEffort { try container.encode(true, forKey: .clearReasoningEffort) }
+    }
+
+    var isEmpty: Bool {
+        status == nil && assignee == nil && priority == nil && title == nil && body == nil && result == nil && blockReason == nil && summary == nil && metadata == nil && modelOverride == nil && providerOverride == nil && !clearModelOverride && reasoningEffort == nil && !clearReasoningEffort
+    }
+}
+
+struct KanbanCommentRequest: Encodable {
+    var author: String
+    var body: String
+}
+
+struct KanbanReassignRequest: Encodable {
+    var profile: String?
+    var reclaimFirst: Bool
+    var reason: String?
+    enum CodingKeys: String, CodingKey {
+        case profile
+        case reclaimFirst = "reclaim_first"
+        case reason
+    }
+}
+
+struct KanbanReclaimRequest: Encodable {
+    var reason: String?
+}
+
+struct KanbanCreateTaskResponse: Codable, Equatable {
+    var task: KanbanTask?
+    var warning: String?
+}
+
+struct KanbanMutationResponse: Codable, Equatable {
+    var ok: Bool?
+    var deleted: Bool?
+    var taskID: String?
+    enum CodingKeys: String, CodingKey {
+        case ok, deleted
+        case taskID = "task_id"
+    }
+}
+
+struct KanbanProfilesResponse: Codable, Equatable { var profiles: [KanbanProfile] }
+struct KanbanProjectsResponse: Codable, Equatable { var projects: [KanbanProject] }

--- a/Conduit/Models/KanbanStatus.swift
+++ b/Conduit/Models/KanbanStatus.swift
@@ -1,6 +1,13 @@
 import SwiftUI
 
 /// Central presentation and mutation metadata for backend workflow statuses.
+///
+/// Capability values mirror the current Hermes desktop board contract
+/// (`LOCKED_COLUMNS = ['review', 'running', 'scheduled']` in
+/// apps/desktop/src/plugins/kanban/ui.tsx): locked lanes are system-owned drop
+/// targets — a card can be dragged OUT of them, never INTO them, and the
+/// backend refuses bare transitions into them (running: 409 direct-set;
+/// scheduled: 409 without an attached wake time; review: claim-path only).
 /// Unknown statuses remain renderable through the fallback metadata but are
 /// never offered as new-task or manual status destinations.
 struct KanbanStatusPresentation: Equatable, Identifiable {
@@ -40,6 +47,14 @@ struct KanbanStatusPresentation: Equatable, Identifiable {
         knownStatuses.contains(rawValue) && forStatus(rawValue).isTaskCreatable
     }
 
+    /// Upstream LOCKED_COLUMNS: system-owned lanes that must never appear as
+    /// manual move/create destinations, while remaining visible on the board.
+    static let lockedDestinations: [String] = ["review", "running", "scheduled"]
+
+    static func isLockedDestination(_ rawValue: String) -> Bool {
+        Self.lockedDestinations.contains(rawValue)
+    }
+
     static func forStatus(_ rawValue: String) -> KanbanStatusPresentation {
         switch rawValue {
         case "triage":
@@ -47,7 +62,9 @@ struct KanbanStatusPresentation: Equatable, Identifiable {
         case "todo":
             return .init(rawValue: rawValue, displayName: "To Do", systemImage: "circle", tint: .secondary, sortOrder: 1, isVisibleOnBoard: true, isManuallySelectable: true, isTaskCreatable: true, isBackendControlled: false)
         case "scheduled":
-            return .init(rawValue: rawValue, displayName: "Scheduled", systemImage: "clock", tint: .purple, sortOrder: 2, isVisibleOnBoard: true, isManuallySelectable: true, isTaskCreatable: true, isBackendControlled: false)
+            // Locked upstream: needs a wake-up time only an agent/CLI attaches;
+            // a bare status set is refused with a 409.
+            return .init(rawValue: rawValue, displayName: "Scheduled", systemImage: "clock", tint: .purple, sortOrder: 2, isVisibleOnBoard: true, isManuallySelectable: false, isTaskCreatable: false, isBackendControlled: true)
         case "ready":
             return .init(rawValue: rawValue, displayName: "Ready", systemImage: "play.circle", tint: .blue, sortOrder: 3, isVisibleOnBoard: true, isManuallySelectable: true, isTaskCreatable: true, isBackendControlled: false)
         case "running":
@@ -55,7 +72,9 @@ struct KanbanStatusPresentation: Equatable, Identifiable {
         case "blocked":
             return .init(rawValue: rawValue, displayName: "Blocked", systemImage: "exclamationmark.octagon", tint: .red, sortOrder: 5, isVisibleOnBoard: true, isManuallySelectable: true, isTaskCreatable: true, isBackendControlled: false)
         case "review":
-            return .init(rawValue: rawValue, displayName: "Review", systemImage: "eye", tint: .orange, sortOrder: 6, isVisibleOnBoard: true, isManuallySelectable: true, isTaskCreatable: true, isBackendControlled: false)
+            // Locked upstream: entered/exited through the dispatcher's claim
+            // path, not by arbitrary status assignment.
+            return .init(rawValue: rawValue, displayName: "Review", systemImage: "eye", tint: .orange, sortOrder: 6, isVisibleOnBoard: true, isManuallySelectable: false, isTaskCreatable: false, isBackendControlled: true)
         case "done":
             return .init(rawValue: rawValue, displayName: "Done", systemImage: "checkmark.circle", tint: .secondary, sortOrder: 7, isVisibleOnBoard: true, isManuallySelectable: true, isTaskCreatable: true, isBackendControlled: false)
         case "archived":

--- a/Conduit/Models/KanbanStatus.swift
+++ b/Conduit/Models/KanbanStatus.swift
@@ -1,34 +1,68 @@
 import SwiftUI
 
-/// Central presentation metadata for backend workflow statuses.
-/// Unknown statuses remain renderable through the fallback metadata.
+/// Central presentation and mutation metadata for backend workflow statuses.
+/// Unknown statuses remain renderable through the fallback metadata but are
+/// never offered as new-task or manual status destinations.
 struct KanbanStatusPresentation: Equatable, Identifiable {
     let rawValue: String
     let displayName: String
     let systemImage: String
     let tint: Color
     let sortOrder: Int
-    let isArchived: Bool
+    let isVisibleOnBoard: Bool
+    let isManuallySelectable: Bool
+    let isTaskCreatable: Bool
+    let isBackendControlled: Bool
+
     var id: String { rawValue }
 
     static let knownStatuses: [String] = [
         "triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"
     ]
 
+    static var manuallySelectableStatuses: [KanbanStatusPresentation] {
+        knownStatuses
+            .map(forStatus)
+            .filter { $0.isManuallySelectable }
+    }
+
+    static var taskCreatableStatuses: [KanbanStatusPresentation] {
+        knownStatuses
+            .map(forStatus)
+            .filter { $0.isTaskCreatable }
+    }
+
+    static func canSelectManually(_ rawValue: String) -> Bool {
+        knownStatuses.contains(rawValue) && forStatus(rawValue).isManuallySelectable
+    }
+
+    static func canCreateTask(in rawValue: String) -> Bool {
+        knownStatuses.contains(rawValue) && forStatus(rawValue).isTaskCreatable
+    }
+
     static func forStatus(_ rawValue: String) -> KanbanStatusPresentation {
         switch rawValue {
-        case "triage": return .init(rawValue: rawValue, displayName: "Triage", systemImage: "tray", tint: .secondary, sortOrder: 0, isArchived: false)
-        case "todo": return .init(rawValue: rawValue, displayName: "To Do", systemImage: "circle", tint: .secondary, sortOrder: 1, isArchived: false)
-        case "scheduled": return .init(rawValue: rawValue, displayName: "Scheduled", systemImage: "clock", tint: .purple, sortOrder: 2, isArchived: false)
-        case "ready": return .init(rawValue: rawValue, displayName: "Ready", systemImage: "play.circle", tint: .blue, sortOrder: 3, isArchived: false)
-        case "running": return .init(rawValue: rawValue, displayName: "Running", systemImage: "arrow.triangle.2.circlepath", tint: .green, sortOrder: 4, isArchived: false)
-        case "blocked": return .init(rawValue: rawValue, displayName: "Blocked", systemImage: "exclamationmark.octagon", tint: .red, sortOrder: 5, isArchived: false)
-        case "review": return .init(rawValue: rawValue, displayName: "Review", systemImage: "eye", tint: .orange, sortOrder: 6, isArchived: false)
-        case "done": return .init(rawValue: rawValue, displayName: "Done", systemImage: "checkmark.circle", tint: .secondary, sortOrder: 7, isArchived: false)
-        case "archived": return .init(rawValue: rawValue, displayName: "Archived", systemImage: "archivebox", tint: .secondary, sortOrder: 8, isArchived: true)
+        case "triage":
+            return .init(rawValue: rawValue, displayName: "Triage", systemImage: "tray", tint: .secondary, sortOrder: 0, isVisibleOnBoard: true, isManuallySelectable: true, isTaskCreatable: true, isBackendControlled: false)
+        case "todo":
+            return .init(rawValue: rawValue, displayName: "To Do", systemImage: "circle", tint: .secondary, sortOrder: 1, isVisibleOnBoard: true, isManuallySelectable: true, isTaskCreatable: true, isBackendControlled: false)
+        case "scheduled":
+            return .init(rawValue: rawValue, displayName: "Scheduled", systemImage: "clock", tint: .purple, sortOrder: 2, isVisibleOnBoard: true, isManuallySelectable: true, isTaskCreatable: true, isBackendControlled: false)
+        case "ready":
+            return .init(rawValue: rawValue, displayName: "Ready", systemImage: "play.circle", tint: .blue, sortOrder: 3, isVisibleOnBoard: true, isManuallySelectable: true, isTaskCreatable: true, isBackendControlled: false)
+        case "running":
+            return .init(rawValue: rawValue, displayName: "Running", systemImage: "arrow.triangle.2.circlepath", tint: .green, sortOrder: 4, isVisibleOnBoard: true, isManuallySelectable: false, isTaskCreatable: false, isBackendControlled: true)
+        case "blocked":
+            return .init(rawValue: rawValue, displayName: "Blocked", systemImage: "exclamationmark.octagon", tint: .red, sortOrder: 5, isVisibleOnBoard: true, isManuallySelectable: true, isTaskCreatable: true, isBackendControlled: false)
+        case "review":
+            return .init(rawValue: rawValue, displayName: "Review", systemImage: "eye", tint: .orange, sortOrder: 6, isVisibleOnBoard: true, isManuallySelectable: true, isTaskCreatable: true, isBackendControlled: false)
+        case "done":
+            return .init(rawValue: rawValue, displayName: "Done", systemImage: "checkmark.circle", tint: .secondary, sortOrder: 7, isVisibleOnBoard: true, isManuallySelectable: true, isTaskCreatable: true, isBackendControlled: false)
+        case "archived":
+            return .init(rawValue: rawValue, displayName: "Archived", systemImage: "archivebox", tint: .secondary, sortOrder: 8, isVisibleOnBoard: true, isManuallySelectable: true, isTaskCreatable: false, isBackendControlled: false)
         default:
             let name = rawValue.replacingOccurrences(of: "_", with: " ").capitalized
-            return .init(rawValue: rawValue, displayName: name.isEmpty ? "Other" : name, systemImage: "circle.dashed", tint: .secondary, sortOrder: 100, isArchived: false)
+            return .init(rawValue: rawValue, displayName: name.isEmpty ? "Other" : name, systemImage: "circle.dashed", tint: .secondary, sortOrder: 100, isVisibleOnBoard: true, isManuallySelectable: false, isTaskCreatable: false, isBackendControlled: true)
         }
     }
 

--- a/Conduit/Models/KanbanStatus.swift
+++ b/Conduit/Models/KanbanStatus.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// Central presentation metadata for backend workflow statuses.
+/// Unknown statuses remain renderable through the fallback metadata.
+struct KanbanStatusPresentation: Equatable, Identifiable {
+    let rawValue: String
+    let displayName: String
+    let systemImage: String
+    let tint: Color
+    let sortOrder: Int
+    let isArchived: Bool
+    var id: String { rawValue }
+
+    static let knownStatuses: [String] = [
+        "triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"
+    ]
+
+    static func forStatus(_ rawValue: String) -> KanbanStatusPresentation {
+        switch rawValue {
+        case "triage": return .init(rawValue: rawValue, displayName: "Triage", systemImage: "tray", tint: .secondary, sortOrder: 0, isArchived: false)
+        case "todo": return .init(rawValue: rawValue, displayName: "To Do", systemImage: "circle", tint: .secondary, sortOrder: 1, isArchived: false)
+        case "scheduled": return .init(rawValue: rawValue, displayName: "Scheduled", systemImage: "clock", tint: .purple, sortOrder: 2, isArchived: false)
+        case "ready": return .init(rawValue: rawValue, displayName: "Ready", systemImage: "play.circle", tint: .blue, sortOrder: 3, isArchived: false)
+        case "running": return .init(rawValue: rawValue, displayName: "Running", systemImage: "arrow.triangle.2.circlepath", tint: .green, sortOrder: 4, isArchived: false)
+        case "blocked": return .init(rawValue: rawValue, displayName: "Blocked", systemImage: "exclamationmark.octagon", tint: .red, sortOrder: 5, isArchived: false)
+        case "review": return .init(rawValue: rawValue, displayName: "Review", systemImage: "eye", tint: .orange, sortOrder: 6, isArchived: false)
+        case "done": return .init(rawValue: rawValue, displayName: "Done", systemImage: "checkmark.circle", tint: .secondary, sortOrder: 7, isArchived: false)
+        case "archived": return .init(rawValue: rawValue, displayName: "Archived", systemImage: "archivebox", tint: .secondary, sortOrder: 8, isArchived: true)
+        default:
+            let name = rawValue.replacingOccurrences(of: "_", with: " ").capitalized
+            return .init(rawValue: rawValue, displayName: name.isEmpty ? "Other" : name, systemImage: "circle.dashed", tint: .secondary, sortOrder: 100, isArchived: false)
+        }
+    }
+
+    static func orderedColumns(_ columns: [KanbanColumn]) -> [KanbanColumn] {
+        columns.sorted {
+            let lhs = forStatus($0.name)
+            let rhs = forStatus($1.name)
+            if lhs.sortOrder != rhs.sortOrder { return lhs.sortOrder < rhs.sortOrder }
+            return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
+        }
+    }
+}

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -519,6 +519,12 @@ final class AppState: ObservableObject {
     @Published var slashCommands: [SlashCommand] = AppState.builtInSlashCommands
     @Published var skills: [CapabilitySkill] = []
     @Published var toolsets: [CapabilityToolset] = []
+    /// Profile that owns the currently displayed skills/toolsets. Rows are
+    /// only presentable while this equals the active profile.
+    @Published private(set) var capabilitiesProfile: String?
+    /// Monotonic request token for capability loads; older requests can never
+    /// commit over newer ones (protects the A -> B -> A race).
+    private var capabilityLoadGeneration: UInt64 = 0
     @Published var mcpServers: [CapabilityMcpServer] = []
     @Published private(set) var voiceCapabilitySnapshot = VoiceCapabilitySnapshot.unavailable
     @Published private(set) var isVoiceEnabled = false
@@ -6492,13 +6498,25 @@ final class AppState: ObservableObject {
 
     @discardableResult
     func loadCapabilities() async -> CapabilityLoadOutcome {
+        capabilityLoadGeneration &+= 1
+        let generation = capabilityLoadGeneration
         let profile = activeProfile
         guard let dashboardTicketBridge else { return .unavailable(profile: profile) }
         async let skillsResult = dashboardTicketBridge.requestJSON(path: dashboardPath("/api/skills", profile: profile))
         async let toolsetsResult = dashboardTicketBridge.requestJSON(path: dashboardPath("/api/tools/toolsets", profile: profile))
+        // Commit gate: this exact request must still be the newest one AND
+        // target the still-active profile (A -> B -> A stale commits rejected).
+        func ownsRequest() -> Bool {
+            CapabilityLoadPolicy.canCommit(
+                generation: generation,
+                latestGeneration: capabilityLoadGeneration,
+                requestedProfile: profile,
+                activeProfile: activeProfile
+            )
+        }
         do {
             let (skillsResponse, toolsetsResponse) = try await (skillsResult, toolsetsResult)
-            guard profile == activeProfile else { return .superseded(requestedProfile: profile, activeProfile: activeProfile) }
+            guard ownsRequest() else { return .superseded(requestedProfile: profile, activeProfile: activeProfile) }
             let skillsValues = skillsResponse["_array"] as? [Any] ?? []
             self.skills = skillsValues.compactMap(decodeCapabilitySkill)
                 .sorted { lhs, rhs in
@@ -6510,9 +6528,10 @@ final class AppState: ObservableObject {
             let toolsetsValues = toolsetsResponse["_array"] as? [Any] ?? []
             self.toolsets = toolsetsValues.compactMap(decodeCapabilityToolset)
                 .sorted { ($0.label ?? $0.name) < ($1.label ?? $1.name) }
+            capabilitiesProfile = profile
             return .success(profile: profile)
         } catch {
-            guard profile == activeProfile else { return .superseded(requestedProfile: profile, activeProfile: activeProfile) }
+            guard ownsRequest() else { return .superseded(requestedProfile: profile, activeProfile: activeProfile) }
             errorMessage = "Could not load capabilities: \(error.localizedDescription)"
             return .failed(profile: profile, message: "Could not load capabilities: \(error.localizedDescription)")
         }
@@ -8621,6 +8640,26 @@ enum KeychainHelper {
 }
 
 // MARK: - Attachment Helper
+
+/// Pure ownership rules for capability loads, extracted for deterministic
+/// testing of the rapid-profile-switch races.
+enum CapabilityLoadPolicy {
+    /// A finished request may commit only while it is still the newest load
+    /// AND its profile is still active (A -> B -> A stale commits rejected).
+    static func canCommit(
+        generation: UInt64,
+        latestGeneration: UInt64,
+        requestedProfile: String,
+        activeProfile: String
+    ) -> Bool {
+        generation == latestGeneration && requestedProfile == activeProfile
+    }
+
+    /// Rows may render only when the snapshot belongs to the active profile.
+    static func shouldPresentRows(snapshotProfile: String?, activeProfile: String) -> Bool {
+        snapshotProfile == activeProfile
+    }
+}
 
 enum AttachmentHelper {
     static func toBase64(_ attachment: Attachment) async -> String {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -8677,14 +8677,33 @@ enum CapabilityLoadPolicy {
         loadError: String?,
         hasRows: Bool
     ) -> PresentationState {
-        guard shouldPresentRows(snapshotProfile: snapshotProfile, activeProfile: activeProfile) else {
-            // Foreign/no snapshot: even a settled foreign error belongs to the
-            // other profile, so show loading until THIS profile settles.
+        let ownsSnapshot = shouldPresentRows(
+            snapshotProfile: snapshotProfile,
+            activeProfile: activeProfile
+        )
+
+        // The view's request token guarantees a settled error belongs to the
+        // CURRENT request/profile - never to a foreign one. So errors surface
+        // before any snapshot-ownership masking; otherwise a failed first
+        // load (no snapshot yet) would hide behind an eternal spinner.
+        if isLoading {
             return .loading
         }
-        if hasRows { return .list(banner: loadError) }
-        if let loadError { return .failure(loadError) }
-        return .emptySuccess
+
+        if let loadError {
+            if ownsSnapshot && hasRows {
+                return .list(banner: loadError)
+            }
+            return .failure(loadError)
+        }
+
+        guard ownsSnapshot else {
+            // No settled result for this profile yet: never render rows that
+            // belong to another profile while the current one is pending.
+            return .loading
+        }
+
+        return hasRows ? .list(banner: nil) : .emptySuccess
     }
 }
 

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -8659,6 +8659,33 @@ enum CapabilityLoadPolicy {
     static func shouldPresentRows(snapshotProfile: String?, activeProfile: String) -> Bool {
         snapshotProfile == activeProfile
     }
+
+    /// Final rendering boundary for the Capabilities screen. Foreign or absent
+    /// snapshots can never resolve to a row-bearing state - toggles must never
+    /// appear under a profile they do not belong to.
+    enum PresentationState: Equatable {
+        case loading
+        case failure(String)
+        case emptySuccess
+        case list(banner: String?)
+    }
+
+    static func resolvePresentation(
+        snapshotProfile: String?,
+        activeProfile: String,
+        isLoading: Bool,
+        loadError: String?,
+        hasRows: Bool
+    ) -> PresentationState {
+        guard shouldPresentRows(snapshotProfile: snapshotProfile, activeProfile: activeProfile) else {
+            // Foreign/no snapshot: even a settled foreign error belongs to the
+            // other profile, so show loading until THIS profile settles.
+            return .loading
+        }
+        if hasRows { return .list(banner: loadError) }
+        if let loadError { return .failure(loadError) }
+        return .emptySuccess
+    }
 }
 
 enum AttachmentHelper {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -6473,14 +6473,32 @@ final class AppState: ObservableObject {
 
     // MARK: - Capabilities
 
-    func loadCapabilities() async {
+    /// Request-scoped result for a capability load. The caller must be able to
+    /// know how THIS request ended without consulting global error/skill
+    /// state, which can be stale or mutated by unrelated flows.
+    enum CapabilityLoadOutcome {
+        case success(profile: String)
+        case failed(profile: String, message: String)
+        case unavailable(profile: String)
+        /// The active profile changed mid-request; the result belongs to an
+        /// abandoned profile and callers should discard it.
+        case superseded(requestedProfile: String, activeProfile: String)
+
+        var isSuperseded: Bool {
+            if case .superseded = self { return true }
+            return false
+        }
+    }
+
+    @discardableResult
+    func loadCapabilities() async -> CapabilityLoadOutcome {
         let profile = activeProfile
-        guard let dashboardTicketBridge else { return }
+        guard let dashboardTicketBridge else { return .unavailable(profile: profile) }
         async let skillsResult = dashboardTicketBridge.requestJSON(path: dashboardPath("/api/skills", profile: profile))
         async let toolsetsResult = dashboardTicketBridge.requestJSON(path: dashboardPath("/api/tools/toolsets", profile: profile))
         do {
             let (skillsResponse, toolsetsResponse) = try await (skillsResult, toolsetsResult)
-            guard profile == activeProfile else { return }
+            guard profile == activeProfile else { return .superseded(requestedProfile: profile, activeProfile: activeProfile) }
             let skillsValues = skillsResponse["_array"] as? [Any] ?? []
             self.skills = skillsValues.compactMap(decodeCapabilitySkill)
                 .sorted { lhs, rhs in
@@ -6492,9 +6510,11 @@ final class AppState: ObservableObject {
             let toolsetsValues = toolsetsResponse["_array"] as? [Any] ?? []
             self.toolsets = toolsetsValues.compactMap(decodeCapabilityToolset)
                 .sorted { ($0.label ?? $0.name) < ($1.label ?? $1.name) }
+            return .success(profile: profile)
         } catch {
-            guard profile == activeProfile else { return }
+            guard profile == activeProfile else { return .superseded(requestedProfile: profile, activeProfile: activeProfile) }
             errorMessage = "Could not load capabilities: \(error.localizedDescription)"
+            return .failed(profile: profile, message: "Could not load capabilities: \(error.localizedDescription)")
         }
     }
 

--- a/Conduit/Services/KanbanService.swift
+++ b/Conduit/Services/KanbanService.swift
@@ -19,6 +19,7 @@ enum KanbanServiceError: LocalizedError, Equatable {
     case invalidManualStatus(String)
     case taskCreatedButMoveFailed(taskID: String?, targetStatus: String, reason: String)
     case mutationInProgress
+    case boardNavigationInProgress
     case invalidQueryParameter(String)
 
     var errorDescription: String? {
@@ -35,6 +36,8 @@ enum KanbanServiceError: LocalizedError, Equatable {
             return "The task was created" + identifier + ", but Hermes could not move it to " + targetStatus + ". It was not duplicated; close this form and refresh the board. " + reason
         case .mutationInProgress:
             return "Another Kanban change is still being saved."
+        case .boardNavigationInProgress:
+            return "Still switching boards. Try again once the new board finishes loading."
         case .invalidQueryParameter(let name):
             // Fail closed: a dropped board/id parameter would silently
             // retarget the request at the backend's current board.
@@ -305,6 +308,11 @@ final class KanbanService {
     }
 
     private func pathComponent(_ value: String) throws -> String {
+        // Exact dot segments navigate URL directories: "tasks/.." would
+        // normalize onto a parent route while keeping the PATCH/DELETE method.
+        guard value != ".", value != ".." else {
+            throw KanbanServiceError.invalidQueryParameter(value)
+        }
         guard let encoded = DashboardPath.encodedQueryComponent(value), !encoded.isEmpty else {
             throw KanbanServiceError.invalidQueryParameter("id")
         }

--- a/Conduit/Services/KanbanService.swift
+++ b/Conduit/Services/KanbanService.swift
@@ -1,0 +1,232 @@
+import Foundation
+
+@MainActor
+protocol DashboardJSONRequester: AnyObject {
+    func requestJSON(
+        path: String,
+        method: String,
+        body: [String: Any]?,
+        timeoutMilliseconds: Int,
+        maxResponseBytes: Int
+    ) async throws -> [String: Any]
+}
+
+extension DashboardTicketBridge: DashboardJSONRequester {}
+
+enum KanbanServiceError: LocalizedError, Equatable {
+    case invalidResponse(String)
+    case emptyTaskID
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidResponse(let message): return message
+        case .emptyTaskID: return "Hermes returned a Kanban task without an ID."
+        }
+    }
+}
+
+/// Typed client for the authenticated Hermes dashboard Kanban plugin.
+/// This depends on the existing dashboard request bridge rather than HermesClient.
+/// Board selection is always sent as a local board query and never changes the
+/// server-wide current-board pointer.
+@MainActor
+final class KanbanService {
+    private let requester: any DashboardJSONRequester
+    private let decoder: JSONDecoder
+    private let encoder: JSONEncoder
+    private static let namespace = "/api/plugins/kanban"
+
+    init(requester: any DashboardJSONRequester) {
+        self.requester = requester
+        decoder = JSONDecoder()
+        encoder = JSONEncoder()
+    }
+
+    func fetchBoards() async throws -> KanbanBoardsResponse {
+        try await decode(KanbanBoardsResponse.self, path: Self.namespace + "/boards")
+    }
+
+    func fetchBoard(slug: String?, includeArchived: Bool) async throws -> KanbanBoard {
+        var params: [String: String] = [:]
+        if includeArchived { params["include_archived"] = "true" }
+        return try await decode(
+            KanbanBoard.self,
+            path: withBoard(Self.namespace + "/board", slug: slug, params: params)
+        )
+    }
+
+    func fetchTask(id: String, board: String?) async throws -> KanbanTaskDetail {
+        guard !id.isEmpty else { throw KanbanServiceError.emptyTaskID }
+        return try await decode(
+            KanbanTaskDetail.self,
+            path: withBoard(Self.namespace + "/tasks/\(pathComponent(id))", slug: board)
+        )
+    }
+
+    func fetchTaskLog(id: String, board: String?, tailBytes: Int = 16_384) async throws -> KanbanWorkerLog {
+        guard !id.isEmpty else { throw KanbanServiceError.emptyTaskID }
+        return try await decode(
+            KanbanWorkerLog.self,
+            path: withBoard(Self.namespace + "/tasks/\(pathComponent(id))/log", slug: board, params: ["tail": String(max(1, tailBytes))])
+        )
+    }
+
+    func fetchProfiles() async throws -> [KanbanProfile] {
+        let response = try await decode(KanbanProfilesResponse.self, path: Self.namespace + "/profiles")
+        return response.profiles
+    }
+
+    func fetchProjects() async throws -> [KanbanProject] {
+        let response = try await decode(KanbanProjectsResponse.self, path: Self.namespace + "/projects")
+        return response.projects
+    }
+
+    func fetchOrchestration() async throws -> KanbanOrchestrationSettings {
+        try await decode(KanbanOrchestrationSettings.self, path: Self.namespace + "/orchestration")
+    }
+
+    func createTask(_ requestBody: KanbanCreateTaskRequest, board: String?) async throws -> KanbanCreateTaskResponse {
+        let response = try await request(
+            path: withBoard(Self.namespace + "/tasks", slug: board),
+            method: "POST",
+            body: try encodedDictionary(requestBody)
+        )
+        return try decodeResponse(KanbanCreateTaskResponse.self, from: response)
+    }
+
+    @discardableResult
+    func updateTask(id: String, board: String?, patch: KanbanTaskPatch) async throws -> KanbanTask? {
+        guard !id.isEmpty else { throw KanbanServiceError.emptyTaskID }
+        let response = try await request(
+            path: withBoard(Self.namespace + "/tasks/\(pathComponent(id))", slug: board),
+            method: "PATCH",
+            body: try encodedDictionary(patch)
+        )
+        return try decodeResponse(TaskEnvelope.self, from: response).task
+    }
+
+    func deleteTask(id: String, board: String?) async throws {
+        guard !id.isEmpty else { throw KanbanServiceError.emptyTaskID }
+        _ = try await request(
+            path: withBoard(Self.namespace + "/tasks/\(pathComponent(id))", slug: board),
+            method: "DELETE",
+            body: nil
+        )
+    }
+
+    func addComment(taskID: String, board: String?, body: String, author: String = "conduit") async throws {
+        guard !taskID.isEmpty else { throw KanbanServiceError.emptyTaskID }
+        let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        _ = try await request(
+            path: withBoard(Self.namespace + "/tasks/\(pathComponent(taskID))/comments", slug: board),
+            method: "POST",
+            body: try encodedDictionary(KanbanCommentRequest(author: author, body: trimmed))
+        )
+    }
+
+    func reassignTask(taskID: String, board: String?, profile: String?, reclaimFirst: Bool = true, reason: String? = nil) async throws {
+        guard !taskID.isEmpty else { throw KanbanServiceError.emptyTaskID }
+        _ = try await request(
+            path: withBoard(Self.namespace + "/tasks/\(pathComponent(taskID))/reassign", slug: board),
+            method: "POST",
+            body: try encodedDictionary(KanbanReassignRequest(profile: profile, reclaimFirst: reclaimFirst, reason: reason))
+        )
+    }
+
+    func reclaimTask(taskID: String, board: String?, reason: String? = nil) async throws {
+        guard !taskID.isEmpty else { throw KanbanServiceError.emptyTaskID }
+        _ = try await request(
+            path: withBoard(Self.namespace + "/tasks/\(pathComponent(taskID))/reclaim", slug: board),
+            method: "POST",
+            body: try encodedDictionary(KanbanReclaimRequest(reason: reason))
+        )
+    }
+
+    func createBoard(slug: String, name: String, projectID: String? = nil) async throws -> KanbanBoardMetadata {
+        struct Body: Encodable {
+            let slug: String
+            let name: String
+            let projectID: String?
+            enum CodingKeys: String, CodingKey { case slug, name; case projectID = "project_id" }
+        }
+        let response = try await request(
+            path: Self.namespace + "/boards",
+            method: "POST",
+            body: try encodedDictionary(Body(slug: slug, name: name, projectID: projectID))
+        )
+        return try decodeResponse(BoardEnvelope.self, from: response).board
+    }
+
+    func updateBoard(slug: String, name: String?, description: String?, defaultWorkdir: String?) async throws -> KanbanBoardMetadata {
+        struct Body: Encodable {
+            let name: String?
+            let description: String?
+            let defaultWorkdir: String?
+            enum CodingKeys: String, CodingKey {
+                case name, description
+                case defaultWorkdir = "default_workdir"
+            }
+        }
+        let response = try await request(
+            path: Self.namespace + "/boards/\(pathComponent(slug))",
+            method: "PATCH",
+            body: try encodedDictionary(Body(name: name, description: description, defaultWorkdir: defaultWorkdir))
+        )
+        return try decodeResponse(BoardEnvelope.self, from: response).board
+    }
+
+    // MARK: - Transport helpers
+
+    private func decode<T: Decodable>(_ type: T.Type, path: String) async throws -> T {
+        let response = try await request(path: path, method: "GET", body: nil)
+        return try decodeResponse(type, from: response)
+    }
+
+    private func request(path: String, method: String, body: [String: Any]?) async throws -> [String: Any] {
+        try await requester.requestJSON(
+            path: path,
+            method: method,
+            body: body,
+            timeoutMilliseconds: 20_000,
+            maxResponseBytes: DataURLLimits.maxJSONResponseBytes
+        )
+    }
+
+    private func decodeResponse<T: Decodable>(_ type: T.Type, from response: [String: Any]) throws -> T {
+        guard JSONSerialization.isValidJSONObject(response), let data = try? JSONSerialization.data(withJSONObject: response) else {
+            throw KanbanServiceError.invalidResponse("Hermes returned an unreadable Kanban response.")
+        }
+        do {
+            return try decoder.decode(type, from: data)
+        } catch {
+            throw KanbanServiceError.invalidResponse("Hermes returned an unexpected Kanban response: \(error.localizedDescription)")
+        }
+    }
+
+    private func encodedDictionary<T: Encodable>(_ value: T) throws -> [String: Any] {
+        let data = try encoder.encode(value)
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw KanbanServiceError.invalidResponse("Could not encode the Kanban request.")
+        }
+        return object
+    }
+
+    private func withBoard(_ path: String, slug: String?, params: [String: String] = [:]) -> String {
+        var values = params
+        if let slug, !slug.isEmpty { values["board"] = slug }
+        guard !values.isEmpty else { return path }
+        let query = values.keys.sorted().compactMap { key -> String? in
+            guard let encodedValue = DashboardPath.encodedQueryComponent(values[key] ?? "") else { return nil }
+            return "\(key)=\(encodedValue)"
+        }.joined(separator: "&")
+        return query.isEmpty ? path : "\(path)?\(query)"
+    }
+
+    private func pathComponent(_ value: String) -> String {
+        DashboardPath.encodedQueryComponent(value) ?? value
+    }
+
+    private struct TaskEnvelope: Decodable { let task: KanbanTask? }
+    private struct BoardEnvelope: Decodable { let board: KanbanBoardMetadata }
+}

--- a/Conduit/Services/KanbanService.swift
+++ b/Conduit/Services/KanbanService.swift
@@ -19,6 +19,7 @@ enum KanbanServiceError: LocalizedError, Equatable {
     case invalidManualStatus(String)
     case taskCreatedButMoveFailed(taskID: String?, targetStatus: String, reason: String)
     case mutationInProgress
+    case invalidQueryParameter(String)
 
     var errorDescription: String? {
         switch self {
@@ -28,33 +29,49 @@ enum KanbanServiceError: LocalizedError, Equatable {
             if status == "running" {
                 return "Hermes controls Running; use the dispatcher/claim path instead of setting it manually."
             }
-            return "Hermes does not allow \(status) as a manual Kanban destination."
+            return "Hermes does not allow " + status + " as a manual Kanban destination."
         case .taskCreatedButMoveFailed(let taskID, let targetStatus, let reason):
-            let identifier = taskID.map { " (task \($0))" } ?? ""
-            return "The task was created\(identifier), but Hermes could not move it to \(targetStatus). It was not duplicated; close this form and refresh the board. \(reason)"
+            let identifier = taskID.map { " (task " + $0 + ")" } ?? ""
+            return "The task was created" + identifier + ", but Hermes could not move it to " + targetStatus + ". It was not duplicated; close this form and refresh the board. " + reason
         case .mutationInProgress:
             return "Another Kanban change is still being saved."
+        case .invalidQueryParameter(let name):
+            // Fail closed: a dropped board/id parameter would silently
+            // retarget the request at the backend's current board.
+            return "Could not build a safe Hermes Kanban request (invalid " + name + "). The operation was cancelled before any data changed."
         }
     }
 }
 
 /// Typed client for the authenticated Hermes dashboard Kanban plugin.
-/// This depends on the existing dashboard request bridge rather than HermesClient.
-/// Board selection is always sent as a local board query and never changes the
-/// server-wide current-board pointer. Profile scoping is kept here so views do
-/// not need to know dashboard routing details.
+///
+/// This depends on the existing dashboard request bridge rather than
+/// HermesClient. Board selection is always sent as a local board query and
+/// never changes the server-wide current-board pointer.
+///
+/// Profile routing: upstream Desktop reaches other Hermes profiles by dialing
+/// a per-profile backend process (each profile is an independent HERMES_HOME;
+/// see apps/desktop/electron/main.ts backendPool). The dashboard plugin API
+/// accepts no profile parameter and always serves the backend's own home, so
+/// this service deliberately sends no fabricated profile query parameter.
+/// Kanban in Conduit reflects the profile of the authenticated dashboard.
 @MainActor
 final class KanbanService {
     private let requester: any DashboardJSONRequester
     private let decoder: JSONDecoder
     private let encoder: JSONEncoder
-    private let profile: String
     private static let namespace = "/api/plugins/kanban"
+    /// Mirrors upstream's 400 ms dispatcher-nudge debounce (api.ts autoNudge).
+    static let dispatcherNudgeDebounceNanoseconds: UInt64 = 400_000_000
+    private let nudgeDebounceIntervalNanoseconds: UInt64
     private var pendingDispatcherNudge: Task<Void, Never>?
 
-    init(requester: any DashboardJSONRequester, profile: String = "default") {
+    init(
+        requester: any DashboardJSONRequester,
+        nudgeDebounceNanoseconds: UInt64 = KanbanService.dispatcherNudgeDebounceNanoseconds
+    ) {
         self.requester = requester
-        self.profile = profile
+        self.nudgeDebounceIntervalNanoseconds = max(1, nudgeDebounceNanoseconds)
         decoder = JSONDecoder()
         encoder = JSONEncoder()
     }
@@ -68,7 +85,7 @@ final class KanbanService {
         if includeArchived { params["include_archived"] = "true" }
         return try await decode(
             KanbanBoard.self,
-            path: withBoard(Self.namespace + "/board", slug: slug, params: params)
+            path: try withBoard(Self.namespace + "/board", slug: slug, params: params)
         )
     }
 
@@ -76,7 +93,7 @@ final class KanbanService {
         guard !id.isEmpty else { throw KanbanServiceError.emptyTaskID }
         return try await decode(
             KanbanTaskDetail.self,
-            path: withBoard(Self.namespace + "/tasks/\(pathComponent(id))", slug: board)
+            path: try withBoard(Self.namespace + "/tasks/" + (try pathComponent(id)), slug: board)
         )
     }
 
@@ -84,7 +101,7 @@ final class KanbanService {
         guard !id.isEmpty else { throw KanbanServiceError.emptyTaskID }
         return try await decode(
             KanbanWorkerLog.self,
-            path: withBoard(Self.namespace + "/tasks/\(pathComponent(id))/log", slug: board, params: ["tail": String(max(1, tailBytes))])
+            path: try withBoard(Self.namespace + "/tasks/" + (try pathComponent(id)) + "/log", slug: board, params: ["tail": String(max(1, tailBytes))])
         )
     }
 
@@ -104,7 +121,7 @@ final class KanbanService {
 
     func createTask(_ requestBody: KanbanCreateTaskRequest, board: String?) async throws -> KanbanCreateTaskResponse {
         let response = try await request(
-            path: withBoard(Self.namespace + "/tasks", slug: board),
+            path: try withBoard(Self.namespace + "/tasks", slug: board),
             method: "POST",
             body: try encodedDictionary(requestBody)
         )
@@ -115,7 +132,7 @@ final class KanbanService {
     func updateTask(id: String, board: String?, patch: KanbanTaskPatch) async throws -> KanbanTask? {
         guard !id.isEmpty else { throw KanbanServiceError.emptyTaskID }
         let response = try await request(
-            path: withBoard(Self.namespace + "/tasks/\(pathComponent(id))", slug: board),
+            path: try withBoard(Self.namespace + "/tasks/" + (try pathComponent(id)), slug: board),
             method: "PATCH",
             body: try encodedDictionary(patch)
         )
@@ -125,7 +142,7 @@ final class KanbanService {
     func deleteTask(id: String, board: String?) async throws {
         guard !id.isEmpty else { throw KanbanServiceError.emptyTaskID }
         _ = try await request(
-            path: withBoard(Self.namespace + "/tasks/\(pathComponent(id))", slug: board),
+            path: try withBoard(Self.namespace + "/tasks/" + (try pathComponent(id)), slug: board),
             method: "DELETE",
             body: nil
         )
@@ -136,7 +153,7 @@ final class KanbanService {
         let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         _ = try await request(
-            path: withBoard(Self.namespace + "/tasks/\(pathComponent(taskID))/comments", slug: board),
+            path: try withBoard(Self.namespace + "/tasks/" + (try pathComponent(taskID)) + "/comments", slug: board),
             method: "POST",
             body: try encodedDictionary(KanbanCommentRequest(author: author, body: trimmed))
         )
@@ -145,7 +162,7 @@ final class KanbanService {
     func reassignTask(taskID: String, board: String?, profile: String?, reclaimFirst: Bool = true, reason: String? = nil) async throws {
         guard !taskID.isEmpty else { throw KanbanServiceError.emptyTaskID }
         _ = try await request(
-            path: withBoard(Self.namespace + "/tasks/\(pathComponent(taskID))/reassign", slug: board),
+            path: try withBoard(Self.namespace + "/tasks/" + (try pathComponent(taskID)) + "/reassign", slug: board),
             method: "POST",
             body: try encodedDictionary(KanbanReassignRequest(profile: profile, reclaimFirst: reclaimFirst, reason: reason))
         )
@@ -154,37 +171,43 @@ final class KanbanService {
     func reclaimTask(taskID: String, board: String?, reason: String? = nil) async throws {
         guard !taskID.isEmpty else { throw KanbanServiceError.emptyTaskID }
         _ = try await request(
-            path: withBoard(Self.namespace + "/tasks/\(pathComponent(taskID))/reclaim", slug: board),
+            path: try withBoard(Self.namespace + "/tasks/" + (try pathComponent(taskID)) + "/reclaim", slug: board),
             method: "POST",
             body: try encodedDictionary(KanbanReclaimRequest(reason: reason))
         )
     }
 
-    /// Best-effort quick path for the backend dispatcher. The short delay
-    /// coalesces rapid writes while keeping the nudge inside the Kanban layer.
-    /// Its result is deliberately ignored: a successful mutation remains a
-    /// success even when no dispatcher is available.
-    func nudgeDispatcher(board: String?) async {
-        if let pendingDispatcherNudge {
-            await pendingDispatcherNudge.value
-            return
-        }
+    // MARK: - Dispatcher nudge
 
-        let task = Task { [weak self] in
+    /// Schedule the upstream-equivalent acceleration hint for the backend
+    /// dispatcher. True fire-and-forget: returns immediately (it never blocks
+    /// or outlives a mutation's success), coalesces rapid writes onto one
+    /// debounced timer, and swallows its own failures - the periodic backend
+    /// tick remains the fallback. The board scope is captured now so a later
+    /// board switch cannot retarget an already-scheduled nudge.
+    func scheduleDispatcherNudge(board: String?) {
+        pendingDispatcherNudge?.cancel()
+        let capturedBoard = board
+        let debounce = nudgeDebounceIntervalNanoseconds
+        pendingDispatcherNudge = Task { [weak self] in
             do {
-                try await Task.sleep(nanoseconds: 75_000_000)
+                try? await Task.sleep(nanoseconds: debounce)
+                if Task.isCancelled { return }
                 guard let self else { return }
                 _ = try? await self.request(
-                    path: self.withBoard(Self.namespace + "/dispatch", slug: board),
+                    path: try self.withBoard(Self.namespace + "/dispatch", slug: capturedBoard),
                     method: "POST",
-                    body: nil
+                    body: [:]
                 )
             } catch {
                 // Dispatch is an acceleration hint, never a mutation dependency.
             }
         }
-        pendingDispatcherNudge = task
-        await task.value
+    }
+
+    /// Test seam: awaits (without cancelling) any in-flight debounced nudge.
+    func awaitPendingDispatcherNudgeForTesting() async {
+        await pendingDispatcherNudge?.value
         pendingDispatcherNudge = nil
     }
 
@@ -214,7 +237,7 @@ final class KanbanService {
             }
         }
         let response = try await request(
-            path: scoped(Self.namespace + "/boards/\(pathComponent(slug))"),
+            path: scoped(Self.namespace + "/boards/" + (try pathComponent(slug))),
             method: "PATCH",
             body: try encodedDictionary(Body(name: name, description: description, defaultWorkdir: defaultWorkdir))
         )
@@ -245,7 +268,7 @@ final class KanbanService {
         do {
             return try decoder.decode(type, from: data)
         } catch {
-            throw KanbanServiceError.invalidResponse("Hermes returned an unexpected Kanban response: \(error.localizedDescription)")
+            throw KanbanServiceError.invalidResponse("Hermes returned an unexpected Kanban response: " + error.localizedDescription)
         }
     }
 
@@ -258,23 +281,33 @@ final class KanbanService {
     }
 
     private func scoped(_ path: String) -> String {
-        withBoard(path, slug: nil)
+        // Reserved seam for future request-scoped parameters. Today the plugin
+        // API takes no profile/scope query and must stay that way.
+        path
     }
 
-    private func withBoard(_ path: String, slug: String?, params: [String: String] = [:]) -> String {
+    /// Throwing query builder: board scope is data-integrity critical, so an
+    /// unencodable parameter fails the request instead of silently vanishing
+    /// (which would retarget the call at the backend's current board).
+    private func withBoard(_ path: String, slug: String?, params: [String: String] = [:]) throws -> String {
         var values = params
         if let slug, !slug.isEmpty { values["board"] = slug }
-        if !profile.isEmpty, profile != "default" { values["profile"] = profile }
         guard !values.isEmpty else { return path }
-        let query = values.keys.sorted().compactMap { key -> String? in
-            guard let encodedValue = DashboardPath.encodedQueryComponent(values[key] ?? "") else { return nil }
-            return "\(key)=\(encodedValue)"
+        let query = try values.keys.sorted().map { key -> String in
+            guard let encodedKey = DashboardPath.encodedQueryComponent(key),
+                  let encodedValue = DashboardPath.encodedQueryComponent(values[key] ?? "") else {
+                throw KanbanServiceError.invalidQueryParameter(key)
+            }
+            return encodedKey + "=" + encodedValue
         }.joined(separator: "&")
-        return query.isEmpty ? path : "\(path)?\(query)"
+        return query.isEmpty ? path : path + "?" + query
     }
 
-    private func pathComponent(_ value: String) -> String {
-        DashboardPath.encodedQueryComponent(value) ?? value
+    private func pathComponent(_ value: String) throws -> String {
+        guard let encoded = DashboardPath.encodedQueryComponent(value), !encoded.isEmpty else {
+            throw KanbanServiceError.invalidQueryParameter("id")
+        }
+        return encoded
     }
 
     private struct TaskEnvelope: Decodable { let task: KanbanTask? }

--- a/Conduit/Services/KanbanService.swift
+++ b/Conduit/Services/KanbanService.swift
@@ -16,11 +16,24 @@ extension DashboardTicketBridge: DashboardJSONRequester {}
 enum KanbanServiceError: LocalizedError, Equatable {
     case invalidResponse(String)
     case emptyTaskID
+    case invalidManualStatus(String)
+    case taskCreatedButMoveFailed(taskID: String?, targetStatus: String, reason: String)
+    case mutationInProgress
 
     var errorDescription: String? {
         switch self {
         case .invalidResponse(let message): return message
         case .emptyTaskID: return "Hermes returned a Kanban task without an ID."
+        case .invalidManualStatus(let status):
+            if status == "running" {
+                return "Hermes controls Running; use the dispatcher/claim path instead of setting it manually."
+            }
+            return "Hermes does not allow \(status) as a manual Kanban destination."
+        case .taskCreatedButMoveFailed(let taskID, let targetStatus, let reason):
+            let identifier = taskID.map { " (task \($0))" } ?? ""
+            return "The task was created\(identifier), but Hermes could not move it to \(targetStatus). It was not duplicated; close this form and refresh the board. \(reason)"
+        case .mutationInProgress:
+            return "Another Kanban change is still being saved."
         }
     }
 }
@@ -28,22 +41,26 @@ enum KanbanServiceError: LocalizedError, Equatable {
 /// Typed client for the authenticated Hermes dashboard Kanban plugin.
 /// This depends on the existing dashboard request bridge rather than HermesClient.
 /// Board selection is always sent as a local board query and never changes the
-/// server-wide current-board pointer.
+/// server-wide current-board pointer. Profile scoping is kept here so views do
+/// not need to know dashboard routing details.
 @MainActor
 final class KanbanService {
     private let requester: any DashboardJSONRequester
     private let decoder: JSONDecoder
     private let encoder: JSONEncoder
+    private let profile: String
     private static let namespace = "/api/plugins/kanban"
+    private var pendingDispatcherNudge: Task<Void, Never>?
 
-    init(requester: any DashboardJSONRequester) {
+    init(requester: any DashboardJSONRequester, profile: String = "default") {
         self.requester = requester
+        self.profile = profile
         decoder = JSONDecoder()
         encoder = JSONEncoder()
     }
 
     func fetchBoards() async throws -> KanbanBoardsResponse {
-        try await decode(KanbanBoardsResponse.self, path: Self.namespace + "/boards")
+        try await decode(KanbanBoardsResponse.self, path: scoped(Self.namespace + "/boards"))
     }
 
     func fetchBoard(slug: String?, includeArchived: Bool) async throws -> KanbanBoard {
@@ -72,17 +89,17 @@ final class KanbanService {
     }
 
     func fetchProfiles() async throws -> [KanbanProfile] {
-        let response = try await decode(KanbanProfilesResponse.self, path: Self.namespace + "/profiles")
+        let response = try await decode(KanbanProfilesResponse.self, path: scoped(Self.namespace + "/profiles"))
         return response.profiles
     }
 
     func fetchProjects() async throws -> [KanbanProject] {
-        let response = try await decode(KanbanProjectsResponse.self, path: Self.namespace + "/projects")
+        let response = try await decode(KanbanProjectsResponse.self, path: scoped(Self.namespace + "/projects"))
         return response.projects
     }
 
     func fetchOrchestration() async throws -> KanbanOrchestrationSettings {
-        try await decode(KanbanOrchestrationSettings.self, path: Self.namespace + "/orchestration")
+        try await decode(KanbanOrchestrationSettings.self, path: scoped(Self.namespace + "/orchestration"))
     }
 
     func createTask(_ requestBody: KanbanCreateTaskRequest, board: String?) async throws -> KanbanCreateTaskResponse {
@@ -143,6 +160,34 @@ final class KanbanService {
         )
     }
 
+    /// Best-effort quick path for the backend dispatcher. The short delay
+    /// coalesces rapid writes while keeping the nudge inside the Kanban layer.
+    /// Its result is deliberately ignored: a successful mutation remains a
+    /// success even when no dispatcher is available.
+    func nudgeDispatcher(board: String?) async {
+        if let pendingDispatcherNudge {
+            await pendingDispatcherNudge.value
+            return
+        }
+
+        let task = Task { [weak self] in
+            do {
+                try await Task.sleep(nanoseconds: 75_000_000)
+                guard let self else { return }
+                _ = try? await self.request(
+                    path: self.withBoard(Self.namespace + "/dispatch", slug: board),
+                    method: "POST",
+                    body: nil
+                )
+            } catch {
+                // Dispatch is an acceleration hint, never a mutation dependency.
+            }
+        }
+        pendingDispatcherNudge = task
+        await task.value
+        pendingDispatcherNudge = nil
+    }
+
     func createBoard(slug: String, name: String, projectID: String? = nil) async throws -> KanbanBoardMetadata {
         struct Body: Encodable {
             let slug: String
@@ -151,7 +196,7 @@ final class KanbanService {
             enum CodingKeys: String, CodingKey { case slug, name; case projectID = "project_id" }
         }
         let response = try await request(
-            path: Self.namespace + "/boards",
+            path: scoped(Self.namespace + "/boards"),
             method: "POST",
             body: try encodedDictionary(Body(slug: slug, name: name, projectID: projectID))
         )
@@ -169,7 +214,7 @@ final class KanbanService {
             }
         }
         let response = try await request(
-            path: Self.namespace + "/boards/\(pathComponent(slug))",
+            path: scoped(Self.namespace + "/boards/\(pathComponent(slug))"),
             method: "PATCH",
             body: try encodedDictionary(Body(name: name, description: description, defaultWorkdir: defaultWorkdir))
         )
@@ -212,9 +257,14 @@ final class KanbanService {
         return object
     }
 
+    private func scoped(_ path: String) -> String {
+        withBoard(path, slug: nil)
+    }
+
     private func withBoard(_ path: String, slug: String?, params: [String: String] = [:]) -> String {
         var values = params
         if let slug, !slug.isEmpty { values["board"] = slug }
+        if !profile.isEmpty, profile != "default" { values["profile"] = profile }
         guard !values.isEmpty else { return path }
         let query = values.keys.sorted().compactMap { key -> String? in
             guard let encodedValue = DashboardPath.encodedQueryComponent(values[key] ?? "") else { return nil }

--- a/Conduit/Services/KanbanService.swift
+++ b/Conduit/Services/KanbanService.swift
@@ -49,12 +49,13 @@ enum KanbanServiceError: LocalizedError, Equatable {
 /// HermesClient. Board selection is always sent as a local board query and
 /// never changes the server-wide current-board pointer.
 ///
-/// Profile routing: upstream Desktop reaches other Hermes profiles by dialing
-/// a per-profile backend process (each profile is an independent HERMES_HOME;
-/// see apps/desktop/electron/main.ts backendPool). The dashboard plugin API
-/// accepts no profile parameter and always serves the backend's own home, so
-/// this service deliberately sends no fabricated profile query parameter.
-/// Kanban in Conduit reflects the profile of the authenticated dashboard.
+/// Profiles: Hermes Kanban is intentionally a SHARED, cross-profile board.
+/// hermes_cli/kanban_db.py anchors boards at the shared Hermes root - when
+/// HERMES_HOME is <root>/profiles/<name>, paths resolve back through
+/// get_default_hermes_root() so every profile joins the same dispatch bus by
+/// design. There is therefore nothing profile-scoped to request: this service
+/// deliberately sends no profile query parameter, and switching Conduit's UI
+/// profile must not reload or re-scope Kanban.
 @MainActor
 final class KanbanService {
     private let requester: any DashboardJSONRequester

--- a/Conduit/Services/KanbanStore.swift
+++ b/Conduit/Services/KanbanStore.swift
@@ -1,0 +1,161 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class KanbanStore: ObservableObject {
+    static let selectedBoardKey = "conduit.kanbanBoardSlug"
+
+    @Published private(set) var boards: [KanbanBoardMetadata] = []
+    @Published private(set) var currentServerBoardSlug = "default"
+    @Published private(set) var board: KanbanBoard?
+    @Published private(set) var profiles: [KanbanProfile] = []
+    @Published private(set) var projects: [KanbanProject] = []
+    @Published private(set) var orchestration: KanbanOrchestrationSettings?
+    @Published private(set) var selectedBoardSlug: String
+    @Published private(set) var isLoading = false
+    @Published private(set) var errorMessage: String?
+
+    private let defaults: UserDefaults
+    private var service: KanbanService?
+    private var requesterID: ObjectIdentifier?
+    private var loadGeneration = 0
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        selectedBoardSlug = defaults.string(forKey: Self.selectedBoardKey) ?? ""
+    }
+
+    var effectiveBoardSlug: String? {
+        selectedBoardSlug.isEmpty ? nil : selectedBoardSlug
+    }
+
+    var selectedBoardMetadata: KanbanBoardMetadata? {
+        let slug = selectedBoardSlug.isEmpty ? currentServerBoardSlug : selectedBoardSlug
+        return boards.first(where: { $0.slug == slug })
+    }
+
+    func configure(requester: (any DashboardJSONRequester)?) {
+        guard let requester else {
+            service = nil
+            requesterID = nil
+            return
+        }
+        let identity = ObjectIdentifier(requester)
+        guard requesterID != identity else { return }
+        service = KanbanService(requester: requester)
+        requesterID = identity
+    }
+
+    func reload(includeArchived: Bool = false) async {
+        loadGeneration &+= 1
+        let generation = loadGeneration
+        guard let service else {
+            board = nil
+            errorMessage = "Connect to a Hermes dashboard to use Kanban."
+            return
+        }
+
+        isLoading = true
+        errorMessage = nil
+        defer {
+            if generation == loadGeneration { isLoading = false }
+        }
+
+        do {
+            let boardResponse = try await service.fetchBoards()
+            guard generation == loadGeneration else { return }
+
+            boards = boardResponse.boards
+            currentServerBoardSlug = boardResponse.current
+
+            if !selectedBoardSlug.isEmpty && !boards.contains(where: { $0.slug == selectedBoardSlug }) {
+                selectedBoardSlug = ""
+                defaults.removeObject(forKey: Self.selectedBoardKey)
+            }
+
+            async let loadedBoard = service.fetchBoard(slug: effectiveBoardSlug, includeArchived: includeArchived)
+            async let loadedProfiles = try? service.fetchProfiles()
+            async let loadedProjects = try? service.fetchProjects()
+            async let loadedOrchestration = try? service.fetchOrchestration()
+
+            let resolvedBoard = try await loadedBoard
+            let resolvedProfiles = await loadedProfiles
+            let resolvedProjects = await loadedProjects
+            let resolvedOrchestration = await loadedOrchestration
+            guard generation == loadGeneration else { return }
+
+            board = resolvedBoard
+            if let resolvedProfiles { profiles = resolvedProfiles }
+            if let resolvedProjects { projects = resolvedProjects }
+            if let resolvedOrchestration { orchestration = resolvedOrchestration }
+        } catch is CancellationError {
+            return
+        } catch {
+            guard generation == loadGeneration else { return }
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func selectBoard(slug: String, includeArchived: Bool = false) async {
+        selectedBoardSlug = slug
+        if slug.isEmpty {
+            defaults.removeObject(forKey: Self.selectedBoardKey)
+        } else {
+            defaults.set(slug, forKey: Self.selectedBoardKey)
+        }
+        await reload(includeArchived: includeArchived)
+    }
+
+    func refresh(includeArchived: Bool = false) async {
+        await reload(includeArchived: includeArchived)
+    }
+
+    func fetchTaskDetail(id: String) async throws -> KanbanTaskDetail {
+        guard let service else { throw KanbanServiceError.invalidResponse("Kanban is not connected.") }
+        return try await service.fetchTask(id: id, board: effectiveBoardSlug)
+    }
+
+    func fetchTaskLog(id: String, tailBytes: Int = 16_384) async throws -> KanbanWorkerLog {
+        guard let service else { throw KanbanServiceError.invalidResponse("Kanban is not connected.") }
+        return try await service.fetchTaskLog(id: id, board: effectiveBoardSlug, tailBytes: tailBytes)
+    }
+
+    @discardableResult
+    func createTask(_ request: KanbanCreateTaskRequest, includeArchived: Bool = false) async throws -> KanbanTask? {
+        guard let service else { throw KanbanServiceError.invalidResponse("Kanban is not connected.") }
+        let response = try await service.createTask(request, board: effectiveBoardSlug)
+        await reload(includeArchived: includeArchived)
+        return response.task
+    }
+
+    @discardableResult
+    func updateTask(id: String, patch: KanbanTaskPatch, includeArchived: Bool = false) async throws -> KanbanTask? {
+        guard let service else { throw KanbanServiceError.invalidResponse("Kanban is not connected.") }
+        let task = try await service.updateTask(id: id, board: effectiveBoardSlug, patch: patch)
+        await reload(includeArchived: includeArchived)
+        return task
+    }
+
+    func deleteTask(id: String, includeArchived: Bool = false) async throws {
+        guard let service else { throw KanbanServiceError.invalidResponse("Kanban is not connected.") }
+        try await service.deleteTask(id: id, board: effectiveBoardSlug)
+        await reload(includeArchived: includeArchived)
+    }
+
+    func addComment(taskID: String, body: String) async throws {
+        guard let service else { throw KanbanServiceError.invalidResponse("Kanban is not connected.") }
+        try await service.addComment(taskID: taskID, board: effectiveBoardSlug, body: body)
+    }
+
+    func reassignTask(taskID: String, profile: String?, reclaimFirst: Bool = true) async throws {
+        guard let service else { throw KanbanServiceError.invalidResponse("Kanban is not connected.") }
+        try await service.reassignTask(taskID: taskID, board: effectiveBoardSlug, profile: profile, reclaimFirst: reclaimFirst)
+        await reload()
+    }
+
+    func reclaimTask(taskID: String, reason: String? = nil) async throws {
+        guard let service else { throw KanbanServiceError.invalidResponse("Kanban is not connected.") }
+        try await service.reclaimTask(taskID: taskID, board: effectiveBoardSlug, reason: reason)
+        await reload()
+    }
+}

--- a/Conduit/Services/KanbanStore.swift
+++ b/Conduit/Services/KanbanStore.swift
@@ -11,18 +11,22 @@ final class KanbanStore: ObservableObject {
     @Published private(set) var profiles: [KanbanProfile] = []
     @Published private(set) var projects: [KanbanProject] = []
     @Published private(set) var orchestration: KanbanOrchestrationSettings?
-    @Published private(set) var selectedBoardSlug: String
+    @Published private(set) var selectedBoardSlug = ""
     @Published private(set) var isLoading = false
+    @Published private(set) var isMutating = false
     @Published private(set) var errorMessage: String?
+    @Published private(set) var mutationErrorMessage: String?
 
     private let defaults: UserDefaults
     private var service: KanbanService?
     private var requesterID: ObjectIdentifier?
+    private var profile = "default"
+    private var serverIdentity = ""
+    private var persistenceKey: String?
     private var loadGeneration = 0
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
-        selectedBoardSlug = defaults.string(forKey: Self.selectedBoardKey) ?? ""
     }
 
     var effectiveBoardSlug: String? {
@@ -34,24 +38,64 @@ final class KanbanStore: ObservableObject {
         return boards.first(where: { $0.slug == slug })
     }
 
-    func configure(requester: (any DashboardJSONRequester)?) {
+    static func scopedBoardKey(serverIdentity: String, profile: String) -> String {
+        "\(selectedBoardKey).\(scopeToken(serverIdentity)).\(scopeToken(profile))"
+    }
+
+    func configure(
+        requester: (any DashboardJSONRequester)?,
+        profile: String = "default",
+        serverIdentity: String = ""
+    ) {
         guard let requester else {
             service = nil
             requesterID = nil
+            board = nil
+            boards = []
             return
         }
+
+        let normalizedProfile = profile.isEmpty ? "default" : profile
+        let normalizedServer = serverIdentity.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         let identity = ObjectIdentifier(requester)
-        guard requesterID != identity else { return }
-        service = KanbanService(requester: requester)
+        let nextPersistenceKey = Self.scopedBoardKey(serverIdentity: normalizedServer, profile: normalizedProfile)
+        guard requesterID != identity || self.profile != normalizedProfile || self.serverIdentity != normalizedServer else {
+            return
+        }
+
+        self.service = KanbanService(requester: requester, profile: normalizedProfile)
         requesterID = identity
+        self.profile = normalizedProfile
+        self.serverIdentity = normalizedServer
+        persistenceKey = nextPersistenceKey
+        selectedBoardSlug = defaults.string(forKey: nextPersistenceKey) ?? ""
+
+        // One-time migration for the pre-profile-scoped key. Once migrated,
+        // every subsequent profile gets an independent board selection.
+        if selectedBoardSlug.isEmpty, let legacy = defaults.string(forKey: Self.selectedBoardKey) {
+            selectedBoardSlug = legacy
+            defaults.set(legacy, forKey: nextPersistenceKey)
+            defaults.removeObject(forKey: Self.selectedBoardKey)
+        }
+
+        board = nil
+        boards = []
+        profiles = []
+        projects = []
+        orchestration = nil
+        currentServerBoardSlug = "default"
+        errorMessage = nil
+        mutationErrorMessage = nil
     }
 
     func reload(includeArchived: Bool = false) async {
+        guard !isLoading else { return }
         loadGeneration &+= 1
         let generation = loadGeneration
         guard let service else {
-            board = nil
-            errorMessage = "Connect to a Hermes dashboard to use Kanban."
+            if board == nil {
+                errorMessage = "Connect to a Hermes dashboard to use Kanban."
+            }
             return
         }
 
@@ -70,7 +114,7 @@ final class KanbanStore: ObservableObject {
 
             if !selectedBoardSlug.isEmpty && !boards.contains(where: { $0.slug == selectedBoardSlug }) {
                 selectedBoardSlug = ""
-                defaults.removeObject(forKey: Self.selectedBoardKey)
+                if let persistenceKey { defaults.removeObject(forKey: persistenceKey) }
             }
 
             async let loadedBoard = service.fetchBoard(slug: effectiveBoardSlug, includeArchived: includeArchived)
@@ -92,21 +136,28 @@ final class KanbanStore: ObservableObject {
             return
         } catch {
             guard generation == loadGeneration else { return }
+            // Keep the last successful board visible during refresh failures.
             errorMessage = error.localizedDescription
         }
+    }
+
+    func poll(includeArchived: Bool = false) async {
+        guard !isMutating, !isLoading else { return }
+        await reload(includeArchived: includeArchived)
     }
 
     func selectBoard(slug: String, includeArchived: Bool = false) async {
         selectedBoardSlug = slug
         if slug.isEmpty {
-            defaults.removeObject(forKey: Self.selectedBoardKey)
-        } else {
-            defaults.set(slug, forKey: Self.selectedBoardKey)
+            if let persistenceKey { defaults.removeObject(forKey: persistenceKey) }
+        } else if let persistenceKey {
+            defaults.set(slug, forKey: persistenceKey)
         }
         await reload(includeArchived: includeArchived)
     }
 
     func refresh(includeArchived: Bool = false) async {
+        guard !isMutating else { return }
         await reload(includeArchived: includeArchived)
     }
 
@@ -121,41 +172,162 @@ final class KanbanStore: ObservableObject {
     }
 
     @discardableResult
-    func createTask(_ request: KanbanCreateTaskRequest, includeArchived: Bool = false) async throws -> KanbanTask? {
-        guard let service else { throw KanbanServiceError.invalidResponse("Kanban is not connected.") }
-        let response = try await service.createTask(request, board: effectiveBoardSlug)
-        await reload(includeArchived: includeArchived)
-        return response.task
+    func createTask(
+        _ request: KanbanCreateTaskRequest,
+        initialStatus: String? = nil,
+        includeArchived: Bool = false
+    ) async throws -> KanbanTask? {
+        guard let service else {
+            let error = KanbanServiceError.invalidResponse("Kanban is not connected.")
+            mutationErrorMessage = error.localizedDescription
+            throw error
+        }
+        let targetStatus = initialStatus ?? (request.triage ? "triage" : "todo")
+
+        return try await performMutation(includeArchived: includeArchived) {
+            guard KanbanStatusPresentation.canCreateTask(in: targetStatus) else {
+                throw KanbanServiceError.invalidManualStatus(targetStatus)
+            }
+
+            var body = request
+            if targetStatus == "triage" { body.triage = true }
+            let response = try await service.createTask(body, board: self.effectiveBoardSlug)
+            var task = response.task
+
+            // The backend owns native triage/default creation. Other supported
+            // manual lanes use one guarded follow-up transition.
+            let needsMove = targetStatus != "todo" && targetStatus != "triage" && task?.status != targetStatus
+            if needsMove {
+                guard let taskID = task?.id, !taskID.isEmpty else {
+                    await service.nudgeDispatcher(board: self.effectiveBoardSlug)
+                    throw KanbanServiceError.taskCreatedButMoveFailed(
+                        taskID: nil,
+                        targetStatus: targetStatus,
+                        reason: "Hermes did not return the created task ID."
+                    )
+                }
+                do {
+                    task = try await service.updateTask(
+                        id: taskID,
+                        board: self.effectiveBoardSlug,
+                        patch: KanbanTaskPatch(status: targetStatus)
+                    ) ?? task
+                } catch {
+                    await service.nudgeDispatcher(board: self.effectiveBoardSlug)
+                    throw KanbanServiceError.taskCreatedButMoveFailed(
+                        taskID: taskID,
+                        targetStatus: targetStatus,
+                        reason: error.localizedDescription
+                    )
+                }
+            }
+
+            await service.nudgeDispatcher(board: self.effectiveBoardSlug)
+            return task
+        }
     }
 
     @discardableResult
     func updateTask(id: String, patch: KanbanTaskPatch, includeArchived: Bool = false) async throws -> KanbanTask? {
-        guard let service else { throw KanbanServiceError.invalidResponse("Kanban is not connected.") }
-        let task = try await service.updateTask(id: id, board: effectiveBoardSlug, patch: patch)
-        await reload(includeArchived: includeArchived)
-        return task
+        guard let service else {
+            let error = KanbanServiceError.invalidResponse("Kanban is not connected.")
+            mutationErrorMessage = error.localizedDescription
+            throw error
+        }
+        return try await performMutation(includeArchived: includeArchived) {
+            if let status = patch.status, !KanbanStatusPresentation.canSelectManually(status) {
+                throw KanbanServiceError.invalidManualStatus(status)
+            }
+            let task = try await service.updateTask(id: id, board: self.effectiveBoardSlug, patch: patch)
+            await service.nudgeDispatcher(board: self.effectiveBoardSlug)
+            return task
+        }
     }
 
     func deleteTask(id: String, includeArchived: Bool = false) async throws {
-        guard let service else { throw KanbanServiceError.invalidResponse("Kanban is not connected.") }
-        try await service.deleteTask(id: id, board: effectiveBoardSlug)
-        await reload(includeArchived: includeArchived)
+        guard let service else {
+            let error = KanbanServiceError.invalidResponse("Kanban is not connected.")
+            mutationErrorMessage = error.localizedDescription
+            throw error
+        }
+        try await performMutation(includeArchived: includeArchived) {
+            try await service.deleteTask(id: id, board: self.effectiveBoardSlug)
+            await service.nudgeDispatcher(board: self.effectiveBoardSlug)
+        }
     }
 
     func addComment(taskID: String, body: String) async throws {
-        guard let service else { throw KanbanServiceError.invalidResponse("Kanban is not connected.") }
-        try await service.addComment(taskID: taskID, board: effectiveBoardSlug, body: body)
+        guard let service else {
+            let error = KanbanServiceError.invalidResponse("Kanban is not connected.")
+            mutationErrorMessage = error.localizedDescription
+            throw error
+        }
+        try await performMutation(includeArchived: false) {
+            try await service.addComment(taskID: taskID, board: self.effectiveBoardSlug, body: body)
+        }
     }
 
     func reassignTask(taskID: String, profile: String?, reclaimFirst: Bool = true) async throws {
-        guard let service else { throw KanbanServiceError.invalidResponse("Kanban is not connected.") }
-        try await service.reassignTask(taskID: taskID, board: effectiveBoardSlug, profile: profile, reclaimFirst: reclaimFirst)
-        await reload()
+        guard let service else {
+            let error = KanbanServiceError.invalidResponse("Kanban is not connected.")
+            mutationErrorMessage = error.localizedDescription
+            throw error
+        }
+        try await performMutation(includeArchived: false) {
+            try await service.reassignTask(taskID: taskID, board: self.effectiveBoardSlug, profile: profile, reclaimFirst: reclaimFirst)
+            await service.nudgeDispatcher(board: self.effectiveBoardSlug)
+        }
     }
 
     func reclaimTask(taskID: String, reason: String? = nil) async throws {
-        guard let service else { throw KanbanServiceError.invalidResponse("Kanban is not connected.") }
-        try await service.reclaimTask(taskID: taskID, board: effectiveBoardSlug, reason: reason)
-        await reload()
+        guard let service else {
+            let error = KanbanServiceError.invalidResponse("Kanban is not connected.")
+            mutationErrorMessage = error.localizedDescription
+            throw error
+        }
+        try await performMutation(includeArchived: false) {
+            try await service.reclaimTask(taskID: taskID, board: self.effectiveBoardSlug, reason: reason)
+            await service.nudgeDispatcher(board: self.effectiveBoardSlug)
+        }
+    }
+
+    func clearMutationError() {
+        mutationErrorMessage = nil
+    }
+
+    func showMutationError(_ error: Error) {
+        mutationErrorMessage = error.localizedDescription
+    }
+
+    // MARK: - Mutation state
+
+    private func performMutation<T>(includeArchived: Bool, operation: () async throws -> T) async throws -> T {
+        guard !isMutating else {
+            let error = KanbanServiceError.mutationInProgress
+            mutationErrorMessage = error.localizedDescription
+            throw error
+        }
+        isMutating = true
+        mutationErrorMessage = nil
+        do {
+            let result = try await operation()
+            isMutating = false
+            await reload(includeArchived: includeArchived)
+            return result
+        } catch {
+            isMutating = false
+            await reload(includeArchived: includeArchived)
+            mutationErrorMessage = error.localizedDescription
+            throw error
+        }
+    }
+
+
+    private static func scopeToken(_ value: String) -> String {
+        Data(value.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
     }
 }

--- a/Conduit/Services/KanbanStore.swift
+++ b/Conduit/Services/KanbanStore.swift
@@ -1,6 +1,15 @@
 import Foundation
 import SwiftUI
 
+/// Immutable capture of everything a mutation needs. Captured BEFORE the first
+/// suspension point so a concurrent board/server switch can never splice a
+/// new board slug (or a different backend) into an in-flight write.
+struct KanbanOperationContext {
+    let service: KanbanService
+    let boardSlug: String?
+    let configurationGeneration: Int
+}
+
 @MainActor
 final class KanbanStore: ObservableObject {
     static let selectedBoardKey = "conduit.kanbanBoardSlug"
@@ -18,15 +27,22 @@ final class KanbanStore: ObservableObject {
     @Published private(set) var mutationErrorMessage: String?
 
     private let defaults: UserDefaults
+    private let makeService: @MainActor (any DashboardJSONRequester) -> KanbanService
     private var service: KanbanService?
     private var requesterID: ObjectIdentifier?
-    private var profile = "default"
     private var serverIdentity = ""
     private var persistenceKey: String?
     private var loadGeneration = 0
+    /// Bumped on every configure(); captured by mutations so post-mutation
+    /// refreshes from an old server/board context are discarded.
+    private var configurationGeneration = 0
 
-    init(defaults: UserDefaults = .standard) {
+    init(
+        defaults: UserDefaults = .standard,
+        serviceFactory: ((any DashboardJSONRequester) -> KanbanService)? = nil
+    ) {
         self.defaults = defaults
+        self.makeService = serviceFactory ?? { KanbanService(requester: $0) }
     }
 
     var effectiveBoardSlug: String? {
@@ -38,17 +54,21 @@ final class KanbanStore: ObservableObject {
         return boards.first(where: { $0.slug == slug })
     }
 
-    static func scopedBoardKey(serverIdentity: String, profile: String) -> String {
-        "\(selectedBoardKey).\(scopeToken(serverIdentity)).\(scopeToken(profile))"
+    /// Board selection is scoped to the dashboard SERVER identity only. The
+    /// plugin API serves the backend's own Hermes home (one profile per
+    /// process), so the server URL - not the app-level UI profile - is the
+    /// real data boundary. Two dashboards never share a selection; switching
+    /// Conduit's active profile on one dashboard intentionally does not either.
+    static func scopedBoardKey(serverIdentity: String) -> String {
+        // Normalize exactly like configure() so equivalent URLs share a key.
+        let normalized = serverIdentity.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return selectedBoardKey + "." + scopeToken(normalized)
     }
 
-    func configure(
-        requester: (any DashboardJSONRequester)?,
-        profile: String = "default",
-        serverIdentity: String = ""
-    ) {
+    func configure(requester: (any DashboardJSONRequester)?, serverIdentity: String = "") {
         guard let requester else {
-            loadGeneration &+= 1
+            configurationGeneration += 1
+            loadGeneration += 1
             isLoading = false
             service = nil
             requesterID = nil
@@ -57,30 +77,27 @@ final class KanbanStore: ObservableObject {
             return
         }
 
-        let normalizedProfile = profile.isEmpty ? "default" : profile
         let normalizedServer = serverIdentity.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         let identity = ObjectIdentifier(requester)
-        let nextPersistenceKey = Self.scopedBoardKey(serverIdentity: normalizedServer, profile: normalizedProfile)
-        guard requesterID != identity || self.profile != normalizedProfile || self.serverIdentity != normalizedServer else {
-            return
-        }
+        if requesterID == identity && self.serverIdentity == normalizedServer { return }
 
-        // Invalidate any cancelled load from the previous bridge/profile. Its
-        // response must not repopulate this store after the profile changes.
-        loadGeneration &+= 1
+        // Invalidate any cancelled load or in-flight mutation from the
+        // previous bridge/server. Their completions must not repopulate this
+        // store after the data source changes.
+        configurationGeneration += 1
+        loadGeneration += 1
         isLoading = false
-        self.service = KanbanService(requester: requester, profile: normalizedProfile)
-        requesterID = identity
-        self.profile = normalizedProfile
-        self.serverIdentity = normalizedServer
-        persistenceKey = nextPersistenceKey
-        selectedBoardSlug = defaults.string(forKey: nextPersistenceKey) ?? ""
 
-        // One-time migration for the pre-profile-scoped key. Once migrated,
-        // every subsequent profile gets an independent board selection.
+        service = makeService(requester)
+        requesterID = identity
+        self.serverIdentity = normalizedServer
+        persistenceKey = Self.scopedBoardKey(serverIdentity: normalizedServer)
+        selectedBoardSlug = defaults.string(forKey: persistenceKey!) ?? ""
+
+        // One-time migration for the pre-scoped key.
         if selectedBoardSlug.isEmpty, let legacy = defaults.string(forKey: Self.selectedBoardKey) {
             selectedBoardSlug = legacy
-            defaults.set(legacy, forKey: nextPersistenceKey)
+            defaults.set(legacy, forKey: persistenceKey!)
             defaults.removeObject(forKey: Self.selectedBoardKey)
         }
 
@@ -96,7 +113,7 @@ final class KanbanStore: ObservableObject {
 
     func reload(includeArchived: Bool = false) async {
         guard !isLoading else { return }
-        loadGeneration &+= 1
+        loadGeneration += 1
         let generation = loadGeneration
         guard let service else {
             if board == nil {
@@ -183,29 +200,34 @@ final class KanbanStore: ObservableObject {
         initialStatus: String? = nil,
         includeArchived: Bool = false
     ) async throws -> KanbanTask? {
-        guard let service else {
-            let error = KanbanServiceError.invalidResponse("Kanban is not connected.")
-            mutationErrorMessage = error.localizedDescription
-            throw error
+        guard !isMutating else {
+            throw recordMutationError(KanbanServiceError.mutationInProgress)
+        }
+        // Context is frozen before the first suspension point.
+        guard let context = makeOperationContext() else {
+            throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
         }
         let targetStatus = initialStatus ?? (request.triage ? "triage" : "todo")
 
-        return try await performMutation(includeArchived: includeArchived) {
+        return try await performMutation(context: context, includeArchived: includeArchived) {
+            // Upstream only exposes creation targets on unlocked lanes; locked
+            // lanes are rejected before any POST so no partial task can exist.
             guard KanbanStatusPresentation.canCreateTask(in: targetStatus) else {
                 throw KanbanServiceError.invalidManualStatus(targetStatus)
             }
 
             var body = request
             if targetStatus == "triage" { body.triage = true }
-            let response = try await service.createTask(body, board: self.effectiveBoardSlug)
+            let response = try await context.service.createTask(body, board: context.boardSlug)
             var task = response.task
 
-            // The backend owns native triage/default creation. Other supported
-            // manual lanes use one guarded follow-up transition.
+            // Upstream parity: native triage landing, otherwise a guarded
+            // follow-up transition when the created status differs from the
+            // requested lane (board.tsx submit()).
             let needsMove = targetStatus != "todo" && targetStatus != "triage" && task?.status != targetStatus
             if needsMove {
                 guard let taskID = task?.id, !taskID.isEmpty else {
-                    await service.nudgeDispatcher(board: self.effectiveBoardSlug)
+                    context.service.scheduleDispatcherNudge(board: context.boardSlug)
                     throw KanbanServiceError.taskCreatedButMoveFailed(
                         taskID: nil,
                         targetStatus: targetStatus,
@@ -213,13 +235,13 @@ final class KanbanStore: ObservableObject {
                     )
                 }
                 do {
-                    task = try await service.updateTask(
+                    task = try await context.service.updateTask(
                         id: taskID,
-                        board: self.effectiveBoardSlug,
+                        board: context.boardSlug,
                         patch: KanbanTaskPatch(status: targetStatus)
                     ) ?? task
                 } catch {
-                    await service.nudgeDispatcher(board: self.effectiveBoardSlug)
+                    context.service.scheduleDispatcherNudge(board: context.boardSlug)
                     throw KanbanServiceError.taskCreatedButMoveFailed(
                         taskID: taskID,
                         targetStatus: targetStatus,
@@ -228,72 +250,79 @@ final class KanbanStore: ObservableObject {
                 }
             }
 
-            await service.nudgeDispatcher(board: self.effectiveBoardSlug)
+            context.service.scheduleDispatcherNudge(board: context.boardSlug)
             return task
         }
     }
 
     @discardableResult
     func updateTask(id: String, patch: KanbanTaskPatch, includeArchived: Bool = false) async throws -> KanbanTask? {
-        guard let service else {
-            let error = KanbanServiceError.invalidResponse("Kanban is not connected.")
-            mutationErrorMessage = error.localizedDescription
-            throw error
+        guard !isMutating else {
+            throw recordMutationError(KanbanServiceError.mutationInProgress)
         }
-        return try await performMutation(includeArchived: includeArchived) {
+        guard let context = makeOperationContext() else {
+            throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
+        }
+        return try await performMutation(context: context, includeArchived: includeArchived) {
             if let status = patch.status, !KanbanStatusPresentation.canSelectManually(status) {
                 throw KanbanServiceError.invalidManualStatus(status)
             }
-            let task = try await service.updateTask(id: id, board: self.effectiveBoardSlug, patch: patch)
-            await service.nudgeDispatcher(board: self.effectiveBoardSlug)
+            let task = try await context.service.updateTask(id: id, board: context.boardSlug, patch: patch)
+            context.service.scheduleDispatcherNudge(board: context.boardSlug)
             return task
         }
     }
 
     func deleteTask(id: String, includeArchived: Bool = false) async throws {
-        guard let service else {
-            let error = KanbanServiceError.invalidResponse("Kanban is not connected.")
-            mutationErrorMessage = error.localizedDescription
-            throw error
+        guard !isMutating else {
+            throw recordMutationError(KanbanServiceError.mutationInProgress)
         }
-        try await performMutation(includeArchived: includeArchived) {
-            try await service.deleteTask(id: id, board: self.effectiveBoardSlug)
-            await service.nudgeDispatcher(board: self.effectiveBoardSlug)
+        guard let context = makeOperationContext() else {
+            throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
+        }
+        try await performMutation(context: context, includeArchived: includeArchived) {
+            try await context.service.deleteTask(id: id, board: context.boardSlug)
+            // Deleting can unblock dependants, so it nudges too (upstream).
+            context.service.scheduleDispatcherNudge(board: context.boardSlug)
         }
     }
 
     func addComment(taskID: String, body: String) async throws {
-        guard let service else {
-            let error = KanbanServiceError.invalidResponse("Kanban is not connected.")
-            mutationErrorMessage = error.localizedDescription
-            throw error
+        guard !isMutating else {
+            throw recordMutationError(KanbanServiceError.mutationInProgress)
         }
-        try await performMutation(includeArchived: false) {
-            try await service.addComment(taskID: taskID, board: self.effectiveBoardSlug, body: body)
+        guard let context = makeOperationContext() else {
+            throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
+        }
+        try await performMutation(context: context, includeArchived: false) {
+            // Comments are not dispatcher-relevant upstream: no nudge.
+            try await context.service.addComment(taskID: taskID, board: context.boardSlug, body: body)
         }
     }
 
     func reassignTask(taskID: String, profile: String?, reclaimFirst: Bool = true) async throws {
-        guard let service else {
-            let error = KanbanServiceError.invalidResponse("Kanban is not connected.")
-            mutationErrorMessage = error.localizedDescription
-            throw error
+        guard !isMutating else {
+            throw recordMutationError(KanbanServiceError.mutationInProgress)
         }
-        try await performMutation(includeArchived: false) {
-            try await service.reassignTask(taskID: taskID, board: self.effectiveBoardSlug, profile: profile, reclaimFirst: reclaimFirst)
-            await service.nudgeDispatcher(board: self.effectiveBoardSlug)
+        guard let context = makeOperationContext() else {
+            throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
+        }
+        try await performMutation(context: context, includeArchived: false) {
+            try await context.service.reassignTask(taskID: taskID, board: context.boardSlug, profile: profile, reclaimFirst: reclaimFirst)
+            context.service.scheduleDispatcherNudge(board: context.boardSlug)
         }
     }
 
     func reclaimTask(taskID: String, reason: String? = nil) async throws {
-        guard let service else {
-            let error = KanbanServiceError.invalidResponse("Kanban is not connected.")
-            mutationErrorMessage = error.localizedDescription
-            throw error
+        guard !isMutating else {
+            throw recordMutationError(KanbanServiceError.mutationInProgress)
         }
-        try await performMutation(includeArchived: false) {
-            try await service.reclaimTask(taskID: taskID, board: self.effectiveBoardSlug, reason: reason)
-            await service.nudgeDispatcher(board: self.effectiveBoardSlug)
+        guard let context = makeOperationContext() else {
+            throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
+        }
+        try await performMutation(context: context, includeArchived: false) {
+            try await context.service.reclaimTask(taskID: taskID, board: context.boardSlug, reason: reason)
+            context.service.scheduleDispatcherNudge(board: context.boardSlug)
         }
     }
 
@@ -307,27 +336,46 @@ final class KanbanStore: ObservableObject {
 
     // MARK: - Mutation state
 
-    private func performMutation<T>(includeArchived: Bool, operation: () async throws -> T) async throws -> T {
-        guard !isMutating else {
-            let error = KanbanServiceError.mutationInProgress
-            mutationErrorMessage = error.localizedDescription
-            throw error
-        }
+    private func makeOperationContext() -> KanbanOperationContext? {
+        guard let service else { return nil }
+        return KanbanOperationContext(
+            service: service,
+            boardSlug: effectiveBoardSlug,
+            configurationGeneration: configurationGeneration
+        )
+    }
+
+    private func performMutation<T>(
+        context: KanbanOperationContext,
+        includeArchived: Bool,
+        operation: () async throws -> T
+    ) async throws -> T {
         isMutating = true
         mutationErrorMessage = nil
+        defer { isMutating = false }
         do {
             let result = try await operation()
-            isMutating = false
-            await reload(includeArchived: includeArchived)
+            if configurationGeneration == context.configurationGeneration {
+                await reload(includeArchived: includeArchived)
+            }
             return result
         } catch {
-            isMutating = false
-            await reload(includeArchived: includeArchived)
+            // Refresh so a partial success (e.g. created-but-not-moved task)
+            // becomes visible even though the overall call failed - unless the
+            // store was reconfigured mid-flight, in which case the fresh load
+            // already reflects the new source.
+            if configurationGeneration == context.configurationGeneration {
+                await reload(includeArchived: includeArchived)
+            }
             mutationErrorMessage = error.localizedDescription
             throw error
         }
     }
 
+    private func recordMutationError(_ error: KanbanServiceError) -> KanbanServiceError {
+        mutationErrorMessage = error.localizedDescription
+        return error
+    }
 
     private static func scopeToken(_ value: String) -> String {
         Data(value.utf8)

--- a/Conduit/Services/KanbanStore.swift
+++ b/Conduit/Services/KanbanStore.swift
@@ -48,6 +48,8 @@ final class KanbanStore: ObservableObject {
         serverIdentity: String = ""
     ) {
         guard let requester else {
+            loadGeneration &+= 1
+            isLoading = false
             service = nil
             requesterID = nil
             board = nil
@@ -63,6 +65,10 @@ final class KanbanStore: ObservableObject {
             return
         }
 
+        // Invalidate any cancelled load from the previous bridge/profile. Its
+        // response must not repopulate this store after the profile changes.
+        loadGeneration &+= 1
+        isLoading = false
         self.service = KanbanService(requester: requester, profile: normalizedProfile)
         requesterID = identity
         self.profile = normalizedProfile

--- a/Conduit/Services/KanbanStore.swift
+++ b/Conduit/Services/KanbanStore.swift
@@ -21,6 +21,11 @@ final class KanbanStore: ObservableObject {
     @Published private(set) var projects: [KanbanProject] = []
     @Published private(set) var orchestration: KanbanOrchestrationSettings?
     @Published private(set) var selectedBoardSlug = ""
+    /// Board identity of the snapshot currently on screen. Set ONLY when a
+    /// load completes for the generation that is still current; mutations
+    /// always target this value so a displayed card can never be written to a
+    /// different board than the one it was read from.
+    @Published private(set) var loadedBoardSlug: String?
     @Published private(set) var isLoading = false
     @Published private(set) var isMutating = false
     @Published private(set) var errorMessage: String?
@@ -34,8 +39,13 @@ final class KanbanStore: ObservableObject {
     private var persistenceKey: String?
     private var loadGeneration = 0
     /// Bumped on every configure(); captured by mutations so post-mutation
-    /// refreshes from an old server/board context are discarded.
+    /// refreshes and UI-state writes from an old server/board context are
+    /// discarded.
     private var configurationGeneration = 0
+    /// Generation of the mutation that currently owns isMutating/
+    /// mutationErrorMessage. Nil when no live operation owns the UI; configure()
+    /// clears it immediately so a stale server's completion becomes inert.
+    private var activeMutationGeneration: Int?
 
     init(
         defaults: UserDefaults = .standard,
@@ -54,11 +64,12 @@ final class KanbanStore: ObservableObject {
         return boards.first(where: { $0.slug == slug })
     }
 
-    /// Board selection is scoped to the dashboard SERVER identity only. The
-    /// plugin API serves the backend's own Hermes home (one profile per
-    /// process), so the server URL - not the app-level UI profile - is the
-    /// real data boundary. Two dashboards never share a selection; switching
-    /// Conduit's active profile on one dashboard intentionally does not either.
+    /// Board selection is scoped to the dashboard SERVER identity only.
+    /// Hermes Kanban is a shared, cross-profile coordination primitive anchored
+    /// at the shared Hermes root (kanban_db.py resolves profiles back through
+    /// get_default_hermes_root()), so profiles on one dashboard intentionally
+    /// see the same boards - there is nothing profile-scoped to persist. Two
+    /// different dashboards (roots) never share a selection.
     static func scopedBoardKey(serverIdentity: String) -> String {
         // Normalize exactly like configure() so equivalent URLs share a key.
         let normalized = serverIdentity.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
@@ -70,10 +81,12 @@ final class KanbanStore: ObservableObject {
             configurationGeneration += 1
             loadGeneration += 1
             isLoading = false
+            endActiveMutationOwnership()
             service = nil
             requesterID = nil
             board = nil
             boards = []
+            loadedBoardSlug = nil
             return
         }
 
@@ -83,10 +96,13 @@ final class KanbanStore: ObservableObject {
 
         // Invalidate any cancelled load or in-flight mutation from the
         // previous bridge/server. Their completions must not repopulate this
-        // store after the data source changes.
+        // store, touch its UI mutation state, or trigger refreshes after the
+        // data source changes.
         configurationGeneration += 1
         loadGeneration += 1
         isLoading = false
+        endActiveMutationOwnership()
+        loadedBoardSlug = nil
 
         service = makeService(requester)
         requesterID = identity
@@ -111,8 +127,11 @@ final class KanbanStore: ObservableObject {
         mutationErrorMessage = nil
     }
 
-    func reload(includeArchived: Bool = false) async {
-        guard !isLoading else { return }
+    /// `superseding: true` lets an explicit user navigation (board selection)
+    /// invalidate and outrun an in-flight background poll. The stale load's
+    /// completion is discarded by the generation checks below.
+    func reload(includeArchived: Bool = false, superseding: Bool = false) async {
+        if !superseding && isLoading { return }
         loadGeneration += 1
         let generation = loadGeneration
         guard let service else {
@@ -122,6 +141,9 @@ final class KanbanStore: ObservableObject {
             return
         }
 
+        // Freeze the requested identity now; whatever completes must match
+        // BOTH this generation AND this slug to be applied.
+        let requestedSlug = effectiveBoardSlug
         isLoading = true
         errorMessage = nil
         defer {
@@ -152,6 +174,9 @@ final class KanbanStore: ObservableObject {
             guard generation == loadGeneration else { return }
 
             board = resolvedBoard
+            // Bind the snapshot to the identity it was actually loaded from:
+            // nil selection means the backend's current board.
+            loadedBoardSlug = requestedSlug ?? currentServerBoardSlug
             if let resolvedProfiles { profiles = resolvedProfiles }
             if let resolvedProjects { projects = resolvedProjects }
             if let resolvedOrchestration { orchestration = resolvedOrchestration }
@@ -176,7 +201,9 @@ final class KanbanStore: ObservableObject {
         } else if let persistenceKey {
             defaults.set(slug, forKey: persistenceKey)
         }
-        await reload(includeArchived: includeArchived)
+        // Explicit navigation supersedes any in-flight poll so the displayed
+        // snapshot converges on the selection instead of racing it.
+        await reload(includeArchived: includeArchived, superseding: true)
     }
 
     func refresh(includeArchived: Bool = false) async {
@@ -186,12 +213,12 @@ final class KanbanStore: ObservableObject {
 
     func fetchTaskDetail(id: String) async throws -> KanbanTaskDetail {
         guard let service else { throw KanbanServiceError.invalidResponse("Kanban is not connected.") }
-        return try await service.fetchTask(id: id, board: effectiveBoardSlug)
+        return try await service.fetchTask(id: id, board: loadedBoardSlug ?? effectiveBoardSlug)
     }
 
     func fetchTaskLog(id: String, tailBytes: Int = 16_384) async throws -> KanbanWorkerLog {
         guard let service else { throw KanbanServiceError.invalidResponse("Kanban is not connected.") }
-        return try await service.fetchTaskLog(id: id, board: effectiveBoardSlug, tailBytes: tailBytes)
+        return try await service.fetchTaskLog(id: id, board: loadedBoardSlug ?? effectiveBoardSlug, tailBytes: tailBytes)
     }
 
     @discardableResult
@@ -338,9 +365,13 @@ final class KanbanStore: ObservableObject {
 
     private func makeOperationContext() -> KanbanOperationContext? {
         guard let service else { return nil }
+        // Bind to the LOADED snapshot identity, never the mutable selection:
+        // a card on screen must be written back to the board it was read from,
+        // even if the user has already started navigating elsewhere.
+        guard let loadedBoardSlug else { return nil }
         return KanbanOperationContext(
             service: service,
-            boardSlug: effectiveBoardSlug,
+            boardSlug: loadedBoardSlug,
             configurationGeneration: configurationGeneration
         )
     }
@@ -350,26 +381,53 @@ final class KanbanStore: ObservableObject {
         includeArchived: Bool,
         operation: () async throws -> T
     ) async throws -> T {
-        isMutating = true
-        mutationErrorMessage = nil
-        defer { isMutating = false }
-        do {
-            let result = try await operation()
-            if configurationGeneration == context.configurationGeneration {
-                await reload(includeArchived: includeArchived)
-            }
-            return result
-        } catch {
-            // Refresh so a partial success (e.g. created-but-not-moved task)
-            // becomes visible even though the overall call failed - unless the
-            // store was reconfigured mid-flight, in which case the fresh load
-            // already reflects the new source.
-            if configurationGeneration == context.configurationGeneration {
-                await reload(includeArchived: includeArchived)
-            }
+        let generation = context.configurationGeneration
+        // Only one operation may own the UI mutation state at a time. The
+        // owning generation is recorded so configure() can revoke ownership
+        // instantly when the data source changes mid-flight.
+        guard activeMutationGeneration == nil else {
+            let error = KanbanServiceError.mutationInProgress
             mutationErrorMessage = error.localizedDescription
             throw error
         }
+        activeMutationGeneration = generation
+        isMutating = true
+        mutationErrorMessage = nil
+        do {
+            let result = try await operation()
+            if configurationGeneration == generation {
+                await reload(includeArchived: includeArchived)
+            }
+            endMutationOwnership(generation: generation)
+            return result
+        } catch {
+            // Ownership check FIRST: after a reconfigure, this completion must
+            // be completely inert - no refresh, no UI error text, no flag flip.
+            let stillOwnsUI = configurationGeneration == generation && activeMutationGeneration == generation
+            if stillOwnsUI {
+                // Refresh so a partial success (e.g. created-but-not-moved
+                // task) becomes visible even though the overall call failed.
+                await reload(includeArchived: includeArchived)
+                mutationErrorMessage = error.localizedDescription
+            }
+            endMutationOwnership(generation: generation)
+            throw error
+        }
+    }
+
+    /// Revokes this operation's UI ownership if it still holds it.
+    private func endMutationOwnership(generation: Int) {
+        guard activeMutationGeneration == generation else { return }
+        activeMutationGeneration = nil
+        if configurationGeneration == generation {
+            isMutating = false
+        }
+    }
+
+    /// Immediately strips any in-flight operation of UI mutation ownership.
+    private func endActiveMutationOwnership() {
+        activeMutationGeneration = nil
+        isMutating = false
     }
 
     private func recordMutationError(_ error: KanbanServiceError) -> KanbanServiceError {

--- a/Conduit/Services/KanbanStore.swift
+++ b/Conduit/Services/KanbanStore.swift
@@ -377,6 +377,12 @@ final class KanbanStore: ObservableObject {
         mutationErrorMessage = nil
     }
 
+    /// Test seam: awaits any in-flight debounced dispatcher nudge owned by the
+    /// active service, so tests need no wall-clock sleeps.
+    func awaitPendingDispatcherNudgeForTesting() async {
+        await service?.awaitPendingDispatcherNudgeForTesting()
+    }
+
     func showMutationError(_ error: Error) {
         mutationErrorMessage = error.localizedDescription
     }

--- a/Conduit/Services/KanbanStore.swift
+++ b/Conduit/Services/KanbanStore.swift
@@ -424,7 +424,10 @@ final class KanbanStore: ObservableObject {
         do {
             let result = try await operation()
             if configurationGeneration == generation {
-                await reload(includeArchived: includeArchived)
+                // A finished mutation is newer authoritative activity than any
+                // passive poll that started before it: supersede so the
+                // reconciliation cannot be dropped behind isLoading.
+                await reload(includeArchived: includeArchived, superseding: true)
             }
             endMutationOwnership(generation: generation)
             return result
@@ -433,9 +436,10 @@ final class KanbanStore: ObservableObject {
             // be completely inert - no refresh, no UI error text, no flag flip.
             let stillOwnsUI = configurationGeneration == generation && activeMutationGeneration == generation
             if stillOwnsUI {
-                // Refresh so a partial success (e.g. created-but-not-moved
-                // task) becomes visible even though the overall call failed.
-                await reload(includeArchived: includeArchived)
+                // Refresh (superseding) so a partial success - e.g. a created
+                // task whose follow-up move failed - becomes visible even when
+                // a passive poll is already in flight.
+                await reload(includeArchived: includeArchived, superseding: true)
                 mutationErrorMessage = error.localizedDescription
             }
             endMutationOwnership(generation: generation)

--- a/Conduit/Services/KanbanStore.swift
+++ b/Conduit/Services/KanbanStore.swift
@@ -59,6 +59,20 @@ final class KanbanStore: ObservableObject {
         selectedBoardSlug.isEmpty ? nil : selectedBoardSlug
     }
 
+    /// The board identity the selection currently resolves to ("Server
+    /// current" collapses onto the server-reported current board).
+    var resolvedSelectedBoardSlug: String {
+        selectedBoardSlug.isEmpty ? currentServerBoardSlug : selectedBoardSlug
+    }
+
+    /// True when the on-screen snapshot belongs to the currently selected
+    /// board. During navigation the stale snapshot stays visible but must be
+    /// non-actionable: mutations are rejected in the store and the view
+    /// disables creation/moves/deletes until the new board finishes loading.
+    var isSelectedSnapshotLoaded: Bool {
+        loadedBoardSlug == resolvedSelectedBoardSlug
+    }
+
     var selectedBoardMetadata: KanbanBoardMetadata? {
         let slug = selectedBoardSlug.isEmpty ? currentServerBoardSlug : selectedBoardSlug
         return boards.first(where: { $0.slug == slug })
@@ -107,13 +121,14 @@ final class KanbanStore: ObservableObject {
         service = makeService(requester)
         requesterID = identity
         self.serverIdentity = normalizedServer
-        persistenceKey = Self.scopedBoardKey(serverIdentity: normalizedServer)
-        selectedBoardSlug = defaults.string(forKey: persistenceKey!) ?? ""
+        let scopedKey = Self.scopedBoardKey(serverIdentity: normalizedServer)
+        persistenceKey = scopedKey
+        selectedBoardSlug = defaults.string(forKey: scopedKey) ?? ""
 
         // One-time migration for the pre-scoped key.
         if selectedBoardSlug.isEmpty, let legacy = defaults.string(forKey: Self.selectedBoardKey) {
             selectedBoardSlug = legacy
-            defaults.set(legacy, forKey: persistenceKey!)
+            defaults.set(legacy, forKey: scopedKey)
             defaults.removeObject(forKey: Self.selectedBoardKey)
         }
 
@@ -141,9 +156,9 @@ final class KanbanStore: ObservableObject {
             return
         }
 
-        // Freeze the requested identity now; whatever completes must match
-        // BOTH this generation AND this slug to be applied.
-        let requestedSlug = effectiveBoardSlug
+        // Freeze nothing yet: the concrete slug can only be known after
+        // /boards returns and invalid-selection validation runs, so the fetch
+        // below always carries an explicit ?board= that matches what we record.
         isLoading = true
         errorMessage = nil
         defer {
@@ -162,7 +177,13 @@ final class KanbanStore: ObservableObject {
                 if let persistenceKey { defaults.removeObject(forKey: persistenceKey) }
             }
 
-            async let loadedBoard = service.fetchBoard(slug: effectiveBoardSlug, includeArchived: includeArchived)
+            // Pin ONE concrete identity for this load. An omitted board=
+            // would let the backend resolve "current" independently at GET
+            // /board time, so loadedBoardSlug could drift from what was truly
+            // fetched if another client moved the pointer in between.
+            let resolvedSlug = selectedBoardSlug.isEmpty ? boardResponse.current : selectedBoardSlug
+
+            async let loadedBoard = service.fetchBoard(slug: resolvedSlug, includeArchived: includeArchived)
             async let loadedProfiles = try? service.fetchProfiles()
             async let loadedProjects = try? service.fetchProjects()
             async let loadedOrchestration = try? service.fetchOrchestration()
@@ -174,9 +195,8 @@ final class KanbanStore: ObservableObject {
             guard generation == loadGeneration else { return }
 
             board = resolvedBoard
-            // Bind the snapshot to the identity it was actually loaded from:
-            // nil selection means the backend's current board.
-            loadedBoardSlug = requestedSlug ?? currentServerBoardSlug
+            // Exactly the slug used in GET /board?board=... above.
+            loadedBoardSlug = resolvedSlug
             if let resolvedProfiles { profiles = resolvedProfiles }
             if let resolvedProjects { projects = resolvedProjects }
             if let resolvedOrchestration { orchestration = resolvedOrchestration }
@@ -387,6 +407,14 @@ final class KanbanStore: ObservableObject {
         // instantly when the data source changes mid-flight.
         guard activeMutationGeneration == nil else {
             let error = KanbanServiceError.mutationInProgress
+            mutationErrorMessage = error.localizedDescription
+            throw error
+        }
+        // Navigation invariant: while the selected and loaded board identities
+        // differ, the visible snapshot belongs to the OLD board. Refuse to act
+        // on it rather than writing old-board data under a new-board UI.
+        guard isSelectedSnapshotLoaded else {
+            let error = KanbanServiceError.boardNavigationInProgress
             mutationErrorMessage = error.localizedDescription
             throw error
         }

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -431,7 +431,7 @@ private struct LegacySettingsView: View {
 // MARK: - Settings home and detail routes
 
 private enum SettingsDestination: Hashable {
-    case profile, model, chat, voice, workspace, memory, gateway, appearance, notifications, about
+    case profile, model, chat, voice, workspace, memory, capabilities, gateway, appearance, notifications, about
 }
 
 private enum ProfileSettingControl {
@@ -551,6 +551,8 @@ struct SettingsView: View {
                 loadModels: loadProfileModelDefaults,
                 fields: Self.memoryFields
             )
+        case .capabilities:
+            CapabilitiesView()
         case .gateway:
             GatewaySettingsDetail(snapshot: snapshot, reconnect: reconnect, disconnect: disconnect, close: { dismiss() }, saveCloudflareAccess: appState.saveCloudflareAccess, removeCloudflareAccess: appState.removeCloudflareAccess)
         case .appearance:
@@ -602,6 +604,7 @@ private struct SettingsHome: View {
                         settingsLink(.voice, icon: "mic.and.signal.meter", title: "Voice", detail: "Speech providers, credentials, and device opt-in")
                         settingsLink(.workspace, icon: "folder", title: "Workspace & safety", detail: "Working directory, approvals, and privacy")
                         settingsLink(.memory, icon: "brain.head.profile", title: "Memory & delegation", detail: "Memory, compression, and child agents")
+                        settingsLink(.capabilities, icon: "puzzlepiece.extension", title: "Capabilities", detail: "Skills, toolsets, and categories")
                     }
                     homeSection("Connection", tint: .conduitAura) {
                         settingsLink(.gateway, icon: "radio", title: "Gateway", detail: snapshot.server ?? "Not connected")

--- a/Conduit/Views/CapabilitiesView.swift
+++ b/Conduit/Views/CapabilitiesView.swift
@@ -7,15 +7,29 @@ struct CapabilitiesView: View {
     @State private var searchText = ""
     @State private var capabilitiesLoading = false
     @State private var loadError: String?
+    /// Token of the most recent request. An older completion can never clear
+    /// the loading flag or set the error of a newer one.
+    @State private var capabilityRequestID = UUID()
+
+    /// Rows may render only when the loaded snapshot belongs to the profile
+    /// that is active right now; a foreign snapshot never shows as B.
+    private var snapshotBelongsToActiveProfile: Bool {
+        CapabilityLoadPolicy.shouldPresentRows(
+            snapshotProfile: appState.capabilitiesProfile,
+            activeProfile: appState.activeProfile
+        )
+    }
 
     var body: some View {
         VStack(spacing: 0) {
-            if capabilitiesLoading && appState.skills.isEmpty && appState.toolsets.isEmpty {
+            if capabilitiesLoading && !snapshotBelongsToActiveProfile {
+                // Loading (or switching profiles): never render another
+                // profile's rows under this one.
                 Spacer()
                 ProgressView("Loading capabilities…")
                     .tint(.conduitAccent)
                 Spacer()
-            } else if let loadError, appState.skills.isEmpty && appState.toolsets.isEmpty {
+            } else if let loadError, !snapshotBelongsToActiveProfile {
                 ContentUnavailableView(
                     "Couldn't Load",
                     systemImage: "exclamationmark.triangle",
@@ -32,7 +46,8 @@ struct CapabilitiesView: View {
                 .listStyle(.plain)
                 .refreshable { await loadCapabilities() }
                 .overlay(alignment: .top) {
-                    if let loadError, !appState.skills.isEmpty || !appState.toolsets.isEmpty {
+                    if let loadError, snapshotBelongsToActiveProfile,
+                       !appState.skills.isEmpty || !appState.toolsets.isEmpty {
                         Text("Refresh failed: \(loadError)")
                             .font(.caption)
                             .foregroundStyle(.secondary)
@@ -114,18 +129,25 @@ struct CapabilitiesView: View {
     }
 
     private func loadCapabilities() async {
+        // Request token: an older completion must never clear the newer
+        // request's loading flag or overwrite its error state (rapid A->B or
+        // A->B->A switching).
+        let myToken = UUID()
+        capabilityRequestID = myToken
         capabilitiesLoading = true
-        // Request-scoped outcome: the result of THIS request is returned
-        // directly; global error/skill state is never treated as the result.
         let requestedProfile = appState.activeProfile
-        defer { capabilitiesLoading = false }
         let outcome = await appState.loadCapabilities()
 
+        guard capabilityRequestID == myToken else { return }
+        capabilitiesLoading = false
         guard appState.activeProfile == requestedProfile, !outcome.isSuperseded else { return }
 
         loadError = Self.localError(
             for: outcome,
-            hasData: !appState.skills.isEmpty || !appState.toolsets.isEmpty
+            hasData: CapabilityLoadPolicy.shouldPresentRows(
+                snapshotProfile: appState.capabilitiesProfile,
+                activeProfile: requestedProfile
+            ) && (!appState.skills.isEmpty || !appState.toolsets.isEmpty)
         )
     }
 

--- a/Conduit/Views/CapabilitiesView.swift
+++ b/Conduit/Views/CapabilitiesView.swift
@@ -115,25 +115,33 @@ struct CapabilitiesView: View {
 
     private func loadCapabilities() async {
         capabilitiesLoading = true
-        // Request-scoped outcome: results from a profile that is no longer
-        // active when the load finishes are discarded, so a stale profile's
-        // data (or error) can never masquerade as the current one's.
+        // Request-scoped outcome: the result of THIS request is returned
+        // directly; global error/skill state is never treated as the result.
         let requestedProfile = appState.activeProfile
         defer { capabilitiesLoading = false }
-        await appState.loadCapabilities()
+        let outcome = await appState.loadCapabilities()
 
-        guard appState.activeProfile == requestedProfile else { return }
+        guard appState.activeProfile == requestedProfile, !outcome.isSuperseded else { return }
 
-        let hasData = !appState.skills.isEmpty || !appState.toolsets.isEmpty
-        if hasData {
-            // A successful load clears any previously surfaced failure.
-            loadError = nil
-        } else if let error = appState.errorMessage {
-            // Real backend failures surface verbatim - repeated identical
-            // failures included. Loaded data stays visible via the banner.
-            loadError = error
-        } else {
-            loadError = "No capabilities found."
+        loadError = Self.localError(
+            for: outcome,
+            hasData: !appState.skills.isEmpty || !appState.toolsets.isEmpty
+        )
+    }
+
+    /// Pure mapping from a request outcome to this screen's local failure
+    /// presentation. Loaded data always stays visible; a failed refresh with a
+    /// populated cache surfaces through the banner instead of wiping content.
+    static func localError(for outcome: AppState.CapabilityLoadOutcome, hasData: Bool) -> String? {
+        switch outcome {
+        case .success:
+            return hasData ? nil : "No capabilities found."
+        case .failed(_, let message):
+            return message
+        case .unavailable:
+            return "Connect to a Hermes dashboard to load capabilities."
+        case .superseded:
+            return nil
         }
     }
 }

--- a/Conduit/Views/CapabilitiesView.swift
+++ b/Conduit/Views/CapabilitiesView.swift
@@ -11,51 +11,64 @@ struct CapabilitiesView: View {
     /// the loading flag or set the error of a newer one.
     @State private var capabilityRequestID = UUID()
 
-    /// Rows may render only when the loaded snapshot belongs to the profile
-    /// that is active right now; a foreign snapshot never shows as B.
-    private var snapshotBelongsToActiveProfile: Bool {
-        CapabilityLoadPolicy.shouldPresentRows(
-            snapshotProfile: appState.capabilitiesProfile,
-            activeProfile: appState.activeProfile
-        )
-    }
-
     var body: some View {
-        VStack(spacing: 0) {
-            if capabilitiesLoading && !snapshotBelongsToActiveProfile {
-                // Loading (or switching profiles): never render another
-                // profile's rows under this one.
+        // Single authoritative rendering boundary: foreign snapshots can never
+        // reach a row-bearing state, so stale toggles can never fire mutations
+        // against the wrong profile.
+        Group {
+            switch CapabilityLoadPolicy.resolvePresentation(
+                snapshotProfile: appState.capabilitiesProfile,
+                activeProfile: appState.activeProfile,
+                isLoading: capabilitiesLoading,
+                loadError: loadError,
+                hasRows: !appState.skills.isEmpty || !appState.toolsets.isEmpty
+            ) {
+        case .loading:
+            VStack(spacing: 0) {
                 Spacer()
                 ProgressView("Loading capabilities…")
                     .tint(.conduitAccent)
                 Spacer()
-            } else if let loadError, !snapshotBelongsToActiveProfile {
+            }
+        case .failure(let message):
+            VStack(spacing: 0) {
                 ContentUnavailableView(
                     "Couldn't Load",
                     systemImage: "exclamationmark.triangle",
-                    description: Text(loadError)
+                    description: Text(message)
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                List {
-                    skillsSection
-                    toolsetsSection
+            }
+            .refreshable { await loadCapabilities() }
+        case .emptySuccess:
+            VStack(spacing: 0) {
+                ContentUnavailableView(
+                    "No capabilities found",
+                    systemImage: "tray",
+                    description: Text("This profile has no enabled skills or toolsets.")
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            .refreshable { await loadCapabilities() }
+        case .list(let banner):
+            List {
+                skillsSection
+                toolsetsSection
+            }
+            .searchable(text: $searchText, prompt: "Search skills")
+            .scrollContentBackground(.hidden)
+            .listStyle(.plain)
+            .refreshable { await loadCapabilities() }
+            .overlay(alignment: .top) {
+                if let banner {
+                    Text("Refresh failed: \(banner)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(8)
+                        .background(.ultraThinMaterial, in: Capsule())
+                        .padding(.top, 6)
                 }
-                .searchable(text: $searchText, prompt: "Search skills")
-                .scrollContentBackground(.hidden)
-                .listStyle(.plain)
-                .refreshable { await loadCapabilities() }
-                .overlay(alignment: .top) {
-                    if let loadError, snapshotBelongsToActiveProfile,
-                       !appState.skills.isEmpty || !appState.toolsets.isEmpty {
-                        Text("Refresh failed: \(loadError)")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .padding(8)
-                            .background(.ultraThinMaterial, in: Capsule())
-                            .padding(.top, 6)
-                    }
-                }
+            }
             }
         }
         .navigationTitle("Capabilities")
@@ -135,6 +148,9 @@ struct CapabilitiesView: View {
         let myToken = UUID()
         capabilityRequestID = myToken
         capabilitiesLoading = true
+        // A genuinely newer request starts with clean local error state; the
+        // token guard below keeps any older completion from re-setting it.
+        loadError = nil
         let requestedProfile = appState.activeProfile
         let outcome = await appState.loadCapabilities()
 

--- a/Conduit/Views/CapabilitiesView.swift
+++ b/Conduit/Views/CapabilitiesView.swift
@@ -31,6 +31,16 @@ struct CapabilitiesView: View {
                 .scrollContentBackground(.hidden)
                 .listStyle(.plain)
                 .refreshable { await loadCapabilities() }
+                .overlay(alignment: .top) {
+                    if let loadError, !appState.skills.isEmpty || !appState.toolsets.isEmpty {
+                        Text("Refresh failed: \(loadError)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .padding(8)
+                            .background(.ultraThinMaterial, in: Capsule())
+                            .padding(.top, 6)
+                    }
+                }
             }
         }
         .navigationTitle("Capabilities")
@@ -105,12 +115,19 @@ struct CapabilitiesView: View {
 
     private func loadCapabilities() async {
         capabilitiesLoading = true
+        let previousError = appState.errorMessage
         defer { capabilitiesLoading = false }
         await appState.loadCapabilities()
-        if let error = appState.errorMessage, error.localizedCaseInsensitiveContains("capabil") {
+
+        let hasData = !appState.skills.isEmpty || !appState.toolsets.isEmpty
+        if let error = appState.errorMessage, error != previousError {
+            // Preserve loaded data while still surfacing a failed refresh.
+            // Do not filter the message by wording: backend errors may change.
             loadError = error
-        } else {
+        } else if hasData {
             loadError = nil
+        } else {
+            loadError = "No capabilities found."
         }
     }
 }

--- a/Conduit/Views/CapabilitiesView.swift
+++ b/Conduit/Views/CapabilitiesView.swift
@@ -1,0 +1,228 @@
+import SwiftUI
+
+/// Settings-owned capabilities browser. It remains scoped to the active Hermes
+/// profile and intentionally reuses AppState's existing loading/mutation APIs.
+struct CapabilitiesView: View {
+    @EnvironmentObject var appState: AppState
+    @State private var searchText = ""
+    @State private var capabilitiesLoading = false
+    @State private var loadError: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if capabilitiesLoading && appState.skills.isEmpty && appState.toolsets.isEmpty {
+                Spacer()
+                ProgressView("Loading capabilities…")
+                    .tint(.conduitAccent)
+                Spacer()
+            } else if let loadError, appState.skills.isEmpty && appState.toolsets.isEmpty {
+                ContentUnavailableView(
+                    "Couldn't Load",
+                    systemImage: "exclamationmark.triangle",
+                    description: Text(loadError)
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List {
+                    skillsSection
+                    toolsetsSection
+                }
+                .searchable(text: $searchText, prompt: "Search skills")
+                .scrollContentBackground(.hidden)
+                .listStyle(.plain)
+                .refreshable { await loadCapabilities() }
+            }
+        }
+        .navigationTitle("Capabilities")
+        .toolbarBackground(.hidden, for: .navigationBar)
+        .task(id: appState.activeProfile) { await loadCapabilities() }
+    }
+
+    @ViewBuilder
+    private var skillsSection: some View {
+        if !filteredSkills.isEmpty {
+            if hasCategories {
+                ForEach(skillsByCategory, id: \.0) { category, skills in
+                    Section(category) {
+                        ForEach(skills) { skill in
+                            CapabilitySkillRow(skill: skill)
+                        }
+                    }
+                }
+            } else {
+                Section("Skills") {
+                    ForEach(filteredSkills) { skill in
+                        CapabilitySkillRow(skill: skill)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var toolsetsSection: some View {
+        if !filteredToolsets.isEmpty {
+            Section("Toolsets") {
+                ForEach(filteredToolsets) { toolset in
+                    CapabilityToolsetRow(toolset: toolset)
+                }
+            }
+        }
+    }
+
+    private var filteredSkills: [CapabilitySkill] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return appState.skills }
+        return appState.skills.filter { skill in
+            skill.name.localizedCaseInsensitiveContains(query)
+                || skill.description?.localizedCaseInsensitiveContains(query) == true
+                || skill.category?.localizedCaseInsensitiveContains(query) == true
+        }
+    }
+
+    private var filteredToolsets: [CapabilityToolset] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return appState.toolsets }
+        return appState.toolsets.filter { toolset in
+            toolset.name.localizedCaseInsensitiveContains(query)
+                || toolset.label?.localizedCaseInsensitiveContains(query) == true
+                || toolset.description?.localizedCaseInsensitiveContains(query) == true
+                || toolset.tools?.joined(separator: " ").localizedCaseInsensitiveContains(query) == true
+        }
+    }
+
+    private var hasCategories: Bool {
+        filteredSkills.contains { $0.category?.isEmpty == false }
+    }
+
+    private var skillsByCategory: [(String, [CapabilitySkill])] {
+        Dictionary(grouping: filteredSkills) { skill in
+            let category = skill.category?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return category.isEmpty ? "Other" : category
+        }
+        .sorted { $0.key.localizedCaseInsensitiveCompare($1.key) == .orderedAscending }
+    }
+
+    private func loadCapabilities() async {
+        capabilitiesLoading = true
+        defer { capabilitiesLoading = false }
+        await appState.loadCapabilities()
+        if let error = appState.errorMessage, error.localizedCaseInsensitiveContains("capabil") {
+            loadError = error
+        } else {
+            loadError = nil
+        }
+    }
+}
+
+private struct CapabilitySkillRow: View {
+    @EnvironmentObject var appState: AppState
+    let skill: CapabilitySkill
+
+    private var provenanceIcon: String? {
+        switch skill.provenance {
+        case "hub": return "bag"
+        case "bundled": return "shippingbox"
+        case "agent": return "wrench"
+        default: return nil
+        }
+    }
+
+    var body: some View {
+        Toggle(isOn: Binding(
+            get: { skill.enabled },
+            set: { newValue in
+                Task { await appState.toggleSkill(name: skill.name, enabled: newValue) }
+            }
+        )) {
+            HStack(spacing: 11) {
+                Image(systemName: provenanceIcon ?? "puzzlepiece.extension")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(skill.enabled ? .conduitAccent : .secondary)
+                    .frame(width: 30, height: 30)
+                    .background(
+                        (skill.enabled ? Color.conduitAccent : Color.secondary).opacity(0.13),
+                        in: Circle()
+                    )
+
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 6) {
+                        Text(skill.name)
+                            .font(.subheadline.weight(.medium))
+                            .lineLimit(1)
+                        if let category = skill.category, !category.isEmpty {
+                            Text(category)
+                                .font(.caption2.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(Color.conduitAura.opacity(0.14), in: Capsule())
+                        }
+                    }
+                    if let desc = skill.description, !desc.isEmpty {
+                        Text(desc)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+                }
+            }
+        }
+        .tint(.conduitAccent)
+        .listRowBackground(Color.clear)
+        .listRowSeparator(.hidden)
+        .listRowInsets(EdgeInsets(top: 3, leading: 0, bottom: 3, trailing: 0))
+    }
+}
+
+private struct CapabilityToolsetRow: View {
+    @EnvironmentObject var appState: AppState
+    let toolset: CapabilityToolset
+
+    var body: some View {
+        Toggle(isOn: Binding(
+            get: { toolset.enabled },
+            set: { newValue in
+                Task { await appState.toggleToolset(name: toolset.name, enabled: newValue) }
+            }
+        )) {
+            HStack(spacing: 11) {
+                Image(systemName: "wrench.and.screwdriver")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(toolset.enabled ? .conduitAccent : .secondary)
+                    .frame(width: 30, height: 30)
+                    .background(
+                        (toolset.enabled ? Color.conduitAccent : Color.secondary).opacity(0.13),
+                        in: Circle()
+                    )
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(toolset.label ?? toolset.name.capitalized)
+                        .font(.subheadline.weight(.medium))
+                        .lineLimit(1)
+                    if let desc = toolset.description, !desc.isEmpty {
+                        Text(desc)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+                    if let tools = toolset.tools, !tools.isEmpty {
+                        Text(tools.joined(separator: ", "))
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                    }
+                }
+
+                Spacer(minLength: 0)
+                Image(systemName: toolset.configured == true ? "checkmark.circle.fill" : "circle.dashed")
+                    .font(.caption)
+                    .foregroundStyle(toolset.configured == true ? .green : .secondary)
+            }
+        }
+        .tint(.conduitAccent)
+        .listRowBackground(Color.clear)
+        .listRowSeparator(.hidden)
+        .listRowInsets(EdgeInsets(top: 3, leading: 0, bottom: 3, trailing: 0))
+    }
+}

--- a/Conduit/Views/CapabilitiesView.swift
+++ b/Conduit/Views/CapabilitiesView.swift
@@ -115,17 +115,23 @@ struct CapabilitiesView: View {
 
     private func loadCapabilities() async {
         capabilitiesLoading = true
-        let previousError = appState.errorMessage
+        // Request-scoped outcome: results from a profile that is no longer
+        // active when the load finishes are discarded, so a stale profile's
+        // data (or error) can never masquerade as the current one's.
+        let requestedProfile = appState.activeProfile
         defer { capabilitiesLoading = false }
         await appState.loadCapabilities()
 
+        guard appState.activeProfile == requestedProfile else { return }
+
         let hasData = !appState.skills.isEmpty || !appState.toolsets.isEmpty
-        if let error = appState.errorMessage, error != previousError {
-            // Preserve loaded data while still surfacing a failed refresh.
-            // Do not filter the message by wording: backend errors may change.
-            loadError = error
-        } else if hasData {
+        if hasData {
+            // A successful load clears any previously surfaced failure.
             loadError = nil
+        } else if let error = appState.errorMessage {
+            // Real backend failures surface verbatim - repeated identical
+            // failures included. Loaded data stays visible via the banner.
+            loadError = error
         } else {
             loadError = "No capabilities found."
         }

--- a/Conduit/Views/KanbanViews.swift
+++ b/Conduit/Views/KanbanViews.swift
@@ -200,6 +200,20 @@ struct KanbanView: View {
                     .padding(.horizontal, 1)
                     .padding(.bottom, 14)
                 }
+                // Navigation invariant: while the newly selected board is
+                // still loading, the visible cards belong to the OLD board.
+                // Keep them as read-only cached content - no taps, menus,
+                // moves, or deletes - until the new snapshot lands.
+                .disabled(!store.isSelectedSnapshotLoaded)
+                .overlay(alignment: .top) {
+                    if !store.isSelectedSnapshotLoaded {
+                        Label("Loading \(store.selectedBoardMetadata?.name ?? store.resolvedSelectedBoardSlug)…", systemImage: "hourglass")
+                            .font(.caption)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 5)
+                            .background(.ultraThinMaterial, in: Capsule())
+                    }
+                }
             } else {
                 Spacer()
             }
@@ -309,7 +323,7 @@ struct KanbanView: View {
                     .frame(width: 36, height: 36)
             }
             .conduitGlassControl(cornerRadius: 14, tint: .conduitAccent.opacity(0.12))
-            .disabled(store.board == nil || store.isMutating)
+            .disabled(store.board == nil || store.isMutating || !store.isSelectedSnapshotLoaded)
             .accessibilityLabel("New Kanban task")
         }
 
@@ -338,19 +352,15 @@ struct KanbanView: View {
 
     private func move(_ task: KanbanTask, to status: String) async {
         guard task.status != status else { return }
-        do {
-            _ = try await store.updateTask(id: task.id, patch: KanbanTaskPatch(status: status), includeArchived: includeArchived)
-        } catch {
-            store.showMutationError(error)
-        }
+        // The store owns mutation-error presentation for the CURRENT
+        // generation; a completion that lost ownership after a server/board
+        // switch is deliberately inert, so there is no second error channel
+        // here that could resurface a stale failure.
+        _ = try? await store.updateTask(id: task.id, patch: KanbanTaskPatch(status: status), includeArchived: includeArchived)
     }
 
     private func delete(_ task: KanbanTask) async {
-        do {
-            try await store.deleteTask(id: task.id, includeArchived: includeArchived)
-        } catch {
-            store.showMutationError(error)
-        }
+        _ = try? await store.deleteTask(id: task.id, includeArchived: includeArchived)
     }
 }
 

--- a/Conduit/Views/KanbanViews.swift
+++ b/Conduit/Views/KanbanViews.swift
@@ -1,5 +1,10 @@
 import SwiftUI
 
+enum KanbanPollingPolicy {
+    static let boardIntervalNanoseconds: UInt64 = 8_000_000_000
+    static let detailIntervalNanoseconds: UInt64 = 4_000_000_000
+}
+
 struct KanbanView: View {
     @EnvironmentObject private var appState: AppState
     @StateObject private var store = KanbanStore()
@@ -13,6 +18,14 @@ struct KanbanView: View {
         appState.dashboardTicketBridge.map { ObjectIdentifier($0) }
     }
 
+    private var configurationKey: String {
+        "\(String(describing: bridgeIdentity))|\(appState.dashboardTicketBridge?.baseURL ?? "")|\(appState.activeProfile)"
+    }
+
+    private var pollingKey: String {
+        "\(configurationKey)|archived=\(includeArchived)"
+    }
+
     private var visibleColumns: [KanbanColumn] {
         guard let board = store.board else { return [] }
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -24,6 +37,7 @@ struct KanbanView: View {
                 tasks: column.tasks.filter {
                     $0.title.localizedCaseInsensitiveContains(query)
                         || $0.body?.localizedCaseInsensitiveContains(query) == true
+                        || $0.latestSummary?.localizedCaseInsensitiveContains(query) == true
                         || $0.assignee?.localizedCaseInsensitiveContains(query) == true
                 }
             )
@@ -75,17 +89,28 @@ struct KanbanView: View {
                     }
                     .refreshable { await store.refresh(includeArchived: includeArchived) }
                     .overlay(alignment: .topTrailing) {
-                        if let errorMessage = store.errorMessage {
-                            Text(errorMessage)
+                        VStack(alignment: .trailing, spacing: 6) {
+                            if let mutationError = store.mutationErrorMessage {
+                                HStack(spacing: 6) {
+                                    Text(mutationError)
+                                    Button { store.clearMutationError() } label: {
+                                        Image(systemName: "xmark.circle.fill")
+                                    }
+                                    .buttonStyle(.plain)
+                                }
                                 .font(.caption)
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(.red)
                                 .padding(8)
                                 .background(.ultraThinMaterial, in: Capsule())
-                                .padding(.top, 4)
+                            } else if let refreshError = store.errorMessage {
+                                Text("Refresh failed: \(refreshError)")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .padding(8)
+                                    .background(.ultraThinMaterial, in: Capsule())
+                            }
                         }
-                    }
-                    .onChange(of: includeArchived) { _, newValue in
-                        Task { await store.refresh(includeArchived: newValue) }
+                        .padding(.top, 4)
                     }
                 }
             } else {
@@ -108,9 +133,23 @@ struct KanbanView: View {
                 .presentationDetents([.medium, .large])
                 .presentationDragIndicator(.visible)
         }
-        .task(id: bridgeIdentity) {
-            store.configure(requester: appState.dashboardTicketBridge)
+        .task(id: pollingKey) {
+            selectedTask = nil
+            store.configure(
+                requester: appState.dashboardTicketBridge,
+                profile: appState.activeProfile,
+                serverIdentity: appState.dashboardTicketBridge?.baseURL ?? ""
+            )
             await store.reload(includeArchived: includeArchived)
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(nanoseconds: KanbanPollingPolicy.boardIntervalNanoseconds)
+                } catch {
+                    break
+                }
+                guard !Task.isCancelled else { break }
+                await store.poll(includeArchived: includeArchived)
+            }
         }
     }
 
@@ -160,7 +199,7 @@ struct KanbanView: View {
                     .frame(width: 36, height: 36)
             }
             .conduitGlassControl(cornerRadius: 14)
-            .disabled(store.isLoading)
+            .disabled(store.isLoading || store.isMutating)
             .accessibilityLabel("Refresh Kanban board")
 
             Button {
@@ -171,7 +210,7 @@ struct KanbanView: View {
                     .frame(width: 36, height: 36)
             }
             .conduitGlassControl(cornerRadius: 14, tint: .conduitAccent.opacity(0.12))
-            .disabled(store.board == nil)
+            .disabled(store.board == nil || store.isMutating)
             .accessibilityLabel("New Kanban task")
         }
 
@@ -203,7 +242,7 @@ struct KanbanView: View {
         do {
             _ = try await store.updateTask(id: task.id, patch: KanbanTaskPatch(status: status), includeArchived: includeArchived)
         } catch {
-            // The board remains visible; the store surfaces the mutation error.
+            store.showMutationError(error)
         }
     }
 
@@ -211,7 +250,7 @@ struct KanbanView: View {
         do {
             try await store.deleteTask(id: task.id, includeArchived: includeArchived)
         } catch {
-            // The board remains visible; the store surfaces the mutation error.
+            store.showMutationError(error)
         }
     }
 }
@@ -238,13 +277,15 @@ private struct KanbanColumnView: View {
                     .font(.caption.monospacedDigit().weight(.semibold))
                     .foregroundStyle(.secondary)
                 Spacer(minLength: 0)
-                Button { onAddTask(column.name) } label: {
-                    Image(systemName: "plus")
-                        .font(.caption.weight(.bold))
+                if presentation.isTaskCreatable {
+                    Button { onAddTask(column.name) } label: {
+                        Image(systemName: "plus")
+                            .font(.caption.weight(.bold))
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel("Add task to " + presentation.displayName)
                 }
-                .buttonStyle(.plain)
-                .foregroundStyle(.secondary)
-                .accessibilityLabel("Add task to " + presentation.displayName)
             }
 
             ScrollView(.vertical, showsIndicators: false) {
@@ -279,9 +320,7 @@ private struct KanbanCardView: View {
     }
 
     private var statusOptions: [KanbanStatusPresentation] {
-        KanbanStatusPresentation.knownStatuses
-            .filter { $0 != "running" }
-            .map(KanbanStatusPresentation.forStatus)
+        KanbanStatusPresentation.manuallySelectableStatuses
     }
 
     var body: some View {
@@ -317,13 +356,13 @@ private struct KanbanCardView: View {
                 .buttonStyle(.plain)
             }
 
-            if let body = task.body, !body.isEmpty {
-                Text(body)
+            if let summary = task.latestSummary, !summary.isEmpty {
+                Text(summary)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(3)
-            } else if let summary = task.latestSummary, !summary.isEmpty {
-                Text(summary)
+            } else if let body = task.body, !body.isEmpty {
+                Text(body)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(3)
@@ -370,6 +409,7 @@ struct KanbanTaskEditorView: View {
     @State private var assignee = ""
     @State private var priority = 0
     @State private var isSaving = false
+    @State private var didCreate = false
     @State private var errorMessage: String?
 
     private var statusPresentation: KanbanStatusPresentation {
@@ -418,15 +458,19 @@ struct KanbanTaskEditorView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
+                    Button(didCreate ? "Close" : "Cancel") { dismiss() }
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button {
-                        Task { await save() }
+                        if didCreate {
+                            dismiss()
+                        } else {
+                            Task { await save() }
+                        }
                     } label: {
-                        if isSaving { ProgressView() } else { Text("Create") }
+                        if isSaving { ProgressView() } else { Text(didCreate ? "Done" : "Create") }
                     }
-                    .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSaving)
+                    .disabled((title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !didCreate) || isSaving)
                 }
             }
         }
@@ -434,26 +478,27 @@ struct KanbanTaskEditorView: View {
 
     private func save() async {
         let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedTitle.isEmpty else { return }
+        guard !trimmedTitle.isEmpty, statusPresentation.isTaskCreatable else { return }
         isSaving = true
         errorMessage = nil
         defer { isSaving = false }
         do {
-            let created = try await store.createTask(
+            _ = try await store.createTask(
                 KanbanCreateTaskRequest(
                     title: trimmedTitle,
                     body: taskBody.isEmpty ? nil : taskBody,
                     assignee: assignee.isEmpty ? nil : assignee,
                     priority: priority,
                     triage: initialStatus == "triage"
-                )
+                ),
+                initialStatus: initialStatus
             )
-            if initialStatus != "todo", let id = created?.id, !id.isEmpty {
-                _ = try await store.updateTask(id: id, patch: KanbanTaskPatch(status: initialStatus))
-            }
             dismiss()
         } catch {
             errorMessage = error.localizedDescription
+            if let kanbanError = error as? KanbanServiceError, case .taskCreatedButMoveFailed = kanbanError {
+                didCreate = true
+            }
         }
     }
 }
@@ -469,8 +514,10 @@ struct KanbanTaskDetailView: View {
     @State private var comment = ""
     @State private var isSaving = false
     @State private var isAddingComment = false
+    @State private var isLoadingDetail = false
     @State private var showDeleteConfirmation = false
     @State private var errorMessage: String?
+    @State private var refreshErrorMessage: String?
 
     init(task: KanbanTask) {
         initialTask = task
@@ -484,9 +531,9 @@ struct KanbanTaskDetailView: View {
     }
 
     private var statusOptions: [KanbanStatusPresentation] {
-        var values = KanbanStatusPresentation.knownStatuses.map(KanbanStatusPresentation.forStatus)
+        var values = KanbanStatusPresentation.manuallySelectableStatuses
         if !values.contains(where: { $0.rawValue == status }) {
-            values.append(KanbanStatusPresentation.forStatus(status))
+            values.insert(KanbanStatusPresentation.forStatus(status), at: 0)
         }
         return values
     }
@@ -499,6 +546,12 @@ struct KanbanTaskDetailView: View {
                     metadataSection
                     commentsSection
                     runsSection
+                    if let refreshErrorMessage {
+                        Text("Refresh failed: \(refreshErrorMessage)")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
                     if let errorMessage {
                         Text(errorMessage)
                             .font(.footnote)
@@ -525,7 +578,16 @@ struct KanbanTaskDetailView: View {
                     }
                 }
             }
-            .task { await loadDetail() }
+            .task(id: initialTask.id) {
+                while !Task.isCancelled {
+                    await loadDetail()
+                    do {
+                        try await Task.sleep(nanoseconds: KanbanPollingPolicy.detailIntervalNanoseconds)
+                    } catch {
+                        break
+                    }
+                }
+            }
             .alert("Delete this task?", isPresented: $showDeleteConfirmation) {
                 Button("Delete", role: .destructive) { Task { await deleteTask() } }
                 Button("Cancel", role: .cancel) {}
@@ -548,6 +610,7 @@ struct KanbanTaskDetailView: View {
                 ForEach(statusOptions) { value in
                     Label(value.displayName, systemImage: value.systemImage)
                         .tag(value.rawValue)
+                        .disabled(!value.isManuallySelectable)
                 }
             }
             .pickerStyle(.menu)
@@ -655,15 +718,23 @@ struct KanbanTaskDetailView: View {
         }
     }
 
-    private func loadDetail() async {
+    private func loadDetail(force: Bool = false) async {
+        guard force || (!isSaving && !isAddingComment), !isLoadingDetail else { return }
+        isLoadingDetail = true
+        defer { isLoadingDetail = false }
         do {
             let loaded = try await store.fetchTaskDetail(id: initialTask.id)
             detail = loaded
             title = loaded.task.title
             taskBody = loaded.task.body ?? ""
             status = loaded.task.status
+            refreshErrorMessage = nil
         } catch {
-            errorMessage = error.localizedDescription
+            if detail == nil {
+                errorMessage = error.localizedDescription
+            } else {
+                refreshErrorMessage = error.localizedDescription
+            }
         }
     }
 
@@ -673,14 +744,20 @@ struct KanbanTaskDetailView: View {
         var patch = KanbanTaskPatch()
         if trimmedTitle != current.title { patch.title = trimmedTitle }
         if taskBody != (current.body ?? "") { patch.body = taskBody }
-        if status != current.status { patch.status = status }
+        if status != current.status {
+            guard KanbanStatusPresentation.canSelectManually(status) else {
+                errorMessage = KanbanServiceError.invalidManualStatus(status).localizedDescription
+                return
+            }
+            patch.status = status
+        }
         guard !patch.isEmpty else { return }
         isSaving = true
         errorMessage = nil
         defer { isSaving = false }
         do {
             _ = try await store.updateTask(id: current.id, patch: patch)
-            await loadDetail()
+            await loadDetail(force: true)
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -695,7 +772,7 @@ struct KanbanTaskDetailView: View {
         do {
             try await store.addComment(taskID: currentTask.id, body: text)
             comment = ""
-            await loadDetail()
+            await loadDetail(force: true)
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/Conduit/Views/KanbanViews.swift
+++ b/Conduit/Views/KanbanViews.swift
@@ -5,6 +5,36 @@ enum KanbanPollingPolicy {
     static let detailIntervalNanoseconds: UInt64 = 4_000_000_000
 }
 
+/// Pure draft-reconciliation rules for the task detail surface, extracted so
+/// polling behavior is deterministically testable without UI timing.
+enum KanbanDetailDraftPolicy {
+    static func isDirty(
+        draftTitle: String,
+        draftBody: String,
+        draftStatus: String,
+        baselineTitle: String,
+        baselineBodyText: String,
+        baselineStatus: String
+    ) -> Bool {
+        draftTitle != baselineTitle
+            || draftBody != baselineBodyText
+            || draftStatus != baselineStatus
+    }
+
+    static func serverMovedIndependently(
+        serverTitle: String,
+        serverBodyText: String,
+        serverStatus: String,
+        baselineTitle: String,
+        baselineBodyText: String,
+        baselineStatus: String
+    ) -> Bool {
+        serverTitle != baselineTitle
+            || serverBodyText != baselineBodyText
+            || serverStatus != baselineStatus
+    }
+}
+
 struct KanbanView: View {
     @EnvironmentObject private var appState: AppState
     @StateObject private var store = KanbanStore()
@@ -13,17 +43,19 @@ struct KanbanView: View {
     @State private var newTaskStatus = "todo"
     @State private var includeArchived = false
     @State private var searchText = ""
+    /// iPhone-native interaction: one selected lane rendered as a vertical
+    /// card list behind a horizontally scrolling chip selector.
+    @State private var selectedLane: String?
 
     private var bridgeIdentity: ObjectIdentifier? {
         appState.dashboardTicketBridge.map { ObjectIdentifier($0) }
     }
 
-    private var configurationKey: String {
-        "\(String(describing: bridgeIdentity))|\(appState.dashboardTicketBridge?.baseURL ?? "")|\(appState.activeProfile)"
-    }
-
+    /// Configuration/polling key. Deliberately EXCLUDES appState.activeProfile:
+    /// the Kanban plugin API serves the dashboard backend's own Hermes home,
+    /// so Conduit's UI profile switch does not change the Kanban data source.
     private var pollingKey: String {
-        "\(configurationKey)|archived=\(includeArchived)"
+        "\(String(describing: bridgeIdentity))|\(appState.dashboardTicketBridge?.baseURL ?? "")|archived=\(includeArchived)"
     }
 
     private var visibleColumns: [KanbanColumn] {
@@ -65,53 +97,32 @@ struct KanbanView: View {
                     ContentUnavailableView("No Columns", systemImage: "rectangle.3.group")
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        LazyHStack(alignment: .top, spacing: 12) {
-                            ForEach(visibleColumns) { column in
-                                KanbanColumnView(
-                                    column: column,
-                                    onOpenTask: { selectedTask = $0 },
-                                    onAddTask: { status in
-                                        newTaskStatus = status
-                                        showNewTask = true
-                                    },
-                                    onMoveTask: { task, status in
-                                        Task { await move(task, to: status) }
-                                    },
-                                    onDeleteTask: { task in
-                                        Task { await delete(task) }
+                    laneBoard
+                        .refreshable { await store.refresh(includeArchived: includeArchived) }
+                        .overlay(alignment: .topTrailing) {
+                            VStack(alignment: .trailing, spacing: 6) {
+                                if let mutationError = store.mutationErrorMessage {
+                                    HStack(spacing: 6) {
+                                        Text(mutationError)
+                                        Button { store.clearMutationError() } label: {
+                                            Image(systemName: "xmark.circle.fill")
+                                        }
+                                        .buttonStyle(.plain)
                                     }
-                                )
-                            }
-                        }
-                        .padding(.horizontal, 2)
-                        .padding(.bottom, 12)
-                    }
-                    .refreshable { await store.refresh(includeArchived: includeArchived) }
-                    .overlay(alignment: .topTrailing) {
-                        VStack(alignment: .trailing, spacing: 6) {
-                            if let mutationError = store.mutationErrorMessage {
-                                HStack(spacing: 6) {
-                                    Text(mutationError)
-                                    Button { store.clearMutationError() } label: {
-                                        Image(systemName: "xmark.circle.fill")
-                                    }
-                                    .buttonStyle(.plain)
-                                }
-                                .font(.caption)
-                                .foregroundStyle(.red)
-                                .padding(8)
-                                .background(.ultraThinMaterial, in: Capsule())
-                            } else if let refreshError = store.errorMessage {
-                                Text("Refresh failed: \(refreshError)")
                                     .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                    .foregroundStyle(.red)
                                     .padding(8)
                                     .background(.ultraThinMaterial, in: Capsule())
+                                } else if let refreshError = store.errorMessage {
+                                    Text("Refresh failed: \(refreshError)")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .padding(8)
+                                        .background(.ultraThinMaterial, in: Capsule())
+                                }
                             }
+                            .padding(.top, 4)
                         }
-                        .padding(.top, 4)
-                    }
                 }
             } else {
                 ContentUnavailableView("No Board", systemImage: "rectangle.3.group")
@@ -137,7 +148,6 @@ struct KanbanView: View {
             selectedTask = nil
             store.configure(
                 requester: appState.dashboardTicketBridge,
-                profile: appState.activeProfile,
                 serverIdentity: appState.dashboardTicketBridge?.baseURL ?? ""
             )
             await store.reload(includeArchived: includeArchived)
@@ -151,6 +161,90 @@ struct KanbanView: View {
                 await store.poll(includeArchived: includeArchived)
             }
         }
+    }
+
+    // MARK: - Lane-based iPhone board
+
+    /// Native mobile interaction: horizontally scrolling lane chips over one
+    /// vertically scrolling card list for the selected lane. Locked/system
+    /// lanes stay visible with their counts but are marked and never offer
+    /// creation, matching upstream LOCKED_COLUMNS semantics.
+    @ViewBuilder
+    private var laneBoard: some View {
+        let columns = visibleColumns
+        VStack(spacing: 10) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 7) {
+                    ForEach(columns) { column in
+                        laneChip(column)
+                    }
+                }
+                .padding(.horizontal, 2)
+                .padding(.vertical, 1)
+            }
+            .frame(height: 34)
+
+            if let column = resolvedLaneColumn(in: columns) {
+                ScrollView(showsIndicators: false) {
+                    LazyVStack(spacing: 9) {
+                        ForEach(column.tasks) { task in
+                            KanbanCardView(
+                                task: task,
+                                onOpen: { selectedTask = task },
+                                onMove: { status in Task { await move(task, to: status) } },
+                                onDelete: { Task { await delete(task) } }
+                            )
+                        }
+                    }
+                    .padding(.horizontal, 1)
+                    .padding(.bottom, 14)
+                }
+            } else {
+                Spacer()
+            }
+        }
+    }
+
+    private func laneChip(_ column: KanbanColumn) -> some View {
+        let presentation = KanbanStatusPresentation.forStatus(column.name)
+        let isSelected = resolvedLaneName(columns: visibleColumns) == column.name
+        return Button {
+            selectedLane = column.name
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: presentation.systemImage)
+                    .font(.caption2)
+                Text(presentation.displayName)
+                    .font(.caption.weight(isSelected ? .bold : .semibold))
+                Text(String(column.tasks.count))
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                if presentation.isBackendControlled {
+                    Image(systemName: "lock.fill")
+                        .font(.system(size: 8))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .padding(.horizontal, 11)
+            .frame(height: 30)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(isSelected ? .primary : .secondary)
+        .conduitGlassControl(cornerRadius: 15, tint: isSelected ? presentation.tint.opacity(0.16) : .clear)
+        .accessibilityLabel(presentation.displayName + ", " + String(column.tasks.count) + " tasks")
+    }
+
+    private func resolvedLaneName(columns: [KanbanColumn]) -> String? {
+        if let selectedLane, columns.contains(where: { $0.name == selectedLane }) {
+            return selectedLane
+        }
+        // Prefer an unlocked default so the first paint shows actionable work.
+        return columns.first(where: { !KanbanStatusPresentation.isLockedDestination($0.name) })?.name ?? columns.first?.name
+    }
+
+    private func resolvedLaneColumn(in columns: [KanbanColumn]) -> KanbanColumn? {
+        guard let name = resolvedLaneName(columns: columns) else { return nil }
+        return columns.first(where: { $0.name == name })
     }
 
     @ViewBuilder
@@ -203,7 +297,11 @@ struct KanbanView: View {
             .accessibilityLabel("Refresh Kanban board")
 
             Button {
-                newTaskStatus = "todo"
+                // Land on the visible lane when it accepts creation; otherwise
+                // fall back to the backend's default unlocked lane.
+                newTaskStatus = selectedLane.flatMap { lane in
+                    KanbanStatusPresentation.canCreateTask(in: lane) ? lane : nil
+                } ?? "todo"
                 showNewTask = true
             } label: {
                 Image(systemName: "plus")
@@ -252,60 +350,6 @@ struct KanbanView: View {
         } catch {
             store.showMutationError(error)
         }
-    }
-}
-
-private struct KanbanColumnView: View {
-    let column: KanbanColumn
-    let onOpenTask: (KanbanTask) -> Void
-    let onAddTask: (String) -> Void
-    let onMoveTask: (KanbanTask, String) -> Void
-    let onDeleteTask: (KanbanTask) -> Void
-
-    private var presentation: KanbanStatusPresentation {
-        KanbanStatusPresentation.forStatus(column.name)
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 9) {
-            HStack(spacing: 7) {
-                Image(systemName: presentation.systemImage)
-                    .foregroundStyle(presentation.tint)
-                Text(presentation.displayName)
-                    .font(.subheadline.weight(.semibold))
-                Text(String(column.tasks.count))
-                    .font(.caption.monospacedDigit().weight(.semibold))
-                    .foregroundStyle(.secondary)
-                Spacer(minLength: 0)
-                if presentation.isTaskCreatable {
-                    Button { onAddTask(column.name) } label: {
-                        Image(systemName: "plus")
-                            .font(.caption.weight(.bold))
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.secondary)
-                    .accessibilityLabel("Add task to " + presentation.displayName)
-                }
-            }
-
-            ScrollView(.vertical, showsIndicators: false) {
-                LazyVStack(spacing: 8) {
-                    ForEach(column.tasks) { task in
-                        KanbanCardView(
-                            task: task,
-                            onOpen: { onOpenTask(task) },
-                            onMove: { onMoveTask(task, $0) },
-                            onDelete: { onDeleteTask(task) }
-                        )
-                    }
-                }
-                .padding(.bottom, 4)
-            }
-            .frame(minHeight: 160, maxHeight: 560)
-        }
-        .padding(11)
-        .frame(width: 286, alignment: .topLeading)
-        .conduitGlassSurface(cornerRadius: 22, tint: presentation.tint.opacity(0.06))
     }
 }
 
@@ -504,13 +548,25 @@ struct KanbanTaskEditorView: View {
 }
 
 struct KanbanTaskDetailView: View {
+    /// Editable fields as last synced from the server. The draft fields below
+    /// are compared against this so a 4-second poll can refresh comments,
+    /// runs, and metadata WITHOUT ever overwriting unsaved user edits.
+    private struct ServerBaseline: Equatable {
+        var title: String
+        var bodyText: String
+        var status: String
+    }
+
     @EnvironmentObject private var store: KanbanStore
     @Environment(\.dismiss) private var dismiss
     let initialTask: KanbanTask
     @State private var detail: KanbanTaskDetail?
+    // Draft (editable) state - owned by the user until saved.
     @State private var title: String
     @State private var taskBody: String
     @State private var status: String
+    @State private var baseline: ServerBaseline
+    @State private var remoteChangeNotice: String?
     @State private var comment = ""
     @State private var isSaving = false
     @State private var isAddingComment = false
@@ -524,11 +580,24 @@ struct KanbanTaskDetailView: View {
         _title = State(initialValue: task.title)
         _taskBody = State(initialValue: task.body ?? "")
         _status = State(initialValue: task.status)
+        _baseline = State(initialValue: ServerBaseline(title: task.title, bodyText: task.body ?? "", status: task.status))
     }
 
     private var currentTask: KanbanTask {
         detail?.task ?? initialTask
     }
+
+    private var hasUnsavedChanges: Bool {
+        KanbanDetailDraftPolicy.isDirty(
+            draftTitle: title,
+            draftBody: taskBody,
+            draftStatus: status,
+            baselineTitle: baseline.title,
+            baselineBodyText: baseline.bodyText,
+            baselineStatus: baseline.status
+        )
+    }
+
 
     private var statusOptions: [KanbanStatusPresentation] {
         var values = KanbanStatusPresentation.manuallySelectableStatuses
@@ -546,6 +615,18 @@ struct KanbanTaskDetailView: View {
                     metadataSection
                     commentsSection
                     runsSection
+                    if let remoteChangeNotice {
+                        Text(remoteChangeNotice)
+                            .font(.footnote)
+                            .foregroundStyle(.orange)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    if hasUnsavedChanges {
+                        Text("Unsaved edits")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
                     if let refreshErrorMessage {
                         Text("Refresh failed: \(refreshErrorMessage)")
                             .font(.footnote)
@@ -719,15 +800,35 @@ struct KanbanTaskDetailView: View {
     }
 
     private func loadDetail(force: Bool = false) async {
+        // A poll never runs underneath an active save/comment write.
         guard force || (!isSaving && !isAddingComment), !isLoadingDetail else { return }
         isLoadingDetail = true
         defer { isLoadingDetail = false }
         do {
             let loaded = try await store.fetchTaskDetail(id: initialTask.id)
+            let server = loaded.task
+            if hasUnsavedChanges {
+                // Preserve the user's draft. Flag external edits to the same
+                // fields so the conflict is visible without destroying input.
+                let serverMoved = KanbanDetailDraftPolicy.serverMovedIndependently(
+                    serverTitle: server.title,
+                    serverBodyText: server.body ?? "",
+                    serverStatus: server.status,
+                    baselineTitle: baseline.title,
+                    baselineBodyText: baseline.bodyText,
+                    baselineStatus: baseline.status
+                )
+                if serverMoved && remoteChangeNotice == nil {
+                    remoteChangeNotice = "This task changed on the server. Your unsaved edits are preserved."
+                }
+            } else {
+                title = server.title
+                taskBody = server.body ?? ""
+                status = server.status
+                baseline = ServerBaseline(title: server.title, bodyText: server.body ?? "", status: server.status)
+                remoteChangeNotice = nil
+            }
             detail = loaded
-            title = loaded.task.title
-            taskBody = loaded.task.body ?? ""
-            status = loaded.task.status
             refreshErrorMessage = nil
         } catch {
             if detail == nil {
@@ -742,9 +843,11 @@ struct KanbanTaskDetailView: View {
         let current = currentTask
         let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
         var patch = KanbanTaskPatch()
-        if trimmedTitle != current.title { patch.title = trimmedTitle }
-        if taskBody != (current.body ?? "") { patch.body = taskBody }
-        if status != current.status {
+        // Diffs run against the last-synced baseline, not the live server
+        // snapshot, so an external edit cannot silently drop a user field.
+        if trimmedTitle != baseline.title { patch.title = trimmedTitle }
+        if taskBody != baseline.bodyText { patch.body = taskBody }
+        if status != baseline.status {
             guard KanbanStatusPresentation.canSelectManually(status) else {
                 errorMessage = KanbanServiceError.invalidManualStatus(status).localizedDescription
                 return
@@ -756,7 +859,15 @@ struct KanbanTaskDetailView: View {
         errorMessage = nil
         defer { isSaving = false }
         do {
-            _ = try await store.updateTask(id: current.id, patch: patch)
+            let saved = try await store.updateTask(id: current.id, patch: patch)
+            // Reconcile the draft with the saved representation and clear the
+            // dirty state before the next poll cycle lands.
+            let savedServer = saved ?? currentTask
+            title = savedServer.title
+            taskBody = savedServer.body ?? taskBody
+            status = savedServer.status
+            baseline = ServerBaseline(title: savedServer.title, bodyText: savedServer.body ?? taskBody, status: savedServer.status)
+            remoteChangeNotice = nil
             await loadDetail(force: true)
         } catch {
             errorMessage = error.localizedDescription

--- a/Conduit/Views/KanbanViews.swift
+++ b/Conduit/Views/KanbanViews.swift
@@ -1,0 +1,719 @@
+import SwiftUI
+
+struct KanbanView: View {
+    @EnvironmentObject private var appState: AppState
+    @StateObject private var store = KanbanStore()
+    @State private var selectedTask: KanbanTask?
+    @State private var showNewTask = false
+    @State private var newTaskStatus = "todo"
+    @State private var includeArchived = false
+    @State private var searchText = ""
+
+    private var bridgeIdentity: ObjectIdentifier? {
+        appState.dashboardTicketBridge.map { ObjectIdentifier($0) }
+    }
+
+    private var visibleColumns: [KanbanColumn] {
+        guard let board = store.board else { return [] }
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let columns = KanbanStatusPresentation.orderedColumns(board.columns)
+        guard !query.isEmpty else { return columns }
+        return columns.map { column in
+            KanbanColumn(
+                name: column.name,
+                tasks: column.tasks.filter {
+                    $0.title.localizedCaseInsensitiveContains(query)
+                        || $0.body?.localizedCaseInsensitiveContains(query) == true
+                        || $0.assignee?.localizedCaseInsensitiveContains(query) == true
+                }
+            )
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 12) {
+            header
+
+            if store.isLoading && store.board == nil {
+                Spacer()
+                ProgressView("Loading board…")
+                    .tint(.conduitAccent)
+                Spacer()
+            } else if let errorMessage = store.errorMessage, store.board == nil {
+                ContentUnavailableView(
+                    "Kanban Unavailable",
+                    systemImage: "rectangle.3.group",
+                    description: Text(errorMessage)
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let board = store.board {
+                if visibleColumns.isEmpty {
+                    ContentUnavailableView("No Columns", systemImage: "rectangle.3.group")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        LazyHStack(alignment: .top, spacing: 12) {
+                            ForEach(visibleColumns) { column in
+                                KanbanColumnView(
+                                    column: column,
+                                    onOpenTask: { selectedTask = $0 },
+                                    onAddTask: { status in
+                                        newTaskStatus = status
+                                        showNewTask = true
+                                    },
+                                    onMoveTask: { task, status in
+                                        Task { await move(task, to: status) }
+                                    },
+                                    onDeleteTask: { task in
+                                        Task { await delete(task) }
+                                    }
+                                )
+                            }
+                        }
+                        .padding(.horizontal, 2)
+                        .padding(.bottom, 12)
+                    }
+                    .refreshable { await store.refresh(includeArchived: includeArchived) }
+                    .overlay(alignment: .topTrailing) {
+                        if let errorMessage = store.errorMessage {
+                            Text(errorMessage)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .padding(8)
+                                .background(.ultraThinMaterial, in: Capsule())
+                                .padding(.top, 4)
+                        }
+                    }
+                    .onChange(of: includeArchived) { _, newValue in
+                        Task { await store.refresh(includeArchived: newValue) }
+                    }
+                }
+            } else {
+                ContentUnavailableView("No Board", systemImage: "rectangle.3.group")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 10)
+        .background(ConduitBackdrop())
+        .sheet(item: $selectedTask) { task in
+            KanbanTaskDetailView(task: task)
+                .environmentObject(store)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
+        }
+        .sheet(isPresented: $showNewTask) {
+            KanbanTaskEditorView(initialStatus: newTaskStatus)
+                .environmentObject(store)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+        }
+        .task(id: bridgeIdentity) {
+            store.configure(requester: appState.dashboardTicketBridge)
+            await store.reload(includeArchived: includeArchived)
+        }
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Kanban")
+                    .font(.title3.weight(.bold))
+                Text(store.selectedBoardMetadata?.name ?? store.selectedBoardMetadata?.slug ?? "Board")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 4)
+
+            Menu {
+                Button {
+                    Task { await store.selectBoard(slug: "", includeArchived: includeArchived) }
+                } label: {
+                    Label("Server current (" + store.currentServerBoardSlug + ")", systemImage: "server.rack")
+                }
+                ForEach(store.boards) { metadata in
+                    Button {
+                        Task { await store.selectBoard(slug: metadata.slug, includeArchived: includeArchived) }
+                    } label: {
+                        HStack {
+                            Text(metadata.name ?? metadata.slug)
+                            if metadata.slug == store.selectedBoardMetadata?.slug && !store.selectedBoardSlug.isEmpty {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            } label: {
+                Image(systemName: "square.grid.2x2")
+                    .frame(width: 36, height: 36)
+            }
+            .conduitGlassControl(cornerRadius: 14)
+            .accessibilityLabel("Choose Kanban board")
+
+            Button {
+                Task { await store.refresh(includeArchived: includeArchived) }
+            } label: {
+                Image(systemName: store.isLoading ? "arrow.triangle.2.circlepath" : "arrow.clockwise")
+                    .frame(width: 36, height: 36)
+            }
+            .conduitGlassControl(cornerRadius: 14)
+            .disabled(store.isLoading)
+            .accessibilityLabel("Refresh Kanban board")
+
+            Button {
+                newTaskStatus = "todo"
+                showNewTask = true
+            } label: {
+                Image(systemName: "plus")
+                    .frame(width: 36, height: 36)
+            }
+            .conduitGlassControl(cornerRadius: 14, tint: .conduitAccent.opacity(0.12))
+            .disabled(store.board == nil)
+            .accessibilityLabel("New Kanban task")
+        }
+
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField("Search tasks", text: $searchText)
+                .textFieldStyle(.plain)
+            if !searchText.isEmpty {
+                Button { searchText = "" } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+            }
+            Toggle("Archived", isOn: $includeArchived)
+                .toggleStyle(.switch)
+                .font(.caption)
+                .labelsHidden()
+                .accessibilityLabel("Show archived tasks")
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 40)
+        .conduitGlassControl(cornerRadius: 15)
+    }
+
+    private func move(_ task: KanbanTask, to status: String) async {
+        guard task.status != status else { return }
+        do {
+            _ = try await store.updateTask(id: task.id, patch: KanbanTaskPatch(status: status), includeArchived: includeArchived)
+        } catch {
+            // The board remains visible; the store surfaces the mutation error.
+        }
+    }
+
+    private func delete(_ task: KanbanTask) async {
+        do {
+            try await store.deleteTask(id: task.id, includeArchived: includeArchived)
+        } catch {
+            // The board remains visible; the store surfaces the mutation error.
+        }
+    }
+}
+
+private struct KanbanColumnView: View {
+    let column: KanbanColumn
+    let onOpenTask: (KanbanTask) -> Void
+    let onAddTask: (String) -> Void
+    let onMoveTask: (KanbanTask, String) -> Void
+    let onDeleteTask: (KanbanTask) -> Void
+
+    private var presentation: KanbanStatusPresentation {
+        KanbanStatusPresentation.forStatus(column.name)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            HStack(spacing: 7) {
+                Image(systemName: presentation.systemImage)
+                    .foregroundStyle(presentation.tint)
+                Text(presentation.displayName)
+                    .font(.subheadline.weight(.semibold))
+                Text(String(column.tasks.count))
+                    .font(.caption.monospacedDigit().weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 0)
+                Button { onAddTask(column.name) } label: {
+                    Image(systemName: "plus")
+                        .font(.caption.weight(.bold))
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .accessibilityLabel("Add task to " + presentation.displayName)
+            }
+
+            ScrollView(.vertical, showsIndicators: false) {
+                LazyVStack(spacing: 8) {
+                    ForEach(column.tasks) { task in
+                        KanbanCardView(
+                            task: task,
+                            onOpen: { onOpenTask(task) },
+                            onMove: { onMoveTask(task, $0) },
+                            onDelete: { onDeleteTask(task) }
+                        )
+                    }
+                }
+                .padding(.bottom, 4)
+            }
+            .frame(minHeight: 160, maxHeight: 560)
+        }
+        .padding(11)
+        .frame(width: 286, alignment: .topLeading)
+        .conduitGlassSurface(cornerRadius: 22, tint: presentation.tint.opacity(0.06))
+    }
+}
+
+private struct KanbanCardView: View {
+    let task: KanbanTask
+    let onOpen: () -> Void
+    let onMove: (String) -> Void
+    let onDelete: () -> Void
+
+    private var presentation: KanbanStatusPresentation {
+        KanbanStatusPresentation.forStatus(task.status)
+    }
+
+    private var statusOptions: [KanbanStatusPresentation] {
+        KanbanStatusPresentation.knownStatuses
+            .filter { $0 != "running" }
+            .map(KanbanStatusPresentation.forStatus)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 7) {
+                Circle()
+                    .fill(presentation.tint)
+                    .frame(width: 7, height: 7)
+                    .padding(.top, 5)
+                Text(task.title)
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(3)
+                Spacer(minLength: 2)
+                Menu {
+                    Section("Move to") {
+                        ForEach(statusOptions) { status in
+                            Button {
+                                onMove(status.rawValue)
+                            } label: {
+                                Label(status.displayName, systemImage: status.systemImage)
+                            }
+                        }
+                    }
+                    Button(role: .destructive, action: onDelete) {
+                        Label("Delete", systemImage: "trash")
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 24, height: 24)
+                }
+                .buttonStyle(.plain)
+            }
+
+            if let body = task.body, !body.isEmpty {
+                Text(body)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(3)
+            } else if let summary = task.latestSummary, !summary.isEmpty {
+                Text(summary)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(3)
+            }
+
+            HStack(spacing: 8) {
+                if let assignee = task.assignee, !assignee.isEmpty {
+                    Label(assignee, systemImage: "person")
+                        .lineLimit(1)
+                }
+                if let priority = task.priority, priority > 0 {
+                    Label(String(priority), systemImage: "flag.fill")
+                }
+                if let comments = task.commentCount, comments > 0 {
+                    Label(String(comments), systemImage: "bubble.left")
+                }
+                Spacer(minLength: 0)
+            }
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+        }
+        .padding(11)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(presentation.tint.opacity(0.18), lineWidth: 1)
+        }
+        .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .onTapGesture(perform: onOpen)
+        .contextMenu {
+            Button { onOpen() } label: { Label("Open", systemImage: "arrow.up.right.square") }
+            Button(role: .destructive, action: onDelete) { Label("Delete", systemImage: "trash") }
+        }
+    }
+}
+
+struct KanbanTaskEditorView: View {
+    @EnvironmentObject private var store: KanbanStore
+    @Environment(\.dismiss) private var dismiss
+    let initialStatus: String
+    @State private var title = ""
+    @State private var taskBody = ""
+    @State private var assignee = ""
+    @State private var priority = 0
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+
+    private var statusPresentation: KanbanStatusPresentation {
+        KanbanStatusPresentation.forStatus(initialStatus)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Task") {
+                    TextField("Title", text: $title)
+                    TextEditor(text: $taskBody)
+                        .frame(minHeight: 120)
+                    Picker("Priority", selection: $priority) {
+                        Text("Normal").tag(0)
+                        Text("High").tag(1)
+                        Text("Urgent").tag(2)
+                        Text("Critical").tag(3)
+                    }
+                    .pickerStyle(.menu)
+                }
+
+                Section("Assignment") {
+                    Picker("Profile", selection: $assignee) {
+                        Text("Unassigned").tag("")
+                        ForEach(store.profiles) { profile in
+                            Text(profile.name).tag(profile.name)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                }
+
+                Section("Workflow") {
+                    Label(statusPresentation.displayName, systemImage: statusPresentation.systemImage)
+                        .foregroundStyle(statusPresentation.tint)
+                    Text("The board selection is local to this device; creating this task will not switch Hermes' global board.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if let errorMessage {
+                    Section { Text(errorMessage).foregroundStyle(.red) }
+                }
+            }
+            .navigationTitle("New task")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button {
+                        Task { await save() }
+                    } label: {
+                        if isSaving { ProgressView() } else { Text("Create") }
+                    }
+                    .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSaving)
+                }
+            }
+        }
+    }
+
+    private func save() async {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty else { return }
+        isSaving = true
+        errorMessage = nil
+        defer { isSaving = false }
+        do {
+            let created = try await store.createTask(
+                KanbanCreateTaskRequest(
+                    title: trimmedTitle,
+                    body: taskBody.isEmpty ? nil : taskBody,
+                    assignee: assignee.isEmpty ? nil : assignee,
+                    priority: priority,
+                    triage: initialStatus == "triage"
+                )
+            )
+            if initialStatus != "todo", let id = created?.id, !id.isEmpty {
+                _ = try await store.updateTask(id: id, patch: KanbanTaskPatch(status: initialStatus))
+            }
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+struct KanbanTaskDetailView: View {
+    @EnvironmentObject private var store: KanbanStore
+    @Environment(\.dismiss) private var dismiss
+    let initialTask: KanbanTask
+    @State private var detail: KanbanTaskDetail?
+    @State private var title: String
+    @State private var taskBody: String
+    @State private var status: String
+    @State private var comment = ""
+    @State private var isSaving = false
+    @State private var isAddingComment = false
+    @State private var showDeleteConfirmation = false
+    @State private var errorMessage: String?
+
+    init(task: KanbanTask) {
+        initialTask = task
+        _title = State(initialValue: task.title)
+        _taskBody = State(initialValue: task.body ?? "")
+        _status = State(initialValue: task.status)
+    }
+
+    private var currentTask: KanbanTask {
+        detail?.task ?? initialTask
+    }
+
+    private var statusOptions: [KanbanStatusPresentation] {
+        var values = KanbanStatusPresentation.knownStatuses.map(KanbanStatusPresentation.forStatus)
+        if !values.contains(where: { $0.rawValue == status }) {
+            values.append(KanbanStatusPresentation.forStatus(status))
+        }
+        return values
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    editorSection
+                    metadataSection
+                    commentsSection
+                    runsSection
+                    if let errorMessage {
+                        Text(errorMessage)
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .padding(16)
+            }
+            .background(ConduitBackdrop())
+            .navigationTitle("Task")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    Menu {
+                        Button(role: .destructive) { showDeleteConfirmation = true } label: {
+                            Label("Delete task", systemImage: "trash")
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis.circle")
+                    }
+                }
+            }
+            .task { await loadDetail() }
+            .alert("Delete this task?", isPresented: $showDeleteConfirmation) {
+                Button("Delete", role: .destructive) { Task { await deleteTask() } }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This removes the task from the selected Hermes board.")
+            }
+        }
+    }
+
+    private var editorSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            TextField("Title", text: $title)
+                .font(.headline)
+                .textFieldStyle(.roundedBorder)
+            TextEditor(text: $taskBody)
+                .frame(minHeight: 150)
+                .padding(4)
+                .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 12))
+            Picker("Status", selection: $status) {
+                ForEach(statusOptions) { value in
+                    Label(value.displayName, systemImage: value.systemImage)
+                        .tag(value.rawValue)
+                }
+            }
+            .pickerStyle(.menu)
+            Button {
+                Task { await saveChanges() }
+            } label: {
+                HStack {
+                    Spacer()
+                    if isSaving { ProgressView() } else { Text("Save changes") }
+                    Spacer()
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.conduitAccent)
+            .disabled(isSaving || title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+        .padding(16)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
+    }
+
+    private var metadataSection: some View {
+        ConduitSettingsSection(title: "Details", symbol: "info.circle", tint: .conduitAura) {
+            SettingsMetricRow(label: "ID", value: currentTask.id, lineLimit: 1)
+            if let assignee = currentTask.assignee, !assignee.isEmpty {
+                SettingsMetricRow(label: "Assignee", value: assignee, lineLimit: 1)
+            }
+            if let priority = currentTask.priority {
+                SettingsMetricRow(label: "Priority", value: String(priority))
+            }
+            if let workspace = currentTask.workspacePath, !workspace.isEmpty {
+                SettingsMetricRow(label: "Workspace", value: workspace, lineLimit: 2)
+            }
+            if let result = currentTask.result, !result.isEmpty {
+                VStack(alignment: .leading, spacing: 5) {
+                    Text("Result")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    Text(result)
+                        .font(.footnote)
+                }
+            }
+        }
+    }
+
+    private var commentsSection: some View {
+        ConduitSettingsSection(title: "Comments", symbol: "bubble.left.and.bubble.right", tint: .conduitAccent) {
+            if let comments = detail?.comments, !comments.isEmpty {
+                ForEach(comments) { value in
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Text(value.author).font(.caption.weight(.semibold))
+                            Spacer()
+                            Text(relativeDate(value.createdAt))
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                        }
+                        Text(value.body).font(.footnote)
+                    }
+                    .padding(.vertical, 3)
+                }
+            } else {
+                Text("No comments yet.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            TextEditor(text: $comment)
+                .frame(minHeight: 80)
+                .padding(4)
+                .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 12))
+            Button {
+                Task { await addComment() }
+            } label: {
+                HStack {
+                    Spacer()
+                    if isAddingComment { ProgressView() } else { Label("Add comment", systemImage: "paperplane") }
+                    Spacer()
+                }
+            }
+            .buttonStyle(.bordered)
+            .disabled(comment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isAddingComment)
+        }
+    }
+
+    @ViewBuilder
+    private var runsSection: some View {
+        if let runs = detail?.runs, !runs.isEmpty {
+            ConduitSettingsSection(title: "Runs", symbol: "terminal", tint: .orange) {
+                ForEach(runs) { run in
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: run.status == "completed" ? "checkmark.circle" : "circle.dotted")
+                            .foregroundStyle(run.status == "completed" ? .green : .secondary)
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(run.status.capitalized).font(.subheadline.weight(.medium))
+                            if let summary = run.summary, !summary.isEmpty {
+                                Text(summary).font(.caption).foregroundStyle(.secondary).lineLimit(3)
+                            }
+                            if let error = run.error, !error.isEmpty {
+                                Text(error).font(.caption).foregroundStyle(.red).lineLimit(3)
+                            }
+                        }
+                        Spacer(minLength: 0)
+                    }
+                }
+            }
+        }
+    }
+
+    private func loadDetail() async {
+        do {
+            let loaded = try await store.fetchTaskDetail(id: initialTask.id)
+            detail = loaded
+            title = loaded.task.title
+            taskBody = loaded.task.body ?? ""
+            status = loaded.task.status
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func saveChanges() async {
+        let current = currentTask
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        var patch = KanbanTaskPatch()
+        if trimmedTitle != current.title { patch.title = trimmedTitle }
+        if taskBody != (current.body ?? "") { patch.body = taskBody }
+        if status != current.status { patch.status = status }
+        guard !patch.isEmpty else { return }
+        isSaving = true
+        errorMessage = nil
+        defer { isSaving = false }
+        do {
+            _ = try await store.updateTask(id: current.id, patch: patch)
+            await loadDetail()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func addComment() async {
+        let text = comment.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        isAddingComment = true
+        errorMessage = nil
+        defer { isAddingComment = false }
+        do {
+            try await store.addComment(taskID: currentTask.id, body: text)
+            comment = ""
+            await loadDetail()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func deleteTask() async {
+        do {
+            try await store.deleteTask(id: currentTask.id)
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func relativeDate(_ epoch: Int?) -> String {
+        guard let epoch else { return "" }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: Date(timeIntervalSince1970: Double(epoch)), relativeTo: Date())
+    }
+}

--- a/Conduit/Views/KanbanViews.swift
+++ b/Conduit/Views/KanbanViews.swift
@@ -52,8 +52,8 @@ struct KanbanView: View {
     }
 
     /// Configuration/polling key. Deliberately EXCLUDES appState.activeProfile:
-    /// the Kanban plugin API serves the dashboard backend's own Hermes home,
-    /// so Conduit's UI profile switch does not change the Kanban data source.
+    /// Hermes Kanban is a shared cross-profile board anchored at the Hermes
+    /// root, so Conduit's UI profile switch does not change Kanban data.
     private var pollingKey: String {
         "\(String(describing: bridgeIdentity))|\(appState.dashboardTicketBridge?.baseURL ?? "")|archived=\(includeArchived)"
     }
@@ -104,10 +104,11 @@ struct KanbanView: View {
                                 if let mutationError = store.mutationErrorMessage {
                                     HStack(spacing: 6) {
                                         Text(mutationError)
-                                        Button { store.clearMutationError() } label: {
-                                            Image(systemName: "xmark.circle.fill")
-                                        }
-                                        .buttonStyle(.plain)
+                                    Button { store.clearMutationError() } label: {
+                                        Image(systemName: "xmark.circle.fill")
+                                    }
+                                    .buttonStyle(.plain)
+                                    .accessibilityLabel("Dismiss Kanban error")
                                     }
                                     .font(.caption)
                                     .foregroundStyle(.red)
@@ -398,6 +399,7 @@ private struct KanbanCardView: View {
                         .frame(width: 24, height: 24)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Task actions")
             }
 
             if let summary = task.latestSummary, !summary.isEmpty {
@@ -657,6 +659,7 @@ struct KanbanTaskDetailView: View {
                     } label: {
                         Image(systemName: "ellipsis.circle")
                     }
+                    .accessibilityLabel("Task actions")
                 }
             }
             .task(id: initialTask.id) {

--- a/Conduit/Views/KanbanViews.swift
+++ b/Conduit/Views/KanbanViews.swift
@@ -449,6 +449,12 @@ private struct KanbanCardView: View {
         }
         .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         .onTapGesture(perform: onOpen)
+        // VoiceOver: expose the whole card as one tappable "Open task" button
+        // while keeping the ellipsis menu and context actions intact.
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityHint("Opens task details")
+        .accessibilityAction(named: "Open task", onOpen)
         .contextMenu {
             Button { onOpen() } label: { Label("Open", systemImage: "arrow.up.right.square") }
             Button(role: .destructive, action: onDelete) { Label("Delete", systemImage: "trash") }

--- a/Conduit/Views/SidebarTab.swift
+++ b/Conduit/Views/SidebarTab.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Persisted sidebar destinations. The raw-value migration is explicit so an
+/// obsolete Capabilities value can never leave the sidebar without a valid tab.
+enum SidebarTab: String, CaseIterable, Identifiable {
+    case sessions = "Sessions"
+    case cron = "Cron"
+    case kanban = "Kanban"
+
+    var id: String { rawValue }
+
+    var icon: String {
+        switch self {
+        case .sessions: return "bubble.left.and.bubble.right"
+        case .cron: return "clock"
+        case .kanban: return "rectangle.3.group"
+        }
+    }
+
+    static func migrated(rawValue: String?) -> SidebarTab {
+        guard let rawValue, let value = SidebarTab(rawValue: rawValue) else {
+            return .sessions
+        }
+        return value
+    }
+}

--- a/Conduit/Views/SidebarView.swift
+++ b/Conduit/Views/SidebarView.swift
@@ -2,7 +2,7 @@
 //  SidebarView.swift
 //  Conduit
 //
-//  Full-screen slide-in sidebar with Sessions / Cron / Capabilities tabs.
+//  Full-screen slide-in sidebar with Sessions / Cron / Kanban tabs.
 //
 
 import SwiftUI
@@ -10,23 +10,14 @@ import SwiftUI
 struct SidebarView: View {
     @EnvironmentObject var appState: AppState
     let onRequestSettings: () -> Void
-    @AppStorage("conduit.sidebarTab") private var selectedTab: SidebarTab = .sessions
+    @AppStorage("conduit.sidebarTab") private var selectedTabRaw = SidebarTab.sessions.rawValue
+
+    private var selectedTab: SidebarTab {
+        get { SidebarTab.migrated(rawValue: selectedTabRaw) }
+        set { selectedTabRaw = newValue.rawValue }
+    }
     @State private var showProfilePicker = false
     @Environment(\.dismiss) private var dismiss
-
-    enum SidebarTab: String, CaseIterable {
-        case sessions = "Sessions"
-        case cron = "Cron"
-        case capabilities = "Capabilities"
-
-        var icon: String {
-            switch self {
-            case .sessions: return "bubble.left.and.bubble.right"
-            case .cron: return "clock"
-            case .capabilities: return "wrench.adjustable"
-            }
-        }
-    }
 
     var body: some View {
         NavigationStack {
@@ -95,7 +86,7 @@ struct SidebarView: View {
                                 Button {
                                     withAnimation(ConduitMotion.response) {
                                         Haptics.selection()
-                                        selectedTab = tab
+                                        selectedTabRaw = tab.rawValue
                                     }
                                 } label: {
                                     Label(tab.rawValue, systemImage: tab.icon)
@@ -121,8 +112,8 @@ struct SidebarView: View {
                             SessionList()
                         case .cron:
                             CronList()
-                        case .capabilities:
-                            CapabilitiesList()
+                        case .kanban:
+                            KanbanView()
                         }
                     }
                     .transition(.opacity.combined(with: .move(edge: .bottom)))
@@ -136,6 +127,10 @@ struct SidebarView: View {
             ProfilePickerSheet()
                 .presentationDetents([.medium, .large])
                 .presentationDragIndicator(.visible)
+        }
+        .onAppear {
+            // Explicitly migrate removed raw values such as Capabilities.
+            selectedTabRaw = SidebarTab.migrated(rawValue: selectedTabRaw).rawValue
         }
     }
 }
@@ -1181,237 +1176,5 @@ private struct CronJobDetailSheet: View {
             }
         }
         .task { await appState.loadCronRuns(for: job) }
-    }
-}
-
-// MARK: - Capabilities List
-
-struct CapabilitiesList: View {
-    @EnvironmentObject var appState: AppState
-    @State private var searchText = ""
-    @State private var capabilitiesLoading = false
-    @State private var loadError: String?
-
-    var body: some View {
-        VStack(spacing: 0) {
-            if capabilitiesLoading && appState.skills.isEmpty && appState.toolsets.isEmpty {
-                Spacer()
-                ProgressView("Loading capabilities…")
-                    .tint(.conduitAccent)
-                Spacer()
-            } else if let loadError, appState.skills.isEmpty && appState.toolsets.isEmpty {
-                ContentUnavailableView(
-                    "Couldn't Load",
-                    systemImage: "exclamationmark.triangle",
-                    description: Text(loadError)
-                )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                List {
-                    skillsSection
-                    toolsetsSection
-                }
-                .searchable(text: $searchText, prompt: "Search skills")
-                .scrollContentBackground(.hidden)
-                .listStyle(.plain)
-                .refreshable { await loadCapabilities() }
-            }
-        }
-        .task(id: appState.activeProfile) { await loadCapabilities() }
-    }
-
-    // MARK: Skills
-
-    @ViewBuilder
-    private var skillsSection: some View {
-        if !filteredSkills.isEmpty {
-            if hasCategories {
-                ForEach(skillsByCategory, id: \.0) { category, skills in
-                    Section(category) {
-                        ForEach(skills) { skill in
-                            CapabilitySkillRow(skill: skill)
-                        }
-                    }
-                }
-            } else {
-                Section("Skills") {
-                    ForEach(filteredSkills) { skill in
-                        CapabilitySkillRow(skill: skill)
-                    }
-                }
-            }
-        }
-    }
-
-    // MARK: Toolsets
-
-    @ViewBuilder
-    private var toolsetsSection: some View {
-        if !filteredToolsets.isEmpty {
-            Section("Toolsets") {
-                ForEach(filteredToolsets) { toolset in
-                    CapabilityToolsetRow(toolset: toolset)
-                }
-            }
-        }
-    }
-
-    // MARK: Filtering & grouping
-
-    private var filteredSkills: [CapabilitySkill] {
-        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !query.isEmpty else { return appState.skills }
-        return appState.skills.filter { skill in
-            [skill.name, skill.description ?? "", skill.category ?? ""]
-                .contains { $0.localizedCaseInsensitiveContains(query) }
-        }
-    }
-
-    private var filteredToolsets: [CapabilityToolset] {
-        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !query.isEmpty else { return appState.toolsets }
-        return appState.toolsets.filter { toolset in
-            [toolset.name, toolset.label ?? "", toolset.description ?? ""]
-                .contains { $0.localizedCaseInsensitiveContains(query) }
-        }
-    }
-
-    private var hasCategories: Bool {
-        appState.skills.contains { $0.category != nil && !($0.category?.isEmpty ?? true) }
-    }
-
-    private var skillsByCategory: [(String, [CapabilitySkill])] {
-        let groups = Dictionary(grouping: filteredSkills) { $0.category ?? "Uncategorized" }
-        return groups.sorted { $0.key < $1.key }
-    }
-
-    // MARK: Loading
-
-    private func loadCapabilities() async {
-        capabilitiesLoading = true
-        defer { capabilitiesLoading = false }
-        await appState.loadCapabilities()
-        if appState.skills.isEmpty && appState.toolsets.isEmpty {
-            loadError = appState.errorMessage ?? "No capabilities found."
-        } else {
-            loadError = nil
-        }
-    }
-}
-
-// MARK: - Skill Row
-
-private struct CapabilitySkillRow: View {
-    @EnvironmentObject var appState: AppState
-    let skill: CapabilitySkill
-
-    private var provenanceIcon: String? {
-        switch skill.provenance {
-        case "hub": return "bag"
-        case "bundled": return "shippingbox"
-        case "agent": return "wrench"
-        default: return nil
-        }
-    }
-
-    var body: some View {
-        Toggle(isOn: Binding(
-            get: { skill.enabled },
-            set: { newValue in
-                Task { await appState.toggleSkill(name: skill.name, enabled: newValue) }
-            }
-        )) {
-            HStack(spacing: 11) {
-                Image(systemName: provenanceIcon ?? "puzzlepiece.extension")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(skill.enabled ? .conduitAccent : .secondary)
-                    .frame(width: 30, height: 30)
-                    .background(
-                        (skill.enabled ? Color.conduitAccent : Color.secondary).opacity(0.13),
-                        in: Circle()
-                    )
-
-                VStack(alignment: .leading, spacing: 3) {
-                    HStack(spacing: 6) {
-                        Text(skill.name)
-                            .font(.subheadline.weight(.medium))
-                            .lineLimit(1)
-                        if let category = skill.category, !category.isEmpty {
-                            Text(category)
-                                .font(.caption2.weight(.semibold))
-                                .foregroundStyle(.secondary)
-                                .padding(.horizontal, 6)
-                                .padding(.vertical, 2)
-                                .background(Color.conduitAura.opacity(0.14), in: Capsule())
-                        }
-                    }
-                    if let desc = skill.description, !desc.isEmpty {
-                        Text(desc)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(2)
-                    }
-                }
-            }
-        }
-        .tint(.conduitAccent)
-        .listRowBackground(Color.clear)
-        .listRowSeparator(.hidden)
-        .listRowInsets(EdgeInsets(top: 3, leading: 0, bottom: 3, trailing: 0))
-    }
-}
-
-// MARK: - Toolset Row
-
-private struct CapabilityToolsetRow: View {
-    @EnvironmentObject var appState: AppState
-    let toolset: CapabilityToolset
-
-    var body: some View {
-        Toggle(isOn: Binding(
-            get: { toolset.enabled },
-            set: { newValue in
-                Task { await appState.toggleToolset(name: toolset.name, enabled: newValue) }
-            }
-        )) {
-            HStack(spacing: 11) {
-                Image(systemName: "wrench.and.screwdriver")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(toolset.enabled ? .conduitAccent : .secondary)
-                    .frame(width: 30, height: 30)
-                    .background(
-                        (toolset.enabled ? Color.conduitAccent : Color.secondary).opacity(0.13),
-                        in: Circle()
-                    )
-
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(toolset.label ?? toolset.name.capitalized)
-                        .font(.subheadline.weight(.medium))
-                        .lineLimit(1)
-                    if let desc = toolset.description, !desc.isEmpty {
-                        Text(desc)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(2)
-                    }
-                    if let tools = toolset.tools, !tools.isEmpty {
-                        Text(tools.joined(separator: ", "))
-                            .font(.caption2)
-                            .foregroundStyle(.tertiary)
-                            .lineLimit(1)
-                    }
-                }
-
-                Spacer(minLength: 0)
-
-                Image(systemName: toolset.configured == true ? "checkmark.circle.fill" : "circle.dashed")
-                    .font(.caption)
-                    .foregroundStyle(toolset.configured == true ? .green : .secondary)
-            }
-        }
-        .tint(.conduitAccent)
-        .listRowBackground(Color.clear)
-        .listRowSeparator(.hidden)
-        .listRowInsets(EdgeInsets(top: 3, leading: 0, bottom: 3, trailing: 0))
     }
 }

--- a/ConduitTests/KanbanTests.swift
+++ b/ConduitTests/KanbanTests.swift
@@ -3,148 +3,243 @@ import XCTest
 
 @MainActor
 final class KanbanTests: XCTestCase {
+    // MARK: - Workflow capability model (upstream LOCKED_COLUMNS parity)
+
     func testSidebarMigrationMapsRemovedCapabilitiesToSessions() {
         XCTAssertEqual(SidebarTab.migrated(rawValue: "Capabilities"), .sessions)
         XCTAssertEqual(SidebarTab.migrated(rawValue: "not-a-tab"), .sessions)
         XCTAssertEqual(SidebarTab.migrated(rawValue: "Kanban"), .kanban)
     }
 
-    func testUnknownStatusHasSafeFallbackPresentation() {
-        let presentation = KanbanStatusPresentation.forStatus("awaiting_customer")
-        XCTAssertEqual(presentation.rawValue, "awaiting_customer")
-        XCTAssertEqual(presentation.displayName, "Awaiting Customer")
-        XCTAssertEqual(presentation.systemImage, "circle.dashed")
-        XCTAssertEqual(presentation.sortOrder, 100)
-        XCTAssertFalse(presentation.isManuallySelectable)
-        XCTAssertFalse(presentation.isTaskCreatable)
-    }
+    func testLockedLanesMatchUpstreamAndAreNotManualDestinations() {
+        // apps/desktop/src/plugins/kanban/ui.tsx: LOCKED_COLUMNS
+        XCTAssertEqual(KanbanStatusPresentation.lockedDestinations, ["review", "running", "scheduled"])
 
-    func testRunningIsVisibleButNotManuallySelectableOrCreatable() {
-        let running = KanbanStatusPresentation.forStatus("running")
-        XCTAssertTrue(running.isVisibleOnBoard)
-        XCTAssertTrue(running.isBackendControlled)
-        XCTAssertFalse(running.isManuallySelectable)
-        XCTAssertFalse(running.isTaskCreatable)
-        XCTAssertFalse(KanbanStatusPresentation.canSelectManually("running"))
-        XCTAssertFalse(KanbanStatusPresentation.canCreateTask(in: "running"))
-        XCTAssertFalse(KanbanStatusPresentation.manuallySelectableStatuses.contains { $0.rawValue == "running" })
+        for lane in ["review", "running", "scheduled"] {
+            XCTAssertFalse(KanbanStatusPresentation.canCreateTask(in: lane), lane)
+            XCTAssertFalse(KanbanStatusPresentation.canSelectManually(lane), lane)
+            let presentation = KanbanStatusPresentation.forStatus(lane)
+            XCTAssertTrue(presentation.isVisibleOnBoard, lane)
+            XCTAssertTrue(presentation.isBackendControlled, lane)
+        }
+        XCTAssertFalse(KanbanStatusPresentation.manuallySelectableStatuses.contains { $0.rawValue == "review" })
+        XCTAssertFalse(KanbanStatusPresentation.manuallySelectableStatuses.contains { $0.rawValue == "scheduled" })
+        XCTAssertFalse(KanbanStatusPresentation.taskCreatableStatuses.contains { $0.rawValue == "review" })
+        XCTAssertFalse(KanbanStatusPresentation.taskCreatableStatuses.contains { $0.rawValue == "scheduled" })
         XCTAssertFalse(KanbanStatusPresentation.taskCreatableStatuses.contains { $0.rawValue == "running" })
     }
 
-    func testStoreRejectsRunningCreationWithoutPosting() async throws {
-        let requester = MockKanbanRequester(responsesByPath: standardKanbanResponses())
-        let store = KanbanStore(defaults: UserDefaults(suiteName: UUID().uuidString)!)
-        store.configure(requester: requester, profile: "default", serverIdentity: "https://example.test")
-
-        do {
-            _ = try await store.createTask(KanbanCreateTaskRequest(title: "Never run directly"), initialStatus: "running")
-            XCTFail("Running must be rejected before create")
-        } catch let error as KanbanServiceError {
-            XCTAssertEqual(error, .invalidManualStatus("running"))
-        }
-
-        XCTAssertFalse(requester.calls.contains { $0.method == "POST" && $0.path.contains("/tasks") })
-        XCTAssertTrue(store.mutationErrorMessage?.contains("dispatcher/claim") == true)
+    func testUnlockedCreationTargetsMatchUpstreamAddableColumns() {
+        let creatable = Set(KanbanStatusPresentation.taskCreatableStatuses.map { $0.rawValue })
+        XCTAssertEqual(creatable, ["triage", "todo", "ready", "blocked", "done"])
+        XCTAssertTrue(KanbanStatusPresentation.canSelectManually("archived"))
+        XCTAssertFalse(KanbanStatusPresentation.canCreateTask(in: "archived"))
     }
 
-    func testTaskDecodingToleratesNumericIdentifiersAndMissingOptionalFields() throws {
-        let data = Data(#"{"id":42,"title":"Needs review","status":"review","priority":"2"}"#.utf8)
-        let task = try JSONDecoder().decode(KanbanTask.self, from: data)
-        XCTAssertEqual(task.id, "42")
-        XCTAssertEqual(task.title, "Needs review")
-        XCTAssertEqual(task.status, "review")
-        XCTAssertEqual(task.priority, 2)
-        XCTAssertNil(task.assignee)
+    func testUnknownStatusHasSafeLockedFallback() {
+        let presentation = KanbanStatusPresentation.forStatus("awaiting_customer")
+        XCTAssertEqual(presentation.displayName, "Awaiting Customer")
+        XCTAssertTrue(presentation.isBackendControlled)
+        XCTAssertFalse(KanbanStatusPresentation.canCreateTask(in: "awaiting_customer"))
+        XCTAssertFalse(KanbanStatusPresentation.canSelectManually("awaiting_customer"))
     }
 
-    func testBoardSelectionIsSentAsQueryAndNeverSwitchesServerBoard() async throws {
-        let requester = MockKanbanRequester(responses: [
-            ["columns": [], "tenants": [], "assignees": [], "latest_event_id": 1, "now": 2]
+    // MARK: - Transport contract
+
+    func testBoardSelectionIsQueryScopedAndNeverSwitchesServerBoard() async throws {
+        let requester = MockKanbanRequester(responsesByPath: [
+            "/api/plugins/kanban/board": ["columns": [], "tenants": [], "assignees": []]
         ])
         let service = KanbanService(requester: requester)
         _ = try await service.fetchBoard(slug: "mobile board", includeArchived: true)
-        XCTAssertEqual(requester.calls.count, 1)
         XCTAssertEqual(requester.calls[0].path, "/api/plugins/kanban/board?board=mobile%20board&include_archived=true")
         XCTAssertEqual(requester.calls[0].method, "GET")
     }
 
-    func testProfileAndBoardQueriesAreOwnedByKanbanService() async throws {
-        let requester = MockKanbanRequester(responses: [
-            ["columns": [], "tenants": [], "assignees": []]
-        ])
-        let service = KanbanService(requester: requester, profile: "work")
-        _ = try await service.fetchBoard(slug: "mobile", includeArchived: false)
-        XCTAssertEqual(requester.calls[0].path, "/api/plugins/kanban/board?board=mobile&profile=work")
-    }
-
-    func testCreateTaskUsesDashboardTaskContract() async throws {
-        let requester = MockKanbanRequester(responses: [
-            ["task": ["id": "task-1", "title": "Ship it", "status": "todo"]]
+    func testUnicodeBoardSlugSurvivesEncoding() async throws {
+        let slug = "b\u{00F6}ard \u{65E5}\u{672C}"
+        let requester = MockKanbanRequester(responsesByPath: [
+            "/api/plugins/kanban/board": ["columns": [], "tenants": [], "assignees": []]
         ])
         let service = KanbanService(requester: requester)
-        let response = try await service.createTask(
-            KanbanCreateTaskRequest(title: "Ship it", body: "Details", assignee: "worker", priority: 2),
-            board: "mobile"
-        )
-        XCTAssertEqual(response.task?.id, "task-1")
-        XCTAssertEqual(requester.calls[0].path, "/api/plugins/kanban/tasks?board=mobile")
-        XCTAssertEqual(requester.calls[0].method, "POST")
-        XCTAssertEqual(requester.calls[0].body?["title"] as? String, "Ship it")
-        XCTAssertEqual(requester.calls[0].body?["workspace_kind"] as? String, "scratch")
-        XCTAssertEqual(requester.calls[0].body?["priority"] as? Int, 2)
+        _ = try await service.fetchBoard(slug: slug, includeArchived: false)
+        let path = try XCTUnwrap(requester.calls.first?.path)
+        XCTAssertTrue(path.hasPrefix("/api/plugins/kanban/board?board="))
+        XCTAssertFalse(path.contains(" "), "spaces must be percent-encoded")
+        XCTAssertTrue(path.lowercased().contains("%c3%b6"), "non-ASCII must be UTF-8 percent-encoded")
     }
 
-    func testTwoStepCreationReportsPartialSuccessWithoutASecondCreate() async throws {
+    func testPluginRequestsNeverCarryFabricatedProfileScope() async throws {
         var responses = standardKanbanResponses()
-        responses["/api/plugins/kanban/tasks"] = ["task": ["id": "task-1", "title": "Scheduled", "status": "todo"]]
-        responses["/api/plugins/kanban/dispatch"] = [:]
-        let requester = MockKanbanRequester(
-            responsesByPath: responses,
-            errorsByPath: ["/api/plugins/kanban/tasks/task-1": MockRequestError.failed("parent dependency blocks Scheduled")]
-        )
-        let store = KanbanStore(defaults: UserDefaults(suiteName: UUID().uuidString)!)
-        store.configure(requester: requester, profile: "default", serverIdentity: "https://example.test")
+        responses["/api/plugins/kanban/tasks"] = ["task": ["id": "t1", "title": "x", "status": "todo"]]
+        let requester = MockKanbanRequester(responsesByPath: responses)
+        let store = makeStore(requester: requester)
+        await store.reload()
+
+        _ = try? await store.createTask(KanbanCreateTaskRequest(title: "No profile param"))
+
+        for call in requester.calls {
+            XCTAssertFalse(call.path.contains("profile="), call.path)
+        }
+    }
+
+    // MARK: - Creation transaction
+
+    func testLockedLaneCreationIsRejectedBeforeAnyPost() async throws {
+        var responses = standardKanbanResponses()
+        responses["/api/plugins/kanban/tasks"] = ["task": ["id": "SHOULD-NOT-EXIST", "title": "x", "status": "todo"]]
+        let requester = MockKanbanRequester(responsesByPath: responses)
+        let store = makeStore(requester: requester)
 
         do {
-            _ = try await store.createTask(KanbanCreateTaskRequest(title: "Scheduled"), initialStatus: "scheduled")
-            XCTFail("The follow-up transition should fail")
+            _ = try await store.createTask(KanbanCreateTaskRequest(title: "Never"), initialStatus: "scheduled")
+            XCTFail("scheduled creation must be rejected client-side")
         } catch let error as KanbanServiceError {
-            guard case .taskCreatedButMoveFailed(let taskID, let targetStatus, let reason) = error else {
-                return XCTFail("Expected an explicit partial-success error")
+            XCTAssertEqual(error, .invalidManualStatus("scheduled"))
+        }
+        do {
+            _ = try await store.createTask(KanbanCreateTaskRequest(title: "Never 2"), initialStatus: "review")
+            XCTFail("review creation must be rejected client-side")
+        } catch {}
+
+        XCTAssertEqual(requester.calls.filter { $0.method == "POST" && ($0.path.hasSuffix("/tasks") || $0.path.contains("/tasks?")) }.count, 0)
+        XCTAssertNotNil(store.mutationErrorMessage)
+    }
+
+    func testTwoStepCreationFailureSurfacesPartialSuccessWithoutDuplicatePost() async throws {
+        var responses = standardKanbanResponses()
+        responses["/api/plugins/kanban/tasks"] = ["task": ["id": "task-1", "title": "Blocked pick", "status": "todo"]]
+        let requester = MockKanbanRequester(
+            responsesByPath: responses,
+            errorsByPath: ["/api/plugins/kanban/tasks/task-1": MockRequestError.failed("parent dependency blocks Blocked")]
+        )
+        let store = makeStore(requester: requester)
+
+        do {
+            _ = try await store.createTask(KanbanCreateTaskRequest(title: "Blocked pick"), initialStatus: "blocked")
+            XCTFail("follow-up transition should fail")
+        } catch let error as KanbanServiceError {
+            guard case .taskCreatedButMoveFailed(let taskID, let target, let reason) = error else {
+                return XCTFail("expected partial-success error, got \(error)")
             }
             XCTAssertEqual(taskID, "task-1")
-            XCTAssertEqual(targetStatus, "scheduled")
+            XCTAssertEqual(target, "blocked")
             XCTAssertTrue(reason.contains("parent dependency"))
         }
 
-        XCTAssertEqual(requester.calls.filter { $0.method == "POST" && $0.path.contains("/tasks") }.count, 1)
+        XCTAssertEqual(requester.calls.filter { $0.method == "POST" && ($0.path.hasSuffix("/tasks") || $0.path.contains("/tasks?")) }.count, 1)
         XCTAssertTrue(store.mutationErrorMessage?.contains("not duplicated") == true)
     }
 
-    func testSuccessfulUpdateNudgesDispatcherAndNudgeFailureIsNonFatal() async throws {
+    // MARK: - Dispatcher nudge
+
+    func testMutationReturnsBeforeNudgeFiresAndNudgeUsesCapturedBoardContext() async throws {
         var responses = standardKanbanResponses()
-        responses["/api/plugins/kanban/tasks/task-1"] = ["task": ["id": "task-1", "title": "Done", "status": "done"]]
-        responses["/api/plugins/kanban/dispatch"] = [:]
+        responses["/api/plugins/kanban/tasks/t1"] = ["task": ["id": "t1", "title": "Done", "status": "done"]]
+        let requester = MockKanbanRequester(responsesByPath: responses)
+        let store = makeStore(requester: requester, nudgeDebounceNanoseconds: 40_000_000)
+        await store.selectBoard(slug: "alpha")
+
+        _ = try await store.updateTask(id: "t1", patch: KanbanTaskPatch(status: "done"))
+        // Fire-and-forget: the write resolved before the debounced dispatch.
+        XCTAssertFalse(requester.calls.contains { $0.path.contains("/dispatch") })
+
+        await flushNudge()
+        let dispatchCalls = requester.calls.filter { $0.path.contains("/dispatch") }
+        XCTAssertEqual(dispatchCalls.count, 1)
+        XCTAssertEqual(dispatchCalls.first?.method, "POST")
+        XCTAssertTrue(dispatchCalls.first?.path.contains("board=alpha") == true)
+    }
+
+    func testDispatchFailureIsNonFatalAndRapidWritesCoalesce() async throws {
+        var responses = standardKanbanResponses()
+        responses["/api/plugins/kanban/tasks/t1"] = ["task": ["id": "t1", "title": "A", "status": "done"]]
         let requester = MockKanbanRequester(
             responsesByPath: responses,
             errorsByPath: ["/api/plugins/kanban/dispatch": MockRequestError.failed("dispatcher unavailable")]
         )
-        let store = KanbanStore(defaults: UserDefaults(suiteName: UUID().uuidString)!)
-        store.configure(requester: requester, profile: "default", serverIdentity: "https://example.test")
+        let store = makeStore(requester: requester, nudgeDebounceNanoseconds: 30_000_000)
+        await store.selectBoard(slug: "alpha")
 
-        _ = try await store.updateTask(id: "task-1", patch: KanbanTaskPatch(status: "done"))
+        _ = try await store.updateTask(id: "t1", patch: KanbanTaskPatch(title: "A"))
+        _ = try await store.updateTask(id: "t1", patch: KanbanTaskPatch(title: "AA"))
+        await flushNudge()
 
-        XCTAssertTrue(requester.calls.contains { $0.path == "/api/plugins/kanban/dispatch" && $0.method == "POST" })
+        XCTAssertEqual(requester.calls.filter { $0.path.contains("/dispatch") }.count, 1)
         XCTAssertNil(store.mutationErrorMessage)
     }
 
-    func testMutationFailureIsSeparateFromBackgroundRefreshFailure() async throws {
-        var responses = standardKanbanResponses()
-        responses["/api/plugins/kanban/tasks/task-1"] = ["task": ["id": "task-1", "title": "Done", "status": "done"]]
+    // MARK: - Immutable mutation context across board switches
+
+    func testInFlightMutationKeepsCapturedBoardAcrossSwitch() async throws {
+        var responses = standardKanbanResponses(boardSlug: "alpha")
+        responses["/api/plugins/kanban/tasks/t1"] = ["task": ["id": "t1", "title": "Moved title", "status": "todo"]]
         let requester = MockKanbanRequester(responsesByPath: responses)
-        let store = KanbanStore(defaults: UserDefaults(suiteName: UUID().uuidString)!)
-        store.configure(requester: requester, profile: "default", serverIdentity: "https://example.test")
+        let store = makeStore(requester: requester, nudgeDebounceNanoseconds: 30_000_000)
+        await store.selectBoard(slug: "alpha")
+
+        requester.hold(pathPrefix: "/api/plugins/kanban/tasks/t1")
+        let mutation = Task { try? await store.updateTask(id: "t1", patch: KanbanTaskPatch(title: "Moved title")) }
+        // Let the mutation reach (and park at) the held PATCH.
+        await Task.yield(); await Task.yield(); await Task.yield()
+
+        await store.selectBoard(slug: "beta")
+        requester.releaseAll()
+        _ = await mutation.value
+        await flushNudge()
+
+        let patchCall = requester.calls.last(where: { $0.method == "PATCH" })
+        XCTAssertTrue(patchCall?.path.contains("board=alpha") == true)
+        let nudgeCall = requester.calls.last(where: { $0.path.contains("/dispatch") })
+        XCTAssertTrue(nudgeCall?.path.contains("board=alpha") == true)
+        XCTAssertNil(store.mutationErrorMessage)
+        XCTAssertEqual(store.selectedBoardSlug, "beta")
+    }
+
+    func testStaleStateAfterServerReconfigureIsDiscarded() async throws {
+        var responsesA = standardKanbanResponses(boardSlug: "a-board")
+        responsesA["/api/plugins/kanban/board"] = [
+            "columns": [["name": "todo", "tasks": [["id": "1", "title": "from A", "status": "todo"]]]],
+            "tenants": [], "assignees": []
+        ]
+        let requesterA = MockKanbanRequester(responsesByPath: responsesA)
+        let store = makeStore(requester: requesterA)
+        store.configure(requester: requesterA, serverIdentity: "https://a.test")
         await store.reload()
+        XCTAssertEqual(store.board?.columns.first?.tasks.first?.title, "from A")
+
+        var responsesB = standardKanbanResponses(boardSlug: "b-board")
+        responsesB["/api/plugins/kanban/board"] = [
+            "columns": [["name": "todo", "tasks": [["id": "2", "title": "from B", "status": "todo"]]]],
+            "tenants": [], "assignees": []
+        ]
+        store.configure(
+            requester: MockKanbanRequester(responsesByPath: responsesB),
+            serverIdentity: "https://b.test"
+        )
+        XCTAssertEqual(store.selectedBoardSlug, "", "selection from server A must not bleed into server B")
+        await store.reload()
+        XCTAssertEqual(store.board?.columns.first?.tasks.first?.title, "from B")
+    }
+
+    // MARK: - Persistence scoping
+
+    func testBoardSelectionPersistenceIsScopedToServerIdentity() {
+        let keyA = KanbanStore.scopedBoardKey(serverIdentity: "https://one.test")
+        let keyB = KanbanStore.scopedBoardKey(serverIdentity: "https://two.test")
+        XCTAssertNotEqual(keyA, keyB)
+        XCTAssertEqual(keyA, KanbanStore.scopedBoardKey(serverIdentity: "https://one.test/"))
+        XCTAssertTrue(keyA.hasPrefix(KanbanStore.selectedBoardKey + "."))
+    }
+
+    // MARK: - Mutation vs refresh error separation
+
+    func testMutationFailureStaysVisibleAndRefreshFailureKeepsBoard() async throws {
+        var responses = standardKanbanResponses()
+        responses["/api/plugins/kanban/tasks/t1"] = ["task": ["id": "t1", "title": "T", "status": "todo"]]
+        let requester = MockKanbanRequester(responsesByPath: responses)
+        let store = makeStore(requester: requester)
+        await store.refresh()
         XCTAssertNotNil(store.board)
 
         requester.errorsByPath["/api/plugins/kanban/boards"] = MockRequestError.failed("temporary refresh failure")
@@ -153,52 +248,77 @@ final class KanbanTests: XCTestCase {
         XCTAssertNotNil(store.errorMessage)
         XCTAssertNil(store.mutationErrorMessage)
 
-        requester.errorsByPath["/api/plugins/kanban/tasks/task-1"] = MockRequestError.failed("task was deleted")
+        requester.errorsByPath.removeValue(forKey: "/api/plugins/kanban/boards")
+        requester.errorsByPath["/api/plugins/kanban/tasks/t1"] = MockRequestError.failed("task was deleted")
         do {
-            _ = try await store.updateTask(id: "task-1", patch: KanbanTaskPatch(title: "Nope"))
-            XCTFail("The explicit mutation should fail")
+            _ = try await store.updateTask(id: "t1", patch: KanbanTaskPatch(title: "Nope"))
+            XCTFail("mutation should fail")
         } catch {
             XCTAssertTrue(store.mutationErrorMessage?.contains("task was deleted") == true)
         }
     }
 
-    func testProfileChangeReloadsWithSameBridgeAndScopesBoardSelection() async throws {
-        let defaults = UserDefaults(suiteName: UUID().uuidString)!
-        let requester = MockKanbanRequester(responsesByPath: standardKanbanResponses(boardSlug: "alpha-board"))
-        let store = KanbanStore(defaults: defaults)
+    // MARK: - Draft preservation policy
 
-        store.configure(requester: requester, profile: "alpha", serverIdentity: "https://example.test")
-        await store.selectBoard(slug: "alpha-board")
-        XCTAssertEqual(store.selectedBoardSlug, "alpha-board")
+    func testDetailPollingPreservesDirtyDraftAndFlagsRemoteChange() {
+        // load "Original" -> user edits -> server says "Server change"
+        let dirty = KanbanDetailDraftPolicy.isDirty(
+            draftTitle: "My draft", draftBody: "", draftStatus: "todo",
+            baselineTitle: "Original", baselineBodyText: "", baselineStatus: "todo"
+        )
+        XCTAssertTrue(dirty)
+        let moved = KanbanDetailDraftPolicy.serverMovedIndependently(
+            serverTitle: "Server change", serverBodyText: "", serverStatus: "todo",
+            baselineTitle: "Original", baselineBodyText: "", baselineStatus: "todo"
+        )
+        XCTAssertTrue(moved)
 
-        store.configure(requester: requester, profile: "beta", serverIdentity: "https://example.test")
-        XCTAssertEqual(store.selectedBoardSlug, "")
-        await store.reload()
-        XCTAssertTrue(requester.calls.contains { $0.path == "/api/plugins/kanban/boards?profile=beta" })
-
-        store.configure(requester: requester, profile: "alpha", serverIdentity: "https://example.test")
-        XCTAssertEqual(store.selectedBoardSlug, "alpha-board")
+        // Clean draft adopts the server snapshot without any notice.
+        XCTAssertFalse(KanbanDetailDraftPolicy.isDirty(
+            draftTitle: "Original", draftBody: "", draftStatus: "todo",
+            baselineTitle: "Original", baselineBodyText: "", baselineStatus: "todo"
+        ))
     }
 
-    func testPatchOnlyContainsExplicitMutationFields() async throws {
-        let requester = MockKanbanRequester(responses: [
-            ["task": ["id": "task-1", "title": "Ship it", "status": "done"]]
-        ])
-        let service = KanbanService(requester: requester)
-        _ = try await service.updateTask(id: "task-1", board: nil, patch: KanbanTaskPatch(status: "done"))
-        XCTAssertEqual(requester.calls[0].body?.keys.sorted(), ["status"])
-        XCTAssertEqual(requester.calls[0].body?["status"] as? String, "done")
+    // MARK: - Tolerant decoding must not crash on hostile numbers
+
+    func testLossyIntDecodingHandlesExtremeAndMalformedValues() throws {
+        let json = "{\"id\":\"t\",\"title\":\"x\",\"status\":\"todo\",\"priority\":1e999,\"created_at\":2.5,\"comment_count\":-3,\"started_at\":\"7\",\"worker_pid\":\"not-a-number\"}"
+        let task = try JSONDecoder().decode(KanbanTask.self, from: Data(json.utf8))
+        XCTAssertNil(task.priority, "unrepresentable huge double must decode as nil, not crash")
+        XCTAssertEqual(task.createdAt, 2)
+        XCTAssertEqual(task.commentCount, -3)
+        XCTAssertEqual(task.startedAt, 7)
+        XCTAssertNil(task.workerPid)
+    }
+
+    // MARK: - Helpers
+
+    private func makeStore(
+        requester: MockKanbanRequester,
+        nudgeDebounceNanoseconds: UInt64? = nil
+    ) -> KanbanStore {
+        let store = KanbanStore(
+            defaults: UserDefaults(suiteName: UUID().uuidString)!,
+            serviceFactory: nudgeDebounceNanoseconds.map { ns in
+                { request in KanbanService(requester: request, nudgeDebounceNanoseconds: ns) }
+            }
+        )
+        store.configure(requester: requester, serverIdentity: "https://example.test")
+        return store
+    }
+
+    private func flushNudge() async {
+        // The instrumented debounce is tens of milliseconds; wait past it and
+        // give the scheduled task a few ticks to finish its POST.
+        try? await Task.sleep(nanoseconds: 250_000_000)
+        await Task.yield()
     }
 }
 
 private enum MockRequestError: LocalizedError {
     case failed(String)
-
-    var errorDescription: String? {
-        switch self {
-        case .failed(let message): return message
-        }
-    }
+    var errorDescription: String? { switch self { case .failed(let m): return m } }
 }
 
 @MainActor
@@ -209,40 +329,51 @@ private final class MockKanbanRequester: DashboardJSONRequester {
         let body: [String: Any]?
     }
 
-    var responses: [[String: Any]]
     var responsesByPath: [String: [String: Any]]
     var errorsByPath: [String: Error]
+    private var holdsActive: Set<String> = []
+    private var heldContinuations: [CheckedContinuation<Void, Never>] = []
     var calls: [Call] = []
 
-    init(
-        responses: [[String: Any]] = [],
-        responsesByPath: [String: [String: Any]] = [:],
-        errorsByPath: [String: Error] = [:]
-    ) {
-        self.responses = responses
+    init(responsesByPath: [String: [String: Any]] = [:], errorsByPath: [String: Error] = [:]) {
         self.responsesByPath = responsesByPath
         self.errorsByPath = errorsByPath
+    }
+
+    /// Park every request whose path starts with the prefix until releaseAll().
+    func hold(pathPrefix: String) { holdsActive.insert(pathPrefix) }
+
+    func releaseAll() {
+        holdsActive.removeAll()
+        for continuation in heldContinuations { continuation.resume() }
+        heldContinuations.removeAll()
     }
 
     func requestJSON(path: String, method: String, body: [String: Any]?, timeoutMilliseconds: Int, maxResponseBytes: Int) async throws -> [String: Any] {
         calls.append(Call(path: path, method: method, body: body))
         let basePath = path.components(separatedBy: "?").first ?? path
+        if !holdsActive.isEmpty, holdsActive.contains(where: { path.hasPrefix($0) || basePath.hasPrefix($0) }) {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                heldContinuations.append(continuation)
+            }
+        }
         if let error = errorsByPath[path] ?? errorsByPath[basePath] { throw error }
         if let response = responsesByPath[path] ?? responsesByPath[basePath] { return response }
-        guard !responses.isEmpty else { return [:] }
-        return responses.removeFirst()
+        return [:]
     }
 }
 
 private func standardKanbanResponses(boardSlug: String = "default") -> [String: [String: Any]] {
     [
         "/api/plugins/kanban/boards": [
-            "boards": [["slug": boardSlug, "name": boardSlug, "is_current": true]],
+            "boards": [
+                ["slug": boardSlug, "name": boardSlug, "is_current": true],
+                ["slug": "beta", "name": "Beta", "is_current": false],
+                ["slug": "alpha", "name": "Alpha", "is_current": false]
+            ],
             "current": boardSlug
         ],
-        "/api/plugins/kanban/board": [
-            "columns": [], "tenants": [], "assignees": [], "latest_event_id": 1, "now": 2
-        ],
+        "/api/plugins/kanban/board": ["columns": [], "tenants": [], "assignees": [], "latest_event_id": 1, "now": 2],
         "/api/plugins/kanban/profiles": ["profiles": []],
         "/api/plugins/kanban/projects": ["projects": []],
         "/api/plugins/kanban/orchestration": [

--- a/ConduitTests/KanbanTests.swift
+++ b/ConduitTests/KanbanTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class KanbanTests: XCTestCase {
+    func testSidebarMigrationMapsRemovedCapabilitiesToSessions() {
+        XCTAssertEqual(SidebarTab.migrated(rawValue: "Capabilities"), .sessions)
+        XCTAssertEqual(SidebarTab.migrated(rawValue: "not-a-tab"), .sessions)
+        XCTAssertEqual(SidebarTab.migrated(rawValue: "Kanban"), .kanban)
+    }
+
+    func testUnknownStatusHasSafeFallbackPresentation() {
+        let presentation = KanbanStatusPresentation.forStatus("awaiting_customer")
+        XCTAssertEqual(presentation.rawValue, "awaiting_customer")
+        XCTAssertEqual(presentation.displayName, "Awaiting Customer")
+        XCTAssertEqual(presentation.systemImage, "circle.dashed")
+        XCTAssertEqual(presentation.sortOrder, 100)
+    }
+
+    func testTaskDecodingToleratesNumericIdentifiersAndMissingOptionalFields() throws {
+        let data = Data(#"{"id":42,"title":"Needs review","status":"review","priority":"2"}"#.utf8)
+        let task = try JSONDecoder().decode(KanbanTask.self, from: data)
+        XCTAssertEqual(task.id, "42")
+        XCTAssertEqual(task.title, "Needs review")
+        XCTAssertEqual(task.status, "review")
+        XCTAssertEqual(task.priority, 2)
+        XCTAssertNil(task.assignee)
+    }
+
+    func testBoardSelectionIsSentAsQueryAndNeverSwitchesServerBoard() async throws {
+        let requester = MockKanbanRequester(responses: [
+            ["columns": [], "tenants": [], "assignees": [], "latest_event_id": 1, "now": 2]
+        ])
+        let service = KanbanService(requester: requester)
+        _ = try await service.fetchBoard(slug: "mobile board", includeArchived: true)
+        XCTAssertEqual(requester.calls.count, 1)
+        XCTAssertEqual(requester.calls[0].path, "/api/plugins/kanban/board?board=mobile%20board&include_archived=true")
+        XCTAssertEqual(requester.calls[0].method, "GET")
+    }
+
+    func testCreateTaskUsesDashboardTaskContract() async throws {
+        let requester = MockKanbanRequester(responses: [
+            ["task": ["id": "task-1", "title": "Ship it", "status": "todo"]]
+        ])
+        let service = KanbanService(requester: requester)
+        let response = try await service.createTask(
+            KanbanCreateTaskRequest(title: "Ship it", body: "Details", assignee: "worker", priority: 2),
+            board: "mobile"
+        )
+        XCTAssertEqual(response.task?.id, "task-1")
+        XCTAssertEqual(requester.calls[0].path, "/api/plugins/kanban/tasks?board=mobile")
+        XCTAssertEqual(requester.calls[0].method, "POST")
+        XCTAssertEqual(requester.calls[0].body?["title"] as? String, "Ship it")
+        XCTAssertEqual(requester.calls[0].body?["workspace_kind"] as? String, "scratch")
+        XCTAssertEqual(requester.calls[0].body?["priority"] as? Int, 2)
+    }
+
+    func testPatchOnlyContainsExplicitMutationFields() async throws {
+        let requester = MockKanbanRequester(responses: [
+            ["task": ["id": "task-1", "title": "Ship it", "status": "done"]]
+        ])
+        let service = KanbanService(requester: requester)
+        _ = try await service.updateTask(id: "task-1", board: nil, patch: KanbanTaskPatch(status: "done"))
+        XCTAssertEqual(requester.calls[0].body?.keys.sorted(), ["status"])
+        XCTAssertEqual(requester.calls[0].body?["status"] as? String, "done")
+    }
+}
+
+@MainActor
+private final class MockKanbanRequester: DashboardJSONRequester {
+    struct Call {
+        let path: String
+        let method: String
+        let body: [String: Any]?
+    }
+
+    var responses: [[String: Any]]
+    var calls: [Call] = []
+
+    init(responses: [[String: Any]]) {
+        self.responses = responses
+    }
+
+    func requestJSON(path: String, method: String, body: [String: Any]?, timeoutMilliseconds: Int, maxResponseBytes: Int) async throws -> [String: Any] {
+        calls.append(Call(path: path, method: method, body: body))
+        guard !responses.isEmpty else { return [:] }
+        return responses.removeFirst()
+    }
+}

--- a/ConduitTests/KanbanTests.swift
+++ b/ConduitTests/KanbanTests.swift
@@ -369,6 +369,67 @@ final class KanbanTests: XCTestCase {
         }
     }
 
+    // MARK: - Mutation reconciliation vs passive poll ordering
+
+    func testMutationReconciliationSupersedesInFlightPassivePoll() async throws {
+        var responses = standardKanbanResponses(boardSlug: "alpha")
+        responses["/api/plugins/kanban/board?board=alpha"] = [
+            "columns": [["name": "todo", "tasks": [["id": "t-old", "title": "stale card", "status": "todo"]]]],
+            "tenants": [], "assignees": []
+        ]
+        let requester = MockKanbanRequester(responsesByPath: responses)
+        let store = makeStore(requester: requester, nudgeDebounceNanoseconds: 30_000_000)
+        await store.refresh()
+        XCTAssertEqual(store.board?.columns.first?.tasks.first?.id, "t-old")
+        let boardFetchesBefore = requester.calls.filter { $0.path.contains("/board?") }.count
+
+        // Park an ordinary 8-second-style passive poll at its first request.
+        requester.hold(pathPrefix: "/api/plugins/kanban/boards")
+        let poll = Task { await store.poll() }
+        // Deterministic wait: the poll must actually be parked before proceeding.
+        for _ in 0..<5000 where requester.heldCount == 0 { await Task.yield() }
+        XCTAssertGreaterThan(requester.heldCount, 0, "passive poll should be parked")
+
+        // Delete succeeds while the poll is still parked. The mutation's own
+        // reconciliation must supersede the parked poll instead of being
+        // dropped behind isLoading.
+        let mutation = Task { try? await store.deleteTask(id: "t-old") }
+        // Wait until the mutation's superseding reconciliation is parked
+        // behind the poll (two held requests), so releaseNext is never early.
+        for _ in 0..<5000 where requester.heldCount < 2 { await Task.yield() }
+        XCTAssertGreaterThanOrEqual(requester.heldCount, 2, "reconciliation should be queued behind the poll")
+
+        // Fresh authoritative state after the delete: the board no longer has
+        // the deleted task. (Mutate the MOCK - the local dict was copied at init.)
+        requester.responsesByPath["/api/plugins/kanban/board?board=alpha"] = [
+            "columns": [], "tenants": [], "assignees": [], "latest_event_id": 2, "now": 3
+        ]
+        // Wake the parked POLL and lift the hold (same-prefix drains too, so
+        // the superseding reconciliation passes through freely afterwards).
+        requester.releaseNext()
+        // The unheld prefix lets the reconciliation's /boards pass freely;
+        // wait until its board fetch lands before asserting.
+        for _ in 0..<5000
+        where requester.calls.filter({ $0.path.contains("/board?") }).count <= boardFetchesBefore {
+            await Task.yield()
+        }
+        _ = await mutation.value
+        await flushNudge()
+
+        // The reconciliation actually issued a NEW board fetch (it was not
+        // dropped because isLoading was true).
+        let boardFetchesAfter = requester.calls.filter { $0.path.contains("/board?") }.count
+        XCTAssertGreaterThan(boardFetchesAfter, boardFetchesBefore, "post-mutation reconciliation must not be skipped")
+        XCTAssertNil(store.mutationErrorMessage)
+        XCTAssertNil(store.board?.columns.first?.tasks.first, "deleted card must be gone from the reconciled snapshot")
+
+        // The released old poll finishes as a stale generation and cannot
+        // resurrect the pre-mutation snapshot.
+        await poll.value
+        XCTAssertNil(store.board?.columns.first?.tasks.first, "old poll must not overwrite post-mutation state")
+        XCTAssertEqual(store.loadedBoardSlug, "alpha")
+    }
+
     // MARK: - Cross-server stale mutation isolation
 
     func testReconfiguredServerIsolatesStaleMutationFailure() async throws {
@@ -596,6 +657,47 @@ final class KanbanTests: XCTestCase {
         XCTAssertTrue(CapabilityLoadPolicy.shouldPresentRows(snapshotProfile: "B", activeProfile: "B"))
     }
 
+    // MARK: - Capabilities rendering boundary policy
+
+    func testForeignSnapshotCanNeverResolveToARowState() {
+        // A rows under active B, spinner not yet running (SwiftUI render race).
+        XCTAssertEqual(
+            CapabilityLoadPolicy.resolvePresentation(snapshotProfile: "A", activeProfile: "B", isLoading: false, loadError: nil, hasRows: true),
+            .loading
+        )
+        // Even a settled foreign error stays masked.
+        XCTAssertEqual(
+            CapabilityLoadPolicy.resolvePresentation(snapshotProfile: "A", activeProfile: "B", isLoading: false, loadError: "A failure", hasRows: true),
+            .loading
+        )
+    }
+
+    func testCurrentSnapshotEmptySuccessShowsExplicitEmptyState() {
+        XCTAssertEqual(
+            CapabilityLoadPolicy.resolvePresentation(snapshotProfile: "B", activeProfile: "B", isLoading: false, loadError: nil, hasRows: false),
+            .emptySuccess
+        )
+    }
+
+    func testCurrentSnapshotEmptyFailureShowsFullFailureState() {
+        XCTAssertEqual(
+            CapabilityLoadPolicy.resolvePresentation(snapshotProfile: "B", activeProfile: "B", isLoading: false, loadError: "boom", hasRows: false),
+            .failure("boom")
+        )
+    }
+
+    func testPopulatedSameProfileRefreshFailureKeepsRowsWithBanner() {
+        XCTAssertEqual(
+            CapabilityLoadPolicy.resolvePresentation(snapshotProfile: "B", activeProfile: "B", isLoading: false, loadError: "refresh boom", hasRows: true),
+            .list(banner: "refresh boom")
+        )
+        // Clean populated load renders the plain list.
+        XCTAssertEqual(
+            CapabilityLoadPolicy.resolvePresentation(snapshotProfile: "B", activeProfile: "B", isLoading: false, loadError: nil, hasRows: true),
+            .list(banner: nil)
+        )
+    }
+
     // MARK: - Helpers
 
     private func makeStore(
@@ -636,7 +738,13 @@ private final class MockKanbanRequester: DashboardJSONRequester {
     var responsesByPath: [String: [String: Any]]
     var errorsByPath: [String: Error]
     private var holdsActive: Set<String> = []
-    private var heldContinuations: [CheckedContinuation<Void, Never>] = []
+    private struct HeldRequest {
+        let prefix: String
+        let continuation: CheckedContinuation<Void, Never>
+    }
+    private var heldRequests: [HeldRequest] = []
+    /// Number of requests currently parked by an active hold.
+    var heldCount: Int { heldRequests.count }
     var calls: [Call] = []
 
     init(responsesByPath: [String: [String: Any]] = [:], errorsByPath: [String: Error] = [:]) {
@@ -647,10 +755,27 @@ private final class MockKanbanRequester: DashboardJSONRequester {
     /// Park every request whose path starts with the prefix until releaseAll().
     func hold(pathPrefix: String) { holdsActive.insert(pathPrefix) }
 
+    /// Wake exactly the oldest parked request and stop holding its prefix, so
+    /// later matching requests (e.g. a superseding reconciliation) pass freely
+    /// while the released one finishes as a stale generation.
+    /// Wake exactly the oldest parked request and stop holding its prefix.
+    /// Any OTHER requests already parked under the same prefix are woken too:
+    /// they proceed as stale generations (their completions discard), while
+    /// later matching requests pass through freely.
+    func releaseNext() {
+        guard let first = heldRequests.first else { return }
+        heldRequests.removeFirst()
+        holdsActive.remove(first.prefix)
+        first.continuation.resume()
+        let samePrefix = heldRequests.filter { $0.prefix == first.prefix }
+        heldRequests.removeAll { $0.prefix == first.prefix }
+        for held in samePrefix { held.continuation.resume() }
+    }
+
     func releaseAll() {
         holdsActive.removeAll()
-        for continuation in heldContinuations { continuation.resume() }
-        heldContinuations.removeAll()
+        for held in heldRequests { held.continuation.resume() }
+        heldRequests.removeAll()
     }
 
     func requestJSON(path: String, method: String, body: [String: Any]?, timeoutMilliseconds: Int, maxResponseBytes: Int) async throws -> [String: Any] {
@@ -658,12 +783,16 @@ private final class MockKanbanRequester: DashboardJSONRequester {
         let basePath = path.components(separatedBy: "?").first ?? path
         if !holdsActive.isEmpty, holdsActive.contains(where: { path.hasPrefix($0) || basePath.hasPrefix($0) }) {
             await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-                heldContinuations.append(continuation)
+                heldRequests.append(HeldRequest(prefix: Self.matchingHoldPrefix(path: path, basePath: basePath, prefixes: holdsActive), continuation: continuation))
             }
         }
         if let error = errorsByPath[path] ?? errorsByPath[basePath] { throw error }
         if let response = responsesByPath[path] ?? responsesByPath[basePath] { return response }
         return [:]
+    }
+
+    private static func matchingHoldPrefix(path: String, basePath: String, prefixes: Set<String>) -> String {
+        prefixes.first { path.hasPrefix($0) || basePath.hasPrefix($0) } ?? ""
     }
 }
 

--- a/ConduitTests/KanbanTests.swift
+++ b/ConduitTests/KanbanTests.swift
@@ -328,23 +328,45 @@ final class KanbanTests: XCTestCase {
         XCTAssertEqual(store.loadedBoardSlug, "alpha", "displayed snapshot must stay bound to A until B loads")
         XCTAssertEqual(store.board?.columns.first?.tasks.first?.id, "t-a")
 
-        // A card from snapshot A mutates board ALPHA, never the pending B.
-        let mutation = Task { try? await store.updateTask(id: "t-a", patch: KanbanTaskPatch(title: "edited on alpha")) }
-        await Task.yield(); await Task.yield(); await Task.yield()
-        let patchCall = requester.calls.last(where: { $0.method == "PATCH" })
-        XCTAssertTrue(patchCall?.path.contains("/tasks/t-a?") == true || patchCall?.path.contains("/tasks/t-a") == true)
-        XCTAssertTrue(patchCall?.path.contains("board=alpha") == true, patchCall?.path ?? "no PATCH")
+        // While B is pending, the stale A snapshot must NOT be actionable:
+        // the store rejects the mutation outright (no PATCH can target A or
+        // B), matching the view's disabled cards and New Task button.
+        let blocked = try? await store.updateTask(id: "t-a", patch: KanbanTaskPatch(title: "edited on alpha"))
+        XCTAssertNil(blocked)
+        XCTAssertEqual(store.mutationErrorMessage, KanbanServiceError.boardNavigationInProgress.localizedDescription)
+        XCTAssertFalse(requester.calls.contains { $0.method == "PATCH" }, "no write may leave during navigation")
+
+        do {
+            _ = try await store.createTask(KanbanCreateTaskRequest(title: "No A create"), initialStatus: "todo")
+            XCTFail("creation must be rejected while navigating")
+        } catch let error as KanbanServiceError {
+            XCTAssertEqual(error, .boardNavigationInProgress)
+        }
+        XCTAssertFalse(requester.calls.contains { $0.method == "POST" && $0.path.contains("/tasks") })
+
+        // The transient navigation hint is dismissed (user-tappable banner);
+        // later phases assert fresh error state only.
+        store.clearMutationError()
 
         requester.releaseAll()
         await poll.value
         await selection.value
-        _ = await mutation.value
         await flushNudge()
 
         XCTAssertEqual(store.selectedBoardSlug, "beta")
         XCTAssertEqual(store.loadedBoardSlug, "beta")
         XCTAssertEqual(store.board?.columns.first?.tasks.first?.title, "from beta", "stale A completion must be discarded")
         XCTAssertNil(store.mutationErrorMessage)
+
+        // Actions become available again once B is the loaded snapshot.
+        XCTAssertTrue(store.isSelectedSnapshotLoaded)
+        requester.errorsByPath["/api/plugins/kanban/tasks/t-b"] = MockRequestError.failed("beta write failed")
+        do {
+            _ = try await store.updateTask(id: "t-b", patch: KanbanTaskPatch(title: "x"))
+            XCTFail("expected current-generation failure to surface")
+        } catch {
+            XCTAssertTrue(store.mutationErrorMessage?.contains("beta write failed") == true)
+        }
     }
 
     // MARK: - Cross-server stale mutation isolation
@@ -453,6 +475,125 @@ final class KanbanTests: XCTestCase {
             "Connect to a Hermes dashboard to load capabilities."
         )
         XCTAssertNil(CapabilitiesView.localError(for: .superseded(requestedProfile: "a", activeProfile: "b"), hasData: true))
+    }
+
+    // MARK: - Concrete slug resolution
+
+    func testInvalidPersistedSelectionResolvesToConcreteCurrentBoard() async throws {
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        var responses = standardKanbanResponses(boardSlug: "beta")
+        // The persisted selection points at a board that no longer exists.
+        responses["/api/plugins/kanban/boards"] = [
+            "boards": [["slug": "beta", "name": "Beta", "is_current": true]],
+            "current": "beta"
+        ]
+        responses["/api/plugins/kanban/board?board=removed-board"] = [:]
+        responses["/api/plugins/kanban/board?board=beta"] = [
+            "columns": [["name": "todo", "tasks": [["id": "b1", "title": "from beta", "status": "todo"]]]],
+            "tenants": [], "assignees": []
+        ]
+        let requester = MockKanbanRequester(responsesByPath: responses)
+        defaults.set("removed-board", forKey: KanbanStore.scopedBoardKey(serverIdentity: "https://example.test"))
+        let store = KanbanStore(defaults: defaults)
+        store.configure(requester: requester, serverIdentity: "https://example.test")
+        await store.reload()
+
+        let boardCall = try XCTUnwrap(requester.calls.last(where: { $0.path.contains("/board?") }))
+        XCTAssertTrue(boardCall.path.contains("board=beta"), boardCall.path)
+        XCTAssertFalse(boardCall.path.contains("removed-board"))
+        XCTAssertEqual(store.selectedBoardSlug, "")
+        XCTAssertEqual(store.loadedBoardSlug, "beta", "loaded identity must equal the fetched slug")
+        XCTAssertEqual(store.board?.columns.first?.tasks.first?.title, "from beta")
+    }
+
+    func testServerCurrentLoadPinsConcreteResolvedSlug() async throws {
+        var responses = standardKanbanResponses(boardSlug: "alpha")
+        responses.removeValue(forKey: "/api/plugins/kanban/board")
+        responses["/api/plugins/kanban/board?board=alpha"] = [
+            "columns": [["name": "todo", "tasks": [["id": "a1", "title": "pinned alpha", "status": "todo"]]]],
+            "tenants": [], "assignees": []
+        ]
+        let requester = MockKanbanRequester(responsesByPath: responses)
+        let store = makeStore(requester: requester)
+        await store.refresh()
+
+        let boardCall = try XCTUnwrap(requester.calls.last(where: { $0.path.contains("/api/plugins/kanban/board") && !$0.path.contains("/boards") }))
+        XCTAssertTrue(boardCall.path.hasSuffix("/board?board=alpha"), "server-current must be pinned before GET /board: \(boardCall.path)")
+        XCTAssertEqual(store.loadedBoardSlug, "alpha")
+    }
+
+    func testDotSegmentIdentifiersFailBeforeTransport() async throws {
+        let requester = MockKanbanRequester(responsesByPath: standardKanbanResponses())
+        let service = KanbanService(requester: requester)
+
+        for bad in [".", ".."] {
+            do {
+                _ = try await service.updateTask(id: bad, board: nil, patch: KanbanTaskPatch(title: "x"))
+                XCTFail("dot segment must be rejected: \(bad)")
+            } catch let error as KanbanServiceError {
+                XCTAssertEqual(error, .invalidQueryParameter(bad))
+            }
+        }
+        XCTAssertTrue(requester.calls.isEmpty, "rejection happens before transport")
+
+        _ = try await service.updateTask(id: "t_99", board: nil, patch: KanbanTaskPatch(title: "ok"))
+        XCTAssertEqual(requester.calls.last?.path, "/api/plugins/kanban/tasks/t_99")
+    }
+
+    func testStaleDeleteFailureIsInvisibleAfterReconfigure() async throws {
+        let requesterA = MockKanbanRequester(responsesByPath: standardKanbanResponses(boardSlug: "a-board"))
+        let store = makeStore(requester: requesterA)
+        await store.refresh()
+
+        requesterA.hold(pathPrefix: "/api/plugins/kanban/tasks/t1")
+        let mutation = Task { try? await store.deleteTask(id: "t1") }
+        await Task.yield(); await Task.yield(); await Task.yield()
+
+        let requesterB = MockKanbanRequester(responsesByPath: standardKanbanResponses(boardSlug: "b-board"))
+        store.configure(requester: requesterB, serverIdentity: "https://b.test")
+        await store.reload()
+        XCTAssertFalse(store.isMutating)
+        let bCallsBefore = requesterB.calls.count
+
+        requesterA.errorsByPath["/api/plugins/kanban/tasks/t1"] = MockRequestError.failed("A delete failed")
+        requesterA.releaseAll()
+        _ = await mutation.value
+
+        XCTAssertNil(store.mutationErrorMessage, "stale View/store channel must stay silent on B")
+        XCTAssertFalse(store.isMutating)
+        XCTAssertEqual(requesterB.calls.count, bCallsBefore)
+
+        // Current-generation delete failures remain visible.
+        requesterB.errorsByPath["/api/plugins/kanban/tasks/t9"] = MockRequestError.failed("B delete failed")
+        do {
+            try await store.deleteTask(id: "t9")
+            XCTFail("expected current-generation failure")
+        } catch {
+            XCTAssertTrue(store.mutationErrorMessage?.contains("B delete failed") == true)
+        }
+    }
+
+    // MARK: - Capability ownership policy (rapid profile switching)
+
+    func testCapabilityCommitPolicyRejectsABAAndForeignProfiles() {
+        // A -> B -> A: old A1 finishes after A2 started; latestGeneration moved on.
+        XCTAssertFalse(CapabilityLoadPolicy.canCommit(
+            generation: 1, latestGeneration: 3, requestedProfile: "A", activeProfile: "A"
+        ))
+        // Newer request for the same still-active profile commits.
+        XCTAssertTrue(CapabilityLoadPolicy.canCommit(
+            generation: 3, latestGeneration: 3, requestedProfile: "A", activeProfile: "A"
+        ))
+        // Profile changed mid-flight.
+        XCTAssertFalse(CapabilityLoadPolicy.canCommit(
+            generation: 2, latestGeneration: 2, requestedProfile: "A", activeProfile: "B"
+        ))
+    }
+
+    func testCapabilityRowsNeverRenderForForeignSnapshotProfile() {
+        XCTAssertFalse(CapabilityLoadPolicy.shouldPresentRows(snapshotProfile: "A", activeProfile: "B"))
+        XCTAssertFalse(CapabilityLoadPolicy.shouldPresentRows(snapshotProfile: nil, activeProfile: "B"))
+        XCTAssertTrue(CapabilityLoadPolicy.shouldPresentRows(snapshotProfile: "B", activeProfile: "B"))
     }
 
     // MARK: - Helpers

--- a/ConduitTests/KanbanTests.swift
+++ b/ConduitTests/KanbanTests.swift
@@ -148,7 +148,7 @@ final class KanbanTests: XCTestCase {
         // Fire-and-forget: the write resolved before the debounced dispatch.
         XCTAssertFalse(requester.calls.contains { $0.path.contains("/dispatch") })
 
-        await flushNudge()
+        await store.awaitPendingDispatcherNudgeForTesting()
         let dispatchCalls = requester.calls.filter { $0.path.contains("/dispatch") }
         XCTAssertEqual(dispatchCalls.count, 1)
         XCTAssertEqual(dispatchCalls.first?.method, "POST")
@@ -167,7 +167,7 @@ final class KanbanTests: XCTestCase {
 
         _ = try await store.updateTask(id: "t1", patch: KanbanTaskPatch(title: "A"))
         _ = try await store.updateTask(id: "t1", patch: KanbanTaskPatch(title: "AA"))
-        await flushNudge()
+        await store.awaitPendingDispatcherNudgeForTesting()
 
         XCTAssertEqual(requester.calls.filter { $0.path.contains("/dispatch") }.count, 1)
         XCTAssertNil(store.mutationErrorMessage)
@@ -190,7 +190,7 @@ final class KanbanTests: XCTestCase {
         await store.selectBoard(slug: "beta")
         requester.releaseAll()
         _ = await mutation.value
-        await flushNudge()
+        await store.awaitPendingDispatcherNudgeForTesting()
 
         let patchCall = requester.calls.last(where: { $0.method == "PATCH" })
         XCTAssertTrue(patchCall?.path.contains("board=alpha") == true)
@@ -287,7 +287,7 @@ final class KanbanTests: XCTestCase {
     // MARK: - Tolerant decoding must not crash on hostile numbers
 
     func testLossyIntDecodingHandlesExtremeAndMalformedValues() throws {
-        let json = "{\"id\":\"t\",\"title\":\"x\",\"status\":\"todo\",\"priority\":1e999,\"created_at\":2.5,\"completed_at\":3.0,\"comment_count\":-3,\"started_at\":\"7\",\"worker_pid\":\"not-a-number\"}"
+        let json = "{\"id\":\"t\",\"title\":\"x\",\"status\":\"todo\",\"priority\":1e300,\"created_at\":2.5,\"completed_at\":3.0,\"comment_count\":-3,\"started_at\":\"7\",\"worker_pid\":\"not-a-number\"}"
         let task = try JSONDecoder().decode(KanbanTask.self, from: Data(json.utf8))
         XCTAssertNil(task.priority, "unrepresentable huge double must decode as nil, not crash")
         XCTAssertNil(task.createdAt, "fractional doubles must not truncate to an integer")
@@ -351,7 +351,7 @@ final class KanbanTests: XCTestCase {
         requester.releaseAll()
         await poll.value
         await selection.value
-        await flushNudge()
+        await store.awaitPendingDispatcherNudgeForTesting()
 
         XCTAssertEqual(store.selectedBoardSlug, "beta")
         XCTAssertEqual(store.loadedBoardSlug, "beta")
@@ -414,7 +414,7 @@ final class KanbanTests: XCTestCase {
             await Task.yield()
         }
         _ = await mutation.value
-        await flushNudge()
+        await store.awaitPendingDispatcherNudgeForTesting()
 
         // The reconciliation actually issued a NEW board fetch (it was not
         // dropped because isLoading was true).
@@ -491,7 +491,7 @@ final class KanbanTests: XCTestCase {
 
         requesterA.releaseAll()
         _ = await mutation.value
-        await flushNudge()
+        await store.awaitPendingDispatcherNudgeForTesting()
 
         XCTAssertNil(store.mutationErrorMessage)
         XCTAssertFalse(store.isMutating)
@@ -660,15 +660,37 @@ final class KanbanTests: XCTestCase {
     // MARK: - Capabilities rendering boundary policy
 
     func testForeignSnapshotCanNeverResolveToARowState() {
-        // A rows under active B, spinner not yet running (SwiftUI render race).
+        // A rows under active B while B's request is still in flight (SwiftUI
+        // render race): the transition state must stay loading, never rows.
+        XCTAssertEqual(
+            CapabilityLoadPolicy.resolvePresentation(snapshotProfile: "A", activeProfile: "B", isLoading: true, loadError: nil, hasRows: true),
+            .loading
+        )
+        // Foreign snapshot with nothing settled for B yet: still loading.
         XCTAssertEqual(
             CapabilityLoadPolicy.resolvePresentation(snapshotProfile: "A", activeProfile: "B", isLoading: false, loadError: nil, hasRows: true),
             .loading
         )
-        // Even a settled foreign error stays masked.
+    }
+
+    func testFailedFirstLoadWithoutSnapshotShowsFailure() {
+        // First load fails before any snapshot exists (e.g. offline).
         XCTAssertEqual(
-            CapabilityLoadPolicy.resolvePresentation(snapshotProfile: "A", activeProfile: "B", isLoading: false, loadError: "A failure", hasRows: true),
-            .loading
+            CapabilityLoadPolicy.resolvePresentation(snapshotProfile: nil, activeProfile: "B", isLoading: false, loadError: "offline", hasRows: false),
+            .failure("offline")
+        )
+    }
+
+    func testNoDashboardUnavailableFirstLoadShowsConnectionFailure() {
+        XCTAssertEqual(
+            CapabilityLoadPolicy.resolvePresentation(
+                snapshotProfile: nil,
+                activeProfile: "B",
+                isLoading: false,
+                loadError: "Connect to a Hermes dashboard to load capabilities.",
+                hasRows: false
+            ),
+            .failure("Connect to a Hermes dashboard to load capabilities.")
         )
     }
 
@@ -713,14 +735,9 @@ final class KanbanTests: XCTestCase {
         store.configure(requester: requester, serverIdentity: "https://example.test")
         return store
     }
-
-    private func flushNudge() async {
-        // The instrumented debounce is tens of milliseconds; wait past it and
-        // give the scheduled task a few ticks to finish its POST.
-        try? await Task.sleep(nanoseconds: 250_000_000)
-        await Task.yield()
-    }
 }
+
+
 
 private enum MockRequestError: LocalizedError {
     case failed(String)

--- a/ConduitTests/KanbanTests.swift
+++ b/ConduitTests/KanbanTests.swift
@@ -90,6 +90,9 @@ final class KanbanTests: XCTestCase {
         responses["/api/plugins/kanban/tasks"] = ["task": ["id": "SHOULD-NOT-EXIST", "title": "x", "status": "todo"]]
         let requester = MockKanbanRequester(responsesByPath: responses)
         let store = makeStore(requester: requester)
+        // Establish a loaded board snapshot before any mutation.
+        await store.refresh()
+        XCTAssertEqual(store.loadedBoardSlug, "default")
 
         do {
             _ = try await store.createTask(KanbanCreateTaskRequest(title: "Never"), initialStatus: "scheduled")
@@ -114,6 +117,7 @@ final class KanbanTests: XCTestCase {
             errorsByPath: ["/api/plugins/kanban/tasks/task-1": MockRequestError.failed("parent dependency blocks Blocked")]
         )
         let store = makeStore(requester: requester)
+        await store.refresh()
 
         do {
             _ = try await store.createTask(KanbanCreateTaskRequest(title: "Blocked pick"), initialStatus: "blocked")
@@ -283,13 +287,172 @@ final class KanbanTests: XCTestCase {
     // MARK: - Tolerant decoding must not crash on hostile numbers
 
     func testLossyIntDecodingHandlesExtremeAndMalformedValues() throws {
-        let json = "{\"id\":\"t\",\"title\":\"x\",\"status\":\"todo\",\"priority\":1e999,\"created_at\":2.5,\"comment_count\":-3,\"started_at\":\"7\",\"worker_pid\":\"not-a-number\"}"
+        let json = "{\"id\":\"t\",\"title\":\"x\",\"status\":\"todo\",\"priority\":1e999,\"created_at\":2.5,\"completed_at\":3.0,\"comment_count\":-3,\"started_at\":\"7\",\"worker_pid\":\"not-a-number\"}"
         let task = try JSONDecoder().decode(KanbanTask.self, from: Data(json.utf8))
         XCTAssertNil(task.priority, "unrepresentable huge double must decode as nil, not crash")
-        XCTAssertEqual(task.createdAt, 2)
+        XCTAssertNil(task.createdAt, "fractional doubles must not truncate to an integer")
+        XCTAssertEqual(task.completedAt, 3, "integral doubles decode exactly")
         XCTAssertEqual(task.commentCount, -3)
         XCTAssertEqual(task.startedAt, 7)
         XCTAssertNil(task.workerPid)
+    }
+
+    // MARK: - Board selection supersedes background polls
+
+    func testBoardSelectionSupersedesInFlightPollAndBindsMutationToLoadedSnapshot() async throws {
+        var responses = standardKanbanResponses(boardSlug: "alpha")
+        responses["/api/plugins/kanban/board?board=alpha"] = [
+            "columns": [["name": "todo", "tasks": [["id": "t-a", "title": "from alpha", "status": "todo"]]]],
+            "tenants": [], "assignees": []
+        ]
+        responses["/api/plugins/kanban/board?board=beta"] = [
+            "columns": [["name": "todo", "tasks": [["id": "t-b", "title": "from beta", "status": "todo"]]]],
+            "tenants": [], "assignees": []
+        ]
+        responses["/api/plugins/kanban/tasks/t-a"] = ["task": ["id": "t-a", "title": "edited on alpha", "status": "todo"]]
+        let requester = MockKanbanRequester(responsesByPath: responses)
+        let store = makeStore(requester: requester)
+        await store.selectBoard(slug: "alpha")
+        XCTAssertEqual(store.loadedBoardSlug, "alpha")
+        XCTAssertEqual(store.board?.columns.first?.tasks.first?.title, "from alpha")
+
+        // Park an ordinary background refresh of board A.
+        requester.hold(pathPrefix: "/api/plugins/kanban/boards")
+        let poll = Task { await store.poll() }
+        await Task.yield(); await Task.yield(); await Task.yield()
+
+        // The user selects B while the A poll is still parked.
+        let selection = Task { await store.selectBoard(slug: "beta") }
+        await Task.yield(); await Task.yield(); await Task.yield()
+        XCTAssertEqual(store.selectedBoardSlug, "beta")
+        XCTAssertEqual(store.loadedBoardSlug, "alpha", "displayed snapshot must stay bound to A until B loads")
+        XCTAssertEqual(store.board?.columns.first?.tasks.first?.id, "t-a")
+
+        // A card from snapshot A mutates board ALPHA, never the pending B.
+        let mutation = Task { try? await store.updateTask(id: "t-a", patch: KanbanTaskPatch(title: "edited on alpha")) }
+        await Task.yield(); await Task.yield(); await Task.yield()
+        let patchCall = requester.calls.last(where: { $0.method == "PATCH" })
+        XCTAssertTrue(patchCall?.path.contains("/tasks/t-a?") == true || patchCall?.path.contains("/tasks/t-a") == true)
+        XCTAssertTrue(patchCall?.path.contains("board=alpha") == true, patchCall?.path ?? "no PATCH")
+
+        requester.releaseAll()
+        await poll.value
+        await selection.value
+        _ = await mutation.value
+        await flushNudge()
+
+        XCTAssertEqual(store.selectedBoardSlug, "beta")
+        XCTAssertEqual(store.loadedBoardSlug, "beta")
+        XCTAssertEqual(store.board?.columns.first?.tasks.first?.title, "from beta", "stale A completion must be discarded")
+        XCTAssertNil(store.mutationErrorMessage)
+    }
+
+    // MARK: - Cross-server stale mutation isolation
+
+    func testReconfiguredServerIsolatesStaleMutationFailure() async throws {
+        var responsesA = standardKanbanResponses(boardSlug: "a-board")
+        let requesterA = MockKanbanRequester(responsesByPath: responsesA)
+        let store = makeStore(requester: requesterA)
+        await store.refresh()
+
+        requesterA.hold(pathPrefix: "/api/plugins/kanban/tasks/t1")
+        let mutation = Task { try? await store.updateTask(id: "t1", patch: KanbanTaskPatch(title: "held")) }
+        await Task.yield(); await Task.yield(); await Task.yield()
+
+        var responsesB = standardKanbanResponses(boardSlug: "b-board")
+        responsesB["/api/plugins/kanban/board"] = [
+            "columns": [["name": "todo", "tasks": [["id": "2", "title": "from B", "status": "todo"]]]],
+            "tenants": [], "assignees": []
+        ]
+        let requesterB = MockKanbanRequester(responsesByPath: responsesB)
+        store.configure(requester: requesterB, serverIdentity: "https://b.test")
+        await store.reload()
+        XCTAssertEqual(store.board?.columns.first?.tasks.first?.title, "from B")
+
+        // configure() revokes the old operation's UI ownership immediately.
+        XCTAssertFalse(store.isMutating)
+        XCTAssertNil(store.mutationErrorMessage)
+        let bCallsBeforeRelease = requesterB.calls.count
+
+        requesterA.errorsByPath["/api/plugins/kanban/tasks/t1"] = MockRequestError.failed("server A exploded")
+        requesterA.releaseAll()
+        _ = await mutation.value
+
+        XCTAssertFalse(store.isMutating)
+        XCTAssertNil(store.mutationErrorMessage, "server A's failure must not surface on server B")
+        XCTAssertEqual(requesterB.calls.count, bCallsBeforeRelease, "stale completion must not trigger a B refresh")
+        XCTAssertEqual(store.board?.columns.first?.tasks.first?.title, "from B")
+    }
+
+    func testReconfiguredServerIsolatesStaleMutationSuccess() async throws {
+        var responsesA = standardKanbanResponses(boardSlug: "a-board")
+        responsesA["/api/plugins/kanban/tasks/t1"] = ["task": ["id": "t1", "title": "saved on A", "status": "todo"]]
+        let requesterA = MockKanbanRequester(responsesByPath: responsesA)
+        let store = makeStore(requester: requesterA)
+        await store.refresh()
+
+        requesterA.hold(pathPrefix: "/api/plugins/kanban/tasks/t1")
+        let mutation = Task { try? await store.updateTask(id: "t1", patch: KanbanTaskPatch(title: "saved on A")) }
+        await Task.yield(); await Task.yield(); await Task.yield()
+
+        var responsesB = standardKanbanResponses(boardSlug: "b-board")
+        responsesB["/api/plugins/kanban/board"] = [
+            "columns": [["name": "todo", "tasks": [["id": "2", "title": "from B", "status": "todo"]]]],
+            "tenants": [], "assignees": []
+        ]
+        let requesterB = MockKanbanRequester(responsesByPath: responsesB)
+        store.configure(requester: requesterB, serverIdentity: "https://b.test")
+        await store.reload()
+        XCTAssertEqual(store.board?.columns.first?.tasks.first?.title, "from B")
+        let bCallsBeforeRelease = requesterB.calls.count
+
+        requesterA.releaseAll()
+        _ = await mutation.value
+        await flushNudge()
+
+        XCTAssertNil(store.mutationErrorMessage)
+        XCTAssertFalse(store.isMutating)
+        XCTAssertEqual(requesterB.calls.count, bCallsBeforeRelease, "old success must not refresh the new server")
+        XCTAssertEqual(store.board?.columns.first?.tasks.first?.title, "from B")
+    }
+
+    // MARK: - Malformed rows
+
+    func testIdLessTaskRowsAreDroppedFromBoardColumns() throws {
+        let json = "{\"name\":\"todo\",\"tasks\":[" +
+            "{\"id\":\"valid-1\",\"title\":\"one\",\"status\":\"todo\"}," +
+            "{\"title\":\"missing a\",\"status\":\"todo\"}," +
+            "{\"status\":\"todo\"}," +
+            "{\"id\":\"valid-2\",\"title\":\"two\",\"status\":\"todo\"}]}"
+        let column = try JSONDecoder().decode(KanbanColumn.self, from: Data(json.utf8))
+        XCTAssertEqual(column.tasks.map(\.id), ["valid-1", "valid-2"])
+        XCTAssertEqual(Set(column.tasks.map(\.id)).count, column.tasks.count, "no duplicate SwiftUI identities possible")
+    }
+
+    // MARK: - Capabilities request-scoped outcome contract
+
+    func testCapabilityOutcomeMappingIsRequestScoped() {
+        typealias Outcome = AppState.CapabilityLoadOutcome
+
+        // Successful load with data clears any local failure.
+        XCTAssertNil(CapabilitiesView.localError(for: .success(profile: "p"), hasData: true))
+        // Successful EMPTY result is distinct from failure and independent of
+        // any stale global error message.
+        XCTAssertEqual(
+            CapabilitiesView.localError(for: .success(profile: "p"), hasData: false),
+            "No capabilities found."
+        )
+        // Failure surfaces verbatim whether or not cached data exists; the
+        // same failure repeated is surfaced again identically.
+        for _ in 0..<2 {
+            XCTAssertEqual(CapabilitiesView.localError(for: .failed(profile: "p", message: "boom"), hasData: true), "boom")
+            XCTAssertEqual(CapabilitiesView.localError(for: .failed(profile: "p", message: "boom"), hasData: false), "boom")
+        }
+        XCTAssertEqual(
+            CapabilitiesView.localError(for: .unavailable(profile: "p"), hasData: false),
+            "Connect to a Hermes dashboard to load capabilities."
+        )
+        XCTAssertNil(CapabilitiesView.localError(for: .superseded(requestedProfile: "a", activeProfile: "b"), hasData: true))
     }
 
     // MARK: - Helpers

--- a/ConduitTests/KanbanTests.swift
+++ b/ConduitTests/KanbanTests.swift
@@ -15,6 +15,36 @@ final class KanbanTests: XCTestCase {
         XCTAssertEqual(presentation.displayName, "Awaiting Customer")
         XCTAssertEqual(presentation.systemImage, "circle.dashed")
         XCTAssertEqual(presentation.sortOrder, 100)
+        XCTAssertFalse(presentation.isManuallySelectable)
+        XCTAssertFalse(presentation.isTaskCreatable)
+    }
+
+    func testRunningIsVisibleButNotManuallySelectableOrCreatable() {
+        let running = KanbanStatusPresentation.forStatus("running")
+        XCTAssertTrue(running.isVisibleOnBoard)
+        XCTAssertTrue(running.isBackendControlled)
+        XCTAssertFalse(running.isManuallySelectable)
+        XCTAssertFalse(running.isTaskCreatable)
+        XCTAssertFalse(KanbanStatusPresentation.canSelectManually("running"))
+        XCTAssertFalse(KanbanStatusPresentation.canCreateTask(in: "running"))
+        XCTAssertFalse(KanbanStatusPresentation.manuallySelectableStatuses.contains { $0.rawValue == "running" })
+        XCTAssertFalse(KanbanStatusPresentation.taskCreatableStatuses.contains { $0.rawValue == "running" })
+    }
+
+    func testStoreRejectsRunningCreationWithoutPosting() async throws {
+        let requester = MockKanbanRequester(responsesByPath: standardKanbanResponses())
+        let store = KanbanStore(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+        store.configure(requester: requester, profile: "default", serverIdentity: "https://example.test")
+
+        do {
+            _ = try await store.createTask(KanbanCreateTaskRequest(title: "Never run directly"), initialStatus: "running")
+            XCTFail("Running must be rejected before create")
+        } catch let error as KanbanServiceError {
+            XCTAssertEqual(error, .invalidManualStatus("running"))
+        }
+
+        XCTAssertFalse(requester.calls.contains { $0.method == "POST" && $0.path.contains("/tasks") })
+        XCTAssertTrue(store.mutationErrorMessage?.contains("dispatcher/claim") == true)
     }
 
     func testTaskDecodingToleratesNumericIdentifiersAndMissingOptionalFields() throws {
@@ -38,6 +68,15 @@ final class KanbanTests: XCTestCase {
         XCTAssertEqual(requester.calls[0].method, "GET")
     }
 
+    func testProfileAndBoardQueriesAreOwnedByKanbanService() async throws {
+        let requester = MockKanbanRequester(responses: [
+            ["columns": [], "tenants": [], "assignees": []]
+        ])
+        let service = KanbanService(requester: requester, profile: "work")
+        _ = try await service.fetchBoard(slug: "mobile", includeArchived: false)
+        XCTAssertEqual(requester.calls[0].path, "/api/plugins/kanban/board?board=mobile&profile=work")
+    }
+
     func testCreateTaskUsesDashboardTaskContract() async throws {
         let requester = MockKanbanRequester(responses: [
             ["task": ["id": "task-1", "title": "Ship it", "status": "todo"]]
@@ -55,6 +94,92 @@ final class KanbanTests: XCTestCase {
         XCTAssertEqual(requester.calls[0].body?["priority"] as? Int, 2)
     }
 
+    func testTwoStepCreationReportsPartialSuccessWithoutASecondCreate() async throws {
+        var responses = standardKanbanResponses()
+        responses["/api/plugins/kanban/tasks"] = ["task": ["id": "task-1", "title": "Scheduled", "status": "todo"]]
+        responses["/api/plugins/kanban/dispatch"] = [:]
+        let requester = MockKanbanRequester(
+            responsesByPath: responses,
+            errorsByPath: ["/api/plugins/kanban/tasks/task-1": MockRequestError.failed("parent dependency blocks Scheduled")]
+        )
+        let store = KanbanStore(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+        store.configure(requester: requester, profile: "default", serverIdentity: "https://example.test")
+
+        do {
+            _ = try await store.createTask(KanbanCreateTaskRequest(title: "Scheduled"), initialStatus: "scheduled")
+            XCTFail("The follow-up transition should fail")
+        } catch let error as KanbanServiceError {
+            guard case .taskCreatedButMoveFailed(let taskID, let targetStatus, let reason) = error else {
+                return XCTFail("Expected an explicit partial-success error")
+            }
+            XCTAssertEqual(taskID, "task-1")
+            XCTAssertEqual(targetStatus, "scheduled")
+            XCTAssertTrue(reason.contains("parent dependency"))
+        }
+
+        XCTAssertEqual(requester.calls.filter { $0.method == "POST" && $0.path.contains("/tasks") }.count, 1)
+        XCTAssertTrue(store.mutationErrorMessage?.contains("not duplicated") == true)
+    }
+
+    func testSuccessfulUpdateNudgesDispatcherAndNudgeFailureIsNonFatal() async throws {
+        var responses = standardKanbanResponses()
+        responses["/api/plugins/kanban/tasks/task-1"] = ["task": ["id": "task-1", "title": "Done", "status": "done"]]
+        responses["/api/plugins/kanban/dispatch"] = [:]
+        let requester = MockKanbanRequester(
+            responsesByPath: responses,
+            errorsByPath: ["/api/plugins/kanban/dispatch": MockRequestError.failed("dispatcher unavailable")]
+        )
+        let store = KanbanStore(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+        store.configure(requester: requester, profile: "default", serverIdentity: "https://example.test")
+
+        _ = try await store.updateTask(id: "task-1", patch: KanbanTaskPatch(status: "done"))
+
+        XCTAssertTrue(requester.calls.contains { $0.path == "/api/plugins/kanban/dispatch" && $0.method == "POST" })
+        XCTAssertNil(store.mutationErrorMessage)
+    }
+
+    func testMutationFailureIsSeparateFromBackgroundRefreshFailure() async throws {
+        var responses = standardKanbanResponses()
+        responses["/api/plugins/kanban/tasks/task-1"] = ["task": ["id": "task-1", "title": "Done", "status": "done"]]
+        let requester = MockKanbanRequester(responsesByPath: responses)
+        let store = KanbanStore(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+        store.configure(requester: requester, profile: "default", serverIdentity: "https://example.test")
+        await store.reload()
+        XCTAssertNotNil(store.board)
+
+        requester.errorsByPath["/api/plugins/kanban/boards"] = MockRequestError.failed("temporary refresh failure")
+        await store.refresh()
+        XCTAssertNotNil(store.board)
+        XCTAssertNotNil(store.errorMessage)
+        XCTAssertNil(store.mutationErrorMessage)
+
+        requester.errorsByPath["/api/plugins/kanban/tasks/task-1"] = MockRequestError.failed("task was deleted")
+        do {
+            _ = try await store.updateTask(id: "task-1", patch: KanbanTaskPatch(title: "Nope"))
+            XCTFail("The explicit mutation should fail")
+        } catch {
+            XCTAssertTrue(store.mutationErrorMessage?.contains("task was deleted") == true)
+        }
+    }
+
+    func testProfileChangeReloadsWithSameBridgeAndScopesBoardSelection() async throws {
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let requester = MockKanbanRequester(responsesByPath: standardKanbanResponses(boardSlug: "alpha-board"))
+        let store = KanbanStore(defaults: defaults)
+
+        store.configure(requester: requester, profile: "alpha", serverIdentity: "https://example.test")
+        await store.selectBoard(slug: "alpha-board")
+        XCTAssertEqual(store.selectedBoardSlug, "alpha-board")
+
+        store.configure(requester: requester, profile: "beta", serverIdentity: "https://example.test")
+        XCTAssertEqual(store.selectedBoardSlug, "")
+        await store.reload()
+        XCTAssertTrue(requester.calls.contains { $0.path == "/api/plugins/kanban/boards?profile=beta" })
+
+        store.configure(requester: requester, profile: "alpha", serverIdentity: "https://example.test")
+        XCTAssertEqual(store.selectedBoardSlug, "alpha-board")
+    }
+
     func testPatchOnlyContainsExplicitMutationFields() async throws {
         let requester = MockKanbanRequester(responses: [
             ["task": ["id": "task-1", "title": "Ship it", "status": "done"]]
@@ -63,6 +188,16 @@ final class KanbanTests: XCTestCase {
         _ = try await service.updateTask(id: "task-1", board: nil, patch: KanbanTaskPatch(status: "done"))
         XCTAssertEqual(requester.calls[0].body?.keys.sorted(), ["status"])
         XCTAssertEqual(requester.calls[0].body?["status"] as? String, "done")
+    }
+}
+
+private enum MockRequestError: LocalizedError {
+    case failed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .failed(let message): return message
+        }
     }
 }
 
@@ -75,15 +210,49 @@ private final class MockKanbanRequester: DashboardJSONRequester {
     }
 
     var responses: [[String: Any]]
+    var responsesByPath: [String: [String: Any]]
+    var errorsByPath: [String: Error]
     var calls: [Call] = []
 
-    init(responses: [[String: Any]]) {
+    init(
+        responses: [[String: Any]] = [],
+        responsesByPath: [String: [String: Any]] = [:],
+        errorsByPath: [String: Error] = [:]
+    ) {
         self.responses = responses
+        self.responsesByPath = responsesByPath
+        self.errorsByPath = errorsByPath
     }
 
     func requestJSON(path: String, method: String, body: [String: Any]?, timeoutMilliseconds: Int, maxResponseBytes: Int) async throws -> [String: Any] {
         calls.append(Call(path: path, method: method, body: body))
+        let basePath = path.components(separatedBy: "?").first ?? path
+        if let error = errorsByPath[path] ?? errorsByPath[basePath] { throw error }
+        if let response = responsesByPath[path] ?? responsesByPath[basePath] { return response }
         guard !responses.isEmpty else { return [:] }
         return responses.removeFirst()
     }
+}
+
+private func standardKanbanResponses(boardSlug: String = "default") -> [String: [String: Any]] {
+    [
+        "/api/plugins/kanban/boards": [
+            "boards": [["slug": boardSlug, "name": boardSlug, "is_current": true]],
+            "current": boardSlug
+        ],
+        "/api/plugins/kanban/board": [
+            "columns": [], "tenants": [], "assignees": [], "latest_event_id": 1, "now": 2
+        ],
+        "/api/plugins/kanban/profiles": ["profiles": []],
+        "/api/plugins/kanban/projects": ["projects": []],
+        "/api/plugins/kanban/orchestration": [
+            "orchestrator_profile": "",
+            "default_assignee": "",
+            "auto_decompose": true,
+            "auto_promote_children": true,
+            "resolved_orchestrator_profile": "default",
+            "resolved_default_assignee": "default"
+        ],
+        "/api/plugins/kanban/dispatch": [:]
+    ]
 }


### PR DESCRIPTION
## Summary

Native Kanban for Conduit: lane-chip + vertical-card-list board, task lifecycle (create/edit/move/delete/comments/reassign/reclaim), board picker with client-local selection, and Settings-hosted Capabilities. HTTP stays on the existing DashboardTicketBridge; HermesClient and all session/chat transport are untouched.

## Correctness safeguards

- **Concrete board identity pinned before fetch**: after GET /boards (and invalid-selection validation), one resolved slug drives both GET /board?board=<slug> and the recorded snapshot identity, so "server current" can never drift between the two requests.
- **Non-interactive stale snapshot during navigation**: while selected != loaded, old cards are read-only cached content (store rejects mutations with an explicit error; view disables cards and New Task) with a loading indicator.
- **Stale-server mutation isolation**: mutations capture an immutable context plus a generation-owned UI token; completions that lose ownership after a dashboard switch never refresh, flip flags, or surface errors - from either the store or view handlers.
- **Capabilities request/profile ownership**: loads return a request-scoped CapabilityLoadOutcome; monotonic generations reject A->B->A commits, a snapshot-profile gate masks foreign rows, and a view token keeps older completions from clearing newer loading state.
- **Locked lanes**: review/running/scheduled match upstream LOCKED_COLUMNS - visible, backend-controlled, never offered as create/move destinations.
- **Dispatcher nudges**: 400 ms debounced, fire-and-forget after successful writes; failures are non-events.
- **Detail polling preserves drafts**: comments/runs/metadata update live; unsaved title/body/status edits win, with a remote-change notice.
- **Fail-closed transport**: dot-segment ids and unencodable board/id values reject before transport; board scope is always an explicit query parameter.
- **Tolerant decoding**: exact integers only (2.5 -> nil); id-less task rows dropped so duplicate SwiftUI identities cannot occur.

## Shared cross-profile Kanban

Hermes Kanban is intentionally shared across profiles: kanban_db anchors boards at the shared Hermes root (profile homes resolve back via get_default_hermes_root()), making it the cross-profile coordination primitive. Conduit therefore sends no profile parameter, does not reload on UI profile switches, and scopes persisted board selection by server/root identity only.

## Validation

Full ios_test run at this head: **1010 test cases passed, 0 failed** across 58 discovered suites / 8 serialized batches (0 hangs, stalls, or uncovered suites). Includes focused regressions for every safeguard above.

## Deferred

- Live /events WebSocket support (polling only in this PR).

