### PR TITLE
feat(kanban): V2 — desktop-parity task creation, actions, and operator detail

### DIFF
--- a/Conduit/Models/KanbanModels.swift
+++ b/Conduit/Models/KanbanModels.swift
@@ -127,8 +127,12 @@ struct KanbanDiagnostic: Codable, Equatable {
         } else if var walker = try? container.nestedUnkeyedContainer(forKey: .actions) {
             // Some element was hostile: walk manually, keeping every row we
             // can normalize and consuming the rest so iteration continues.
+            // The counter guarantees termination even against payloads where
+            // both decode attempts fail without advancing the cursor.
             var decoded: [KanbanDiagnosticAction] = []
-            while !walker.isAtEnd {
+            var safetyCounter = 0
+            while !walker.isAtEnd && safetyCounter < 10_000 {
+                safetyCounter += 1
                 if let action = try? walker.decode(KanbanDiagnosticAction.self) {
                     decoded.append(action)
                 } else {
@@ -139,6 +143,8 @@ struct KanbanDiagnostic: Codable, Equatable {
         } else {
             actions = []
         }
+        // Absent/lost count renders as 1 (never "×N"), matching how the
+        // drawer treats single occurrences; 0 would hide real repeats.
         count = container.decodeLossyInt(forKey: .count) ?? 1
         lastSeenAt = container.decodeLossyInt(forKey: .lastSeenAt)
         data = try? container.decodeIfPresent([String: AnyCodable].self, forKey: .data)

--- a/Conduit/Models/KanbanModels.swift
+++ b/Conduit/Models/KanbanModels.swift
@@ -53,6 +53,27 @@ struct KanbanDiagnosticAction: Codable, Equatable {
     var label: String
     var payload: [String: AnyCodable]?
     var suggested: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case kind, label, payload, suggested
+    }
+
+    init(kind: String, label: String, payload: [String: AnyCodable]? = nil, suggested: Bool? = nil) {
+        self.kind = kind
+        self.label = label
+        self.payload = payload
+        self.suggested = suggested
+    }
+
+    /// Tolerant decode: recovery actions are operator-critical, so degrade
+    /// individual field types instead of dropping the action.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        kind = container.decodeLossyString(forKey: .kind) ?? ""
+        label = container.decodeLossyString(forKey: .label) ?? ""
+        payload = try? container.decodeIfPresent([String: AnyCodable].self, forKey: .payload)
+        suggested = try? container.decodeIfPresent(Bool.self, forKey: .suggested)
+    }
 }
 
 struct KanbanDiagnostic: Codable, Equatable {
@@ -68,6 +89,59 @@ struct KanbanDiagnostic: Codable, Equatable {
     enum CodingKeys: String, CodingKey {
         case kind, severity, title, detail, actions, count, data
         case lastSeenAt = "last_seen_at"
+    }
+
+    init(
+        kind: String,
+        severity: String,
+        title: String,
+        detail: String,
+        actions: [KanbanDiagnosticAction],
+        count: Int,
+        lastSeenAt: Int? = nil,
+        data: [String: AnyCodable]? = nil
+    ) {
+        self.kind = kind
+        self.severity = severity
+        self.title = title
+        self.detail = detail
+        self.actions = actions
+        self.count = count
+        self.lastSeenAt = lastSeenAt
+        self.data = data
+    }
+
+    /// Tolerant decode (V2 §14): a partially-hostile diagnostic row still
+    /// renders — identity text degrades to "", numeric fields fail safely to
+    /// zero/nil, and a non-array actions payload becomes an empty list.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        kind = container.decodeLossyString(forKey: .kind) ?? ""
+        severity = container.decodeLossyString(forKey: .severity) ?? ""
+        title = container.decodeLossyString(forKey: .title) ?? ""
+        detail = container.decodeLossyString(forKey: .detail) ?? ""
+        let typedActions = try? container.decodeIfPresent([KanbanDiagnosticAction].self, forKey: .actions)
+        if let typedActions {
+            // Whole-array typed decode succeeded.
+            actions = typedActions
+        } else if var walker = try? container.nestedUnkeyedContainer(forKey: .actions) {
+            // Some element was hostile: walk manually, keeping every row we
+            // can normalize and consuming the rest so iteration continues.
+            var decoded: [KanbanDiagnosticAction] = []
+            while !walker.isAtEnd {
+                if let action = try? walker.decode(KanbanDiagnosticAction.self) {
+                    decoded.append(action)
+                } else {
+                    _ = try? walker.decode(AnyCodable.self)
+                }
+            }
+            actions = decoded
+        } else {
+            actions = []
+        }
+        count = container.decodeLossyInt(forKey: .count) ?? 1
+        lastSeenAt = container.decodeLossyInt(forKey: .lastSeenAt)
+        data = try? container.decodeIfPresent([String: AnyCodable].self, forKey: .data)
     }
 }
 
@@ -367,6 +441,15 @@ struct KanbanEvent: Codable, Identifiable, Equatable {
     var payload: AnyCodable?
     var createdAt: Int?
     var runID: String?
+
+    init(id: String, taskID: String? = nil, kind: String, payload: AnyCodable? = nil, createdAt: Int? = nil, runID: String? = nil) {
+        self.id = id
+        self.taskID = taskID
+        self.kind = kind
+        self.payload = payload
+        self.createdAt = createdAt
+        self.runID = runID
+    }
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -775,3 +858,52 @@ struct KanbanMutationResponse: Codable, Equatable {
 
 struct KanbanProfilesResponse: Codable, Equatable { var profiles: [KanbanProfile] }
 struct KanbanProjectsResponse: Codable, Equatable { var projects: [KanbanProject] }
+
+// MARK: - Model options (per-task worker override catalog)
+
+/// GET /api/plugins/kanban/model-options — the backend-curated provider/model
+/// roster for per-task overrides (plugins/kanban/dashboard/plugin_api.py
+/// `model_options`). Curated server-side so the picker can never offer a
+/// provider:model pair a Hermes worker would refuse. Decoded tolerantly:
+/// an unavailable inventory degrades to an empty list and the UI falls back
+/// to free-text entry.
+struct KanbanModelOptionsResponse: Codable, Equatable {
+    var providers: [KanbanModelProviderOption]
+
+    init(providers: [KanbanModelProviderOption] = []) { self.providers = providers }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        providers = (try? container.decodeIfPresent([KanbanModelProviderOption].self, forKey: .providers)) ?? []
+    }
+
+    enum CodingKeys: String, CodingKey { case providers }
+}
+
+struct KanbanModelProviderOption: Codable, Equatable, Identifiable {
+    var slug: String
+    var label: String?
+    var models: [String]
+
+    var id: String { slug }
+    var displayName: String {
+        let resolved = label ?? slug
+        return resolved.isEmpty ? slug : resolved
+    }
+
+    init(slug: String, label: String? = nil, models: [String] = []) {
+        self.slug = slug
+        self.label = label
+        self.models = models
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        slug = container.decodeLossyString(forKey: .slug) ?? ""
+        label = try? container.decodeIfPresent(String.self, forKey: .label)
+        let rawModels = (try? container.decodeIfPresent([String].self, forKey: .models)) ?? []
+        models = rawModels.filter { !$0.isEmpty }
+    }
+
+    enum CodingKeys: String, CodingKey { case slug, label, models }
+}

--- a/Conduit/Services/KanbanService.swift
+++ b/Conduit/Services/KanbanService.swift
@@ -123,6 +123,15 @@ final class KanbanService {
         try await decode(KanbanOrchestrationSettings.self, path: scoped(Self.namespace + "/orchestration"))
     }
 
+    /// Backend-curated provider/model roster for per-task overrides
+    /// (`GET /model-options`). Board-independent, so no board query is sent.
+    /// Unusable rows (empty slug or no models — e.g. a degraded inventory
+    /// payload) are dropped here so every caller sees an offerable catalog.
+    func fetchModelOptions() async throws -> [KanbanModelProviderOption] {
+        let response = try await decode(KanbanModelOptionsResponse.self, path: scoped(Self.namespace + "/model-options"))
+        return response.providers.filter { !$0.slug.isEmpty && !$0.models.isEmpty }
+    }
+
     func createTask(_ requestBody: KanbanCreateTaskRequest, board: String?) async throws -> KanbanCreateTaskResponse {
         let response = try await request(
             path: try withBoard(Self.namespace + "/tasks", slug: board),

--- a/Conduit/Services/KanbanStore.swift
+++ b/Conduit/Services/KanbanStore.swift
@@ -354,6 +354,42 @@ final class KanbanStore: ObservableObject {
     }
 
     func deleteTask(id: String, includeArchived: Bool = false) async throws {
+        // !isMutating is the fast-path UX rejection only; performMutation
+        // additionally enforces the structural activeMutationGeneration and
+        // snapshot invariants inside the same actor turn.
+        guard !isMutating else {
+            throw recordMutationError(KanbanServiceError.mutationInProgress)
+        }
+        guard let context = makeOperationContext() else {
+            throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
+        }
+        try await performMutation(context: context, includeArchived: includeArchived) {
+            try await context.service.deleteTask(id: id, board: context.boardSlug)
+            // Deleting can unblock dependants, so it nudges too (upstream).
+            context.service.scheduleDispatcherNudge(board: context.boardSlug)
+        }
+    }
+
+    /// Context-bound permanent deletion for STAGED destructive confirmations
+    /// (card Delete…). TOCTOU-closed: the staged ownership stamp is validated
+    /// against the currently loaded context AND the mutation operation
+    /// context is captured back-to-back — both on the MainActor, before the
+    /// first suspension point — so validation and capture are atomic. A
+    /// confirmation staged for server/board A can therefore never execute a
+    /// DELETE under context B, even when the store reconfigures or switches
+    /// boards between the confirmation tap and the spawned Task's execution.
+    /// The view-level KanbanCardDeletePolicy check remains only as early UX
+    /// rejection; THIS is the hard safety boundary and fails closed.
+    func deleteTask(id: String, expectedContext: KanbanBoardContextStamp, includeArchived: Bool = false) async throws {
+        guard isSelectedSnapshotLoaded, loadedContextStamp == expectedContext else {
+            // Fail closed: the staged confirmation no longer owns the loaded
+            // board/server context. Discard it without any destructive
+            // request — a colliding task id on the new board is never a match.
+            throw recordMutationError(KanbanServiceError.boardNavigationInProgress)
+        }
+        // !isMutating is the fast-path UX rejection only; performMutation
+        // additionally enforces the structural activeMutationGeneration and
+        // snapshot invariants inside the same actor turn.
         guard !isMutating else {
             throw recordMutationError(KanbanServiceError.mutationInProgress)
         }

--- a/Conduit/Services/KanbanStore.swift
+++ b/Conduit/Services/KanbanStore.swift
@@ -241,6 +241,14 @@ final class KanbanStore: ObservableObject {
         return try await service.fetchTaskLog(id: id, board: loadedBoardSlug ?? effectiveBoardSlug, tailBytes: tailBytes)
     }
 
+    /// Provider/model roster for the per-task override picker. Read-only
+    /// auxiliary data: failures are surfaced to the caller (the picker falls
+    /// back to free-text entry) but never touch board state.
+    func fetchModelOptions() async throws -> [KanbanModelProviderOption] {
+        guard let service else { throw KanbanServiceError.invalidResponse("Kanban is not connected.") }
+        return try await service.fetchModelOptions()
+    }
+
     @discardableResult
     func createTask(
         _ request: KanbanCreateTaskRequest,

--- a/Conduit/Services/KanbanStore.swift
+++ b/Conduit/Services/KanbanStore.swift
@@ -10,6 +10,17 @@ struct KanbanOperationContext {
     let configurationGeneration: Int
 }
 
+/// Immutable board/server ownership of the currently loaded snapshot: the
+/// loaded board slug plus the configuration generation that produced it.
+/// Destructive confirmations staged on one context (e.g. a pending card
+/// delete) must match this stamp EXACTLY before executing — a task id alone
+/// is never an ownership token, because ids can collide across independent
+/// boards/servers.
+struct KanbanBoardContextStamp: Equatable {
+    let boardSlug: String
+    let configurationGeneration: Int
+}
+
 @MainActor
 final class KanbanStore: ObservableObject {
     static let selectedBoardKey = "conduit.kanbanBoardSlug"
@@ -71,6 +82,20 @@ final class KanbanStore: ObservableObject {
     /// disables creation/moves/deletes until the new board finishes loading.
     var isSelectedSnapshotLoaded: Bool {
         loadedBoardSlug == resolvedSelectedBoardSlug
+    }
+
+    /// Stamp of the board/server context that currently owns mutations, or
+    /// nil while no snapshot is loaded. Staged destructive confirmations
+    /// capture this at STAGE time and must match it again at CONFIRM time;
+    /// any board or server switch (different slug, or a configure() that
+    /// bumps the generation) invalidates the staged request fail-closed.
+    /// Note the generation deliberately does NOT change on reloads, polls,
+    /// or board selections — only configure() moves it (and configure()
+    /// early-returns for an identical requester+URL, matching the mutation
+    /// ownership model; do not "fix" the counter into every reload).
+    var loadedContextStamp: KanbanBoardContextStamp? {
+        guard let loadedBoardSlug else { return nil }
+        return KanbanBoardContextStamp(boardSlug: loadedBoardSlug, configurationGeneration: configurationGeneration)
     }
 
     var selectedBoardMetadata: KanbanBoardMetadata? {

--- a/Conduit/Views/Kanban/KanbanTaskComposerView.swift
+++ b/Conduit/Views/Kanban/KanbanTaskComposerView.swift
@@ -233,14 +233,17 @@ struct KanbanTaskComposerView: View {
     private var goalModeRows: some View {
         Toggle("Goal Mode", isOn: $draft.goalMode)
         if draft.goalMode {
+            // Symmetric ladder: Unlimited -> 5 -> 10 -> 15 … and back down to
+            // Unlimited; both directions walk the same rungs.
             Stepper(
                 "Max turns: \(draft.goalMaxTurns.map(String.init) ?? "Unlimited")",
                 onIncrement: {
-                    draft.goalMaxTurns = min(10_000, (draft.goalMaxTurns ?? 10) + 5)
+                    let base = draft.goalMaxTurns ?? 0
+                    draft.goalMaxTurns = min(10_000, base + 5)
                 },
                 onDecrement: {
-                    let current = draft.goalMaxTurns ?? 10
-                    draft.goalMaxTurns = current <= 1 ? nil : max(1, current - 5)
+                    guard let current = draft.goalMaxTurns else { return }
+                    draft.goalMaxTurns = current <= 5 ? nil : current - 5
                 }
             )
             .accessibilityHint("Bounds how long the Goal Mode worker may loop")
@@ -301,8 +304,13 @@ struct KanbanTaskComposerView: View {
     }
 
     private func parentTitle(for id: String) -> String {
-        let title = store.board?.columns.flatMap(\.tasks).first(where: { $0.id == id })?.title
-        return title?.isEmpty == false ? title! : KanbanShortID.of(id)
+        guard let title = store.board?.columns.flatMap(\.tasks).first(where: { $0.id == id })?.title,
+              !title.isEmpty else {
+            // Parent left the snapshot (or was filtered); the short ID stays
+            // a stable, honest label until the next board load.
+            return KanbanShortID.of(id)
+        }
+        return title
     }
 
     private var laneSection: some View {
@@ -369,7 +377,9 @@ struct KanbanTaskComposerView: View {
         }
         // Double-submission guard: the saving flag disables re-entry while the
         // request is in flight, and `didCreate` flips the button to Done.
-        .disabled(draft.trimmedTitle.isEmpty && !didCreate || isSaving)
+        // Parentheses make the intended grouping explicit:
+        // (empty title AND not-yet-created) OR saving right now.
+        .disabled((draft.trimmedTitle.isEmpty && !didCreate) || isSaving)
     }
 
     private func seedWorkspaceFromBoard() {
@@ -377,7 +387,10 @@ struct KanbanTaskComposerView: View {
         guard let metadata = boardMetadata else { return }
         // Derive the initial editor value from the board's REAL configured
         // default (desktop parity), falling back to scratch only when the
-        // board carries no default workspace kind.
+        // board carries no default workspace kind. Deliberately ONCE: after
+        // this first seed the selection belongs to the operator — silently
+        // rewriting it because board metadata refreshed mid-composition
+        // would discard an explicit choice.
         draft.workspaceKind = KanbanWorkspaceKind.initialKind(boardDefault: metadata.defaultWorkspaceKind)
         didSeedWorkspaceFromBoard = true
     }

--- a/Conduit/Views/Kanban/KanbanTaskComposerView.swift
+++ b/Conduit/Views/Kanban/KanbanTaskComposerView.swift
@@ -1,0 +1,809 @@
+import SwiftUI
+
+/// Mobile-native New Task composer (Kanban V2).
+///
+/// Desktop-parity semantics (see docs/KANBAN_V2_AUDIT.md) in a grouped,
+/// push/sheet-driven iPhone form:
+/// - Assignment follows Hermes Default/Profile/Parked exactly: Default sends
+///   the orchestration-resolved assignee, Parked omits the field.
+/// - The workspace selection initializes from the SELECTED BOARD's real
+///   `default_workspace_kind` (backend fallback scratch) and shows the board's
+///   inherited `default_workdir`.
+/// - Model/provider/reasoning is detached form state — nothing here mutates a
+///   live chat session.
+/// - Skills are task-specific selections serialized exactly as the backend
+///   expects (trimmed string array), not capability toggles.
+/// - Goal Mode maps to `goal_mode` (+ optional `goal_max_turns`); it is NOT
+///   Conduit's chat YOLO setting.
+struct KanbanTaskComposerView: View {
+    @EnvironmentObject private var store: KanbanStore
+    @EnvironmentObject private var appState: AppState
+    @Environment(\.dismiss) private var dismiss
+
+    let initialStatus: String
+
+    @State private var draft = KanbanComposerDraft()
+    @State private var isSaving = false
+    @State private var didCreate = false
+    @State private var errorMessage: String?
+    /// Board defaults can land after the sheet opens; seed once, never fight
+    /// an explicit user choice.
+    @State private var didSeedWorkspaceFromBoard = false
+
+    @State private var showModelSheet = false
+    @State private var showSkillsSheet = false
+    @State private var showParentSheet = false
+
+    init(initialStatus: String) {
+        self.initialStatus = initialStatus
+    }
+
+    private var statusPresentation: KanbanStatusPresentation {
+        KanbanStatusPresentation.forStatus(initialStatus)
+    }
+
+    /// Upstream New Task dialog: `useOrchestration()?.resolved_default_assignee || 'default'`.
+    private var resolvedDefaultAssignee: String {
+        let resolved = store.orchestration?.resolvedDefaultAssignee.trimmingCharacters(in: .whitespaces) ?? ""
+        return resolved.isEmpty ? "default" : resolved
+    }
+
+    private var boardMetadata: KanbanBoardMetadata? {
+        store.selectedBoardMetadata
+    }
+
+    private var rosterWithoutDefault: [KanbanProfile] {
+        store.profiles.filter { $0.name != resolvedDefaultAssignee }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                basicsSection
+                assignmentSection
+                executionSection
+                dependenciesSection
+                laneSection
+                if let errorMessage {
+                    Section {
+                        Label(errorMessage, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                            .font(.footnote)
+                    }
+                }
+            }
+            .navigationTitle(didCreate ? "Task created" : "New task")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(didCreate ? "Close" : "Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    creationButton
+                }
+            }
+            .onAppear(perform: seedWorkspaceFromBoard)
+            .onChange(of: boardMetadata?.defaultWorkspaceKind) { _, _ in
+                seedWorkspaceFromBoard()
+            }
+            .sheet(isPresented: $showModelSheet) {
+                KanbanModelOverrideSheet(value: modelOverrideBinding)
+                    .presentationDetents([.medium, .large])
+            }
+            .sheet(isPresented: $showSkillsSheet) {
+                KanbanSkillsPickerSheet(selected: skillsBinding)
+                    .presentationDetents([.medium, .large])
+            }
+            .sheet(isPresented: $showParentSheet) {
+                KanbanParentPickerSheet(
+                    selectedParentID: parentBinding,
+                    excludedTaskID: nil
+                )
+                .presentationDetents([.medium, .large])
+            }
+        }
+        .interactiveDismissDisabled(isSaving)
+    }
+
+    // MARK: - Sections
+
+    private var basicsSection: some View {
+        Section("Basics") {
+            TextField("Title", text: $draft.title)
+                .accessibilityLabel("Task title")
+            TextEditor(text: $draft.body)
+                .frame(minHeight: 100)
+                .accessibilityLabel("Task description")
+            Picker("Priority", selection: $draft.priority) {
+                Text("Normal").tag(0)
+                Text("High").tag(1)
+                Text("Urgent").tag(2)
+                Text("Critical").tag(3)
+            }
+        }
+    }
+
+    private var assignmentSection: some View {
+        Section {
+            Picker("Assigned to", selection: assigneeSelectionBinding) {
+                Text("Default (\(resolvedDefaultAssignee))")
+                    .tag(KanbanAssigneeSelection.inheritDefault)
+                ForEach(rosterWithoutDefault) { profile in
+                    Text(profile.name).tag(KanbanAssigneeSelection.profile(profile.name))
+                }
+                Text("Parked (won't run)")
+                    .tag(KanbanAssigneeSelection.parked)
+            }
+        } header: {
+            Text("Assignment")
+        } footer: {
+            Text("Default uses Hermes' resolved default assignee (\(resolvedDefaultAssignee)). Parked leaves the task unassigned so no worker claims it.")
+        }
+    }
+
+    private var executionSection: some View {
+        Section {
+            Picker("Workspace", selection: $draft.workspaceKind) {
+                ForEach(KanbanWorkspaceKind.allCases) { kind in
+                    Text(kind.displayName + (kind == boardDefaultKind ? " · board default" : ""))
+                        .tag(kind)
+                }
+            }
+            if draft.workspaceKind.allowsPathOverride {
+                TextField(
+                    boardDefaultDir != nil ? "Leave empty to inherit \(boardDefaultDir!)" : "Optional path override",
+                    text: $draft.workspacePath
+                )
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .accessibilityLabel("Workspace path override")
+                if let dir = boardDefaultDir {
+                    Text("Leave empty to inherit the board's project directory: \(dir)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("Leave empty to inherit the board's project directory.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            modelRow
+            skillsRow
+            goalModeRows
+        } header: {
+            Text("Execution")
+        } footer: {
+            if boardDefaultDir != nil && !draft.workspaceKind.allowsPathOverride {
+                Text("The board's project directory (\(boardDefaultDir!)) applies to this task.")
+            }
+        }
+    }
+
+    private var boardDefaultKind: KanbanWorkspaceKind {
+        KanbanWorkspaceKind.initialKind(boardDefault: boardMetadata?.defaultWorkspaceKind)
+    }
+
+    private var boardDefaultDir: String? {
+        guard let dir = boardMetadata?.defaultWorkdir?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !dir.isEmpty else { return nil }
+        return dir
+    }
+
+    private var modelRow: some View {
+        Button {
+            showModelSheet = true
+        } label: {
+            HStack {
+                Text("Model")
+                    .foregroundStyle(.primary)
+                Spacer()
+                Text(draft.modelOverride.label(inheritCopy: "Inherit from profile"))
+                    .font(.callout)
+                    .foregroundStyle(draft.modelOverride.isInherited ? .secondary : .primary)
+                    .lineLimit(1)
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .accessibilityHint("Opens the per-task model, provider, and reasoning override picker")
+    }
+
+    private var skillsRow: some View {
+        Button {
+            showSkillsSheet = true
+        } label: {
+            HStack {
+                Text("Skills")
+                    .foregroundStyle(.primary)
+                Spacer()
+                Text(draft.skills.isEmpty ? "None" : "\(draft.skills.count) selected")
+                    .font(.callout)
+                    .foregroundStyle(draft.skills.isEmpty ? .secondary : .primary)
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .accessibilityHint("Opens the task skill picker")
+    }
+
+    @ViewBuilder
+    private var goalModeRows: some View {
+        Toggle("Goal Mode", isOn: $draft.goalMode)
+        if draft.goalMode {
+            Stepper(
+                "Max turns: \(draft.goalMaxTurns.map(String.init) ?? "Unlimited")",
+                onIncrement: {
+                    draft.goalMaxTurns = min(10_000, (draft.goalMaxTurns ?? 10) + 5)
+                },
+                onDecrement: {
+                    let current = draft.goalMaxTurns ?? 10
+                    draft.goalMaxTurns = current <= 1 ? nil : max(1, current - 5)
+                }
+            )
+            .accessibilityHint("Bounds how long the Goal Mode worker may loop")
+            Text("The worker loops until a judge agrees the goal is met. Leave unlimited only with caution.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var dependenciesSection: some View {
+        Section {
+            if draft.parents.isEmpty {
+                Button {
+                    showParentSheet = true
+                } label: {
+                    HStack {
+                        Text("Depends on")
+                            .foregroundStyle(.primary)
+                        Spacer()
+                        Text("None")
+                            .foregroundStyle(.secondary)
+                        Image(systemName: "chevron.right")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+            } else {
+                ForEach(draft.parents, id: \.self) { parentID in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(parentTitle(for: parentID))
+                                .font(.subheadline)
+                                .foregroundStyle(.primary)
+                            Text(KanbanShortID.of(parentID))
+                                .font(.caption2.monospaced())
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Button(role: .destructive) {
+                            draft.parents.removeAll { $0 == parentID }
+                        } label: {
+                            Image(systemName: "minus.circle.fill")
+                        }
+                        .accessibilityLabel("Remove dependency \(parentTitle(for: parentID))")
+                    }
+                }
+                Button {
+                    showParentSheet = true
+                } label: {
+                    Label("Change…", systemImage: "arrow.triangle.2.circlepath")
+                }
+            }
+        } header: {
+            Text("Dependencies")
+        } footer: {
+            Text("The new task stays blocked until its parent completes.")
+        }
+    }
+
+    private func parentTitle(for id: String) -> String {
+        let title = store.board?.columns.flatMap(\.tasks).first(where: { $0.id == id })?.title
+        return title?.isEmpty == false ? title! : KanbanShortID.of(id)
+    }
+
+    private var laneSection: some View {
+        Section {
+            Label(statusPresentation.displayName, systemImage: statusPresentation.systemImage)
+                .foregroundStyle(statusPresentation.tint)
+            Text("The board selection is local to this device; creating this task will not switch Hermes' global board.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        } header: {
+            Text("Lands in")
+        }
+    }
+
+    // MARK: - Bindings
+
+    private var assigneeSelectionBinding: Binding<KanbanAssigneeSelection> {
+        Binding(
+            get: { draft.assignee },
+            set: { draft.assignee = $0 }
+        )
+    }
+
+    private var modelOverrideBinding: Binding<TaskModelOverride> {
+        Binding(
+            get: { draft.modelOverride },
+            set: { draft.modelOverride = $0 }
+        )
+    }
+
+    private var skillsBinding: Binding<[String]> {
+        Binding(
+            get: { draft.skills },
+            set: { draft.skills = $0 }
+        )
+    }
+
+    private var parentBinding: Binding<String?> {
+        Binding(
+            get: { draft.parents.first },
+            set: { newValue in
+                // Desktop exposes a SINGLE parent even though the API accepts
+                // multiple; match the product behavior.
+                draft.parents = newValue.map { [$0] } ?? []
+            }
+        )
+    }
+
+    // MARK: - Creation
+
+    private var creationButton: some View {
+        Button {
+            if didCreate {
+                dismiss()
+            } else {
+                Task { await create() }
+            }
+        } label: {
+            if isSaving {
+                ProgressView()
+            } else {
+                Text(didCreate ? "Done" : "Create")
+            }
+        }
+        // Double-submission guard: the saving flag disables re-entry while the
+        // request is in flight, and `didCreate` flips the button to Done.
+        .disabled(draft.trimmedTitle.isEmpty && !didCreate || isSaving)
+    }
+
+    private func seedWorkspaceFromBoard() {
+        guard !didSeedWorkspaceFromBoard else { return }
+        guard let metadata = boardMetadata else { return }
+        // Derive the initial editor value from the board's REAL configured
+        // default (desktop parity), falling back to scratch only when the
+        // board carries no default workspace kind.
+        draft.workspaceKind = KanbanWorkspaceKind.initialKind(boardDefault: metadata.defaultWorkspaceKind)
+        didSeedWorkspaceFromBoard = true
+    }
+
+    private func create() async {
+        guard !isSaving, !didCreate else { return }
+        do {
+            // One validation layer decides whether this draft may become a
+            // request; views never hand-roll ad hoc checks.
+            let request = try KanbanComposerValidator.makeRequest(
+                from: draft,
+                resolvedDefaultAssignee: resolvedDefaultAssignee
+            )
+            isSaving = true
+            errorMessage = nil
+            defer { isSaving = false }
+            _ = try await store.createTask(request, initialStatus: initialStatus)
+            dismiss()
+        } catch let error as KanbanDraftValidationError {
+            errorMessage = error.localizedDescription
+        } catch {
+            errorMessage = error.localizedDescription
+            if let kanbanError = error as? KanbanServiceError,
+               case .taskCreatedButMoveFailed = kanbanError {
+                // Partial success: the task EXISTS but could not be moved into
+                // the requested lane. Flip to the Done state so the user cannot
+                // resubmit and duplicate it.
+                didCreate = true
+            }
+        }
+    }
+}
+
+// MARK: - Model override sheet
+
+/// Provider → Model → Reasoning selection backed by the kanban plugin's
+/// curated `/model-options` roster, with a free-text fallback when the server
+/// inventory is unavailable. Entirely detached from any live session model.
+struct KanbanModelOverrideSheet: View {
+    @EnvironmentObject private var store: KanbanStore
+    @Environment(\.dismiss) private var dismiss
+    @Binding var value: TaskModelOverride
+
+    @State private var providers: [KanbanModelProviderOption] = []
+    @State private var isLoadingOptions = false
+    @State private var loadFailed = false
+    @State private var query = ""
+    @State private var expandedProvider: String?
+    @State private var customProvider = ""
+    @State private var customModel = ""
+
+    private var inheritCopy: String { "Inherit from profile" }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Button {
+                        value = TaskModelOverride()
+                    } label: {
+                        HStack {
+                            Text(inheritCopy)
+                            Spacer()
+                            if value.isInherited {
+                                Image(systemName: "checkmark")
+                                    .foregroundStyle(.conduitAccent)
+                            }
+                        }
+                    }
+                    .disabled(value.isInherited)
+                    .accessibilityHint("Uses the assigned profile's own model and reasoning settings")
+                } footer: {
+                    Text("An unset override runs the task on the assigned profile's own model, provider, and reasoning effort.")
+                }
+
+                reasoningSection
+                catalogSection
+                if loadFailed || providers.isEmpty {
+                    customEntrySection
+                }
+            }
+            .navigationTitle("Model override")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .task { await loadOptions() }
+            .onAppear(perform: seedCustomFields)
+        }
+    }
+
+    private var reasoningSection: some View {
+        Section("Reasoning effort") {
+            Picker("Effort", selection: effortBinding) {
+                Text("Inherit").tag("")
+                ForEach(TaskModelOverride.validReasoningEfforts, id: \.self) { effort in
+                    Text(displayEffort(effort)).tag(effort)
+                }
+            }
+        }
+    }
+
+    private var filteredProviders: [KanbanModelProviderOption] {
+        let trimmed = query.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !trimmed.isEmpty else { return providers }
+        return providers.compactMap { provider in
+            if provider.slug.lowercased().contains(trimmed) || provider.displayName.lowercased().contains(trimmed) {
+                return provider
+            }
+            let models = provider.models.filter { $0.lowercased().contains(trimmed) }
+            return models.isEmpty ? nil : KanbanModelProviderOption(slug: provider.slug, label: provider.label, models: models)
+        }
+    }
+
+    @ViewBuilder
+    private var catalogSection: some View {
+        Section {
+            if isLoadingOptions {
+                HStack { ProgressView(); Text("Loading models…") }.foregroundStyle(.secondary)
+            }
+            ForEach(filteredProviders) { provider in
+                providerDisclosure(provider)
+            }
+            if !isLoadingOptions && providers.isEmpty {
+                Text("No curated model catalog available from Hermes — enter a provider and model below.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        } header: {
+            Text("Catalog")
+        } footer: {
+            Text("Curated by Hermes so a worker can always spawn what you pick.")
+        }
+    }
+
+    private func providerDisclosure(_ provider: KanbanModelProviderOption) -> some View {
+        DisclosureGroup(isExpanded: expandedBinding(provider.slug)) {
+            ForEach(provider.models, id: \.self) { model in
+                Button {
+                    value = TaskModelOverride(provider: provider.slug, model: model, reasoningEffort: value.reasoningEffort)
+                } label: {
+                    HStack {
+                        Text(model)
+                        Spacer()
+                        if isSelected(provider.slug, model) {
+                            Image(systemName: "checkmark")
+                                .foregroundStyle(.conduitAccent)
+                        }
+                    }
+                }
+                .foregroundStyle(.primary)
+            }
+        } label: {
+            Text(provider.displayName)
+        }
+    }
+
+    private var customEntrySection: some View {
+        Section("Custom (free text)") {
+            TextField("Provider", text: $customProvider)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+            TextField("Model", text: $customModel)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+            Button("Use this override") {
+                let provider = customProvider.trimmingCharacters(in: .whitespaces)
+                let model = customModel.trimmingCharacters(in: .whitespaces)
+                value = TaskModelOverride(
+                    provider: provider.isEmpty ? nil : provider,
+                    model: model.isEmpty ? nil : model,
+                    reasoningEffort: value.reasoningEffort
+                )
+            }
+            .disabled(customModel.trimmingCharacters(in: .whitespaces).isEmpty)
+        }
+    }
+
+    private var effortBinding: Binding<String> {
+        Binding(
+            get: { value.reasoningEffort ?? "" },
+            set: { value.reasoningEffort = $0.isEmpty ? nil : $0 }
+        )
+    }
+
+    private func expandedBinding(_ slug: String) -> Binding<Bool> {
+        Binding(
+            get: { expandedProvider == slug },
+            set: { expandedProvider = $0 ? slug : (expandedProvider == slug ? nil : expandedProvider) }
+        )
+    }
+
+    private func isSelected(_ providerSlug: String, _ model: String) -> Bool {
+        value.provider == providerSlug && value.model == model
+    }
+
+    private func displayEffort(_ effort: String) -> String {
+        effort == "none" ? "None (thinking off)" : effort.capitalized.replacingOccurrences(of: "Xhigh", with: "Extra High")
+    }
+
+    private func seedCustomFields() {
+        customProvider = value.provider ?? ""
+        customModel = value.model ?? ""
+    }
+
+    private func loadOptions() async {
+        guard providers.isEmpty else { return }
+        isLoadingOptions = true
+        defer { isLoadingOptions = false }
+        do {
+            providers = try await store.fetchModelOptions().filter { !$0.models.isEmpty }
+            // Pre-expand the provider matching the current override.
+            if let current = value.provider,
+               let match = providers.first(where: { $0.slug == current }) {
+                expandedProvider = match.slug
+            }
+        } catch {
+            loadFailed = true
+        }
+    }
+}
+
+// MARK: - Skills picker
+
+/// Task-specific skill multi-select. This selects WHICH skills a task uses;
+/// it deliberately does not enable/disable profile capabilities (that remains
+/// Capabilities Settings' job). Seeds from the active Hermes configuration's
+/// skill list and allows manual entry for anything unlisted (upstream accepts
+/// arbitrary comma-separated names).
+struct KanbanSkillsPickerSheet: View {
+    @EnvironmentObject private var appState: AppState
+    @Environment(\.dismiss) private var dismiss
+    @Binding var selected: [String]
+
+    @State private var query = ""
+    @State private var customName = ""
+
+    private var availableSkills: [CapabilitySkill] {
+        appState.skills
+    }
+
+    private var filteredSkills: [CapabilitySkill] {
+        let trimmed = query.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !trimmed.isEmpty else { return availableSkills }
+        return availableSkills.filter {
+            $0.name.lowercased().contains(trimmed)
+                || ($0.description ?? "").lowercased().contains(trimmed)
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                if !selected.isEmpty {
+                    Section("Selected") {
+                        ForEach(selected, id: \.self) { name in
+                            HStack {
+                                Text(name)
+                                Spacer()
+                                Button {
+                                    selected.removeAll { $0 == name }
+                                } label: {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .foregroundStyle(.secondary)
+                                }
+                                .accessibilityLabel("Remove skill \(name)")
+                            }
+                        }
+                    }
+                }
+
+                Section {
+                    ForEach(filteredSkills) { skill in
+                        Button {
+                            toggle(skill.name)
+                        } label: {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(skill.name)
+                                        .foregroundStyle(.primary)
+                                    if let description = skill.description, !description.isEmpty {
+                                        Text(description)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                            .lineLimit(2)
+                                    }
+                                }
+                                Spacer()
+                                if isSelected(skill.name) {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .foregroundStyle(.conduitAccent)
+                                }
+                            }
+                        }
+                        .accessibilityLabel("Skill \(skill.name)")
+                        .accessibilityHint(isSelected(skill.name) ? "Selected" : "Not selected")
+                    }
+                    if filteredSkills.isEmpty {
+                        Text("No skills match.")
+                            .foregroundStyle(.secondary)
+                    }
+                } header: {
+                    Text("Available skills")
+                }
+
+                Section("Add manually") {
+                    HStack {
+                        TextField("skill-name", text: $customName)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                        Button("Add") { addCustom() }
+                            .disabled(customName.trimmingCharacters(in: .whitespaces).isEmpty)
+                    }
+                }
+            }
+            .searchable(text: $query, prompt: "Search skills")
+            .navigationTitle("Skills")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func isSelected(_ name: String) -> Bool {
+        selected.contains(name)
+    }
+
+    private func toggle(_ name: String) {
+        if isSelected(name) {
+            selected.removeAll { $0 == name }
+        } else {
+            selected.append(name)
+        }
+    }
+
+    private func addCustom() {
+        let name = customName.trimmingCharacters(in: .whitespaces)
+        guard !name.isEmpty else { return }
+        if !isSelected(name) {
+            selected.append(name)
+        }
+        customName = ""
+    }
+}
+
+// MARK: - Parent picker
+
+/// Single-parent selection over the CURRENT BOARD snapshot, mirroring
+/// Desktop's New Task dialog (one parent, even though the API accepts lists).
+struct KanbanParentPickerSheet: View {
+    @EnvironmentObject private var store: KanbanStore
+    @Environment(\.dismiss) private var dismiss
+    @Binding var selectedParentID: String?
+    /// Edit flows pass the current task here so nothing can depend on itself.
+    let excludedTaskID: String?
+
+    @State private var query = ""
+
+    private var candidates: [KanbanTask] {
+        let all = (store.board?.columns ?? []).flatMap(\.tasks)
+        let filtered = all.filter { $0.id != excludedTaskID }
+        let trimmed = query.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !trimmed.isEmpty else { return filtered }
+        return filtered.filter {
+            $0.title.lowercased().contains(trimmed) || $0.id.lowercased().contains(trimmed)
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Button {
+                    selectedParentID = nil
+                } label: {
+                    HStack {
+                        Text("— no parent —")
+                        Spacer()
+                        if selectedParentID == nil {
+                            Image(systemName: "checkmark")
+                                .foregroundStyle(.conduitAccent)
+                        }
+                    }
+                }
+                ForEach(candidates) { task in
+                    Button {
+                        selectedParentID = task.id
+                    } label: {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(task.title)
+                                    .foregroundStyle(.primary)
+                                    .lineLimit(2)
+                                HStack(spacing: 6) {
+                                    Text(KanbanShortID.of(task.id))
+                                        .font(.caption2.monospaced())
+                                    Text(KanbanStatusPresentation.forStatus(task.status).displayName)
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            Spacer()
+                            if selectedParentID == task.id {
+                                Image(systemName: "checkmark")
+                                    .foregroundStyle(.conduitAccent)
+                            }
+                        }
+                    }
+                }
+                if candidates.isEmpty {
+                    Text("No other tasks on this board.")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .searchable(text: $query, prompt: "Search tasks")
+            .navigationTitle("Parent task")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+}

--- a/Conduit/Views/Kanban/KanbanTaskDetailView.swift
+++ b/Conduit/Views/Kanban/KanbanTaskDetailView.swift
@@ -51,6 +51,12 @@ struct KanbanTaskDetailView: View {
     @State private var showReassignSheet = false
     @State private var showModelSheet = false
     @State private var modelOverrideDraft = TaskModelOverride()
+    /// The CURRENT model-editor sheet session: the task identity the sheet
+    /// was opened for plus the SERVER override frozen at open time. "Did the
+    /// user edit anything?" is always draft vs THIS baseline — never vs a
+    /// later poll — so a no-edit dismissal can never overwrite a concurrent
+    /// server change, and a session for task A can never commit against B.
+    @State private var modelOverrideSession: KanbanModelOverrideSession?
     @State private var errorMessage: String?
     @State private var refreshErrorMessage: String?
 
@@ -227,6 +233,9 @@ struct KanbanTaskDetailView: View {
                 errorMessage = nil
                 refreshErrorMessage = nil
                 modelOverrideDraft = TaskModelOverride()
+                // The open editor session belonged to the departed identity;
+                // its dismissal must never commit against the new one.
+                modelOverrideSession = nil
             }
             .sheet(isPresented: $showReassignSheet) {
                 KanbanReassignSheet(taskID: displayedTaskID, currentAssignee: displayedTask?.assignee)
@@ -239,12 +248,26 @@ struct KanbanTaskDetailView: View {
                     .presentationDetents([.medium, .large])
             }
             .onChange(of: showModelSheet) { wasOpen, nowOpen in
-                if !nowOpen && wasOpen {
-                    // Commit-on-dismiss (desktop parity: the drawer PATCHes on
-                    // change). Diff the edited override against the CURRENT
-                    // server snapshot so a poll landing mid-edit can neither
-                    // clobber the user nor duplicate the write.
-                    let next = modelOverrideDraft
+                guard !nowOpen, wasOpen else { return }
+                defer { modelOverrideSession = nil }
+                // Two conceptually separate comparisons (V2 correctness):
+                //   draft vs sheet-open baseline  -> did the user edit anything?
+                //   draft vs current server value -> what wire mutation is required?
+                // A no-edit dismissal can NEVER overwrite a server value that
+                // changed while the sheet was open; an actual edit is diffed
+                // against the CURRENT server snapshot below for correct
+                // clear/set flags.
+                switch KanbanModelOverrideSessionPolicy.dismissalOutcome(
+                    session: modelOverrideSession,
+                    draft: modelOverrideDraft,
+                    displayedTaskID: displayedTaskID
+                ) {
+                case .noWrite:
+                    return
+                case .commit(let next):
+                    // The user edited; compute the wire mutation against the
+                    // CURRENT server snapshot so a poll landing mid-edit can
+                    // neither clobber the user nor duplicate the write.
                     guard let serverTask = displayedTask,
                           next != TaskModelOverride(task: serverTask) else { return }
                     Task { await commitModelOverride(next) }
@@ -382,12 +405,18 @@ struct KanbanTaskDetailView: View {
                 SettingsMetricRow(label: "Workspace", value: path, lineLimit: 2)
             }
             Button {
-                // Seed the EDITOR draft from the current displayed SERVER task
-                // the moment the sheet opens. While the sheet is closed the
-                // row below renders the server value directly, so a poll that
-                // changes the override updates the row — and an open editor
-                // draft is never clobbered by polling.
-                modelOverrideDraft = KanbanModelOverrideDisplayPolicy.override(for: displayedTask)
+                // Begin a NEW sheet session: freeze the server value AT OPEN
+                // TIME as both the editor draft and the session baseline.
+                // While the sheet is closed the row below renders the server
+                // value directly; while it is open, polling may move the
+                // server underneath, but "did the user edit?" stays draft vs
+                // baseline — the server change is never mistaken for an edit.
+                let serverOverride = KanbanModelOverrideDisplayPolicy.override(for: displayedTask)
+                modelOverrideSession = KanbanModelOverrideSession(
+                    taskID: displayedTaskID,
+                    baseline: serverOverride
+                )
+                modelOverrideDraft = serverOverride
                 showModelSheet = true
             } label: {
                 HStack(spacing: 8) {
@@ -1175,6 +1204,50 @@ enum KanbanModelOverrideDisplayPolicy {
     /// The visible Model-row label.
     static func label(for displayedTask: KanbanTask?, inheritCopy: String) -> String {
         override(for: displayedTask).label(inheritCopy: inheritCopy)
+    }
+}
+
+/// One model-override editor sheet session: the task identity the sheet was
+/// opened for, and the SERVER override value frozen at open time.
+struct KanbanModelOverrideSession: Equatable {
+    let taskID: String
+    let baseline: TaskModelOverride
+}
+
+/// Dismissal rules for the model override editor (Kanban V2 correctness).
+///
+/// Keeps two comparisons conceptually separate:
+/// - draft vs sheet-open baseline  -> did the user edit anything?
+/// - draft vs current server value -> what wire mutation is required?
+///
+/// A no-edit dismissal can never overwrite a server value that changed while
+/// the sheet was open (the draft matches the baseline, whatever the server
+/// now holds), and a session belonging to one task identity never commits
+/// against another.
+enum KanbanModelOverrideSessionPolicy {
+    enum DismissalOutcome: Equatable {
+        /// Nothing may be written: no user edit, no session, a foreign
+        /// identity, or a session already invalidated by navigation.
+        case noWrite
+        /// The user edited after opening; commit this value. The wire
+        /// mutation is computed against the CURRENT server snapshot at
+        /// commit time (correct clear/set semantics).
+        case commit(TaskModelOverride)
+    }
+
+    static func dismissalOutcome(
+        session: KanbanModelOverrideSession?,
+        draft: TaskModelOverride,
+        displayedTaskID: String
+    ) -> DismissalOutcome {
+        guard let session else { return .noWrite }
+        // A sheet session belongs to exactly one task identity: a session
+        // opened for A must never commit against B.
+        guard session.taskID == displayedTaskID else { return .noWrite }
+        // USER-EDIT test: against the sheet-open baseline, NOT the live
+        // server value (which polling may have moved under the sheet).
+        guard draft != session.baseline else { return .noWrite }
+        return .commit(draft)
     }
 }
 

--- a/Conduit/Views/Kanban/KanbanTaskDetailView.swift
+++ b/Conduit/Views/Kanban/KanbanTaskDetailView.swift
@@ -163,7 +163,13 @@ struct KanbanTaskDetailView: View {
             }
             .onChange(of: displayedTaskID) { _, newValue in
                 guard newValue != detail?.task.id else { return }
+                // Identity switch (dependency tap): drop everything the old
+                // identity owned BEFORE the replacement load starts, so the
+                // old poll's completion can neither repopulate collections nor
+                // flash its errors onto the new screen.
                 detail = nil
+                isLoadingDetail = false
+                isSaving = false
                 title = ""
                 taskBody = ""
                 status = "todo"
@@ -731,13 +737,21 @@ struct KanbanTaskDetailView: View {
     private func loadDetail(force: Bool = false) async {
         // A poll never runs underneath an active save/comment write.
         guard force || (!isSaving && !isAddingComment && !isRequeuing), !isLoadingDetail else { return }
+        // Freeze THIS fetch's identity up front. If the operator taps a
+        // dependency mid-flight, every completion below is discarded: no
+        // data, no error text, no baseline churn may cross identities.
+        let expectedID = displayedTaskID
         isLoadingDetail = true
-        defer { isLoadingDetail = false }
+        // A STALE completion must not clear the replacement load's spinner:
+        // only the current identity may release the flag.
+        defer {
+            if displayedTaskID == expectedID { isLoadingDetail = false }
+        }
         do {
-            let loaded = try await store.fetchTaskDetail(id: displayedTaskID)
-            guard loaded.task.id == displayedTaskID || loaded.task.id.isEmpty else {
-                // A stale completion for the PREVIOUS displayed task must be
-                // discarded, not rendered under the new one.
+            let loaded = try await store.fetchTaskDetail(id: expectedID)
+            guard displayedTaskID == expectedID else { return }
+            guard loaded.task.id == expectedID || loaded.task.id.isEmpty else {
+                // Defensive double-check against a server-side id mismatch.
                 return
             }
             let server = loaded.task
@@ -764,7 +778,12 @@ struct KanbanTaskDetailView: View {
             }
             detail = loaded
             refreshErrorMessage = nil
+        } catch is CancellationError {
+            // The poll loop was replaced (identity switch or dismissal); its
+            // cancellation must never render as a user-facing failure.
+            return
         } catch {
+            guard displayedTaskID == expectedID else { return }
             if detail == nil {
                 errorMessage = error.localizedDescription
             } else {

--- a/Conduit/Views/Kanban/KanbanTaskDetailView.swift
+++ b/Conduit/Views/Kanban/KanbanTaskDetailView.swift
@@ -1,0 +1,974 @@
+import SwiftUI
+
+/// Task operator detail (Kanban V2).
+///
+/// Desktop drawer parity adapted to iPhone navigation:
+/// - Assignment/reassignment through the DEDICATED `/reassign` endpoint
+///   (reclaim-first, upstream default), never a generic assignee PATCH.
+/// - Model/provider/reasoning override visible and editable where the backend
+///   permits (PATCH with explicit clear flags), showing inheritance clearly.
+/// - Diagnostics with the backend's structured recovery actions (reclaim,
+///   copy CLI hint). No recovery mutation is ever invented from text.
+/// - Dependencies (Blocked by / Blocks) with replace-current-detail tap
+///   navigation — no recursive sheet stacks.
+/// - Activity timeline mapping known event kinds to prose; unknown kinds get
+///   a graceful fallback.
+/// - Richer runs and a dedicated worker-log screen.
+///
+/// The V1 draft-safety core is PRESERVED: a 4-second poll refreshes comments,
+/// runs, events, and metadata but never overwrites unsaved user edits; diffs
+/// run against the last-synced server baseline.
+struct KanbanTaskDetailView: View {
+    /// Editable fields as last synced from the server. The draft fields below
+    /// are compared against this so a poll can refresh collections WITHOUT
+    /// ever overwriting unsaved user edits.
+    private struct ServerBaseline: Equatable {
+        var title: String
+        var bodyText: String
+        var status: String
+    }
+
+    @EnvironmentObject private var store: KanbanStore
+    @Environment(\.dismiss) private var dismiss
+
+    private let initialTask: KanbanTask
+    /// Replace-current-detail navigation target for dependency taps. The
+    /// sheet never stacks another sheet; it swaps the displayed identity.
+    @State private var displayedTaskID: String
+    @State private var detail: KanbanTaskDetail?
+    // Draft (editable) state — owned by the user until saved.
+    @State private var title: String
+    @State private var taskBody: String
+    @State private var status: String
+    @State private var baseline: ServerBaseline
+    @State private var remoteChangeNotice: String?
+    @State private var comment = ""
+    @State private var isSaving = false
+    @State private var isAddingComment = false
+    @State private var isRequeuing = false
+    @State private var isLoadingDetail = false
+    @State private var showDeleteConfirmation = false
+    @State private var showReassignSheet = false
+    @State private var showModelSheet = false
+    @State private var modelOverrideDraft = TaskModelOverride()
+    @State private var errorMessage: String?
+    @State private var refreshErrorMessage: String?
+
+    init(task: KanbanTask) {
+        initialTask = task
+        _displayedTaskID = State(initialValue: task.id)
+        _title = State(initialValue: task.title)
+        _taskBody = State(initialValue: task.body ?? "")
+        _status = State(initialValue: task.status)
+        _baseline = State(initialValue: ServerBaseline(title: task.title, bodyText: task.body ?? "", status: task.status))
+    }
+
+    private var currentTask: KanbanTask {
+        detail?.task ?? initialTask
+    }
+
+    private var isRunning: Bool {
+        currentTask.status == "running"
+    }
+
+    private var hasUnsavedChanges: Bool {
+        KanbanDetailDraftPolicy.isDirty(
+            draftTitle: title,
+            draftBody: taskBody,
+            draftStatus: status,
+            baselineTitle: baseline.title,
+            baselineBodyText: baseline.bodyText,
+            baselineStatus: baseline.status
+        )
+    }
+
+    private var statusOptions: [KanbanStatusPresentation] {
+        var values = KanbanStatusPresentation.manuallySelectableStatuses
+        if !values.contains(where: { $0.rawValue == status }) {
+            values.insert(KanbanStatusPresentation.forStatus(status), at: 0)
+        }
+        return values
+    }
+
+    private var hasDispatcherFallback: Bool {
+        !(store.orchestration?.resolvedDefaultAssignee ?? "").isEmpty
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    editorSection
+                    assignmentExecutionSection
+                    if currentTask.status == "ready", (currentTask.assignee ?? "").isEmpty, !hasDispatcherFallback {
+                        readyUnassignedCallout
+                    }
+                    diagnosticsSection
+                    dependenciesSection
+                    commentsSection
+                    activitySection
+                    runsSection
+                    workerLogLink
+                    if let remoteChangeNotice {
+                        Text(remoteChangeNotice)
+                            .font(.footnote)
+                            .foregroundStyle(.orange)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    if hasUnsavedChanges {
+                        Text("Unsaved edits")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+                    if let refreshErrorMessage {
+                        Text("Refresh failed: \(refreshErrorMessage)")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    if let errorMessage {
+                        Text(errorMessage)
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .padding(16)
+            }
+            .background(ConduitBackdrop())
+            .navigationTitle("Task")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    actionsMenu
+                }
+            }
+            // Replace-current-detail: dependency taps swap the polled identity;
+            // drafts re-seed because the user navigated away from them.
+            .task(id: displayedTaskID) {
+                await loadDetail(force: true)
+                while !Task.isCancelled {
+                    do {
+                        try await Task.sleep(nanoseconds: KanbanPollingPolicy.detailIntervalNanoseconds)
+                    } catch {
+                        break
+                    }
+                    guard !Task.isCancelled else { break }
+                    await loadDetail()
+                }
+            }
+            .onChange(of: displayedTaskID) { _, newValue in
+                guard newValue != detail?.task.id else { return }
+                detail = nil
+                title = ""
+                taskBody = ""
+                status = "todo"
+                baseline = ServerBaseline(title: "", bodyText: "", status: "todo")
+                remoteChangeNotice = nil
+                errorMessage = nil
+                refreshErrorMessage = nil
+                modelOverrideDraft = TaskModelOverride()
+            }
+            .sheet(isPresented: $showReassignSheet) {
+                KanbanReassignSheet(taskID: displayedTaskID, currentAssignee: currentTask.assignee)
+                    .environmentObject(store)
+                    .presentationDetents([.medium])
+            }
+            .sheet(isPresented: $showModelSheet) {
+                KanbanModelOverrideSheet(value: $modelOverrideDraft)
+                    .environmentObject(store)
+                    .presentationDetents([.medium, .large])
+            }
+            .onChange(of: showModelSheet) { wasOpen, nowOpen in
+                if !nowOpen && wasOpen {
+                    // Commit-on-dismiss (desktop parity: the drawer PATCHes on
+                    // change). Diff the edited override against the CURRENT
+                    // server snapshot so a poll landing mid-edit can neither
+                    // clobber the user nor duplicate the write.
+                    let next = modelOverrideDraft
+                    if next != TaskModelOverride(task: currentTask) {
+                        Task { await commitModelOverride(next) }
+                    }
+                }
+            }
+            .alert("Delete this task?", isPresented: $showDeleteConfirmation) {
+                Button("Delete", role: .destructive) { Task { await deleteTask() } }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This permanently removes the task from the selected Hermes board.")
+            }
+        }
+    }
+
+    private var hasAnyServerOverride: Bool {
+        !(currentTask.modelOverride ?? "").isEmpty
+            || !(currentTask.providerOverride ?? "").isEmpty
+            || !(currentTask.reasoningEffort ?? "").isEmpty
+    }
+
+    // MARK: - Actions menu
+
+    private var actionsMenu: some View {
+        Menu {
+            Button {
+                KanbanClipboard.copy(currentTask.id, announcement: "Task ID copied")
+            } label: {
+                Label("Copy Task ID", systemImage: "doc.on.doc")
+            }
+            Button {
+                KanbanClipboard.copy(currentTask.title.isEmpty ? currentTask.id : currentTask.title, announcement: "Title copied")
+            } label: {
+                Label("Copy Task Title", systemImage: "doc.on.doc.fill")
+            }
+            Button {
+                showReassignSheet = true
+            } label: {
+                Label("Reassign…", systemImage: "person.2")
+            }
+            Divider()
+            // Archive is first-class but NOT destructive upstream (plain
+            // archived-status PATCH), so it carries no destructive styling.
+            Button {
+                Task { await archiveTask() }
+            } label: {
+                Label("Archive", systemImage: "archivebox")
+            }
+            .disabled(currentTask.status == "archived")
+            Button(role: .destructive) {
+                showDeleteConfirmation = true
+            } label: {
+                Label("Delete…", systemImage: "trash")
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle")
+        }
+        .accessibilityLabel("Task actions")
+    }
+
+    // MARK: - Editor
+
+    private var editorSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            TextField("Title", text: $title)
+                .font(.headline)
+                .textFieldStyle(.roundedBorder)
+            TextEditor(text: $taskBody)
+                .frame(minHeight: 120)
+                .padding(4)
+                .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 12))
+            Picker("Status", selection: $status) {
+                ForEach(statusOptions) { value in
+                    Label(value.displayName, systemImage: value.systemImage)
+                        .tag(value.rawValue)
+                        .disabled(!value.isManuallySelectable)
+                }
+            }
+            .pickerStyle(.menu)
+            Button {
+                Task { await saveChanges() }
+            } label: {
+                HStack {
+                    Spacer()
+                    if isSaving { ProgressView() } else { Text("Save changes") }
+                    Spacer()
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.conduitAccent)
+            .disabled(isSaving || title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+        .padding(16)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
+    }
+
+    // MARK: - Assignment & execution
+
+    private var assignmentExecutionSection: some View {
+        ConduitSettingsSection(title: "Assignment & Execution", symbol: "person.crop.rectangle.stack", tint: .conduitAura) {
+            HStack(spacing: 8) {
+                Text("Assignee")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 8)
+                if let assignee = currentTask.assignee, !assignee.isEmpty {
+                    Text(assignee)
+                        .lineLimit(1)
+                } else {
+                    Text("Unassigned" + (currentTask.status == "ready" && hasDispatcherFallback ? " → default" : ""))
+                        .foregroundStyle(.secondary)
+                }
+                Button {
+                    showReassignSheet = true
+                } label: {
+                    Image(systemName: "arrow.triangle.2.circlepath.person")
+                }
+                .accessibilityLabel("Reassign task")
+            }
+            if let priority = currentTask.priority {
+                SettingsMetricRow(label: "Priority", value: String(priority))
+            }
+            if let workspaceKind = currentTask.workspaceKind, !workspaceKind.isEmpty,
+               let path = currentTask.workspacePath, !path.isEmpty {
+                SettingsMetricRow(label: "Workspace", value: workspaceKind + ": " + path, lineLimit: 2)
+            } else if let path = currentTask.workspacePath, !path.isEmpty {
+                SettingsMetricRow(label: "Workspace", value: path, lineLimit: 2)
+            }
+            Button {
+                modelOverrideDraft = TaskModelOverride(task: currentTask)
+                showModelSheet = true
+            } label: {
+                HStack(spacing: 8) {
+                    Text("Model")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    Spacer(minLength: 8)
+                    Text(modelOverrideDraft.label(inheritCopy: "Inherit from profile"))
+                        .foregroundStyle(hasAnyServerOverride ? Color.primary : Color.secondary)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.trailing)
+                    Image(systemName: "chevron.right")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .accessibilityHint("Edits the per-task model, provider, and reasoning override")
+            if isRunning, let pid = currentTask.workerPid {
+                SettingsMetricRow(label: "Worker PID", value: String(pid))
+            }
+            if let createdBy = currentTask.createdBy, !createdBy.isEmpty {
+                SettingsMetricRow(label: "Created by", value: createdBy, lineLimit: 1)
+            }
+            if let failures = currentTask.consecutiveFailures, failures > 0 {
+                SettingsMetricRow(label: "Consecutive failures", value: String(failures))
+            }
+            if let failure = currentTask.lastFailureError, !failure.isEmpty {
+                VStack(alignment: .leading, spacing: 5) {
+                    Text("Last failure")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    Text(failure)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+            }
+        }
+    }
+
+    private var readyUnassignedCallout: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label("Ready but unassigned", systemImage: "bolt.slash")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.orange)
+            Text("No profile is attached and Hermes has no default assignee configured, so this task will not run until someone assigns it.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            Button {
+                showReassignSheet = true
+            } label: {
+                Text("Reassign now")
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.orange.opacity(0.08), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(Color.orange.opacity(0.35), lineWidth: 1)
+        }
+    }
+
+    // MARK: - Diagnostics
+
+    @ViewBuilder
+    private var diagnosticsSection: some View {
+        if let diagnostics = currentTask.diagnostics, !diagnostics.isEmpty {
+            ConduitSettingsSection(title: "Diagnostics (\(diagnostics.count))", symbol: "stethoscope", tint: .red) {
+                ForEach(Array(diagnostics.enumerated()), id: \.offset) { _, diagnostic in
+                    diagnosticCard(diagnostic)
+                }
+            }
+        }
+    }
+
+    private func diagnosticCard(_ diagnostic: KanbanDiagnostic) -> some View {
+        let severityColor = severityTint(diagnostic.severity)
+        return VStack(alignment: .leading, spacing: 7) {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Image(systemName: severityIcon(diagnostic.severity))
+                    .foregroundStyle(severityColor)
+                Text(diagnostic.title.isEmpty ? diagnostic.kind : diagnostic.title)
+                    .font(.subheadline.weight(.semibold))
+                if diagnostic.count > 1 {
+                    Text("×\(diagnostic.count)")
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+            }
+            if !diagnostic.detail.isEmpty {
+                Text(diagnostic.detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            ForEach(Array(diagnostic.actions.filter { action in
+                action.kind == "reclaim" || action.kind == "cli_hint"
+            }.enumerated()), id: \.offset) { _, action in
+                diagnosticActionButton(action)
+            }
+        }
+        .padding(11)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(severityColor.opacity(0.07), in: RoundedRectangle(cornerRadius: 13, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 13, style: .continuous)
+                .strokeBorder(severityColor.opacity(0.3), lineWidth: 1)
+        }
+    }
+
+    /// Only the backend's OWN structured actions are executable: `reclaim`
+    /// maps to the dedicated reclaim endpoint, `cli_hint` copies its command.
+    /// Anything else renders as inert text; no recovery mutation is ever
+    /// invented from returned strings.
+    @ViewBuilder
+    private func diagnosticActionButton(_ action: KanbanDiagnosticAction) -> some View {
+        switch action.kind {
+        case "reclaim":
+            Button {
+                Task { await reclaimTask(reason: nil) }
+            } label: {
+                Label(action.label.isEmpty ? "Reclaim" : action.label, systemImage: "arrow.clockwise.circle")
+            }
+            .buttonStyle(.bordered)
+            .tint(action.suggested == true ? .conduitAccent : .secondary)
+        case "cli_hint":
+            Button {
+                let command = action.payload?["command"]?.stringValue ?? action.label
+                KanbanClipboard.copy(command, announcement: "Recovery command copied")
+            } label: {
+                Label(action.label.isEmpty ? "Copy command" : action.label, systemImage: "doc.on.doc")
+            }
+            .buttonStyle(.bordered)
+        default:
+            EmptyView()
+        }
+    }
+
+    private func severityTint(_ severity: String) -> Color {
+        switch severity.lowercased() {
+        case "critical", "error": return .red
+        case "warning": return .orange
+        default: return .secondary
+        }
+    }
+
+    private func severityIcon(_ severity: String) -> String {
+        switch severity.lowercased() {
+        case "critical": return "exclamationmark.octagon.fill"
+        case "error": return "exclamationmark.triangle.fill"
+        case "warning": return "exclamationmark.triangle"
+        default: return "info.circle"
+        }
+    }
+
+    // MARK: - Dependencies
+
+    @ViewBuilder
+    private var dependenciesSection: some View {
+        if let links = detail?.links, !links.parents.isEmpty || !links.children.isEmpty {
+            ConduitSettingsSection(title: "Dependencies", symbol: "arrow.triangle.branch", tint: .conduitAura) {
+                if !links.parents.isEmpty {
+                    dependencyGroup(title: "Blocked by", ids: links.parents)
+                }
+                if !links.children.isEmpty {
+                    dependencyGroup(title: "Blocks", ids: links.children)
+                }
+            }
+        }
+    }
+
+    private func dependencyGroup(title: String, ids: [String]) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            ForEach(ids, id: \.self) { linkedID in
+                Button {
+                    // Replace-current-detail navigation: safe on iPhone, no
+                    // recursive sheet stacks.
+                    displayedTaskID = linkedID
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: "link")
+                            .foregroundStyle(.tertiary)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(linkedTaskTitle(for: linkedID))
+                                .foregroundStyle(.primary)
+                                .lineLimit(1)
+                            HStack(spacing: 5) {
+                                Text(KanbanShortID.of(linkedID))
+                                    .font(.caption2.monospaced())
+                                    .foregroundStyle(.tertiary)
+                                if let linkedStatus = linkedTaskStatus(for: linkedID) {
+                                    Text(KanbanStatusPresentation.forStatus(linkedStatus).displayName)
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+                .accessibilityLabel("Open linked task \(linkedTaskTitle(for: linkedID))")
+            }
+        }
+    }
+
+    private func linkedTaskTitle(for id: String) -> String {
+        let title = store.board?.columns.flatMap(\.tasks).first(where: { $0.id == id })?.title
+        return title?.isEmpty == false ? title! : KanbanShortID.of(id)
+    }
+
+    private func linkedTaskStatus(for id: String) -> String? {
+        store.board?.columns.flatMap(\.tasks).first(where: { $0.id == id })?.status
+    }
+
+    // MARK: - Comments
+
+    private var commentsSection: some View {
+        ConduitSettingsSection(title: "Comments", symbol: "bubble.left.and.bubble.right", tint: .conduitAccent) {
+            if let comments = detail?.comments, !comments.isEmpty {
+                ForEach(comments) { value in
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Text(value.author).font(.caption.weight(.semibold))
+                            Spacer()
+                            Text(relativeDate(value.createdAt))
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                        }
+                        Text(value.body).font(.footnote)
+                    }
+                    .padding(.vertical, 3)
+                }
+            } else {
+                Text("No comments yet.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            TextEditor(text: $comment)
+                .frame(minHeight: 70)
+                .padding(4)
+                .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 12))
+                .accessibilityLabel("New comment")
+            if isRunning {
+                Text("Comments reach the live worker between turns as an out-of-band note.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            HStack(spacing: 10) {
+                Button {
+                    Task { await addComment() }
+                } label: {
+                    HStack {
+                        Spacer()
+                        if isAddingComment { ProgressView() } else { Label(isRunning ? "Send" : "Add comment", systemImage: "paperplane") }
+                        Spacer()
+                    }
+                }
+                .buttonStyle(.bordered)
+                .disabled(comment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isAddingComment)
+                if isRunning {
+                    // Upstream "Note & requeue": post the note, then reclaim so
+                    // the dispatcher re-runs the task with the note in context.
+                    Button {
+                        Task { await noteAndRequeue() }
+                    } label: {
+                        HStack {
+                            Spacer()
+                            if isRequeuing { ProgressView() } else { Label("Note & requeue", systemImage: "arrow.uturn.backward.circle") }
+                            Spacer()
+                        }
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.orange)
+                    .disabled(comment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isRequeuing)
+                }
+            }
+        }
+    }
+
+    // MARK: - Activity
+
+    @ViewBuilder
+    private var activitySection: some View {
+        if let events = detail?.events, !events.isEmpty {
+            ConduitSettingsSection(title: "Activity (\(events.count))", symbol: "clock.arrow.circlepath", tint: .conduitAccent) {
+                ForEach(events.prefix(60)) { event in
+                    let row = KanbanActivityFormatter.row(for: event)
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Circle()
+                            .fill(Color.conduitAccent.opacity(0.55))
+                            .frame(width: 6, height: 6)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(row.label)
+                                .font(.caption.weight(.medium))
+                            if let extra = row.detail, !extra.isEmpty {
+                                Text(extra)
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(2)
+                            }
+                        }
+                        Spacer(minLength: 0)
+                        Text(relativeDate(event.createdAt))
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+                if events.count > 60 {
+                    Text("\(events.count - 60) earlier events hidden")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Runs
+
+    @ViewBuilder
+    private var runsSection: some View {
+        if let runs = detail?.runs, !runs.isEmpty {
+            ConduitSettingsSection(title: "Runs (\(runs.count))", symbol: "terminal", tint: .orange) {
+                ForEach(runs) { run in
+                    runRow(run)
+                }
+            }
+        }
+    }
+
+    private func runRow(_ run: KanbanRun) -> some View {
+        let failed = KanbanRunPresentation.isFailed(run)
+        return VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Image(systemName: failed ? "xmark.octagon.fill" : (run.outcome == "completed" || run.status == "completed" ? "checkmark.circle.fill" : "circle.dotted"))
+                    .foregroundStyle(failed ? Color.red : (run.outcome == "completed" || run.status == "completed" ? Color.green : Color.secondary))
+                Text(KanbanRunPresentation.outcomeLabel(run))
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(failed ? Color.red : Color.primary)
+                if let stepKey = run.stepKey, !stepKey.isEmpty {
+                    Text(stepKey)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 0)
+                if let duration = KanbanRunPresentation.durationText(start: run.startedAt, end: run.endedAt) {
+                    Text(duration)
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+            }
+            HStack(spacing: 8) {
+                if let profile = run.profile, !profile.isEmpty {
+                    Label(profile, systemImage: "person")
+                        .lineLimit(1)
+                }
+                if let pid = run.workerPID {
+                    Text("pid \(pid)")
+                        .monospacedDigit()
+                }
+                Spacer(minLength: 0)
+                Text(relativeDate(run.endedAt ?? run.startedAt))
+                    .foregroundStyle(.tertiary)
+            }
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            if let error = run.error, !error.isEmpty {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .lineLimit(4)
+            } else if let summary = run.summary, !summary.isEmpty {
+                Text(summary)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(4)
+            }
+        }
+        .padding(.vertical, 3)
+    }
+
+    // MARK: - Worker log
+
+    private var workerLogLink: some View {
+        NavigationLink {
+            KanbanWorkerLogScreen(taskID: displayedTaskID)
+                .environmentObject(store)
+        } label: {
+            HStack {
+                Label("Worker Log", systemImage: "doc.text.magnifyingglass")
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .buttonStyle(.plain)
+        .padding(16)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
+    }
+
+    // MARK: - Data
+
+    private func loadDetail(force: Bool = false) async {
+        // A poll never runs underneath an active save/comment write.
+        guard force || (!isSaving && !isAddingComment && !isRequeuing), !isLoadingDetail else { return }
+        isLoadingDetail = true
+        defer { isLoadingDetail = false }
+        do {
+            let loaded = try await store.fetchTaskDetail(id: displayedTaskID)
+            guard loaded.task.id == displayedTaskID || loaded.task.id.isEmpty else {
+                // A stale completion for the PREVIOUS displayed task must be
+                // discarded, not rendered under the new one.
+                return
+            }
+            let server = loaded.task
+            if hasUnsavedChanges {
+                // Preserve the user's draft. Flag external edits to the same
+                // fields so the conflict is visible without destroying input.
+                let serverMoved = KanbanDetailDraftPolicy.serverMovedIndependently(
+                    serverTitle: server.title,
+                    serverBodyText: server.body ?? "",
+                    serverStatus: server.status,
+                    baselineTitle: baseline.title,
+                    baselineBodyText: baseline.bodyText,
+                    baselineStatus: baseline.status
+                )
+                if serverMoved && remoteChangeNotice == nil {
+                    remoteChangeNotice = "This task changed on the server. Your unsaved edits are preserved."
+                }
+            } else {
+                title = server.title
+                taskBody = server.body ?? ""
+                status = server.status
+                baseline = ServerBaseline(title: server.title, bodyText: server.body ?? "", status: server.status)
+                remoteChangeNotice = nil
+            }
+            detail = loaded
+            refreshErrorMessage = nil
+        } catch {
+            if detail == nil {
+                errorMessage = error.localizedDescription
+            } else {
+                refreshErrorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    // MARK: - Mutations
+
+    private func saveChanges() async {
+        let current = currentTask
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        var patch = KanbanTaskPatch()
+        // Diffs run against the last-synced baseline, not the live server
+        // snapshot, so an external edit cannot silently drop a user field.
+        if trimmedTitle != baseline.title { patch.title = trimmedTitle }
+        if taskBody != baseline.bodyText { patch.body = taskBody }
+        if status != baseline.status {
+            guard KanbanStatusPresentation.canSelectManually(status) else {
+                errorMessage = KanbanServiceError.invalidManualStatus(status).localizedDescription
+                return
+            }
+            patch.status = status
+        }
+        guard !patch.isEmpty else { return }
+        isSaving = true
+        errorMessage = nil
+        defer { isSaving = false }
+        do {
+            let saved = try await store.updateTask(id: current.id, patch: patch)
+            let savedServer = saved ?? currentTask
+            title = savedServer.title
+            taskBody = savedServer.body ?? taskBody
+            status = savedServer.status
+            baseline = ServerBaseline(title: savedServer.title, bodyText: savedServer.body ?? taskBody, status: savedServer.status)
+            remoteChangeNotice = nil
+            await loadDetail(force: true)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    /// Committed immediately on change (desktop parity): PATCH with explicit
+    /// clear flags computed against the CURRENT server snapshot.
+    private func commitModelOverride(_ next: TaskModelOverride) async {
+        let patch = TaskModelOverride.patch(from: currentTask, to: next)
+        guard !patch.isEmpty else { return }
+        isSaving = true
+        defer { isSaving = false }
+        do {
+            _ = try await store.updateTask(id: currentTask.id, patch: patch)
+            await loadDetail(force: true)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func archiveTask() async {
+        guard currentTask.status != "archived" else { return }
+        do {
+            _ = try await store.updateTask(id: currentTask.id, patch: KanbanTaskPatch(status: "archived"))
+            await loadDetail(force: true)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func addComment() async {
+        let text = comment.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        isAddingComment = true
+        errorMessage = nil
+        defer { isAddingComment = false }
+        do {
+            try await store.addComment(taskID: displayedTaskID, body: text)
+            comment = ""
+            await loadDetail(force: true)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    /// Note & requeue: two supported mutations composed exactly like the
+    /// desktop drawer (comment first, then reclaim).
+    private func noteAndRequeue() async {
+        let text = comment.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        isRequeuing = true
+        errorMessage = nil
+        defer { isRequeuing = false }
+        do {
+            try await store.addComment(taskID: displayedTaskID, body: text)
+            try await store.reclaimTask(taskID: displayedTaskID)
+            comment = ""
+            await loadDetail(force: true)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func reclaimTask(reason: String?) async {
+        do {
+            try await store.reclaimTask(taskID: displayedTaskID, reason: reason)
+            await loadDetail(force: true)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func deleteTask() async {
+        do {
+            try await store.deleteTask(id: currentTask.id)
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func relativeDate(_ epoch: Int?) -> String {
+        guard let epoch else { return "" }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: Date(timeIntervalSince1970: Double(epoch)), relativeTo: Date())
+    }
+}
+
+// MARK: - Reassign sheet
+
+/// Dedicated reassignment surface backed by POST /tasks/{id}/reassign with
+/// reclaim_first=true (upstream drawer behavior): switching profiles releases
+/// a running worker claim first and resets the failure streak.
+struct KanbanReassignSheet: View {
+    @EnvironmentObject private var store: KanbanStore
+    @Environment(\.dismiss) private var dismiss
+    let taskID: String
+    let currentAssignee: String?
+
+    @State private var pendingProfile: String?
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Profiles") {
+                    ForEach(store.profiles) { profile in
+                        Button {
+                            Task { await reassign(to: profile.name) }
+                        } label: {
+                            HStack {
+                                Text(profile.name)
+                                Spacer()
+                                if profile.name == currentAssignee {
+                                    Image(systemName: "checkmark")
+                                        .foregroundStyle(.conduitAccent)
+                                }
+                                if pendingProfile == profile.name {
+                                    ProgressView()
+                                }
+                            }
+                        }
+                        .disabled(pendingProfile != nil)
+                    }
+                }
+                if (currentAssignee ?? "").isEmpty == false {
+                    Section {
+                        Button(role: .destructive) {
+                            Task { await reassign(to: nil) }
+                        } label: {
+                            HStack {
+                                Text("Unassign (parked — won't run)")
+                                if pendingProfile == "__unassign__" { ProgressView() }
+                            }
+                        }
+                        .disabled(pendingProfile != nil)
+                    }
+                }
+                if let errorMessage {
+                    Section {
+                        Text(errorMessage).foregroundStyle(.red).font(.footnote)
+                    }
+                }
+            }
+            .navigationTitle("Reassign")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+        .interactiveDismissDisabled(pendingProfile != nil)
+    }
+
+    private func reassign(to profile: String?) async {
+        pendingProfile = profile ?? "__unassign__"
+        errorMessage = nil
+        defer { pendingProfile = nil }
+        do {
+            // The dedicated reassignment endpoint (reclaim-first, upstream).
+            try await store.reassignTask(taskID: taskID, profile: profile, reclaimFirst: true)
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/Conduit/Views/Kanban/KanbanTaskDetailView.swift
+++ b/Conduit/Views/Kanban/KanbanTaskDetailView.swift
@@ -63,12 +63,31 @@ struct KanbanTaskDetailView: View {
         _baseline = State(initialValue: ServerBaseline(title: task.title, bodyText: task.body ?? "", status: task.status))
     }
 
-    private var currentTask: KanbanTask {
-        detail?.task ?? initialTask
+    /// The actionable task for the CURRENT displayed identity — the only
+    /// object any task-specific render or mutation may go through — or nil
+    /// while that identity's detail is loading / failed to load.
+    ///
+    /// INVARIANT: whenever non-nil, displayedTask.id == displayedTaskID.
+    /// The opening task is a legal actionable task ONLY while the screen
+    /// still displays the identity it opened with: after a dependency tap
+    /// swaps the identity, a slow or failed replacement load must NEVER fall
+    /// back to the previous task's data.
+    private var displayedTask: KanbanTask? {
+        KanbanDetailIdentityPolicy.actionableTask(
+            displayedID: displayedTaskID,
+            detailTask: detail?.task,
+            initialTask: initialTask
+        )
+    }
+
+    /// True once the displayed identity has an actionable task (loaded
+    /// detail, or the still-current opening task).
+    private var isDisplayedTaskLoaded: Bool {
+        displayedTask != nil
     }
 
     private var isRunning: Bool {
-        currentTask.status == "running"
+        displayedTask?.status == "running"
     }
 
     private var hasUnsavedChanges: Bool {
@@ -98,40 +117,55 @@ struct KanbanTaskDetailView: View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 14) {
-                    editorSection
-                    assignmentExecutionSection
-                    if currentTask.status == "ready", (currentTask.assignee ?? "").isEmpty, !hasDispatcherFallback {
-                        readyUnassignedCallout
-                    }
-                    diagnosticsSection
-                    dependenciesSection
-                    commentsSection
-                    activitySection
-                    runsSection
-                    workerLogLink
-                    if let remoteChangeNotice {
-                        Text(remoteChangeNotice)
-                            .font(.footnote)
-                            .foregroundStyle(.orange)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    if hasUnsavedChanges {
-                        Text("Unsaved edits")
-                            .font(.caption2.weight(.semibold))
-                            .foregroundStyle(.secondary)
-                            .frame(maxWidth: .infinity, alignment: .trailing)
-                    }
-                    if let refreshErrorMessage {
-                        Text("Refresh failed: \(refreshErrorMessage)")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    if let errorMessage {
-                        Text(errorMessage)
-                            .font(.footnote)
-                            .foregroundStyle(.red)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                    // Identity gate: while the displayed identity has no
+                    // actionable task (a replacement detail is loading or
+                    // failed), NO task-specific content renders or acts — the
+                    // task this screen opened with must not leak through as
+                    // the displayed task's data.
+                    if let currentTask = displayedTask {
+                        editorSection
+                        assignmentExecutionSection
+                        if currentTask.status == "ready", (currentTask.assignee ?? "").isEmpty, !hasDispatcherFallback {
+                            readyUnassignedCallout
+                        }
+                        diagnosticsSection
+                        dependenciesSection
+                        commentsSection
+                        activitySection
+                        runsSection
+                        workerLogLink
+                        if let remoteChangeNotice {
+                            Text(remoteChangeNotice)
+                                .font(.footnote)
+                                .foregroundStyle(.orange)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        if hasUnsavedChanges {
+                            Text("Unsaved edits")
+                                .font(.caption2.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity, alignment: .trailing)
+                        }
+                        if let refreshErrorMessage {
+                            Text("Refresh failed: \(refreshErrorMessage)")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        if let errorMessage {
+                            Text(errorMessage)
+                                .font(.footnote)
+                                .foregroundStyle(.red)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    } else if let errorMessage {
+                        // The displayed identity's detail failed to load. The
+                        // screen stays on THIS identity (the poll loop keeps
+                        // retrying it); the task that opened the screen is
+                        // never resurrected as actionable content.
+                        loadFailureView(errorMessage)
+                    } else {
+                        replacementLoadingView
                     }
                 }
                 .padding(16)
@@ -170,6 +204,21 @@ struct KanbanTaskDetailView: View {
                 detail = nil
                 isLoadingDetail = false
                 isSaving = false
+                // Comment-flow spinners are released ONLY through
+                // identity-guarded defers, and a stale completion must skip
+                // that release — so the swap itself clears the flags (and
+                // the unsent draft) the departing identity owned. Otherwise
+                // the new identity's Add-comment button and its poll guard
+                // stay frozen forever, and A's unsent text could post to B.
+                isAddingComment = false
+                isRequeuing = false
+                comment = ""
+                // No sheet/alert may stay armed over the replacement
+                // identity: a presented editor or confirmation belongs to
+                // the departed task and must never act on the new one.
+                showReassignSheet = false
+                showModelSheet = false
+                showDeleteConfirmation = false
                 title = ""
                 taskBody = ""
                 status = "todo"
@@ -180,7 +229,7 @@ struct KanbanTaskDetailView: View {
                 modelOverrideDraft = TaskModelOverride()
             }
             .sheet(isPresented: $showReassignSheet) {
-                KanbanReassignSheet(taskID: displayedTaskID, currentAssignee: currentTask.assignee)
+                KanbanReassignSheet(taskID: displayedTaskID, currentAssignee: displayedTask?.assignee)
                     .environmentObject(store)
                     .presentationDetents([.medium])
             }
@@ -196,9 +245,9 @@ struct KanbanTaskDetailView: View {
                     // server snapshot so a poll landing mid-edit can neither
                     // clobber the user nor duplicate the write.
                     let next = modelOverrideDraft
-                    if next != TaskModelOverride(task: currentTask) {
-                        Task { await commitModelOverride(next) }
-                    }
+                    guard let serverTask = displayedTask,
+                          next != TaskModelOverride(task: serverTask) else { return }
+                    Task { await commitModelOverride(next) }
                 }
             }
             .alert("Delete this task?", isPresented: $showDeleteConfirmation) {
@@ -211,9 +260,10 @@ struct KanbanTaskDetailView: View {
     }
 
     private var hasAnyServerOverride: Bool {
-        !(currentTask.modelOverride ?? "").isEmpty
-            || !(currentTask.providerOverride ?? "").isEmpty
-            || !(currentTask.reasoningEffort ?? "").isEmpty
+        guard let task = displayedTask else { return false }
+        return !(task.modelOverride ?? "").isEmpty
+            || !(task.providerOverride ?? "").isEmpty
+            || !(task.reasoningEffort ?? "").isEmpty
     }
 
     // MARK: - Actions menu
@@ -221,20 +271,27 @@ struct KanbanTaskDetailView: View {
     private var actionsMenu: some View {
         Menu {
             Button {
-                KanbanClipboard.copy(currentTask.id, announcement: "Task ID copied")
+                if let task = displayedTask {
+                    KanbanClipboard.copy(task.id, announcement: "Task ID copied")
+                }
             } label: {
                 Label("Copy Task ID", systemImage: "doc.on.doc")
             }
+            .disabled(!isDisplayedTaskLoaded)
             Button {
-                KanbanClipboard.copy(currentTask.title.isEmpty ? currentTask.id : currentTask.title, announcement: "Title copied")
+                if let task = displayedTask {
+                    KanbanClipboard.copy(task.title.isEmpty ? task.id : task.title, announcement: "Title copied")
+                }
             } label: {
                 Label("Copy Task Title", systemImage: "doc.on.doc.fill")
             }
+            .disabled(!isDisplayedTaskLoaded)
             Button {
                 showReassignSheet = true
             } label: {
                 Label("Reassign…", systemImage: "person.2")
             }
+            .disabled(!isDisplayedTaskLoaded)
             Divider()
             // Archive is first-class but NOT destructive upstream (plain
             // archived-status PATCH), so it carries no destructive styling.
@@ -243,12 +300,13 @@ struct KanbanTaskDetailView: View {
             } label: {
                 Label("Archive", systemImage: "archivebox")
             }
-            .disabled(currentTask.status == "archived")
+            .disabled(!isDisplayedTaskLoaded || displayedTask?.status == "archived")
             Button(role: .destructive) {
                 showDeleteConfirmation = true
             } label: {
                 Label("Delete…", systemImage: "trash")
             }
+            .disabled(!isDisplayedTaskLoaded)
         } label: {
             Image(systemName: "ellipsis.circle")
         }
@@ -300,11 +358,11 @@ struct KanbanTaskDetailView: View {
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
                 Spacer(minLength: 8)
-                if let assignee = currentTask.assignee, !assignee.isEmpty {
+                if let assignee = displayedTask?.assignee, !assignee.isEmpty {
                     Text(assignee)
                         .lineLimit(1)
                 } else {
-                    Text("Unassigned" + (currentTask.status == "ready" && hasDispatcherFallback ? " → default" : ""))
+                    Text("Unassigned" + (displayedTask?.status == "ready" && hasDispatcherFallback ? " → default" : ""))
                         .foregroundStyle(.secondary)
                 }
                 Button {
@@ -314,17 +372,22 @@ struct KanbanTaskDetailView: View {
                 }
                 .accessibilityLabel("Reassign task")
             }
-            if let priority = currentTask.priority {
+            if let priority = displayedTask?.priority {
                 SettingsMetricRow(label: "Priority", value: String(priority))
             }
-            if let workspaceKind = currentTask.workspaceKind, !workspaceKind.isEmpty,
-               let path = currentTask.workspacePath, !path.isEmpty {
+            if let workspaceKind = displayedTask?.workspaceKind, !workspaceKind.isEmpty,
+               let path = displayedTask?.workspacePath, !path.isEmpty {
                 SettingsMetricRow(label: "Workspace", value: workspaceKind + ": " + path, lineLimit: 2)
-            } else if let path = currentTask.workspacePath, !path.isEmpty {
+            } else if let path = displayedTask?.workspacePath, !path.isEmpty {
                 SettingsMetricRow(label: "Workspace", value: path, lineLimit: 2)
             }
             Button {
-                modelOverrideDraft = TaskModelOverride(task: currentTask)
+                // Seed the EDITOR draft from the current displayed SERVER task
+                // the moment the sheet opens. While the sheet is closed the
+                // row below renders the server value directly, so a poll that
+                // changes the override updates the row — and an open editor
+                // draft is never clobbered by polling.
+                modelOverrideDraft = KanbanModelOverrideDisplayPolicy.override(for: displayedTask)
                 showModelSheet = true
             } label: {
                 HStack(spacing: 8) {
@@ -332,7 +395,9 @@ struct KanbanTaskDetailView: View {
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(.secondary)
                     Spacer(minLength: 8)
-                    Text(modelOverrideDraft.label(inheritCopy: "Inherit from profile"))
+                    // Display-only: derived from the loaded server task,
+                    // never from the editor draft.
+                    Text(KanbanModelOverrideDisplayPolicy.label(for: displayedTask, inheritCopy: "Inherit from profile"))
                         .foregroundStyle(hasAnyServerOverride ? Color.primary : Color.secondary)
                         .lineLimit(2)
                         .multilineTextAlignment(.trailing)
@@ -342,16 +407,16 @@ struct KanbanTaskDetailView: View {
                 }
             }
             .accessibilityHint("Edits the per-task model, provider, and reasoning override")
-            if isRunning, let pid = currentTask.workerPid {
+            if isRunning, let pid = displayedTask?.workerPid {
                 SettingsMetricRow(label: "Worker PID", value: String(pid))
             }
-            if let createdBy = currentTask.createdBy, !createdBy.isEmpty {
+            if let createdBy = displayedTask?.createdBy, !createdBy.isEmpty {
                 SettingsMetricRow(label: "Created by", value: createdBy, lineLimit: 1)
             }
-            if let failures = currentTask.consecutiveFailures, failures > 0 {
+            if let failures = displayedTask?.consecutiveFailures, failures > 0 {
                 SettingsMetricRow(label: "Consecutive failures", value: String(failures))
             }
-            if let failure = currentTask.lastFailureError, !failure.isEmpty {
+            if let failure = displayedTask?.lastFailureError, !failure.isEmpty {
                 VStack(alignment: .leading, spacing: 5) {
                     Text("Last failure")
                         .font(.caption.weight(.semibold))
@@ -392,7 +457,7 @@ struct KanbanTaskDetailView: View {
 
     @ViewBuilder
     private var diagnosticsSection: some View {
-        if let diagnostics = currentTask.diagnostics, !diagnostics.isEmpty {
+        if let diagnostics = displayedTask?.diagnostics, !diagnostics.isEmpty {
             ConduitSettingsSection(title: "Diagnostics (\(diagnostics.count))", symbol: "stethoscope", tint: .red) {
                 ForEach(Array(diagnostics.enumerated()), id: \.offset) { _, diagnostic in
                     diagnosticCard(diagnostic)
@@ -750,8 +815,17 @@ struct KanbanTaskDetailView: View {
         do {
             let loaded = try await store.fetchTaskDetail(id: expectedID)
             guard displayedTaskID == expectedID else { return }
-            guard loaded.task.id == expectedID || loaded.task.id.isEmpty else {
+            guard loaded.task.id == expectedID else {
                 // Defensive double-check against a server-side id mismatch.
+                // An EMPTY-id payload under a NON-empty displayed identity is
+                // a server contract violation: the identity policy correctly
+                // refuses to make it actionable, so surface it as THIS
+                // identity's load failure (failure view + poll retry) rather
+                // than letting the screen spin forever. The empty/empty
+                // same-identity case flows through the equality branch above.
+                if loaded.task.id.isEmpty, !expectedID.isEmpty {
+                    errorMessage = KanbanServiceError.invalidResponse("Task detail returned an invalid id.").localizedDescription
+                }
                 return
             }
             let server = loaded.task
@@ -776,6 +850,14 @@ struct KanbanTaskDetailView: View {
                 baseline = ServerBaseline(title: server.title, bodyText: server.body ?? "", status: server.status)
                 remoteChangeNotice = nil
             }
+            // Recovery from a load-failure state: a successful load for the
+            // displayed identity clears the load-failure error so content
+            // renders clean. Conditioned on the identity having NO
+            // actionable task: on the opening identity (actionable through
+            // initialTask while detail is nil) a mutation error raised in
+            // that window keeps its existing persistence semantics instead
+            // of being wiped by this poll.
+            if displayedTask == nil { errorMessage = nil }
             detail = loaded
             refreshErrorMessage = nil
         } catch is CancellationError {
@@ -795,7 +877,10 @@ struct KanbanTaskDetailView: View {
     // MARK: - Mutations
 
     private func saveChanges() async {
-        let current = currentTask
+        // Freeze the actionable task AND its identity before the first
+        // suspension point: this save may only ever touch this task's UI.
+        guard let startedTask = displayedTask else { return }
+        let expectedID = displayedTaskID
         let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
         var patch = KanbanTaskPatch()
         // Diffs run against the last-synced baseline, not the live server
@@ -812,10 +897,23 @@ struct KanbanTaskDetailView: View {
         guard !patch.isEmpty else { return }
         isSaving = true
         errorMessage = nil
-        defer { isSaving = false }
+        // A stale completion must not clear a saving spinner that now belongs
+        // to the displayed task's own operations.
+        defer {
+            if KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) {
+                isSaving = false
+            }
+        }
         do {
-            let saved = try await store.updateTask(id: current.id, patch: patch)
-            let savedServer = saved ?? currentTask
+            let saved = try await store.updateTask(id: startedTask.id, patch: patch)
+            let completion = KanbanDetailMutationPolicy.saveCompletion(
+                startedTask: startedTask,
+                response: saved,
+                displayedTaskID: displayedTaskID
+            )
+            // After a dependency tap the completion is UI-inert: no draft,
+            // baseline, error, or refresh for the task now displayed.
+            guard completion.isActive, let savedServer = completion.serverTask else { return }
             title = savedServer.title
             taskBody = savedServer.body ?? taskBody
             status = savedServer.status
@@ -823,6 +921,7 @@ struct KanbanTaskDetailView: View {
             remoteChangeNotice = nil
             await loadDetail(force: true)
         } catch {
+            guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
             errorMessage = error.localizedDescription
         }
     }
@@ -830,24 +929,35 @@ struct KanbanTaskDetailView: View {
     /// Committed immediately on change (desktop parity): PATCH with explicit
     /// clear flags computed against the CURRENT server snapshot.
     private func commitModelOverride(_ next: TaskModelOverride) async {
-        let patch = TaskModelOverride.patch(from: currentTask, to: next)
+        guard let startedTask = displayedTask else { return }
+        let expectedID = displayedTaskID
+        let patch = TaskModelOverride.patch(from: startedTask, to: next)
         guard !patch.isEmpty else { return }
         isSaving = true
-        defer { isSaving = false }
+        defer {
+            if KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) {
+                isSaving = false
+            }
+        }
         do {
-            _ = try await store.updateTask(id: currentTask.id, patch: patch)
+            _ = try await store.updateTask(id: startedTask.id, patch: patch)
+            guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
             await loadDetail(force: true)
         } catch {
+            guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
             errorMessage = error.localizedDescription
         }
     }
 
     private func archiveTask() async {
-        guard currentTask.status != "archived" else { return }
+        guard let startedTask = displayedTask, startedTask.status != "archived" else { return }
+        let expectedID = displayedTaskID
         do {
-            _ = try await store.updateTask(id: currentTask.id, patch: KanbanTaskPatch(status: "archived"))
+            _ = try await store.updateTask(id: startedTask.id, patch: KanbanTaskPatch(status: "archived"))
+            guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
             await loadDetail(force: true)
         } catch {
+            guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
             errorMessage = error.localizedDescription
         }
     }
@@ -855,52 +965,122 @@ struct KanbanTaskDetailView: View {
     private func addComment() async {
         let text = comment.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return }
+        let expectedID = displayedTaskID
         isAddingComment = true
         errorMessage = nil
-        defer { isAddingComment = false }
+        defer {
+            if KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) {
+                isAddingComment = false
+            }
+        }
         do {
-            try await store.addComment(taskID: displayedTaskID, body: text)
+            try await store.addComment(taskID: expectedID, body: text)
+            guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
             comment = ""
             await loadDetail(force: true)
         } catch {
+            guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
             errorMessage = error.localizedDescription
         }
     }
 
     /// Note & requeue: two supported mutations composed exactly like the
-    /// desktop drawer (comment first, then reclaim).
+    /// desktop drawer (comment first, then reclaim) — but with OBSERVABLE
+    /// partial success: the draft is consumed the moment the note reaches the
+    /// server, and a reclaim failure afterwards is reported as partial
+    /// success without ever reposting the note.
     private func noteAndRequeue() async {
         let text = comment.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return }
+        let expectedID = displayedTaskID
         isRequeuing = true
         errorMessage = nil
-        defer { isRequeuing = false }
-        do {
-            try await store.addComment(taskID: displayedTaskID, body: text)
-            try await store.reclaimTask(taskID: displayedTaskID)
-            comment = ""
-            await loadDetail(force: true)
-        } catch {
-            errorMessage = error.localizedDescription
+        defer {
+            if KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) {
+                isRequeuing = false
+            }
         }
+        let outcome = await KanbanNoteAndRequeueFlow.perform(
+            text: text,
+            postComment: { body in try await store.addComment(taskID: expectedID, body: body) },
+            reclaim: { try await store.reclaimTask(taskID: expectedID) },
+            onCommentPosted: {
+                // Consume the draft immediately: the note already exists on
+                // the server, so a retry after a reclaim failure must never
+                // post it a second time.
+                if KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) {
+                    comment = ""
+                }
+            }
+        )
+        guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
+        if let message = KanbanNoteAndRequeueFlow.message(for: outcome) {
+            errorMessage = message
+            return
+        }
+        await loadDetail(force: true)
     }
 
     private func reclaimTask(reason: String?) async {
+        let expectedID = displayedTaskID
         do {
-            try await store.reclaimTask(taskID: displayedTaskID, reason: reason)
+            try await store.reclaimTask(taskID: expectedID, reason: reason)
+            guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
             await loadDetail(force: true)
         } catch {
+            guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
             errorMessage = error.localizedDescription
         }
     }
 
     private func deleteTask() async {
+        guard let startedTask = displayedTask else { return }
+        let expectedID = displayedTaskID
         do {
-            try await store.deleteTask(id: currentTask.id)
+            try await store.deleteTask(id: startedTask.id)
+            // A delete started for another identity must NEVER dismiss the
+            // screen while it displays this task.
+            guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
             dismiss()
         } catch {
+            guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
             errorMessage = error.localizedDescription
         }
+    }
+
+    // MARK: - Replacement identity states
+
+    /// The displayed identity's detail is loading: nothing task-specific may
+    /// render or act — in particular, the task the screen opened with must
+    /// not leak through as this screen's content.
+    private var replacementLoadingView: some View {
+        VStack(spacing: 10) {
+            ProgressView()
+            Text("Loading task…")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 60)
+    }
+
+    /// The displayed identity's detail failed to load: the failure belongs to
+    /// THIS identity and the screen stays on it (the poll loop keeps
+    /// retrying); the previous task is never resurrected as content.
+    private func loadFailureView(_ message: String) -> some View {
+        VStack(spacing: 10) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.title2)
+                .foregroundStyle(.orange)
+            Text("Couldn't load this task")
+                .font(.subheadline.weight(.semibold))
+            Text(message)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 60)
     }
 
     private func relativeDate(_ epoch: Int?) -> String {
@@ -908,6 +1088,144 @@ struct KanbanTaskDetailView: View {
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .abbreviated
         return formatter.localizedString(for: Date(timeIntervalSince1970: Double(epoch)), relativeTo: Date())
+    }
+}
+
+// MARK: - Detail identity & mutation ownership policies
+
+/// Identity resolution for the task detail screen (Kanban V2 correctness).
+///
+/// A task detail screen may only display or mutate data belonging to its
+/// current displayed identity. The opening task is a legal actionable task
+/// ONLY while the displayed identity is still that task: once a dependency
+/// tap swaps the identity, a loading or failed replacement load must NEVER
+/// fall back to the previous task's data.
+enum KanbanDetailIdentityPolicy {
+    /// The actionable task for `displayedID`, or nil while that identity is
+    /// not loaded. STRICT invariant: result.id == displayedID whenever
+    /// non-nil. A detail task whose id does not equal the displayed id —
+    /// including a server task with an EMPTY id under a non-empty displayed
+    /// id — is never actionable: the mutation policies gate on
+    /// startedTask.id == displayedTaskID, so honoring such a task would aim
+    /// PATCH/DELETE at an empty task id and make its own saves silently
+    /// inert. The mismatched case renders the loading/failed state and the
+    /// poll keeps retrying the displayed identity.
+    static func actionableTask(displayedID: String, detailTask: KanbanTask?, initialTask: KanbanTask) -> KanbanTask? {
+        if let detailTask, detailTask.id == displayedID {
+            return detailTask
+        }
+        // The opening task may act ONLY for its own identity: after a
+        // dependency tap to another id there is deliberately NO fallback.
+        return displayedID == initialTask.id ? initialTask : nil
+    }
+}
+
+/// Async-ownership rules for task-detail mutations (Kanban V2 correctness).
+///
+/// Every task-specific async operation captures its identity before its
+/// first suspension point. After every await, the completion may touch
+/// detail UI state ONLY while the identity it started for is still the
+/// displayed one — otherwise it is UI-inert: the server write may still
+/// finish, but it must not overwrite the displayed task's draft/baseline,
+/// surface the old task's error, dismiss the screen, or trigger a refresh
+/// for the displayed task.
+enum KanbanDetailMutationPolicy {
+    static func completionIsActive(startedTaskID: String, displayedTaskID: String) -> Bool {
+        startedTaskID == displayedTaskID
+    }
+
+    struct SaveCompletion: Equatable {
+        /// False → the whole completion is inert: no draft, baseline, error,
+        /// or refresh changes are permitted.
+        let isActive: Bool
+        /// The task whose values seed the draft/baseline when active — ALWAYS
+        /// the task that started the save (or its server response), never
+        /// whatever task is displayed when the response lands.
+        let serverTask: KanbanTask?
+    }
+
+    static func saveCompletion(startedTask: KanbanTask, response: KanbanTask?, displayedTaskID: String) -> SaveCompletion {
+        guard completionIsActive(startedTaskID: startedTask.id, displayedTaskID: displayedTaskID) else {
+            return SaveCompletion(isActive: false, serverTask: nil)
+        }
+        // A response that does not echo the STARTED task's id is a server
+        // contract violation: never let it seed the started task's baseline.
+        // An empty-id response is honored only for the empty/empty identity
+        // case, mirroring the load path's acceptance rule; the forced reload
+        // afterwards re-syncs from the authoritative task.
+        let trusted = response.flatMap { $0.id == startedTask.id || ($0.id.isEmpty && startedTask.id.isEmpty) ? $0 : nil } ?? startedTask
+        return SaveCompletion(isActive: true, serverTask: trusted)
+    }
+}
+
+/// Model-row display rules (Kanban V2 correctness).
+///
+/// The NON-EDITING row derives from the current loaded SERVER task, so an
+/// existing override is visible immediately (without opening the editor) and
+/// a poll that changes the override updates the row. `modelOverrideDraft` is
+/// the ACTIVE EDITOR draft only: it exists solely while the sheet is open
+/// and is never a display source (polling can never clobber it).
+enum KanbanModelOverrideDisplayPolicy {
+    /// The server override to show (and to seed the editor with) for the
+    /// displayed task; inherit/empty while none or not yet loaded.
+    static func override(for displayedTask: KanbanTask?) -> TaskModelOverride {
+        displayedTask.map { TaskModelOverride(task: $0) } ?? TaskModelOverride()
+    }
+
+    /// The visible Model-row label.
+    static func label(for displayedTask: KanbanTask?, inheritCopy: String) -> String {
+        override(for: displayedTask).label(inheritCopy: inheritCopy)
+    }
+}
+
+/// Note & requeue as an explicit two-step operation with OBSERVABLE partial
+/// success (Kanban V2 correctness): the comment draft is consumed the moment
+/// the note reaches the server, and a later reclaim failure is reported as
+/// partial success — a retry can never repost the note.
+enum KanbanNoteAndRequeueFlow {
+    struct Outcome: Equatable {
+        /// The note reached the server — the input MUST be consumed now,
+        /// whatever happens to the reclaim step.
+        let commentPosted: Bool
+        /// Full success: note posted AND task requeued.
+        let requeued: Bool
+        /// Underlying failure detail when the flow did not fully succeed.
+        let failureDetail: String?
+    }
+
+    static func perform(
+        text: String,
+        postComment: @MainActor (String) async throws -> Void,
+        reclaim: @MainActor () async throws -> Void,
+        onCommentPosted: @MainActor () -> Void
+    ) async -> Outcome {
+        do {
+            try await postComment(text)
+        } catch {
+            return Outcome(commentPosted: false, requeued: false, failureDetail: error.localizedDescription)
+        }
+        // The note now exists on the server: consume the draft BEFORE the
+        // reclaim attempt so a reclaim failure can never double-post it.
+        await onCommentPosted()
+        do {
+            try await reclaim()
+        } catch {
+            return Outcome(commentPosted: true, requeued: false, failureDetail: error.localizedDescription)
+        }
+        return Outcome(commentPosted: true, requeued: true, failureDetail: nil)
+    }
+
+    /// User-facing wording. A posted note + failed reclaim is PARTIAL success
+    /// and must be described as such — the note is already on the server.
+    static func message(for outcome: Outcome) -> String? {
+        switch (outcome.commentPosted, outcome.requeued, outcome.failureDetail) {
+        case (false, _, let detail?):
+            return detail
+        case (true, false, let detail?):
+            return "The note was posted, but the task could not be requeued. (\(detail))"
+        default:
+            return nil
+        }
     }
 }
 

--- a/Conduit/Views/Kanban/KanbanTaskDetailView.swift
+++ b/Conduit/Views/Kanban/KanbanTaskDetailView.swift
@@ -250,27 +250,31 @@ struct KanbanTaskDetailView: View {
             .onChange(of: showModelSheet) { wasOpen, nowOpen in
                 guard !nowOpen, wasOpen else { return }
                 defer { modelOverrideSession = nil }
-                // Two conceptually separate comparisons (V2 correctness):
-                //   draft vs sheet-open baseline  -> did the user edit anything?
-                //   draft vs current server value -> what wire mutation is required?
+                // THREE conceptually separate concerns (V2 correctness):
+                //   1. draft vs sheet-open baseline -> did the user edit anything?
+                //   2. displayed server task NOW     -> authorizes the write and
+                //      defines the network target (frozen BELOW, before the
+                //      async Task is spawned);
+                //   3. post-await identity guard     -> may the completion touch
+                //      the CURRENT UI (stale completions stay UI-inert).
                 // A no-edit dismissal can NEVER overwrite a server value that
                 // changed while the sheet was open; an actual edit is diffed
-                // against the CURRENT server snapshot below for correct
-                // clear/set flags.
-                switch KanbanModelOverrideSessionPolicy.dismissalOutcome(
+                // against the captured server snapshot for correct clear/set
+                // flags. Freezing the target here closes the dismiss-to-Task
+                // scheduling gap: a navigation A -> B between dismissal and
+                // execution can never retarget the PATCH to B.
+                guard let target = KanbanModelOverrideSessionPolicy.commitTarget(
                     session: modelOverrideSession,
                     draft: modelOverrideDraft,
+                    displayedTask: displayedTask,
                     displayedTaskID: displayedTaskID
-                ) {
-                case .noWrite:
-                    return
-                case .commit(let next):
-                    // The user edited; compute the wire mutation against the
-                    // CURRENT server snapshot so a poll landing mid-edit can
-                    // neither clobber the user nor duplicate the write.
-                    guard let serverTask = displayedTask,
-                          next != TaskModelOverride(task: serverTask) else { return }
-                    Task { await commitModelOverride(next) }
+                ) else { return }
+                Task {
+                    await commitModelOverride(
+                        target.value,
+                        startedTask: target.startedTask,
+                        expectedID: target.expectedID
+                    )
                 }
             }
             .alert("Delete this task?", isPresented: $showDeleteConfirmation) {
@@ -956,10 +960,14 @@ struct KanbanTaskDetailView: View {
     }
 
     /// Committed immediately on change (desktop parity): PATCH with explicit
-    /// clear flags computed against the CURRENT server snapshot.
-    private func commitModelOverride(_ next: TaskModelOverride) async {
-        guard let startedTask = displayedTask else { return }
-        let expectedID = displayedTaskID
+    /// clear flags computed against the CAPTURED server snapshot. The
+    /// mutation identity (startedTask + expectedID) is frozen by the caller
+    /// BEFORE the async Task is spawned; this method deliberately never
+    /// re-reads displayedTask/displayedTaskID to choose its network target,
+    /// so navigation between dismissal and execution cannot retarget the
+    /// PATCH. Post-await identity guards keep the completion UI-inert on any
+    /// other displayed identity.
+    private func commitModelOverride(_ next: TaskModelOverride, startedTask: KanbanTask, expectedID: String) async {
         let patch = TaskModelOverride.patch(from: startedTask, to: next)
         guard !patch.isEmpty else { return }
         isSaving = true
@@ -1248,6 +1256,42 @@ enum KanbanModelOverrideSessionPolicy {
         // server value (which polling may have moved under the sheet).
         guard draft != session.baseline else { return .noWrite }
         return .commit(draft)
+    }
+
+    /// The frozen mutation identity for a committed model edit: the edited
+    /// value, the DISPLAYED SERVER TASK captured at dismissal (which both
+    /// authorizes the write and defines the network target), and its
+    /// identity. Computed synchronously at dismissal — BEFORE the async
+    /// commit Task is spawned — so the commit can never re-read a different
+    /// displayed task to choose what it PATCHes.
+    struct CommitTarget: Equatable {
+        let value: TaskModelOverride
+        let startedTask: KanbanTask
+        let expectedID: String
+    }
+
+    /// Resolves the commit target at dismissal time. Requires: a session for
+    /// the current identity, a REAL user edit (vs the sheet-open baseline),
+    /// an actionable displayed task whose id matches the displayed identity,
+    /// and an edited value that still differs from the current server
+    /// override (no duplicate write). Anything else — including a nil
+    /// session (never opened, or reset by navigation), which yields nil
+    /// through dismissalOutcome's .noWrite — writes nothing.
+    static func commitTarget(
+        session: KanbanModelOverrideSession?,
+        draft: TaskModelOverride,
+        displayedTask: KanbanTask?,
+        displayedTaskID: String
+    ) -> CommitTarget? {
+        guard case .commit(let next) = dismissalOutcome(
+            session: session,
+            draft: draft,
+            displayedTaskID: displayedTaskID
+        ) else { return nil }
+        guard let serverTask = displayedTask,
+              serverTask.id == displayedTaskID,
+              next != TaskModelOverride(task: serverTask) else { return nil }
+        return CommitTarget(value: next, startedTask: serverTask, expectedID: displayedTaskID)
     }
 }
 

--- a/Conduit/Views/Kanban/KanbanV2Support.swift
+++ b/Conduit/Views/Kanban/KanbanV2Support.swift
@@ -1,0 +1,558 @@
+import SwiftUI
+import UIKit
+
+// MARK: - Short task ID
+
+/// Upstream `shortId` (apps/desktop/src/plugins/kanban/ui.tsx): strips the `t_`
+/// prefix and keeps six characters so cards/chips stay compact.
+enum KanbanShortID {
+    static func of(_ id: String?) -> String {
+        let value = id ?? ""
+        let stripped = value.hasPrefix("t_") ? String(value.dropFirst(2)) : value
+        return String(stripped.prefix(6))
+    }
+}
+
+// MARK: - Clipboard
+
+/// Single seam for Kanban copy actions so every use gets the same pasteboard
+/// handling plus a VoiceOver announcement, instead of scattering raw
+/// `UIPasteboard.general` calls through views.
+@MainActor
+enum KanbanClipboard {
+    static func copy(_ text: String, announcement: String) {
+        guard !text.isEmpty else { return }
+        UIPasteboard.general.string = text
+        UIAccessibility.post(notification: .announcement, argument: announcement)
+    }
+}
+
+// MARK: - Lane resolution policy
+
+/// One canonical answer to "which lane does the UI consider active?".
+///
+/// The iPhone board shows a chip selector over a vertical card list; before the
+/// user taps a chip nothing is stored in `selectedLane`, yet a lane IS visibly
+/// resolved for display. Every consumer (visible column, New Task initial
+/// status, lane-level UI state) must ask THIS policy instead of reading the
+/// raw selection, or the global + button would silently fall back to Todo
+/// while Triage is on screen.
+enum KanbanLanePolicy {
+    /// The lane the board actually presents: an explicit selection that still
+    /// exists on the snapshot, else the first unlocked lane, else the first
+    /// lane at all (a fully locked snapshot still deserves a visible lane).
+    static func effectiveSelectedLane(selected: String?, columns: [KanbanColumn]) -> String? {
+        guard !columns.isEmpty else { return nil }
+        if let selected, !selected.isEmpty, columns.contains(where: { $0.name == selected }) {
+            return selected
+        }
+        return columns.first(where: { !KanbanStatusPresentation.isLockedDestination($0.name) })?.name
+            ?? columns.first?.name
+    }
+
+    /// Creation target derived from the effective visible lane. Locked lanes
+    /// are never valid creation targets (upstream gives them no add button);
+    /// they collapse to the backend's default unlocked landing lane.
+    static func newTaskInitialStatus(effectiveLane: String?) -> String {
+        guard let effectiveLane, KanbanStatusPresentation.canCreateTask(in: effectiveLane) else {
+            return "todo"
+        }
+        return effectiveLane
+    }
+}
+
+// MARK: - Model / provider / reasoning override
+
+/// A detached per-task worker override. `nil` means "inherit the assigned
+/// profile's own setting" — exactly upstream's empty-string sentinel in
+/// apps/desktop/src/plugins/kanban/model-override.tsx, without mutating any
+/// live chat/session model state.
+struct TaskModelOverride: Equatable {
+    var provider: String?
+    var model: String?
+    var reasoningEffort: String?
+
+    /// Backend-valid effort values (`hermes_constants.VALID_REASONING_EFFORTS`
+    /// plus "none", which is a real VALUE meaning thinking off — not a clear).
+    static let validReasoningEfforts: [String] = [
+        "none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"
+    ]
+
+    var isInherited: Bool {
+        (model ?? "").trimmingCharacters(in: .whitespaces).isEmpty
+            && (provider ?? "").trimmingCharacters(in: .whitespaces).isEmpty
+            && (reasoningEffort ?? "").trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    init(provider: String? = nil, model: String? = nil, reasoningEffort: String? = nil) {
+        self.provider = provider
+        self.model = model
+        self.reasoningEffort = reasoningEffort
+    }
+
+    /// Reads the server's per-task fields back into an override value.
+    init(task: KanbanTask) {
+        self.init(
+            provider: task.providerOverride,
+            model: task.modelOverride,
+            reasoningEffort: task.reasoningEffort
+        )
+    }
+
+    /// `provider: model · Effort`, or the inherit copy when unset (mirrors
+    /// upstream `overrideLabel`).
+    func label(inheritCopy: String) -> String {
+        if isInherited { return inheritCopy }
+        let modelName = model?.trimmingCharacters(in: .whitespaces) ?? ""
+        let providerName = provider?.trimmingCharacters(in: .whitespaces) ?? ""
+        let base = modelName.isEmpty
+            ? inheritCopy
+            : (providerName.isEmpty ? modelName : "\(providerName): \(modelName)")
+        if let effort = reasoningEffort?.trimmingCharacters(in: .whitespaces), !effort.isEmpty {
+            return base + " · " + effortCapitalized(effort)
+        }
+        return base
+    }
+
+    private func effortCapitalized(_ value: String) -> String {
+        value == "xhigh" ? "Extra High" : value.capitalized
+    }
+
+    /// Create-time serialization (upstream `overrideCreateFields`): omit
+    /// untouched fields entirely so backend defaults apply; a provider is only
+    /// meaningful alongside a model.
+    func applyToCreateRequest(_ request: inout KanbanCreateTaskRequest) {
+        let modelName = model?.trimmingCharacters(in: .whitespaces)
+        let providerName = provider?.trimmingCharacters(in: .whitespaces)
+        let effort = reasoningEffort?.trimmingCharacters(in: .whitespaces)
+        if let modelName, !modelName.isEmpty {
+            request.modelOverride = modelName
+            if let providerName, !providerName.isEmpty {
+                request.providerOverride = providerName
+            }
+        }
+        if let effort, !effort.isEmpty {
+            request.reasoningEffort = effort
+        }
+    }
+
+    /// Edit-time serialization against the task's CURRENT server values
+    /// (upstream `overridePatch`): explicit clear flags exist because a missing
+    /// PATCH field means "not sent", not "set to NULL".
+    static func patch(from current: KanbanTask, to next: TaskModelOverride) -> KanbanTaskPatch {
+        var patch = KanbanTaskPatch()
+        let nextModel = next.model?.trimmingCharacters(in: .whitespaces)
+        let nextProvider = next.provider?.trimmingCharacters(in: .whitespaces)
+        let nextEffort = next.reasoningEffort?.trimmingCharacters(in: .whitespaces)
+
+        let currentHasModelOverride = (current.modelOverride ?? "").trimmingCharacters(in: .whitespaces).isEmpty == false
+            || (current.providerOverride ?? "").trimmingCharacters(in: .whitespaces).isEmpty == false
+
+        if let nextModel, !nextModel.isEmpty {
+            patch.modelOverride = nextModel
+            // Desktop parity: provider_override is sent ONLY when explicitly
+            // chosen (blank is omitted, never sent as ""), because the
+            // explicit clear flag is what resets both fields upstream.
+            if let nextProvider, !nextProvider.isEmpty {
+                patch.providerOverride = nextProvider
+            }
+        } else if currentHasModelOverride {
+            patch.clearModelOverride = true
+        }
+
+        if let nextEffort, !nextEffort.isEmpty {
+            patch.reasoningEffort = nextEffort
+        } else if !(current.reasoningEffort ?? "").isEmpty {
+            patch.clearReasoningEffort = true
+        }
+        return patch
+    }
+}
+
+// MARK: - Workspace kinds
+
+/// Upstream `WORKSPACE_KINDS` / backend `VALID_WORKSPACE_KINDS`:
+/// scratch | worktree | dir.
+enum KanbanWorkspaceKind: String, CaseIterable, Identifiable {
+    case scratch
+    case worktree
+    case dir
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .scratch: return "Scratch"
+        case .worktree: return "Worktree"
+        case .dir: return "Directory"
+        }
+    }
+
+    /// A user path override is only meaningful for worktree/dir tasks
+    /// (desktop hides the field for scratch and never sends it).
+    var allowsPathOverride: Bool { self != .scratch }
+
+    /// Board metadata → initial editor value. The backend's own fallback when
+    /// no board default exists is scratch (`_default_workspace_kind`).
+    static func initialKind(boardDefault: String?) -> KanbanWorkspaceKind {
+        guard let raw = boardDefault?.trimmingCharacters(in: .whitespaces).lowercased(),
+              let kind = KanbanWorkspaceKind(rawValue: raw) else {
+            return .scratch
+        }
+        return kind
+    }
+}
+
+// MARK: - Assignee selection
+
+/// Assignment semantics mirrored from Desktop's New Task dialog:
+/// - `.inheritDefault` sends the orchestration-resolved default assignee
+///   (never a silent nil) — title-only creates must RUN.
+/// - `.profile(name)` pins one roster profile.
+/// - `.parked` OMITS the assignee field entirely (backend nil = unassigned;
+///   desktop labels this "unassigned (parked — won't run)"). There is no
+///   separate Conduit meaning for these values.
+enum KanbanAssigneeSelection: Equatable, Hashable {
+    case inheritDefault
+    case profile(String)
+    case parked
+
+    /// The wire value for POST /tasks.
+    func requestValue(resolvedDefaultAssignee: String) -> String? {
+        switch self {
+        case .inheritDefault:
+            let resolved = resolvedDefaultAssignee.trimmingCharacters(in: .whitespaces)
+            return resolved.isEmpty ? "default" : resolved
+        case .profile(let name):
+            return name
+        case .parked:
+            return nil
+        }
+    }
+
+    /// Reassign endpoint value: nil/"" unassigns upstream, so Parked maps to
+    /// nil there as well.
+    var reassignProfile: String? {
+        switch self {
+        case .inheritDefault: return nil
+        case .profile(let name): return name
+        case .parked: return nil
+        }
+    }
+}
+
+// MARK: - Composer draft
+
+/// Detached form state for the mobile task composer. Nothing here touches the
+/// live session model or store until Create is tapped.
+struct KanbanComposerDraft: Equatable {
+    var title = ""
+    var body = ""
+    var priority = 0
+    var assignee: KanbanAssigneeSelection = .inheritDefault
+    var workspaceKind: KanbanWorkspaceKind = .scratch
+    var workspacePath = ""
+    var skills: [String] = []
+    var parents: [String] = []
+    var goalMode = false
+    var goalMaxTurns: Int?
+    var modelOverride = TaskModelOverride()
+
+    var trimmedTitle: String {
+        title.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+enum KanbanDraftValidationError: LocalizedError, Equatable {
+    case emptyTitle
+    case invalidWorkspacePath(KanbanWorkspaceKind)
+    case invalidReasoningEffort(String)
+    case invalidSkill(String)
+    case duplicateParent(String)
+    case invalidGoalMaxTurns(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyTitle:
+            return "A title is required."
+        case .invalidWorkspacePath(let kind):
+            return "A workspace path can only be set for \(kind.displayName) tasks. Hermes scratch tasks resolve their own directory."
+        case .invalidReasoningEffort(let value):
+            return "\"\(value)\" is not a valid reasoning effort for a Hermes worker."
+        case .invalidSkill(let skill):
+            return "\"\(skill)\" is not a usable skill name."
+        case .duplicateParent(let id):
+            return "Task \(id) is already listed as a parent."
+        case .invalidGoalMaxTurns(let turns):
+            return "Goal Mode max turns must be at least 1 (got \(turns))."
+        }
+    }
+}
+
+/// The single validation layer for task creation. Views render state; this
+/// type decides whether a draft may become a request.
+enum KanbanComposerValidator {
+    /// Trims/dedupes skills while preserving order. Skill names must survive
+    /// verbatim (they are matched against Hermes' installed skills), so only
+    /// surrounding whitespace is removed and exact duplicates collapse.
+    static func sanitizedSkills(_ skills: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for raw in skills {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, !seen.contains(trimmed) else { continue }
+            seen.insert(trimmed)
+            result.append(trimmed)
+        }
+        return result
+    }
+
+    static func sanitizedParents(_ parents: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for raw in parents {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, !seen.contains(trimmed) else { continue }
+            seen.insert(trimmed)
+            result.append(trimmed)
+        }
+        return result
+    }
+
+    static func validate(_ draft: KanbanComposerDraft) throws {
+        guard !draft.trimmedTitle.isEmpty else { throw KanbanDraftValidationError.emptyTitle }
+
+        // Scratch resolves its own directory upstream; a path there is an
+        // invalid combination the backend would ignore or misread.
+        let path = draft.workspacePath.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !draft.workspaceKind.allowsPathOverride && !path.isEmpty {
+            throw KanbanDraftValidationError.invalidWorkspacePath(draft.workspaceKind)
+        }
+
+        if let effort = draft.modelOverride.reasoningEffort?.trimmingCharacters(in: .whitespaces),
+           !effort.isEmpty,
+           !TaskModelOverride.validReasoningEfforts.contains(effort) {
+            throw KanbanDraftValidationError.invalidReasoningEffort(effort)
+        }
+
+        // Blank/duplicate skill entries are dropped by sanitization (upstream
+        // splits a comma list and filters empties); anything surviving with
+        // no content is a programming error worth surfacing.
+        for skill in sanitizedSkills(draft.skills) where skill.isEmpty {
+            throw KanbanDraftValidationError.invalidSkill(skill)
+        }
+
+        // Duplicate parent check runs against the RAW draft values so a view
+        // bug cannot silently collapse two intended dependencies into one.
+        let rawParents = draft.parents
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        if rawParents.count != Set(rawParents).count {
+            let duplicated = rawParents.first(where: { candidate in
+                rawParents.filter { $0 == candidate }.count > 1
+            })
+            if let duplicated {
+                throw KanbanDraftValidationError.duplicateParent(duplicated)
+            }
+        }
+
+        if draft.goalMode, let turns = draft.goalMaxTurns, turns < 1 {
+            throw KanbanDraftValidationError.invalidGoalMaxTurns(turns)
+        }
+    }
+
+    /// Builds the POST /tasks body from a validated draft. `triage` is left
+    /// false here: the store owns the guarded create+move transaction keyed on
+    /// the requested lane.
+    static func makeRequest(
+        from draft: KanbanComposerDraft,
+        resolvedDefaultAssignee: String
+    ) throws -> KanbanCreateTaskRequest {
+        try validate(draft)
+
+        let bodyText = draft.body.trimmingCharacters(in: .whitespacesAndNewlines)
+        let path = draft.workspacePath.trimmingCharacters(in: .whitespacesAndNewlines)
+        var request = KanbanCreateTaskRequest(
+            title: draft.trimmedTitle,
+            body: bodyText.isEmpty ? nil : draft.body,
+            assignee: draft.assignee.requestValue(resolvedDefaultAssignee: resolvedDefaultAssignee),
+            priority: max(0, draft.priority),
+            workspaceKind: draft.workspaceKind.rawValue,
+            workspacePath: draft.workspaceKind.allowsPathOverride && !path.isEmpty ? path : nil,
+            parents: sanitizedParents(draft.parents),
+            triage: false,
+            skills: sanitizedSkills(draft.skills).isEmpty ? nil : sanitizedSkills(draft.skills),
+            goalMode: draft.goalMode,
+            // Goal turns only travel when Goal Mode is on (upstream leaves the
+            // field nil otherwise).
+            goalMaxTurns: draft.goalMode ? draft.goalMaxTurns : nil
+        )
+        draft.modelOverride.applyToCreateRequest(&request)
+        return request
+    }
+}
+
+// MARK: - Activity event presentation
+
+/// Ports upstream `eventText` (drawer.tsx): known backend event kinds become
+/// operator-readable rows with the payload folded into a detail line; unknown
+/// kinds degrade to `kind words` plus compact key=value detail so future
+/// backend events still say something instead of rendering opaque JSON.
+enum KanbanActivityFormatter {
+    struct Row: Equatable {
+        let label: String
+        let detail: String?
+    }
+
+    static func row(for event: KanbanEvent) -> Row {
+        let payload = event.payload?.objectValue ?? [:]
+        let string = { (key: String) -> String? in
+            guard let value = payload[key]?.stringValue, !value.isEmpty else { return nil }
+            return value
+        }
+        let status = { (key: String) -> String? in
+            guard let raw = string(key) else { return nil }
+            return KanbanStatusPresentation.forStatus(raw).displayName
+        }
+
+        switch event.kind {
+        case "created":
+            var parts: [String] = []
+            if let s = status("status") { parts.append("as \(s)") }
+            if let a = string("assignee") { parts.append("for \(a)") }
+            return Row(label: "Task created", detail: parts.isEmpty ? nil : parts.joined(separator: " "))
+        case "status":
+            let reason = string("reason")
+            let detail: String?
+            if reason == "parent_reopened" {
+                detail = "parent \(string("parent") ?? "") reopened"
+            } else {
+                detail = reason
+            }
+            return Row(label: "Moved to \(status("status") ?? "?")", detail: detail)
+        case "assigned":
+            if let assignee = string("assignee") {
+                return Row(label: "Assigned to \(assignee)", detail: nil)
+            }
+            return Row(label: "Unassigned", detail: nil)
+        case "commented":
+            return Row(label: "Comment from \(string("author") ?? "someone")", detail: nil)
+        case "claimed":
+            return Row(
+                label: string("source_status") == "review" ? "Claimed from review" : "Claimed by worker",
+                detail: nil
+            )
+        case "spawned":
+            let pid = payload["pid"]?.intValue
+            return Row(label: "Worker started", detail: pid.map { "pid \($0)" })
+        case "completed":
+            return Row(label: "Completed", detail: nil)
+        case "blocked":
+            return Row(label: "Blocked", detail: string("reason"))
+        case "unblocked":
+            return Row(label: "Unblocked → \(status("status") ?? "")", detail: nil)
+        case "reclaimed":
+            return Row(label: "Reclaimed", detail: string("reason"))
+        case "specified":
+            return Row(label: "Fleshed out by triage specifier", detail: nil)
+        case "promoted":
+            return Row(label: "Promoted", detail: nil)
+        case "scheduled":
+            return Row(label: "Scheduled", detail: string("reason"))
+        case "archived":
+            return Row(label: "Archived", detail: nil)
+        case "reprioritized":
+            let priority = payload["priority"]?.intValue
+            return Row(label: "Priority set to \(priority.map(String.init) ?? "?")", detail: nil)
+        case "edited":
+            return Row(label: "Details edited", detail: nil)
+        default:
+            // Compact key=value detail over SCALAR payload entries only;
+            // nested objects/arrays stay out of the row.
+            let scalars = payload.compactMap { key, value -> String? in
+                switch value {
+                case .string(let s): return "\(key)=\(s)"
+                case .number(let n):
+                    if let exact = Int(exactly: n) { return "\(key)=\(exact)" }
+                    return "\(key)=\(n)"
+                case .bool(let b): return "\(key)=\(b)"
+                case .null, .array, .object: return nil
+                }
+            }
+            .sorted()
+            .joined(separator: " ")
+            let label = event.kind.replacingOccurrences(of: "_", with: " ")
+            return Row(label: label, detail: scalars.isEmpty ? nil : scalars)
+        }
+    }
+}
+
+// MARK: - Run presentation
+
+/// Shared run-row classification (upstream drawer runs list).
+enum KanbanRunPresentation {
+    static let failedOutcomes: [String] = ["crashed", "failed", "timed_out", "gave_up"]
+
+    static func isFailed(_ run: KanbanRun) -> Bool {
+        failedOutcomes.contains(run.outcome ?? run.status)
+    }
+
+    static func durationText(start: Int?, end: Int?) -> String? {
+        guard let start, let end, end >= start, start > 0 else { return nil }
+        let seconds = end - start
+        if seconds >= 86_400 {
+            return "\(seconds / 86_400)d"
+        }
+        if seconds >= 3_600 {
+            return "\(seconds / 3_600)h"
+        }
+        if seconds >= 60 {
+            return "\(seconds / 60)m"
+        }
+        return "\(seconds)s"
+    }
+
+    static func outcomeLabel(_ run: KanbanRun) -> String {
+        (run.outcome ?? run.status).replacingOccurrences(of: "_", with: " ")
+    }
+}
+
+// MARK: - Card liveness
+
+/// Card machine-activity state (upstream `arcState`): running workers tick,
+/// running workers whose heartbeat died go stale (>120s), queued states show
+/// who is attached.
+enum KanbanCardLiveness {
+    enum State: Equatable {
+        case running
+        case stale
+        case queued
+    }
+
+    /// Seconds without a heartbeat before a running worker reads as stale
+    /// (upstream ui.tsx uses 120s).
+    static let staleHeartbeatSeconds = 120
+
+    static func state(for task: KanbanTask, now: Date = Date()) -> State? {
+        if task.status == "running" {
+            if let heartbeat = task.lastHeartbeatAt,
+               now.timeIntervalSince1970 - Double(heartbeat) > Double(staleHeartbeatSeconds) {
+                return .stale
+            }
+            return .running
+        }
+        let queued = task.status == "triage"
+            || task.status == "review"
+            || (task.status == "ready" && task.assignee != nil && !task.assignee!.isEmpty)
+        return queued ? .queued : nil
+    }
+
+    static func elapsedText(startedAt: Int?, now: Date = Date()) -> String? {
+        guard let startedAt, startedAt > 0 else { return nil }
+        let seconds = max(0, Int(now.timeIntervalSince1970) - startedAt)
+        if seconds >= 86_400 { return "\(seconds / 86_400)d" }
+        if seconds >= 3_600 { return "\(seconds / 3_600)h" }
+        if seconds >= 60 { return "\(seconds / 60)m" }
+        return "\(seconds)s"
+    }
+}

--- a/Conduit/Views/Kanban/KanbanV2Support.swift
+++ b/Conduit/Views/Kanban/KanbanV2Support.swift
@@ -230,15 +230,11 @@ enum KanbanAssigneeSelection: Equatable, Hashable {
         }
     }
 
-    /// Reassign endpoint value: nil/"" unassigns upstream, so Parked maps to
-    /// nil there as well.
-    var reassignProfile: String? {
-        switch self {
-        case .inheritDefault: return nil
-        case .profile(let name): return name
-        case .parked: return nil
-        }
-    }
+    // NOTE: there is deliberately no "reassign value" accessor here. The
+    // reassign ENDPOINT treats nil/"" as UNASSIGN (upstream ReassignBody),
+    // which is NOT interchangeable with the create-time Default resolution.
+    // Mixing those semantics could silently park a task; reassignment takes
+    // an explicit profile name or an explicit unassign, nothing else.
 }
 
 // MARK: - Composer draft
@@ -336,11 +332,9 @@ enum KanbanComposerValidator {
         }
 
         // Blank/duplicate skill entries are dropped by sanitization (upstream
-        // splits a comma list and filters empties); anything surviving with
-        // no content is a programming error worth surfacing.
-        for skill in sanitizedSkills(draft.skills) where skill.isEmpty {
-            throw KanbanDraftValidationError.invalidSkill(skill)
-        }
+        // splits a comma list and filters empties), so there is nothing to
+        // reject per-skill here; makeRequest serializes exactly what this
+        // validation accepts via the same sanitizer.
 
         // Duplicate parent check runs against the RAW draft values so a view
         // bug cannot silently collapse two intended dependencies into one.
@@ -370,18 +364,24 @@ enum KanbanComposerValidator {
     ) throws -> KanbanCreateTaskRequest {
         try validate(draft)
 
+        // Sanitize exactly once and reuse the results so validation and wire
+        // serialization can never disagree about what was accepted.
+        let skills = sanitizedSkills(draft.skills)
+        let parents = sanitizedParents(draft.parents)
+
         let bodyText = draft.body.trimmingCharacters(in: .whitespacesAndNewlines)
         let path = draft.workspacePath.trimmingCharacters(in: .whitespacesAndNewlines)
         var request = KanbanCreateTaskRequest(
             title: draft.trimmedTitle,
-            body: bodyText.isEmpty ? nil : draft.body,
+            // Trimmed for the wire (upstream sends body.trim() || undefined).
+            body: bodyText.isEmpty ? nil : bodyText,
             assignee: draft.assignee.requestValue(resolvedDefaultAssignee: resolvedDefaultAssignee),
             priority: max(0, draft.priority),
             workspaceKind: draft.workspaceKind.rawValue,
             workspacePath: draft.workspaceKind.allowsPathOverride && !path.isEmpty ? path : nil,
-            parents: sanitizedParents(draft.parents),
+            parents: parents,
             triage: false,
-            skills: sanitizedSkills(draft.skills).isEmpty ? nil : sanitizedSkills(draft.skills),
+            skills: skills.isEmpty ? nil : skills,
             goalMode: draft.goalMode,
             // Goal turns only travel when Goal Mode is on (upstream leaves the
             // field nil otherwise).
@@ -481,7 +481,7 @@ enum KanbanActivityFormatter {
             }
             .sorted()
             .joined(separator: " ")
-            let label = event.kind.replacingOccurrences(of: "_", with: " ")
+            let label = event.kind.replacingOccurrences(of: "_", with: " ").capitalized
             return Row(label: label, detail: scalars.isEmpty ? nil : scalars)
         }
     }

--- a/Conduit/Views/Kanban/KanbanWorkerLogScreen.swift
+++ b/Conduit/Views/Kanban/KanbanWorkerLogScreen.swift
@@ -111,14 +111,20 @@ struct KanbanWorkerLogScreen: View {
 
     /// Keeps the NEWEST output when the fetched tail still exceeds the render
     /// budget, prefixing an explicit omission marker instead of freezing the
-    /// phone on a giant string.
+    /// phone on a giant string. The marker is accounted against the budget so
+    /// the returned string NEVER exceeds `maxRenderedCharacters`, newline or
+    /// not.
     static func renderTail(_ content: String) -> String {
         guard content.count > maxRenderedCharacters else { return content }
-        let suffix = String(content.suffix(maxRenderedCharacters))
-        // Avoid starting mid-line.
+        let marker = "[older output omitted]"
+        // Reserve room for the marker up front so no path can exceed budget.
+        // Clamped so even a hypothetical tiny budget cannot underflow.
+        let suffix = String(content.suffix(max(0, maxRenderedCharacters - marker.count)))
+        // Avoid starting mid-line; a tail with no newline at all still stays
+        // within budget because the slice was already sized for it.
         let firstNewline = suffix.firstIndex(of: "\n")
         let trimmed = firstNewline.map { String(suffix[$0...]) } ?? suffix
-        return "[older output omitted]" + trimmed
+        return marker + trimmed
     }
 
     private func load(scrollProxy: ScrollViewProxy? = nil) async {
@@ -128,7 +134,12 @@ struct KanbanWorkerLogScreen: View {
         do {
             // Board context comes pinned from the store's loaded snapshot.
             log = try await store.fetchTaskLog(id: taskID, tailBytes: Self.tailBytes)
+            // One run-loop turn lets SwiftUI lay out the (possibly huge)
+            // monospaced text before we jump to the bottom; bail out if the
+            // screen was dismissed during that window instead of scrolling a
+            // dead proxy.
             try? await Task.sleep(nanoseconds: 120_000_000)
+            guard !Task.isCancelled else { return }
             scrollProxy?.scrollTo("logBottom", anchor: .bottom)
         } catch {
             errorMessage = error.localizedDescription

--- a/Conduit/Views/Kanban/KanbanWorkerLogScreen.swift
+++ b/Conduit/Views/Kanban/KanbanWorkerLogScreen.swift
@@ -26,27 +26,43 @@ struct KanbanWorkerLogScreen: View {
     @State private var log: KanbanWorkerLog?
     @State private var isLoading = false
     @State private var errorMessage: String?
+    /// Set when a REFRESH failed while a log is already cached: the cached
+    /// content stays on screen with a small banner; the full "unavailable"
+    /// state is reserved for initial loads with nothing cached.
+    @State private var refreshErrorMessage: String?
 
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
                 VStack(alignment: .leading, spacing: 10) {
-                    if isLoading && log == nil {
+                    switch KanbanWorkerLogPresentation.resolve(
+                        log: log,
+                        loadError: errorMessage,
+                        refreshError: refreshErrorMessage
+                    ) {
+                    case .loading:
                         HStack {
                             Spacer()
                             ProgressView("Loading worker log…")
                             Spacer()
                         }
                         .padding(.top, 40)
-                    } else if let errorMessage {
+                    case .unavailable(let message):
                         ContentUnavailableView(
                             "Log unavailable",
                             systemImage: "doc.text.magnifyingglass",
-                            description: Text(errorMessage)
+                            description: Text(message)
                         )
                         .padding(.top, 40)
-                    } else if let log {
-                        if !log.exists {
+                    case .content(let cachedLog, let refreshError):
+                        if let refreshError {
+                            // Non-destructive banner: a failed refresh NEVER
+                            // evicts the cached log from the screen.
+                            Label("Refresh failed: \(refreshError)", systemImage: "exclamationmark.circle")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+                        if !cachedLog.exists {
                             ContentUnavailableView(
                                 "No worker output yet",
                                 systemImage: "terminal",
@@ -54,8 +70,8 @@ struct KanbanWorkerLogScreen: View {
                             )
                             .padding(.top, 40)
                         } else {
-                            summaryFooter(log)
-                            logText(log)
+                            summaryFooter(cachedLog)
+                            logText(cachedLog)
                                 .id("logBottom")
                         }
                     }
@@ -134,6 +150,8 @@ struct KanbanWorkerLogScreen: View {
         do {
             // Board context comes pinned from the store's loaded snapshot.
             log = try await store.fetchTaskLog(id: taskID, tailBytes: Self.tailBytes)
+            // A successful refresh clears any stale refresh banner.
+            refreshErrorMessage = nil
             // One run-loop turn lets SwiftUI lay out the (possibly huge)
             // monospaced text before we jump to the bottom; bail out if the
             // screen was dismissed during that window instead of scrolling a
@@ -142,7 +160,40 @@ struct KanbanWorkerLogScreen: View {
             guard !Task.isCancelled else { return }
             scrollProxy?.scrollTo("logBottom", anchor: .bottom)
         } catch {
-            errorMessage = error.localizedDescription
+            if log == nil {
+                // Initial load failure: nothing is cached, so the full
+                // "unavailable" state applies.
+                errorMessage = error.localizedDescription
+            } else {
+                // Refresh failure with cached content: keep the log visible
+                // and surface a small non-destructive banner instead.
+                refreshErrorMessage = error.localizedDescription
+            }
         }
+    }
+}
+
+// MARK: - Presentation
+
+/// Presentation resolution for the worker-log screen, extracted so the
+/// cached-content refresh-failure rule is deterministically testable:
+/// a failed refresh must never evict an already-loaded log, and a successful
+/// refresh clears the banner.
+enum KanbanWorkerLogPresentation: Equatable {
+    /// No log yet and no failure: initial load in flight.
+    case loading
+    /// Nothing cached and the load failed: full unavailable state.
+    case unavailable(String)
+    /// A log is on screen. refreshError is non-nil when the most recent
+    /// REFRESH failed — the cached content stays visible with a small,
+    /// non-destructive banner.
+    case content(log: KanbanWorkerLog, refreshError: String?)
+
+    static func resolve(log: KanbanWorkerLog?, loadError: String?, refreshError: String?) -> KanbanWorkerLogPresentation {
+        guard let log else {
+            if let loadError { return .unavailable(loadError) }
+            return .loading
+        }
+        return .content(log: log, refreshError: refreshError)
     }
 }

--- a/Conduit/Views/Kanban/KanbanWorkerLogScreen.swift
+++ b/Conduit/Views/Kanban/KanbanWorkerLogScreen.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+
+/// Dedicated worker-log screen (Kanban V2 §18).
+///
+/// - Loads once on appearance and otherwise refreshes EXPLICITLY — no
+///   background polling while hidden, and nothing polls at all unless this
+///   screen is on screen.
+/// - Requests the backend's tail window (`?tail=` bytes, upstream caps at
+///   2 MiB) so enormous logs never reach the phone whole.
+/// - Renders a capped, selectable monospaced tail with the newest output at
+///   the bottom; the full-size/truncation facts stay visible.
+struct KanbanWorkerLogScreen: View {
+    @EnvironmentObject private var store: KanbanStore
+    @Environment(\.dismiss) private var dismiss
+
+    let taskID: String
+
+    /// Tail window requested from the backend. 64 KiB matches the drawer's
+    /// "plenty for the drawer" sizing while staying far below the backend's
+    /// 2 MiB ceiling.
+    static let tailBytes = 65_536
+    /// Render cap: SwiftUI Text chokes on megabyte strings; past this we keep
+    /// the newest slice and say so.
+    static let maxRenderedCharacters = 60_000
+
+    @State private var log: KanbanWorkerLog?
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 10) {
+                    if isLoading && log == nil {
+                        HStack {
+                            Spacer()
+                            ProgressView("Loading worker log…")
+                            Spacer()
+                        }
+                        .padding(.top, 40)
+                    } else if let errorMessage {
+                        ContentUnavailableView(
+                            "Log unavailable",
+                            systemImage: "doc.text.magnifyingglass",
+                            description: Text(errorMessage)
+                        )
+                        .padding(.top, 40)
+                    } else if let log {
+                        if !log.exists {
+                            ContentUnavailableView(
+                                "No worker output yet",
+                                systemImage: "terminal",
+                                description: Text("This task has not spawned a worker, so there is no log.")
+                            )
+                            .padding(.top, 40)
+                        } else {
+                            summaryFooter(log)
+                            logText(log)
+                                .id("logBottom")
+                        }
+                    }
+                }
+                .padding(14)
+            }
+            .background(ConduitBackdrop())
+            .navigationTitle("Worker Log")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        Task { await load() }
+                    } label: {
+                        Image(systemName: isLoading ? "arrow.triangle.2.circlepath" : "arrow.clockwise")
+                    }
+                    .disabled(isLoading)
+                    .accessibilityLabel("Refresh worker log")
+                }
+            }
+            .task { await load(scrollProxy: proxy) }
+        }
+    }
+
+    private func summaryFooter(_ log: KanbanWorkerLog) -> some View {
+        HStack(spacing: 8) {
+            Text(ByteCountFormatter.string(fromByteCount: Int64(log.sizeBytes), countStyle: .memory))
+            if log.truncated {
+                Text("· showing last \(Self.tailBytes / 1024) KiB")
+                    .foregroundStyle(.orange)
+            }
+            Spacer()
+        }
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+    }
+
+    @ViewBuilder
+    private func logText(_ log: KanbanWorkerLog) -> some View {
+        let rendered = Self.renderTail(log.content)
+        if rendered.isEmpty {
+            Text("(log is empty)")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        } else {
+            Text(rendered)
+                .font(.system(size: 11, weight: .regular, design: .monospaced))
+                .textSelection(.enabled)
+                .lineLimit(nil)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    /// Keeps the NEWEST output when the fetched tail still exceeds the render
+    /// budget, prefixing an explicit omission marker instead of freezing the
+    /// phone on a giant string.
+    static func renderTail(_ content: String) -> String {
+        guard content.count > maxRenderedCharacters else { return content }
+        let suffix = String(content.suffix(maxRenderedCharacters))
+        // Avoid starting mid-line.
+        let firstNewline = suffix.firstIndex(of: "\n")
+        let trimmed = firstNewline.map { String(suffix[$0...]) } ?? suffix
+        return "[older output omitted]" + trimmed
+    }
+
+    private func load(scrollProxy: ScrollViewProxy? = nil) async {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+        do {
+            // Board context comes pinned from the store's loaded snapshot.
+            log = try await store.fetchTaskLog(id: taskID, tailBytes: Self.tailBytes)
+            try? await Task.sleep(nanoseconds: 120_000_000)
+            scrollProxy?.scrollTo("logBottom", anchor: .bottom)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/Conduit/Views/KanbanViews.swift
+++ b/Conduit/Views/KanbanViews.swift
@@ -35,6 +35,35 @@ enum KanbanDetailDraftPolicy {
     }
 }
 
+/// Permanent deletion from CARDS is a two-step action (Kanban V2
+/// correctness). Card entry points — the ellipsis menu AND the context menu —
+/// only STAGE a confirmation request; the destructive DELETE is issued solely
+/// by an explicit confirmation. Lane moves and Archive stay immediate and
+/// non-destructive.
+enum KanbanCardDeletePolicy {
+    enum Request: Equatable {
+        case none
+        case confirm(KanbanTask)
+        case perform(KanbanTask)
+    }
+
+    /// What a card's Delete… entry resolves to: NEVER the destructive
+    /// mutation by itself.
+    static func cardRequestedDelete(for task: KanbanTask) -> Request {
+        .confirm(task)
+    }
+
+    /// Cancellation stages nothing.
+    static func cancelled() -> Request {
+        .none
+    }
+
+    /// Only an explicit confirm resolves to the destructive request.
+    static func confirmed(staged: KanbanTask?) -> Request {
+        staged.map { .perform($0) } ?? .none
+    }
+}
+
 struct KanbanView: View {
     @EnvironmentObject private var appState: AppState
     @StateObject private var store = KanbanStore()
@@ -46,6 +75,11 @@ struct KanbanView: View {
     /// iPhone-native interaction: one selected lane rendered as a vertical
     /// card list behind a horizontally scrolling chip selector.
     @State private var selectedLane: String?
+    /// Permanent deletion from a card is a TWO-STEP action (V2): BOTH card
+    /// entry points (ellipsis menu and context menu) stage the task here,
+    /// and only an explicit confirmation issues the destructive DELETE.
+    /// Archive and lane moves stay immediate.
+    @State private var pendingDeleteTask: KanbanTask?
 
     private var bridgeIdentity: ObjectIdentifier? {
         appState.dashboardTicketBridge.map { ObjectIdentifier($0) }
@@ -145,6 +179,24 @@ struct KanbanView: View {
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
         }
+        // Permanent deletion from cards is CONFIRMED before the DELETE is
+        // issued; the wording matches the detail screen's delete alert. The
+        // staged task is passed BY VALUE through the alert's presenting
+        // binding, so the destructive action never depends on reading
+        // mutable state that alert dismissal may already have cleared.
+        .alert(
+            "Delete this task?",
+            isPresented: Binding(
+                get: { pendingDeleteTask != nil },
+                set: { if !$0 { pendingDeleteTask = nil } }
+            ),
+            presenting: pendingDeleteTask
+        ) { task in
+            Button("Delete", role: .destructive) { confirmCardDelete(task) }
+            Button("Cancel", role: .cancel) { pendingDeleteTask = nil }
+        } message: { _ in
+            Text("This permanently removes the task from the selected Hermes board.")
+        }
         .task(id: pollingKey) {
             selectedTask = nil
             store.configure(
@@ -195,7 +247,7 @@ struct KanbanView: View {
                                 onOpen: { selectedTask = task },
                                 onMove: { status in Task { await move(task, to: status) } },
                                 onArchive: { Task { await archive(task) } },
-                                onDelete: { Task { await delete(task) } }
+                                onDelete: { stageCardDelete(task) }
                             )
                         }
                     }
@@ -377,6 +429,24 @@ struct KanbanView: View {
 
     private func delete(_ task: KanbanTask) async {
         _ = try? await store.deleteTask(id: task.id, includeArchived: includeArchived)
+    }
+
+    /// A card's Delete… entry STAGES the shared board-level confirmation; it
+    /// never issues the destructive mutation directly.
+    private func stageCardDelete(_ task: KanbanTask) {
+        if case .confirm(let staged) = KanbanCardDeletePolicy.cardRequestedDelete(for: task) {
+            pendingDeleteTask = staged
+        }
+    }
+
+    /// Only an explicit confirmation resolves the staged request to a
+    /// permanent DELETE. The staged task arrives BY VALUE from the alert's
+    /// presenting binding, so presentation-dismissal ordering can never
+    /// detach the action from its task.
+    private func confirmCardDelete(_ staged: KanbanTask) {
+        pendingDeleteTask = nil
+        guard case .perform(let task) = KanbanCardDeletePolicy.confirmed(staged: staged) else { return }
+        Task { await delete(task) }
     }
 }
 

--- a/Conduit/Views/KanbanViews.swift
+++ b/Conduit/Views/KanbanViews.swift
@@ -35,22 +35,34 @@ enum KanbanDetailDraftPolicy {
     }
 }
 
+/// A staged destructive delete request: the task captured BY VALUE plus the
+/// loaded board/server context (KanbanBoardContextStamp) that staged it.
+/// The task id alone is deliberately NOT the ownership token — ids can
+/// collide across independent boards/servers.
+struct PendingCardDelete: Equatable {
+    let task: KanbanTask
+    let stamp: KanbanBoardContextStamp
+
+    var taskID: String { task.id }
+}
+
 /// Permanent deletion from CARDS is a two-step action (Kanban V2
 /// correctness). Card entry points — the ellipsis menu AND the context menu —
-/// only STAGE a confirmation request; the destructive DELETE is issued solely
-/// by an explicit confirmation. Lane moves and Archive stay immediate and
-/// non-destructive.
+/// only STAGE a confirmation request BOUND to the board/server context that
+/// staged it; the destructive DELETE is issued solely by an explicit
+/// confirmation that still owns that exact context. Lane moves and Archive
+/// stay immediate and non-destructive.
 enum KanbanCardDeletePolicy {
     enum Request: Equatable {
         case none
-        case confirm(KanbanTask)
+        case confirm(PendingCardDelete)
         case perform(KanbanTask)
     }
 
     /// What a card's Delete… entry resolves to: NEVER the destructive
-    /// mutation by itself.
-    static func cardRequestedDelete(for task: KanbanTask) -> Request {
-        .confirm(task)
+    /// mutation by itself — always a context-stamped confirmation.
+    static func cardRequestedDelete(for task: KanbanTask, stamp: KanbanBoardContextStamp) -> Request {
+        .confirm(PendingCardDelete(task: task, stamp: stamp))
     }
 
     /// Cancellation stages nothing.
@@ -58,9 +70,23 @@ enum KanbanCardDeletePolicy {
         .none
     }
 
-    /// Only an explicit confirm resolves to the destructive request.
-    static func confirmed(staged: KanbanTask?) -> Request {
-        staged.map { .perform($0) } ?? .none
+    /// FAIL-CLOSED ownership validation at the destructive boundary: the
+    /// staged confirmation may resolve to a DELETE only while the store's
+    /// currently loaded context is EXACTLY the context that staged it (same
+    /// board slug AND same configuration generation) and the visible
+    /// snapshot is still the actionable one. After a board switch, a server
+    /// reconfigure, or during in-flight board navigation, the stale request
+    /// is discarded without sending anything.
+    static func confirmed(
+        staged: PendingCardDelete?,
+        currentStamp: KanbanBoardContextStamp?,
+        isSnapshotActionable: Bool
+    ) -> Request {
+        guard isSnapshotActionable,
+              let staged,
+              let currentStamp,
+              staged.stamp == currentStamp else { return .none }
+        return .perform(staged.task)
     }
 }
 
@@ -76,10 +102,11 @@ struct KanbanView: View {
     /// card list behind a horizontally scrolling chip selector.
     @State private var selectedLane: String?
     /// Permanent deletion from a card is a TWO-STEP action (V2): BOTH card
-    /// entry points (ellipsis menu and context menu) stage the task here,
-    /// and only an explicit confirmation issues the destructive DELETE.
-    /// Archive and lane moves stay immediate.
-    @State private var pendingDeleteTask: KanbanTask?
+    /// entry points (ellipsis menu and context menu) stage the task here
+    /// TOGETHER WITH the loaded board/server context that staged it, and
+    /// only an explicit confirmation that still owns that context issues the
+    /// destructive DELETE. Archive and lane moves stay immediate.
+    @State private var pendingDelete: PendingCardDelete?
 
     private var bridgeIdentity: ObjectIdentifier? {
         appState.dashboardTicketBridge.map { ObjectIdentifier($0) }
@@ -181,21 +208,29 @@ struct KanbanView: View {
         }
         // Permanent deletion from cards is CONFIRMED before the DELETE is
         // issued; the wording matches the detail screen's delete alert. The
-        // staged task is passed BY VALUE through the alert's presenting
-        // binding, so the destructive action never depends on reading
-        // mutable state that alert dismissal may already have cleared.
+        // staged request (task + staging context) is passed BY VALUE through
+        // the alert's presenting binding, so the destructive action never
+        // depends on reading mutable state that alert dismissal may already
+        // have cleared — and confirmCardDelete re-validates context
+        // ownership before anything is sent.
         .alert(
             "Delete this task?",
             isPresented: Binding(
-                get: { pendingDeleteTask != nil },
-                set: { if !$0 { pendingDeleteTask = nil } }
+                get: { pendingDelete != nil },
+                set: { if !$0 { pendingDelete = nil } }
             ),
-            presenting: pendingDeleteTask
-        ) { task in
-            Button("Delete", role: .destructive) { confirmCardDelete(task) }
-            Button("Cancel", role: .cancel) { pendingDeleteTask = nil }
+            presenting: pendingDelete
+        ) { staged in
+            Button("Delete", role: .destructive) { confirmCardDelete(staged) }
+            Button("Cancel", role: .cancel) { pendingDelete = nil }
         } message: { _ in
             Text("This permanently removes the task from the selected Hermes board.")
+        }
+        // Proactive disarm: when the loaded board identity changes, any
+        // staged destructive confirmation is now foreign. (The confirm-time
+        // ownership check below remains the hard boundary.)
+        .onChange(of: store.loadedBoardSlug) { _, _ in
+            pendingDelete = nil
         }
         .task(id: pollingKey) {
             selectedTask = nil
@@ -432,20 +467,32 @@ struct KanbanView: View {
     }
 
     /// A card's Delete… entry STAGES the shared board-level confirmation; it
-    /// never issues the destructive mutation directly.
+    /// never issues the destructive mutation directly. The task is captured
+    /// BY VALUE together with the loaded board/server context stamp, so the
+    /// confirmation can later prove it still owns the store's current
+    /// context before deleting.
     private func stageCardDelete(_ task: KanbanTask) {
-        if case .confirm(let staged) = KanbanCardDeletePolicy.cardRequestedDelete(for: task) {
-            pendingDeleteTask = staged
+        // Stage-time gate mirrors the confirm-time gate: only an actionable
+        // loaded context may stage a destructive confirmation at all.
+        guard let stamp = store.loadedContextStamp, store.isSelectedSnapshotLoaded else { return }
+        if case .confirm(let staged) = KanbanCardDeletePolicy.cardRequestedDelete(for: task, stamp: stamp) {
+            pendingDelete = staged
         }
     }
 
-    /// Only an explicit confirmation resolves the staged request to a
-    /// permanent DELETE. The staged task arrives BY VALUE from the alert's
-    /// presenting binding, so presentation-dismissal ordering can never
-    /// detach the action from its task.
-    private func confirmCardDelete(_ staged: KanbanTask) {
-        pendingDeleteTask = nil
-        guard case .perform(let task) = KanbanCardDeletePolicy.confirmed(staged: staged) else { return }
+    /// Only an explicit confirmation that still owns the staging context
+    /// resolves to a permanent DELETE. FAIL-CLOSED: if the board or server
+    /// context has changed (different slug, new configuration generation, or
+    /// an in-flight board navigation), the stale confirmation is discarded
+    /// without any request — even if the new board happens to contain a task
+    /// with the same id.
+    private func confirmCardDelete(_ staged: PendingCardDelete) {
+        pendingDelete = nil
+        guard case .perform(let task) = KanbanCardDeletePolicy.confirmed(
+            staged: staged,
+            currentStamp: store.loadedContextStamp,
+            isSnapshotActionable: store.isSelectedSnapshotLoaded
+        ) else { return }
         Task { await delete(task) }
     }
 }

--- a/Conduit/Views/KanbanViews.swift
+++ b/Conduit/Views/KanbanViews.swift
@@ -422,6 +422,16 @@ private struct KanbanCardView: View {
                                 Label(status.displayName, systemImage: status.systemImage)
                             }
                         }
+                        // The CURRENT lane stays visible but inert, matching
+                        // desktop StatusMenu (name === status || !locked): a
+                        // non-control child renders as a disabled Menu row.
+                        HStack {
+                            Label(presentation.displayName, systemImage: presentation.systemImage)
+                            Spacer()
+                            Image(systemName: "checkmark")
+                        }
+                        .foregroundStyle(.secondary)
+                        .accessibilityHint("Current lane")
                     }
                     Section {
                         Button {

--- a/Conduit/Views/KanbanViews.swift
+++ b/Conduit/Views/KanbanViews.swift
@@ -140,9 +140,9 @@ struct KanbanView: View {
                 .presentationDragIndicator(.visible)
         }
         .sheet(isPresented: $showNewTask) {
-            KanbanTaskEditorView(initialStatus: newTaskStatus)
+            KanbanTaskComposerView(initialStatus: newTaskStatus)
                 .environmentObject(store)
-                .presentationDetents([.medium, .large])
+                .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
         }
         .task(id: pollingKey) {
@@ -191,8 +191,10 @@ struct KanbanView: View {
                         ForEach(column.tasks) { task in
                             KanbanCardView(
                                 task: task,
+                                hasDispatcherFallback: !(store.orchestration?.resolvedDefaultAssignee ?? "").isEmpty,
                                 onOpen: { selectedTask = task },
                                 onMove: { status in Task { await move(task, to: status) } },
+                                onArchive: { Task { await archive(task) } },
                                 onDelete: { Task { await delete(task) } }
                             )
                         }
@@ -249,12 +251,17 @@ struct KanbanView: View {
         .accessibilityLabel(presentation.displayName + ", " + String(column.tasks.count) + " tasks")
     }
 
+    /// THE canonical visible-lane answer. Every consumer — the chip
+    /// highlight, the card list, and the New Task button's initial status —
+    /// must ask this instead of reading raw `selectedLane`, which stays nil
+    /// until the user explicitly taps a chip even though a lane IS resolved
+    /// for display (first unlocked lane). See KanbanLanePolicy.
+    private var effectiveSelectedLane: String? {
+        KanbanLanePolicy.effectiveSelectedLane(selected: selectedLane, columns: visibleColumns)
+    }
+
     private func resolvedLaneName(columns: [KanbanColumn]) -> String? {
-        if let selectedLane, columns.contains(where: { $0.name == selectedLane }) {
-            return selectedLane
-        }
-        // Prefer an unlocked default so the first paint shows actionable work.
-        return columns.first(where: { !KanbanStatusPresentation.isLockedDestination($0.name) })?.name ?? columns.first?.name
+        KanbanLanePolicy.effectiveSelectedLane(selected: selectedLane, columns: columns)
     }
 
     private func resolvedLaneColumn(in columns: [KanbanColumn]) -> KanbanColumn? {
@@ -312,11 +319,13 @@ struct KanbanView: View {
             .accessibilityLabel("Refresh Kanban board")
 
             Button {
-                // Land on the visible lane when it accepts creation; otherwise
-                // fall back to the backend's default unlocked lane.
-                newTaskStatus = selectedLane.flatMap { lane in
-                    KanbanStatusPresentation.canCreateTask(in: lane) ? lane : nil
-                } ?? "todo"
+                // The global + creates relative to the lane the UI actually
+                // considers visible (effectiveSelectedLane), NOT the raw chip
+                // selection — selectedLane stays nil until a chip is tapped,
+                // and falling back to Todo then would ignore the resolved
+                // visible lane. Locked lanes collapse to the default unlocked
+                // landing status.
+                newTaskStatus = KanbanLanePolicy.newTaskInitialStatus(effectiveLane: effectiveSelectedLane)
                 showNewTask = true
             } label: {
                 Image(systemName: "plus")
@@ -359,6 +368,13 @@ struct KanbanView: View {
         _ = try? await store.updateTask(id: task.id, patch: KanbanTaskPatch(status: status), includeArchived: includeArchived)
     }
 
+    /// Upstream archive semantics: a plain PATCH status='archived'
+    /// (kanban_db.archive_task). NOT destructive, so no confirmation.
+    private func archive(_ task: KanbanTask) async {
+        guard task.status != "archived" else { return }
+        _ = try? await store.updateTask(id: task.id, patch: KanbanTaskPatch(status: "archived"), includeArchived: includeArchived)
+    }
+
     private func delete(_ task: KanbanTask) async {
         _ = try? await store.deleteTask(id: task.id, includeArchived: includeArchived)
     }
@@ -366,8 +382,12 @@ struct KanbanView: View {
 
 private struct KanbanCardView: View {
     let task: KanbanTask
+    /// Whether Hermes has ANY configured default assignee fallback. When not,
+    /// an unassigned ready card would silently never run — worth surfacing.
+    var hasDispatcherFallback: Bool = true
     let onOpen: () -> Void
     let onMove: (String) -> Void
+    let onArchive: () -> Void
     let onDelete: () -> Void
 
     private var presentation: KanbanStatusPresentation {
@@ -375,7 +395,11 @@ private struct KanbanCardView: View {
     }
 
     private var statusOptions: [KanbanStatusPresentation] {
-        KanbanStatusPresentation.manuallySelectableStatuses
+        KanbanStatusPresentation.manuallySelectableStatuses.filter { $0.rawValue != task.status }
+    }
+
+    private var liveness: KanbanCardLiveness.State? {
+        KanbanCardLiveness.state(for: task)
     }
 
     var body: some View {
@@ -399,8 +423,27 @@ private struct KanbanCardView: View {
                             }
                         }
                     }
-                    Button(role: .destructive, action: onDelete) {
-                        Label("Delete", systemImage: "trash")
+                    Section {
+                        Button {
+                            copy(text: task.id, notice: "Task ID copied")
+                        } label: {
+                            Label("Copy Task ID", systemImage: "doc.on.doc")
+                        }
+                        Button {
+                            copy(text: task.title, notice: "Title copied")
+                        } label: {
+                            Label("Copy Task Title", systemImage: "doc.on.doc.fill")
+                        }
+                    }
+                    Section {
+                        // First-class archive: plain PATCH semantics upstream,
+                        // so no destructive confirmation language.
+                        Button(action: onArchive) {
+                            Label("Archive", systemImage: "archivebox")
+                        }
+                        Button(role: .destructive, action: onDelete) {
+                            Label("Delete…", systemImage: "trash")
+                        }
                     }
                 } label: {
                     Image(systemName: "ellipsis")
@@ -424,21 +467,7 @@ private struct KanbanCardView: View {
                     .lineLimit(3)
             }
 
-            HStack(spacing: 8) {
-                if let assignee = task.assignee, !assignee.isEmpty {
-                    Label(assignee, systemImage: "person")
-                        .lineLimit(1)
-                }
-                if let priority = task.priority, priority > 0 {
-                    Label(String(priority), systemImage: "flag.fill")
-                }
-                if let comments = task.commentCount, comments > 0 {
-                    Label(String(comments), systemImage: "bubble.left")
-                }
-                Spacer(minLength: 0)
-            }
-            .font(.caption2)
-            .foregroundStyle(.tertiary)
+            operationalFooter
         }
         .padding(11)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -455,472 +484,73 @@ private struct KanbanCardView: View {
         .accessibilityAddTraits(.isButton)
         .accessibilityHint("Opens task details")
         .accessibilityAction(named: "Open task", onOpen)
+        .accessibilityAction(named: "Copy task ID") { copy(text: task.id, notice: "Task ID copied") }
+        .accessibilityAction(named: "Copy task title") { copy(text: task.title, notice: "Title copied") }
         .contextMenu {
             Button { onOpen() } label: { Label("Open", systemImage: "arrow.up.right.square") }
-            Button(role: .destructive, action: onDelete) { Label("Delete", systemImage: "trash") }
-        }
-    }
-}
-
-struct KanbanTaskEditorView: View {
-    @EnvironmentObject private var store: KanbanStore
-    @Environment(\.dismiss) private var dismiss
-    let initialStatus: String
-    @State private var title = ""
-    @State private var taskBody = ""
-    @State private var assignee = ""
-    @State private var priority = 0
-    @State private var isSaving = false
-    @State private var didCreate = false
-    @State private var errorMessage: String?
-
-    private var statusPresentation: KanbanStatusPresentation {
-        KanbanStatusPresentation.forStatus(initialStatus)
-    }
-
-    var body: some View {
-        NavigationStack {
-            Form {
-                Section("Task") {
-                    TextField("Title", text: $title)
-                    TextEditor(text: $taskBody)
-                        .frame(minHeight: 120)
-                    Picker("Priority", selection: $priority) {
-                        Text("Normal").tag(0)
-                        Text("High").tag(1)
-                        Text("Urgent").tag(2)
-                        Text("Critical").tag(3)
-                    }
-                    .pickerStyle(.menu)
-                }
-
-                Section("Assignment") {
-                    Picker("Profile", selection: $assignee) {
-                        Text("Unassigned").tag("")
-                        ForEach(store.profiles) { profile in
-                            Text(profile.name).tag(profile.name)
-                        }
-                    }
-                    .pickerStyle(.menu)
-                }
-
-                Section("Workflow") {
-                    Label(statusPresentation.displayName, systemImage: statusPresentation.systemImage)
-                        .foregroundStyle(statusPresentation.tint)
-                    Text("The board selection is local to this device; creating this task will not switch Hermes' global board.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                if let errorMessage {
-                    Section { Text(errorMessage).foregroundStyle(.red) }
+            ForEach(statusOptions) { status in
+                Button { onMove(status.rawValue) } label: {
+                    Label("Move to \(status.displayName)", systemImage: status.systemImage)
                 }
             }
-            .navigationTitle("New task")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(didCreate ? "Close" : "Cancel") { dismiss() }
-                }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button {
-                        if didCreate {
-                            dismiss()
-                        } else {
-                            Task { await save() }
-                        }
-                    } label: {
-                        if isSaving { ProgressView() } else { Text(didCreate ? "Done" : "Create") }
-                    }
-                    .disabled((title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !didCreate) || isSaving)
-                }
+            Button { copy(text: task.id, notice: "Task ID copied") } label: {
+                Label("Copy Task ID", systemImage: "doc.on.doc")
             }
+            Button { copy(text: task.title, notice: "Title copied") } label: {
+                Label("Copy Task Title", systemImage: "doc.on.doc.fill")
+            }
+            Divider()
+            Button(action: onArchive) { Label("Archive", systemImage: "archivebox") }
+            Button(role: .destructive, action: onDelete) { Label("Delete…", systemImage: "trash") }
         }
     }
 
-    private func save() async {
-        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedTitle.isEmpty, statusPresentation.isTaskCreatable else { return }
-        isSaving = true
-        errorMessage = nil
-        defer { isSaving = false }
-        do {
-            _ = try await store.createTask(
-                KanbanCreateTaskRequest(
-                    title: trimmedTitle,
-                    body: taskBody.isEmpty ? nil : taskBody,
-                    assignee: assignee.isEmpty ? nil : assignee,
-                    priority: priority,
-                    triage: initialStatus == "triage"
-                ),
-                initialStatus: initialStatus
-            )
-            dismiss()
-        } catch {
-            errorMessage = error.localizedDescription
-            if let kanbanError = error as? KanbanServiceError, case .taskCreatedButMoveFailed = kanbanError {
-                didCreate = true
-            }
-        }
-    }
-}
-
-struct KanbanTaskDetailView: View {
-    /// Editable fields as last synced from the server. The draft fields below
-    /// are compared against this so a 4-second poll can refresh comments,
-    /// runs, and metadata WITHOUT ever overwriting unsaved user edits.
-    private struct ServerBaseline: Equatable {
-        var title: String
-        var bodyText: String
-        var status: String
-    }
-
-    @EnvironmentObject private var store: KanbanStore
-    @Environment(\.dismiss) private var dismiss
-    let initialTask: KanbanTask
-    @State private var detail: KanbanTaskDetail?
-    // Draft (editable) state - owned by the user until saved.
-    @State private var title: String
-    @State private var taskBody: String
-    @State private var status: String
-    @State private var baseline: ServerBaseline
-    @State private var remoteChangeNotice: String?
-    @State private var comment = ""
-    @State private var isSaving = false
-    @State private var isAddingComment = false
-    @State private var isLoadingDetail = false
-    @State private var showDeleteConfirmation = false
-    @State private var errorMessage: String?
-    @State private var refreshErrorMessage: String?
-
-    init(task: KanbanTask) {
-        initialTask = task
-        _title = State(initialValue: task.title)
-        _taskBody = State(initialValue: task.body ?? "")
-        _status = State(initialValue: task.status)
-        _baseline = State(initialValue: ServerBaseline(title: task.title, bodyText: task.body ?? "", status: task.status))
-    }
-
-    private var currentTask: KanbanTask {
-        detail?.task ?? initialTask
-    }
-
-    private var hasUnsavedChanges: Bool {
-        KanbanDetailDraftPolicy.isDirty(
-            draftTitle: title,
-            draftBody: taskBody,
-            draftStatus: status,
-            baselineTitle: baseline.title,
-            baselineBodyText: baseline.bodyText,
-            baselineStatus: baseline.status
-        )
-    }
-
-
-    private var statusOptions: [KanbanStatusPresentation] {
-        var values = KanbanStatusPresentation.manuallySelectableStatuses
-        if !values.contains(where: { $0.rawValue == status }) {
-            values.insert(KanbanStatusPresentation.forStatus(status), at: 0)
-        }
-        return values
-    }
-
-    var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 14) {
-                    editorSection
-                    metadataSection
-                    commentsSection
-                    runsSection
-                    if let remoteChangeNotice {
-                        Text(remoteChangeNotice)
-                            .font(.footnote)
-                            .foregroundStyle(.orange)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    if hasUnsavedChanges {
-                        Text("Unsaved edits")
-                            .font(.caption2.weight(.semibold))
-                            .foregroundStyle(.secondary)
-                            .frame(maxWidth: .infinity, alignment: .trailing)
-                    }
-                    if let refreshErrorMessage {
-                        Text("Refresh failed: \(refreshErrorMessage)")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    if let errorMessage {
-                        Text(errorMessage)
-                            .font(.footnote)
-                            .foregroundStyle(.red)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                }
-                .padding(16)
-            }
-            .background(ConduitBackdrop())
-            .navigationTitle("Task")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Done") { dismiss() }
-                }
-                ToolbarItem(placement: .primaryAction) {
-                    Menu {
-                        Button(role: .destructive) { showDeleteConfirmation = true } label: {
-                            Label("Delete task", systemImage: "trash")
-                        }
-                    } label: {
-                        Image(systemName: "ellipsis.circle")
-                    }
-                    .accessibilityLabel("Task actions")
-                }
-            }
-            .task(id: initialTask.id) {
-                while !Task.isCancelled {
-                    await loadDetail()
-                    do {
-                        try await Task.sleep(nanoseconds: KanbanPollingPolicy.detailIntervalNanoseconds)
-                    } catch {
-                        break
-                    }
-                }
-            }
-            .alert("Delete this task?", isPresented: $showDeleteConfirmation) {
-                Button("Delete", role: .destructive) { Task { await deleteTask() } }
-                Button("Cancel", role: .cancel) {}
-            } message: {
-                Text("This removes the task from the selected Hermes board.")
-            }
-        }
-    }
-
-    private var editorSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            TextField("Title", text: $title)
-                .font(.headline)
-                .textFieldStyle(.roundedBorder)
-            TextEditor(text: $taskBody)
-                .frame(minHeight: 150)
-                .padding(4)
-                .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 12))
-            Picker("Status", selection: $status) {
-                ForEach(statusOptions) { value in
-                    Label(value.displayName, systemImage: value.systemImage)
-                        .tag(value.rawValue)
-                        .disabled(!value.isManuallySelectable)
-                }
-            }
-            .pickerStyle(.menu)
-            Button {
-                Task { await saveChanges() }
-            } label: {
-                HStack {
-                    Spacer()
-                    if isSaving { ProgressView() } else { Text("Save changes") }
-                    Spacer()
-                }
-            }
-            .buttonStyle(.borderedProminent)
-            .tint(.conduitAccent)
-            .disabled(isSaving || title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-        }
-        .padding(16)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
-    }
-
-    private var metadataSection: some View {
-        ConduitSettingsSection(title: "Details", symbol: "info.circle", tint: .conduitAura) {
-            SettingsMetricRow(label: "ID", value: currentTask.id, lineLimit: 1)
-            if let assignee = currentTask.assignee, !assignee.isEmpty {
-                SettingsMetricRow(label: "Assignee", value: assignee, lineLimit: 1)
-            }
-            if let priority = currentTask.priority {
-                SettingsMetricRow(label: "Priority", value: String(priority))
-            }
-            if let workspace = currentTask.workspacePath, !workspace.isEmpty {
-                SettingsMetricRow(label: "Workspace", value: workspace, lineLimit: 2)
-            }
-            if let result = currentTask.result, !result.isEmpty {
-                VStack(alignment: .leading, spacing: 5) {
-                    Text("Result")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                    Text(result)
-                        .font(.footnote)
-                }
-            }
-        }
-    }
-
-    private var commentsSection: some View {
-        ConduitSettingsSection(title: "Comments", symbol: "bubble.left.and.bubble.right", tint: .conduitAccent) {
-            if let comments = detail?.comments, !comments.isEmpty {
-                ForEach(comments) { value in
-                    VStack(alignment: .leading, spacing: 4) {
-                        HStack {
-                            Text(value.author).font(.caption.weight(.semibold))
-                            Spacer()
-                            Text(relativeDate(value.createdAt))
-                                .font(.caption2)
-                                .foregroundStyle(.tertiary)
-                        }
-                        Text(value.body).font(.footnote)
-                    }
-                    .padding(.vertical, 3)
-                }
-            } else {
-                Text("No comments yet.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-            }
-            TextEditor(text: $comment)
-                .frame(minHeight: 80)
-                .padding(4)
-                .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 12))
-            Button {
-                Task { await addComment() }
-            } label: {
-                HStack {
-                    Spacer()
-                    if isAddingComment { ProgressView() } else { Label("Add comment", systemImage: "paperplane") }
-                    Spacer()
-                }
-            }
-            .buttonStyle(.bordered)
-            .disabled(comment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isAddingComment)
-        }
-    }
-
+    /// Selective operational indicators (V2 §20): short ID, child progress,
+    /// link counts, diagnostics warnings, run clock / stale heartbeat, and
+    /// the genuine silent-failure warning — nothing decorative.
     @ViewBuilder
-    private var runsSection: some View {
-        if let runs = detail?.runs, !runs.isEmpty {
-            ConduitSettingsSection(title: "Runs", symbol: "terminal", tint: .orange) {
-                ForEach(runs) { run in
-                    HStack(alignment: .top, spacing: 10) {
-                        Image(systemName: run.status == "completed" ? "checkmark.circle" : "circle.dotted")
-                            .foregroundStyle(run.status == "completed" ? .green : .secondary)
-                        VStack(alignment: .leading, spacing: 3) {
-                            Text(run.status.capitalized).font(.subheadline.weight(.medium))
-                            if let summary = run.summary, !summary.isEmpty {
-                                Text(summary).font(.caption).foregroundStyle(.secondary).lineLimit(3)
-                            }
-                            if let error = run.error, !error.isEmpty {
-                                Text(error).font(.caption).foregroundStyle(.red).lineLimit(3)
-                            }
-                        }
-                        Spacer(minLength: 0)
-                    }
-                }
+    private var operationalFooter: some View {
+        HStack(spacing: 8) {
+            if liveness == .stale {
+                Label("no heartbeat", systemImage: "heartbeat.slash")
+                    .foregroundStyle(.orange)
+            } else if task.status == "running", let elapsed = KanbanCardLiveness.elapsedText(startedAt: task.startedAt) {
+                Label(elapsed, systemImage: "timer")
+                    .foregroundStyle(KanbanStatusPresentation.forStatus("running").tint)
             }
-        }
-    }
-
-    private func loadDetail(force: Bool = false) async {
-        // A poll never runs underneath an active save/comment write.
-        guard force || (!isSaving && !isAddingComment), !isLoadingDetail else { return }
-        isLoadingDetail = true
-        defer { isLoadingDetail = false }
-        do {
-            let loaded = try await store.fetchTaskDetail(id: initialTask.id)
-            let server = loaded.task
-            if hasUnsavedChanges {
-                // Preserve the user's draft. Flag external edits to the same
-                // fields so the conflict is visible without destroying input.
-                let serverMoved = KanbanDetailDraftPolicy.serverMovedIndependently(
-                    serverTitle: server.title,
-                    serverBodyText: server.body ?? "",
-                    serverStatus: server.status,
-                    baselineTitle: baseline.title,
-                    baselineBodyText: baseline.bodyText,
-                    baselineStatus: baseline.status
-                )
-                if serverMoved && remoteChangeNotice == nil {
-                    remoteChangeNotice = "This task changed on the server. Your unsaved edits are preserved."
-                }
-            } else {
-                title = server.title
-                taskBody = server.body ?? ""
-                status = server.status
-                baseline = ServerBaseline(title: server.title, bodyText: server.body ?? "", status: server.status)
-                remoteChangeNotice = nil
+            if task.status == "ready", (task.assignee ?? "").isEmpty, !hasDispatcherFallback {
+                Label("won't run", systemImage: "bolt.slash")
+                    .foregroundStyle(.orange)
             }
-            detail = loaded
-            refreshErrorMessage = nil
-        } catch {
-            if detail == nil {
-                errorMessage = error.localizedDescription
-            } else {
-                refreshErrorMessage = error.localizedDescription
+            if let progress = task.progress, progress.total > 0 {
+                Label("\(progress.done)/\(progress.total)", systemImage: "checklist")
             }
-        }
-    }
-
-    private func saveChanges() async {
-        let current = currentTask
-        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
-        var patch = KanbanTaskPatch()
-        // Diffs run against the last-synced baseline, not the live server
-        // snapshot, so an external edit cannot silently drop a user field.
-        if trimmedTitle != baseline.title { patch.title = trimmedTitle }
-        if taskBody != baseline.bodyText { patch.body = taskBody }
-        if status != baseline.status {
-            guard KanbanStatusPresentation.canSelectManually(status) else {
-                errorMessage = KanbanServiceError.invalidManualStatus(status).localizedDescription
-                return
+            if let comments = task.commentCount, comments > 0 {
+                Label(String(comments), systemImage: "bubble.left")
             }
-            patch.status = status
+            let links = (task.linkCounts?.parents ?? 0) + (task.linkCounts?.children ?? 0)
+            if links > 0 {
+                Label(String(links), systemImage: "arrow.triangle.branch")
+            }
+            if let priority = task.priority, priority > 0 {
+                Label(String(priority), systemImage: "flag.fill")
+            }
+            Spacer(minLength: 0)
+            if let warnings = task.warnings, warnings.count > 0 {
+                Label(String(warnings.count), systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.red)
+            }
+            Text(KanbanShortID.of(task.id))
+                .font(.caption2.monospaced())
         }
-        guard !patch.isEmpty else { return }
-        isSaving = true
-        errorMessage = nil
-        defer { isSaving = false }
-        do {
-            let saved = try await store.updateTask(id: current.id, patch: patch)
-            // Reconcile the draft with the saved representation and clear the
-            // dirty state before the next poll cycle lands.
-            let savedServer = saved ?? currentTask
-            title = savedServer.title
-            taskBody = savedServer.body ?? taskBody
-            status = savedServer.status
-            baseline = ServerBaseline(title: savedServer.title, bodyText: savedServer.body ?? taskBody, status: savedServer.status)
-            remoteChangeNotice = nil
-            await loadDetail(force: true)
-        } catch {
-            errorMessage = error.localizedDescription
-        }
+        .font(.caption2)
+        .foregroundStyle(.tertiary)
     }
 
-    private func addComment() async {
-        let text = comment.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty else { return }
-        isAddingComment = true
-        errorMessage = nil
-        defer { isAddingComment = false }
-        do {
-            try await store.addComment(taskID: currentTask.id, body: text)
-            comment = ""
-            await loadDetail(force: true)
-        } catch {
-            errorMessage = error.localizedDescription
-        }
-    }
-
-    private func deleteTask() async {
-        do {
-            try await store.deleteTask(id: currentTask.id)
-            dismiss()
-        } catch {
-            errorMessage = error.localizedDescription
-        }
-    }
-
-    private func relativeDate(_ epoch: Int?) -> String {
-        guard let epoch else { return "" }
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: Date(timeIntervalSince1970: Double(epoch)), relativeTo: Date())
+    private func copy(text: String, notice: String) {
+        KanbanClipboard.copy(text, announcement: notice)
     }
 }
+
+// The minimal New Task editor was superseded by KanbanTaskComposerView
+// (Conduit/Views/Kanban/KanbanTaskComposerView.swift) in Kanban V2.

--- a/Conduit/Views/KanbanViews.swift
+++ b/Conduit/Views/KanbanViews.swift
@@ -462,9 +462,6 @@ struct KanbanView: View {
         _ = try? await store.updateTask(id: task.id, patch: KanbanTaskPatch(status: "archived"), includeArchived: includeArchived)
     }
 
-    private func delete(_ task: KanbanTask) async {
-        _ = try? await store.deleteTask(id: task.id, includeArchived: includeArchived)
-    }
 
     /// A card's Delete… entry STAGES the shared board-level confirmation; it
     /// never issues the destructive mutation directly. The task is captured
@@ -485,7 +482,11 @@ struct KanbanView: View {
     /// context has changed (different slug, new configuration generation, or
     /// an in-flight board navigation), the stale confirmation is discarded
     /// without any request — even if the new board happens to contain a task
-    /// with the same id.
+    /// with the same id. The check below is EARLY UX REJECTION only: the
+    /// spawned delete passes the staged stamp to the store's context-bound
+    /// deleteTask, which re-validates ownership and captures its mutation
+    /// context ATOMICALLY — the hard boundary that closes the check-to-
+    /// Task-scheduling TOCTOU window.
     private func confirmCardDelete(_ staged: PendingCardDelete) {
         pendingDelete = nil
         guard case .perform(let task) = KanbanCardDeletePolicy.confirmed(
@@ -493,7 +494,13 @@ struct KanbanView: View {
             currentStamp: store.loadedContextStamp,
             isSnapshotActionable: store.isSelectedSnapshotLoaded
         ) else { return }
-        Task { await delete(task) }
+        Task {
+            try? await store.deleteTask(
+                id: task.id,
+                expectedContext: staged.stamp,
+                includeArchived: includeArchived
+            )
+        }
     }
 }
 

--- a/ConduitTests/KanbanV2CorrectnessTests.swift
+++ b/ConduitTests/KanbanV2CorrectnessTests.swift
@@ -333,8 +333,8 @@ final class KanbanV2CorrectnessTests: XCTestCase {
             KanbanCardDeletePolicy.cardRequestedDelete(for: makeTask(id: "t1"), stamp: stamp)
         )
 
-        // Context unchanged: the confirmation resolves and the view's delete
-        // issues exactly one DELETE to the staging board.
+        // Context unchanged: the confirmation resolves and the view issues the
+        // CONTEXT-BOUND delete exactly as production does.
         guard case .perform(let task) = KanbanCardDeletePolicy.confirmed(
             staged: staged,
             currentStamp: store.loadedContextStamp,
@@ -342,13 +342,108 @@ final class KanbanV2CorrectnessTests: XCTestCase {
         ) else {
             return XCTFail("an unchanged context must honor the confirmed delete")
         }
-        try await store.deleteTask(id: task.id)
+        try await store.deleteTask(id: task.id, expectedContext: staged!.stamp)
         await store.awaitPendingDispatcherNudgeForTesting()
 
         let deletes = requester.calls.filter { $0.method == "DELETE" }
         XCTAssertEqual(deletes.count, 1, "exactly one DELETE for the staged task")
         XCTAssertTrue(deletes[0].path.contains("/tasks/t1"), deletes[0].path)
         XCTAssertTrue(deletes[0].path.contains("board=alpha"), deletes[0].path)
+    }
+
+    // MARK: - 6c. Card delete check-to-dispatch TOCTOU (store boundary)
+
+    func testContextBoundDeleteFailsClosedWhenServerReconfiguresBeforeContextCapture() async throws {
+        // The exact check -> Task-scheduling race: the alert confirmation
+        // VALIDATES on server A, the spawned Task captures its mutation
+        // context only later — after the store has reconfigured to server B.
+        // The store-level boundary must fail closed on the STAGED stamp.
+        var responsesA = contextRaceResponses(boardSlug: "alpha")
+        responsesA["/api/plugins/kanban/tasks/t1"] = ["ok": true]
+        let requesterA = ContextRaceMockRequester(responsesByPath: responsesA)
+        let store = makeContextRaceStore(requester: requesterA)
+        await store.refresh()
+
+        let stampA = try XCTUnwrap(store.loadedContextStamp)
+        let staged = stagedIfConfirm(
+            KanbanCardDeletePolicy.cardRequestedDelete(for: makeTask(id: "t1"), stamp: stampA)
+        )!
+        // The view-level early check passes on A (this is the TOCTOU window:
+        // validation happened BEFORE the switch below).
+        guard case .perform = KanbanCardDeletePolicy.confirmed(
+            staged: staged,
+            currentStamp: store.loadedContextStamp,
+            isSnapshotActionable: store.isSelectedSnapshotLoaded
+        ) else {
+            return XCTFail("precondition: the confirmation must validate on A before the switch")
+        }
+
+        // ...the store reconfigures to server B BEFORE the spawned Task runs.
+        let requesterB = ContextRaceMockRequester(responsesByPath: contextRaceResponses(boardSlug: "beta"))
+        store.configure(requester: requesterB, serverIdentity: "https://b.test")
+        await store.reload()
+
+        // The Task executes the context-bound delete with the STILL-STAGED
+        // stamp A: it must throw fail-closed and send zero DELETEs anywhere.
+        do {
+            try await store.deleteTask(id: staged.taskID, expectedContext: staged.stamp)
+            XCTFail("context-bound delete must fail closed after a server reconfigure")
+        } catch let error as KanbanServiceError {
+            // Pin the exact fail-closed branch: the STAMP guard, not some
+            // other rejection path.
+            XCTAssertEqual(error, .boardNavigationInProgress)
+        } catch {
+            XCTFail("unexpected error type: \(error)")
+        }
+        XCTAssertFalse(store.isMutating, "a fail-closed delete must not claim mutation ownership")
+        XCTAssertEqual(store.mutationErrorMessage, KanbanServiceError.boardNavigationInProgress.localizedDescription)
+        XCTAssertFalse(requesterB.calls.contains { $0.method == "DELETE" }, "zero DELETE reaches server B")
+        XCTAssertFalse(requesterA.calls.contains { $0.method == "DELETE" }, "zero destructive request occurs on A either")
+    }
+
+    func testContextBoundDeleteFailsClosedAcrossSameServerBoardSwitchWithCollidingId() async throws {
+        // Same server, colliding task id on both boards: the check->dispatch
+        // race must not let a staged A confirmation delete B's t1.
+        var responses = contextRaceResponses(boardSlug: "alpha")
+        responses["/api/plugins/kanban/board?board=alpha"] = [
+            "columns": [["name": "todo", "tasks": [["id": "t1", "title": "on alpha", "status": "todo"]]]],
+            "tenants": [], "assignees": []
+        ]
+        responses["/api/plugins/kanban/board?board=beta"] = [
+            "columns": [["name": "todo", "tasks": [["id": "t1", "title": "on beta", "status": "todo"]]]],
+            "tenants": [], "assignees": []
+        ]
+        responses["/api/plugins/kanban/tasks/t1"] = ["ok": true]
+        let requester = ContextRaceMockRequester(responsesByPath: responses)
+        let store = makeContextRaceStore(requester: requester)
+        await store.selectBoard(slug: "alpha")
+
+        let stampA = try XCTUnwrap(store.loadedContextStamp)
+        XCTAssertEqual(stampA.boardSlug, "alpha")
+        let staged = stagedIfConfirm(
+            KanbanCardDeletePolicy.cardRequestedDelete(for: makeTask(id: "t1"), stamp: stampA)
+        )!
+        guard case .perform = KanbanCardDeletePolicy.confirmed(
+            staged: staged,
+            currentStamp: store.loadedContextStamp,
+            isSnapshotActionable: store.isSelectedSnapshotLoaded
+        ) else {
+            return XCTFail("precondition: the confirmation must validate on board A")
+        }
+
+        // Board switches on the SAME server before the Task runs.
+        await store.selectBoard(slug: "beta")
+
+        do {
+            try await store.deleteTask(id: staged.taskID, expectedContext: staged.stamp)
+            XCTFail("a confirmation staged on board A must never delete on board B")
+        } catch let error as KanbanServiceError {
+            XCTAssertEqual(error, .boardNavigationInProgress)
+        } catch {
+            XCTFail("unexpected error type: \(error)")
+        }
+        XCTAssertFalse(store.isMutating)
+        XCTAssertFalse(requester.calls.contains { $0.method == "DELETE" }, "zero DELETE for any board, colliding id or not")
     }
 
     // MARK: - 7. Existing model override display
@@ -515,6 +610,109 @@ final class KanbanV2CorrectnessTests: XCTestCase {
                 displayedTaskID: "task-a"
             ),
             .noWrite
+        )
+    }
+
+    // MARK: - 7c. Model commit target frozen before async dispatch
+
+    func testModelCommitTargetFreezesIdentityBeforeAsyncDispatch() {
+        // The model editor for task A dismisses with a REAL user edit...
+        let serverA = makeTask(id: "task-a", extra: ["model_override": "model-a"])
+        let session = KanbanModelOverrideSession(
+            taskID: "task-a",
+            baseline: TaskModelOverride(task: serverA)
+        )
+        let edited = TaskModelOverride(model: "model-c")
+        let target = KanbanModelOverrideSessionPolicy.commitTarget(
+            session: session,
+            draft: edited,
+            displayedTask: serverA,
+            displayedTaskID: "task-a"
+        )
+        guard let target else {
+            return XCTFail("a real edit on the matching identity must produce a commit target")
+        }
+
+        // ...then the user navigates A -> dependency B BEFORE the spawned
+        // commit Task runs. The commit must use the FROZEN identity: the
+        // PATCH target stays task-a and never becomes task-b.
+        XCTAssertEqual(target.startedTask.id, "task-a")
+        XCTAssertEqual(target.expectedID, "task-a")
+        let patch = TaskModelOverride.patch(from: target.startedTask, to: target.value)
+        XCTAssertEqual(patch.modelOverride, "model-c")
+
+        // The stale A completion remains UI-inert on B.
+        XCTAssertFalse(
+            KanbanDetailMutationPolicy.completionIsActive(startedTaskID: target.expectedID, displayedTaskID: "task-b"),
+            "an A completion must never touch B's UI after navigation"
+        )
+    }
+
+    func testModelCommitTargetNoEditAfterConcurrentServerChangeWritesNothing() {
+        // Session-level no-edit rule expressed through the commit target:
+        // server moved A -> B while the sheet was open, user made no edit.
+        let serverAtOpen = makeTask(id: "t1", extra: ["model_override": "model-a"])
+        let session = KanbanModelOverrideSession(
+            taskID: "t1",
+            baseline: TaskModelOverride(task: serverAtOpen)
+        )
+        let untouchedDraft = TaskModelOverride(task: serverAtOpen)
+        // Polling delivered the newer server value B to the displayed task.
+        let serverNow = makeTask(id: "t1", extra: ["model_override": "model-b"])
+
+        XCTAssertNil(
+            KanbanModelOverrideSessionPolicy.commitTarget(
+                session: session,
+                draft: untouchedDraft,
+                displayedTask: serverNow,
+                displayedTaskID: "t1"
+            ),
+            "a no-edit dismissal must never produce a commit target, even when the server moved"
+        )
+    }
+
+    func testModelCommitTargetRejectsDisplayedIdentityMismatch() {
+        // Belt-and-braces: the captured server task must belong to the
+        // displayed identity at dismissal; anything else writes nothing.
+        let serverA = makeTask(id: "task-a", extra: ["model_override": "model-a"])
+        let session = KanbanModelOverrideSession(
+            taskID: "task-a",
+            baseline: TaskModelOverride(task: serverA)
+        )
+        let edited = TaskModelOverride(model: "model-c")
+        XCTAssertNil(
+            KanbanModelOverrideSessionPolicy.commitTarget(
+                session: session,
+                draft: edited,
+                displayedTask: serverA,
+                displayedTaskID: "task-b"
+            ),
+            "a session for A must not commit when the displayed identity is B"
+        )
+    }
+
+    func testModelCommitTargetNoDuplicateWriteWhenEditMatchesMovedServerValue() {
+        // The user independently edited to exactly the value a mid-edit poll
+        // landed on: the server already holds it, so the no-duplicate-write
+        // gate must yield NO commit target (zero PATCH).
+        let serverAtOpen = makeTask(id: "t1", extra: ["model_override": "model-a"])
+        let session = KanbanModelOverrideSession(
+            taskID: "t1",
+            baseline: TaskModelOverride(task: serverAtOpen)
+        )
+        let serverNow = makeTask(id: "t1", extra: ["model_override": "model-c"])
+        let editedToServerValue = TaskModelOverride(model: "model-c")
+        // Real user edit (differs from the open-time baseline)...
+        XCTAssertNotEqual(editedToServerValue, session.baseline)
+        // ...but the server already moved to that exact value.
+        XCTAssertNil(
+            KanbanModelOverrideSessionPolicy.commitTarget(
+                session: session,
+                draft: editedToServerValue,
+                displayedTask: serverNow,
+                displayedTaskID: "t1"
+            ),
+            "an edit that matches the current server value must not produce a duplicate PATCH"
         )
     }
 

--- a/ConduitTests/KanbanV2CorrectnessTests.swift
+++ b/ConduitTests/KanbanV2CorrectnessTests.swift
@@ -1,0 +1,381 @@
+import XCTest
+@testable import Conduit
+
+/// Final correctness pass for Kanban V2 (PR #93): task-identity invariants
+/// on the detail screen, card-delete confirmation, model-override display,
+/// Note & requeue partial success, and worker-log cached-content rules.
+///
+/// These tests exercise the extracted policies the views execute — the same
+/// no-UI-timing idiom as KanbanTests/KanbanV2Tests.
+@MainActor
+final class KanbanV2CorrectnessTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private enum CorrectnessTestError: LocalizedError {
+        case failed(String)
+        var errorDescription: String? {
+            switch self {
+            case .failed(let message): return message
+            }
+        }
+    }
+
+    private func makeTask(id: String, extra: [String: Any] = [:]) -> KanbanTask {
+        var object: [String: Any] = ["id": id, "title": "T", "status": "todo"]
+        for (key, value) in extra { object[key] = value }
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        return try! JSONDecoder().decode(KanbanTask.self, from: data)
+    }
+
+    // MARK: - 1/2. Dependency navigation & failed replacement fetch
+
+    func testDependencyNavigationNeverExposesPreviousTaskAsActionable() {
+        let taskA = makeTask(id: "task-a", extra: ["title": "A"])
+        let taskB = makeTask(id: "task-b", extra: ["title": "B"])
+
+        // Opened A, then tapped dependency B: the screen's identity is B and
+        // B's detail request is still in flight. A — the OPENING task — must
+        // not be actionable: no A metadata, no Copy ID/Title of A, no
+        // Archive/Delete/model mutations against A.
+        XCTAssertNil(
+            KanbanDetailIdentityPolicy.actionableTask(displayedID: "task-b", detailTask: nil, initialTask: taskA),
+            "a loading replacement must never fall back to the opening task"
+        )
+
+        // Once B's detail lands, B is the actionable task.
+        XCTAssertEqual(
+            KanbanDetailIdentityPolicy.actionableTask(displayedID: "task-b", detailTask: taskB, initialTask: taskA)?.id,
+            "task-b"
+        )
+
+        // A detail belonging to a DIFFERENT identity than the one displayed
+        // can never become actionable (stale poll completion).
+        XCTAssertNil(
+            KanbanDetailIdentityPolicy.actionableTask(displayedID: "task-b", detailTask: taskA, initialTask: taskA)
+        )
+
+        // The opening identity keeps its V1 behavior: A is actionable on A's
+        // own screen even before the first detail load completes.
+        XCTAssertEqual(
+            KanbanDetailIdentityPolicy.actionableTask(displayedID: "task-a", detailTask: nil, initialTask: taskA)?.id,
+            "task-a"
+        )
+    }
+
+    func testFailedReplacementFetchNeverResurrectsPreviousTask() {
+        let taskA = makeTask(id: "task-a")
+        // B's fetch failed: the failure belongs to B and the screen stays on
+        // B's identity — A must not come back as the actionable task.
+        let actionable = KanbanDetailIdentityPolicy.actionableTask(
+            displayedID: "task-b",
+            detailTask: nil,
+            initialTask: taskA
+        )
+        XCTAssertNil(actionable, "a failed replacement fetch must never resurrect the previous task")
+    }
+
+    // MARK: - 3/4/5. Stale mutation completions
+
+    func testStaleSaveCompletionCannotOverwriteDisplayedTask() {
+        let taskA = makeTask(id: "task-a", extra: ["title": "A title"])
+        let serverA = makeTask(id: "task-a", extra: ["title": "A title (server)"])
+
+        // Save started on A, response arrives after navigation to B: the
+        // completion is inert — no draft/baseline write, no error, no
+        // refresh for B.
+        let staleWithResponse = KanbanDetailMutationPolicy.saveCompletion(
+            startedTask: taskA,
+            response: serverA,
+            displayedTaskID: "task-b"
+        )
+        XCTAssertFalse(staleWithResponse.isActive)
+        XCTAssertNil(staleWithResponse.serverTask)
+
+        // Same shape with no response body: still inert.
+        let staleNoResponse = KanbanDetailMutationPolicy.saveCompletion(
+            startedTask: taskA,
+            response: nil,
+            displayedTaskID: "task-b"
+        )
+        XCTAssertFalse(staleNoResponse.isActive)
+        XCTAssertNil(staleNoResponse.serverTask)
+    }
+
+    func testStaleSaveFailureCannotShowErrorOnDisplayedTask() {
+        // The same ownership gate governs the catch path: a failure that
+        // started for A may not surface anywhere while B is displayed.
+        XCTAssertFalse(
+            KanbanDetailMutationPolicy.completionIsActive(startedTaskID: "task-a", displayedTaskID: "task-b")
+        )
+        XCTAssertTrue(
+            KanbanDetailMutationPolicy.completionIsActive(startedTaskID: "task-b", displayedTaskID: "task-b")
+        )
+    }
+
+    func testStaleDestructiveCompletionCannotDismissDisplayedTask() {
+        // Delete started on A, A's delete succeeds after navigation to B:
+        // the completion gate keeps it from dismissing B's screen (and from
+        // surfacing A's errors or refreshes on B).
+        XCTAssertFalse(
+            KanbanDetailMutationPolicy.completionIsActive(startedTaskID: "task-a", displayedTaskID: "task-b"),
+            "a stale delete completion must never dismiss or mutate the displayed task's screen"
+        )
+    }
+
+    func testActiveSaveCompletionSeedsBaselineFromStartedTaskOrItsResponse() {
+        let taskA = makeTask(id: "task-a", extra: ["title": "A title"])
+        // Active completion with no task in the response must seed from the
+        // task that STARTED the save — never from whatever task is displayed
+        // when the response lands (the old saved ?? currentTask re-read).
+        let noResponse = KanbanDetailMutationPolicy.saveCompletion(
+            startedTask: taskA,
+            response: nil,
+            displayedTaskID: "task-a"
+        )
+        XCTAssertTrue(noResponse.isActive)
+        XCTAssertEqual(noResponse.serverTask?.id, "task-a")
+        XCTAssertEqual(noResponse.serverTask?.title, "A title")
+
+        // Active completion WITH a server response seeds from the response
+        // for the started identity.
+        let serverResponse = makeTask(id: "task-a", extra: ["title": "A title (server)"])
+        let withResponse = KanbanDetailMutationPolicy.saveCompletion(
+            startedTask: taskA,
+            response: serverResponse,
+            displayedTaskID: "task-a"
+        )
+        XCTAssertTrue(withResponse.isActive)
+        XCTAssertEqual(withResponse.serverTask?.title, "A title (server)")
+
+        // A response echoing a DIFFERENT id never seeds the started task's
+        // baseline — the started task stands in until the forced reload
+        // re-syncs from the authoritative task.
+        let foreignResponse = makeTask(id: "task-z", extra: ["title": "Foreign title"])
+        let withForeign = KanbanDetailMutationPolicy.saveCompletion(
+            startedTask: taskA,
+            response: foreignResponse,
+            displayedTaskID: "task-a"
+        )
+        XCTAssertTrue(withForeign.isActive)
+        XCTAssertEqual(withForeign.serverTask?.id, "task-a")
+        XCTAssertEqual(withForeign.serverTask?.title, "A title")
+
+        // An EMPTY-id response under a NON-empty started task is the same
+        // contract violation: the started task seeds the baseline until the
+        // forced reload re-syncs.
+        let emptyIDResponse = makeTask(id: "", extra: ["title": "Poisoned"])
+        let withEmptyID = KanbanDetailMutationPolicy.saveCompletion(
+            startedTask: taskA,
+            response: emptyIDResponse,
+            displayedTaskID: "task-a"
+        )
+        XCTAssertTrue(withEmptyID.isActive)
+        XCTAssertEqual(withEmptyID.serverTask?.id, "task-a")
+        XCTAssertEqual(withEmptyID.serverTask?.title, "A title")
+    }
+
+    func testMismatchedEmptyIDDetailIsNeverActionable() {
+        let taskA = makeTask(id: "task-a")
+        let emptyID = makeTask(id: "")
+        let taskB = makeTask(id: "task-b")
+        // Same-identity empty/empty still matches through the equality
+        // branch (an identity fetched BY its own empty id).
+        XCTAssertEqual(
+            KanbanDetailIdentityPolicy.actionableTask(displayedID: "", detailTask: emptyID, initialTask: taskA)?.id,
+            ""
+        )
+        // A detail with an EMPTY id under a NON-EMPTY displayed identity is a
+        // server contract violation: honoring it would aim mutations at an
+        // empty task id and break startedTask.id == displayedTaskID gating
+        // (silently inert saves, PATCH/DELETE against /tasks/""). It must be
+        // non-actionable — the loading/failed state renders and the poll
+        // keeps retrying the displayed identity.
+        XCTAssertNil(
+            KanbanDetailIdentityPolicy.actionableTask(displayedID: "task-b", detailTask: emptyID, initialTask: taskA),
+            "an empty-id detail must never stand in for a non-empty displayed identity"
+        )
+        // The general boundary: a detail belonging to a different identity
+        // can never become actionable, and a true match always does.
+        XCTAssertNil(
+            KanbanDetailIdentityPolicy.actionableTask(displayedID: "task-b", detailTask: taskA, initialTask: taskA)
+        )
+        XCTAssertNotNil(
+            KanbanDetailIdentityPolicy.actionableTask(displayedID: "task-b", detailTask: taskB, initialTask: taskA)
+        )
+    }
+
+    // MARK: - 6. Card delete confirmation
+
+    func testCardDeleteActionNeverIssuesDestructiveMutationDirectly() {
+        let task = makeTask(id: "task-a")
+
+        // Both card entry points (ellipsis menu and context menu) route
+        // through the staging request: never the destructive mutation.
+        let staged = KanbanCardDeletePolicy.cardRequestedDelete(for: task)
+        XCTAssertEqual(staged, .confirm(task))
+        if case .perform = staged {
+            XCTFail("a card action must never issue the destructive DELETE directly")
+        }
+
+        // Only an explicit confirmation resolves to the destructive request.
+        XCTAssertEqual(KanbanCardDeletePolicy.confirmed(staged: task), .perform(task))
+        XCTAssertEqual(KanbanCardDeletePolicy.cancelled(), .none)
+        XCTAssertEqual(KanbanCardDeletePolicy.confirmed(staged: nil), .none)
+    }
+
+    // MARK: - 7. Existing model override display
+
+    func testExistingModelOverrideDisplaysWithoutOpeningEditor() {
+        let overridden = makeTask(id: "task-a", extra: [
+            "model_override": "glm-4.7",
+            "provider_override": "zhipu",
+            "reasoning_effort": "high"
+        ])
+        // The visible row label derives from the loaded SERVER task, so an
+        // existing override shows immediately — without opening the sheet.
+        let label = KanbanModelOverrideDisplayPolicy.label(for: overridden, inheritCopy: "Inherit from profile")
+        XCTAssertTrue(label.contains("zhipu"), label)
+        XCTAssertTrue(label.contains("glm-4.7"), label)
+        XCTAssertTrue(label.contains("High"), label)
+        XCTAssertFalse(label.contains("Inherit"), label)
+
+        // An inherited task still inherits.
+        let inherited = makeTask(id: "task-b")
+        XCTAssertEqual(
+            KanbanModelOverrideDisplayPolicy.label(for: inherited, inheritCopy: "Inherit from profile"),
+            "Inherit from profile"
+        )
+        // Not-yet-loaded replacement identity: inherit copy, never stale
+        // data from the previous task.
+        XCTAssertEqual(
+            KanbanModelOverrideDisplayPolicy.label(for: nil, inheritCopy: "Inherit from profile"),
+            "Inherit from profile"
+        )
+    }
+
+    func testModelOverrideEditorDraftIsIndependentOfLaterServerChanges() {
+        let serverAtOpen = makeTask(id: "task-a", extra: [
+            "model_override": "glm-4.7",
+            "provider_override": "zhipu"
+        ])
+        // The editor draft is seeded from the server task at OPEN time only.
+        let seededDraft = KanbanModelOverrideDisplayPolicy.override(for: serverAtOpen)
+        XCTAssertEqual(seededDraft.model, "glm-4.7")
+        // A later poll that changes the server override updates the DISPLAY
+        // row (server-derived) but never the seeded editor draft: polling
+        // cannot clobber an open editor, and loadDetail has no draft writes.
+        let serverAfterPoll = makeTask(id: "task-a", extra: [
+            "model_override": "glm-5.3",
+            "provider_override": "zhipu"
+        ])
+        XCTAssertEqual(
+            KanbanModelOverrideDisplayPolicy.label(for: serverAfterPoll, inheritCopy: "Inherit from profile"),
+            "zhipu: glm-5.3"
+        )
+        XCTAssertEqual(seededDraft.model, "glm-4.7", "the editor draft is never rewritten by later server loads")
+    }
+
+    // MARK: - 8. Note & requeue partial success
+
+    func testNotePostedThenRequeueFailedIsExplicitPartialSuccess() async throws {
+        var events: [String] = []
+        var commentPostCount = 0
+
+        let outcome = await KanbanNoteAndRequeueFlow.perform(
+            text: "check the logs",
+            postComment: { _ in
+                commentPostCount += 1
+                events.append("comment-post")
+            },
+            reclaim: {
+                events.append("reclaim-attempt")
+                throw CorrectnessTestError.failed("reclaim exploded")
+            },
+            onCommentPosted: { events.append("draft-cleared") }
+        )
+
+        XCTAssertTrue(outcome.commentPosted)
+        XCTAssertFalse(outcome.requeued)
+        XCTAssertEqual(commentPostCount, 1, "a failed reclaim must never cause a second comment POST")
+        XCTAssertEqual(
+            events,
+            ["comment-post", "draft-cleared", "reclaim-attempt"],
+            "strict order IS the contract: the draft is consumed the moment the note reaches the server and BEFORE the reclaim attempt, so a reclaim failure can never hide whether the note posted"
+        )
+        let message = try XCTUnwrap(KanbanNoteAndRequeueFlow.message(for: outcome))
+        XCTAssertTrue(message.contains("note was posted"), message)
+        XCTAssertTrue(message.contains("could not be requeued"), message)
+        XCTAssertTrue(message.contains("reclaim exploded"), message)
+    }
+
+    func testNoteFailureKeepsDraftAndSurfacesPlainError() async {
+        var draftCleared = false
+        let outcome = await KanbanNoteAndRequeueFlow.perform(
+            text: "note",
+            postComment: { _ in throw CorrectnessTestError.failed("comment 500") },
+            reclaim: { XCTFail("reclaim must not be attempted when the comment failed") },
+            onCommentPosted: { draftCleared = true }
+        )
+        XCTAssertFalse(outcome.commentPosted)
+        XCTAssertFalse(outcome.requeued)
+        XCTAssertFalse(draftCleared, "a failed POST keeps the draft so the user can retry")
+        XCTAssertEqual(KanbanNoteAndRequeueFlow.message(for: outcome), "comment 500")
+    }
+
+    func testNoteAndRequeueFullSuccessClearsDraftAndReportsNothing() async {
+        var postedBody: String?
+        var draftCleared = false
+        let outcome = await KanbanNoteAndRequeueFlow.perform(
+            text: "note",
+            postComment: { body in postedBody = body },
+            reclaim: { },
+            onCommentPosted: { draftCleared = true }
+        )
+        XCTAssertEqual(postedBody, "note")
+        XCTAssertTrue(outcome.commentPosted)
+        XCTAssertTrue(outcome.requeued)
+        XCTAssertTrue(draftCleared)
+        XCTAssertNil(KanbanNoteAndRequeueFlow.message(for: outcome))
+    }
+
+    // MARK: - 9. Worker-log cached content on refresh failure
+
+    func testWorkerLogInitialFailureShowsFullUnavailableState() {
+        // Nothing cached + load failed → full unavailable state.
+        XCTAssertEqual(
+            KanbanWorkerLogPresentation.resolve(log: nil, loadError: "boom", refreshError: nil),
+            .unavailable("boom")
+        )
+        // Nothing cached, still loading (no error yet) → loading state.
+        XCTAssertEqual(
+            KanbanWorkerLogPresentation.resolve(log: nil, loadError: nil, refreshError: nil),
+            .loading
+        )
+    }
+
+    func testWorkerLogRefreshFailurePreservesCachedContent() {
+        let cached = KanbanWorkerLog(exists: true, sizeBytes: 12, content: "hello world", truncated: false)
+        // Refresh failed WITH a cached log: the cache stays visible with a
+        // non-destructive banner — the load error must NOT evict it.
+        XCTAssertEqual(
+            KanbanWorkerLogPresentation.resolve(log: cached, loadError: "refresh boom", refreshError: "refresh boom"),
+            .content(log: cached, refreshError: "refresh boom")
+        )
+        // Documented precedence: cached CONTENT always outranks a (possibly
+        // stale) loadError — only the dedicated refresh banner channel may
+        // carry a failure while a log is cached.
+        XCTAssertEqual(
+            KanbanWorkerLogPresentation.resolve(log: cached, loadError: "stale load error", refreshError: nil),
+            .content(log: cached, refreshError: nil)
+        )
+    }
+
+    func testWorkerLogSuccessfulRefreshClearsTheBanner() {
+        let fresh = KanbanWorkerLog(exists: true, sizeBytes: 9, content: "fresh log", truncated: false)
+        XCTAssertEqual(
+            KanbanWorkerLogPresentation.resolve(log: fresh, loadError: nil, refreshError: nil),
+            .content(log: fresh, refreshError: nil)
+        )
+    }
+}

--- a/ConduitTests/KanbanV2CorrectnessTests.swift
+++ b/ConduitTests/KanbanV2CorrectnessTests.swift
@@ -21,6 +21,14 @@ final class KanbanV2CorrectnessTests: XCTestCase {
         }
     }
 
+    private func makeContextRaceStore(requester: ContextRaceMockRequester) -> KanbanStore {
+        let store = KanbanStore(
+            defaults: UserDefaults(suiteName: UUID().uuidString)!
+        )
+        store.configure(requester: requester, serverIdentity: "https://a.test")
+        return store
+    }
+
     private func makeTask(id: String, extra: [String: Any] = [:]) -> KanbanTask {
         var object: [String: Any] = ["id": id, "title": "T", "status": "todo"]
         for (key, value) in extra { object[key] = value }
@@ -209,19 +217,138 @@ final class KanbanV2CorrectnessTests: XCTestCase {
 
     func testCardDeleteActionNeverIssuesDestructiveMutationDirectly() {
         let task = makeTask(id: "task-a")
+        let stamp = KanbanBoardContextStamp(boardSlug: "alpha", configurationGeneration: 3)
 
         // Both card entry points (ellipsis menu and context menu) route
-        // through the staging request: never the destructive mutation.
-        let staged = KanbanCardDeletePolicy.cardRequestedDelete(for: task)
-        XCTAssertEqual(staged, .confirm(task))
+        // through the staging request: never the destructive mutation, and
+        // always stamped with the staging board/server context.
+        let staged = KanbanCardDeletePolicy.cardRequestedDelete(for: task, stamp: stamp)
+        XCTAssertEqual(
+            staged,
+            .confirm(PendingCardDelete(task: task, stamp: stamp))
+        )
         if case .perform = staged {
             XCTFail("a card action must never issue the destructive DELETE directly")
         }
 
-        // Only an explicit confirmation resolves to the destructive request.
-        XCTAssertEqual(KanbanCardDeletePolicy.confirmed(staged: task), .perform(task))
+        // Only an explicit confirmation that still owns the staging context
+        // resolves to the destructive request.
+        XCTAssertEqual(
+            KanbanCardDeletePolicy.confirmed(staged: stagedIfConfirm(staged), currentStamp: stamp, isSnapshotActionable: true),
+            .perform(task)
+        )
         XCTAssertEqual(KanbanCardDeletePolicy.cancelled(), .none)
-        XCTAssertEqual(KanbanCardDeletePolicy.confirmed(staged: nil), .none)
+        XCTAssertEqual(
+            KanbanCardDeletePolicy.confirmed(staged: nil, currentStamp: stamp, isSnapshotActionable: true),
+            .none
+        )
+    }
+
+    /// Staging helper mirroring the view: only a .confirm carries a pending
+    /// delete; anything else stages nothing.
+    private func stagedIfConfirm(_ request: KanbanCardDeletePolicy.Request) -> PendingCardDelete? {
+        if case .confirm(let pending) = request { return pending }
+        return nil
+    }
+
+    // MARK: - 6b. Card delete context ownership (staged confirmation races)
+
+    func testStagedCardDeleteIsInertAfterServerReconfigure() async throws {
+        let requesterA = ContextRaceMockRequester(responsesByPath: contextRaceResponses(boardSlug: "alpha"))
+        let store = makeContextRaceStore(requester: requesterA)
+        await store.refresh()
+
+        // Stage exactly as the view does: task by value + current stamp.
+        let stampA = try XCTUnwrap(store.loadedContextStamp)
+        let staged = stagedIfConfirm(
+            KanbanCardDeletePolicy.cardRequestedDelete(for: makeTask(id: "t1"), stamp: stampA)
+        )
+
+        // The dashboard/server reconfigures to B before the user confirms.
+        let requesterB = ContextRaceMockRequester(responsesByPath: contextRaceResponses(boardSlug: "beta"))
+        store.configure(requester: requesterB, serverIdentity: "https://b.test")
+        await store.reload()
+
+        let outcome = KanbanCardDeletePolicy.confirmed(
+            staged: staged,
+            currentStamp: store.loadedContextStamp,
+            isSnapshotActionable: store.isSelectedSnapshotLoaded
+        )
+        XCTAssertEqual(outcome, KanbanCardDeletePolicy.Request.none, "a confirmation staged on server A must never delete on server B")
+        XCTAssertFalse(requesterB.calls.contains { $0.method == "DELETE" }, "zero DELETE requests may reach server B")
+        XCTAssertFalse(requesterA.calls.contains { $0.method == "DELETE" }, "nothing was sent to A either — the request was discarded before any transport")
+    }
+
+    func testStagedCardDeleteIsInertAfterBoardSwitchOnSameServer() async throws {
+        // The SAME task id exists on both boards: the id alone must never be
+        // the ownership token.
+        var responses = contextRaceResponses(boardSlug: "alpha")
+        responses["/api/plugins/kanban/board?board=alpha"] = [
+            "columns": [["name": "todo", "tasks": [["id": "t1", "title": "on alpha", "status": "todo"]]]],
+            "tenants": [], "assignees": []
+        ]
+        responses["/api/plugins/kanban/board?board=beta"] = [
+            "columns": [["name": "todo", "tasks": [["id": "t1", "title": "on beta", "status": "todo"]]]],
+            "tenants": [], "assignees": []
+        ]
+        let requester = ContextRaceMockRequester(responsesByPath: responses)
+        let store = makeContextRaceStore(requester: requester)
+        await store.selectBoard(slug: "alpha")
+
+        let stampA = try XCTUnwrap(store.loadedContextStamp)
+        XCTAssertEqual(stampA.boardSlug, "alpha")
+        let staged = stagedIfConfirm(
+            KanbanCardDeletePolicy.cardRequestedDelete(for: makeTask(id: "t1"), stamp: stampA)
+        )
+
+        // Confirm while the new board is still loading (loaded snapshot is
+        // still alpha, but it is no longer actionable): discarded.
+        let inFlightOutcome = KanbanCardDeletePolicy.confirmed(
+            staged: staged,
+            currentStamp: KanbanBoardContextStamp(boardSlug: "alpha", configurationGeneration: stampA.configurationGeneration),
+            isSnapshotActionable: false
+        )
+        XCTAssertEqual(inFlightOutcome, KanbanCardDeletePolicy.Request.none, "an in-flight board navigation must invalidate a staged confirmation")
+
+        // Select board B on the SAME server and let it load.
+        await store.selectBoard(slug: "beta")
+        let outcome = KanbanCardDeletePolicy.confirmed(
+            staged: staged,
+            currentStamp: store.loadedContextStamp,
+            isSnapshotActionable: store.isSelectedSnapshotLoaded
+        )
+        XCTAssertEqual(outcome, KanbanCardDeletePolicy.Request.none, "a confirmation staged on board A must never delete on board B, even for a colliding task id")
+        XCTAssertFalse(requester.calls.contains { $0.method == "DELETE" }, "zero DELETE requests may leave for any board")
+    }
+
+    func testConfirmedCardDeleteOnUnchangedContextSendsExactlyOneDelete() async throws {
+        var responses = contextRaceResponses(boardSlug: "alpha")
+        responses["/api/plugins/kanban/tasks/t1"] = ["ok": true]
+        let requester = ContextRaceMockRequester(responsesByPath: responses)
+        let store = makeContextRaceStore(requester: requester)
+        await store.refresh()
+
+        let stamp = try XCTUnwrap(store.loadedContextStamp)
+        let staged = stagedIfConfirm(
+            KanbanCardDeletePolicy.cardRequestedDelete(for: makeTask(id: "t1"), stamp: stamp)
+        )
+
+        // Context unchanged: the confirmation resolves and the view's delete
+        // issues exactly one DELETE to the staging board.
+        guard case .perform(let task) = KanbanCardDeletePolicy.confirmed(
+            staged: staged,
+            currentStamp: store.loadedContextStamp,
+            isSnapshotActionable: store.isSelectedSnapshotLoaded
+        ) else {
+            return XCTFail("an unchanged context must honor the confirmed delete")
+        }
+        try await store.deleteTask(id: task.id)
+        await store.awaitPendingDispatcherNudgeForTesting()
+
+        let deletes = requester.calls.filter { $0.method == "DELETE" }
+        XCTAssertEqual(deletes.count, 1, "exactly one DELETE for the staged task")
+        XCTAssertTrue(deletes[0].path.contains("/tasks/t1"), deletes[0].path)
+        XCTAssertTrue(deletes[0].path.contains("board=alpha"), deletes[0].path)
     }
 
     // MARK: - 7. Existing model override display
@@ -274,6 +401,121 @@ final class KanbanV2CorrectnessTests: XCTestCase {
             "zhipu: glm-5.3"
         )
         XCTAssertEqual(seededDraft.model, "glm-4.7", "the editor draft is never rewritten by later server loads")
+    }
+
+    // MARK: - 7b. Model sheet session (no-edit vs server-changed race)
+
+    func testModelSheetBaselineSeedingPinsToTheDisplayPolicy() {
+        // The view seeds both the draft and the session baseline through
+        // KanbanModelOverrideDisplayPolicy.override(for:); the tests below
+        // seed raw TaskModelOverride(task:). Pin their equality so the two
+        // can never drift apart silently.
+        let serverTask = makeTask(id: "t1", extra: [
+            "model_override": "model-a",
+            "provider_override": "prov-a",
+            "reasoning_effort": "high"
+        ])
+        XCTAssertEqual(
+            KanbanModelOverrideDisplayPolicy.override(for: serverTask),
+            TaskModelOverride(task: serverTask)
+        )
+    }
+
+    func testModelSheetNoEditDismissNeverOverwritesConcurrentServerChange() {
+        let serverAtOpen = makeTask(id: "t1", extra: ["model_override": "model-a"])
+        let session = KanbanModelOverrideSession(
+            taskID: "t1",
+            baseline: TaskModelOverride(task: serverAtOpen)
+        )
+        // The user opened the editor and made NO changes.
+        let untouchedDraft = TaskModelOverride(task: serverAtOpen)
+
+        // While the sheet stayed open, the server moved to B.
+        let serverNow = makeTask(id: "t1", extra: ["model_override": "model-b"])
+        // Precondition of the OLD bug: draft != current server would have
+        // been misread as "the user edited" and PATCHed A back over B.
+        XCTAssertNotEqual(untouchedDraft, TaskModelOverride(task: serverNow))
+
+        // The session baseline says the user never edited: no write at all,
+        // so B remains authoritative and zero PATCH requests are made.
+        XCTAssertEqual(
+            KanbanModelOverrideSessionPolicy.dismissalOutcome(
+                session: session,
+                draft: untouchedDraft,
+                displayedTaskID: "t1"
+            ),
+            .noWrite
+        )
+    }
+
+    func testModelSheetUserEditCommitsDiffedAgainstCurrentServer() {
+        let serverAtOpen = makeTask(id: "t1", extra: ["model_override": "model-a"])
+        let session = KanbanModelOverrideSession(
+            taskID: "t1",
+            baseline: TaskModelOverride(task: serverAtOpen)
+        )
+        // The user deliberately edited the draft to C.
+        let edited = TaskModelOverride(model: "model-c")
+
+        // And the server moved to B while the sheet was open.
+        let serverNow = makeTask(id: "t1", extra: [
+            "model_override": "model-b",
+            "provider_override": "prov-b"
+        ])
+
+        // The user's edit IS committed...
+        XCTAssertEqual(
+            KanbanModelOverrideSessionPolicy.dismissalOutcome(
+                session: session,
+                draft: edited,
+                displayedTaskID: "t1"
+            ),
+            .commit(edited)
+        )
+
+        // ...and the wire mutation is diffed against the CURRENT server B
+        // (not the open-time baseline): model set to C, no spurious clears.
+        let patch = TaskModelOverride.patch(from: serverNow, to: edited)
+        XCTAssertEqual(patch.modelOverride, "model-c")
+        XCTAssertFalse(patch.clearModelOverride)
+        XCTAssertNil(patch.providerOverride, "provider is sent only when explicitly chosen (desktop parity)")
+
+        // Explicit-clear semantics survive: editing to INHERIT clears the
+        // server's B override through the dedicated clear flag.
+        let inheritPatch = TaskModelOverride.patch(from: serverNow, to: TaskModelOverride())
+        XCTAssertTrue(inheritPatch.clearModelOverride)
+        XCTAssertFalse(inheritPatch.clearReasoningEffort)
+    }
+
+    func testModelSheetSessionNeverCommitsForAnotherTaskIdentity() {
+        let serverA = makeTask(id: "task-a", extra: ["model_override": "model-a"])
+        let session = KanbanModelOverrideSession(
+            taskID: "task-a",
+            baseline: TaskModelOverride(task: serverA)
+        )
+        let edited = TaskModelOverride(model: "model-c")
+
+        // Dependency navigation replaced the displayed identity: the old
+        // session must not PATCH either A or B.
+        XCTAssertEqual(
+            KanbanModelOverrideSessionPolicy.dismissalOutcome(
+                session: session,
+                draft: edited,
+                displayedTaskID: "task-b"
+            ),
+            .noWrite
+        )
+
+        // A missing session (never opened, or reset by navigation) writes
+        // nothing either.
+        XCTAssertEqual(
+            KanbanModelOverrideSessionPolicy.dismissalOutcome(
+                session: nil,
+                draft: edited,
+                displayedTaskID: "task-a"
+            ),
+            .noWrite
+        )
     }
 
     // MARK: - 8. Note & requeue partial success
@@ -378,4 +620,55 @@ final class KanbanV2CorrectnessTests: XCTestCase {
             .content(log: fresh, refreshError: nil)
         )
     }
+}
+
+// MARK: - Card-delete context-race doubles
+
+@MainActor
+private final class ContextRaceMockRequester: DashboardJSONRequester {
+    struct Call {
+        let path: String
+        let method: String
+        let body: [String: Any]?
+    }
+
+    var responsesByPath: [String: [String: Any]]
+    var errorsByPath: [String: Error] = [:]
+    var calls: [Call] = []
+
+    init(responsesByPath: [String: [String: Any]] = [:]) {
+        self.responsesByPath = responsesByPath
+    }
+
+    func requestJSON(path: String, method: String, body: [String: Any]?, timeoutMilliseconds: Int, maxResponseBytes: Int) async throws -> [String: Any] {
+        calls.append(Call(path: path, method: method, body: body))
+        let basePath = path.components(separatedBy: "?").first ?? path
+        if let error = errorsByPath[path] ?? errorsByPath[basePath] { throw error }
+        if let response = responsesByPath[path] ?? responsesByPath[basePath] { return response }
+        return [:]
+    }
+}
+
+private func contextRaceResponses(boardSlug: String) -> [String: [String: Any]] {
+    [
+        "/api/plugins/kanban/boards": [
+            "boards": [
+                ["slug": boardSlug, "name": boardSlug, "is_current": true],
+                ["slug": "beta", "name": "Beta", "is_current": false]
+            ],
+            "current": boardSlug
+        ],
+        "/api/plugins/kanban/board": ["columns": [], "tenants": [], "assignees": [], "latest_event_id": 1, "now": 2],
+        "/api/plugins/kanban/profiles": ["profiles": []],
+        "/api/plugins/kanban/projects": ["projects": []],
+        "/api/plugins/kanban/orchestration": [
+            "orchestrator_profile": "",
+            "default_assignee": "",
+            "auto_decompose": true,
+            "auto_promote_children": true,
+            "resolved_orchestrator_profile": "default",
+            "resolved_default_assignee": "default"
+        ],
+        "/api/plugins/kanban/dispatch": [:]
+    ]
 }

--- a/ConduitTests/KanbanV2Tests.swift
+++ b/ConduitTests/KanbanV2Tests.swift
@@ -1,0 +1,640 @@
+import XCTest
+@testable import Conduit
+
+/// Kanban V2 semantics: composer serialization, assignment/workspace/model
+/// inheritance rules, lane policy, actions, diagnostics/dependencies decoding,
+/// and worker-log context. V1's KanbanTests.swift remains untouched.
+@MainActor
+final class KanbanV2Tests: XCTestCase {
+
+    // MARK: - Effective visible lane (V2 §9 regression)
+
+    private func columns(_ names: [String]) -> [KanbanColumn] {
+        names.map { KanbanColumn(name: $0) }
+    }
+
+    func testGlobalPlusUsesEffectiveVisibleLaneNotRawSelection() {
+        // The user never tapped a chip (selected == nil), yet the UI resolved
+        // Triage as the visible lane. The New Task initial status MUST follow
+        // the effective lane, not fall back to Todo.
+        let board = columns(["triage", "todo", "ready"])
+        let lane = KanbanLanePolicy.effectiveSelectedLane(selected: nil, columns: board)
+        XCTAssertEqual(lane, "triage")
+        XCTAssertEqual(KanbanLanePolicy.newTaskInitialStatus(effectiveLane: lane), "triage")
+    }
+
+    func testExplicitSelectionWinsAndLockedSelectionCollapsesToTodo() {
+        let board = columns(["triage", "todo", "running"])
+        XCTAssertEqual(
+            KanbanLanePolicy.effectiveSelectedLane(selected: "todo", columns: board),
+            "todo"
+        )
+        // A locked lane is never a valid creation target.
+        let locked = KanbanLanePolicy.effectiveSelectedLane(selected: "running", columns: board)
+        XCTAssertEqual(locked, "running", "locked lanes stay VIEWABLE")
+        XCTAssertEqual(
+            KanbanLanePolicy.newTaskInitialStatus(effectiveLane: locked),
+            "todo",
+            "creation on a locked lane collapses to the default unlocked status"
+        )
+    }
+
+    func testAllLockedBoardStillResolvesFirstLane() {
+        let board = columns(["review", "scheduled"])
+        XCTAssertEqual(KanbanLanePolicy.effectiveSelectedLane(selected: nil, columns: board), "review")
+        XCTAssertNil(KanbanLanePolicy.effectiveSelectedLane(selected: nil, columns: []))
+        XCTAssertEqual(KanbanLanePolicy.newTaskInitialStatus(effectiveLane: nil), "todo")
+    }
+
+    func testMissingSelectedLaneFallsBackToUnlockedDefault() {
+        // selected references a column that left the snapshot (e.g. archived).
+        let board = columns(["ready", "done"])
+        XCTAssertEqual(
+            KanbanLanePolicy.effectiveSelectedLane(selected: "vanished", columns: board),
+            "ready"
+        )
+    }
+
+    // MARK: - Assignment Default / Profile / Parked (V2 §2)
+
+    func testAssigneeSelectionMatchesUpstreamWireSemantics() {
+        // Default sends the RESOLVED orchestration default — never silently nil.
+        XCTAssertEqual(
+            KanbanAssigneeSelection.inheritDefault.requestValue(resolvedDefaultAssignee: "archimedes"),
+            "archimedes"
+        )
+        XCTAssertEqual(
+            KanbanAssigneeSelection.inheritDefault.requestValue(resolvedDefaultAssignee: "   "),
+            "default",
+            "empty resolution falls back to 'default' like the desktop dialog"
+        )
+        // Parked OMITS assignee entirely (backend nil = unassigned).
+        XCTAssertNil(KanbanAssigneeSelection.parked.requestValue(resolvedDefaultAssignee: "archimedes"))
+        // Explicit profile pins that profile.
+        XCTAssertEqual(
+            KanbanAssigneeSelection.profile("lancelot").requestValue(resolvedDefaultAssignee: "archimedes"),
+            "lancelot"
+        )
+    }
+
+    // MARK: - Workspace default + override serialization (V2 §3)
+
+    func testBoardDefaultWorkspaceKindInitializesComposer() {
+        XCTAssertEqual(KanbanWorkspaceKind.initialKind(boardDefault: nil), .scratch)
+        XCTAssertEqual(KanbanWorkspaceKind.initialKind(boardDefault: ""), .scratch)
+        XCTAssertEqual(KanbanWorkspaceKind.initialKind(boardDefault: "worktree"), .worktree)
+        XCTAssertEqual(KanbanWorkspaceKind.initialKind(boardDefault: "dir"), .dir)
+        XCTAssertEqual(KanbanWorkspaceKind.initialKind(boardDefault: "scratch"), .scratch)
+        XCTAssertEqual(KanbanWorkspaceKind.initialKind(boardDefault: "  Worktree "), .worktree, "case/space tolerant")
+        XCTAssertEqual(KanbanWorkspaceKind.initialKind(boardDefault: "banana"), .scratch, "unknown falls back to backend scratch default")
+    }
+
+    func testExplicitWorkspaceOverrideSerializesCorrectly() throws {
+        var draft = KanbanComposerDraft()
+        draft.title = "Worktree task"
+        draft.workspaceKind = .worktree
+        draft.workspacePath = " /repos/hermes-agent "
+        let request = try KanbanComposerValidator.makeRequest(from: draft, resolvedDefaultAssignee: "default")
+        XCTAssertEqual(request.workspaceKind, "worktree")
+        XCTAssertEqual(request.workspacePath, "/repos/hermes-agent", "path trimmed and sent for worktree")
+
+        draft.workspaceKind = .scratch
+        draft.workspacePath = ""
+        let scratchRequest = try KanbanComposerValidator.makeRequest(from: draft, resolvedDefaultAssignee: "default")
+        XCTAssertEqual(scratchRequest.workspaceKind, "scratch")
+        XCTAssertNil(scratchRequest.workspacePath, "scratch never carries a path")
+    }
+
+    func testScratchWithPathIsAnInvalidCombination() {
+        var draft = KanbanComposerDraft()
+        draft.title = "Bad combo"
+        draft.workspaceKind = .scratch
+        draft.workspacePath = "/somewhere"
+        XCTAssertThrowsError(try KanbanComposerValidator.makeRequest(from: draft, resolvedDefaultAssignee: "default")) { error in
+            XCTAssertEqual(error as? KanbanDraftValidationError, .invalidWorkspacePath(.scratch))
+        }
+    }
+
+    // MARK: - Model / provider / reasoning (V2 §4)
+
+    func testModelOverrideInheritsByOmittingCreateFields() throws {
+        var draft = KanbanComposerDraft()
+        draft.title = "Inherit"
+        let request = try KanbanComposerValidator.makeRequest(from: draft, resolvedDefaultAssignee: "default")
+        XCTAssertNil(request.modelOverride)
+        XCTAssertNil(request.providerOverride)
+        XCTAssertNil(request.reasoningEffort)
+    }
+
+    func testModelOverrideSerializesModelProviderEffortOnCreate() throws {
+        var draft = KanbanComposerDraft()
+        draft.title = "Pinned"
+        draft.modelOverride = TaskModelOverride(provider: "openai", model: "gpt-test", reasoningEffort: "high")
+        let request = try KanbanComposerValidator.makeRequest(from: draft, resolvedDefaultAssignee: "default")
+        XCTAssertEqual(request.modelOverride, "gpt-test")
+        XCTAssertEqual(request.providerOverride, "openai")
+        XCTAssertEqual(request.reasoningEffort, "high")
+
+        // Provider without a model is meaningless upstream and must be omitted.
+        draft.modelOverride = TaskModelOverride(provider: "openai", model: nil, reasoningEffort: nil)
+        let providerOnly = try KanbanComposerValidator.makeRequest(from: draft, resolvedDefaultAssignee: "default")
+        XCTAssertNil(providerOnly.modelOverride)
+        XCTAssertNil(providerOnly.providerOverride)
+    }
+
+    func testReasoningEffortNoneIsARealValueAndUnknownIsRejected() throws {
+        var draft = KanbanComposerDraft()
+        draft.title = "Thinking off"
+        draft.modelOverride = TaskModelOverride(reasoningEffort: "none")
+        let request = try KanbanComposerValidator.makeRequest(from: draft, resolvedDefaultAssignee: "default")
+        XCTAssertEqual(request.reasoningEffort, "none", "none = thinking OFF, not a clear")
+
+        draft.modelOverride = TaskModelOverride(reasoningEffort: "maximum")
+        XCTAssertThrowsError(try KanbanComposerValidator.validate(draft)) { error in
+            XCTAssertEqual(error as? KanbanDraftValidationError, .invalidReasoningEffort("maximum"))
+        }
+    }
+
+    func testModelOverridePatchCarriesValuesAndClearFlags() {
+        let serverTask = makeTask(
+            id: "t1",
+            extra: [
+                "model_override": "old-model",
+                "provider_override": "old-provider",
+                "reasoning_effort": "low"
+            ]
+        )
+
+        // Back to inherit => explicit clear flags.
+        let cleared = TaskModelOverride.patch(from: serverTask, to: TaskModelOverride())
+        XCTAssertTrue(cleared.clearModelOverride)
+        XCTAssertTrue(cleared.clearReasoningEffort)
+        XCTAssertNil(cleared.modelOverride)
+
+        // New model replaces; effort kept separate.
+        let switched = TaskModelOverride.patch(
+            from: serverTask,
+            to: TaskModelOverride(provider: "anthropic", model: "claude-test", reasoningEffort: "high")
+        )
+        XCTAssertFalse(switched.clearModelOverride)
+        XCTAssertEqual(switched.modelOverride, "claude-test")
+        XCTAssertEqual(switched.providerOverride, "anthropic")
+        XCTAssertEqual(switched.reasoningEffort, "high")
+
+        // Dropping ONLY the model does not silently reset an explicit effort.
+        let modelDropped = TaskModelOverride.patch(
+            from: serverTask,
+            to: TaskModelOverride(reasoningEffort: "ultra")
+        )
+        XCTAssertTrue(modelDropped.clearModelOverride)
+        XCTAssertFalse(modelDropped.clearReasoningEffort)
+        XCTAssertEqual(modelDropped.reasoningEffort, "ultra")
+    }
+
+    // MARK: - Skills (V2 §5)
+
+    func testSelectedSkillsSerializeTrimmedAndDeduplicated() throws {
+        var draft = KanbanComposerDraft()
+        draft.title = "Skilled"
+        draft.skills = [" github ", "translation", "github", "", "   ", "code-review"]
+        let request = try KanbanComposerValidator.makeRequest(from: draft, resolvedDefaultAssignee: "default")
+        XCTAssertEqual(request.skills, ["github", "translation", "code-review"])
+
+        draft.skills = ["   "]
+        let empty = try KanbanComposerValidator.makeRequest(from: draft, resolvedDefaultAssignee: "default")
+        XCTAssertNil(empty.skills, "an all-blank selection serializes as absent")
+    }
+
+    // MARK: - Goal Mode (V2 §6)
+
+    func testGoalModeSerializesWithOptionalMaxTurns() throws {
+        var draft = KanbanComposerDraft()
+        draft.title = "Goal"
+        draft.goalMode = true
+        draft.goalMaxTurns = 25
+        let request = try KanbanComposerValidator.makeRequest(from: draft, resolvedDefaultAssignee: "default")
+        XCTAssertTrue(request.goalMode)
+        XCTAssertEqual(request.goalMaxTurns, 25)
+
+        draft.goalMode = false
+        let off = try KanbanComposerValidator.makeRequest(from: draft, resolvedDefaultAssignee: "default")
+        XCTAssertFalse(off.goalMode)
+        XCTAssertNil(off.goalMaxTurns, "turns only travel when Goal Mode is enabled")
+    }
+
+    func testGoalModeZeroTurnsRejectedWhenEnabled() {
+        var draft = KanbanComposerDraft()
+        draft.title = "Goal"
+        draft.goalMode = true
+        draft.goalMaxTurns = 0
+        XCTAssertThrowsError(try KanbanComposerValidator.validate(draft)) { error in
+            XCTAssertEqual(error as? KanbanDraftValidationError, .invalidGoalMaxTurns(0))
+        }
+        // Disabled Goal Mode with a stale turn value is fine.
+        draft.goalMode = false
+        XCTAssertNoThrow(try KanbanComposerValidator.validate(draft))
+    }
+
+    // MARK: - Parents (V2 §7)
+
+    func testParentDependenciesSerializeAsList() throws {
+        var draft = KanbanComposerDraft()
+        draft.title = "Child"
+        draft.parents = [" t_parent_1 "]
+        let request = try KanbanComposerValidator.makeRequest(from: draft, resolvedDefaultAssignee: "default")
+        XCTAssertEqual(request.parents, ["t_parent_1"])
+    }
+
+    func testDuplicateParentsAreSanitized() {
+        let sanitized = KanbanComposerValidator.sanitizedParents(["a", "a", " b ", ""])
+        XCTAssertEqual(sanitized, ["a", "b"])
+    }
+
+    // MARK: - Creation validation (V2 §8)
+
+    func testEmptyTitleIsRejectedByTheValidationLayer() {
+        let draft = KanbanComposerDraft()
+        XCTAssertThrowsError(try KanbanComposerValidator.makeRequest(from: draft, resolvedDefaultAssignee: "x")) { error in
+            XCTAssertEqual(error as? KanbanDraftValidationError, .emptyTitle)
+        }
+    }
+
+    func testPriorityIsClampedNonNegative() throws {
+        var draft = KanbanComposerDraft()
+        draft.title = "P"
+        draft.priority = -5
+        let request = try KanbanComposerValidator.makeRequest(from: draft, resolvedDefaultAssignee: "d")
+        XCTAssertEqual(request.priority, 0)
+    }
+
+    // MARK: - Actions (V2 §10)
+
+    func testArchiveSendsArchivedStatusPatch() async throws {
+        let requester = V2MockKanbanRequester()
+        requester.responsesByPath["/api/plugins/kanban/tasks/t9"] = ["task": ["id": "t9", "title": "x", "status": "archived"]]
+        let service = KanbanService(requester: requester)
+        _ = try await service.updateTask(id: "t9", board: "alpha", patch: KanbanTaskPatch(status: "archived"))
+        let call = try XCTUnwrap(requester.calls.last)
+        XCTAssertEqual(call.method, "PATCH")
+        XCTAssertTrue(call.path.hasPrefix("/api/plugins/kanban/tasks/t9?board=alpha"), call.path)
+        XCTAssertEqual(call.body?["status"] as? String, "archived")
+    }
+
+    func testArchivePassesTheManualCapabilityGate() {
+        // Upstream archive_task is reached via PATCH status='archived'; the
+        // client capability matrix must not block it.
+        XCTAssertTrue(KanbanStatusPresentation.canSelectManually("archived"))
+    }
+
+    func testDeleteRemainsDeleteMethod() async throws {
+        let requester = V2MockKanbanRequester()
+        let service = KanbanService(requester: requester)
+        try await service.deleteTask(id: "t1", board: "beta")
+        let call = try XCTUnwrap(requester.calls.last)
+        XCTAssertEqual(call.method, "DELETE")
+        XCTAssertTrue(call.path.contains("/tasks/t1"))
+        XCTAssertTrue(call.path.contains("board=beta"))
+    }
+
+    func testMoveToRunningIsRefusedBeforeAnyTransport() async throws {
+        var responses = standardKanbanResponses(boardSlug: "alpha")
+        responses["/api/plugins/kanban/tasks/t1"] = ["task": ["id": "t1", "title": "x", "status": "todo"]]
+        let requester = V2MockKanbanRequester(responsesByPath: responses)
+        let store = makeStore(requester: requester)
+        await store.refresh()
+
+        do {
+            _ = try await store.updateTask(id: "t1", patch: KanbanTaskPatch(status: "running"))
+            XCTFail("manual move into Running must be refused")
+        } catch {}
+        XCTAssertFalse(requester.calls.contains { $0.method == "PATCH" })
+    }
+
+    func testShortIDHelperMatchesUpstreamSemantics() {
+        XCTAssertEqual(KanbanShortID.of("t_abcdef123456"), "abcdef")
+        XCTAssertEqual(KanbanShortID.of("abcdef123456"), "abcdef", "ids without prefix still shorten")
+        XCTAssertEqual(KanbanShortID.of("t_ab"), "ab")
+        XCTAssertEqual(KanbanShortID.of(nil), "")
+    }
+
+    // MARK: - Reassignment / reclaim (V2 §12, §19)
+
+    func testReassignUsesDedicatedEndpointWithReclaimFirstBody() async throws {
+        let requester = V2MockKanbanRequester()
+        let service = KanbanService(requester: requester)
+        try await service.reassignTask(taskID: "t7", board: "alpha", profile: "archimedes", reclaimFirst: true)
+        let call = try XCTUnwrap(requester.calls.last)
+        XCTAssertEqual(call.method, "POST")
+        XCTAssertTrue(call.path.contains("/tasks/t7/reassign"))
+        XCTAssertTrue(call.path.contains("board=alpha"))
+        XCTAssertEqual(call.body?["profile"] as? String, "archimedes")
+        XCTAssertEqual(call.body?["reclaim_first"] as? Bool, true)
+    }
+
+    func testReclaimUsesDedicatedEndpoint() async throws {
+        let requester = V2MockKanbanRequester()
+        let service = KanbanService(requester: requester)
+        try await service.reclaimTask(taskID: "t7", board: "alpha", reason: "stuck")
+        let call = try XCTUnwrap(requester.calls.last)
+        XCTAssertTrue(call.path.contains("/tasks/t7/reclaim"))
+        XCTAssertEqual(call.body?["reason"] as? String, "stuck")
+    }
+
+    func testStaleReassignCompletionCannotTouchNewServer() async throws {
+        var responsesA = standardKanbanResponses(boardSlug: "a-board")
+        responsesA["/api/plugins/kanban/profiles"] = ["profiles": [["name": "alpha-profile", "is_default": true, "description": "", "description_auto": false]]]
+        let requesterA = V2MockKanbanRequester(responsesByPath: responsesA)
+        let store = makeStore(requester: requesterA)
+        await store.refresh()
+
+        requesterA.hold(pathPrefix: "/api/plugins/kanban/tasks/t1/reassign")
+        let mutation = Task { try? await store.reassignTask(taskID: "t1", profile: "beta-profile", reclaimFirst: true) }
+        await Task.yield(); await Task.yield(); await Task.yield()
+
+        let requesterB = V2MockKanbanRequester(responsesByPath: standardKanbanResponses(boardSlug: "b-board"))
+        store.configure(requester: requesterB, serverIdentity: "https://b.test")
+        await store.reload()
+        let bCallsBeforeRelease = requesterB.calls.count
+
+        requesterA.errorsByPath["/api/plugins/kanban/tasks/t1/reassign"] = MockRequestError.failed("A reassign exploded")
+        requesterA.releaseAll()
+        _ = await mutation.value
+
+        XCTAssertNil(store.mutationErrorMessage, "stale completion must be inert on server B")
+        XCTAssertFalse(store.isMutating)
+        XCTAssertEqual(requesterB.calls.count, bCallsBeforeRelease)
+    }
+
+    // MARK: - Diagnostics & dependencies decoding (V2 §14, §15)
+
+    func testMalformedDiagnosticsDoNotCrashDecoding() throws {
+        let json = "{" +
+            "\"id\":\"t1\",\"title\":\"x\",\"status\":\"blocked\"," +
+            "\"diagnostics\":[" +
+            "{\"kind\":\"stale_claim\",\"severity\":\"warning\",\"title\":\"Stale claim\",\"detail\":\"no heartbeat\",\"count\":\"3\",\"last_seen_at\":\"1700\",\"actions\":[{\"kind\":\"reclaim\",\"label\":\"Reclaim\"}]}," +
+            "{\"severity\":123,\"actions\":\"not-an-array\",\"data\":{\"weird\":[1,2]}}" +
+            "]}"
+        let task = try JSONDecoder().decode(KanbanTask.self, from: Data(json.utf8))
+        let diagnostics = try XCTUnwrap(task.diagnostics)
+        XCTAssertEqual(diagnostics.count, 2, "hostile rows normalize instead of crashing or vanishing wholesale")
+        XCTAssertEqual(diagnostics[0].count, 3, "stringly count decodes lossily")
+        XCTAssertEqual(diagnostics[0].lastSeenAt, 1700)
+        XCTAssertEqual(diagnostics[0].actions.first?.kind, "reclaim")
+        XCTAssertEqual(diagnostics[1].kind, "", "missing identity text degrades to empty")
+        XCTAssertEqual(diagnostics[1].severity, "123", "wrong-typed scalars degrade through the lossy string path")
+        XCTAssertTrue(diagnostics[1].actions.isEmpty, "a non-array actions payload becomes an empty list")
+    }
+
+    func testDiagnosticCLIHintActionCarriesCommandPayload() throws {
+        let json = "{" +
+            "\"id\":\"t1\",\"title\":\"x\",\"status\":\"blocked\"," +
+            "\"diagnostics\":[{\"kind\":\"k\",\"severity\":\"error\",\"title\":\"T\",\"detail\":\"D\",\"count\":1," +
+            "\"actions\":[{\"kind\":\"cli_hint\",\"label\":\"Copy fix\",\"payload\":{\"command\":\"hermes kanban reclaim t1\"}}]}]}"
+        let task = try JSONDecoder().decode(KanbanTask.self, from: Data(json.utf8))
+        let action = try XCTUnwrap(task.diagnostics?.first?.actions.first)
+        XCTAssertEqual(action.payload?["command"]?.stringValue, "hermes kanban reclaim t1")
+    }
+
+    func testDependencyLinksDecodeIntoParentsAndChildren() throws {
+        let json = "{" +
+            "\"task\":{\"id\":\"kid\",\"title\":\"child\",\"status\":\"blocked\"}," +
+            "\"comments\":[],\"events\":[],\"attachments\":[]," +
+            "\"links\":{\"parents\":[\"t_parent\"],\"children\":[\"t_grand\"]}," +
+            "\"child_results\":[],\"runs\":[]}"
+        let detail = try JSONDecoder().decode(KanbanTaskDetail.self, from: Data(json.utf8))
+        XCTAssertEqual(detail.links.parents, ["t_parent"])
+        XCTAssertEqual(detail.links.children, ["t_grand"])
+    }
+
+    // MARK: - Activity presentation (V2 §16)
+
+    private func makeEvent(kind: String, payload: [String: AnyCodable] = [:]) -> KanbanEvent {
+        KanbanEvent(id: "1", taskID: "t", kind: kind, payload: payload.isEmpty ? nil : .object(payload), createdAt: 100)
+    }
+
+    func testKnownActivityEventsMapToHumanRows() {
+        let moved = KanbanActivityFormatter.row(for: makeEvent(kind: "status", payload: ["status": .string("ready")]))
+        XCTAssertEqual(moved.label, "Moved to Ready")
+
+        let assigned = KanbanActivityFormatter.row(for: makeEvent(kind: "assigned", payload: ["assignee": .string("arch")]))
+        XCTAssertEqual(assigned.label, "Assigned to arch")
+
+        let unassigned = KanbanActivityFormatter.row(for: makeEvent(kind: "assigned", payload: [:]))
+        XCTAssertEqual(unassigned.label, "Unassigned")
+
+        let spawned = KanbanActivityFormatter.row(for: makeEvent(kind: "spawned", payload: ["pid": .number(4242)]))
+        XCTAssertEqual(spawned.label, "Worker started")
+        XCTAssertEqual(spawned.detail, "pid 4242")
+
+        let claimedFromReview = KanbanActivityFormatter.row(for: makeEvent(kind: "claimed", payload: ["source_status": .string("review")]))
+        XCTAssertEqual(claimedFromReview.label, "Claimed from review")
+    }
+
+    func testUnknownActivityEventGetsGracefulFallback() {
+        let row = KanbanActivityFormatter.row(
+            for: makeEvent(kind: "quantum_sync", payload: ["shard": .string("a"), "level": .number(2)])
+        )
+        XCTAssertEqual(row.label, "quantum sync", "unknown kinds become readable words")
+        XCTAssertEqual(row.detail, "level=2 shard=a", "scalar payload folds into detail; no raw JSON dump, no crash")
+
+        let emptyRow = KanbanActivityFormatter.row(for: makeEvent(kind: "mystery"))
+        XCTAssertEqual(emptyRow.label, "mystery")
+        XCTAssertNil(emptyRow.detail)
+    }
+
+    func testParentReopenedReasonIsExplained() {
+        let row = KanbanActivityFormatter.row(
+            for: makeEvent(kind: "status", payload: ["status": .string("blocked"), "reason": .string("parent_reopened"), "parent": .string("t_p")])
+        )
+        XCTAssertEqual(row.detail, "parent t_p reopened")
+    }
+
+    // MARK: - Runs presentation (V2 §17)
+
+    func testRunFailureClassificationMatchesUpstreamSet() {
+        for outcome in ["crashed", "failed", "timed_out", "gave_up"] {
+            let run = makeRun(outcome: outcome)
+            XCTAssertTrue(KanbanRunPresentation.isFailed(run), outcome)
+        }
+        XCTAssertFalse(KanbanRunPresentation.isFailed(makeRun(outcome: "completed")))
+        XCTAssertFalse(KanbanRunPresentation.isFailed(makeRun(outcome: nil, status: "completed")))
+        XCTAssertTrue(KanbanRunPresentation.isFailed(makeRun(outcome: nil, status: "failed")), "falls back through status")
+    }
+
+    func testRunDurationFormatting() {
+        XCTAssertEqual(KanbanRunPresentation.durationText(start: 100, end: 130), "30s")
+        XCTAssertEqual(KanbanRunPresentation.durationText(start: 100, end: 220), "2m")
+        XCTAssertEqual(KanbanRunPresentation.durationText(start: 100, end: 5000), "1h")
+        XCTAssertNil(KanbanRunPresentation.durationText(start: nil, end: 200))
+        XCTAssertNil(KanbanRunPresentation.durationText(start: 300, end: 100), "end before start is not a duration")
+    }
+
+    // MARK: - Worker log context (V2 §18)
+
+    func testWorkerLogFetchPinsBoardAndTail() async throws {
+        let requester = V2MockKanbanRequester()
+        requester.responsesByPath["/api/plugins/kanban/tasks/t1/log"] = [
+            "exists": true, "size_bytes": 12, "content": "hello\nworld", "truncated": false
+        ]
+        let service = KanbanService(requester: requester)
+        let log = try await service.fetchTaskLog(id: "t1", board: "alpha", tailBytes: 65_536)
+        XCTAssertTrue(log.exists)
+        XCTAssertEqual(log.content, "hello\nworld")
+        let call = try XCTUnwrap(requester.calls.last)
+        XCTAssertTrue(call.path.contains("/tasks/t1/log?"), call.path)
+        XCTAssertTrue(call.path.contains("tail=65536"), call.path)
+        XCTAssertTrue(call.path.contains("board=alpha"), call.path)
+    }
+
+    func testStoreWorkerLogUsesLoadedSnapshotBoard() async throws {
+        var responses = standardKanbanResponses(boardSlug: "alpha")
+        responses["/api/plugins/kanban/tasks/t-log/log?board=alpha&tail=1024"] = [
+            "exists": true, "size_bytes": 1, "content": "x", "truncated": false
+        ]
+        let requester = V2MockKanbanRequester(responsesByPath: responses)
+        let store = makeStore(requester: requester)
+        await store.selectBoard(slug: "alpha")
+        let log = try await store.fetchTaskLog(id: "t-log", tailBytes: 1024)
+        XCTAssertTrue(log.exists)
+        XCTAssertTrue(
+            requester.calls.contains { $0.path.contains("/tasks/t-log/log?board=alpha&tail=1024") },
+            requester.calls.map(\.path).joined(separator: " | ")
+        )
+    }
+
+    func testWorkerLogRenderTailCapsAndKeepsNewest() {
+        let huge = String(repeating: "x", count: 70_000)
+        let rendered = KanbanWorkerLogScreen.renderTail(huge)
+        XCTAssertLessThanOrEqual(rendered.count, KanbanWorkerLogScreen.maxRenderedCharacters + 40)
+        XCTAssertTrue(rendered.hasPrefix("[older output omitted]"))
+        XCTAssertEqual(KanbanWorkerLogScreen.renderTail("small"), "small")
+    }
+
+    // MARK: - Model options decoding (V2 §4)
+
+    func testModelOptionsDecodeTolerantly() async throws {
+        let empty = try JSONDecoder().decode(KanbanModelOptionsResponse.self, from: Data("{}".utf8))
+        XCTAssertTrue(empty.providers.isEmpty)
+
+        let json = "{" +
+            "\"providers\":[" +
+            "{\"slug\":\"openai\",\"label\":\"OpenAI\",\"models\":[\"gpt-a\",\"\",\"gpt-b\"]}," +
+            "{\"models\":\"junk\"}" +
+            "]}"
+        let decoded = try JSONDecoder().decode(KanbanModelOptionsResponse.self, from: Data(json.utf8))
+        XCTAssertEqual(decoded.providers.count, 2, "hostile rows normalize instead of crashing")
+        XCTAssertEqual(decoded.providers[0].models, ["gpt-a", "gpt-b"])
+
+        // The service boundary drops unusable rows so the picker only ever
+        // sees an offerable catalog.
+        let mock = V2MockKanbanRequester()
+        mock.responsesByPath["/api/plugins/kanban/model-options"] =
+            try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any] ?? [:]
+        let service = KanbanService(requester: mock)
+        let options = try await service.fetchModelOptions()
+        XCTAssertEqual(options.count, 1)
+        XCTAssertEqual(options[0].slug, "openai")
+        XCTAssertEqual(options[0].models, ["gpt-a", "gpt-b"])
+    }
+
+    // MARK: - Helpers
+
+    private func makeTask(id: String, extra: [String: Any]) -> KanbanTask {
+        var object: [String: Any] = ["id": id, "title": "T", "status": "todo"]
+        for (key, value) in extra { object[key] = value }
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        return try! JSONDecoder().decode(KanbanTask.self, from: data)
+    }
+
+    private func makeRun(outcome: String?, status: String = "completed") -> KanbanRun {
+        var object: [String: Any] = ["id": "r1", "status": status]
+        if let outcome { object["outcome"] = outcome }
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        return try! JSONDecoder().decode(KanbanRun.self, from: data)
+    }
+
+    private func makeStore(
+        requester: V2MockKanbanRequester,
+        nudgeDebounceNanoseconds: UInt64? = nil
+    ) -> KanbanStore {
+        let store = KanbanStore(
+            defaults: UserDefaults(suiteName: UUID().uuidString)!,
+            serviceFactory: nudgeDebounceNanoseconds.map { ns in
+                { request in KanbanService(requester: request, nudgeDebounceNanoseconds: ns) }
+            }
+        )
+        store.configure(requester: requester, serverIdentity: "https://example.test")
+        return store
+    }
+}
+
+// MARK: - Test doubles
+
+private enum MockRequestError: LocalizedError {
+    case failed(String)
+    var errorDescription: String? { switch self { case .failed(let m): return m } }
+}
+
+@MainActor
+private final class V2MockKanbanRequester: DashboardJSONRequester {
+    struct Call {
+        let path: String
+        let method: String
+        let body: [String: Any]?
+    }
+
+    var responsesByPath: [String: [String: Any]]
+    var errorsByPath: [String: Error] = [:]
+    private var holdsActive: Set<String> = []
+    private struct HeldRequest {
+        let continuation: CheckedContinuation<Void, Never>
+    }
+    private var heldRequests: [HeldRequest] = []
+    var calls: [Call] = []
+
+    init(responsesByPath: [String: [String: Any]] = [:]) {
+        self.responsesByPath = responsesByPath
+    }
+
+    func hold(pathPrefix: String) { holdsActive.insert(pathPrefix) }
+
+    func releaseAll() {
+        holdsActive.removeAll()
+        for held in heldRequests { held.continuation.resume() }
+        heldRequests.removeAll()
+    }
+
+    func requestJSON(path: String, method: String, body: [String: Any]?, timeoutMilliseconds: Int, maxResponseBytes: Int) async throws -> [String: Any] {
+        calls.append(Call(path: path, method: method, body: body))
+        let basePath = path.components(separatedBy: "?").first ?? path
+        if !holdsActive.isEmpty, holdsActive.contains(where: { path.hasPrefix($0) || basePath.hasPrefix($0) }) {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                heldRequests.append(HeldRequest(continuation: continuation))
+            }
+        }
+        if let error = errorsByPath[path] ?? errorsByPath[basePath] { throw error }
+        if let response = responsesByPath[path] ?? responsesByPath[basePath] { return response }
+        return [:]
+    }
+}
+
+private func standardKanbanResponses(boardSlug: String = "default") -> [String: [String: Any]] {
+    [
+        "/api/plugins/kanban/boards": [
+            "boards": [["slug": boardSlug, "name": boardSlug, "is_current": true]],
+            "current": boardSlug
+        ],
+        "/api/plugins/kanban/board": ["columns": [], "tenants": [], "assignees": [], "latest_event_id": 1, "now": 2],
+        "/api/plugins/kanban/profiles": ["profiles": []],
+        "/api/plugins/kanban/projects": ["projects": []],
+        "/api/plugins/kanban/orchestration": [
+            "orchestrator_profile": "",
+            "default_assignee": "",
+            "auto_decompose": true,
+            "resolved_orchestrator_profile": "default",
+            "resolved_default_assignee": "default"
+        ],
+        "/api/plugins/kanban/dispatch": [:],
+        "/api/plugins/kanban/model-options": ["providers": []]
+    ]
+}

--- a/ConduitTests/KanbanV2Tests.swift
+++ b/ConduitTests/KanbanV2Tests.swift
@@ -434,11 +434,11 @@ final class KanbanV2Tests: XCTestCase {
         let row = KanbanActivityFormatter.row(
             for: makeEvent(kind: "quantum_sync", payload: ["shard": .string("a"), "level": .number(2)])
         )
-        XCTAssertEqual(row.label, "quantum sync", "unknown kinds become readable words")
+        XCTAssertEqual(row.label, "Quantum Sync", "unknown kinds become readable words")
         XCTAssertEqual(row.detail, "level=2 shard=a", "scalar payload folds into detail; no raw JSON dump, no crash")
 
         let emptyRow = KanbanActivityFormatter.row(for: makeEvent(kind: "mystery"))
-        XCTAssertEqual(emptyRow.label, "mystery")
+        XCTAssertEqual(emptyRow.label, "Mystery")
         XCTAssertNil(emptyRow.detail)
     }
 
@@ -535,6 +535,57 @@ final class KanbanV2Tests: XCTestCase {
         XCTAssertEqual(options.count, 1)
         XCTAssertEqual(options[0].slug, "openai")
         XCTAssertEqual(options[0].models, ["gpt-a", "gpt-b"])
+    }
+
+
+    // MARK: - Review-pass hardening (render cap, walker termination, wire contracts)
+
+    func testRenderTailStaysWithinBudgetEvenWithoutNewlines() {
+        let budget = KanbanWorkerLogScreen.maxRenderedCharacters
+        // Exactly at budget: returned verbatim, no marker.
+        XCTAssertEqual(KanbanWorkerLogScreen.renderTail(String(repeating: "a", count: budget)).count, budget)
+        // One over budget with NO newline anywhere: must still be capped.
+        let rendered = KanbanWorkerLogScreen.renderTail(String(repeating: "x", count: budget + 1))
+        XCTAssertLessThanOrEqual(rendered.count, budget)
+        XCTAssertTrue(rendered.hasPrefix("[older output omitted]"))
+    }
+
+    func testRenderTailResumesAtLineBoundaryWhenAvailable() {
+        let budget = KanbanWorkerLogScreen.maxRenderedCharacters
+        var content = String(repeating: "=", count: budget - 10)
+        content += "\nNEWEST LINE"
+        let rendered = KanbanWorkerLogScreen.renderTail(content)
+        XCTAssertTrue(rendered.hasSuffix("NEWEST LINE"))
+        XCTAssertFalse(rendered.contains("======="), "mid-line prefix is trimmed to the line boundary")
+    }
+
+    func testHostileActionsArrayTerminatesDecoding() throws {
+        // Every element is scalar junk: neither typed decode nor the AnyCodable
+        // consumer has an easy row; the bounded walker must still terminate.
+        let json = "{" +
+            "\"id\":\"t1\",\"title\":\"x\",\"status\":\"blocked\"," +
+            "\"diagnostics\":[{\"kind\":\"k\",\"severity\":\"error\",\"title\":\"T\",\"detail\":\"D\",\"count\":1," +
+            "\"actions\":[1, true, \"text\", null]}]}"
+        let task = try JSONDecoder().decode(KanbanTask.self, from: Data(json.utf8))
+        XCTAssertEqual(task.diagnostics?.first?.actions.count, 0, "scalar junk normalizes to no actions")
+    }
+
+    func testModelOnlyPatchOmitsProviderSoBackendNullsIt() {
+        // Backend contract (kanban_db.set_model_override): a PATCH carrying
+        // model_override without provider_override writes provider=NULL — the
+        // stale provider cannot survive a model-only edit. Conduit matches by
+        // OMITTING the field (never sending "").
+        let serverTask = makeTask(id: "t1", extra: [
+            "model_override": "old-model",
+            "provider_override": "old-provider"
+        ])
+        let patch = TaskModelOverride.patch(
+            from: serverTask,
+            to: TaskModelOverride(model: "new-model")
+        )
+        XCTAssertEqual(patch.modelOverride, "new-model")
+        XCTAssertNil(patch.providerOverride, "omitted on the wire so the backend nulls the stored provider")
+        XCTAssertFalse(patch.clearModelOverride)
     }
 
     // MARK: - Helpers

--- a/docs/KANBAN_V2_AUDIT.md
+++ b/docs/KANBAN_V2_AUDIT.md
@@ -1,0 +1,54 @@
+# Kanban V2 — Upstream Audit (source of truth: NousResearch/hermes-agent)
+
+Audited files (upstream HEAD, shallow clone):
+- `plugins/kanban/dashboard/plugin_api.py` (backend routes/schemas)
+- `hermes_cli/kanban_db.py` (validation constants, create_task)
+- `apps/desktop/src/plugins/kanban/{board,drawer,model-override,ui,i18n,api,types}.tsx/ts`
+
+## 1. Task creation field matrix
+
+| Field | Desktop exposes? | Backend field (`CreateTaskBody`) | Required? | Default / inheritance | Conduit support |
+|---|---|---|---|---|---|
+| title | yes (Input) | `title: str` | yes | — | exists |
+| body/description | yes (Textarea) | `body: Optional[str]` | no | nil | exists |
+| priority | yes (number input, default 0) | `priority: int = 0` | no | 0 | exists (picker) |
+| assignee | yes: select `Default (<resolved>)` / profiles (minus resolved) / `Parked` | `assignee: Optional[str]` | no | Desktop sends `resolved_default_assignee \|\| "default"`; **Parked ⇒ omit the field entirely** (nil = unassigned; dispatcher default-assignee may pick up ready tasks later) | exists as raw string; V2 adds selection enum |
+| workspace kind | yes: `scratch\|worktree\|dir`, initialized from board `default_workspace_kind` (fallback scratch) | `workspace_kind: str = 'scratch'`; validated against `{scratch, worktree, dir}` | no | board metadata → backend fallback scratch | request field existed but UI never set it from board; V2 fixes |
+| workspace path | yes when kind ≠ scratch; empty = inherit board `default_workdir`; placeholder shows it | `workspace_path: Optional[str]` | no | backend resolves board/project dir | exists; V2 UI |
+| skills | yes: free-text comma list (i18n placeholder `translation, github`) | `skills: Optional[list[str]]` | no | none | field exists; V2 adds picker seeded from Hermes `/api/skills` names + manual entry; serialized trimmed array |
+| model override | yes (`ModelOverrideField`, detached state) | `model_override: Optional[str]` | no | unset = assigned profile's own model | exists; V2 UI |
+| provider override | yes (part of same control) | `provider_override: Optional[str]` | no | unset | exists; V2 UI |
+| reasoning effort | yes (effort submenu; '' = inherit; `none` = thinking off is a VALUE) | `reasoning_effort: Optional[str]`; valid: `none,minimal,low,medium,high,xhigh,max,ultra` (`hermes_constants.VALID_REASONING_EFFORTS` + none) | no | profile's own effort | exists; V2 UI |
+| parents | yes: SINGLE parent select over board tasks (`parents: [parent]`), even though API accepts a list | `parents: list[str]` | no | [] | field exists; V2 single-parent picker matching product behavior |
+| Goal Mode | yes: plain toggle. No max-turns control in Desktop UI | `goal_mode: bool = False`, `goal_max_turns: Optional[int] = None` | no | false / nil | fields exist; V2 toggle + max-turns control revealed only when enabled (API-backed mobile addition) |
+| project ID | not in dialog (board-scoped project inherited server-side when omitted) | `project_id: Optional[str]` | no | board's scoped project | keep omitted |
+| initial status | per-lane add button targets that lane; global New Task targets **triage**; locked lanes get no add button | `triage: bool` (+ follow-up PATCH when target ≠ created status) | no | triage flag → triage else ready/todo | store already implements guarded two-step creation |
+| tenant | not in dialog | `tenant: Optional[str]` | no | nil | unchanged |
+| idempotency key / max_runtime_seconds | not in dialog | accepted by API | no | nil | unchanged (kept for future) |
+| estimate | yes (`estimateNew` button; makes an aux-model call) | POST `/estimate` | — | — | **deferred** (per task §21) |
+
+Create submit semantics (desktop `submit()`): `assignee = PARKED ? undefined : (assignee \|\| resolvedDefault)`; `workspace_path` only sent when kind ≠ scratch and non-empty; model fields via `overrideCreateFields` (**omit** untouched fields on create); `goal_mode` always sent; `parents` only when chosen; `triage` flag only for triage target; then PATCH status if returned task status ≠ requested lane.
+
+## 2. Task detail / mutation matrix
+
+- **PATCH `UpdateTaskBody`**: `status, assignee, priority, title, body, result, block_reason, summary, metadata, model_override, provider_override, clear_model_override, reasoning_effort, clear_reasoning_effort`. NO goal-mode fields post-create ⇒ **Goal Mode is create-only**.
+- Status transitions: `done`(complete_task), `blocked`(block_task), `scheduled`(schedule_task), `review`(request_review, only running/ready), `ready`(unblock/reopen/direct), `archived`(archive_task — plain PATCH, NOT destructive), `running`→400 direct-set, `todo/triage` direct. Unknown → 400.
+- **Archive** = `PATCH {status:'archived'}` from drawer ⋯ menu. Delete = DELETE with destructive confirm (mobile keeps confirm).
+- Drawer ⋯ menu: Copy task id · Copy title · Archive · Delete. Card context menu: Open/select/move-to-unlocked/delete.
+- **Reassign**: POST `/tasks/{id}/reassign` `{profile, reclaim_first:true, reason?}` (drawer assignee menu lists roster profiles only). `profile` nil/"" unassigns.
+- **Reclaim**: POST `/tasks/{id}/reclaim` `{reason?}`; 409 unless claimable (running).
+- **Note & requeue** (running): addComment then reclaim — both endpoints Conduit already has.
+- Diagnostics actions: only `reclaim` (button → reclaim endpoint) and `cli_hint` (copy `payload.command`). Never invent other mutations.
+- Worker log GET `/tasks/{id}/log?tail=<bytes ≤ 2_000_000>` → `{exists,size_bytes,content,truncated}` (Conduit decodes this already).
+- Activity event kinds mapped upstream: `created,status,assigned,commented,claimed,spawned,completed,blocked,unblocked,reclaimed,specified,promoted,scheduled,archived,reprioritized` (+ `edited`); unknown kinds fall back to kind + key=value detail.
+- Runs: outcome/status badge (failed set `crashed|failed|timed_out|gave_up`), profile, duration(ended−started), relative time, error/summary lines.
+- Model options source: desktop uses SDK catalog menu; kanban plugin also serves GET `/model-options` (`{providers:[{slug,label,models[]}]}`) curated so the dropdown can never offer a pair Hermes would reject — Conduit uses this via KanbanService (keeps Kanban networking on DashboardTicketBridge).
+
+## 3. Deliberate mobile deviations
+1. Composer is a grouped Form (Basics/Assignment/Execution/Dependencies) instead of one flat dialog; selectors push/sheet.
+2. Skills: searchable multi-select sheet seeded from active Hermes config (`appState.skills` names) + manual add — superset of desktop's comma text input; identical serialized form.
+3. Goal Mode max-turns stepper exposed (API supports `goal_max_turns`; desktop hides it).
+4. Move To remains the movement primitive (no drag between columns); card menu gains Copy ID/Title/Archive.
+5. Worker log is a dedicated push-in screen with explicit refresh (no 3s auto-poll while hidden).
+6. Dependency chips show title + short id + status (data desktop doesn't render); tap replaces current detail (no sheet stacking).
+7. Estimate controls deferred.


### PR DESCRIPTION
# Kanban V2 — Desktop Parity for Task Creation, Actions, and Operator Detail

Builds on the merged V1 native Kanban (PR #92). Target: **Desktop semantic parity + native iPhone interaction**, using current upstream `NousResearch/hermes-agent` (`plugins/kanban/dashboard/plugin_api.py` + `apps/desktop/src/plugins/kanban/*`) as the behavioral source of truth. Full field-by-field audit: `docs/KANBAN_V2_AUDIT.md`.

## V2A — Task creation & actions
- **New Task composer** (`KanbanTaskComposerView`) replaces the minimal editor: Basics / Assignment / Execution / Dependencies / Lands-in, with push-or-sheet selectors.
- **Assignment**: Desktop-exact semantics — *Default* sends the orchestration `resolved_default_assignee` (fallback `default`), roster profiles minus the default, *Parked* **omits** `assignee` entirely. No invented Conduit meanings.
- **Workspace**: initial kind derived from the selected board's real `default_workspace_kind` (backend fallback `scratch`); board `default_workdir` shown as the inherited directory; path override only for worktree/dir; scratch+path rejected by validation.
- **Model/provider/reasoning override**: detached `TaskModelOverride`; create omits untouched fields (upstream `overrideCreateFields`); picker backed by the kanban plugin's curated `GET /model-options` via KanbanService (stays on DashboardTicketBridge) with free-text fallback; efforts = backend-valid set incl. `none` as a value. Fast/YOLO deliberately excluded.
- **Skills**: searchable multi-select seeded from active Hermes config skills + manual entry; serialized trimmed/deduped exactly like upstream's comma list; not tied to Capabilities toggles.
- **Goal Mode**: `goal_mode` toggle; `goal_max_turns` stepper revealed only when enabled (API-backed mobile addition); create-only upstream — kept create-only. Never mapped to YOLO.
- **Parents**: single-parent picker over the board snapshot (Desktop product behavior), title/short-ID/status context, self-dependency excluded.
- **Validation**: single layer (`KanbanComposerValidator`) — title, workspace/path combination, effort validity, skill/parent sanitization, Goal-turn bounds; locked lanes remain non-creatable via the existing capability gate.
- **effectiveSelectedLane fix**: global + now creates relative to the lane the UI actually shows (`KanbanLanePolicy`), not raw chip selection that stayed nil until tapped; regression-tested.
- **Card actions**: Move To (capability matrix), Copy Task ID, Copy Task Title, Archive (plain `PATCH status=archived`, non-destructive per upstream), Delete (confirmed). Clipboard via `KanbanClipboard` with VoiceOver announcements.

## V2B — Operator detail
- **Reassignment** through the dedicated `POST /tasks/:id/reassign` (reclaim-first), roster sheet + explicit unassign; ready-but-unassigned callout when no dispatcher fallback exists; reclaim exposed in diagnostics and Note-&-requeue.
- **Model/runtime overrides** displayed with clear inherit state; edited via PATCH with explicit clear flags diffed against the CURRENT server snapshot on sheet dismiss (poll-safe).
- **Diagnostics**: severity-tinted cards (title ×count, detail) executing only backend-structured actions — Reclaim button, cli-hint copies its command. Nothing invented from text.
- **Dependencies**: Blocked-by / Blocks chips with title + short ID + status; tap does replace-current-detail navigation (no sheet stacking).
- **Activity**: chronological timeline mapping 16 known event kinds to prose; unknown kinds degrade to capitalized kind words + scalar key=value detail (never raw JSON, never crashes).
- **Runs**: outcome/failure classification (crashed/failed/timed_out/gave_up), profile, pid, duration, relative time, error/summary.
- **Worker Log**: dedicated screen — 64 KiB tail request, budget-accounted render cap (≤60k chars guaranteed), line-boundary resume, selectable monospaced text, explicit refresh, cancellation-aware scroll-to-bottom, no background polling.
- **Cards** gain selective operational indicators: short ID, child progress n/m, link count, diagnostics warning count, running elapsed clock, stale-heartbeat (>120s), unassigned-ready "won't run".

## Preserved V1 architecture (unchanged)
DashboardTicketBridge-only networking via dedicated `KanbanService`; no HermesClient/session/WebSocket changes; no /events socket; concrete board slug pinning; stale-snapshot non-actionability during navigation; immutable mutation context (service+slug+generation); superseding post-mutation reconciliation; fire-and-forget debounced dispatcher nudge; cross-profile shared-board semantics (no fabricated ?profile=); locked lanes running/review/scheduled never manual/create targets; dirty-draft-safe 4s polling; id-less row filtering; fail-closed URL construction; lane-chip + vertical-card mobile design.

## Deliberately deferred
Board admin/orchestration editing/bulk ops/filters-grouping; attachment upload; estimate UI; /events WebSocket; background notifications.

## Tests
39 new cases in `KanbanV2Tests.swift` (lane policy regression incl. §9 effective-lane fix, wire serialization for every new field incl. Default/Parked wire shapes, inheritance vs clear-flag patch contracts pinned against `kanban_db.set_model_override` full-row semantics, hostile diagnostics/actions payloads, unknown-event fallback, log fetch context/tail, render-cap boundaries).

## Validation
- Full `ios_test`: **60/60 suites passed, 1082 cases executed, 0 failed/skipped/hangs, 0 uncovered** (final TOCTOU ownership pass head; includes KanbanV2CorrectnessTests with 29 deterministic identity/context-ownership regression cases).
- Multi-model local review (deepseek-v4-flash / step-3.7-flash / mimo-v2.5 + consolidation): first pass REQUEST CHANGES (3 BLOCKER, 7 WARNING) → all actionable findings fixed or disproven against upstream backend code; re-review of fix delta: **APPROVE 3/3, 15/15 fixes verified RESOLVED**, remaining items SUGGESTION/NIT only (the cheap ones applied in 28d568d).
- Session/chat transport untouched: changed files are Kanban models/service/store/views (+new Kanban view files/tests/doc) only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added mobile Kanban task creation with assignment, workspace, model, skills, dependencies, validation, and destination lane options.
  - Added model/provider selection and worker log viewing with cached and error states.
  - Enhanced task details, cards, diagnostics, activity, and run information.

- **Bug Fixes**
  - Improved malformed data handling and stale-update protection.
  - Added safer deletion confirmation and mutation handling when boards or configurations change.

- **Documentation**
  - Added a Kanban functionality and behavior audit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
