### PR TITLE
feat(kanban): V3A — orchestration, profile routing, dispatcher nudge, triage Specify/Decompose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ jobs:
     name: Build & Test
     runs-on: macos-26
     # Outer emergency limit only — wedge detection lives in
-    # scripts/ci-run-tests.sh (per-attempt wall-clock budget of 16 min).
-    # Worst case: ~4 min setup + 2 × (≤3 min bootstatus-bounded reset +
-    # 16 min budget + ~25 s kill/diagnostics) ≈ 43 min, so a bounded run
-    # fits; this cap exists for the residual cases the budget cannot reach
-    # (e.g. a wedged CoreSimulatorService blocking simctl itself).
+    # scripts/ci-run-tests.sh (per-attempt wall-clock budget, temporarily
+    # defaulted to 20 min as a cold-run ceiling). Headroom is tight when a
+    # second full-length attempt is needed; the 45-min cap remains the
+    # ultimate bound, and it exists for the residual cases the budget cannot
+    # reach (e.g. a wedged CoreSimulatorService blocking simctl itself).
     timeout-minutes: 45
 
     steps:
@@ -70,13 +70,15 @@ jobs:
 
       - name: Run tests
         # scripts/ci-run-tests.sh owns the retry loop. Each attempt gets its
-        # own wall-clock budget (default 16 min; healthy runs take 7-13) so a
-        # hung test or wedged simulator is killed and retried instead of
-        # stalling until the 45-min job timeout — which remains the outer
-        # emergency limit, not the wedge-detection mechanism. The script also
-        # boots the simulator before every attempt, streams raw xcodebuild
-        # output into this step's log, and leaves per-attempt logs + any
-        # partial .xcresult bundles for the upload step below.
+        # own wall-clock budget (default 1200 s = 20 min, a temporary
+        # cold-run ceiling; healthy runs take 7-13 min) so a hung test or
+        # wedged simulator is killed and retried instead of stalling until
+        # the 45-min job timeout — which remains the outer emergency limit,
+        # not the wedge-detection mechanism. See the script header for the
+        # exact worst-case caveat. The script also boots the simulator before
+        # every attempt, streams raw xcodebuild output into this step's log,
+        # and leaves per-attempt logs + any partial .xcresult bundles for the
+        # upload step below.
         run: bash scripts/ci-run-tests.sh
 
       - name: Upload test results on failure

--- a/Conduit/Models/KanbanModels.swift
+++ b/Conduit/Models/KanbanModels.swift
@@ -655,6 +655,10 @@ struct KanbanProject: Codable, Identifiable, Equatable {
 }
 
 struct KanbanOrchestrationSettings: Codable, Equatable {
+    /// Backend default for auto_promote_children when config omits it
+    /// (plugin_api.py GET /orchestration: bool(cfg.get("auto_promote_children", True))).
+    static let defaultAutoPromoteChildren = true
+
     var orchestratorProfile: String
     var defaultAssignee: String
     var autoDecompose: Bool

--- a/Conduit/Models/KanbanModels.swift
+++ b/Conduit/Models/KanbanModels.swift
@@ -913,3 +913,145 @@ struct KanbanModelProviderOption: Codable, Equatable, Identifiable {
 
     enum CodingKeys: String, CodingKey { case slug, label, models }
 }
+
+// MARK: - V3A: Orchestration mutation + triage action contracts
+//
+// Wire fidelity audited against NousResearch/hermes-agent @ fd760435c
+// (see docs/KANBAN_V3A_AUDIT.md):
+// - "" is the wire encoding of "Default"/inherit for the orchestration
+//   profile pickers — never a Conduit-specific sentinel.
+// - Specify/Decompose return HTTP 200 even on semantic failure; the client
+//   must inspect ok / reason (plugin_api.py specify/decompose docs).
+
+/// Partial body for PUT /orchestration. Only present fields are written;
+/// "" clears an override so the server falls back to the active default
+/// profile. Every field is optional BY DESIGN (nil = not sent).
+struct KanbanOrchestrationPatch: Encodable, Equatable {
+    var orchestratorProfile: String?
+    var defaultAssignee: String?
+    var autoDecompose: Bool?
+    var autoPromoteChildren: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case orchestratorProfile = "orchestrator_profile"
+        case defaultAssignee = "default_assignee"
+        case autoDecompose = "auto_decompose"
+        case autoPromoteChildren = "auto_promote_children"
+    }
+
+    init(
+        orchestratorProfile: String? = nil,
+        defaultAssignee: String? = nil,
+        autoDecompose: Bool? = nil,
+        autoPromoteChildren: Bool? = nil
+    ) {
+        self.orchestratorProfile = orchestratorProfile
+        self.defaultAssignee = defaultAssignee
+        self.autoDecompose = autoDecompose
+        self.autoPromoteChildren = autoPromoteChildren
+    }
+
+    var isEmpty: Bool {
+        orchestratorProfile == nil && defaultAssignee == nil
+            && autoDecompose == nil && autoPromoteChildren == nil
+    }
+}
+
+/// POST /tasks/{id}/specify response. ok:false is a SEMANTIC failure that
+/// still rides an HTTP 200 — the backend deliberately reports it as a normal
+/// body so the UI can render reason inline and retry without reloading.
+struct KanbanSpecifyResponse: Codable, Equatable {
+    var ok: Bool
+    var taskID: String
+    var reason: String?
+    var newTitle: String?
+
+    enum CodingKeys: String, CodingKey {
+        case ok, reason
+        case taskID = "task_id"
+        case newTitle = "new_title"
+    }
+
+    init(ok: Bool, taskID: String, reason: String? = nil, newTitle: String? = nil) {
+        self.ok = ok
+        self.taskID = taskID
+        self.reason = reason
+        self.newTitle = newTitle
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        ok = (try? container.decode(Bool.self, forKey: .ok)) ?? false
+        taskID = container.decodeLossyString(forKey: .taskID) ?? ""
+        reason = try? container.decodeIfPresent(String.self, forKey: .reason)
+        newTitle = try? container.decodeIfPresent(String.self, forKey: .newTitle)
+    }
+}
+
+/// POST /tasks/{id}/decompose response. Same HTTP-200-bears-semantic-failure
+/// contract as Specify. child_ids is NOT authoritative board state — it is
+/// the list of created children (in creation order); Conduit reconciles by
+/// reloading the board and the current/root task.
+struct KanbanDecomposeResponse: Codable, Equatable {
+    var ok: Bool
+    var taskID: String
+    var reason: String?
+    var fanout: Bool
+    var childIDs: [String]
+    var newTitle: String?
+
+    enum CodingKeys: String, CodingKey {
+        case ok, reason, fanout
+        case taskID = "task_id"
+        case childIDs = "child_ids"
+        case newTitle = "new_title"
+    }
+
+    init(ok: Bool, taskID: String, reason: String? = nil, fanout: Bool = false, childIDs: [String] = [], newTitle: String? = nil) {
+        self.ok = ok
+        self.taskID = taskID
+        self.reason = reason
+        self.fanout = fanout
+        self.childIDs = childIDs
+        self.newTitle = newTitle
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        ok = (try? container.decode(Bool.self, forKey: .ok)) ?? false
+        taskID = container.decodeLossyString(forKey: .taskID) ?? ""
+        reason = try? container.decodeIfPresent(String.self, forKey: .reason)
+        fanout = (try? container.decode(Bool.self, forKey: .fanout)) ?? false
+        childIDs = (try? container.decodeIfPresent([String].self, forKey: .childIDs)) ?? []
+        newTitle = try? container.decodeIfPresent(String.self, forKey: .newTitle)
+    }
+}
+
+/// POST /profiles/{name}/describe-auto response. A non-ok outcome is NOT an
+/// HTTP error either (e.g. "no auxiliary client configured") — the editor
+/// renders reason inline.
+struct KanbanAutoDescribeResponse: Codable, Equatable {
+    var ok: Bool
+    var profile: String
+    var reason: String?
+    var description: String?
+
+    enum CodingKeys: String, CodingKey {
+        case ok, reason, profile, description
+    }
+
+    init(ok: Bool, profile: String, reason: String? = nil, description: String? = nil) {
+        self.ok = ok
+        self.profile = profile
+        self.reason = reason
+        self.description = description
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        ok = (try? container.decode(Bool.self, forKey: .ok)) ?? false
+        profile = container.decodeLossyString(forKey: .profile) ?? ""
+        reason = try? container.decodeIfPresent(String.self, forKey: .reason)
+        description = try? container.decodeIfPresent(String.self, forKey: .description)
+    }
+}

--- a/Conduit/Services/KanbanService.swift
+++ b/Conduit/Services/KanbanService.swift
@@ -21,6 +21,15 @@ enum KanbanServiceError: LocalizedError, Equatable {
     case mutationInProgress
     case boardNavigationInProgress
     case invalidQueryParameter(String)
+    /// The backend answered HTTP 200 with {ok: false, reason: ...}. The server
+    /// write did NOT happen (or was refused); the reason is stable product
+    /// semantics and must be shown verbatim, never replaced by a made-up
+    /// message.
+    case actionDeclined(reason: String)
+    /// The mutation reached the server, but the authoritative refresh after it
+    /// failed. The mutation itself SUCCEEDED — this must never read as the
+    /// mutation failing.
+    case mutationSucceededButRefreshFailed(detail: String)
 
     var errorDescription: String? {
         switch self {
@@ -42,6 +51,12 @@ enum KanbanServiceError: LocalizedError, Equatable {
             // Fail closed: a dropped board/id parameter would silently
             // retarget the request at the backend's current board.
             return "Could not build a safe Hermes Kanban request (invalid " + name + "). The operation was cancelled before any data changed."
+        case .actionDeclined(let reason):
+            // The backend's own reason (e.g. "task is not in triage") is the
+            // product semantics; never translate it into a generic failure.
+            return reason.isEmpty ? "Hermes declined the action." : reason
+        case .mutationSucceededButRefreshFailed(let detail):
+            return "The change was saved, but the board could not be refreshed. " + detail
         }
     }
 }
@@ -190,6 +205,99 @@ final class KanbanService {
         )
     }
 
+    // MARK: - V3A: Orchestration settings (server-global; no board query)
+
+    /// PUT /orchestration — only present patch fields are written; ""
+    /// clears an override (server falls back to the active default profile).
+    /// Returns the resolved echo the backend always answers with.
+    func updateOrchestration(_ patch: KanbanOrchestrationPatch) async throws -> KanbanOrchestrationSettings {
+        let response = try await request(
+            path: scoped(Self.namespace + "/orchestration"),
+            method: "PUT",
+            body: try encodedDictionary(patch)
+        )
+        return try decodeResponse(KanbanOrchestrationSettings.self, from: response)
+    }
+
+    // MARK: - V3A: Profile routing descriptions (server-global; no board query)
+
+    /// PATCH /profiles/{name} {description}. Empty text CLEARS the
+    /// description; the backend stores user-authored text with
+    /// description_auto=false so auto-generation never silently replaces it.
+    func updateProfileDescription(profile: String, description: String) async throws {
+        _ = try await request(
+            path: scoped(Self.namespace + "/profiles/" + (try pathComponent(profile))),
+            method: "PATCH",
+            body: try encodedDictionary(ProfileDescriptionBody(description: description))
+        )
+    }
+
+    /// POST /profiles/{name}/describe-auto {overwrite}. The generated text is
+    /// PERSISTED immediately (description_auto=true). A non-ok outcome is NOT
+    /// an HTTP error — the caller renders the backend reason inline.
+    func autoDescribeProfile(profile: String, overwrite: Bool = true) async throws -> KanbanAutoDescribeResponse {
+        let response = try await request(
+            path: scoped(Self.namespace + "/profiles/" + (try pathComponent(profile)) + "/describe-auto"),
+            method: "POST",
+            body: ["overwrite": overwrite]
+        )
+        return try decodeResponse(KanbanAutoDescribeResponse.self, from: response)
+    }
+
+    // MARK: - V3A: Triage actions (Specify / Decompose)
+
+    /// POST /tasks/{id}/specify — LLM-fleshes a TRIAGE task and promotes it
+    /// to todo (recompute_ready may then promote it to ready). HTTP 200 does
+    /// not imply success: {ok:false, reason} is a semantic refusal and throws
+    /// actionDeclined(reason) so callers display the backend reason verbatim.
+    func specifyTask(id: String, board: String?, author: String = "conduit") async throws -> KanbanSpecifyResponse {
+        guard !id.isEmpty else { throw KanbanServiceError.emptyTaskID }
+        let response = try await request(
+            path: try withBoard(Self.namespace + "/tasks/" + (try pathComponent(id)) + "/specify", slug: board),
+            method: "POST",
+            body: try encodedDictionary(TriageActionAuthorBody(author: author))
+        )
+        let outcome = try decodeResponse(KanbanSpecifyResponse.self, from: response)
+        guard outcome.ok else {
+            throw KanbanServiceError.actionDeclined(reason: outcome.reason ?? "Hermes declined to specify this task.")
+        }
+        return outcome
+    }
+
+    /// POST /tasks/{id}/decompose — LLM-fans a TRIAGE task into a child graph
+    /// (children created, sibling dependency edges, root kept as parent of the
+    /// graph and promoted to todo). Same semantic-failure contract as
+    /// specify. The response is NOT authoritative board state: callers reload
+    /// the board and the root task afterwards.
+    func decomposeTask(id: String, board: String?, author: String = "conduit") async throws -> KanbanDecomposeResponse {
+        guard !id.isEmpty else { throw KanbanServiceError.emptyTaskID }
+        let response = try await request(
+            path: try withBoard(Self.namespace + "/tasks/" + (try pathComponent(id)) + "/decompose", slug: board),
+            method: "POST",
+            body: try encodedDictionary(TriageActionAuthorBody(author: author))
+        )
+        let outcome = try decodeResponse(KanbanDecomposeResponse.self, from: response)
+        guard outcome.ok else {
+            throw KanbanServiceError.actionDeclined(reason: outcome.reason ?? "Hermes declined to decompose this task.")
+        }
+        return outcome
+    }
+
+    // MARK: - V3A: Manual dispatcher nudge
+
+    /// Immediate POST /dispatch for the captured board (board menu action).
+    /// Unlike the debounced auto-nudge this posts right away so the operator
+    /// gets direct feedback. Response counters are intentionally ignored: the
+    /// desktop renders nothing from them and Conduit must not fabricate
+    /// diagnostics.
+    func nudgeDispatcher(board: String?) async throws {
+        _ = try await request(
+            path: try withBoard(Self.namespace + "/dispatch", slug: board),
+            method: "POST",
+            body: [:]
+        )
+    }
+
     // MARK: - Dispatcher nudge
 
     /// Schedule the upstream-equivalent acceleration hint for the backend
@@ -330,4 +438,7 @@ final class KanbanService {
 
     private struct TaskEnvelope: Decodable { let task: KanbanTask? }
     private struct BoardEnvelope: Decodable { let board: KanbanBoardMetadata }
+    private struct ProfileDescriptionBody: Encodable { let description: String }
+    private struct TriageActionAuthorBody: Encodable { let author: String }
+
 }

--- a/Conduit/Services/KanbanService.swift
+++ b/Conduit/Services/KanbanService.swift
@@ -26,10 +26,6 @@ enum KanbanServiceError: LocalizedError, Equatable {
     /// semantics and must be shown verbatim, never replaced by a made-up
     /// message.
     case actionDeclined(reason: String)
-    /// The mutation reached the server, but the authoritative refresh after it
-    /// failed. The mutation itself SUCCEEDED — this must never read as the
-    /// mutation failing.
-    case mutationSucceededButRefreshFailed(detail: String)
 
     var errorDescription: String? {
         switch self {
@@ -55,8 +51,6 @@ enum KanbanServiceError: LocalizedError, Equatable {
             // The backend's own reason (e.g. "task is not in triage") is the
             // product semantics; never translate it into a generic failure.
             return reason.isEmpty ? "Hermes declined the action." : reason
-        case .mutationSucceededButRefreshFailed(let detail):
-            return "The change was saved, but the board could not be refreshed. " + detail
         }
     }
 }

--- a/Conduit/Services/KanbanStore.swift
+++ b/Conduit/Services/KanbanStore.swift
@@ -442,6 +442,139 @@ final class KanbanStore: ObservableObject {
         }
     }
 
+    // MARK: - V3A: Orchestration settings
+
+    /// PUT /orchestration (server-global, but still server-ownership-safe:
+    /// the mutation context pins the loaded board/server generation and the
+    /// post-mutation superseding reload refreshes GET /orchestration).
+    /// Upstream does NOT nudge the dispatcher for settings saves.
+    @discardableResult
+    func updateOrchestration(_ patch: KanbanOrchestrationPatch, includeArchived: Bool = false) async throws -> KanbanOrchestrationSettings? {
+        guard !isMutating else {
+            throw recordMutationError(KanbanServiceError.mutationInProgress)
+        }
+        guard let context = makeOperationContext() else {
+            throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
+        }
+        return try await performMutation(context: context, includeArchived: includeArchived) {
+            let settings = try await context.service.updateOrchestration(patch)
+            // Adopt the backend's resolved echo ONLY while this mutation still
+            // owns the current generation: after configure() the completion is
+            // inert and must not repopulate the newly configured store.
+            if configurationGeneration == context.configurationGeneration {
+                orchestration = settings
+            }
+            return settings
+        }
+    }
+
+    // MARK: - V3A: Profile routing descriptions
+
+    /// PATCH /profiles/{name} {description}. Not dispatcher-relevant upstream
+    /// (the desktop saves descriptions without a nudge).
+    func updateProfileDescription(profile: String, description: String, includeArchived: Bool = false) async throws {
+        guard !isMutating else {
+            throw recordMutationError(KanbanServiceError.mutationInProgress)
+        }
+        guard let context = makeOperationContext() else {
+            throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
+        }
+        try await performMutation(context: context, includeArchived: includeArchived) {
+            try await context.service.updateProfileDescription(profile: profile, description: description)
+        }
+    }
+
+    /// POST /profiles/{name}/describe-auto. The generated text is persisted
+    /// immediately server-side; a non-ok outcome is a SEMANTIC refusal the
+    /// caller renders inline (never an HTTP error, never a fabricated
+    /// failure).
+    @discardableResult
+    func autoDescribeProfile(profile: String, overwrite: Bool = true, includeArchived: Bool = false) async throws -> KanbanAutoDescribeResponse {
+        guard !isMutating else {
+            throw recordMutationError(KanbanServiceError.mutationInProgress)
+        }
+        guard let context = makeOperationContext() else {
+            throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
+        }
+        return try await performMutation(context: context, includeArchived: includeArchived) {
+            let outcome = try await context.service.autoDescribeProfile(profile: profile, overwrite: overwrite)
+            if outcome.ok, let generated = outcome.description,
+               configurationGeneration == context.configurationGeneration {
+                // Adopt the authoritative generated text locally (generation-
+                // guarded: a stale completion never repopulates the store);
+                // reload also refreshes profile descriptions.
+                profiles = profiles.map {
+                    $0.name == outcome.profile ? KanbanProfile(
+                        name: $0.name,
+                        isDefault: $0.isDefault,
+                        description: generated,
+                        descriptionAuto: true,
+                        model: $0.model,
+                        provider: $0.provider,
+                        skillCount: $0.skillCount
+                    ) : $0
+                }
+            }
+            return outcome
+        }
+    }
+
+    // MARK: - V3A: Triage actions
+
+    /// Specify a TRIAGE task: POST /tasks/{id}/specify, then supersede stale
+    /// board polling with an authoritative reload. The backend flips the task
+    /// triage -> todo (and recompute_ready may promote it to ready). A
+    /// semantic {ok:false} refusal throws the backend reason; the task is
+    /// left intact and the failure is recorded as the current-generation
+    /// mutation error.
+    @discardableResult
+    func specifyTask(id: String, includeArchived: Bool = false) async throws -> KanbanSpecifyResponse {
+        guard !isMutating else {
+            throw recordMutationError(KanbanServiceError.mutationInProgress)
+        }
+        guard let context = makeOperationContext() else {
+            throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
+        }
+        return try await performMutation(context: context, includeArchived: includeArchived) {
+            try await context.service.specifyTask(id: id, board: context.boardSlug)
+        }
+    }
+
+    /// Decompose a TRIAGE task: POST /tasks/{id}/decompose, then reconcile
+    /// from authoritative REST state (performMutation's superseding reload).
+    /// The response is child ids only — Conduit NEVER synthesizes cards from
+    /// it. Semantic refusal throws the backend reason.
+    @discardableResult
+    func decomposeTask(id: String, includeArchived: Bool = false) async throws -> KanbanDecomposeResponse {
+        guard !isMutating else {
+            throw recordMutationError(KanbanServiceError.mutationInProgress)
+        }
+        guard let context = makeOperationContext() else {
+            throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
+        }
+        return try await performMutation(context: context, includeArchived: includeArchived) {
+            try await context.service.decomposeTask(id: id, board: context.boardSlug)
+        }
+    }
+
+    // MARK: - V3A: Manual dispatcher nudge
+
+    /// Explicit board-menu nudge. Ownership-disciplined like every mutation:
+    /// the request is issued only while the captured context still owns the
+    /// UI, and a completion after configure() is inert. The board reload
+    /// after success doubles as the authoritative post-nudge refresh.
+    func nudgeDispatcher(includeArchived: Bool = false) async throws {
+        guard !isMutating else {
+            throw recordMutationError(KanbanServiceError.mutationInProgress)
+        }
+        guard let context = makeOperationContext() else {
+            throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
+        }
+        try await performMutation(context: context, includeArchived: includeArchived) {
+            try await context.service.nudgeDispatcher(board: context.boardSlug)
+        }
+    }
+
     func clearMutationError() {
         mutationErrorMessage = nil
     }

--- a/Conduit/Services/KanbanStore.swift
+++ b/Conduit/Services/KanbanStore.swift
@@ -477,7 +477,7 @@ final class KanbanStore: ObservableObject {
         guard let context = makeOperationContext() else {
             throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
         }
-        return try await performMutation(context: context, includeArchived: includeArchived) {
+        return try await performMutation(context: context, includeArchived: includeArchived, scope: .server) {
             let settings = try await context.service.updateOrchestration(patch)
             // Adopt the backend's resolved echo ONLY while this mutation still
             // owns the current generation: after configure() the completion is
@@ -508,7 +508,7 @@ final class KanbanStore: ObservableObject {
         guard let context = makeOperationContext() else {
             throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
         }
-        try await performMutation(context: context, includeArchived: includeArchived) {
+        try await performMutation(context: context, includeArchived: includeArchived, scope: .server) {
             try await context.service.updateProfileDescription(profile: profile, description: description)
         }
     }
@@ -533,7 +533,7 @@ final class KanbanStore: ObservableObject {
         guard let context = makeOperationContext() else {
             throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
         }
-        return try await performMutation(context: context, includeArchived: includeArchived) {
+        return try await performMutation(context: context, includeArchived: includeArchived, scope: .server) {
             let outcome = try await context.service.autoDescribeProfile(profile: profile, overwrite: overwrite)
             if outcome.ok, let generated = outcome.description,
                configurationGeneration == context.configurationGeneration {
@@ -682,9 +682,25 @@ final class KanbanStore: ObservableObject {
         )
     }
 
+    /// Whether a mutation requires the loaded snapshot to be the actionable
+    /// (selected) board:
+    /// - .board (default): board-scoped writes (create/update/delete task,
+    ///   Specify, Decompose, Nudge, reassign/reclaim) must never act on a
+    ///   stale snapshot - during a board transition they fail closed.
+    /// - .server: SERVER-GLOBAL writes (orchestration settings, profile
+    ///   descriptions) carry no board query upstream; their ownership is the
+    ///   configuration generation (already validated by
+    ///   validateExpectedServerContext), and a same-server board transition
+    ///   must not reject them.
+    enum MutationScope {
+        case board
+        case server
+    }
+
     private func performMutation<T>(
         context: KanbanOperationContext,
         includeArchived: Bool,
+        scope: MutationScope = .board,
         operation: () async throws -> T
     ) async throws -> T {
         let generation = context.configurationGeneration
@@ -696,10 +712,15 @@ final class KanbanStore: ObservableObject {
             mutationErrorMessage = error.localizedDescription
             throw error
         }
-        // Navigation invariant: while the selected and loaded board identities
-        // differ, the visible snapshot belongs to the OLD board. Refuse to act
-        // on it rather than writing old-board data under a new-board UI.
-        guard isSelectedSnapshotLoaded else {
+        // Navigation invariant (board-scoped mutations only): while the
+        // selected and loaded board identities differ, the visible snapshot
+        // belongs to the OLD board - refuse to act on it rather than writing
+        // old-board data under a new-board UI. Server-global mutations skip
+        // this guard: their wire target is the server, which has not changed
+        // during a same-server board transition. The superseding reload after
+        // success converges onto the CURRENTLY selected board, so the old
+        // board can never be restored by the reconciliation.
+        guard scope == .server || isSelectedSnapshotLoaded else {
             let error = KanbanServiceError.boardNavigationInProgress
             mutationErrorMessage = error.localizedDescription
             throw error

--- a/Conduit/Services/KanbanStore.swift
+++ b/Conduit/Services/KanbanStore.swift
@@ -58,6 +58,18 @@ final class KanbanStore: ObservableObject {
     /// clears it immediately so a stale server's completion becomes inert.
     private var activeMutationGeneration: Int?
 
+    /// The current configuration generation, captured BEFORE a suspension so a
+    /// completion can prove it still belongs to the current server/board
+    /// context (store-level UI-inertness for view-local state writing).
+    var currentConfigurationGeneration: Int { configurationGeneration }
+
+    /// True while a captured generation is still the store's current
+    /// configuration generation - the ownership check for view-local
+    /// completions (sheets/editors) that must stay UI-inert after configure().
+    func isCurrentConfiguration(_ generation: Int) -> Bool {
+        configurationGeneration == generation
+    }
+
     init(
         defaults: UserDefaults = .standard,
         serviceFactory: ((any DashboardJSONRequester) -> KanbanService)? = nil

--- a/Conduit/Services/KanbanStore.swift
+++ b/Conduit/Services/KanbanStore.swift
@@ -461,10 +461,19 @@ final class KanbanStore: ObservableObject {
     /// post-mutation superseding reload refreshes GET /orchestration).
     /// Upstream does NOT nudge the dispatcher for settings saves.
     @discardableResult
-    func updateOrchestration(_ patch: KanbanOrchestrationPatch, includeArchived: Bool = false) async throws -> KanbanOrchestrationSettings? {
+    func updateOrchestration(
+        _ patch: KanbanOrchestrationPatch,
+        expectedContext: KanbanBoardContextStamp? = nil,
+        includeArchived: Bool = false
+    ) async throws -> KanbanOrchestrationSettings? {
         guard !isMutating else {
             throw recordMutationError(KanbanServiceError.mutationInProgress)
         }
+        // Orchestration is SERVER-GLOBAL on the wire (no board query): the
+        // captured stamp is validated on its configuration GENERATION only,
+        // so a same-server board switch never aborts a valid settings save,
+        // while a server reconfigure still fails closed (review F-2).
+        try validateExpectedServerContext(expectedContext)
         guard let context = makeOperationContext() else {
             throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
         }
@@ -484,10 +493,18 @@ final class KanbanStore: ObservableObject {
 
     /// PATCH /profiles/{name} {description}. Not dispatcher-relevant upstream
     /// (the desktop saves descriptions without a nudge).
-    func updateProfileDescription(profile: String, description: String, includeArchived: Bool = false) async throws {
+    func updateProfileDescription(
+        profile: String,
+        description: String,
+        expectedContext: KanbanBoardContextStamp? = nil,
+        includeArchived: Bool = false
+    ) async throws {
         guard !isMutating else {
             throw recordMutationError(KanbanServiceError.mutationInProgress)
         }
+        // Server-global endpoint: generation-scoped validation (see
+        // updateOrchestration for the F-2 rationale).
+        try validateExpectedServerContext(expectedContext)
         guard let context = makeOperationContext() else {
             throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
         }
@@ -501,10 +518,18 @@ final class KanbanStore: ObservableObject {
     /// caller renders inline (never an HTTP error, never a fabricated
     /// failure).
     @discardableResult
-    func autoDescribeProfile(profile: String, overwrite: Bool = true, includeArchived: Bool = false) async throws -> KanbanAutoDescribeResponse {
+    func autoDescribeProfile(
+        profile: String,
+        overwrite: Bool = true,
+        expectedContext: KanbanBoardContextStamp? = nil,
+        includeArchived: Bool = false
+    ) async throws -> KanbanAutoDescribeResponse {
         guard !isMutating else {
             throw recordMutationError(KanbanServiceError.mutationInProgress)
         }
+        // Server-global endpoint: generation-scoped validation (see
+        // updateOrchestration for the F-2 rationale).
+        try validateExpectedServerContext(expectedContext)
         guard let context = makeOperationContext() else {
             throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
         }
@@ -540,10 +565,15 @@ final class KanbanStore: ObservableObject {
     /// left intact and the failure is recorded as the current-generation
     /// mutation error.
     @discardableResult
-    func specifyTask(id: String, includeArchived: Bool = false) async throws -> KanbanSpecifyResponse {
+    func specifyTask(
+        id: String,
+        expectedContext: KanbanBoardContextStamp? = nil,
+        includeArchived: Bool = false
+    ) async throws -> KanbanSpecifyResponse {
         guard !isMutating else {
             throw recordMutationError(KanbanServiceError.mutationInProgress)
         }
+        try validateExpectedContext(expectedContext)
         guard let context = makeOperationContext() else {
             throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
         }
@@ -557,10 +587,15 @@ final class KanbanStore: ObservableObject {
     /// The response is child ids only — Conduit NEVER synthesizes cards from
     /// it. Semantic refusal throws the backend reason.
     @discardableResult
-    func decomposeTask(id: String, includeArchived: Bool = false) async throws -> KanbanDecomposeResponse {
+    func decomposeTask(
+        id: String,
+        expectedContext: KanbanBoardContextStamp? = nil,
+        includeArchived: Bool = false
+    ) async throws -> KanbanDecomposeResponse {
         guard !isMutating else {
             throw recordMutationError(KanbanServiceError.mutationInProgress)
         }
+        try validateExpectedContext(expectedContext)
         guard let context = makeOperationContext() else {
             throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
         }
@@ -575,10 +610,14 @@ final class KanbanStore: ObservableObject {
     /// the request is issued only while the captured context still owns the
     /// UI, and a completion after configure() is inert. The board reload
     /// after success doubles as the authoritative post-nudge refresh.
-    func nudgeDispatcher(includeArchived: Bool = false) async throws {
+    func nudgeDispatcher(
+        expectedContext: KanbanBoardContextStamp? = nil,
+        includeArchived: Bool = false
+    ) async throws {
         guard !isMutating else {
             throw recordMutationError(KanbanServiceError.mutationInProgress)
         }
+        try validateExpectedContext(expectedContext)
         guard let context = makeOperationContext() else {
             throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
         }
@@ -602,6 +641,33 @@ final class KanbanStore: ObservableObject {
     }
 
     // MARK: - Mutation state
+
+    /// Context-bound ownership validation (V3A final pass): a UI operation
+    /// captured its board/server stamp synchronously at the tap; the store
+    /// revalidates it HERE, back-to-back with makeOperationContext() on the
+    /// MainActor before the first suspension point. A stale stamp (board
+    /// switch, server reconfigure, or in-flight navigation) fails closed in
+    /// the same actor turn as the capture — a mutation started for A can
+    /// never silently retarget to B.
+    private func validateExpectedContext(_ expectedContext: KanbanBoardContextStamp?) throws {
+        guard let expectedContext else { return }
+        guard isSelectedSnapshotLoaded, loadedContextStamp == expectedContext else {
+            throw recordMutationError(KanbanServiceError.boardNavigationInProgress)
+        }
+    }
+
+    /// Server-scoped variant for SERVER-GLOBAL writes (orchestration settings,
+    /// profile descriptions): the wire request carries NO board query, so the
+    /// UI ownership token is the server CONFIGURATION GENERATION (inside the
+    /// captured stamp). A board switch on the SAME server keeps the generation
+    /// and must not abort the valid write; a server reconfigure bumps the
+    /// generation and fails closed exactly like the full-stamp check.
+    private func validateExpectedServerContext(_ expectedContext: KanbanBoardContextStamp?) throws {
+        guard let expectedContext else { return }
+        guard configurationGeneration == expectedContext.configurationGeneration else {
+            throw recordMutationError(KanbanServiceError.boardNavigationInProgress)
+        }
+    }
 
     private func makeOperationContext() -> KanbanOperationContext? {
         guard let service else { return nil }

--- a/Conduit/Views/Kanban/KanbanOrchestrationSettingsSheet.swift
+++ b/Conduit/Views/Kanban/KanbanOrchestrationSettingsSheet.swift
@@ -148,6 +148,12 @@ struct KanbanOrchestrationSettingsSheet: View {
                 }
             }
             .onAppear(perform: seedOnce)
+            // The sheet may open before orchestration data lands (e.g. right
+            // after launch); re-seed the moment it arrives. seedOnce is
+            // idempotent, so a later remediation is a no-op.
+            .onChange(of: store.orchestration) { _, _ in
+                seedOnce()
+            }
         }
         .interactiveDismissDisabled(isSaving)
     }
@@ -160,9 +166,7 @@ struct KanbanOrchestrationSettingsSheet: View {
         guard seed == nil else { return }
         guard let settings = store.orchestration else { return }
         autoDecompose = settings.autoDecompose
-        // Backend default is True when config omits it (plugin_api.py GET
-        // /orchestration: bool(cfg.get("auto_promote_children", True))).
-        autoPromoteChildren = settings.autoPromoteChildren ?? true
+        autoPromoteChildren = settings.autoPromoteChildren ?? KanbanOrchestrationSettings.defaultAutoPromoteChildren
         orchestratorProfile = settings.orchestratorProfile
         defaultAssignee = settings.defaultAssignee
         seed = Seed(
@@ -174,16 +178,25 @@ struct KanbanOrchestrationSettingsSheet: View {
     }
 
     private func save() async {
-        guard hasChanges else { return }
+        guard hasChanges, !patch.isEmpty else { return }
+        // Freeze server/board ownership BEFORE the suspension: a completion
+        // from a stale generation is UI-inert (its echo must not re-base this
+        // sheet against a server that no longer owns the screen).
+        let generation = store.currentConfigurationGeneration
         isSaving = true
         errorMessage = nil
         notice = nil
-        defer { isSaving = false }
+        defer {
+            if store.isCurrentConfiguration(generation) {
+                isSaving = false
+            }
+        }
         do {
             // Re-seed from the authoritative echo (when available) so a later
             // poll cannot present stale "unsaved changes"; if the refresh
             // failed the saved draft values still become the new baseline.
             let updated = try await store.updateOrchestration(patch)
+            guard store.isCurrentConfiguration(generation) else { return }
             autoDecompose = updated?.autoDecompose ?? autoDecompose
             autoPromoteChildren = updated?.autoPromoteChildren ?? autoPromoteChildren
             orchestratorProfile = updated?.orchestratorProfile ?? orchestratorProfile
@@ -196,6 +209,7 @@ struct KanbanOrchestrationSettingsSheet: View {
             )
             notice = "Orchestration settings saved."
         } catch {
+            guard store.isCurrentConfiguration(generation) else { return }
             // The store owns the current-generation error presentation too;
             // the inline copy keeps the sheet self-contained.
             errorMessage = error.localizedDescription

--- a/Conduit/Views/Kanban/KanbanOrchestrationSettingsSheet.swift
+++ b/Conduit/Views/Kanban/KanbanOrchestrationSettingsSheet.swift
@@ -1,0 +1,204 @@
+import SwiftUI
+
+/// Mobile-native Orchestration Settings (Kanban V3A).
+///
+/// Desktop parity (apps/desktop/src/plugins/kanban/orchestration.tsx) in a
+/// grouped iPhone form:
+/// - "Default" is the wire value "" (empty string) — the backend clears the
+///   override and falls back to the active default profile. No Conduit
+///   sentinel is ever introduced.
+/// - Configured vs resolved values are shown honestly: the Default row reads
+///   "Default (coder)" when the server resolves to coder, without implying
+///   coder was persisted.
+/// - Only changed fields are PUT (the backend writes only present fields).
+/// - Saving is ownership-safe through KanbanStore and never touches
+///   HermesClient / session transport; upstream nudges nothing for settings.
+struct KanbanOrchestrationSettingsSheet: View {
+    @EnvironmentObject private var store: KanbanStore
+    @Environment(\.dismiss) private var dismiss
+
+    // Editor draft, seeded ONCE from the current server snapshot so a
+    // background poll can never clobber an in-progress edit.
+    @State private var autoDecompose = true
+    @State private var autoPromoteChildren = true
+    @State private var orchestratorProfile = ""
+    @State private var defaultAssignee = ""
+    @State private var seed: Seed?
+    @State private var isSaving = false
+    @State private var notice: String?
+    @State private var errorMessage: String?
+
+    private struct Seed: Equatable {
+        var autoDecompose: Bool
+        var autoPromoteChildren: Bool
+        var orchestratorProfile: String
+        var defaultAssignee: String
+    }
+
+    private var hasChanges: Bool {
+        guard let seed else { return false }
+        return autoDecompose != seed.autoDecompose
+            || autoPromoteChildren != seed.autoPromoteChildren
+            || orchestratorProfile != seed.orchestratorProfile
+            || defaultAssignee != seed.defaultAssignee
+    }
+
+    private var patch: KanbanOrchestrationPatch {
+        guard let seed else { return KanbanOrchestrationPatch() }
+        return KanbanOrchestrationPatch(
+            orchestratorProfile: orchestratorProfile != seed.orchestratorProfile ? orchestratorProfile : nil,
+            defaultAssignee: defaultAssignee != seed.defaultAssignee ? defaultAssignee : nil,
+            autoDecompose: autoDecompose != seed.autoDecompose ? autoDecompose : nil,
+            autoPromoteChildren: autoPromoteChildren != seed.autoPromoteChildren ? autoPromoteChildren : nil
+        )
+    }
+
+    private var orchestratorSelectionLabel: String {
+        if !orchestratorProfile.isEmpty { return orchestratorProfile }
+        return KanbanOrchestrationDisplay.defaultOptionLabel(
+            configured: "",
+            resolved: store.orchestration?.resolvedOrchestratorProfile ?? ""
+        )
+    }
+
+    private var assigneeSelectionLabel: String {
+        if !defaultAssignee.isEmpty { return defaultAssignee }
+        return KanbanOrchestrationDisplay.defaultOptionLabel(
+            configured: "",
+            resolved: store.orchestration?.resolvedDefaultAssignee ?? ""
+        )
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if store.orchestration == nil {
+                    ContentUnavailableView(
+                        "Orchestration Settings Unavailable",
+                        systemImage: "slider.horizontal.3",
+                        description: Text("Load a Kanban board to read the server's orchestration settings.")
+                    )
+                } else {
+                    Form {
+                        Section {
+                            Toggle("Auto Decompose", isOn: $autoDecompose)
+                                .accessibilityHint("Fans eligible triage tasks into child task graphs")
+                            Toggle("Auto Promote Children", isOn: $autoPromoteChildren)
+                                .accessibilityHint("Promotes parent-free decomposed children to Ready")
+                        } footer: {
+                            Text("Auto Decompose lets the dispatcher decompose eligible triage tasks. Auto Promote Children moves parent-free children to Ready instead of leaving them in To Do.")
+                        }
+
+                        Section("Orchestrator Profile") {
+                            Picker("Orchestrator Profile", selection: $orchestratorProfile) {
+                                Text(orchestratorSelectionLabel).tag("")
+                                ForEach(store.profiles) { profile in
+                                    Text(profile.name).tag(profile.name)
+                                }
+                            }
+                            .pickerStyle(.menu)
+                            Text(footnote(configured: orchestratorProfile, resolved: store.orchestration?.resolvedOrchestratorProfile ?? ""))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Section("Default Assignee") {
+                            Picker("Default Assignee", selection: $defaultAssignee) {
+                                Text(assigneeSelectionLabel).tag("")
+                                ForEach(store.profiles) { profile in
+                                    Text(profile.name).tag(profile.name)
+                                }
+                            }
+                            .pickerStyle(.menu)
+                            Text(footnote(configured: defaultAssignee, resolved: store.orchestration?.resolvedDefaultAssignee ?? ""))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        if let errorMessage {
+                            Section {
+                                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                                    .font(.footnote)
+                                    .foregroundStyle(.red)
+                            }
+                        }
+                        if let notice {
+                            Section {
+                                Label(notice, systemImage: "checkmark.circle")
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Orchestration Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button {
+                        Task { await save() }
+                    } label: {
+                        if isSaving { ProgressView() } else { Text("Save") }
+                    }
+                    .disabled(!hasChanges || isSaving)
+                }
+            }
+            .onAppear(perform: seedOnce)
+        }
+        .interactiveDismissDisabled(isSaving)
+    }
+
+    private func footnote(configured: String, resolved: String) -> String {
+        KanbanOrchestrationDisplay.resolveFootnote(configured: configured, resolved: resolved)
+    }
+
+    private func seedOnce() {
+        guard seed == nil else { return }
+        guard let settings = store.orchestration else { return }
+        autoDecompose = settings.autoDecompose
+        // Backend default is True when config omits it (plugin_api.py GET
+        // /orchestration: bool(cfg.get("auto_promote_children", True))).
+        autoPromoteChildren = settings.autoPromoteChildren ?? true
+        orchestratorProfile = settings.orchestratorProfile
+        defaultAssignee = settings.defaultAssignee
+        seed = Seed(
+            autoDecompose: autoDecompose,
+            autoPromoteChildren: autoPromoteChildren,
+            orchestratorProfile: orchestratorProfile,
+            defaultAssignee: defaultAssignee
+        )
+    }
+
+    private func save() async {
+        guard hasChanges else { return }
+        isSaving = true
+        errorMessage = nil
+        notice = nil
+        defer { isSaving = false }
+        do {
+            // Re-seed from the authoritative echo (when available) so a later
+            // poll cannot present stale "unsaved changes"; if the refresh
+            // failed the saved draft values still become the new baseline.
+            let updated = try await store.updateOrchestration(patch)
+            autoDecompose = updated?.autoDecompose ?? autoDecompose
+            autoPromoteChildren = updated?.autoPromoteChildren ?? autoPromoteChildren
+            orchestratorProfile = updated?.orchestratorProfile ?? orchestratorProfile
+            defaultAssignee = updated?.defaultAssignee ?? defaultAssignee
+            seed = Seed(
+                autoDecompose: autoDecompose,
+                autoPromoteChildren: autoPromoteChildren,
+                orchestratorProfile: orchestratorProfile,
+                defaultAssignee: defaultAssignee
+            )
+            notice = "Orchestration settings saved."
+        } catch {
+            // The store owns the current-generation error presentation too;
+            // the inline copy keeps the sheet self-contained.
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/Conduit/Views/Kanban/KanbanOrchestrationSettingsSheet.swift
+++ b/Conduit/Views/Kanban/KanbanOrchestrationSettingsSheet.swift
@@ -27,6 +27,9 @@ struct KanbanOrchestrationSettingsSheet: View {
     @State private var isSaving = false
     @State private var notice: String?
     @State private var errorMessage: String?
+    /// Local busy-flag ownership (V3A final pass): the operation that started
+    /// isSaving owns its release, independent of server generations.
+    @State private var liveness = KanbanEditorLiveness()
 
     private struct Seed: Equatable {
         var autoDecompose: Bool
@@ -130,21 +133,30 @@ struct KanbanOrchestrationSettingsSheet: View {
                             }
                         }
                     }
+                    // V3A final pass: no control may be edited while a Save is
+                    // in flight, so a completion can structurally never
+                    // clobber a post-submit edit. The busy state itself is
+                    // established synchronously by saveTapped() BEFORE the
+                    // Task is spawned.
+                    .disabled(isSaving)
                 }
             }
             .navigationTitle("Orchestration Settings")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
+                    // F-3: no dismissing mid-save - the busy flow owns the
+                    // sheet until it lands or fails.
                     Button("Close") { dismiss() }
+                        .disabled(isSaving)
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button {
-                        Task { await save() }
+                        saveTapped()
                     } label: {
                         if isSaving { ProgressView() } else { Text("Save") }
                     }
-                    .disabled(!hasChanges || isSaving)
+                    .disabled(!hasChanges || isSaving || !store.isSelectedSnapshotLoaded)
                 }
             }
             .onAppear(perform: seedOnce)
@@ -177,25 +189,41 @@ struct KanbanOrchestrationSettingsSheet: View {
         )
     }
 
-    private func save() async {
-        guard hasChanges, !patch.isEmpty else { return }
-        // Freeze server/board ownership BEFORE the suspension: a completion
-        // from a stale generation is UI-inert (its echo must not re-base this
-        // sheet against a server that no longer owns the screen).
+    /// V3A final pass: Save tap freezes the draft VALUES (via the computed
+    /// patch), the board/server stamp, the server generation, and the busy
+    /// state synchronously BEFORE any Task is spawned. Orchestration is
+    /// server-global on the wire, but the loaded board/server stamp is still
+    /// the UI ownership token: a sheet seeded from server A can never write
+    /// its draft to B after a reconfiguration.
+    private func saveTapped() {
+        guard !isSaving, hasChanges, !patch.isEmpty,
+              store.isSelectedSnapshotLoaded,
+              let stamp = store.loadedContextStamp else { return }
+        let patch = patch
         let generation = store.currentConfigurationGeneration
+        let operationID = liveness.begin()
         isSaving = true
         errorMessage = nil
         notice = nil
-        defer {
-            if store.isCurrentConfiguration(generation) {
-                isSaving = false
-            }
+        Task {
+            await performSave(patch: patch, context: stamp, generation: generation, operationID: operationID)
         }
+    }
+
+    private func performSave(
+        patch: KanbanOrchestrationPatch,
+        context: KanbanBoardContextStamp,
+        generation: Int,
+        operationID: Int
+    ) async {
         do {
             // Re-seed from the authoritative echo (when available) so a later
             // poll cannot present stale "unsaved changes"; if the refresh
             // failed the saved draft values still become the new baseline.
-            let updated = try await store.updateOrchestration(patch)
+            let updated = try await store.updateOrchestration(patch, expectedContext: context)
+            // Local busy release is owned by THIS operation, never by the
+            // server generation (a stale completion still releases it).
+            if liveness.owns(operationID) { isSaving = false }
             guard store.isCurrentConfiguration(generation) else { return }
             autoDecompose = updated?.autoDecompose ?? autoDecompose
             autoPromoteChildren = updated?.autoPromoteChildren ?? autoPromoteChildren
@@ -209,6 +237,7 @@ struct KanbanOrchestrationSettingsSheet: View {
             )
             notice = "Orchestration settings saved."
         } catch {
+            if liveness.owns(operationID) { isSaving = false }
             guard store.isCurrentConfiguration(generation) else { return }
             // The store owns the current-generation error presentation too;
             // the inline copy keeps the sheet self-contained.

--- a/Conduit/Views/Kanban/KanbanProfileRoutingScreen.swift
+++ b/Conduit/Views/Kanban/KanbanProfileRoutingScreen.swift
@@ -98,6 +98,10 @@ struct KanbanProfileDescriptionEditorView: View {
     @State private var notice: String?
     @State private var errorMessage: String?
     @State private var showDiscardConfirmation = false
+    /// Local busy-flag ownership: the operation that STARTED isSaving/
+    /// isGenerating owns their release, independent of server generations
+    /// (a stale completion must still release the flags it owns).
+    @State private var liveness = KanbanEditorLiveness()
 
     init(profile: KanbanProfile) {
         self.profile = profile
@@ -139,8 +143,12 @@ struct KanbanProfileDescriptionEditorView: View {
             }
 
             Section {
+                // V3A final pass: the identity (profile name), the board/server
+                // stamp, the SUBMITTED value and the busy state are all frozen
+                // synchronously in the button action (saveTapped) BEFORE any
+                // Task is spawned - closing the tap -> Task-scheduling gap.
                 Button {
-                    Task { await save() }
+                    saveTapped()
                 } label: {
                     HStack {
                         Spacer()
@@ -148,7 +156,7 @@ struct KanbanProfileDescriptionEditorView: View {
                         Spacer()
                     }
                 }
-                .disabled(!isDirty || isSaving || isGenerating)
+                .disabled(!isDirty || isSaving || isGenerating || !store.isSelectedSnapshotLoaded)
 
                 Button {
                     requestGenerate()
@@ -159,7 +167,7 @@ struct KanbanProfileDescriptionEditorView: View {
                         Spacer()
                     }
                 }
-                .disabled(isSaving || isGenerating)
+                .disabled(isSaving || isGenerating || !store.isSelectedSnapshotLoaded)
             }
 
             if let errorMessage {
@@ -188,7 +196,7 @@ struct KanbanProfileDescriptionEditorView: View {
                 // Explicitly drop the unsaved draft BEFORE generating (the
                 // generation would otherwise persist over the editor's draft).
                 draft = KanbanProfileDescriptionPolicy.discard(draft: draft, baseline: baseline.description)
-                Task { await generate() }
+                startGenerate()
             }
             Button("Cancel", role: .cancel) {}
         } message: {
@@ -197,70 +205,157 @@ struct KanbanProfileDescriptionEditorView: View {
         .interactiveDismissDisabled(isSaving || isGenerating)
     }
 
+    // MARK: - V3A final pass: synchronous tap handlers
+
+    /// Save tap: freezes profile identity, board/server stamp, the SUBMITTED
+    /// (trimmed) value, the server generation, and the busy state - all
+    /// synchronously, BEFORE the Task is spawned. An editor opened for server
+    /// A / profile X can therefore never save against server B / profile X,
+    /// and a newer local edit made while the request is pending is never
+    /// marked saved (the submission is frozen by value).
+    private func saveTapped() {
+        guard isDirty, !isSaving, !isGenerating,
+              store.isSelectedSnapshotLoaded,
+              let stamp = store.loadedContextStamp else { return }
+        isSaving = true
+        errorMessage = nil
+        notice = nil
+        let submitted = trimmedDraft
+        let sessionProfile = profile.name
+        let generation = store.currentConfigurationGeneration
+        let operationID = liveness.begin()
+        Task {
+            await performSave(
+                submitted: submitted,
+                sessionProfile: sessionProfile,
+                context: stamp,
+                generation: generation,
+                operationID: operationID
+            )
+        }
+    }
+
+    private func performSave(
+        submitted: String,
+        sessionProfile: String,
+        context: KanbanBoardContextStamp,
+        generation: Int,
+        operationID: Int
+    ) async {
+        do {
+            try await store.updateProfileDescription(
+                profile: sessionProfile,
+                description: submitted,
+                expectedContext: context
+            )
+            // Local busy release is owned by THIS operation, never by the
+            // server generation (a stale completion still releases it).
+            if liveness.owns(operationID) { isSaving = false }
+            guard store.isCurrentConfiguration(generation) else { return }
+            // Server/UI result applies only while this operation still owns
+            // the current lifecycle AND the editor still edits this profile.
+            let outcome = KanbanProfileDescriptionPolicy.saveCompletion(
+                submitted: submitted,
+                currentRawDraft: draft,
+                currentTrimmedDraft: trimmedDraft
+            )
+            baseline = KanbanProfileDescriptionPolicy.Snapshot(
+                profile: sessionProfile,
+                description: outcome.baselineDescription,
+                isAuto: outcome.baselineIsAuto
+            )
+            draft = outcome.draft
+            errorMessage = nil
+            notice = outcome.notice
+        } catch {
+            if liveness.owns(operationID) { isSaving = false }
+            guard store.isCurrentConfiguration(generation) else { return }
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    /// Requests generation, honoring the dirty-draft gate.
     private func requestGenerate() {
         switch KanbanProfileDescriptionPolicy.resolveGenerate(draft: trimmedDraft, baseline: baseline.description) {
         case .allowed:
-            Task { await generate() }
+            startGenerate()
         case .requiresDiscard:
             // Never silently overwrite an unsaved manual draft.
             showDiscardConfirmation = true
         }
     }
 
-    private func save() async {
-        // Freeze the server/board ownership BEFORE the first suspension point:
-        // a completion from a stale generation is UI-inert - it must not
-        // rewrite the editor's baseline/draft or show "saved" for a server
-        // that no longer owns this screen (review W-1).
-        let sessionProfile = profile.name
-        let generation = store.currentConfigurationGeneration
-        isSaving = true
-        errorMessage = nil
-        notice = nil
-        defer {
-            if store.isCurrentConfiguration(generation) {
-                isSaving = false
-            }
-        }
-        do {
-            try await store.updateProfileDescription(profile: sessionProfile, description: trimmedDraft)
-            guard store.isCurrentConfiguration(generation) else { return }
-            baseline = KanbanProfileDescriptionPolicy.Snapshot(profile: sessionProfile, description: trimmedDraft, isAuto: false)
-            draft = trimmedDraft
-            notice = "Description saved."
-        } catch {
-            guard store.isCurrentConfiguration(generation) else { return }
-            errorMessage = error.localizedDescription
-        }
-    }
-
-    private func generate() async {
-        let sessionProfile = profile.name
-        let generation = store.currentConfigurationGeneration
+    /// Generate tap (or confirmed discard-and-generate): freezes the profile
+    /// identity, board/server stamp, the editor snapshot AT SUBMISSION, the
+    /// server generation and the busy state synchronously, before any Task.
+    /// The submission snapshot is what generation later compares against:
+    /// newer manual typing (after submission) is preserved, never clobbered
+    /// by the generated server value.
+    private func startGenerate() {
+        guard !isGenerating, !isSaving,
+              store.isSelectedSnapshotLoaded,
+              let stamp = store.loadedContextStamp else { return }
         isGenerating = true
         errorMessage = nil
         notice = nil
-        defer {
-            if store.isCurrentConfiguration(generation) {
-                isGenerating = false
-            }
+        // TRIMMED, matching saveTapped: generateCompletion compares
+        // trimmed/trimmed, so a whitespace-ragged submission is never
+        // misclassified as "newer typing" (review F-1).
+        let submittedDraft = trimmedDraft
+        let sessionProfile = profile.name
+        let generation = store.currentConfigurationGeneration
+        let operationID = liveness.begin()
+        Task {
+            await performGenerate(
+                submittedDraft: submittedDraft,
+                sessionProfile: sessionProfile,
+                context: stamp,
+                generation: generation,
+                operationID: operationID
+            )
         }
+    }
+
+    private func performGenerate(
+        submittedDraft: String,
+        sessionProfile: String,
+        context: KanbanBoardContextStamp,
+        generation: Int,
+        operationID: Int
+    ) async {
         do {
             // Generated text is persisted server-side immediately with
             // description_auto=true; the editor adopts the authoritative text.
-            let outcome = try await store.autoDescribeProfile(profile: sessionProfile, overwrite: true)
+            let outcome = try await store.autoDescribeProfile(
+                profile: sessionProfile,
+                overwrite: true,
+                expectedContext: context
+            )
+            if liveness.owns(operationID) { isGenerating = false }
             guard store.isCurrentConfiguration(generation) else { return }
             if outcome.ok {
                 let generated = outcome.description ?? ""
-                baseline = KanbanProfileDescriptionPolicy.Snapshot(profile: sessionProfile, description: generated, isAuto: true)
-                draft = generated
-                notice = "Generated automatically — review recommended."
+                let completion = KanbanProfileDescriptionPolicy.generateCompletion(
+                    submittedDraft: submittedDraft,
+                    currentRawDraft: draft,
+                    currentTrimmedDraft: trimmedDraft,
+                    generated: generated
+                )
+                baseline = KanbanProfileDescriptionPolicy.Snapshot(
+                    profile: sessionProfile,
+                    description: completion.baselineDescription,
+                    isAuto: completion.baselineIsAuto
+                )
+                draft = completion.draft
+                errorMessage = nil
+                notice = completion.notice
             } else {
                 // Semantic refusal (e.g. "no auxiliary client configured"):
                 // the backend reason IS the product semantics.
                 errorMessage = outcome.reason ?? "Hermes could not generate a description."
             }
         } catch {
+            if liveness.owns(operationID) { isGenerating = false }
             guard store.isCurrentConfiguration(generation) else { return }
             errorMessage = error.localizedDescription
         }

--- a/Conduit/Views/Kanban/KanbanProfileRoutingScreen.swift
+++ b/Conduit/Views/Kanban/KanbanProfileRoutingScreen.swift
@@ -110,8 +110,11 @@ struct KanbanProfileDescriptionEditorView: View {
         _draft = State(initialValue: profile.description)
     }
 
+    /// Dirty compares the TRIMMED draft against the server-trimmed baseline,
+    /// so a trailing newline from the TextEditor can never produce a no-op
+    /// PATCH that "saves" the same text back.
     private var isDirty: Bool {
-        KanbanProfileDescriptionPolicy.isDirty(draft: draft, baseline: baseline.description)
+        KanbanProfileDescriptionPolicy.isDirty(draft: trimmedDraft, baseline: baseline.description)
     }
 
     private var trimmedDraft: String {
@@ -132,7 +135,7 @@ struct KanbanProfileDescriptionEditorView: View {
             } header: {
                 Text("Routing Description")
             } footer: {
-                Text("The decomposer reads these descriptions to route child tasks to the best specialist profile. Empty descriptions fall back to name matching.")
+                Text("The decomposer reads these descriptions to route child tasks to the best specialist profile. Saving an empty description clears it (Hermes then falls back to name matching).")
             }
 
             Section {
@@ -182,6 +185,9 @@ struct KanbanProfileDescriptionEditorView: View {
             titleVisibility: .visible
         ) {
             Button("Discard & Generate", role: .destructive) {
+                // Explicitly drop the unsaved draft BEFORE generating (the
+                // generation would otherwise persist over the editor's draft).
+                draft = KanbanProfileDescriptionPolicy.discard(draft: draft, baseline: baseline.description)
                 Task { await generate() }
             }
             Button("Cancel", role: .cancel) {}
@@ -192,7 +198,7 @@ struct KanbanProfileDescriptionEditorView: View {
     }
 
     private func requestGenerate() {
-        switch KanbanProfileDescriptionPolicy.resolveGenerate(draft: draft, baseline: baseline.description) {
+        switch KanbanProfileDescriptionPolicy.resolveGenerate(draft: trimmedDraft, baseline: baseline.description) {
         case .allowed:
             Task { await generate() }
         case .requiresDiscard:
@@ -202,36 +208,40 @@ struct KanbanProfileDescriptionEditorView: View {
     }
 
     private func save() async {
+        // Freeze the server/board ownership BEFORE the first suspension point:
+        // a completion from a stale generation is UI-inert - it must not
+        // rewrite the editor's baseline/draft or show "saved" for a server
+        // that no longer owns this screen (review W-1).
         let sessionProfile = profile.name
-        guard KanbanProfileDescriptionPolicy.completionIsActive(sessionProfile: sessionProfile, currentProfile: profile.name) else { return }
+        let generation = store.currentConfigurationGeneration
         isSaving = true
         errorMessage = nil
         notice = nil
         defer {
-            if KanbanProfileDescriptionPolicy.completionIsActive(sessionProfile: sessionProfile, currentProfile: profile.name) {
+            if store.isCurrentConfiguration(generation) {
                 isSaving = false
             }
         }
         do {
             try await store.updateProfileDescription(profile: sessionProfile, description: trimmedDraft)
-            guard KanbanProfileDescriptionPolicy.completionIsActive(sessionProfile: sessionProfile, currentProfile: profile.name) else { return }
+            guard store.isCurrentConfiguration(generation) else { return }
             baseline = KanbanProfileDescriptionPolicy.Snapshot(profile: sessionProfile, description: trimmedDraft, isAuto: false)
             draft = trimmedDraft
             notice = "Description saved."
         } catch {
-            guard KanbanProfileDescriptionPolicy.completionIsActive(sessionProfile: sessionProfile, currentProfile: profile.name) else { return }
+            guard store.isCurrentConfiguration(generation) else { return }
             errorMessage = error.localizedDescription
         }
     }
 
     private func generate() async {
         let sessionProfile = profile.name
-        guard KanbanProfileDescriptionPolicy.completionIsActive(sessionProfile: sessionProfile, currentProfile: profile.name) else { return }
+        let generation = store.currentConfigurationGeneration
         isGenerating = true
         errorMessage = nil
         notice = nil
         defer {
-            if KanbanProfileDescriptionPolicy.completionIsActive(sessionProfile: sessionProfile, currentProfile: profile.name) {
+            if store.isCurrentConfiguration(generation) {
                 isGenerating = false
             }
         }
@@ -239,7 +249,7 @@ struct KanbanProfileDescriptionEditorView: View {
             // Generated text is persisted server-side immediately with
             // description_auto=true; the editor adopts the authoritative text.
             let outcome = try await store.autoDescribeProfile(profile: sessionProfile, overwrite: true)
-            guard KanbanProfileDescriptionPolicy.completionIsActive(sessionProfile: sessionProfile, currentProfile: profile.name) else { return }
+            guard store.isCurrentConfiguration(generation) else { return }
             if outcome.ok {
                 let generated = outcome.description ?? ""
                 baseline = KanbanProfileDescriptionPolicy.Snapshot(profile: sessionProfile, description: generated, isAuto: true)
@@ -251,7 +261,7 @@ struct KanbanProfileDescriptionEditorView: View {
                 errorMessage = outcome.reason ?? "Hermes could not generate a description."
             }
         } catch {
-            guard KanbanProfileDescriptionPolicy.completionIsActive(sessionProfile: sessionProfile, currentProfile: profile.name) else { return }
+            guard store.isCurrentConfiguration(generation) else { return }
             errorMessage = error.localizedDescription
         }
     }

--- a/Conduit/Views/Kanban/KanbanProfileRoutingScreen.swift
+++ b/Conduit/Views/Kanban/KanbanProfileRoutingScreen.swift
@@ -1,0 +1,258 @@
+import SwiftUI
+
+/// Profiles — the routing descriptions used by the Kanban orchestrator and
+/// decomposer (V3A §4). A push-style list; each row opens the description
+/// editor for that profile.
+struct KanbanProfileRoutingScreen: View {
+    @EnvironmentObject private var store: KanbanStore
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    if store.profiles.isEmpty {
+                        Text("No profiles on this Hermes server yet.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(store.profiles) { profile in
+                            NavigationLink {
+                                KanbanProfileDescriptionEditorView(profile: profile)
+                                    .environmentObject(store)
+                            } label: {
+                                profileRow(profile)
+                            }
+                        }
+                    }
+                } footer: {
+                    Text("Hermes routes triage decomposition across these profiles by their routing description. A clear description helps the decomposer pick the right specialist.")
+                }
+            }
+            .navigationTitle("Profiles")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func profileRow(_ profile: KanbanProfile) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 6) {
+                Text(profile.name)
+                    .font(.subheadline.weight(.semibold))
+                if profile.isDefault {
+                    Text("default")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                if profile.descriptionAuto {
+                    Label("auto", systemImage: "sparkles")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                        .labelStyle(.titleOnly)
+                }
+                Spacer()
+                if profile.description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Text("undescribed")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            let trimmed = profile.description.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                Text(trimmed)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+/// Single-profile routing description editor (V3A §4).
+///
+/// Ownership rules (all enforced by KanbanProfileDescriptionPolicy):
+/// - The editor captures its baseline ONCE at open; the draft belongs to the
+///   user until saved.
+/// - "Generate Automatically" persists generated text server-side
+///   immediately, so it can NEVER silently overwrite an unsaved manual draft:
+///   a dirty draft forces an explicit discard confirmation first.
+/// - A save/generation completion is UI-inert for a different profile
+///   identity; underneath, KanbanStore's generation guard is the hard
+///   boundary.
+struct KanbanProfileDescriptionEditorView: View {
+    @EnvironmentObject private var store: KanbanStore
+    @Environment(\.dismiss) private var dismiss
+
+    private let profile: KanbanProfile
+
+    @State private var draft: String
+    @State private var baseline: KanbanProfileDescriptionPolicy.Snapshot
+    @State private var isSaving = false
+    @State private var isGenerating = false
+    @State private var notice: String?
+    @State private var errorMessage: String?
+    @State private var showDiscardConfirmation = false
+
+    init(profile: KanbanProfile) {
+        self.profile = profile
+        let snapshot = KanbanProfileDescriptionPolicy.Snapshot(
+            profile: profile.name,
+            description: profile.description,
+            isAuto: profile.descriptionAuto
+        )
+        _baseline = State(initialValue: snapshot)
+        _draft = State(initialValue: profile.description)
+    }
+
+    private var isDirty: Bool {
+        KanbanProfileDescriptionPolicy.isDirty(draft: draft, baseline: baseline.description)
+    }
+
+    private var trimmedDraft: String {
+        draft.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                TextEditor(text: $draft)
+                    .frame(minHeight: 140)
+                    .accessibilityLabel("Routing description for \(profile.name)")
+                if baseline.isAuto {
+                    Label("Automatically generated — review recommended", systemImage: "sparkles")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
+            } header: {
+                Text("Routing Description")
+            } footer: {
+                Text("The decomposer reads these descriptions to route child tasks to the best specialist profile. Empty descriptions fall back to name matching.")
+            }
+
+            Section {
+                Button {
+                    Task { await save() }
+                } label: {
+                    HStack {
+                        Spacer()
+                        if isSaving { ProgressView() } else { Text("Save") }
+                        Spacer()
+                    }
+                }
+                .disabled(!isDirty || isSaving || isGenerating)
+
+                Button {
+                    requestGenerate()
+                } label: {
+                    HStack {
+                        Spacer()
+                        if isGenerating { ProgressView() } else { Label("Generate Automatically", systemImage: "sparkles") }
+                        Spacer()
+                    }
+                }
+                .disabled(isSaving || isGenerating)
+            }
+
+            if let errorMessage {
+                Section {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle")
+                        .font(.footnote)
+                        .foregroundStyle(.red)
+                }
+            }
+            if let notice {
+                Section {
+                    Label(notice, systemImage: "checkmark.circle")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .navigationTitle(profile.name)
+        .navigationBarTitleDisplayMode(.inline)
+        .confirmationDialog(
+            "Discard unsaved changes?",
+            isPresented: $showDiscardConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Discard & Generate", role: .destructive) {
+                Task { await generate() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Generating replaces the current text. Your unsaved edits will be lost.")
+        }
+        .interactiveDismissDisabled(isSaving || isGenerating)
+    }
+
+    private func requestGenerate() {
+        switch KanbanProfileDescriptionPolicy.resolveGenerate(draft: draft, baseline: baseline.description) {
+        case .allowed:
+            Task { await generate() }
+        case .requiresDiscard:
+            // Never silently overwrite an unsaved manual draft.
+            showDiscardConfirmation = true
+        }
+    }
+
+    private func save() async {
+        let sessionProfile = profile.name
+        guard KanbanProfileDescriptionPolicy.completionIsActive(sessionProfile: sessionProfile, currentProfile: profile.name) else { return }
+        isSaving = true
+        errorMessage = nil
+        notice = nil
+        defer {
+            if KanbanProfileDescriptionPolicy.completionIsActive(sessionProfile: sessionProfile, currentProfile: profile.name) {
+                isSaving = false
+            }
+        }
+        do {
+            try await store.updateProfileDescription(profile: sessionProfile, description: trimmedDraft)
+            guard KanbanProfileDescriptionPolicy.completionIsActive(sessionProfile: sessionProfile, currentProfile: profile.name) else { return }
+            baseline = KanbanProfileDescriptionPolicy.Snapshot(profile: sessionProfile, description: trimmedDraft, isAuto: false)
+            draft = trimmedDraft
+            notice = "Description saved."
+        } catch {
+            guard KanbanProfileDescriptionPolicy.completionIsActive(sessionProfile: sessionProfile, currentProfile: profile.name) else { return }
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func generate() async {
+        let sessionProfile = profile.name
+        guard KanbanProfileDescriptionPolicy.completionIsActive(sessionProfile: sessionProfile, currentProfile: profile.name) else { return }
+        isGenerating = true
+        errorMessage = nil
+        notice = nil
+        defer {
+            if KanbanProfileDescriptionPolicy.completionIsActive(sessionProfile: sessionProfile, currentProfile: profile.name) {
+                isGenerating = false
+            }
+        }
+        do {
+            // Generated text is persisted server-side immediately with
+            // description_auto=true; the editor adopts the authoritative text.
+            let outcome = try await store.autoDescribeProfile(profile: sessionProfile, overwrite: true)
+            guard KanbanProfileDescriptionPolicy.completionIsActive(sessionProfile: sessionProfile, currentProfile: profile.name) else { return }
+            if outcome.ok {
+                let generated = outcome.description ?? ""
+                baseline = KanbanProfileDescriptionPolicy.Snapshot(profile: sessionProfile, description: generated, isAuto: true)
+                draft = generated
+                notice = "Generated automatically — review recommended."
+            } else {
+                // Semantic refusal (e.g. "no auxiliary client configured"):
+                // the backend reason IS the product semantics.
+                errorMessage = outcome.reason ?? "Hermes could not generate a description."
+            }
+        } catch {
+            guard KanbanProfileDescriptionPolicy.completionIsActive(sessionProfile: sessionProfile, currentProfile: profile.name) else { return }
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/Conduit/Views/Kanban/KanbanTaskDetailView.swift
+++ b/Conduit/Views/Kanban/KanbanTaskDetailView.swift
@@ -50,9 +50,14 @@ struct KanbanTaskDetailView: View {
     @State private var showDeleteConfirmation = false
     /// Triage actions (V3A): Specify / Decompose are offered ONLY for
     /// eligible (triage) tasks, and Decompose always requires confirmation.
+    /// Both actions freeze the task identity + board/server stamp AT THE TAP
+    /// (PendingTriageAction) and the store revalidates the stamp at its
+    /// mutation boundary; Decompose additionally stages its PendingTriageAction
+    /// BY VALUE through the confirmation dialog, so confirming an action
+    /// staged for task A can never act on task B after navigation.
     @State private var isSpecifying = false
     @State private var isDecomposing = false
-    @State private var showDecomposeConfirmation = false
+    @State private var pendingDecompose: PendingTriageAction?
     @State private var actionNotice: String?
     @State private var showReassignSheet = false
     @State private var showModelSheet = false
@@ -244,7 +249,7 @@ struct KanbanTaskDetailView: View {
                 showDeleteConfirmation = false
                 isSpecifying = false
                 isDecomposing = false
-                showDecomposeConfirmation = false
+                pendingDecompose = nil
                 actionNotice = nil
                 title = ""
                 taskBody = ""
@@ -306,13 +311,23 @@ struct KanbanTaskDetailView: View {
             }
             .confirmationDialog(
                 KanbanTriageActionsPolicy.decomposeConfirmationTitle,
-                isPresented: $showDecomposeConfirmation,
-                titleVisibility: .visible
-            ) {
-                Button("Decompose") { Task { await decomposeTask() } }
-                Button("Cancel", role: .cancel) {}
-            } message: {
+                isPresented: Binding(
+                    get: { pendingDecompose != nil },
+                    set: { if !$0 { pendingDecompose = nil } }
+                ),
+                titleVisibility: .visible,
+                presenting: pendingDecompose
+            ) { staged in
+                Button("Decompose") { confirmDecompose(staged) }
+                Button("Cancel", role: .cancel) { pendingDecompose = nil }
+            } message: { _ in
                 Text(KanbanTriageActionsPolicy.decomposeConfirmationMessage)
+            }
+            // Proactive disarm: when the loaded board identity changes, any
+            // staged triage action is now foreign. The confirm-time store
+            // stamp revalidation remains the hard boundary.
+            .onChange(of: store.loadedBoardSlug) { _, _ in
+                pendingDecompose = nil
             }
         }
     }
@@ -505,7 +520,18 @@ struct KanbanTaskDetailView: View {
         if KanbanTriagePolicy.isEligible(task: displayedTask) {
             ConduitSettingsSection(title: "Triage Actions", symbol: "tray.and.arrow.down", tint: .conduitAccent) {
                 Button {
-                    Task { await specifyTask() }
+                    // V3A final pass: capture the task identity + board/server
+                    // stamp SYNCHRONOUSLY at the tap, then schedule. The store
+                    // revalidates the stamp at its mutation boundary; a task
+                    // shown as A at tap time can never be specified as B.
+                    guard let pending = PendingTriageAction.capture(
+                        task: displayedTask,
+                        isSnapshotActionable: store.isSelectedSnapshotLoaded,
+                        stamp: store.loadedContextStamp
+                    ) else { return }
+                    isSpecifying = true
+                    errorMessage = nil
+                    Task { await specifyTask(pending: pending) }
                 } label: {
                     HStack {
                         Spacer()
@@ -519,11 +545,17 @@ struct KanbanTaskDetailView: View {
 
                 Button {
                     // Decompose may create and assign multiple dependent
-                    // tasks: it is ALWAYS confirmation-gated (the action
-                    // policy answers, never the view directly).
-                    if KanbanTriageActionsPolicy.decomposeTap() == .confirm {
-                        showDecomposeConfirmation = true
-                    }
+                    // tasks: it is ALWAYS confirmation-gated, and the
+                    // confirmation is bound BY VALUE to the task/context
+                    // staged at this tap (the action policy answers, never
+                    // the view directly).
+                    guard KanbanTriageActionsPolicy.decomposeTap() == .confirm,
+                          let pending = PendingTriageAction.capture(
+                              task: displayedTask,
+                              isSnapshotActionable: store.isSelectedSnapshotLoaded,
+                              stamp: store.loadedContextStamp
+                          ) else { return }
+                    pendingDecompose = pending
                 } label: {
                     HStack {
                         Spacer()
@@ -535,6 +567,18 @@ struct KanbanTaskDetailView: View {
                 .disabled(isSpecifying || isDecomposing)
             }
         }
+    }
+
+    /// Confirmation of a STAGED action only: the staged task identity and
+    /// stamp are passed BY VALUE to the store, which revalidates the stamp
+    /// back-to-back with its operation-context capture. After task
+    /// navigation, board switching, or server reconfiguration the stale
+    /// confirmation is discarded without any request.
+    private func confirmDecompose(_ staged: PendingTriageAction) {
+        pendingDecompose = nil
+        isDecomposing = true
+        errorMessage = nil
+        Task { await decomposeTask(pending: staged) }
     }
 
     private var readyUnassignedCallout: some View {
@@ -1150,18 +1194,19 @@ struct KanbanTaskDetailView: View {
     /// authoritative reload and this screen re-syncs the detail from the
     /// server. A semantic {ok:false} refusal surfaces the backend reason
     /// and leaves the task entirely intact.
-    private func specifyTask() async {
-        guard let startedTask = displayedTask else { return }
-        let expectedID = displayedTaskID
-        isSpecifying = true
-        errorMessage = nil
+    private func specifyTask(pending: PendingTriageAction) async {
+        // The mutation identity is the STAGED value, never a re-read of the
+        // mutable display state: an action started for A must finish as A
+        // (or fail closed), even after the user navigates to B.
+        let expectedID = pending.taskID
+        let expectedContext = pending.context
         defer {
             if KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) {
                 isSpecifying = false
             }
         }
         do {
-            _ = try await store.specifyTask(id: startedTask.id)
+            _ = try await store.specifyTask(id: expectedID, expectedContext: expectedContext)
             guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
             actionNotice = KanbanTriageActionsPolicy.successNoticeWithRefreshFailure(
                 base: "Task specified",
@@ -1180,18 +1225,20 @@ struct KanbanTaskDetailView: View {
     /// into cards. A refresh failure AFTER a successful mutation is
     /// reported as partial success — the action succeeded, only the
     /// refresh failed (the passive poll recovers it).
-    private func decomposeTask() async {
-        guard let startedTask = displayedTask else { return }
-        let expectedID = displayedTaskID
-        isDecomposing = true
-        errorMessage = nil
+    private func decomposeTask(pending: PendingTriageAction) async {
+        // The staged confirmation value is the only valid identity: the
+        // store revalidates its stamp before issuing anything, and this
+        // completion stays UI-inert unless the displayed task is still the
+        // staged one.
+        let expectedID = pending.taskID
+        let expectedContext = pending.context
         defer {
             if KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) {
                 isDecomposing = false
             }
         }
         do {
-            let response = try await store.decomposeTask(id: startedTask.id)
+            let response = try await store.decomposeTask(id: expectedID, expectedContext: expectedContext)
             guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
             let base = KanbanTriageActionsPolicy.successNotice(fanout: response.fanout, childCount: response.childIDs.count) ?? "Decompose succeeded"
             // PARTIAL SUCCESS distinction: the mutation landed, so any

--- a/Conduit/Views/Kanban/KanbanTaskDetailView.swift
+++ b/Conduit/Views/Kanban/KanbanTaskDetailView.swift
@@ -147,6 +147,16 @@ struct KanbanTaskDetailView: View {
                         activitySection
                         runsSection
                         workerLogLink
+                        // V3A success feedback lives OUTSIDE the eligibility-
+                        // gated Triage Actions section: after a successful
+                        // Specify/Decompose the task leaves triage and the
+                        // section disappears - the notice must survive.
+                        if let actionNotice {
+                            Label(actionNotice, systemImage: "checkmark.circle")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
                         if let remoteChangeNotice {
                             Text(remoteChangeNotice)
                                 .font(.footnote)
@@ -509,8 +519,11 @@ struct KanbanTaskDetailView: View {
 
                 Button {
                     // Decompose may create and assign multiple dependent
-                    // tasks: it is ALWAYS confirmation-gated.
-                    showDecomposeConfirmation = true
+                    // tasks: it is ALWAYS confirmation-gated (the action
+                    // policy answers, never the view directly).
+                    if KanbanTriageActionsPolicy.decomposeTap() == .confirm {
+                        showDecomposeConfirmation = true
+                    }
                 } label: {
                     HStack {
                         Spacer()
@@ -520,12 +533,6 @@ struct KanbanTaskDetailView: View {
                 }
                 .buttonStyle(.bordered)
                 .disabled(isSpecifying || isDecomposing)
-
-                if let actionNotice {
-                    Label(actionNotice, systemImage: "checkmark.circle")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
             }
         }
     }
@@ -1156,7 +1163,10 @@ struct KanbanTaskDetailView: View {
         do {
             _ = try await store.specifyTask(id: startedTask.id)
             guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
-            actionNotice = "Task specified"
+            actionNotice = KanbanTriageActionsPolicy.successNoticeWithRefreshFailure(
+                base: "Task specified",
+                storeRefreshError: store.errorMessage
+            )
             await loadDetail(force: true)
         } catch {
             guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
@@ -1183,7 +1193,14 @@ struct KanbanTaskDetailView: View {
         do {
             let response = try await store.decomposeTask(id: startedTask.id)
             guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
-            actionNotice = KanbanTriageActionsPolicy.successNotice(fanout: response.fanout, childCount: response.childIDs.count)
+            let base = KanbanTriageActionsPolicy.successNotice(fanout: response.fanout, childCount: response.childIDs.count) ?? "Decompose succeeded"
+            // PARTIAL SUCCESS distinction: the mutation landed, so any
+            // failure the store recorded now is a REFRESH failure. Never
+            // blame the decompose itself.
+            actionNotice = KanbanTriageActionsPolicy.successNoticeWithRefreshFailure(
+                base: base,
+                storeRefreshError: store.errorMessage
+            )
             await loadDetail(force: true)
         } catch {
             guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }

--- a/Conduit/Views/Kanban/KanbanTaskDetailView.swift
+++ b/Conduit/Views/Kanban/KanbanTaskDetailView.swift
@@ -48,6 +48,12 @@ struct KanbanTaskDetailView: View {
     @State private var isRequeuing = false
     @State private var isLoadingDetail = false
     @State private var showDeleteConfirmation = false
+    /// Triage actions (V3A): Specify / Decompose are offered ONLY for
+    /// eligible (triage) tasks, and Decompose always requires confirmation.
+    @State private var isSpecifying = false
+    @State private var isDecomposing = false
+    @State private var showDecomposeConfirmation = false
+    @State private var actionNotice: String?
     @State private var showReassignSheet = false
     @State private var showModelSheet = false
     @State private var modelOverrideDraft = TaskModelOverride()
@@ -131,6 +137,7 @@ struct KanbanTaskDetailView: View {
                     if let currentTask = displayedTask {
                         editorSection
                         assignmentExecutionSection
+                        triageActionsSection
                         if currentTask.status == "ready", (currentTask.assignee ?? "").isEmpty, !hasDispatcherFallback {
                             readyUnassignedCallout
                         }
@@ -225,6 +232,10 @@ struct KanbanTaskDetailView: View {
                 showReassignSheet = false
                 showModelSheet = false
                 showDeleteConfirmation = false
+                isSpecifying = false
+                isDecomposing = false
+                showDecomposeConfirmation = false
+                actionNotice = nil
                 title = ""
                 taskBody = ""
                 status = "todo"
@@ -282,6 +293,16 @@ struct KanbanTaskDetailView: View {
                 Button("Cancel", role: .cancel) {}
             } message: {
                 Text("This permanently removes the task from the selected Hermes board.")
+            }
+            .confirmationDialog(
+                KanbanTriageActionsPolicy.decomposeConfirmationTitle,
+                isPresented: $showDecomposeConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button("Decompose") { Task { await decomposeTask() } }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text(KanbanTriageActionsPolicy.decomposeConfirmationMessage)
             }
         }
     }
@@ -457,6 +478,53 @@ struct KanbanTaskDetailView: View {
                     Text(failure)
                         .font(.caption)
                         .foregroundStyle(.red)
+                }
+            }
+        }
+    }
+
+    // MARK: - Triage actions (V3A)
+
+    /// Dedicated Triage Actions section: shown ONLY for eligible (triage)
+    /// tasks — the backend refusal contract is `task is not in triage`,
+    /// so no other status may ever expose these actions (and never on
+    /// generic cards). Decompose surfaces a confirmation; Specify is a
+    /// direct action; both report the backend's semantic refusal verbatim.
+    @ViewBuilder
+    private var triageActionsSection: some View {
+        if KanbanTriagePolicy.isEligible(task: displayedTask) {
+            ConduitSettingsSection(title: "Triage Actions", symbol: "tray.and.arrow.down", tint: .conduitAccent) {
+                Button {
+                    Task { await specifyTask() }
+                } label: {
+                    HStack {
+                        Spacer()
+                        if isSpecifying { ProgressView() } else { Label("Specify Task", systemImage: "sparkles") }
+                        Spacer()
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.conduitAccent)
+                .disabled(isSpecifying || isDecomposing)
+
+                Button {
+                    // Decompose may create and assign multiple dependent
+                    // tasks: it is ALWAYS confirmation-gated.
+                    showDecomposeConfirmation = true
+                } label: {
+                    HStack {
+                        Spacer()
+                        if isDecomposing { ProgressView() } else { Label("Decompose Into Tasks", systemImage: "flask") }
+                        Spacer()
+                    }
+                }
+                .buttonStyle(.bordered)
+                .disabled(isSpecifying || isDecomposing)
+
+                if let actionNotice {
+                    Label(actionNotice, systemImage: "checkmark.circle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
             }
         }
@@ -1063,6 +1131,59 @@ struct KanbanTaskDetailView: View {
         do {
             try await store.reclaimTask(taskID: expectedID, reason: reason)
             guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
+            await loadDetail(force: true)
+        } catch {
+            guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    /// Specify (V3A): POST /tasks/{id}/specify for an eligible triage task.
+    /// On success the store supersedes stale board polling with an
+    /// authoritative reload and this screen re-syncs the detail from the
+    /// server. A semantic {ok:false} refusal surfaces the backend reason
+    /// and leaves the task entirely intact.
+    private func specifyTask() async {
+        guard let startedTask = displayedTask else { return }
+        let expectedID = displayedTaskID
+        isSpecifying = true
+        errorMessage = nil
+        defer {
+            if KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) {
+                isSpecifying = false
+            }
+        }
+        do {
+            _ = try await store.specifyTask(id: startedTask.id)
+            guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
+            actionNotice = "Task specified"
+            await loadDetail(force: true)
+        } catch {
+            guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    /// Decompose (V3A): confirmation-gated fan-out. Success reconciles from
+    /// authoritative REST state (the store's superseding board reload plus
+    /// this detail reload); the child-ids response is never synthesized
+    /// into cards. A refresh failure AFTER a successful mutation is
+    /// reported as partial success — the action succeeded, only the
+    /// refresh failed (the passive poll recovers it).
+    private func decomposeTask() async {
+        guard let startedTask = displayedTask else { return }
+        let expectedID = displayedTaskID
+        isDecomposing = true
+        errorMessage = nil
+        defer {
+            if KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) {
+                isDecomposing = false
+            }
+        }
+        do {
+            let response = try await store.decomposeTask(id: startedTask.id)
+            guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
+            actionNotice = KanbanTriageActionsPolicy.successNotice(fanout: response.fanout, childCount: response.childIDs.count)
             await loadDetail(force: true)
         } catch {
             guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }

--- a/Conduit/Views/Kanban/KanbanTaskDetailView.swift
+++ b/Conduit/Views/Kanban/KanbanTaskDetailView.swift
@@ -58,6 +58,13 @@ struct KanbanTaskDetailView: View {
     @State private var isSpecifying = false
     @State private var isDecomposing = false
     @State private var pendingDecompose: PendingTriageAction?
+    /// V3A merge pass: task/context marker of the LAST successful
+    /// Specify/Decompose. While the displayed identity matches it, the Triage
+    /// Actions stay suppressed even if a failed authoritative refresh leaves
+    /// the cached detail reporting triage - a committed task is never offered
+    /// a second triage mutation. Cleared by authoritative reconciliation or
+    /// identity/context replacement.
+    @State private var completedTriageMutation: CompletedTriageMutation?
     @State private var actionNotice: String?
     @State private var showReassignSheet = false
     @State private var showModelSheet = false
@@ -128,6 +135,18 @@ struct KanbanTaskDetailView: View {
 
     private var hasDispatcherFallback: Bool {
         !(store.orchestration?.resolvedDefaultAssignee ?? "").isEmpty
+    }
+
+    /// True while the displayed identity still matches a completed triage
+    /// mutation for its board/server context (cached triage status must not
+    /// re-expose Specify/Decompose for a task whose server-side action
+    /// already committed).
+    private var triageActionsSuppressed: Bool {
+        KanbanTriageCompletionPolicy.isSuppressed(
+            completed: completedTriageMutation,
+            displayedTaskID: displayedTaskID,
+            context: store.loadedContextStamp
+        )
     }
 
     var body: some View {
@@ -250,6 +269,7 @@ struct KanbanTaskDetailView: View {
                 isSpecifying = false
                 isDecomposing = false
                 pendingDecompose = nil
+                completedTriageMutation = nil
                 actionNotice = nil
                 title = ""
                 taskBody = ""
@@ -324,10 +344,12 @@ struct KanbanTaskDetailView: View {
                 Text(KanbanTriageActionsPolicy.decomposeConfirmationMessage)
             }
             // Proactive disarm: when the loaded board identity changes, any
-            // staged triage action is now foreign. The confirm-time store
-            // stamp revalidation remains the hard boundary.
+            // staged triage action AND any completion marker are now foreign.
+            // The confirm-time store stamp revalidation remains the hard
+            // boundary.
             .onChange(of: store.loadedBoardSlug) { _, _ in
                 pendingDecompose = nil
+                completedTriageMutation = nil
             }
         }
     }
@@ -517,7 +539,10 @@ struct KanbanTaskDetailView: View {
     /// direct action; both report the backend's semantic refusal verbatim.
     @ViewBuilder
     private var triageActionsSection: some View {
-        if KanbanTriagePolicy.isEligible(task: displayedTask) {
+        // Suppression outranks the cached status: a task whose Specify/
+        // Decompose already committed must not be offered the actions again
+        // merely because the authoritative refresh failed (merge pass).
+        if KanbanTriagePolicy.isEligible(task: displayedTask), !triageActionsSuppressed {
             ConduitSettingsSection(title: "Triage Actions", symbol: "tray.and.arrow.down", tint: .conduitAccent) {
                 Button {
                     // V3A final pass: capture the task identity + board/server
@@ -1011,6 +1036,13 @@ struct KanbanTaskDetailView: View {
             // of being wiped by this poll.
             if displayedTask == nil { errorMessage = nil }
             detail = loaded
+            // Authoritative reconciliation: once the detail confirms the task
+            // left triage, the completion marker clears and the normal status
+            // gate owns the visibility. If it still reports triage, the
+            // marker KEEPS the actions suppressed.
+            if KanbanTriageCompletionPolicy.shouldClearAfterReconciliation(reconciledStatus: loaded.task.status) {
+                completedTriageMutation = nil
+            }
             refreshErrorMessage = nil
         } catch is CancellationError {
             // The poll loop was replaced (identity switch or dismissal); its
@@ -1208,6 +1240,10 @@ struct KanbanTaskDetailView: View {
         do {
             _ = try await store.specifyTask(id: expectedID, expectedContext: expectedContext)
             guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
+            // Record the committed mutation BEFORE the refresh attempt: even
+            // if the detail fetch fails and the cached task still says
+            // triage, the actions must stay suppressed (merge pass).
+            completedTriageMutation = CompletedTriageMutation(taskID: expectedID, context: expectedContext)
             actionNotice = KanbanTriageActionsPolicy.successNoticeWithRefreshFailure(
                 base: "Task specified",
                 storeRefreshError: store.errorMessage
@@ -1240,6 +1276,9 @@ struct KanbanTaskDetailView: View {
         do {
             let response = try await store.decomposeTask(id: expectedID, expectedContext: expectedContext)
             guard KanbanDetailMutationPolicy.completionIsActive(startedTaskID: expectedID, displayedTaskID: displayedTaskID) else { return }
+            // Record the committed mutation BEFORE the refresh attempt (see
+            // specifyTask - suppression must survive a failed refresh).
+            completedTriageMutation = CompletedTriageMutation(taskID: expectedID, context: expectedContext)
             let base = KanbanTriageActionsPolicy.successNotice(fanout: response.fanout, childCount: response.childIDs.count) ?? "Decompose succeeded"
             // PARTIAL SUCCESS distinction: the mutation landed, so any
             // failure the store recorded now is a REFRESH failure. Never

--- a/Conduit/Views/Kanban/KanbanV3ASupport.swift
+++ b/Conduit/Views/Kanban/KanbanV3ASupport.swift
@@ -146,6 +146,70 @@ enum KanbanProfileDescriptionPolicy {
     }
 }
 
+// MARK: - Triage completion suppression (V3A merge pass)
+
+/// Marker that a Specify/Decompose mutation COMMITTED for a captured
+/// task/context. While the displayed identity matches this marker, the Triage
+/// Actions section stays suppressed even if the cached detail still reports
+/// status triage after a failed authoritative refresh - a second request must
+/// never be staged for a task whose server-side action already succeeded.
+/// The marker is never derived from the human-readable actionNotice string.
+struct CompletedTriageMutation: Equatable {
+    let taskID: String
+    let context: KanbanBoardContextStamp
+}
+
+enum KanbanTriageCompletionPolicy {
+    /// The displayed task/context still matches the completed mutation:
+    /// triage actions must be suppressed.
+    static func isSuppressed(
+        completed: CompletedTriageMutation?,
+        displayedTaskID: String,
+        context: KanbanBoardContextStamp?
+    ) -> Bool {
+        guard let completed, let context else { return false }
+        return completed.taskID == displayedTaskID && completed.context == context
+    }
+
+    /// After an authoritative detail load: once the reconciled status is no
+    /// longer triage, the normal status gate hides the actions and the marker
+    /// is cleared. If it STILL reports triage, suppression must remain in
+    /// force until authoritative state establishes validity again.
+    static func shouldClearAfterReconciliation(reconciledStatus: String) -> Bool {
+        reconciledStatus != "triage"
+    }
+}
+
+// MARK: - Nudge notice presentation state (V3A merge pass)
+
+/// Token-guarded transient nudge feedback. The token makes the 2-second
+/// auto-hide timer safe across rapid nudges AND board switches: a board
+/// change clears the notice immediately and bumps the token so the OLD
+/// timer can never mutate a newer notice.
+struct KanbanNudgeNoticeState: Equatable {
+    private(set) var token = 0
+    private(set) var notice: String?
+
+    /// Shows feedback and returns the hide-token the caller's timer must use.
+    mutating func show(_ text: String) -> Int {
+        token += 1
+        notice = text
+        return token
+    }
+
+    /// Hides only the notice instance whose token is still current.
+    mutating func hideIfCurrent(_ id: Int) {
+        if token == id { notice = nil }
+    }
+
+    /// Board/server context changed: drop any visible feedback NOW and bump
+    /// the token so an in-flight old timer cannot clear a later notice.
+    mutating func invalidateOnContextChange() {
+        token += 1
+        notice = nil
+    }
+}
+
 // MARK: - Nudge feedback ownership (V3A final pass)
 
 /// Whether a completed dispatcher nudge may show its success feedback.

--- a/Conduit/Views/Kanban/KanbanV3ASupport.swift
+++ b/Conduit/Views/Kanban/KanbanV3ASupport.swift
@@ -1,5 +1,168 @@
 import SwiftUI
 
+// MARK: - Staged triage action (V3A final pass)
+
+/// The immutable payload of a user-initiated Triage action: the TASK identity
+/// plus the board/server stamp that authorized it, both frozen SYNCHRONOUSLY
+/// at the tap - never re-read after asynchronous scheduling. Decompose stages
+/// this value through its confirmation so confirming an action staged for A
+/// can never act on B (task navigation, board switch, or server reconfigure
+/// all invalidate the stamp, and the store revalidates it as its hard
+/// boundary).
+struct PendingTriageAction: Equatable {
+    let taskID: String
+    let context: KanbanBoardContextStamp
+}
+
+extension PendingTriageAction {
+    /// Synchronous capture helper: nil when the snapshot is not actionable or
+    /// no loaded context exists, so the caller never schedules work on an
+    /// unowned identity.
+    static func capture(task: KanbanTask?, isSnapshotActionable: Bool, stamp: KanbanBoardContextStamp?) -> PendingTriageAction? {
+        guard let task, let stamp, isSnapshotActionable, !task.id.isEmpty else { return nil }
+        return PendingTriageAction(taskID: task.id, context: stamp)
+    }
+}
+
+// MARK: - Editor completion ownership (V3A final pass)
+
+/// Local busy-flag liveness for administrator editors (V3A final pass).
+///
+/// A busy flag (isSaving/isGenerating) is owned by the LOCAL operation that
+/// started it, via a monotonic token - NOT by the server configuration
+/// generation. A completion from a stale generation must be UI-inert for
+/// server data/notices/baselines, but it must still release the busy flag it
+/// owns; otherwise a sheet reconfiguring mid-flight stays permanently busy
+/// (stuck interactiveDismissDisabled).
+///
+/// One token stream serves BOTH flags per editor; that is sound only because
+/// the tap guards and .disabled states enforce mutual exclusion (a save and a
+/// generation can never be concurrently in flight), so an older operation
+/// never needs to release a flag a newer one would own.
+struct KanbanEditorLiveness {
+    private(set) var token = 0
+
+    /// Begins a new operation and returns the token only the NEWEST operation
+    /// may release the busy flag with.
+    mutating func begin() -> Int {
+        token += 1
+        return token
+    }
+
+    func owns(_ operationID: Int) -> Bool {
+        operationID == token
+    }
+}
+
+/// Editor completion outcomes that preserve newer local edits (V3A final
+/// pass). All rules are pure so the guarantees are deterministically testable.
+enum KanbanProfileDescriptionPolicy {
+    struct Snapshot: Equatable {
+        let profile: String
+        let description: String
+        let isAuto: Bool
+    }
+
+    struct CompletionOutcome: Equatable {
+        /// The server baseline after the write (the SUBMITTED value, or the
+        /// generated value returned by the server).
+        let baselineDescription: String
+        let baselineIsAuto: Bool
+        /// What the editor should display now.
+        let draft: String
+        /// True when the editor must remain dirty (newer local typing).
+        let isDirtyAfter: Bool
+        /// User-facing notice; nil = no notice.
+        let notice: String?
+    }
+
+    static func isDirty(draft: String, baseline: String) -> Bool {
+        draft != baseline
+    }
+
+    /// What tapping "Generate Automatically" may do given the editor state.
+    enum GenerateResolution: Equatable {
+        case allowed
+        case requiresDiscard
+    }
+
+    static func resolveGenerate(draft: String, baseline: String) -> GenerateResolution {
+        isDirty(draft: draft, baseline: baseline) ? .requiresDiscard : .allowed
+    }
+
+    /// After a confirmed discard the draft is dropped and generation is legal.
+    static func discard(draft: String, baseline: String) -> String {
+        baseline
+    }
+
+    /// Save completed successfully for the submitted value. The server
+    /// baseline is ALWAYS the submitted value - and the draft is normalized
+    /// to it only while the user has not typed anything newer since
+    /// submission. Newer typing is preserved (raw, WYSIWYG) and the editor
+    /// stays dirty: the newer text was never persisted.
+    static func saveCompletion(submitted: String, currentRawDraft: String, currentTrimmedDraft: String) -> CompletionOutcome {
+        if currentTrimmedDraft == submitted {
+            return CompletionOutcome(
+                baselineDescription: submitted,
+                baselineIsAuto: false,
+                draft: submitted,
+                isDirtyAfter: false,
+                notice: "Description saved."
+            )
+        }
+        return CompletionOutcome(
+            baselineDescription: submitted,
+            baselineIsAuto: false,
+            draft: currentRawDraft,
+            isDirtyAfter: true,
+            notice: "Description saved. Your newer edits are still unsaved."
+        )
+    }
+
+    /// Auto-generation completed with the server's generated value. The
+    /// server baseline is the generated text (persisted with
+    /// description_auto=true). The draft is replaced by the generated text
+    /// ONLY while the user has not typed since generation started; newer
+    /// manual typing is preserved (raw, WYSIWYG), stays dirty against the
+    /// generated baseline, and is never silently discarded (no automatic
+    /// follow-up PATCH).
+    static func generateCompletion(submittedDraft: String, currentRawDraft: String, currentTrimmedDraft: String, generated: String) -> CompletionOutcome {
+        if currentTrimmedDraft == submittedDraft {
+            return CompletionOutcome(
+                baselineDescription: generated,
+                baselineIsAuto: true,
+                draft: generated,
+                isDirtyAfter: false,
+                notice: "Generated automatically — review recommended."
+            )
+        }
+        return CompletionOutcome(
+            baselineDescription: generated,
+            baselineIsAuto: true,
+            draft: currentRawDraft,
+            isDirtyAfter: true,
+            notice: "Hermes generated a new routing description. Your newer local edits were preserved and are still unsaved."
+        )
+    }
+}
+
+// MARK: - Nudge feedback ownership (V3A final pass)
+
+/// Whether a completed dispatcher nudge may show its success feedback.
+/// The captured board/server stamp must still own the loaded, actionable
+/// snapshot - a /dispatch that finished on server A after the UI moved to B
+/// must display nothing on B. The stamp embeds the configuration generation,
+/// so stamp equality is also authoritative for server reconfigures.
+enum KanbanNudgePolicy {
+    static func shouldShowNotice(
+        capturedStamp: KanbanBoardContextStamp,
+        currentStamp: KanbanBoardContextStamp?,
+        isSnapshotActionable: Bool
+    ) -> Bool {
+        isSnapshotActionable && currentStamp == capturedStamp
+    }
+}
+
 // MARK: - Triage eligibility
 
 /// Triage action eligibility (V3A). The backend gates BOTH Specify and
@@ -48,45 +211,6 @@ enum KanbanOrchestrationDisplay {
             return "Default resolves to \(resolvedName)."
         }
         return "Pinned to \(configuredName)."
-    }
-}
-
-// MARK: - Profile description editor ownership
-
-/// Dirty-state ownership for the profile routing description editor (V3A §4).
-///
-/// Generating a description persists text server-side immediately (describe-
-/// auto with overwrite:true). Therefore the editor MUST NOT let generation
-/// silently clobber an unsaved manual draft: the user has to explicitly
-/// discard it first. All rules are pure so the guarantee is testable without
-/// UI timing.
-enum KanbanProfileDescriptionPolicy {
-    struct Snapshot: Equatable {
-        let profile: String
-        let description: String
-        let isAuto: Bool
-    }
-
-    static func isDirty(draft: String, baseline: String) -> Bool {
-        draft != baseline
-    }
-
-    /// What tapping "Generate Automatically" may do given the editor state.
-    enum GenerateResolution: Equatable {
-        /// No unsaved draft: generate immediately.
-        case allowed
-        /// An unsaved manual draft exists: generation must not proceed until
-        /// the user explicitly discards the draft.
-        case requiresDiscard
-    }
-
-    static func resolveGenerate(draft: String, baseline: String) -> GenerateResolution {
-        isDirty(draft: draft, baseline: baseline) ? .requiresDiscard : .allowed
-    }
-
-    /// After a confirmed discard the draft is dropped and generation is legal.
-    static func discard(draft: String, baseline: String) -> String {
-        baseline
     }
 }
 

--- a/Conduit/Views/Kanban/KanbanV3ASupport.swift
+++ b/Conduit/Views/Kanban/KanbanV3ASupport.swift
@@ -1,0 +1,139 @@
+import SwiftUI
+
+// MARK: - Triage eligibility
+
+/// Triage action eligibility (V3A). The backend gates BOTH Specify and
+/// Decompose on `status == 'triage'` (kanban_specify.py / kanban_decompose.py:
+/// "task is not in triage" is the only status refusal), so the mobile UI must
+/// never offer these actions on any other lane — no generic card-level
+/// exposure anywhere.
+enum KanbanTriagePolicy {
+    static func isEligible(status: String) -> Bool {
+        status == "triage"
+    }
+
+    static func isEligible(task: KanbanTask?) -> Bool {
+        task.map { isEligible(status: $0.status) } ?? false
+    }
+}
+
+// MARK: - Orchestration display semantics (configured vs resolved)
+
+/// Presentation rules for the orchestration settings sheet (V3A §3).
+///
+/// The backend distinguishes the CONFIGURED value (`"`"` = unset/Default) from
+/// the RESOLVED effective value (active default profile). The UI must show
+/// both honestly — e.g. `Default (coder)` — instead of implying that `coder`
+/// was explicitly persisted.
+enum KanbanOrchestrationDisplay {
+    /// Picker option label for the Default row of a profile selector.
+    /// `configured` is the wire value ("" = unset); `resolved` is the
+    /// effective profile named by the backend.
+    static func defaultOptionLabel(configured: String, resolved: String) -> String {
+        if resolved.trimmingCharacters(in: .whitespaces).isEmpty {
+            return "Default"
+        }
+        return "Default (\(resolved.trimmingCharacters(in: .whitespaces)))"
+    }
+
+    /// Footer copy for a profile selector: describes what Default resolves to,
+    /// or confirms an explicit pinned profile.
+    static func resolveFootnote(configured: String, resolved: String) -> String {
+        let resolvedName = resolved.trimmingCharacters(in: .whitespaces)
+        let configuredName = configured.trimmingCharacters(in: .whitespaces)
+        if configuredName.isEmpty {
+            if resolvedName.isEmpty {
+                return "Default inherits the active Hermes profile."
+            }
+            return "Default resolves to \(resolvedName)."
+        }
+        return "Pinned to \(configuredName)."
+    }
+}
+
+// MARK: - Profile description editor ownership
+
+/// Dirty-state ownership for the profile routing description editor (V3A §4).
+///
+/// Generating a description persists text server-side immediately (describe-
+/// auto with overwrite:true). Therefore the editor MUST NOT let generation
+/// silently clobber an unsaved manual draft: the user has to explicitly
+/// discard it first. All rules are pure so the guarantee is testable without
+/// UI timing.
+enum KanbanProfileDescriptionPolicy {
+    struct Snapshot: Equatable {
+        let profile: String
+        let description: String
+        let isAuto: Bool
+    }
+
+    static func isDirty(draft: String, baseline: String) -> Bool {
+        draft != baseline
+    }
+
+    /// What tapping "Generate Automatically" may do given the editor state.
+    enum GenerateResolution: Equatable {
+        /// No unsaved draft: generate immediately.
+        case allowed
+        /// An unsaved manual draft exists: generation must not proceed until
+        /// the user explicitly discards the draft.
+        case requiresDiscard
+    }
+
+    static func resolveGenerate(draft: String, baseline: String) -> GenerateResolution {
+        isDirty(draft: draft, baseline: baseline) ? .requiresDiscard : .allowed
+    }
+
+    /// After a confirmed discard the draft is dropped and generation is legal.
+    static func discard(draft: String, baseline: String) -> String {
+        baseline
+    }
+
+    /// A completion (save or generation) for `sessionProfile` may update the
+    /// editor only while the editor still edits that same profile. This is the
+    /// view-level identity guard; the store's generation guard is the hard
+    /// boundary underneath it.
+    static func completionIsActive(sessionProfile: String, currentProfile: String) -> Bool {
+        sessionProfile == currentProfile
+    }
+}
+
+// MARK: - Triage action flows
+
+/// Confirmation + result-presentation rules for the Triage Actions section
+/// (V3A §6–8). Decompose may create and assign multiple dependent tasks, so
+/// it MUST be gated behind an explicit confirmation; the wording mirrors the
+/// upstream contract (children created, assigned to profiles, root kept).
+enum KanbanTriageActionsPolicy {
+    /// A user tap on "Decompose" resolves to a confirmation request, never
+    /// directly to the mutation.
+    enum DecomposeRequest: Equatable {
+        case none
+        case confirm
+    }
+
+    static func decomposeTap() -> DecomposeRequest {
+        .confirm
+    }
+
+    /// The confirmation dialog copy (title + message).
+    static let decomposeConfirmationTitle = "Decompose this task?"
+    static let decomposeConfirmationMessage = "Hermes may create and assign multiple dependent tasks."
+
+    /// Success notice after a completed decompose, built from the backend's
+    /// own `fanout` / `child_ids` counts — real product semantics, never
+    /// fabricated diagnostics.
+    static func successNotice(fanout: Bool, childCount: Int) -> String? {
+        if fanout {
+            return "Decomposed into \(childCount) task" + (childCount == 1 ? "" : "s")
+        }
+        return "Task specified (no fan-out)"
+    }
+
+    /// Partial-success wording when the mutation reached the server but the
+    /// authoritative refresh afterwards failed: the failure belongs to the
+    /// REFRESH, never to the action itself.
+    static func refreshFailureNotice(actionLabel: String, detail: String) -> String {
+        "\(actionLabel), but the task could not be refreshed. \(detail)"
+    }
+}

--- a/Conduit/Views/Kanban/KanbanV3ASupport.swift
+++ b/Conduit/Views/Kanban/KanbanV3ASupport.swift
@@ -88,14 +88,6 @@ enum KanbanProfileDescriptionPolicy {
     static func discard(draft: String, baseline: String) -> String {
         baseline
     }
-
-    /// A completion (save or generation) for `sessionProfile` may update the
-    /// editor only while the editor still edits that same profile. This is the
-    /// view-level identity guard; the store's generation guard is the hard
-    /// boundary underneath it.
-    static func completionIsActive(sessionProfile: String, currentProfile: String) -> Bool {
-        sessionProfile == currentProfile
-    }
 }
 
 // MARK: - Triage action flows
@@ -127,13 +119,18 @@ enum KanbanTriageActionsPolicy {
         if fanout {
             return "Decomposed into \(childCount) task" + (childCount == 1 ? "" : "s")
         }
-        return "Task specified (no fan-out)"
+        // Decompose's single-task fallback (backend fanout=false == a
+        // spec-style promotion; distinct from a plain Specify).
+        return "Decomposed (single task, no fan-out)"
     }
 
-    /// Partial-success wording when the mutation reached the server but the
+    /// Partial-success notice when the mutation reached the server but the
     /// authoritative refresh afterwards failed: the failure belongs to the
-    /// REFRESH, never to the action itself.
-    static func refreshFailureNotice(actionLabel: String, detail: String) -> String {
-        "\(actionLabel), but the task could not be refreshed. \(detail)"
+    /// REFRESH, never to the action itself. storeRefreshError is the board
+    /// banner the store recorded for a failed reload (nil = refresh fine).
+    static func successNoticeWithRefreshFailure(base: String, storeRefreshError: String?) -> String {
+        guard let storeRefreshError,
+              !storeRefreshError.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return base }
+        return "\(base), but the board could not be refreshed. \(storeRefreshError)"
     }
 }

--- a/Conduit/Views/KanbanViews.swift
+++ b/Conduit/Views/KanbanViews.swift
@@ -112,10 +112,9 @@ struct KanbanView: View {
     @State private var showOrchestrationSettings = false
     @State private var showProfileRouting = false
     /// Unobtrusive post-nudge feedback ("Dispatcher nudged"); transient only.
-    @State private var nudgeNotice: String?
-    /// Monotonic token so a rapid second nudge invalidates the first notice's
-    /// auto-hide timer (a stale timer must never clear the newer notice).
-    @State private var nudgeNoticeToken = 0
+    /// Token-guarded so a rapid second nudge OR a board switch invalidates an
+    /// older auto-hide timer (a stale timer must never clear a newer notice).
+    @State private var nudgeNoticeState = KanbanNudgeNoticeState()
 
     private var bridgeIdentity: ObjectIdentifier? {
         appState.dashboardTicketBridge.map { ObjectIdentifier($0) }
@@ -181,7 +180,7 @@ struct KanbanView: View {
                         .refreshable { await store.refresh(includeArchived: includeArchived) }
                         .overlay(alignment: .topTrailing) {
                             VStack(alignment: .trailing, spacing: 6) {
-                                if let nudgeNotice {
+                                if let nudgeNotice = nudgeNoticeState.notice {
                                     Label(nudgeNotice, systemImage: "checkmark.circle")
                                         .font(.caption)
                                         .foregroundStyle(.green)
@@ -270,12 +269,17 @@ struct KanbanView: View {
         // ownership check below remains the hard boundary.)
         .onChange(of: store.loadedBoardSlug) { _, _ in
             pendingDelete = nil
+            // V3A merge pass: a board switch drops any visible nudge feedback
+            // IMMEDIATELY (the alpha success capsule must never linger on
+            // beta) and bumps the token so the old auto-hide timer can never
+            // mutate a later notice.
+            nudgeNoticeState.invalidateOnContextChange()
         }
         .onChange(of: serverIdentityKey) { _, _ in
             // Server changed: the admin sheets belonged to the old server.
             showOrchestrationSettings = false
             showProfileRouting = false
-            nudgeNotice = nil
+            nudgeNoticeState.invalidateOnContextChange()
         }
         .task(id: pollingKey) {
             selectedTask = nil
@@ -318,17 +322,19 @@ struct KanbanView: View {
                 currentStamp: store.loadedContextStamp,
                 isSnapshotActionable: store.isSelectedSnapshotLoaded
             ) else { return }
-            nudgeNoticeToken += 1
-            let token = nudgeNoticeToken
-            withAnimation(.easeOut(duration: 0.15)) { nudgeNotice = "Dispatcher nudged" }
+            var token = 0
+            withAnimation(.easeOut(duration: 0.15)) {
+                token = nudgeNoticeState.show("Dispatcher nudged")
+            }
             do {
                 try await Task.sleep(nanoseconds: 2_000_000_000)
             } catch {
                 return // cancelled (view dismissed / task replaced): leave as-is
             }
-            // Only the LATEST notice may clear itself.
-            guard nudgeNoticeToken == token, !Task.isCancelled else { return }
-            withAnimation(.easeOut(duration: 0.3)) { nudgeNotice = nil }
+            guard !Task.isCancelled else { return }
+            // Only the notice instance whose token is still current may clear
+            // itself (a newer nudge or a board switch already invalidated it).
+            withAnimation(.easeOut(duration: 0.3)) { nudgeNoticeState.hideIfCurrent(token) }
         } catch {
             // Store-owned mutation error presentation (current generation only).
         }

--- a/Conduit/Views/KanbanViews.swift
+++ b/Conduit/Views/KanbanViews.swift
@@ -107,6 +107,12 @@ struct KanbanView: View {
     /// only an explicit confirmation that still owns that context issues the
     /// destructive DELETE. Archive and lane moves stay immediate.
     @State private var pendingDelete: PendingCardDelete?
+    /// V3A board-level administration: orchestration settings sheet,
+    /// profile routing descriptions, and the manual dispatcher nudge.
+    @State private var showOrchestrationSettings = false
+    @State private var showProfileRouting = false
+    /// Unobtrusive post-nudge feedback ("Dispatcher nudged"); transient only.
+    @State private var nudgeNotice: String?
 
     private var bridgeIdentity: ObjectIdentifier? {
         appState.dashboardTicketBridge.map { ObjectIdentifier($0) }
@@ -162,6 +168,14 @@ struct KanbanView: View {
                         .refreshable { await store.refresh(includeArchived: includeArchived) }
                         .overlay(alignment: .topTrailing) {
                             VStack(alignment: .trailing, spacing: 6) {
+                                if let nudgeNotice {
+                                    Label(nudgeNotice, systemImage: "checkmark.circle")
+                                        .font(.caption)
+                                        .foregroundStyle(.green)
+                                        .padding(8)
+                                        .background(.ultraThinMaterial, in: Capsule())
+                                        .transition(.opacity)
+                                }
                                 if let mutationError = store.mutationErrorMessage {
                                     HStack(spacing: 6) {
                                         Text(mutationError)
@@ -202,6 +216,18 @@ struct KanbanView: View {
         }
         .sheet(isPresented: $showNewTask) {
             KanbanTaskComposerView(initialStatus: newTaskStatus)
+                .environmentObject(store)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
+        }
+        .sheet(isPresented: $showOrchestrationSettings) {
+            KanbanOrchestrationSettingsSheet()
+                .environmentObject(store)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+        }
+        .sheet(isPresented: $showProfileRouting) {
+            KanbanProfileRoutingScreen()
                 .environmentObject(store)
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
@@ -248,6 +274,22 @@ struct KanbanView: View {
                 guard !Task.isCancelled else { break }
                 await store.poll(includeArchived: includeArchived)
             }
+        }
+    }
+
+    /// Manual dispatcher nudge (V3A §5): a lightweight board action with
+    /// unobtrusive feedback. The store owns board/server context safety and
+    /// the current-generation error presentation; this view only adds the
+    /// transient "Dispatcher nudged" notice on success. No diagnostics are
+    /// fabricated from the backend response (the desktop renders none either).
+    private func nudgeDispatcher() async {
+        do {
+            try await store.nudgeDispatcher(includeArchived: includeArchived)
+            withAnimation(.easeOut(duration: 0.15)) { nudgeNotice = "Dispatcher nudged" }
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            withAnimation(.easeOut(duration: 0.3)) { nudgeNotice = nil }
+        } catch {
+            // Store-owned mutation error presentation (current generation only).
         }
     }
 
@@ -394,6 +436,38 @@ struct KanbanView: View {
             }
             .conduitGlassControl(cornerRadius: 14)
             .accessibilityLabel("Choose Kanban board")
+
+            // V3A board-level administration stays behind ONE extra menu so
+            // the main header is not overcrowded (task spec: "Kanban / Board
+            // Name [ … ]").
+            Menu {
+                Button {
+                    showOrchestrationSettings = true
+                } label: {
+                    Label("Orchestration Settings…", systemImage: "slider.horizontal.3")
+                }
+                .disabled(store.orchestration == nil && store.isLoading)
+
+                Button {
+                    showProfileRouting = true
+                } label: {
+                    Label("Profiles…", systemImage: "person.3")
+                }
+
+                Divider()
+
+                Button {
+                    Task { await nudgeDispatcher() }
+                } label: {
+                    Label("Nudge Dispatcher", systemImage: "arrow.forward.circle")
+                }
+                .disabled(store.isMutating || !store.isSelectedSnapshotLoaded)
+            } label: {
+                Image(systemName: "ellipsis.circle")
+                    .frame(width: 36, height: 36)
+            }
+            .conduitGlassControl(cornerRadius: 14)
+            .accessibilityLabel("Kanban board actions")
 
             Button {
                 Task { await store.refresh(includeArchived: includeArchived) }

--- a/Conduit/Views/KanbanViews.swift
+++ b/Conduit/Views/KanbanViews.swift
@@ -113,6 +113,9 @@ struct KanbanView: View {
     @State private var showProfileRouting = false
     /// Unobtrusive post-nudge feedback ("Dispatcher nudged"); transient only.
     @State private var nudgeNotice: String?
+    /// Monotonic token so a rapid second nudge invalidates the first notice's
+    /// auto-hide timer (a stale timer must never clear the newer notice).
+    @State private var nudgeNoticeToken = 0
 
     private var bridgeIdentity: ObjectIdentifier? {
         appState.dashboardTicketBridge.map { ObjectIdentifier($0) }
@@ -285,8 +288,16 @@ struct KanbanView: View {
     private func nudgeDispatcher() async {
         do {
             try await store.nudgeDispatcher(includeArchived: includeArchived)
+            nudgeNoticeToken += 1
+            let token = nudgeNoticeToken
             withAnimation(.easeOut(duration: 0.15)) { nudgeNotice = "Dispatcher nudged" }
-            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            do {
+                try await Task.sleep(nanoseconds: 2_000_000_000)
+            } catch {
+                return // cancelled (view dismissed / task replaced): leave as-is
+            }
+            // Only the LATEST notice may clear itself.
+            guard nudgeNoticeToken == token, !Task.isCancelled else { return }
             withAnimation(.easeOut(duration: 0.3)) { nudgeNotice = nil }
         } catch {
             // Store-owned mutation error presentation (current generation only).

--- a/Conduit/Views/KanbanViews.swift
+++ b/Conduit/Views/KanbanViews.swift
@@ -128,6 +128,16 @@ struct KanbanView: View {
         "\(String(describing: bridgeIdentity))|\(appState.dashboardTicketBridge?.baseURL ?? "")|archived=\(includeArchived)"
     }
 
+    /// Server identity only (bridge + URL). When THIS changes, administrator
+    /// sheets (orchestration settings / profiles) owned by the old server
+    /// must not remain open over the new one: a settings editor seeded from
+    /// A would otherwise sit on top of B. Board selection within the same
+    /// server does NOT dismiss them (their data is server-global), and
+    /// ordinary board polling never changes this key.
+    private var serverIdentityKey: String {
+        "\(String(describing: bridgeIdentity))|\(appState.dashboardTicketBridge?.baseURL ?? "")"
+    }
+
     private var visibleColumns: [KanbanColumn] {
         guard let board = store.board else { return [] }
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -261,6 +271,12 @@ struct KanbanView: View {
         .onChange(of: store.loadedBoardSlug) { _, _ in
             pendingDelete = nil
         }
+        .onChange(of: serverIdentityKey) { _, _ in
+            // Server changed: the admin sheets belonged to the old server.
+            showOrchestrationSettings = false
+            showProfileRouting = false
+            nudgeNotice = nil
+        }
         .task(id: pollingKey) {
             selectedTask = nil
             store.configure(
@@ -281,13 +297,27 @@ struct KanbanView: View {
     }
 
     /// Manual dispatcher nudge (V3A §5): a lightweight board action with
-    /// unobtrusive feedback. The store owns board/server context safety and
-    /// the current-generation error presentation; this view only adds the
-    /// transient "Dispatcher nudged" notice on success. No diagnostics are
-    /// fabricated from the backend response (the desktop renders none either).
-    private func nudgeDispatcher() async {
+    /// unobtrusive feedback. The board/server stamp is captured
+    /// SYNCHRONOUSLY by nudgeTapped() before any Task; the store revalidates
+    /// it at its mutation boundary. No diagnostics are fabricated from the
+    /// backend response (the desktop renders none either).
+    private func nudgeTapped() {
+        guard !store.isMutating, store.isSelectedSnapshotLoaded,
+              let stamp = store.loadedContextStamp else { return }
+        Task { await nudgeDispatcher(context: stamp) }
+    }
+
+    private func nudgeDispatcher(context: KanbanBoardContextStamp) async {
         do {
-            try await store.nudgeDispatcher(includeArchived: includeArchived)
+            try await store.nudgeDispatcher(expectedContext: context, includeArchived: includeArchived)
+            // V3A final pass: a /dispatch that succeeded on the OLD server
+            // after the UI moved elsewhere is UI-inert - its success must
+            // never surface as feedback on the new context.
+            guard KanbanNudgePolicy.shouldShowNotice(
+                capturedStamp: context,
+                currentStamp: store.loadedContextStamp,
+                isSnapshotActionable: store.isSelectedSnapshotLoaded
+            ) else { return }
             nudgeNoticeToken += 1
             let token = nudgeNoticeToken
             withAnimation(.easeOut(duration: 0.15)) { nudgeNotice = "Dispatcher nudged" }
@@ -468,7 +498,10 @@ struct KanbanView: View {
                 Divider()
 
                 Button {
-                    Task { await nudgeDispatcher() }
+                    // V3A final pass: capture the board/server stamp
+                    // SYNCHRONOUSLY at the tap; a nudge staged for A can
+                    // never fire against B.
+                    nudgeTapped()
                 } label: {
                     Label("Nudge Dispatcher", systemImage: "arrow.forward.circle")
                 }

--- a/ConduitTests/KanbanV3ATests.swift
+++ b/ConduitTests/KanbanV3ATests.swift
@@ -281,6 +281,7 @@ final class KanbanV3ATests: XCTestCase {
         let task = Task { try? await store.autoDescribeProfile(profile: "coder", overwrite: true) }
         await requesterA.waitForSuspension()
 
+        let generation = store.currentConfigurationGeneration
         let requesterB = V3AMockRequester(responsesByPath: routes(boardSlug: "beta"))
         store.configure(requester: requesterB, serverIdentity: "https://b.test")
         requesterA.resumeSuspended()
@@ -289,15 +290,26 @@ final class KanbanV3ATests: XCTestCase {
         XCTAssertNil(store.mutationErrorMessage)
         XCTAssertTrue(store.profiles.isEmpty, "stale profile completion must not repopulate the new context")
         XCTAssertEqual(requesterB.calls.count, 0)
-        XCTAssertEqual(
-            KanbanProfileDescriptionPolicy.completionIsActive(sessionProfile: "coder", currentProfile: "coder"),
-            true
+        XCTAssertFalse(
+            store.isCurrentConfiguration(generation),
+            "the view-local generation guard sees the ownership loss immediately"
         )
-        XCTAssertEqual(
-            KanbanProfileDescriptionPolicy.completionIsActive(sessionProfile: "coder", currentProfile: "lancelot"),
-            false,
-            "a session for A never updates B's editor"
-        )
+    }
+
+    func testStoreGenerationTokenFlipsOnConfigure() async {
+        let requesterA = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha"))
+        let store = makeStore(requester: requesterA)
+        await store.reload()
+        let generationA = store.currentConfigurationGeneration
+
+        XCTAssertTrue(store.isCurrentConfiguration(generationA), "a fresh token stays current")
+        XCTAssertEqual(generationA, store.currentConfigurationGeneration, "token stable across loads")
+
+        let requesterB = V3AMockRequester(responsesByPath: routes(boardSlug: "beta"))
+        store.configure(requester: requesterB, serverIdentity: "https://b.test")
+
+        XCTAssertFalse(store.isCurrentConfiguration(generationA), "configure() invalidates captured tokens")
+        XCTAssertTrue(store.isCurrentConfiguration(store.currentConfigurationGeneration))
     }
 
     // MARK: - 4. Manual dispatcher nudge
@@ -596,12 +608,50 @@ final class KanbanV3ATests: XCTestCase {
     }
 
     func testPartialSuccessRefreshWordingNeverBlamesTheMutation() {
-        let notice = KanbanTriageActionsPolicy.refreshFailureNotice(
-            actionLabel: "Decomposition succeeded",
-            detail: "network unreachable"
+        // Mutation succeeded + refresh failed: the wording blames the refresh.
+        let notice = KanbanTriageActionsPolicy.successNoticeWithRefreshFailure(
+            base: "Decomposed into 3 tasks",
+            storeRefreshError: "network unreachable"
         )
-        XCTAssertTrue(notice.hasPrefix("Decomposition succeeded"))
+        XCTAssertTrue(notice.hasPrefix("Decomposed into 3 tasks"))
         XCTAssertTrue(notice.contains("could not be refreshed"))
+        XCTAssertTrue(notice.hasSuffix("network unreachable"))
+        // Refresh fine: exact base passes through untouched.
+        XCTAssertEqual(
+            KanbanTriageActionsPolicy.successNoticeWithRefreshFailure(base: "Task specified", storeRefreshError: nil),
+            "Task specified"
+        )
+        XCTAssertEqual(
+            KanbanTriageActionsPolicy.successNoticeWithRefreshFailure(base: "Task specified", storeRefreshError: "  "),
+            "Task specified",
+            "blank refresh errors never wrap the base"
+        )
+        // Decompose fanout=false single-task fallback wording.
+        XCTAssertEqual(KanbanTriageActionsPolicy.successNotice(fanout: false, childCount: 0), "Decomposed (single task, no fan-out)")
+    }
+
+    func testSpecifyResponseDecodesTolerantly() throws {
+        let json = """
+        {"ok": true, "task_id": "t7", "reason": "specified", "new_title": "Tightened"}
+        """
+        let outcome = try JSONDecoder().decode(KanbanSpecifyResponse.self, from: Data(json.utf8))
+        XCTAssertTrue(outcome.ok)
+        XCTAssertEqual(outcome.taskID, "t7")
+        XCTAssertEqual(outcome.newTitle, "Tightened")
+
+        // Tolerant decode mirror of the Decompose case: hostile field types
+        // degrade without crashing.
+        let malformed = """
+        {"ok": "nope", "task_id": 7, "new_title": ["array"]}
+        """
+        let tolerant = try JSONDecoder().decode(KanbanSpecifyResponse.self, from: Data(malformed.utf8))
+        XCTAssertFalse(tolerant.ok)
+        XCTAssertEqual(tolerant.taskID, "7")
+        XCTAssertNil(tolerant.newTitle, "non-string new_title fails safe to nil")
+    }
+
+    func testAutoPromoteChildrenBackendDefaultConstant() {
+        XCTAssertTrue(KanbanOrchestrationSettings.defaultAutoPromoteChildren, "upstream config default is true")
     }
 
     func testDecomposeResponseDecodesTolerantly() throws {

--- a/ConduitTests/KanbanV3ATests.swift
+++ b/ConduitTests/KanbanV3ATests.swift
@@ -1,0 +1,763 @@
+import XCTest
+@testable import Conduit
+
+/// Kanban V3A semantics: lifecycle audit, orchestration settings (configured
+/// vs resolved), profile routing descriptions, manual dispatcher nudge, and
+/// the Specify/Decompose triage actions — with semantic-failure
+/// (HTTP-200-but-ok:false) handling and full async ownership discipline.
+///
+/// No test sleeps: suspensions use a continuation handshake in the mock
+/// requester (deterministic, like V2's ContextRaceMockRequester idiom).
+@MainActor
+final class KanbanV3ATests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeTask(id: String, status: String = "triage", extra: [String: Any] = [:]) -> KanbanTask {
+        var object: [String: Any] = ["id": id, "title": "T \(id)", "status": status]
+        for (key, value) in extra { object[key] = value }
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        return try! JSONDecoder().decode(KanbanTask.self, from: data)
+    }
+
+    private func makeStore(requester: V3AMockRequester) -> KanbanStore {
+        let store = KanbanStore(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+        store.configure(requester: requester, serverIdentity: "https://a.test")
+        return store
+    }
+
+    private func routes(
+        boardSlug: String = "alpha",
+        task: KanbanTask? = nil,
+        profiles: [[String: Any]] = V3AMockRequester.defaultProfiles,
+        orchestration: [String: Any] = V3AMockRequester.defaultOrchestration
+    ) -> [String: [String: Any]] {
+        [
+            "/api/plugins/kanban/boards": [
+                "boards": [["slug": boardSlug, "name": "Alpha", "is_current": true]],
+                "current": boardSlug,
+            ],
+            "/api/plugins/kanban/board": V3AMockRequester.staticBoard(task: task),
+            "/api/plugins/kanban/profiles": ["profiles": profiles],
+            "/api/plugins/kanban/projects": ["projects": []],
+            "/api/plugins/kanban/orchestration": orchestration,
+            "/api/plugins/kanban/dispatch": [:]
+        ]
+    }
+
+    // MARK: - 1. Lifecycle audit
+
+    func testLockedDestinationsAreExactlyReviewRunningScheduled() {
+        XCTAssertEqual(
+            KanbanStatusPresentation.lockedDestinations.sorted(),
+            ["review", "running", "scheduled"]
+        )
+        for status in KanbanStatusPresentation.lockedDestinations {
+            XCTAssertFalse(KanbanStatusPresentation.forStatus(status).isManuallySelectable)
+            XCTAssertFalse(KanbanStatusPresentation.forStatus(status).isTaskCreatable)
+            XCTAssertTrue(KanbanStatusPresentation.forStatus(status).isBackendControlled)
+        }
+    }
+
+    func testEveryUnlockedStatusStaysManuallySelectable() {
+        let unlocked = KanbanStatusPresentation.knownStatuses.filter {
+            !KanbanStatusPresentation.isLockedDestination($0)
+        }
+        for status in unlocked {
+            XCTAssertTrue(
+                KanbanStatusPresentation.forStatus(status).isManuallySelectable,
+                "\(status) must remain a manual destination (V2 policy unchanged)"
+            )
+        }
+    }
+
+    func testUnknownStatusesNeverBecomeActionableDestinations() {
+        XCTAssertFalse(KanbanStatusPresentation.canSelectManually("warp_drive"))
+        XCTAssertFalse(KanbanStatusPresentation.canCreateTask(in: "warp_drive"))
+        XCTAssertTrue(KanbanStatusPresentation.forStatus("warp_drive").isBackendControlled)
+    }
+
+    func testTriageActionsGateStrictlyOnTriageStatus() {
+        for status in ["todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived", "unknown_x"] {
+            XCTAssertFalse(KanbanTriagePolicy.isEligible(status: status), "\(status) must never expose Specify/Decompose")
+        }
+        XCTAssertTrue(KanbanTriagePolicy.isEligible(status: "triage"))
+        XCTAssertTrue(KanbanTriagePolicy.isEligible(task: makeTask(id: "t1", status: "triage")))
+        XCTAssertFalse(KanbanTriagePolicy.isEligible(task: nil))
+    }
+
+    // MARK: - 2. Orchestration: wire semantics + store behavior
+
+    func testOrchestrationResponseDecodesConfiguredAndResolvedSeparately() throws {
+        let json = """
+        {"orchestrator_profile": "", "default_assignee": "", "auto_decompose": true,
+         "auto_promote_children": true, "resolved_orchestrator_profile": "default",
+         "resolved_default_assignee": "coder", "active_profile": "default"}
+        """
+        let settings = try JSONDecoder().decode(KanbanOrchestrationSettings.self, from: Data(json.utf8))
+        XCTAssertEqual(settings.orchestratorProfile, "", "configured value is the raw wire value")
+        XCTAssertEqual(settings.defaultAssignee, "")
+        XCTAssertEqual(settings.resolvedOrchestratorProfile, "default")
+        XCTAssertEqual(settings.resolvedDefaultAssignee, "coder")
+        XCTAssertEqual(settings.autoDecompose, true)
+        XCTAssertEqual(settings.autoPromoteChildren, true)
+    }
+
+    func testOrchestrationPatchEncodesDefaultAsEmptyStringNotSentinel() throws {
+        let patch = KanbanOrchestrationPatch(orchestratorProfile: "", autoDecompose: true)
+        let data = try JSONEncoder().encode(patch)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(object["orchestrator_profile"] as? String, "", "Default is the empty string on the wire")
+        XCTAssertEqual(object["auto_decompose"] as? Bool, true)
+        XCTAssertNil(object["default_assignee"], "untouched fields are omitted entirely")
+        XCTAssertNil(object["auto_promote_children"])
+    }
+
+    func testOrchestrationPatchPinsExplicitProfilesAndBools() throws {
+        let patch = KanbanOrchestrationPatch(orchestratorProfile: "archimedes", defaultAssignee: "lancelot", autoPromoteChildren: false)
+        let data = try JSONEncoder().encode(patch)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(object["orchestrator_profile"] as? String, "archimedes")
+        XCTAssertEqual(object["default_assignee"] as? String, "lancelot")
+        XCTAssertEqual(object["auto_promote_children"] as? Bool, false)
+    }
+
+    func testOrchestrationDisplayDistinguishesConfiguredFromResolved() {
+        XCTAssertEqual(KanbanOrchestrationDisplay.defaultOptionLabel(configured: "", resolved: "coder"), "Default (coder)")
+        XCTAssertEqual(KanbanOrchestrationDisplay.defaultOptionLabel(configured: "", resolved: "  coder  "), "Default (coder)", "resolved trimmed for display")
+        XCTAssertEqual(KanbanOrchestrationDisplay.defaultOptionLabel(configured: "", resolved: ""), "Default")
+        XCTAssertEqual(KanbanOrchestrationDisplay.resolveFootnote(configured: "", resolved: "coder"), "Default resolves to coder.")
+        XCTAssertEqual(KanbanOrchestrationDisplay.resolveFootnote(configured: "coder", resolved: "coder"), "Pinned to coder.", "explicit pin is labeled as pinned, not defaulted")
+    }
+
+    func testUpdateOrchestrationPostsOnlyChangedFieldsAndAdoptsEcho() async throws {
+        let requester = V3AMockRequester(responsesByPath: routes())
+        let store = makeStore(requester: requester)
+        await store.reload()
+        XCTAssertEqual(store.orchestration?.defaultAssignee, "")
+
+        let patch = KanbanOrchestrationPatch(defaultAssignee: "coder")
+        let updated = try await store.updateOrchestration(patch)
+
+        XCTAssertEqual(updated?.defaultAssignee, "coder", "backend echo adopted")
+        // Authoritative refresh after the mutation (superseding reload) sees
+        // the updated server state via the merged orchestration mock.
+        XCTAssertGreaterThanOrEqual(requester.boardFetches, 2)
+        XCTAssertEqual(store.orchestration?.defaultAssignee, "coder")
+        XCTAssertNil(store.mutationErrorMessage)
+
+        let putCalls = requester.calls.filter { $0.method == "PUT" && $0.path.hasSuffix("/orchestration") }
+        XCTAssertEqual(putCalls.count, 1)
+        XCTAssertEqual(putCalls.first?.body?["default_assignee"] as? String, "coder")
+        XCTAssertNil(putCalls.first?.body?["orchestrator_profile"], "unchanged field not sent")
+    }
+
+    func testUpdateOrchestrationStaleGenerationIsFullyInert() async throws {
+        let requesterA = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha"))
+        let store = makeStore(requester: requesterA)
+        await store.reload()
+
+        // Suspend the PUT inside the mock; the call IS recorded, then the
+        // request parks until the test resumes it.
+        requesterA.suspend(method: "PUT", basePath: "/api/plugins/kanban/orchestration")
+        let task = Task { try? await store.updateOrchestration(KanbanOrchestrationPatch(autoDecompose: false)) }
+        await requesterA.waitForSuspension()
+        XCTAssertEqual(requesterA.calls.filter { $0.method == "PUT" }.count, 1)
+        XCTAssertTrue(store.isMutating)
+
+        // Ownership loss: the server/board context is replaced mid-flight.
+        let requesterB = V3AMockRequester(responsesByPath: routes(boardSlug: "beta"))
+        store.configure(requester: requesterB, serverIdentity: "https://b.test")
+        XCTAssertFalse(store.isMutating, "configure() strips mutation ownership immediately")
+
+        requesterA.resumeSuspended()
+        _ = await task.value
+
+        XCTAssertFalse(store.isMutating)
+        XCTAssertNil(store.mutationErrorMessage, "stale completion must not surface errors")
+        XCTAssertNil(store.orchestration, "stale echo must not repopulate the new server context")
+        XCTAssertNil(store.board)
+        XCTAssertEqual(requesterB.calls.count, 0, "no request may fire against the new context")
+    }
+
+    func testUpdateOrchestrationNetworkFailureSurfacesAndClearsOwnership() async {
+        let requester = V3AMockRequester(responsesByPath: routes())
+        requester.errorsByPath["/api/plugins/kanban/orchestration"] = URLError(.cannotConnectToHost)
+        let store = makeStore(requester: requester)
+        await store.reload()
+
+        do {
+            _ = try await store.updateOrchestration(KanbanOrchestrationPatch(autoDecompose: false))
+            XCTFail("expected a network failure")
+        } catch {
+            XCTAssertFalse(store.isMutating, "ownership released after failure")
+            XCTAssertNotNil(store.mutationErrorMessage)
+        }
+    }
+
+    // MARK: - 3. Profile routing descriptions
+
+    func testProfileDescriptionManualSaveWireAndNoNudge() async throws {
+        let requester = V3AMockRequester(responsesByPath: routes())
+        let store = makeStore(requester: requester)
+        await store.reload()
+
+        try await store.updateProfileDescription(profile: "coder", description: "Swift/iOS implementation and debugging")
+
+        let patchCalls = requester.calls.filter { $0.method == "PATCH" && $0.path.hasSuffix("/profiles/coder") }
+        XCTAssertEqual(patchCalls.count, 1)
+        XCTAssertEqual(patchCalls.first?.body?["description"] as? String, "Swift/iOS implementation and debugging")
+        XCTAssertFalse(requester.calls.contains { $0.path.contains("/dispatch") }, "upstream saves descriptions without a dispatcher nudge")
+    }
+
+    func testAutoDescribePostsOverwriteTrueAndAdoptsGeneratedText() async throws {
+        let requester = V3AMockRequester(responsesByPath: routes())
+        requester.responsesByPath["/api/plugins/kanban/profiles/coder/describe-auto"] = [
+            "ok": true, "profile": "coder", "reason": "", "description": "Swift/iOS implementation and debugging.",
+        ]
+        // The authoritative profiles refetch after the mutation returns the
+        // server-persisted generated text (description_auto=true).
+        let generated = [
+            "name": "coder", "is_default": false, "model": "", "provider": "",
+            "description": "Swift/iOS implementation and debugging.", "description_auto": true, "skill_count": 3,
+        ] as [String: Any]
+        requester.profilesProvider = { fetch in
+            ["profiles": fetch >= 2 ? [generated, V3AMockRequester.defaultProfiles[1]] : V3AMockRequester.defaultProfiles]
+        }
+        let store = makeStore(requester: requester)
+        await store.reload()
+
+        let outcome = try await store.autoDescribeProfile(profile: "coder", overwrite: true)
+
+        XCTAssertTrue(outcome.ok)
+        let postCalls = requester.calls.filter { $0.method == "POST" && $0.path.hasSuffix("/profiles/coder/describe-auto") }
+        XCTAssertEqual(postCalls.count, 1)
+        XCTAssertEqual(postCalls.first?.body?["overwrite"] as? Bool, true)
+        let profile = store.profiles.first { $0.name == "coder" }
+        XCTAssertEqual(profile?.description, "Swift/iOS implementation and debugging.", "generated text adopted")
+        XCTAssertEqual(profile?.descriptionAuto, true)
+        XCTAssertFalse(requester.calls.contains { $0.path.contains("/dispatch") })
+    }
+
+    func testAutoDescribeSemanticRefusalReturnsReasonWithoutThrowing() async throws {
+        let requester = V3AMockRequester(responsesByPath: routes())
+        requester.responsesByPath["/api/plugins/kanban/profiles/coder/describe-auto"] = [
+            "ok": false, "profile": "coder", "reason": "no auxiliary client configured", "description": nil as Any?,
+        ]
+        let store = makeStore(requester: requester)
+        await store.reload()
+        let before = store.profiles.first { $0.name == "coder" }?.description
+
+        let outcome = try await store.autoDescribeProfile(profile: "coder", overwrite: true)
+
+        XCTAssertFalse(outcome.ok)
+        XCTAssertEqual(outcome.reason, "no auxiliary client configured", "backend reason is the product semantics")
+        XCTAssertEqual(store.profiles.first { $0.name == "coder" }?.description, before)
+        XCTAssertNil(store.mutationErrorMessage, "semantic refusal is an outcome, not a mutation failure")
+    }
+
+    func testGenerateNeverOverwritesDirtyDraftWithoutExplicitDiscard() {
+        XCTAssertEqual(
+            KanbanProfileDescriptionPolicy.resolveGenerate(draft: "my draft", baseline: "server text"),
+            .requiresDiscard
+        )
+        XCTAssertEqual(
+            KanbanProfileDescriptionPolicy.resolveGenerate(draft: "server text", baseline: "server text"),
+            .allowed
+        )
+        XCTAssertEqual(
+            KanbanProfileDescriptionPolicy.discard(draft: "my draft", baseline: "server text"),
+            "server text",
+            "discard drops the draft back to the baseline"
+        )
+    }
+
+    func testStaleProfileCompletionIsIdentityInert() async throws {
+        let requesterA = V3AMockRequester(responsesByPath: routes())
+        let store = makeStore(requester: requesterA)
+        await store.reload()
+
+        requesterA.suspend(method: "POST", basePath: "/api/plugins/kanban/profiles/coder/describe-auto")
+        let task = Task { try? await store.autoDescribeProfile(profile: "coder", overwrite: true) }
+        await requesterA.waitForSuspension()
+
+        let requesterB = V3AMockRequester(responsesByPath: routes(boardSlug: "beta"))
+        store.configure(requester: requesterB, serverIdentity: "https://b.test")
+        requesterA.resumeSuspended()
+        _ = await task.value
+
+        XCTAssertNil(store.mutationErrorMessage)
+        XCTAssertTrue(store.profiles.isEmpty, "stale profile completion must not repopulate the new context")
+        XCTAssertEqual(requesterB.calls.count, 0)
+        XCTAssertEqual(
+            KanbanProfileDescriptionPolicy.completionIsActive(sessionProfile: "coder", currentProfile: "coder"),
+            true
+        )
+        XCTAssertEqual(
+            KanbanProfileDescriptionPolicy.completionIsActive(sessionProfile: "coder", currentProfile: "lancelot"),
+            false,
+            "a session for A never updates B's editor"
+        )
+    }
+
+    // MARK: - 4. Manual dispatcher nudge
+
+    func testManualNudgePostsToCapturedBoardOnly() async throws {
+        let requester = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha"))
+        let store = makeStore(requester: requester)
+        await store.reload()
+
+        try await store.nudgeDispatcher()
+
+        let dispatchCalls = requester.calls.filter { $0.method == "POST" && $0.path.contains("/dispatch") }
+        XCTAssertEqual(dispatchCalls.count, 1)
+        XCTAssertTrue(dispatchCalls.first?.path.contains("board=alpha") ?? false, "nudge carries the captured board slug")
+        XCTAssertEqual(dispatchCalls.first?.body?.isEmpty ?? false, true, "empty body matches upstream POST /dispatch")
+        XCTAssertNil(store.mutationErrorMessage)
+        XCTAssertGreaterThanOrEqual(requester.boardFetches, 2, "success reconciles with an authoritative board refresh")
+    }
+
+    func testNudgeRefusedWhileSnapshotIsNotActionable() async {
+        let requester = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha"))
+        // Beta exists on the server; selecting it starts a superseding load
+        // whose board fetch FAILS, leaving the stale alpha snapshot visible
+        // but non-actionable.
+        requester.responsesByPath["/api/plugins/kanban/boards"] = [
+            "boards": [
+                ["slug": "alpha", "name": "Alpha", "is_current": true],
+                ["slug": "beta", "name": "Beta", "is_current": false],
+            ],
+            "current": "alpha",
+        ]
+        requester.boardProvider = { fetch in
+            if fetch >= 2 { throw URLError(.cannotConnectToHost) }
+            return V3AMockRequester.staticBoard(task: nil)
+        }
+        let store = makeStore(requester: requester)
+        await store.reload()
+        XCTAssertTrue(store.isSelectedSnapshotLoaded)
+
+        await store.selectBoard(slug: "beta")
+        XCTAssertFalse(store.isSelectedSnapshotLoaded)
+
+        do {
+            try await store.nudgeDispatcher()
+            XCTFail("expected the navigation guard to refuse the nudge")
+        } catch KanbanServiceError.boardNavigationInProgress {
+            // expected: fail-closed
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        XCTAssertFalse(requester.calls.contains { $0.path.contains("/dispatch") }, "no nudge may fire for a stale snapshot")
+    }
+
+    func testNudgeAfterOwnershipLossNeverFiresAgainstNewContext() async {
+        let requesterA = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha"))
+        let store = makeStore(requester: requesterA)
+        await store.reload()
+
+        requesterA.suspend(method: "POST", basePath: "/api/plugins/kanban/dispatch")
+        let task = Task { try? await store.nudgeDispatcher() }
+        await requesterA.waitForSuspension()
+        XCTAssertEqual(requesterA.calls.filter { $0.path.contains("/dispatch") }.count, 1)
+
+        let requesterB = V3AMockRequester(responsesByPath: routes(boardSlug: "beta"))
+        store.configure(requester: requesterB, serverIdentity: "https://b.test")
+        requesterA.resumeSuspended()
+        _ = await task.value
+
+        XCTAssertEqual(requesterB.calls.count, 0)
+        XCTAssertFalse(store.isMutating)
+        XCTAssertNil(store.mutationErrorMessage)
+    }
+
+    // MARK: - 5. Specify
+
+    func testSpecifySuccessReloadsAuthoritativeTaskState() async throws {
+        let t1 = makeTask(id: "t1", status: "triage")
+        let afterSpecify = makeTask(id: "t1", status: "todo")
+        let requester = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha", task: t1))
+        // After the mutation the authoritative board moves t1 to todo.
+        requester.boardProvider = { fetch in
+            fetch >= 2 ? V3AMockRequester.staticBoard(task: afterSpecify) : V3AMockRequester.staticBoard(task: t1)
+        }
+        requester.responsesByPath["/api/plugins/kanban/tasks/t1/specify"] = [
+            "ok": true, "task_id": "t1", "reason": "specified", "new_title": "Tightened title",
+        ]
+        let store = makeStore(requester: requester)
+        await store.reload()
+        XCTAssertEqual(store.board?.columns.first { $0.name == "triage" }?.tasks.first?.id, "t1")
+
+        let outcome = try await store.specifyTask(id: "t1")
+
+        XCTAssertTrue(outcome.ok)
+        XCTAssertEqual(outcome.newTitle, "Tightened title")
+        XCTAssertEqual(requester.boardFetches, 2, "post-mutation superseding reload")
+        XCTAssertNil(store.board?.columns.first { $0.name == "triage" }?.tasks.first, "t1 left triage")
+        XCTAssertEqual(store.board?.columns.first { $0.name == "todo" }?.tasks.first?.id, "t1", "reconciled from authoritative REST state")
+        XCTAssertNil(store.mutationErrorMessage)
+        XCTAssertTrue(requester.calls.contains {
+            $0.method == "POST" && $0.path.contains("/tasks/t1/specify") && $0.path.contains("board=alpha")
+        })
+    }
+
+    func testSpecifySemanticFailureSurfacesBackendReasonAndLeavesTaskIntact() async {
+        let t1 = makeTask(id: "t1", status: "triage")
+        let requester = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha", task: t1))
+        requester.responsesByPath["/api/plugins/kanban/tasks/t1/specify"] = [
+            "ok": false,
+            "task_id": "t1",
+            "reason": "task is not in triage (status='todo')",
+            "new_title": nil as Any?,
+        ]
+        let store = makeStore(requester: requester)
+        await store.reload()
+
+        do {
+            _ = try await store.specifyTask(id: "t1")
+            XCTFail("semantic failure must throw")
+        } catch let error as KanbanServiceError {
+            XCTAssertEqual(error, .actionDeclined(reason: "task is not in triage (status='todo')"))
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        XCTAssertTrue(store.mutationErrorMessage?.contains("task is not in triage") == true, "backend reason shown verbatim")
+        XCTAssertEqual(store.board?.columns.first { $0.name == "triage" }?.tasks.first?.id, "t1", "task left intact on semantic refusal")
+        XCTAssertEqual(store.board?.columns.first { $0.name == "todo" }?.tasks.isEmpty, true)
+    }
+
+    func testSpecifyNetworkFailureIsDistinctFromSemanticFailure() async {
+        let t1 = makeTask(id: "t1", status: "triage")
+        let requester = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha", task: t1))
+        requester.errorsByPath["/api/plugins/kanban/tasks/t1/specify"] = URLError(.timedOut)
+        let store = makeStore(requester: requester)
+        await store.reload()
+
+        do {
+            _ = try await store.specifyTask(id: "t1")
+            XCTFail("expected failure")
+        } catch is KanbanServiceError {
+            XCTFail("a network failure is not a semantic actionDeclined")
+        } catch {
+            XCTAssertFalse(store.isMutating)
+            XCTAssertNotNil(store.mutationErrorMessage)
+        }
+    }
+
+    func testSpecifyStaleCompletionAfterServerSwitchIsInert() async {
+        let t1 = makeTask(id: "t1", status: "triage")
+        let requesterA = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha", task: t1))
+        requesterA.responsesByPath["/api/plugins/kanban/tasks/t1/specify"] = [
+            "ok": true, "task_id": "t1", "reason": "specified", "new_title": nil as Any?,
+        ]
+        let store = makeStore(requester: requesterA)
+        await store.reload()
+
+        requesterA.suspend(method: "POST", basePath: "/api/plugins/kanban/tasks/t1/specify")
+        let task = Task { try? await store.specifyTask(id: "t1") }
+        await requesterA.waitForSuspension()
+
+        let requesterB = V3AMockRequester(responsesByPath: routes(boardSlug: "beta"))
+        store.configure(requester: requesterB, serverIdentity: "https://b.test")
+        requesterA.resumeSuspended()
+        _ = await task.value
+
+        XCTAssertEqual(requesterB.calls.count, 0, "mutation started for A must never touch B")
+        XCTAssertNil(store.mutationErrorMessage)
+        XCTAssertNil(store.board, "no stale reload may repopulate B's UI")
+        XCTAssertFalse(store.isMutating)
+    }
+
+    // MARK: - 6. Decompose
+
+    func testDecomposeTapRequiresExplicitConfirmation() {
+        XCTAssertEqual(KanbanTriageActionsPolicy.decomposeTap(), .confirm, "a tap resolves to a confirmation, never the mutation")
+        XCTAssertEqual(KanbanTriageActionsPolicy.decomposeConfirmationTitle, "Decompose this task?")
+        XCTAssertEqual(
+            KanbanTriageActionsPolicy.decomposeConfirmationMessage,
+            "Hermes may create and assign multiple dependent tasks."
+        )
+    }
+
+    func testDecomposeSuccessReconcilesFromAuthoritativeBoardReload() async throws {
+        let t1 = makeTask(id: "t1", status: "triage")
+        let requester = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha", task: t1))
+        requester.responsesByPath["/api/plugins/kanban/tasks/t1/decompose"] = [
+            "ok": true,
+            "task_id": "t1",
+            "reason": "decomposed into 2 children",
+            "fanout": true,
+            "child_ids": ["c1", "c2"],
+            "new_title": nil as Any?,
+        ]
+        // Authoritative server state after fan-out: root t1 -> todo with two
+        // children c1/c2 in todo. Conduit must render THIS, not synthesize
+        // cards from the response (the response carries ids only).
+        let afterColumns: [[String: Any]] = [
+            ["name": "triage", "tasks": []],
+            ["name": "todo", "tasks": [
+                ["id": "t1", "title": "Root", "status": "todo"],
+                ["id": "c1", "title": "Child 1", "status": "todo"],
+                ["id": "c2", "title": "Child 2", "status": "todo"],
+            ]],
+            ["name": "ready", "tasks": []],
+        ]
+        let requesterBoard = V3AMockRequester.board(columns: afterColumns)
+        requester.boardProvider = { fetch in
+            fetch >= 2 ? requesterBoard : V3AMockRequester.staticBoard(task: t1)
+        }
+        let store = makeStore(requester: requester)
+        await store.reload()
+
+        let outcome = try await store.decomposeTask(id: "t1")
+
+        XCTAssertTrue(outcome.ok)
+        XCTAssertEqual(outcome.childIDs, ["c1", "c2"])
+        XCTAssertEqual(
+            KanbanTriageActionsPolicy.successNotice(fanout: outcome.fanout, childCount: outcome.childIDs.count),
+            "Decomposed into 2 tasks"
+        )
+        XCTAssertEqual(requester.boardFetches, 2, "authoritative superseding reload after decompose")
+        let todoIDs = store.board?.columns.filter { $0.name == "todo" }.flatMap(\.tasks).map(\.id) ?? []
+        XCTAssertEqual(todoIDs, ["t1", "c1", "c2"], "board reflects the authoritative fan-out, never synthetic cards")
+        XCTAssertNil(store.mutationErrorMessage)
+    }
+
+    func testDecomposeSemanticFailurePreservesTaskAndSurfacesReason() async {
+        let t1 = makeTask(id: "t1", status: "triage")
+        let requester = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha", task: t1))
+        requester.responsesByPath["/api/plugins/kanban/tasks/t1/decompose"] = [
+            "ok": false, "task_id": "t1", "reason": "task moved out of triage before decomposition",
+            "fanout": false, "child_ids": [], "new_title": nil as Any?,
+        ]
+        let store = makeStore(requester: requester)
+        await store.reload()
+
+        do {
+            _ = try await store.decomposeTask(id: "t1")
+            XCTFail("semantic failure must throw")
+        } catch let error as KanbanServiceError {
+            XCTAssertEqual(error, .actionDeclined(reason: "task moved out of triage before decomposition"))
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        XCTAssertEqual(store.board?.columns.first { $0.name == "triage" }?.tasks.first?.id, "t1", "task intact")
+        XCTAssertEqual(store.mutationErrorMessage, "task moved out of triage before decomposition")
+    }
+
+    func testDecomposeSuccessWithFailedRefreshIsPartialSuccessNotFailure() async throws {
+        let t1 = makeTask(id: "t1", status: "triage")
+        let requester = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha", task: t1))
+        requester.responsesByPath["/api/plugins/kanban/tasks/t1/decompose"] = [
+            "ok": true, "task_id": "t1", "reason": "decomposed into 1 children",
+            "fanout": true, "child_ids": ["c1"], "new_title": nil as Any?,
+        ]
+        // The decompose SUCCEEDS, but the authoritative refresh afterwards
+        // fails — the board must stay cached (never cleared) and the mutation
+        // must not be reported as failed.
+        requester.boardProvider = { fetch in
+            if fetch >= 2 { throw URLError(.cannotConnectToHost) }
+            return V3AMockRequester.staticBoard(task: t1)
+        }
+        let store = makeStore(requester: requester)
+        await store.reload()
+
+        let outcome = try await store.decomposeTask(id: "t1")
+        XCTAssertTrue(outcome.ok, "the decompose itself succeeded")
+        XCTAssertNil(store.mutationErrorMessage, "the mutation must not be presented as failed")
+        XCTAssertNotNil(store.board, "cached board content survives a failed refresh")
+        XCTAssertNotNil(store.errorMessage, "the REFRESH failure is its own banner channel")
+        XCTAssertFalse(store.isMutating)
+    }
+
+    func testDecomposeServerNavigationRaceIsInert() async {
+        let t1 = makeTask(id: "t1", status: "triage")
+        let requesterA = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha", task: t1))
+        requesterA.responsesByPath["/api/plugins/kanban/tasks/t1/decompose"] = [
+            "ok": true, "task_id": "t1", "reason": "decomposed into 1 children",
+            "fanout": true, "child_ids": ["c1"], "new_title": nil as Any?,
+        ]
+        let store = makeStore(requester: requesterA)
+        await store.reload()
+
+        requesterA.suspend(method: "POST", basePath: "/api/plugins/kanban/tasks/t1/decompose")
+        let task = Task { try? await store.decomposeTask(id: "t1") }
+        await requesterA.waitForSuspension()
+
+        let requesterB = V3AMockRequester(responsesByPath: routes(boardSlug: "beta"))
+        store.configure(requester: requesterB, serverIdentity: "https://b.test")
+        requesterA.resumeSuspended()
+        _ = await task.value
+
+        XCTAssertEqual(requesterB.calls.count, 0, "decompose started for A must never reconcile B")
+        XCTAssertNil(store.board)
+        XCTAssertNil(store.mutationErrorMessage)
+        XCTAssertFalse(store.isMutating)
+    }
+
+    func testPartialSuccessRefreshWordingNeverBlamesTheMutation() {
+        let notice = KanbanTriageActionsPolicy.refreshFailureNotice(
+            actionLabel: "Decomposition succeeded",
+            detail: "network unreachable"
+        )
+        XCTAssertTrue(notice.hasPrefix("Decomposition succeeded"))
+        XCTAssertTrue(notice.contains("could not be refreshed"))
+    }
+
+    func testDecomposeResponseDecodesTolerantly() throws {
+        let json = """
+        {"ok": true, "task_id": "t9", "reason": "decomposed into 0 children",
+         "fanout": false, "child_ids": [], "new_title": "Tightened"}
+        """
+        let outcome = try JSONDecoder().decode(KanbanDecomposeResponse.self, from: Data(json.utf8))
+        XCTAssertTrue(outcome.ok)
+        XCTAssertFalse(outcome.fanout)
+        XCTAssertEqual(outcome.childIDs, [])
+        XCTAssertEqual(outcome.newTitle, "Tightened")
+
+        let malformed = """
+        {"ok": "yes", "task_id": 7, "child_ids": "nope"}
+        """
+        let tolerant = try JSONDecoder().decode(KanbanDecomposeResponse.self, from: Data(malformed.utf8))
+        XCTAssertFalse(tolerant.ok, "non-bool ok fails safely")
+        // Lossy string decoding converts a numeric task_id ("7") rather than
+        // crashing or dropping the identity; non-array child_ids degrades to [].
+        XCTAssertEqual(tolerant.taskID, "7")
+        XCTAssertEqual(tolerant.childIDs, [])
+    }
+}
+
+// MARK: - V3A request double
+
+/// Deterministic DashboardJSONRequester double: static or closure-backed
+/// responses, recorded calls, per-request error injection, and a
+/// continuation handshake to suspend a request mid-flight (no sleeps).
+@MainActor
+private final class V3AMockRequester: DashboardJSONRequester {
+    struct Call {
+        let path: String
+        let method: String
+        let body: [String: Any]?
+    }
+
+    static let defaultProfiles: [[String: Any]] = [
+        ["name": "coder", "is_default": false, "model": "", "provider": "",
+         "description": "Swift/iOS implementation and debugging", "description_auto": false, "skill_count": 3],
+        ["name": "default", "is_default": true, "model": "", "provider": "",
+         "description": "General purpose", "description_auto": true, "skill_count": 0],
+    ]
+
+    static let defaultOrchestration: [String: Any] = [
+        "orchestrator_profile": "",
+        "default_assignee": "",
+        "auto_decompose": true,
+        "auto_promote_children": true,
+        "resolved_orchestrator_profile": "default",
+        "resolved_default_assignee": "coder",
+        "active_profile": "default",
+    ]
+
+    static func board(columns: [[String: Any]]) -> [String: Any] {
+        ["columns": columns, "tenants": [], "assignees": [], "latest_event_id": 1, "now": 2]
+    }
+
+    /// JSON-compatible task row: the transport layer re-serializes mock
+    /// responses with JSONSerialization, so structs must not leak in.
+    private static func taskJSON(_ task: KanbanTask) -> [String: Any] {
+        let data = try! JSONEncoder().encode(task)
+        return try! JSONSerialization.jsonObject(with: data) as! [String: Any]
+    }
+
+    static func staticBoard(task: KanbanTask?) -> [String: Any] {
+        let rows: [[String: Any]] = task.map { [taskJSON($0)] } ?? []
+        let columns: [[String: Any]] = [
+            ["name": "triage", "tasks": task?.status == "triage" ? rows : []],
+            ["name": "todo", "tasks": task?.status == "todo" ? rows : []],
+            ["name": "ready", "tasks": []],
+        ]
+        return board(columns: columns)
+    }
+
+    var responsesByPath: [String: [String: Any]]
+    var errorsByPath: [String: Error] = [:]
+    var boardProvider: (Int) throws -> [String: Any]
+    var profilesProvider: (Int) -> [String: Any]
+    var boardFetches = 0
+    var calls: [Call] = []
+
+    /// Live orchestration state: seeded from the initial route map, then
+    /// merged by every PUT so the post-mutation GET sees the new value.
+    private var orchestrationResponse: [String: Any]
+
+    private var suspendEntries: [(method: String, basePath: String)] = []
+    private var suspended: [CheckedContinuation<Void, Never>] = []
+    private var suspensionWaiters: [CheckedContinuation<Void, Never>] = []
+
+    init(responsesByPath: [String: [String: Any]] = [:]) {
+        self.responsesByPath = responsesByPath
+        // Default: serve the route-map board (falling back to an empty board)
+        // so tests that never override the provider still load the fixture.
+        let staticBoardRow = responsesByPath["/api/plugins/kanban/board"]
+        boardProvider = { _ in
+            staticBoardRow ?? V3AMockRequester.staticBoard(task: nil)
+        }
+        profilesProvider = { [responsesByPath] _ in
+            responsesByPath["/api/plugins/kanban/profiles"] ?? ["profiles": []]
+        }
+        orchestrationResponse = responsesByPath["/api/plugins/kanban/orchestration"] ?? V3AMockRequester.defaultOrchestration
+    }
+
+    func suspend(method: String, basePath: String) {
+        suspendEntries.append((method, basePath))
+    }
+
+    func waitForSuspension() async {
+        if !suspended.isEmpty {
+            suspended.removeAll()
+            return
+        }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            suspensionWaiters.append(continuation)
+        }
+    }
+
+    func resumeSuspended() {
+        let pending = suspended
+        suspended.removeAll()
+        pending.forEach { $0.resume() }
+    }
+
+    func requestJSON(path: String, method: String, body: [String: Any]?, timeoutMilliseconds: Int, maxResponseBytes: Int) async throws -> [String: Any] {
+        let call = Call(path: path, method: method, body: body)
+        calls.append(call)
+        let basePath = path.components(separatedBy: "?").first ?? path
+
+        if suspendEntries.contains(where: { $0.method == method && $0.basePath == basePath }) {
+            suspendEntries.removeAll { $0.method == method && $0.basePath == basePath }
+            suspensionWaiters.forEach { $0.resume() }
+            suspensionWaiters.removeAll()
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                suspended.append(continuation)
+            }
+        }
+
+        if let error = errorsByPath[path] ?? errorsByPath[basePath] { throw error }
+        if method == "GET", basePath == "/api/plugins/kanban/board" {
+            boardFetches += 1
+            return try boardProvider(boardFetches)
+        }
+        if method == "GET", basePath == "/api/plugins/kanban/profiles" {
+            return profilesProvider(calls.filter { $0.method == "GET" && $0.path.contains("/profiles") }.count)
+        }
+        if basePath == "/api/plugins/kanban/orchestration" {
+            if method == "PUT", let body {
+                for (key, value) in body where !(value is NSNull) {
+                    orchestrationResponse[key] = value
+                }
+            }
+            return orchestrationResponse
+        }
+        if let response = responsesByPath[path] ?? responsesByPath[basePath] { return response }
+        return [:]
+    }
+}

--- a/ConduitTests/KanbanV3ATests.swift
+++ b/ConduitTests/KanbanV3ATests.swift
@@ -480,6 +480,408 @@ final class KanbanV3ATests: XCTestCase {
         XCTAssertFalse(store.isMutating)
     }
 
+    // MARK: - 7. V3A final pass: mutation identity frozen before scheduling
+
+    func testPendingTriageActionCaptureFreezesIdentityAndStamp() {
+        let task = makeTask(id: "t1", status: "triage")
+        let stamp = KanbanBoardContextStamp(boardSlug: "alpha", configurationGeneration: 3)
+        let pending = PendingTriageAction.capture(task: task, isSnapshotActionable: true, stamp: stamp)
+        XCTAssertEqual(pending?.taskID, "t1")
+        XCTAssertEqual(pending?.context, stamp)
+        // A capture is refused entirely when the identity is not owned.
+        XCTAssertNil(PendingTriageAction.capture(task: task, isSnapshotActionable: false, stamp: stamp))
+        XCTAssertNil(PendingTriageAction.capture(task: task, isSnapshotActionable: true, stamp: nil))
+        XCTAssertNil(PendingTriageAction.capture(task: nil, isSnapshotActionable: true, stamp: stamp))
+    }
+
+    func testSpecifyStaleCapturedContextFailsClosedWithoutAnyRequest() async {
+        let t1 = makeTask(id: "t1", status: "triage")
+        let requesterA = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha", task: t1))
+        let store = makeStore(requester: requesterA)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected a loaded context") }
+
+        // Server B replaces A between the tap (capture) and Task execution.
+        let requesterB = V3AMockRequester(responsesByPath: routes(boardSlug: "beta"))
+        store.configure(requester: requesterB, serverIdentity: "https://b.test")
+
+        do {
+            _ = try await store.specifyTask(id: "t1", expectedContext: stampA)
+            XCTFail("a stale captured stamp must fail closed")
+        } catch KanbanServiceError.boardNavigationInProgress {
+            // fail-closed, expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        XCTAssertEqual(requesterB.calls.count, 0, "zero request may reach server B")
+        XCTAssertFalse(requesterA.calls.contains { $0.path.contains("/tasks/t1/specify") }, "no specify may fire after capture invalidation")
+    }
+
+    func testDecomposeStagedConfirmationFailsClosedAfterNavigation() async {
+        let t1 = makeTask(id: "t1", status: "triage")
+        let requester = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha", task: t1))
+        requester.responsesByPath["/api/plugins/kanban/boards"] = [
+            "boards": [
+                ["slug": "alpha", "name": "Alpha", "is_current": true],
+                ["slug": "beta", "name": "Beta", "is_current": false],
+            ],
+            "current": "alpha",
+        ]
+        // Beta's board fetch fails: the stale alpha snapshot stays visible but
+        // non-actionable while beta loads.
+        requester.boardProvider = { fetch in
+            if fetch >= 2 { throw URLError(.cannotConnectToHost) }
+            return V3AMockRequester.staticBoard(task: t1)
+        }
+        let store = makeStore(requester: requester)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected a loaded context") }
+
+        // Stage for A, then navigate before confirming.
+        let staged = PendingTriageAction(taskID: t1.id, context: stampA)
+        await store.selectBoard(slug: "beta")
+        XCTAssertFalse(store.isSelectedSnapshotLoaded)
+
+        do {
+            _ = try await store.decomposeTask(id: staged.taskID, expectedContext: staged.context)
+            XCTFail("a stale staged confirmation must fail closed")
+        } catch KanbanServiceError.boardNavigationInProgress {
+            // fail-closed, expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        XCTAssertFalse(requester.calls.contains { $0.path.contains("/decompose") }, "zero decompose may fire for a stale confirmation")
+    }
+
+    func testOrchestrationSaveProceedsAfterSameServerBoardSwitch() async throws {
+        // F-2: orchestration is server-global on the wire; a board switch on
+        // the SAME server (generation unchanged) must not abort a valid
+        // settings save - only a server reconfigure invalidates the stamp.
+        let requester = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha"))
+        requester.responsesByPath["/api/plugins/kanban/boards"] = [
+            "boards": [
+                ["slug": "alpha", "name": "Alpha", "is_current": true],
+                ["slug": "beta", "name": "Beta", "is_current": false],
+            ],
+            "current": "alpha",
+        ]
+        let store = makeStore(requester: requester)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected a loaded context") }
+
+        // Same-server navigation completes successfully before the mutation.
+        await store.selectBoard(slug: "beta")
+        XCTAssertTrue(store.isSelectedSnapshotLoaded)
+        XCTAssertEqual(store.loadedBoardSlug, "beta")
+
+        let updated = try await store.updateOrchestration(
+            KanbanOrchestrationPatch(autoDecompose: false),
+            expectedContext: stampA
+        )
+        XCTAssertEqual(updated?.autoDecompose, false, "same-server save proceeds")
+        XCTAssertNil(store.mutationErrorMessage)
+        let putCalls = requester.calls.filter { $0.method == "PUT" && $0.path.hasSuffix("/orchestration") }
+        XCTAssertEqual(putCalls.count, 1)
+        XCTAssertFalse(putCalls.first?.path.contains("board=") ?? false, "server-global PUT carries no board query")
+    }
+
+    func testProfileSaveAndGenerateProceedAfterSameServerBoardSwitch() async throws {
+        // G-1 parity: profile endpoints are server-global too - a completed
+        // same-server board switch must not abort a valid save or generation.
+        let requester = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha"))
+        requester.responsesByPath["/api/plugins/kanban/boards"] = [
+            "boards": [
+                ["slug": "alpha", "name": "Alpha", "is_current": true],
+                ["slug": "beta", "name": "Beta", "is_current": false],
+            ],
+            "current": "alpha",
+        ]
+        requester.responsesByPath["/api/plugins/kanban/profiles/coder/describe-auto"] = [
+            "ok": true, "profile": "coder", "reason": "", "description": "Generated text",
+        ]
+        let store = makeStore(requester: requester)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected a loaded context") }
+
+        await store.selectBoard(slug: "beta")
+        XCTAssertTrue(store.isSelectedSnapshotLoaded)
+
+        try await store.updateProfileDescription(
+            profile: "coder",
+            description: "New description",
+            expectedContext: stampA
+        )
+        XCTAssertNil(store.mutationErrorMessage)
+        XCTAssertTrue(requester.calls.contains { $0.method == "PATCH" && $0.path.contains("/profiles/coder") })
+
+        let outcome = try await store.autoDescribeProfile(profile: "coder", overwrite: true, expectedContext: stampA)
+        XCTAssertTrue(outcome.ok)
+        XCTAssertFalse(requester.calls.contains { $0.path.contains("board=") && $0.path.contains("profiles") }, "no board query on server-global profile calls")
+    }
+
+    func testOrchestrationSaveStaleContextCannotReachServerB() async {
+        let requesterA = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha"))
+        let store = makeStore(requester: requesterA)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected a loaded context") }
+
+        let requesterB = V3AMockRequester(responsesByPath: routes(boardSlug: "beta"))
+        store.configure(requester: requesterB, serverIdentity: "https://b.test")
+
+        do {
+            _ = try await store.updateOrchestration(
+                KanbanOrchestrationPatch(autoDecompose: false),
+                expectedContext: stampA
+            )
+            XCTFail("a stale stamp must fail closed")
+        } catch KanbanServiceError.boardNavigationInProgress {
+            // fail-closed, expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        XCTAssertEqual(requesterB.calls.count, 0, "zero PUT may reach server B")
+    }
+
+    func testProfileSaveStaleContextCannotReachServerB() async {
+        let requesterA = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha"))
+        let store = makeStore(requester: requesterA)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected a loaded context") }
+
+        let requesterB = V3AMockRequester(responsesByPath: routes(boardSlug: "beta"))
+        store.configure(requester: requesterB, serverIdentity: "https://b.test")
+
+        do {
+            try await store.updateProfileDescription(
+                profile: "coder",
+                description: "New description",
+                expectedContext: stampA
+            )
+            XCTFail("a stale stamp must fail closed")
+        } catch KanbanServiceError.boardNavigationInProgress {
+            // fail-closed, expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        XCTAssertEqual(requesterB.calls.count, 0, "zero PATCH may reach server B")
+    }
+
+    func testProfileGenerateStaleContextCannotReachServerB() async {
+        let requesterA = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha"))
+        let store = makeStore(requester: requesterA)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected a loaded context") }
+
+        let requesterB = V3AMockRequester(responsesByPath: routes(boardSlug: "beta"))
+        store.configure(requester: requesterB, serverIdentity: "https://b.test")
+
+        do {
+            _ = try await store.autoDescribeProfile(profile: "coder", overwrite: true, expectedContext: stampA)
+            XCTFail("a stale stamp must fail closed")
+        } catch KanbanServiceError.boardNavigationInProgress {
+            // fail-closed, expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        XCTAssertEqual(requesterB.calls.count, 0, "zero describe-auto may reach server B")
+    }
+
+    func testNudgeStaleContextCannotReachServerB() async {
+        let requesterA = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha"))
+        let store = makeStore(requester: requesterA)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected a loaded context") }
+
+        let requesterB = V3AMockRequester(responsesByPath: routes(boardSlug: "beta"))
+        store.configure(requester: requesterB, serverIdentity: "https://b.test")
+
+        do {
+            try await store.nudgeDispatcher(expectedContext: stampA)
+            XCTFail("a stale stamp must fail closed")
+        } catch KanbanServiceError.boardNavigationInProgress {
+            // fail-closed, expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        XCTAssertEqual(requesterB.calls.count, 0, "zero dispatch may reach server B")
+    }
+
+    // MARK: - 8. V3A final pass: in-flight editor state
+
+    func testProfileSavePreservesEditsMadeAfterSubmission() {
+        // submit "A"; user types "B" while pending; A succeeds
+        let outcome = KanbanProfileDescriptionPolicy.saveCompletion(
+            submitted: "A",
+            currentRawDraft: "B",
+            currentTrimmedDraft: "B"
+        )
+        XCTAssertEqual(outcome.baselineDescription, "A", "server baseline is the SUBMITTED value")
+        XCTAssertEqual(outcome.draft, "B", "newer local typing is preserved, never marked saved")
+        XCTAssertTrue(outcome.isDirtyAfter, "the newer text was never persisted: editor stays dirty")
+        XCTAssertTrue(outcome.notice?.contains("still unsaved") == true)
+
+        // no post-submit edit: normalized clean
+        let clean = KanbanProfileDescriptionPolicy.saveCompletion(
+            submitted: "A",
+            currentRawDraft: "A",
+            currentTrimmedDraft: "A"
+        )
+        XCTAssertEqual(clean.draft, "A")
+        XCTAssertFalse(clean.isDirtyAfter)
+        XCTAssertEqual(clean.notice, "Description saved.")
+
+        // a trailing-newline-only change is NOT a newer edit (dirty compares
+        // the trimmed draft)
+        let newline = KanbanProfileDescriptionPolicy.saveCompletion(
+            submitted: "A",
+            currentRawDraft: "A\n",
+            currentTrimmedDraft: "A"
+        )
+        XCTAssertFalse(newline.isDirtyAfter)
+    }
+
+    func testProfileGeneratePreservesEditsTypedWhilePending() {
+        // generation starts from "A"; user types "B" while pending; server
+        // generates "C"
+        let outcome = KanbanProfileDescriptionPolicy.generateCompletion(
+            submittedDraft: "A",
+            currentRawDraft: "B",
+            currentTrimmedDraft: "B",
+            generated: "C"
+        )
+        XCTAssertEqual(outcome.baselineDescription, "C", "server baseline is the generated value")
+        XCTAssertEqual(outcome.baselineIsAuto, true)
+        XCTAssertEqual(outcome.draft, "B", "newer manual typing is preserved, not overwritten by C")
+        XCTAssertTrue(outcome.isDirtyAfter, "remaining dirty against the generated baseline")
+        XCTAssertTrue(outcome.notice?.contains("preserved") == true, "non-destructive notice")
+
+        // no typing while pending: generated text is adopted cleanly
+        let clean = KanbanProfileDescriptionPolicy.generateCompletion(
+            submittedDraft: "A",
+            currentRawDraft: "A",
+            currentTrimmedDraft: "A",
+            generated: "C"
+        )
+        XCTAssertEqual(clean.draft, "C")
+        XCTAssertFalse(clean.isDirtyAfter)
+
+        // F-1: the submission snapshot is TRIMMED (startGenerate freezes the
+        // trimmed draft), so a whitespace-ragged editor state is never
+        // misclassified as "newer typing": the generated value is adopted.
+        let ragged = KanbanProfileDescriptionPolicy.generateCompletion(
+            submittedDraft: "A",
+            currentRawDraft: "A\n",
+            currentTrimmedDraft: "A",
+            generated: "C"
+        )
+        XCTAssertEqual(ragged.draft, "C", "trailing newline is not newer typing")
+        XCTAssertFalse(ragged.isDirtyAfter)
+        XCTAssertEqual(ragged.notice, "Generated automatically — review recommended.")
+    }
+
+    func testEditorLivenessTokenOwnsBusyReleaseIndependentlyOfGeneration() {
+        var liveness = KanbanEditorLiveness()
+        let op1 = liveness.begin()
+        XCTAssertTrue(liveness.owns(op1))
+        let op2 = liveness.begin()
+        XCTAssertFalse(liveness.owns(op1), "a newer operation owns the busy flag now")
+        XCTAssertTrue(liveness.owns(op2))
+        XCTAssertEqual(liveness.token, op2, "monotonic token")
+    }
+
+    func testOperationCompletionAfterReconfigureStillReleasesBusyFlag() async {
+        // Operation A starts under generation A; the server changes to B
+        // before A completes; A's completion is UI-inert for server data but
+        // the LIFETIME ownership check (liveness token) is independent of the
+        // generation, so the local busy flag is still released.
+        let requesterA = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha"))
+        let store = makeStore(requester: requesterA)
+        await store.reload()
+
+        requesterA.suspend(method: "POST", basePath: "/api/plugins/kanban/profiles/coder/describe-auto")
+        let operation = Task { try? await store.autoDescribeProfile(profile: "coder", overwrite: true) }
+        await requesterA.waitForSuspension()
+
+        let requesterB = V3AMockRequester(responsesByPath: routes(boardSlug: "beta"))
+        store.configure(requester: requesterB, serverIdentity: "https://b.test")
+        requesterA.resumeSuspended()
+        _ = await operation.value
+
+        // Store-level stale-completion guarantees unchanged...
+        XCTAssertNil(store.mutationErrorMessage)
+        XCTAssertEqual(requesterB.calls.count, 0)
+        // ...and the LIFETIME layer: the token the operation started with no
+        // longer owns the busy flag for a subsequent operation, i.e. the
+        // local flag release never depends on the server generation.
+        var liveness = KanbanEditorLiveness()
+        let opA = liveness.begin()
+        _ = liveness.begin() // a newer operation (post-reconfigure UI)
+        XCTAssertFalse(liveness.owns(opA))
+    }
+
+    // MARK: - 9. V3A final pass: continuation-helper + nudge feedback
+
+    func testWaitForSuspensionWhenRequestParksFirstDoesNotDestroyContinuation() async {
+        let requester = V3AMockRequester(responsesByPath: routes())
+        let store = makeStore(requester: requester)
+        await store.reload()
+
+        requester.suspend(method: "PUT", basePath: "/api/plugins/kanban/orchestration")
+        let operation = Task { try? await store.updateOrchestration(KanbanOrchestrationPatch(autoDecompose: false)) }
+
+        // Scheduling order: request parks BEFORE waitForSuspension() executes.
+        await requester.waitUntilParked()
+        await requester.waitForSuspension()
+        // The parked continuation must STILL be the one resumeSuspended
+        // releases (the old removeAll() destroyed it -> deadlock).
+        requester.resumeSuspended()
+        _ = await operation.value
+
+        XCTAssertFalse(store.isMutating)
+        XCTAssertNil(store.mutationErrorMessage)
+        XCTAssertNotNil(store.orchestration, "operation completed and reconciled")
+    }
+
+    func testWaitForSuspensionRegistersBeforeParkStillReleases() async {
+        let requester = V3AMockRequester(responsesByPath: routes())
+        let store = makeStore(requester: requester)
+        await store.reload()
+
+        requester.suspend(method: "POST", basePath: "/api/plugins/kanban/dispatch")
+        let waiter = Task { await requester.waitForSuspension() }
+        let operation = Task { try? await store.nudgeDispatcher() }
+        await waiter.value // wakes the moment the request parks
+        XCTAssertEqual(requester.calls.filter { $0.path.contains("/dispatch") }.count, 1)
+
+        requester.resumeSuspended()
+        _ = await operation.value
+        XCTAssertFalse(store.isMutating)
+        XCTAssertNil(store.mutationErrorMessage)
+    }
+
+    func testStaleNudgeSuccessShowsNoFeedbackOnNewContext() {
+        let stampA = KanbanBoardContextStamp(boardSlug: "alpha", configurationGeneration: 7)
+        let stampB = KanbanBoardContextStamp(boardSlug: "beta", configurationGeneration: 8)
+        XCTAssertFalse(
+            KanbanNudgePolicy.shouldShowNotice(capturedStamp: stampA, currentStamp: stampB, isSnapshotActionable: true),
+            "a /dispatch that finished on A must not surface as feedback on B"
+        )
+        XCTAssertFalse(
+            KanbanNudgePolicy.shouldShowNotice(capturedStamp: stampA, currentStamp: nil, isSnapshotActionable: true)
+        )
+        XCTAssertFalse(
+            KanbanNudgePolicy.shouldShowNotice(capturedStamp: stampA, currentStamp: stampA, isSnapshotActionable: false),
+            "a stale/non-actionable snapshot never shows nudge feedback"
+        )
+    }
+
+    func testNudgeNoticeStillShownWhenContextUnchanged() {
+        let stampA = KanbanBoardContextStamp(boardSlug: "alpha", configurationGeneration: 7)
+        XCTAssertTrue(
+            KanbanNudgePolicy.shouldShowNotice(capturedStamp: stampA, currentStamp: stampA, isSnapshotActionable: true)
+        )
+    }
+
     // MARK: - 6. Decompose
 
     func testDecomposeTapRequiresExplicitConfirmation() {
@@ -742,6 +1144,8 @@ private final class V3AMockRequester: DashboardJSONRequester {
     private var suspendEntries: [(method: String, basePath: String)] = []
     private var suspended: [CheckedContinuation<Void, Never>] = []
     private var suspensionWaiters: [CheckedContinuation<Void, Never>] = []
+    private var parkedCount = 0
+    private var parkedWaiters: [CheckedContinuation<Void, Never>] = []
 
     init(responsesByPath: [String: [String: Any]] = [:]) {
         self.responsesByPath = responsesByPath
@@ -761,13 +1165,28 @@ private final class V3AMockRequester: DashboardJSONRequester {
         suspendEntries.append((method, basePath))
     }
 
+    /// FIX (V3A final pass, review): never destroys the parked request
+    /// continuation. If the request already parked, this returns immediately
+    /// and resumeSuspended() alone owns the release; otherwise it registers a
+    /// waiter that requestJSON resumes the moment the request parks.
     func waitForSuspension() async {
         if !suspended.isEmpty {
-            suspended.removeAll()
             return
         }
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
             suspensionWaiters.append(continuation)
+        }
+    }
+
+    /// Deterministic "the request has parked" signal for the park-before-
+    /// waiter scheduling order (no sleeps): returns once the suspended
+    /// request is parked and waiting for resumeSuspended.
+    func waitUntilParked() async {
+        if parkedCount > 0 {
+            return
+        }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            parkedWaiters.append(continuation)
         }
     }
 
@@ -784,6 +1203,9 @@ private final class V3AMockRequester: DashboardJSONRequester {
 
         if suspendEntries.contains(where: { $0.method == method && $0.basePath == basePath }) {
             suspendEntries.removeAll { $0.method == method && $0.basePath == basePath }
+            parkedCount += 1
+            parkedWaiters.forEach { $0.resume() }
+            parkedWaiters.removeAll()
             suspensionWaiters.forEach { $0.resume() }
             suspensionWaiters.removeAll()
             await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in

--- a/ConduitTests/KanbanV3ATests.swift
+++ b/ConduitTests/KanbanV3ATests.swift
@@ -619,6 +619,151 @@ final class KanbanV3ATests: XCTestCase {
         XCTAssertFalse(requester.calls.contains { $0.path.contains("board=") && $0.path.contains("profiles") }, "no board query on server-global profile calls")
     }
 
+    func testServerGlobalSaveProceedsDuringInFlightBoardTransition() async throws {
+        // Merge pass: a server-global orchestration save must stay valid while
+        // a same-server alpha -> beta transition is IN FLIGHT (selected = beta,
+        // loaded = alpha, snapshot not actionable).
+        let requester = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha"))
+        requester.responsesByPath["/api/plugins/kanban/boards"] = [
+            "boards": [
+                ["slug": "alpha", "name": "Alpha", "is_current": true],
+                ["slug": "beta", "name": "Beta", "is_current": false],
+            ],
+            "current": "alpha",
+        ]
+        requester.boardProvider = { _ in V3AMockRequester.staticBoard(task: nil) }
+        requester.blockedBoardFetches = [2] // hold the beta load mid-flight
+        let store = makeStore(requester: requester)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected a loaded context") }
+
+        let navigation = Task { await store.selectBoard(slug: "beta") }
+        await requester.waitUntilBoardFetchParked()
+        XCTAssertFalse(store.isSelectedSnapshotLoaded, "navigation is genuinely in flight")
+
+        let updated = try await store.updateOrchestration(
+            KanbanOrchestrationPatch(autoDecompose: false),
+            expectedContext: stampA
+        )
+        XCTAssertEqual(updated?.autoDecompose, false, "same-server in-flight transition does not reject the save")
+        XCTAssertEqual(
+            requester.calls.filter { $0.method == "PUT" && $0.path.hasSuffix("/orchestration") }.count,
+            1,
+            "PUT occurs exactly once"
+        )
+        XCTAssertNil(store.mutationErrorMessage, "no boardNavigationInProgress")
+
+        requester.releaseBoardFetches()
+        await navigation.value
+        XCTAssertEqual(store.loadedBoardSlug, "beta", "reconciliation converges onto the currently selected board")
+    }
+
+    func testServerGlobalProfileSaveProceedsDuringInFlightBoardTransition() async throws {
+        let requester = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha"))
+        requester.responsesByPath["/api/plugins/kanban/boards"] = [
+            "boards": [
+                ["slug": "alpha", "name": "Alpha", "is_current": true],
+                ["slug": "beta", "name": "Beta", "is_current": false],
+            ],
+            "current": "alpha",
+        ]
+        requester.boardProvider = { _ in V3AMockRequester.staticBoard(task: nil) }
+        requester.blockedBoardFetches = [2]
+        let store = makeStore(requester: requester)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected a loaded context") }
+
+        let navigation = Task { await store.selectBoard(slug: "beta") }
+        await requester.waitUntilBoardFetchParked()
+
+        try await store.updateProfileDescription(profile: "coder", description: "New text", expectedContext: stampA)
+        XCTAssertNil(store.mutationErrorMessage)
+        XCTAssertEqual(
+            requester.calls.filter { $0.method == "PATCH" && $0.path.contains("/profiles/coder") }.count,
+            1,
+            "PATCH still occurs exactly once"
+        )
+
+        requester.releaseBoardFetches()
+        await navigation.value
+        XCTAssertEqual(store.loadedBoardSlug, "beta")
+    }
+
+    func testServerGlobalGenerateProceedsDuringInFlightBoardTransition() async throws {
+        let requester = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha"))
+        requester.responsesByPath["/api/plugins/kanban/boards"] = [
+            "boards": [
+                ["slug": "alpha", "name": "Alpha", "is_current": true],
+                ["slug": "beta", "name": "Beta", "is_current": false],
+            ],
+            "current": "alpha",
+        ]
+        requester.boardProvider = { _ in V3AMockRequester.staticBoard(task: nil) }
+        requester.blockedBoardFetches = [2]
+        requester.responsesByPath["/api/plugins/kanban/profiles/coder/describe-auto"] = [
+            "ok": true, "profile": "coder", "reason": "", "description": "Generated",
+        ]
+        let store = makeStore(requester: requester)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected a loaded context") }
+
+        let navigation = Task { await store.selectBoard(slug: "beta") }
+        await requester.waitUntilBoardFetchParked()
+
+        let outcome = try await store.autoDescribeProfile(profile: "coder", overwrite: true, expectedContext: stampA)
+        XCTAssertTrue(outcome.ok)
+        XCTAssertNil(store.mutationErrorMessage)
+        XCTAssertEqual(
+            requester.calls.filter { $0.method == "POST" && $0.path.contains("/profiles/coder/describe-auto") }.count,
+            1,
+            "describe-auto still occurs exactly once"
+        )
+
+        requester.releaseBoardFetches()
+        await navigation.value
+        XCTAssertEqual(store.loadedBoardSlug, "beta")
+    }
+
+    func testBoardScopedSpecifyFailsClosedDuringInFlightBoardTransition() async {
+        // S-1 negative branch: BOARD-scoped mutations must keep the
+        // fail-closed invariant during a PARKED (not failed) transition -
+        // selected beta, loaded alpha, snapshot not actionable.
+        let t1 = makeTask(id: "t1", status: "triage")
+        let requester = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha", task: t1))
+        requester.responsesByPath["/api/plugins/kanban/boards"] = [
+            "boards": [
+                ["slug": "alpha", "name": "Alpha", "is_current": true],
+                ["slug": "beta", "name": "Beta", "is_current": false],
+            ],
+            "current": "alpha",
+        ]
+        requester.boardProvider = { fetch in
+            V3AMockRequester.staticBoard(task: fetch >= 2 ? nil : t1)
+        }
+        requester.blockedBoardFetches = [2]
+        let store = makeStore(requester: requester)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected a loaded context") }
+
+        let navigation = Task { await store.selectBoard(slug: "beta") }
+        await requester.waitUntilBoardFetchParked()
+        XCTAssertFalse(store.isSelectedSnapshotLoaded)
+
+        do {
+            _ = try await store.specifyTask(id: "t1", expectedContext: stampA)
+            XCTFail("a board-scoped mutation must fail closed during the transition")
+        } catch KanbanServiceError.boardNavigationInProgress {
+            // expected fail-closed
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        XCTAssertFalse(requester.calls.contains { $0.path.contains("/tasks/t1/specify") }, "zero specify may fire")
+
+        requester.releaseBoardFetches()
+        await navigation.value
+        XCTAssertEqual(store.loadedBoardSlug, "beta")
+    }
+
     func testOrchestrationSaveStaleContextCannotReachServerB() async {
         let requesterA = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha"))
         let store = makeStore(requester: requesterA)
@@ -789,14 +934,17 @@ final class KanbanV3ATests: XCTestCase {
         XCTAssertEqual(liveness.token, op2, "monotonic token")
     }
 
-    func testOperationCompletionAfterReconfigureStillReleasesBusyFlag() async {
-        // Operation A starts under generation A; the server changes to B
-        // before A completes; A's completion is UI-inert for server data but
-        // the LIFETIME ownership check (liveness token) is independent of the
-        // generation, so the local busy flag is still released.
+    func testStaleCompletionStillOwnsItsLocalBusyTokenAfterReconfigure() async {
+        // The editor starts ONE operation and captures its liveness token
+        // BEFORE the simulated reconfigure - this is precisely the contract
+        // the test asserts (merge pass: the old version fabricated an
+        // unrelated fresh token and proved nothing).
+        var liveness = KanbanEditorLiveness()
+        let operationID = liveness.begin()
         let requesterA = V3AMockRequester(responsesByPath: routes(boardSlug: "alpha"))
         let store = makeStore(requester: requesterA)
         await store.reload()
+        let generationA = store.currentConfigurationGeneration
 
         requesterA.suspend(method: "POST", basePath: "/api/plugins/kanban/profiles/coder/describe-auto")
         let operation = Task { try? await store.autoDescribeProfile(profile: "coder", overwrite: true) }
@@ -807,16 +955,66 @@ final class KanbanV3ATests: XCTestCase {
         requesterA.resumeSuspended()
         _ = await operation.value
 
-        // Store-level stale-completion guarantees unchanged...
+        // Independent facts the view relies on for busy-release:
+        XCTAssertFalse(store.isCurrentConfiguration(generationA), "generation A is stale after the reconfigure")
+        XCTAssertTrue(liveness.owns(operationID), "the STALE completion still owns its local busy token, so it can release the flag")
+        // Store-level inertness of the stale completion is preserved:
         XCTAssertNil(store.mutationErrorMessage)
         XCTAssertEqual(requesterB.calls.count, 0)
-        // ...and the LIFETIME layer: the token the operation started with no
-        // longer owns the busy flag for a subsequent operation, i.e. the
-        // local flag release never depends on the server generation.
-        var liveness = KanbanEditorLiveness()
-        let opA = liveness.begin()
-        _ = liveness.begin() // a newer operation (post-reconfigure UI)
-        XCTAssertFalse(liveness.owns(opA))
+    }
+
+    // MARK: - V3A merge pass: triage completion suppression
+
+    func testTriageCompletionSuppressionSurvivesFailedRefresh() {
+        let stamp = KanbanBoardContextStamp(boardSlug: "alpha", configurationGeneration: 4)
+        let marker = CompletedTriageMutation(taskID: "t1", context: stamp)
+        // Cached detail still reports triage: suppression holds - no second
+        // request can be staged for the committed task.
+        XCTAssertTrue(KanbanTriageCompletionPolicy.isSuppressed(completed: marker, displayedTaskID: "t1", context: stamp))
+        // Task replaced.
+        XCTAssertFalse(KanbanTriageCompletionPolicy.isSuppressed(completed: marker, displayedTaskID: "t2", context: stamp))
+        // Board/server context replaced.
+        XCTAssertFalse(KanbanTriageCompletionPolicy.isSuppressed(
+            completed: marker,
+            displayedTaskID: "t1",
+            context: KanbanBoardContextStamp(boardSlug: "beta", configurationGeneration: 4)
+        ))
+        // No loaded context / no marker: never suppressed.
+        XCTAssertFalse(KanbanTriageCompletionPolicy.isSuppressed(completed: marker, displayedTaskID: "t1", context: nil))
+        XCTAssertFalse(KanbanTriageCompletionPolicy.isSuppressed(completed: nil, displayedTaskID: "t1", context: stamp))
+    }
+
+    func testTriageCompletionMarkerClearsOnlyAfterAuthoritativeReconciliation() {
+        XCTAssertTrue(KanbanTriageCompletionPolicy.shouldClearAfterReconciliation(reconciledStatus: "todo"))
+        XCTAssertTrue(KanbanTriageCompletionPolicy.shouldClearAfterReconciliation(reconciledStatus: "ready"))
+        XCTAssertTrue(KanbanTriageCompletionPolicy.shouldClearAfterReconciliation(reconciledStatus: "done"))
+        // The task still reports triage from an authoritative load: the
+        // marker KEEPS the actions suppressed until state proves otherwise.
+        XCTAssertFalse(KanbanTriageCompletionPolicy.shouldClearAfterReconciliation(reconciledStatus: "triage"))
+    }
+
+    // MARK: - V3A merge pass: nudge notice invalidation
+
+    func testNudgeNoticeClearsOnBoardChangeAndOldTimerIsInert() {
+        var state = KanbanNudgeNoticeState()
+        let alphaTimer = state.show("Dispatcher nudged")
+        XCTAssertEqual(state.notice, "Dispatcher nudged")
+
+        // Board switch alpha -> beta: feedback clears IMMEDIATELY.
+        state.invalidateOnContextChange()
+        XCTAssertNil(state.notice)
+        // The old alpha auto-hide timer firing later changes nothing.
+        state.hideIfCurrent(alphaTimer)
+        XCTAssertNil(state.notice)
+
+        // A later beta notice cannot be cleared by the old timer...
+        let betaTimer = state.show("Dispatcher nudged")
+        XCTAssertEqual(state.notice, "Dispatcher nudged")
+        state.hideIfCurrent(alphaTimer)
+        XCTAssertEqual(state.notice, "Dispatcher nudged", "the stale timer is inert for the newer notice")
+        // ...only its own (current) timer clears it.
+        state.hideIfCurrent(betaTimer)
+        XCTAssertNil(state.notice)
     }
 
     // MARK: - 9. V3A final pass: continuation-helper + nudge feedback
@@ -1146,6 +1344,27 @@ private final class V3AMockRequester: DashboardJSONRequester {
     private var suspensionWaiters: [CheckedContinuation<Void, Never>] = []
     private var parkedCount = 0
     private var parkedWaiters: [CheckedContinuation<Void, Never>] = []
+    /// Board-fetch gate (merge pass): suspends specific GET /board fetches so
+    /// a test can hold a board navigation IN FLIGHT while server-global
+    /// mutations run, then release it and observe convergence.
+    var blockedBoardFetches: [Int] = []
+    private var boardGateContinuations: [CheckedContinuation<Void, Never>] = []
+    private var boardGateWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func waitUntilBoardFetchParked() async {
+        if !boardGateContinuations.isEmpty {
+            return
+        }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            boardGateWaiters.append(continuation)
+        }
+    }
+
+    func releaseBoardFetches() {
+        let pending = boardGateContinuations
+        boardGateContinuations.removeAll()
+        pending.forEach { $0.resume() }
+    }
 
     init(responsesByPath: [String: [String: Any]] = [:]) {
         self.responsesByPath = responsesByPath
@@ -1216,6 +1435,13 @@ private final class V3AMockRequester: DashboardJSONRequester {
         if let error = errorsByPath[path] ?? errorsByPath[basePath] { throw error }
         if method == "GET", basePath == "/api/plugins/kanban/board" {
             boardFetches += 1
+            if blockedBoardFetches.contains(boardFetches) {
+                boardGateWaiters.forEach { $0.resume() }
+                boardGateWaiters.removeAll()
+                await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                    boardGateContinuations.append(continuation)
+                }
+            }
             return try boardProvider(boardFetches)
         }
         if method == "GET", basePath == "/api/plugins/kanban/profiles" {

--- a/docs/KANBAN_LIFECYCLE_MATRIX.md
+++ b/docs/KANBAN_LIFECYCLE_MATRIX.md
@@ -1,0 +1,20 @@
+# Kanban Lifecycle / Status Matrix — V3A (audit-verified 2026-08-23)
+
+Audited upstream: NousResearch/hermes-agent @ fd760435c (2026-08-22). Evidence: kanban_db.py VALID_STATUSES:102,
+ui.tsx LOCKED_COLUMNS:51, board.tsx:317, plugin_api.py PATCH /tasks/:869-972, POST /tasks:623.
+
+| Status | User create target? | Manual move target? | Backend/system transition? | Desktop behavior | Conduit V3A behavior |
+|---|---|---|---|---|---|
+| triage | YES (via triage flag) | YES (PATCH _set_status_direct) | specifier/decomposer flip triage→todo | creatable; specifier target | create OK; move OK; Specify/Decompose eligible |
+| todo | YES (landing when parents open) | YES | recompute_ready promotes todo→ready | creatable | create/move OK |
+| scheduled | NO | NO (desktop locks; PATCH works only from todo/ready/running/blocked via schedule_task — park semantics, not a plain target) | cron/automation parks; unblock_task exits | LOCKED_COLUMNS | visible; locked; never offered |
+| ready | YES (default landing when parent-free) | YES | dispatcher claims ready→running | creatable / claim target | create/move OK |
+| running | NO | NO — PATCH → HTTP 400 hard lock | worker/dispatcher owned | LOCKED_COLUMNS | visible; locked; claim/reclaim paths only |
+| blocked | YES (create + PATCH block_task) | YES | dispatcher may unblock when parents done; sticky worker blocks stay | manual + worker transitions | create/move OK |
+| review | NO | NO (request_review path only — parents+claim gated; not a generic move target) | claim/review dispatcher path | LOCKED_COLUMNS | visible; locked |
+| done | YES | YES (PATCH complete_task) | worker completes | manual + worker | create/move OK |
+| archived | NO create | YES (PATCH archive_task) | archive releases parents (recompute_ready) | archive action | archive action/move OK |
+| unknown | NO | NO | treated system/backend-controlled | fallback render | render-only fallback |
+
+Differences from Conduit V2 policy: NONE. LOCKED_COLUMNS unchanged; no creation/move contract change; scheduled's REST path no longer
+requires a wake time but Desktop still refuses it as a target, so the user-facing policy is unchanged (documented, no regression needed).

--- a/docs/KANBAN_V3A_AUDIT.md
+++ b/docs/KANBAN_V3A_AUDIT.md
@@ -1,0 +1,90 @@
+# Kanban V3A — Upstream Audit (authoritative contract basis)
+
+- Upstream repo: NousResearch/hermes-agent (clone: C:\Users\Micro\AppData\Local\Temp\hermes-agent-upstream)
+- Audited revision: **fd760435c6688a2b6c6b7436dde30e267237baef** ("test(bedrock): make the botocore stub windows airtight — kills the vendored-import flake")
+- Commit date: 2026-08-22 19:30:10 -0700
+- Audit date: 2026-08-23 (session)
+- Sources: plugins/kanban/dashboard/plugin_api.py, hermes_cli/kanban_db.py, hermes_cli/kanban_specify.py,
+  hermes_cli/kanban_decompose.py, apps/desktop/src/plugins/kanban/{api.ts,types.ts,orchestration.tsx,ui.tsx,board.tsx,drawer.tsx}
+- Backend behavior is authoritative for correctness; Desktop is authoritative for product semantics where the backend permits several.
+
+## 1. Lifecycle / status contract (VS the V2-era assumptions)
+- VALID_STATUSES (kanban_db.py:102): triage, todo, scheduled, ready, running, blocked, review, done, archived — unchanged.
+- Desktop LOCKED_COLUMNS (ui.tsx:51): ['review', 'running', 'scheduled'] — UNCHANGED.
+- Move menu filter (board.tsx:317): .filter(name => name !== task.status && !isLockedTarget(name)) — locked lanes are never offered;
+  drag into a locked lane shows a lockedReason toast (board.tsx:1242-1243).
+- PATCH /tasks/{id} status handling (plugin_api.py:869-972):
+  - done → complete_task; blocked → block_task; review → request_review (force=True for dashboard human actions; still gated on parents/claims);
+    ready → unblock/_reopen_if_review/_set_status_direct; archived → archive_task; todo/triage → _set_status_direct (TRIAGE IS a legal PATCH destination);
+  - scheduled → schedule_task (valid only FROM todo/ready/running/blocked — kanban_db.py:7915-7957); no wake-time argument exists in the current REST path;
+    desktop still refuses to offer it (LOCKED_COLUMNS).
+  - running → HTTP 400 "Cannot set status to 'running' directly; use the dispatcher/claim path" — still hard-locked;
+    unknown status → 400; invalid transition → 409.
+- Create (POST /tasks, plugin_api.py:623): no status field; kanban_db.create_task (3158+) → triage=True forces 'triage', else 'ready' when no
+  open parents else 'todo' (VALID_INITIAL_STATUSES exists only for internal caller; not reachable from REST).
+- Conduit V2 policy conclusion: NO policy change required. review/running/scheduled remain system-owned manual destinations in Desktop
+  (LOCKED_COLUMNS unchanged); backend 'scheduled' still sits behind schedule_task (park semantics, not the old wake-time story, but still
+  not offered by Desktop and still not a plain drag target). triage/todo/ready/blocked/done/archived remain manual move targets;
+  creation targets unchanged. Conduit's existing KanbanStatusPresentation matrix is preserved verbatim.
+
+## 2. Orchestration settings
+- GET /orchestration (plugin_api.py:2778-2818) → {
+    orchestrator_profile: "", default_assignee: "", auto_decompose: bool (default True),
+    auto_promote_children: bool (default True),
+    resolved_orchestrator_profile: str, resolved_default_assignee: str, active_profile: str }
+  Unset config = "" (empty string). Resolved fills in active default profile when unset/unknown.
+- PUT /orchestration (2821-2889), body OrchestrationSettingsBody {orchestrator_profile?: str, default_assignee?: str,
+  auto_decompose?: bool, auto_promote_children?: bool}. Only present fields are written. "" clears the override (falls back to default).
+  Unknown profile name → HTTP 400. Response = GET shape (resolved echo). Server-global (NO board query param). Not dispatcher-nudged.
+- Desktop picker (orchestration.tsx): value || '__default__' sentinel; onSave('__default__' → ''). So "Default" ⇔ "" empty string on the wire.
+  No Conduit-specific encoding needed.
+
+## 3. Profile routing descriptions
+- GET /profiles (2628-2655) → {profiles:[{name, is_default, model, provider, description, description_auto, skill_count}]} — matches Conduit KanbanProfile.
+- PATCH /profiles/{name} (2658-2688), body {description: str} → stores description (trimmed; "" clears) with description_auto=FALSE (user-authored).
+  Response {ok, profile, description}. Not nudged. Unknown profile → 404. normalize_profile_name: "default" is valid.
+- POST /profiles/{name}/describe-auto (2691-2716), body {overwrite: bool} → LLM-generated; PERSISTS immediately with description_auto=TRUE.
+  Response {ok, profile, reason, description}. Non-ok is NOT an HTTP error (e.g. "no auxiliary client configured") — render reason inline.
+  Desktop sends overwrite:true and replaces its local draft from result.description + refetches (orchestration.tsx auto onSuccess).
+- Conduit addition required by the task (desktop has no guard): generating must NOT silently overwrite an unsaved manual draft → dirty-state ownership.
+
+## 4. Dispatcher nudge (manual)
+- POST /dispatch?board=<slug> body {} (plugin_api.py:2281-2299) → DispatchResult asdict {spawned: list[(id, assignee, workspace)], ...}.
+  Desktop nudgeDispatcher ignores the body except {spawned?: unknown[]}; failures are non-events (nudged() .catch). Conduit: unobtrusive
+  "Dispatcher nudged" only; no fabricated diagnostics. Board-scoped. Auto-nudge is debounced 400 ms (api.ts autoNudge) after task writes.
+
+## 5. Specify
+- POST /tasks/{task_id}/specify?board=<slug>, body SpecifyBody {author?: str} (plugin_api.py:1800-1841).
+- Valid input: ONLY status == 'triage' (kanban_specify.py:159-162) → else outcome ok:false "task is not in triage (status=...)"; unknown id → "unknown task id".
+- Behavior: aux LLM {title, body}; lenient JSON parse (fallback: whole reply as body, title untouched); specify_triage_task (kanban_db.py:7189-7277)
+  updates title/body/assignee when provided and flips status triage → todo in one write txn; audit comment only when fields actually changed;
+  'specified' event; recompute_ready() afterwards (parent-free tasks → ready immediately).
+- Response: {ok, task_id, reason, new_title} — HTTP 200 EVEN when ok:false ("A non-OK outcome is NOT an HTTP error — the UI renders the
+  reason inline"). Semantic failure MUST be inspected by the client.
+- Resulting status: todo (then possibly ready via recompute_ready). Dependencies/metadata unchanged. Author recorded on comment.
+
+## 6. Decompose
+- POST /tasks/{task_id}/decompose?board=<slug>, body DecomposeBody {author?: str} (plugin_api.py:2727-2763).
+- Valid input: ONLY status == 'triage' (kanban_decompose.py:288-291; same ok:false reason shape); unknown id likewise.
+- LLM returns fanout:true + tasks[{title, body, assignee, parents(indices)}] OR fanout:false (single-task tighten == specify + optional assignee).
+- fanout:false → specify_triage_task with assignee only when task.assignee is empty; outcome ok, fanout=false, new_title.
+- fanout:true → decompose_triage_task (kanban_db.py:7280-7510), single write txn: creates children (status 'todo', tenant + workspace
+  inherited from root, per-child overrides; children NEVER assignee=None — invalid picks rewritten to default_assignee); sibling dependency
+  edges per parents indices; root task becomes child of every child (root wakes when all children done); root flips triage → todo and is
+  assigned the ORCHESTRATOR profile; audit comment "Decomposed into <ids>..."; 'decomposed' event {child_ids, root_assignee};
+  cycle check (Kahn) → ValueError → outcome ok:false "DB rejected graph: ...". auto_promote (config auto_promote_children, default True)
+  → recompute_ready() promotes parent-free children to 'ready'; when False children stay 'todo' (manual-review-first workflows).
+- Response: {ok, task_id, reason, fanout, child_ids: [], new_title} — HTTP 200 even when ok:false.
+- Root task is NOT deleted; it remains the orchestration/root task. Response is NOT a full board snapshot (ids only — do NOT synthesize
+  child cards; reload authoritative board + task instead).
+- Failure reasons observed: unknown task id / not in triage / auxiliary client unavailable / LLM error / malformed JSON /
+  fanout=true with empty tasks / tasks[i].title missing / DB rejected graph / task moved out of triage before decomposition.
+- Non-ok reasons are stable product semantics → display verbatim.
+
+## 7. Desktop triage actions
+- Desktop exposes NO Specify/Decompose task actions (grep of board/drawer/orchestration/plugin: none). Endpoints serve the CLI and the
+  gateway auto-decompose path. Conduit's Triage Actions are a mobile-native operational addition following the backend contract exactly
+  (triage-only gating, {ok, reason} result semantics, no HTTP-error conflation).
+
+## 8. Conduit file:line evidence
+- Clerked above per claim (plugin_api.py / kanban_db.py / kanban_specify.py / kanban_decompose.py / api.ts / orchestration.tsx / ui.tsx / board.tsx line refs).

--- a/docs/KANBAN_V3A_AUDIT.md
+++ b/docs/KANBAN_V3A_AUDIT.md
@@ -1,6 +1,6 @@
 # Kanban V3A — Upstream Audit (authoritative contract basis)
 
-- Upstream repo: NousResearch/hermes-agent (clone: C:\Users\Micro\AppData\Local\Temp\hermes-agent-upstream)
+- Upstream repo: https://github.com/NousResearch/hermes-agent (clone at any revision >= the audited commit and diff against it)
 - Audited revision: **fd760435c6688a2b6c6b7436dde30e267237baef** ("test(bedrock): make the botocore stub windows airtight — kills the vendored-import flake")
 - Commit date: 2026-08-22 19:30:10 -0700
 - Audit date: 2026-08-23 (session)

--- a/docs/KANBAN_V3_PLAN.md
+++ b/docs/KANBAN_V3_PLAN.md
@@ -1,0 +1,79 @@
+# Hermes Conduit — Kanban V3 Plan (V3A implemented here; V3B–V3D scoped)
+
+Status: V3A implementation in progress. Written 2026-08-23.
+
+## Repo / branch facts
+- Repo: kaishi00/hermes-conduit (origin: https://github.com/kaishi00/hermes-conduit.git)
+- Worktree: C:\Users\Micro\OneDrive\Documents\hermes-conduit-kanban-v3a
+- Branch: feature/kanban-v3a-orchestration-triage (tracks origin/main)
+- Base commit: 10719f4 — "Merge pull request #93 from kaishi00/feature/kanban-v2" (V2 merged; upstream iOS baseline)
+- iOS test target: remote Mac ios-mac, /Users/agrias/projects/hermes-conduit-swiftui, scheme Conduit, prepare 'xcodegen generate' (.ios-test.json at repo root)
+- project.yml picks up Conduit/** and ConduitTests/** automatically (XcodeGen). Never edit Conduit.xcodeproj.
+
+## Keep-out list (do NOT modify)
+- Conduit/Services/HermesClient.swift, chat/session WebSocket transport, reconnect logic, session restoration, prompt submission, streaming, message handling, viewport restoration.
+- Conduit/Models/KanbanStatus.swift status policy UNLESS the current upstream audit proves the contract changed (then isolate + regress-test the change).
+- V1/V2 invariants: DashboardTicketBridge-only Kanban networking; dedicated KanbanService; KanbanStore mutation ownership (KanbanOperationContext, configurationGeneration, performMutation, loadedBoardSlug, loadedContextStamp); concrete board slug pinning; stale-board non-actionability; shared cross-profile semantics (no ?profile= fabrication); post-mutation superseding reconciliation; dirty task drafts; dependency/model-editor identity isolation; context-bound destructive confirmation; polling fallback; lane-chip + vertical-card layout.
+
+## Session playbook (how to continue if interrupted)
+1. Read this file.
+2. git -C worktree status (expect: uncommitted V3A work on branch feature/kanban-v3a-orchestration-triage).
+3. Read C:\Users\Micro\AppData\Local\Temp\kanban-v3a-audit\REPORT.md (upstream audit; clone path + SHA inside).
+4. Finish open todos: implement service/store/views/tests -> xcodegen sync to Mac -> ios_test {} full -> multi-model review (workflows/multi-model-review.js) -> fix blockers -> push + PR -> final 17-item report.
+5. AGENTS.md review gate applies BEFORE pushing to any PR.
+
+## V3A scope (this branch)
+- Re-audit lifecycle/status semantics vs V2 (matrix in report).
+- Orchestration settings: read + update (auto_decompose, orchestrator_profile, default_assignee, auto_promote_children if present). Model configured vs resolved (resolved_* fields already decoded in KanbanOrchestrationSettings).
+- Profile routing descriptions: list, edit (manual save), generate automatically; description_auto flag already decoded in KanbanProfile; dirty-draft protection; 'Automatically generated — review recommended' state if upstream stages generation.
+- Nudge Dispatcher: lightweight board menu action (existing debounced POST /dispatch machinery extended for manual nudges; keep fire-and-forget but return unobtrusive 'Dispatcher nudged').
+- Triage: Specify + Decompose as Task Detail 'Triage Actions' section, only when eligible (status == 'triage' per upstream audit; verify exact gate).
+- Ownership discipline for every new mutation (freeze context pre-suspension; generation-guarded completions; post-mutation superseding board/detail reload).
+- Error taxonomy: HTTP/network vs semantic {ok:false, reason} vs stale completion vs success-with-failed-refresh.
+- Tests: lifecycle, orchestration read/update/defaults encoding, profiles (save/generate/dirty/stale), dispatcher (context, no-request-after-ownership-loss), specify (success/semantic-fail/network-fail/invalid-state/stale), decompose (success/semantic-fail/confirmation/reload/partial refresh failure/navigation race). No sleeps.
+- Preserve entire existing suite; run full ios_test.
+
+## Planned file layout (V3A)
+- Conduit/Models/KanbanModels.swift: extend with orchestrations-patch/profile-description/(specify+decompose response) model types; tolerant decode; Codable wire fidelity from audit.
+- Conduit/Services/KanbanService.swift: fetchProfileDescriptions (profiles already fetched), updateProfileDescription(profile:description:), generateProfileDescription(profile:), updateOrchestration(_ patch:), specifyTask(id:board:), decomposeTask(id:board:), manual nudge (or reuse scheduleDispatcherNudge with immediate-post variant); all behind DashboardJSONRequester; no HermesClient.
+- Conduit/Services/KanbanStore.swift: store mutations mirrored on existing performMutation discipline; new published state for profile descriptions if needed (profiles already published); orchestration update; specify/decompose completion reconciliation (superseding reload of board+detail).
+- Conduit/Views/KanbanViews.swift: board header gains an ellipsis '…' menu (Orchestration Settings…, Profiles routing list, Nudge Dispatcher). Keep header uncrowded.
+- Conduit/Views/Kanban/KanbanOrchestrationSettingsSheet.swift (new): toggles + profile pickers; render 'Default (resolved)' clearly for configured-vs-resolved.
+- Conduit/Views/Kanban/KanbanProfileRoutingScreen.swift (new): list + editor with multiline TextEditor, Save, Generate Automatically, generated-review banner, dirty ownership.
+- Conduit/Views/Kanban/KanbanTaskDetailView.swift: 'Triage Actions' section gated on eligibility; Specify button; Decompose button + confirmationDialog ("Decompose this task?" with wording); semantic failure shown inline; success -> authoritative reload.
+- ConduitTests/KanbanV3ATests.swift (new): policy + store-level deterministic tests with ContextRaceMockRequester-style mock (define locally in the test file).
+
+## V3A completion checklist (from task)
+[ ] upstream lifecycle semantics re-audited (SHA + date recorded)
+[ ] orchestration settings readable/editable
+[ ] configured vs resolved defaults represented correctly
+[ ] profile routing descriptions editable
+[ ] auto-description generation works (upstream semantics)
+[ ] dispatcher nudged manually
+[ ] eligible Triage tasks expose Specify
+[ ] eligible Triage tasks expose Decompose
+[ ] semantic failures distinguished from HTTP success
+[ ] Decompose requires confirmation
+[ ] successful actions reconcile from authoritative REST state
+[ ] every new mutation board/server/task ownership-safe
+[ ] V1/V2 mutation protections intact
+[ ] full ios_test passes
+
+## V3B (NEXT phase, do not implement here) — Board Administration + Board Views
+- New Board / Edit Board / Archive Board (service methods createBoard/updateBoard already exist read-side; add store+UI), project & default_workdir editing.
+- assignee filter, tenant filter (board payload already carries tenants/assignees arrays), Show Archived integration (include_archived exists), Group Running by Profile.
+- Use actual upstream create/update/archive semantics; preserve per-dashboard board-selection persistence (scopedBoardKey).
+- Own branch + PR + focused tests + full ios_test.
+
+## V3C (later) — Bulk Operations
+- Temporary mobile selection mode; bulk Move/Assign/Priority/Archive/Delete; UX like "Cancel | 3 Selected ... [Move] [Assign] [More…]".
+- Bulk APIs may return per-task failures; NOT globally transactional unless upstream is; UI shows '2 tasks updated / 1 task failed / Task C <reason>'.
+- Own branch + PR + tests + ios_test.
+
+## V3D (later) — Live Events
+- board-scoped /events WebSocket; architecture: upstream event -> debounce/coalesce -> invalidate relevant state -> authoritative REST refetch; event payload NEVER canonical board state; keep polling fallback; slow safety poll while healthy.
+- Independent review (new long-lived connection, new reconnect/context ownership concerns); do NOT reuse chat/session WebSocket transport.
+- Own branch + PR + tests + ios_test.
+
+## Final V3A report (17 items)
+1 starting Conduit commit (10719f4) 2 upstream SHA+audit date 3 lifecycle matrix + V2 diffs 4 endpoints/contracts audited 5 orchestration settings implemented 6 default/inheritance semantics 7 profile description editing/generation 8 nudge behavior 9 Specify behavior 10 Decompose behavior 11 semantic failure handling 12 concurrency/context ownership 13 files changed 14 tests added 15 exact full ios_test count 16 confirmation HermesClient/session transport untouched 17 V3B/V3C/V3D scope.

--- a/docs/KANBAN_V3_PLAN.md
+++ b/docs/KANBAN_V3_PLAN.md
@@ -4,10 +4,9 @@ Status: V3A implementation in progress. Written 2026-08-23.
 
 ## Repo / branch facts
 - Repo: kaishi00/hermes-conduit (origin: https://github.com/kaishi00/hermes-conduit.git)
-- Worktree: C:\Users\Micro\OneDrive\Documents\hermes-conduit-kanban-v3a
-- Branch: feature/kanban-v3a-orchestration-triage (tracks origin/main)
+- Branch: feature/kanban-v3a-orchestration-triage (tracking origin/main; PR #94)
 - Base commit: 10719f4 — "Merge pull request #93 from kaishi00/feature/kanban-v2" (V2 merged; upstream iOS baseline)
-- iOS test target: remote Mac ios-mac, /Users/agrias/projects/hermes-conduit-swiftui, scheme Conduit, prepare 'xcodegen generate' (.ios-test.json at repo root)
+- iOS test target: the Harness ios_test tool against this repo (scheme Conduit, prepare 'xcodegen generate'; see .ios-test.json at the repo root)
 - project.yml picks up Conduit/** and ConduitTests/** automatically (XcodeGen). Never edit Conduit.xcodeproj.
 
 ## Keep-out list (do NOT modify)
@@ -17,9 +16,9 @@ Status: V3A implementation in progress. Written 2026-08-23.
 
 ## Session playbook (how to continue if interrupted)
 1. Read this file.
-2. git -C worktree status (expect: uncommitted V3A work on branch feature/kanban-v3a-orchestration-triage).
-3. Read C:\Users\Micro\AppData\Local\Temp\kanban-v3a-audit\REPORT.md (upstream audit; clone path + SHA inside).
-4. Finish open todos: implement service/store/views/tests -> xcodegen sync to Mac -> ios_test {} full -> multi-model review (workflows/multi-model-review.js) -> fix blockers -> push + PR -> final 17-item report.
+2. git status in the phase worktree (expect: branch feature/kanban-v3a-orchestration-triage).
+3. Upstream audit: docs/KANBAN_V3A_AUDIT.md (upstream commit SHA recorded; re-verify if the upstream head moved).
+4. Finish open todos: implement service/store/views/tests -> run the Harness ios_test tool (full) -> multi-model review (workflows/multi-model-review.js) -> fix findings -> push + PR -> final 17-item report.
 5. AGENTS.md review gate applies BEFORE pushing to any PR.
 
 ## V3A scope (this branch)

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -10,12 +10,16 @@
 # Contract:
 #   - Runs the full suite up to 2 times. Exit 0 = some attempt passed.
 #     Exit 1 = every attempt failed or timed out.
-#   - Each attempt gets ATTEMPT_TIMEOUT_SECS (default 960 = 16 min; healthy
-#     runs finish in 7-13 min). Sized so the worst case — setup + a killed
-#     attempt 1 + simulator reboots (bootstatus is bounded at 180s each) + a
-#     full attempt 2 — stays under the 45-minute job timeout. A timed-out
-#     attempt is killed by process group and its status flows through the
-#     retry loop exactly like a test failure.
+#   - Each attempt gets ATTEMPT_TIMEOUT_SECS (default 1200 = 20 min; healthy
+#     runs finish in 7-13 min). The 20-minute value is a temporary cold-run
+#     ceiling intended to prevent healthy-but-slow first attempts from being
+#     killed at 16 minutes and forcing an expensive simulator erase/retry. The
+#     workflow's 45-minute job timeout remains the ultimate bound, so in the
+#     pathological case a second full-length attempt may not receive its entire
+#     nominal 20-minute budget. The intent is: prefer one 17-20 minute
+#     successful cold attempt over killing it at 16 minutes + erase/reboot +
+#     warm retry. A timed-out attempt is killed by process group and its status
+#     flows through the retry loop exactly like a test failure.
 #   - The simulator is explicitly booted (shutdown → boot → bootstatus) before
 #     EVERY attempt, including the first.
 #   - After a TIMED-OUT attempt the retry erases the dedicated simulator before
@@ -29,7 +33,7 @@
 # Required env:
 #   SIMULATOR            UDID of the iOS simulator to test against.
 # Optional env:
-#   ATTEMPT_TIMEOUT_SECS per-attempt budget in seconds (default 960).
+#   ATTEMPT_TIMEOUT_SECS per-attempt budget in seconds (default 1200).
 #   ATTEMPTS             max attempts (default 2).
 #
 # Bash 3.2 compatible (GitHub macOS runners default to /bin/bash).
@@ -37,7 +41,10 @@
 set -uo pipefail
 
 SIMULATOR="${SIMULATOR:-}"
-ATTEMPT_TIMEOUT_SECS="${ATTEMPT_TIMEOUT_SECS:-960}"
+# TEMPORARY ceiling (Kanban V3 merge): raise/revert via this default.
+# TODO(kanban-v3): revert to 960 once the cold-run page-ceiling work
+# (see header comment) is no longer needed.
+ATTEMPT_TIMEOUT_SECS="${ATTEMPT_TIMEOUT_SECS:-1200}"
 ATTEMPTS="${ATTEMPTS:-2}"
 
 if [ -z "$SIMULATOR" ]; then


### PR DESCRIPTION
## V3A — Orchestration + Triage (Kanban V3, phase A)

Implements phase 1 of the Kanban V3 roadmap: making the board administrable and operational from Conduit, while preserving native mobile interaction and every V1/V2 correctness invariant.

### Upstream audit (source of truth)
- Reviewed NousResearch/hermes-agent at **fd760435c** (2026-08-22) — backend plugin_api.py/kanban_db.py/kanban_specify.py/kanban_decompose.py + Desktop apps/desktop/src/plugins/kanban.
- Lifecycle re-audit: LOCKED_COLUMNS = review/running/scheduled **unchanged**; PATCH-400 running, request_review/schedule_task gating unchanged; triage/todo/ready/blocked/done/archived remain manual move targets => **Conduit V2 status policy kept intact, no regression** (docs/KANBAN_LIFECYCLE_MATRIX.md).
- Full contract notes in docs/KANBAN_V3A_AUDIT.md; plan incl. V3B/V3C/V3D in docs/KANBAN_V3_PLAN.md.

### What ships
- **Orchestration settings** (GET/PUT /orchestration): Auto Decompose, Auto Promote Children, Orchestrator Profile + Default Assignee pickers; wire-faithful "" = Default (no Conduit sentinel); configured vs resolved shown honestly (Default (coder)); only changed fields PUT.
- **Profile routing descriptions** (PATCH /profiles/{name}, POST /profiles/{name}/describe-auto): editor with Save + Generate Automatically, generated flag (description_auto) surfaced as „Automatically generated — review recommended“, and a dirty-draft guard — generation never silently overwrites an unsaved manual draft.
- **Nudge Dispatcher**: lightweight board-menu action; unobtrusive „Dispatcher nudged“; no fabricated diagnostics.
- **Triage actions** (Task Detail, only for status == triage): Specify Task and confirmation-gated Decompose Into Tasks with the upstream wording; ok:false-on-HTTP-200 semantic refusals surfaced verbatim with the task left intact; success reconciles from authoritative REST reloads — child cards are never synthesized.
- **Ownership**: every new mutation reuses the V1/V2 context discipline (capture before suspension, generation-guarded completions, post-mutation superseding reload, no request after ownership loss). View-local completions now prove ownership via store.currentConfigurationGeneration (fixes the review-raised tautological guard).
- **Error taxonomy**: network vs semantic actionDeclined vs stale completion vs success-with-failed-refresh („…, but the board could not be refreshed. …“).

### Testing
- New ConduitTests/KanbanV3ATests.swift (29 cases): lifecycle audit, orchestration wire/defaults, profiles save/generate/dirty/stale, nudge context safety, specify/decompose success + semantic failure + ownership races + partial success. Deterministic (continuation-handshake mock, no sleeps).
- Full ios_test on the branch: **61/61 suites, 1139 test cases, 0 failed/skipped**.
- Kept out per scope: HermesClient and chat/session WebSocket transport untouched (diff contains no such files).

### Review gate
- Local multi-model review (deepseek-v4-flash / step-3.7-flash / mimo-v2.5): first pass REQUEST CHANGES -> 3 WARNINGs (tautological view staleness guard, dead partial-success wording, sheet seeding trap) all fixed; re-review of the fix-delta: **unanimous APPROVE**, W-1..W-3 verified FIXED at call sites, no blockers.

### Roadmap
V3A stops here. V3B (board administration + filters), V3C (bulk ops), V3D (/events live sync) are planned but intentionally not in this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kanban orchestration settings for decomposition, child promotion, profiles, and default assignees.
  * Added profile routing description editing and automatic description generation.
  * Added task Specify and Decompose actions with confirmations, progress, and feedback.
  * Added board administration actions, including dispatcher nudging.

* **Bug Fixes**
  * Improved handling of backend refusals, stale operations, refreshes, and navigation changes.
  * Prevented outdated actions or completions from affecting newer tasks, boards, or edits.
  * Improved feedback handling when switching servers or boards.

* **Documentation**
  * Added Kanban lifecycle, audit, and implementation planning documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Final correctness pass (commit d260786, review-driven)
- Mutation identity frozen synchronously at the tap for every V3A mutation (Specify/Decompose via PendingTriageAction {taskID, board/server stamp}; orchestration/profile saves and generation freeze profile/patch/stamp/generation/busy in the button action).
- KanbanStore validates each captured stamp back-to-back with operation-context capture before the first suspension; server-global endpoints (orchestration, profiles) validate on the configuration generation so a same-server board switch never aborts a valid save, while a server reconfigure fails closed with zero requests.
- Decompose confirmation is staged BY VALUE (task+stamp through the presenting-data confirmationDialog); confirming an action staged for A can never act on B.
- Profile Save/Generate preserve edits made after submission (submitted value frozen; newer typing kept raw and dirty; non-destructive notice for generation); orchestration controls are disabled while saving.
- Busy flags release via a local monotonic liveness token, independent of server generations (stale completions are data-inert but still release); admin sheets dismiss when the server identity key changes.
- Stale Nudge success shows no feedback on a different server/board (KanbanNudgePolicy).
- Test harness: waitForSuspension no longer destroys the parked continuation; park-before-waiter order is deterministically covered.
- 16 deterministic regression tests added (no sleeps); docs machine paths removed.

## Merge pass (commit e5ae353)
- Server-global mutations (orchestration settings, profile save, describe-auto) now run through MutationScope .server: generation-validated and immune to same-server board transitions; the superseding reload converges onto the currently selected board. Board-scoped operations keep the exact isSelectedSnapshotLoaded fail-closed invariant.
- Successful Specify/Decompose records a CompletedTriageMutation before the refresh attempt: the Triage Actions stay suppressed across a failed authoritative refresh (cached triage must never re-expose the actions), and the marker clears only on authoritative non-triage reconciliation or identity/context replacement.
- Nudge feedback runs through a token-guarded KanbanNudgeNoticeState: a board or server change clears the visible notice immediately and makes old auto-hide timers inert.
- Liveness/reconfigure regression test now captures its token before the reconfigure and asserts both facts independently.
- CI: ATTEMPT_TIMEOUT_SECS default 960 -> 1200 (temporary cold-run ceiling; documented in script + workflow comments; outer 45-minute job timeout unchanged).
- +7 deterministic regression tests (no sleeps).