### PR TITLE
feat(kanban): V3B — board administration, filters, Running grouped by profile

### DIFF
--- a/Conduit/Models/KanbanModels.swift
+++ b/Conduit/Models/KanbanModels.swift
@@ -365,11 +365,17 @@ struct KanbanBoardMetadata: Codable, Identifiable, Equatable {
     var defaultWorkspaceKind: String?
     var projectID: String?
     var projectName: String?
+    /// V3B: added from the audited GET /boards contract. Optional metadata is
+    /// decoded tolerantly — a missing/odd icon/color/archived field must
+    /// never make an otherwise usable board disappear.
+    var icon: String?
+    var color: String?
+    var archived: Bool?
 
     var id: String { slug }
 
     enum CodingKeys: String, CodingKey {
-        case slug, name, description
+        case slug, name, description, icon, color, archived
         case isCurrent = "is_current"
         case total
         case defaultWorkdir = "default_workdir"
@@ -389,9 +395,12 @@ struct KanbanBoardMetadata: Codable, Identifiable, Equatable {
         defaultWorkspaceKind = try? container.decodeIfPresent(String.self, forKey: .defaultWorkspaceKind)
         projectID = try? container.decodeIfPresent(String.self, forKey: .projectID)
         projectName = try? container.decodeIfPresent(String.self, forKey: .projectName)
+        icon = try? container.decodeIfPresent(String.self, forKey: .icon)
+        color = try? container.decodeIfPresent(String.self, forKey: .color)
+        archived = try? container.decodeIfPresent(Bool.self, forKey: .archived)
     }
 
-    init(slug: String, name: String? = nil, description: String? = nil, isCurrent: Bool? = nil, total: Int? = nil, defaultWorkdir: String? = nil, defaultWorkspaceKind: String? = nil, projectID: String? = nil, projectName: String? = nil) {
+    init(slug: String, name: String? = nil, description: String? = nil, isCurrent: Bool? = nil, total: Int? = nil, defaultWorkdir: String? = nil, defaultWorkspaceKind: String? = nil, projectID: String? = nil, projectName: String? = nil, icon: String? = nil, color: String? = nil, archived: Bool? = nil) {
         self.slug = slug
         self.name = name
         self.description = description
@@ -401,6 +410,9 @@ struct KanbanBoardMetadata: Codable, Identifiable, Equatable {
         self.defaultWorkspaceKind = defaultWorkspaceKind
         self.projectID = projectID
         self.projectName = projectName
+        self.icon = icon
+        self.color = color
+        self.archived = archived
     }
 }
 
@@ -1057,5 +1069,117 @@ struct KanbanAutoDescribeResponse: Codable, Equatable {
         profile = container.decodeLossyString(forKey: .profile) ?? ""
         reason = try? container.decodeIfPresent(String.self, forKey: .reason)
         description = try? container.decodeIfPresent(String.self, forKey: .description)
+    }
+}
+
+// MARK: - V3B: Board administration wire contracts
+//
+// Audited at NousResearch/hermes-agent f293e7206 (docs/KANBAN_V3B_AUDIT.md):
+// - POST /boards is IDEMPOTENT on slug collision (returns existing metadata;
+//   the response carries no created flag - Conduit never fabricates one).
+// - Tri-state PATCH: omitted = leave unchanged, "" = clear, value = set.
+// - switch is sent explicitly false; Conduit never mutates the server-wide
+//   current-board pointer (POST /boards/{slug}/switch is never called).
+
+/// POST /boards body. slug is validated upstream (lowercase alphanumeric,
+/// 1-64 chars, hyphens/underscores allowed after the first char). project_id
+/// accepts an id or slug and mirrors the project's primary repo into
+/// default_workdir unless default_workdir is passed explicitly. switch is
+/// ALWAYS false from Conduit.
+struct KanbanCreateBoardRequest: Encodable, Equatable {
+    var slug: String
+    var name: String?
+    var description: String?
+    var icon: String?
+    var color: String?
+    var defaultWorkdir: String?
+    var projectID: String?
+    /// Compile-time-enforced: Conduit NEVER asks the server to switch its
+    /// current-board pointer; selection after create is Conduit-local.
+    let switchRequested: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case slug, name, description, icon, color
+        case defaultWorkdir = "default_workdir"
+        case projectID = "project_id"
+        case switchRequested = "switch"
+    }
+
+    init(
+        slug: String,
+        name: String? = nil,
+        description: String? = nil,
+        icon: String? = nil,
+        color: String? = nil,
+        defaultWorkdir: String? = nil,
+        projectID: String? = nil,
+        switchRequested: Bool = false
+    ) {
+        self.slug = slug
+        self.name = name
+        self.description = description
+        self.icon = icon
+        self.color = color
+        self.defaultWorkdir = defaultWorkdir
+        self.projectID = projectID
+        self.switchRequested = switchRequested
+    }
+}
+
+/// PATCH /boards/{slug} body. nil = field omitted (leave unchanged);
+/// "" = clear the field (default_workdir / project_id); value = set
+/// (empty strings NEVER leak from Swift optionals as clears).
+struct KanbanUpdateBoardPatch: Encodable, Equatable {
+    var name: String?
+    var description: String?
+    var icon: String?
+    var color: String?
+    var defaultWorkdir: String?
+    var projectID: String?
+
+    enum CodingKeys: String, CodingKey {
+        case name, description, icon, color
+        case defaultWorkdir = "default_workdir"
+        case projectID = "project_id"
+    }
+
+    init(
+        name: String? = nil,
+        description: String? = nil,
+        icon: String? = nil,
+        color: String? = nil,
+        defaultWorkdir: String? = nil,
+        projectID: String? = nil
+    ) {
+        self.name = name
+        self.description = description
+        self.icon = icon
+        self.color = color
+        self.defaultWorkdir = defaultWorkdir
+        self.projectID = projectID
+    }
+
+    var isEmpty: Bool {
+        name == nil && description == nil && icon == nil && color == nil
+            && defaultWorkdir == nil && projectID == nil
+    }
+}
+
+/// DELETE /boards/{slug} result (archive default; hard-delete never sent).
+struct KanbanDeleteBoardResult: Codable, Equatable {
+    var action: String?
+    var slug: String?
+    var newPath: String?
+
+    enum CodingKeys: String, CodingKey {
+        case action, slug
+        case newPath = "new_path"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        action = try? container.decodeIfPresent(String.self, forKey: .action)
+        slug = try? container.decodeIfPresent(String.self, forKey: .slug)
+        newPath = try? container.decodeIfPresent(String.self, forKey: .newPath)
     }
 }

--- a/Conduit/Services/KanbanService.swift
+++ b/Conduit/Services/KanbanService.swift
@@ -326,37 +326,44 @@ final class KanbanService {
         pendingDispatcherNudge = nil
     }
 
-    func createBoard(slug: String, name: String, projectID: String? = nil) async throws -> KanbanBoardMetadata {
-        struct Body: Encodable {
-            let slug: String
-            let name: String
-            let projectID: String?
-            enum CodingKeys: String, CodingKey { case slug, name; case projectID = "project_id" }
-        }
+    /// POST /boards (V3B). The upstream contract is idempotent on slug
+    /// collision (create_board returns existing metadata) and validates the
+    /// slug (lowercase alnum, 1-64 chars, \-_ allowed after the first char).
+    /// switch is sent EXPLICITLY false: Conduit never mutates the server-wide
+    /// current-board pointer; selection after create is Conduit-local.
+    func createBoard(_ payload: KanbanCreateBoardRequest) async throws -> KanbanBoardMetadata {
         let response = try await request(
             path: scoped(Self.namespace + "/boards"),
             method: "POST",
-            body: try encodedDictionary(Body(slug: slug, name: name, projectID: projectID))
+            body: try encodedDictionary(payload)
         )
         return try decodeResponse(BoardEnvelope.self, from: response).board
     }
 
-    func updateBoard(slug: String, name: String?, description: String?, defaultWorkdir: String?) async throws -> KanbanBoardMetadata {
-        struct Body: Encodable {
-            let name: String?
-            let description: String?
-            let defaultWorkdir: String?
-            enum CodingKeys: String, CodingKey {
-                case name, description
-                case defaultWorkdir = "default_workdir"
-            }
-        }
+    /// PATCH /boards/{slug} (V3B). Tri-state field semantics match upstream
+    /// RenameBoardBody: omitted = leave unchanged, "" = clear (workdir /
+    /// project), value = set (workdir validated server-side). Slug immutable.
+    func updateBoard(slug: String, patch: KanbanUpdateBoardPatch) async throws -> KanbanBoardMetadata {
         let response = try await request(
             path: scoped(Self.namespace + "/boards/" + (try pathComponent(slug))),
             method: "PATCH",
-            body: try encodedDictionary(Body(name: name, description: description, defaultWorkdir: defaultWorkdir))
+            body: try encodedDictionary(patch)
         )
         return try decodeResponse(BoardEnvelope.self, from: response).board
+    }
+
+    /// DELETE /boards/{slug} WITHOUT the delete query → upstream archives the
+    /// board (moves its directory under _archived/; recoverable). The
+    /// hard-delete query option is intentionally never sent by Conduit. The
+    /// result envelope is decoded so the caller can verify the action really
+    /// was an archive.
+    func archiveBoard(slug: String) async throws -> KanbanDeleteBoardResult {
+        let response = try await request(
+            path: scoped(Self.namespace + "/boards/" + (try pathComponent(slug))),
+            method: "DELETE",
+            body: nil
+        )
+        return try decodeResponse(DeleteBoardEnvelope.self, from: response).result
     }
 
     // MARK: - Transport helpers
@@ -432,6 +439,7 @@ final class KanbanService {
 
     private struct TaskEnvelope: Decodable { let task: KanbanTask? }
     private struct BoardEnvelope: Decodable { let board: KanbanBoardMetadata }
+    private struct DeleteBoardEnvelope: Decodable { let result: KanbanDeleteBoardResult }
     private struct ProfileDescriptionBody: Encodable { let description: String }
     private struct TriageActionAuthorBody: Encodable { let author: String }
 

--- a/Conduit/Services/KanbanStore.swift
+++ b/Conduit/Services/KanbanStore.swift
@@ -672,7 +672,7 @@ final class KanbanStore: ObservableObject {
     func updateBoard(
         slug: String,
         patch: KanbanUpdateBoardPatch,
-        expectedContext: KanbanBoardContextStamp? = nil,
+        expectedContext: KanbanBoardContextStamp,
         includeArchived: Bool = false
     ) async throws -> KanbanBoardMetadata {
         guard !isMutating else {
@@ -724,7 +724,7 @@ final class KanbanStore: ObservableObject {
     @discardableResult
     func archiveBoard(
         slug: String,
-        expectedContext: KanbanBoardContextStamp? = nil,
+        expectedContext: KanbanBoardContextStamp,
         includeArchived: Bool = false
     ) async throws -> Bool {
         guard !isMutating else {
@@ -844,21 +844,21 @@ final class KanbanStore: ObservableObject {
     }
 
     /// Board-administration target binding (V3B final pass): the EXPLICIT
-    /// target board slug must equal the board slug contained in the ownership
-    /// stamp — and the stamp must still prove the currently actionable loaded
-    /// context. A stale Board Settings sheet (target slug alpha) combined
-    /// with a newly current context (stamp beta) can therefore never PATCH or
-    /// DELETE alpha during the sheet-dismiss window. Back-to-back with
-    /// makeOperationContext() on the MainActor, before any suspension.
+    /// target board slug must equal the board slug contained in the (REQUIRED)
+    /// ownership stamp — and the stamp must still prove the currently
+    /// actionable loaded context. A stale Board Settings sheet (target slug
+    /// alpha) combined with a newly current context (stamp beta) can
+    /// therefore never PATCH or DELETE alpha during the sheet-dismiss window.
+    /// The stamp is non-optional BY TYPE: a board-targeted admin mutation can
+    /// never run without ownership. Back-to-back with makeOperationContext()
+    /// on the MainActor, before any suspension.
     private func validateExpectedBoardTarget(
         slug: String,
-        expectedContext: KanbanBoardContextStamp?
+        expectedContext: KanbanBoardContextStamp
     ) throws {
         try validateExpectedContext(expectedContext)
-        if let expectedContext {
-            guard expectedContext.boardSlug == slug else {
-                throw recordMutationError(KanbanServiceError.boardNavigationInProgress)
-            }
+        guard expectedContext.boardSlug == slug else {
+            throw recordMutationError(KanbanServiceError.boardNavigationInProgress)
         }
     }
 

--- a/Conduit/Services/KanbanStore.swift
+++ b/Conduit/Services/KanbanStore.swift
@@ -626,6 +626,190 @@ final class KanbanStore: ObservableObject {
         }
     }
 
+    // MARK: - V3B: Board administration
+
+    /// POST /boards (server-scope: the write targets the server's board
+    /// registry, validated by the configuration generation). switch is never
+    /// requested, so the server-wide current-board pointer is untouched; on
+    /// success Conduit selects the returned concrete slug LOCALLY (persisted
+    /// per dashboard) and reconciles from authoritative state.
+    @discardableResult
+    func createBoard(
+        _ request: KanbanCreateBoardRequest,
+        expectedContext: KanbanBoardContextStamp? = nil,
+        includeArchived: Bool = false
+    ) async throws -> KanbanBoardMetadata {
+        guard !isMutating else {
+            throw recordMutationError(KanbanServiceError.mutationInProgress)
+        }
+        try validateExpectedServerContext(expectedContext)
+        // Defense-in-depth: the UI gates on the derived slug, but the store
+        // refuses a malformed slug before any request reaches the network.
+        guard KanbanBoardSlugPolicy.isValid(request.slug) else {
+            throw recordMutationError(KanbanServiceError.actionDeclined(
+                reason: "Invalid board slug — use 1-64 lowercase letters or numbers with hyphens/underscores."
+            ))
+        }
+        guard let context = makeOperationContext() else {
+            throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
+        }
+        return try await performMutation(context: context, includeArchived: includeArchived, scope: .server) {
+            let created = try await context.service.createBoard(request)
+            // Local selection only: never switch the server pointer.
+            if configurationGeneration == context.configurationGeneration,
+               !created.slug.isEmpty {
+                selectedBoardSlug = created.slug
+                if let persistenceKey { defaults.set(created.slug, forKey: persistenceKey) }
+            }
+            return created
+        }
+    }
+
+    /// PATCH /boards/{slug} tied to the CONCRETE board slug the settings
+    /// sheet was opened for (board-scope full-stamp validation). The network
+    /// target is the captured slug, never whatever board is selected later.
+    @discardableResult
+    func updateBoard(
+        slug: String,
+        patch: KanbanUpdateBoardPatch,
+        expectedContext: KanbanBoardContextStamp? = nil,
+        includeArchived: Bool = false
+    ) async throws -> KanbanBoardMetadata {
+        guard !isMutating else {
+            throw recordMutationError(KanbanServiceError.mutationInProgress)
+        }
+        // The captured slug is frozen by the view at stage time and never
+        // re-read; the store validates the CONTEXT stamp (a same-named board
+        // on another server can never be hit). An all-nil patch is a no-op.
+        try validateExpectedContext(expectedContext)
+        // An all-nil patch is a no-op: never waste a PATCH on it.
+        guard !patch.isEmpty else {
+            if let existing = boards.first(where: { $0.slug == slug }) {
+                return existing
+            }
+            throw recordMutationError(KanbanServiceError.invalidResponse("No board changes to save."))
+        }
+        guard let context = makeOperationContext() else {
+            throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
+        }
+        return try await performMutation(context: context, includeArchived: includeArchived) {
+            let updated = try await context.service.updateBoard(slug: slug, patch: patch)
+            // Adopt the authoritative echo while this mutation still owns the
+            // current generation; the superseding reload refreshes board
+            // metadata + content afterwards.
+            if configurationGeneration == context.configurationGeneration {
+                boards = boards.map { $0.slug == updated.slug ? updated : $0 }
+            }
+            return updated
+        }
+    }
+
+    /// DELETE /boards/{slug} (archive only - the hard-delete query is never
+    /// sent). Staged via PendingBoardArchive and revalidated at this
+    /// boundary. On success the board list is re-fetched authoritatively, the
+    /// LOCAL selection is validated against it, a disappearing selected board
+    /// falls back through the existing rules, and the board is reloaded. The
+    /// server-wide current pointer is never touched by Conduit.
+    /// Archiving the backend-immortal default board is refused up front
+    /// (remove_board raises upstream; this is defense-in-depth so the bubble
+    /// never reaches the network).
+    private func refuseDefaultBoardArchive(_ slug: String) throws {
+        guard slug != "default" else {
+            throw recordMutationError(KanbanServiceError.actionDeclined(
+                reason: "Hermes does not allow archiving the default board."
+            ))
+        }
+    }
+
+    @discardableResult
+    func archiveBoard(
+        slug: String,
+        expectedContext: KanbanBoardContextStamp? = nil,
+        includeArchived: Bool = false
+    ) async throws -> Bool {
+        guard !isMutating else {
+            throw recordMutationError(KanbanServiceError.mutationInProgress)
+        }
+        try refuseDefaultBoardArchive(slug)
+        try validateExpectedContext(expectedContext)
+        guard let context = makeOperationContext() else {
+            throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
+        }
+        let generation = context.configurationGeneration
+        // Bespoke ownership flow (review W-1..W-4): ONE owned reconciliation
+        // pass after the DELETE, so the partial-success wording survives and
+        // no second superseding reload is issued.
+        guard activeMutationGeneration == nil else {
+            throw recordMutationError(KanbanServiceError.mutationInProgress)
+        }
+        activeMutationGeneration = generation
+        isMutating = true
+        mutationErrorMessage = nil
+        do {
+            let result = try await context.service.archiveBoard(slug: slug)
+            if result.action != "archived" {
+                throw KanbanServiceError.invalidResponse(
+                    "Hermes answered the board delete with an unexpected result: " + (result.action ?? "unknown")
+                )
+            }
+            if configurationGeneration == generation {
+                let refreshFailure = await reconcileAfterBoardRemoval(generation: generation, includeArchived: includeArchived)
+                if let refreshFailure {
+                    // The archive itself succeeded - report the REFRESH
+                    // failure as partial success, never as a failed archive.
+                    errorMessage = KanbanBoardAdminMessage.archiveRefreshFailureMessage(refreshFailure)
+                }
+            }
+            endMutationOwnership(generation: generation)
+            return true
+        } catch {
+            let stillOwnsUI = configurationGeneration == generation && activeMutationGeneration == generation
+            if stillOwnsUI {
+                await reload(includeArchived: includeArchived, superseding: true)
+                mutationErrorMessage = error.localizedDescription
+            }
+            endMutationOwnership(generation: generation)
+            throw error
+        }
+    }
+
+    /// Post-archive reconciliation: refresh the authoritative board list,
+    /// drop a local selection whose slug no longer exists (persisted
+    /// per-dashboard key cleared), and converge the board onto the fallback
+    /// with ONE superseding reload.
+    ///
+    /// Returns the refresh failure detail (from the boards fetch OR the
+    /// convergence reload) while the generation is still current, so the
+    /// CALLER owns the wording: the archive itself succeeded, so any failure
+    /// here is the partial-success refresh channel.
+    @discardableResult
+    func reconcileAfterBoardRemoval(generation: Int, includeArchived: Bool) async -> String? {
+        guard configurationGeneration == generation, let service else { return nil }
+        do {
+            let response = try await service.fetchBoards()
+            guard configurationGeneration == generation else { return nil }
+            boards = response.boards
+            currentServerBoardSlug = response.current
+            if !selectedBoardSlug.isEmpty,
+               !boards.contains(where: { $0.slug == selectedBoardSlug }) {
+                selectedBoardSlug = ""
+                if let persistenceKey { defaults.removeObject(forKey: persistenceKey) }
+            }
+            errorMessage = nil
+            // Converge on the validated selection (fallback = server current).
+            await reload(includeArchived: includeArchived, superseding: true)
+            if configurationGeneration == generation, let errorMessage {
+                return errorMessage
+            }
+            return nil
+        } catch {
+            if configurationGeneration == generation {
+                return error.localizedDescription
+            }
+            return nil
+        }
+    }
+
     func clearMutationError() {
         mutationErrorMessage = nil
     }

--- a/Conduit/Services/KanbanStore.swift
+++ b/Conduit/Services/KanbanStore.swift
@@ -678,10 +678,10 @@ final class KanbanStore: ObservableObject {
         guard !isMutating else {
             throw recordMutationError(KanbanServiceError.mutationInProgress)
         }
-        // The captured slug is frozen by the view at stage time and never
-        // re-read; the store validates the CONTEXT stamp (a same-named board
-        // on another server can never be hit). An all-nil patch is a no-op.
-        try validateExpectedContext(expectedContext)
+        // The explicit target slug must equal the slug inside the shared
+        // ownership stamp (a stale sheet can never PATCH a different board
+        // during the dismissal window). An all-nil patch is a no-op.
+        try validateExpectedBoardTarget(slug: slug, expectedContext: expectedContext)
         // An all-nil patch is a no-op: never waste a PATCH on it.
         guard !patch.isEmpty else {
             if let existing = boards.first(where: { $0.slug == slug }) {
@@ -731,7 +731,10 @@ final class KanbanStore: ObservableObject {
             throw recordMutationError(KanbanServiceError.mutationInProgress)
         }
         try refuseDefaultBoardArchive(slug)
-        try validateExpectedContext(expectedContext)
+        // The staged target slug must equal the slug inside the stamp: a
+        // confirmation staged for alpha can never archive beta (or vice
+        // versa) after the context moved.
+        try validateExpectedBoardTarget(slug: slug, expectedContext: expectedContext)
         guard let context = makeOperationContext() else {
             throw recordMutationError(KanbanServiceError.invalidResponse("Kanban is not connected."))
         }
@@ -837,6 +840,25 @@ final class KanbanStore: ObservableObject {
         guard let expectedContext else { return }
         guard isSelectedSnapshotLoaded, loadedContextStamp == expectedContext else {
             throw recordMutationError(KanbanServiceError.boardNavigationInProgress)
+        }
+    }
+
+    /// Board-administration target binding (V3B final pass): the EXPLICIT
+    /// target board slug must equal the board slug contained in the ownership
+    /// stamp — and the stamp must still prove the currently actionable loaded
+    /// context. A stale Board Settings sheet (target slug alpha) combined
+    /// with a newly current context (stamp beta) can therefore never PATCH or
+    /// DELETE alpha during the sheet-dismiss window. Back-to-back with
+    /// makeOperationContext() on the MainActor, before any suspension.
+    private func validateExpectedBoardTarget(
+        slug: String,
+        expectedContext: KanbanBoardContextStamp?
+    ) throws {
+        try validateExpectedContext(expectedContext)
+        if let expectedContext {
+            guard expectedContext.boardSlug == slug else {
+                throw recordMutationError(KanbanServiceError.boardNavigationInProgress)
+            }
         }
     }
 

--- a/Conduit/Views/Kanban/KanbanBoardAdministrationSupport.swift
+++ b/Conduit/Views/Kanban/KanbanBoardAdministrationSupport.swift
@@ -118,13 +118,22 @@ enum KanbanBoardPatchPolicy {
                 }
             }
         case .none:
-            // None / Scratch: clear any existing workdir explicitly.
-            if baselineWorkdir != nil {
+            // None / Scratch: clear any existing workdir explicitly - and on
+            // a PROJECT change too, so the new project's implicit mirror is
+            // suppressed (symmetry with the .custom branch; the UI hides
+            // None while a project is selected, defense-in-depth otherwise).
+            if projectChanged || baselineWorkdir != nil {
                 patch.defaultWorkdir = ""
             }
         case .custom(let path):
             let trimmedPath = path.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmedPath != (baselineWorkdir ?? "") {
+            // A project change makes upstream IMPLICITLY mirror the new
+            // project's primary repo when default_workdir is omitted — so the
+            // explicit Custom path must travel even when its string equals
+            // the OLD baseline workdir, to override that implicit behavior.
+            // Without a project change, an unchanged custom path stays
+            // omitted (no redundant PATCH fields).
+            if projectChanged || trimmedPath != (baselineWorkdir ?? "") {
                 patch.defaultWorkdir = trimmedPath
             }
         }

--- a/Conduit/Views/Kanban/KanbanBoardAdministrationSupport.swift
+++ b/Conduit/Views/Kanban/KanbanBoardAdministrationSupport.swift
@@ -1,0 +1,308 @@
+import SwiftUI
+
+// MARK: - Board slug policy (V3B)
+
+/// Slug derivation + validation mirroring upstream exactly:
+/// - Desktop derives the slug from the board name via
+///   name.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+///   (apps/desktop board-switcher.tsx NewBoardDialog).
+/// - Backend accepts ^[a-z0-9][a-z0-9\-_]{0,63}$ after normalization
+///   (kanban_db._normalize_board_slug); malformed slugs -> HTTP 400.
+enum KanbanBoardSlugPolicy {
+    static func derivedSlug(from name: String) -> String {
+        let lowered = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        var slug = ""
+        var pendingDash = false
+        for scalar in lowered.unicodeScalars {
+            let isAlnum = (scalar.value >= 0x61 && scalar.value <= 0x7A)
+                || (scalar.value >= 0x30 && scalar.value <= 0x39)
+            if isAlnum {
+                if pendingDash, !slug.isEmpty {
+                    slug.append("-")
+                }
+                pendingDash = false
+                slug.unicodeScalars.append(scalar)
+            } else {
+                pendingDash = true
+            }
+        }
+        return slug
+    }
+
+    /// Backend-compatible (kanban_db._BOARD_SLUG_RE):
+    /// ^[a-z0-9][a-z0-9\-_]{0,63}$ - lowercase alphanumeric START, then
+    /// lowercase alphanumerics / hyphens / underscores, max 64 chars.
+    static func isValid(_ slug: String) -> Bool {
+        guard !slug.isEmpty, slug.count <= 64 else { return false }
+        let restAllowed = Set("abcdefghijklmnopqrstuvwxyz0123456789-_")
+        guard let first = slug.first, restAllowed.contains(first),
+              !(first == "-" || first == "_") else { return false }
+        for character in slug.dropFirst() {
+            guard character.isASCII, restAllowed.contains(character) else { return false }
+        }
+        return true
+    }
+}
+
+// MARK: - Board PATCH tri-state builder (V3B)
+
+/// Editor draft for Board Settings / New Board. The PATCH builder maps
+/// baseline-vs-draft to the upstream tri-state exactly:
+/// nil = omit (leave unchanged), "" = clear, value = set.
+struct KanbanBoardEditorDraft: Equatable {
+    var name: String
+    var description: String
+    /// nil = No Project ("" on the wire when clearing).
+    var projectID: String?
+    var workspace: KanbanDefaultWorkspaceChoice
+}
+
+/// How the board's default workspace is represented.
+enum KanbanDefaultWorkspaceChoice: Equatable, Hashable {
+    /// Follow the selected project's primary repo (upstream mirrors it into
+    /// default_workdir whenever project_id is sent without default_workdir).
+    case projectDefault
+    /// No workdir (scratch); "" clears the field.
+    case none
+    /// Explicit directory path.
+    case custom(String)
+}
+
+enum KanbanBoardPatchPolicy {
+    /// Primary repo path of a project, used to decide whether the board's
+    /// workdir is already "following" its project (a re-mirror no-op).
+    static func primaryPath(of projectID: String?, projects: [KanbanProject]) -> String? {
+        guard let projectID, !projectID.isEmpty else { return nil }
+        guard let project = projects.first(where: { $0.id == projectID }) else { return nil }
+        let path = (project.primaryPath ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        return path.isEmpty ? nil : path
+    }
+
+    /// PATCH built from server baseline vs submitted draft. Every wire value
+    /// is decided explicitly - a missing Swift optional can never turn into a
+    /// JSON clear, and a pure name edit never touches project/workdir.
+    static func patch(
+        baseline: KanbanBoardMetadata,
+        draft: KanbanBoardEditorDraft,
+        projects: [KanbanProject]
+    ) -> KanbanUpdateBoardPatch {
+        var patch = KanbanUpdateBoardPatch()
+        let baselineName = baseline.name ?? ""
+        let baselineDescription = baseline.description ?? ""
+        let baselineProject: String? = (baseline.projectID ?? "").isEmpty ? nil : baseline.projectID
+        let baselineWorkdir: String? = (baseline.defaultWorkdir ?? "").isEmpty ? nil : baseline.defaultWorkdir
+
+        let trimmedName = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedName != baselineName { patch.name = trimmedName }
+        if draft.description != baselineDescription { patch.description = draft.description }
+
+        let draftProject: String? = (draft.projectID ?? "").isEmpty ? nil : draft.projectID
+        let projectChanged = draftProject != baselineProject
+        if projectChanged {
+            patch.projectID = draftProject ?? ""
+        }
+
+        switch draft.workspace {
+        case .projectDefault:
+            // Project Default (only offered when a project is selected):
+            // the workdir must follow the project's primary repo.
+            // - project changed -> the project write alone re-mirrors;
+            // - project unchanged but the workdir DRIFTED from the project's
+            //   primary repo -> re-sending the SAME project id re-mirrors;
+            // - workdir already == the project's primary repo -> no-op.
+            // default_workdir is always omitted on this branch.
+            if !projectChanged, let draftProject {
+                let primary = primaryPath(of: draftProject, projects: projects)
+                if baselineWorkdir != primary {
+                    patch.projectID = draftProject
+                }
+            }
+        case .none:
+            // None / Scratch: clear any existing workdir explicitly.
+            if baselineWorkdir != nil {
+                patch.defaultWorkdir = ""
+            }
+        case .custom(let path):
+            let trimmedPath = path.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedPath != (baselineWorkdir ?? "") {
+                patch.defaultWorkdir = trimmedPath
+            }
+        }
+        return patch
+    }
+
+    /// Create-time request. switch is ALWAYS false. With a selected project,
+    /// upstream mirrors the project repo into default_workdir unless an
+    /// explicit path is given - so .none with a project resolves to the
+    /// mirror upstream (documented; the create UI hides .none once a project
+    /// is picked).
+    static func createRequest(
+        slug: String,
+        name: String,
+        description: String,
+        projectID: String?,
+        workspace: KanbanDefaultWorkspaceChoice
+    ) -> KanbanCreateBoardRequest {
+        var request = KanbanCreateBoardRequest(
+            slug: slug,
+            name: name.isEmpty ? nil : name,
+            description: description.isEmpty ? nil : description,
+            projectID: (projectID ?? "").isEmpty ? nil : projectID,
+            switchRequested: false
+        )
+        switch workspace {
+        case .projectDefault:
+            break // server mirrors when project set
+        case .none:
+            request.defaultWorkdir = nil
+        case .custom(let path):
+            let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+            request.defaultWorkdir = trimmed.isEmpty ? nil : trimmed
+        }
+        return request
+    }
+}
+
+// MARK: - Client-side filters (V3B)
+
+/// Client-side task predicate matching upstream Desktop (board.tsx): search
+/// over title/body/id, tenant exact equality, assignee exact equality, AND
+/// composition. Conduit additionally keeps its existing useful matches
+/// (latest summary, assignee) in the search set. Filters never mutate the
+/// authoritative board - visible columns are derived from it.
+enum KanbanBoardFilterPolicy {
+    static func matchesSearch(_ task: KanbanTask, _ query: String) -> Bool {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !q.isEmpty else { return true }
+        return task.title.lowercased().contains(q)
+            || (task.body ?? "").lowercased().contains(q)
+            || task.id.lowercased().contains(q)
+            || (task.latestSummary ?? "").lowercased().contains(q)
+            || (task.assignee ?? "").lowercased().contains(q)
+    }
+
+    static func matchesAssignee(_ task: KanbanTask, _ assignee: String?) -> Bool {
+        guard let assignee, !assignee.isEmpty else { return true }
+        // Exact equality with the TASK's own assignee - never the resolved
+        // default fallback (an unassigned Ready task is not "coder").
+        return task.assignee == assignee
+    }
+
+    static func matchesTenant(_ task: KanbanTask, _ tenant: String?) -> Bool {
+        guard let tenant, !tenant.isEmpty else { return true }
+        return task.tenant == tenant
+    }
+
+    static func matches(task: KanbanTask, search: String, assignee: String?, tenant: String?) -> Bool {
+        matchesSearch(task, search)
+            && matchesAssignee(task, assignee)
+            && matchesTenant(task, tenant)
+    }
+
+    /// A filter referencing a profile/tenant absent from the newly loaded
+    /// board must fail harmlessly instead of making the board look empty
+    /// forever: resolve to nil (all) when the roster no longer contains it.
+    static func validatedFilter(_ value: String?, available: [String]) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        return available.contains(value) ? value : nil
+    }
+
+    /// The visible (derived) column set: authoritative ordered columns with
+    /// each column's tasks filtered. Never mutates the authoritative board.
+    static func visibleColumns(
+        board: KanbanBoard,
+        search: String,
+        assignee: String?,
+        tenant: String?
+    ) -> [KanbanColumn] {
+        let resolvedAssignee = validatedFilter(assignee, available: board.assignees)
+        let resolvedTenant = validatedFilter(tenant, available: board.tenants)
+        let q = search
+        let hasCriteria = !q.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || resolvedAssignee != nil || resolvedTenant != nil
+        let columns = KanbanStatusPresentation.orderedColumns(board.columns)
+        guard hasCriteria else { return columns }
+        return columns.map { column in
+            KanbanColumn(
+                name: column.name,
+                tasks: column.tasks.filter {
+                    matches(task: $0, search: q, assignee: resolvedAssignee, tenant: resolvedTenant)
+                }
+            )
+        }
+    }
+}
+
+// MARK: - Running grouped by profile (V3B)
+
+/// Sub-groups the Running lane by the task's OWN assignee, with an
+/// "unassigned" fallback for tasks lacking one - exactly upstream's
+/// key = task.assignee || UNASSIGNED_LANE (board.tsx:378) with groups sorted
+/// by key (localeCompare; case-insensitive-equivalent ordering here). Applies
+/// ONLY to the running lane and ONLY after all filters.
+enum KanbanRunningGroupPolicy {
+    struct Group: Equatable, Identifiable {
+        let key: String
+        let displayName: String
+        let tasks: [KanbanTask]
+        var id: String { key }
+    }
+
+    static let unassignedKey = "unassigned"
+
+    static func shouldApply(lane: String, enabled: Bool) -> Bool {
+        lane == "running" && enabled
+    }
+
+    static func group(_ tasks: [KanbanTask]) -> [Group] {
+        var buckets: [String: [KanbanTask]] = [:]
+        for task in tasks {
+            let key = task.assignee ?? unassignedKey
+            buckets[key, default: []].append(task)
+        }
+        // Deterministic: case-insensitive primary, raw tie-break so equal
+        // spellings ("Coder" vs "coder") still sort stable.
+        let orderedKeys = buckets.keys.sorted { lhs, rhs in
+            let order = lhs.localizedCaseInsensitiveCompare(rhs)
+            return order == .orderedAscending || (order == .orderedSame && lhs < rhs)
+        }
+        return orderedKeys.map { key in
+            Group(
+                key: key,
+                displayName: key == unassignedKey ? "Unassigned" : key,
+                tasks: buckets[key] ?? []
+            )
+        }
+    }
+}
+
+// MARK: - Staged board archive (V3B)
+
+/// A staged Archive confirmation: the concrete target board slug + display
+/// name plus the board/server stamp that authorized it, captured BY VALUE at
+/// stage time. The store revalidates the stamp at its mutation boundary (same
+/// pattern as card Delete / triage actions): a confirmation staged for
+/// server A / board X can never archive a same-named board on server B.
+struct PendingBoardArchive: Equatable {
+    let slug: String
+    let displayName: String
+    let stamp: KanbanBoardContextStamp
+}
+
+// MARK: - Admin messaging (V3B)
+
+enum KanbanBoardAdminMessage {
+    /// POST /boards is idempotent and carries NO created flag upstream; the
+    /// only honest client-side distinction is whether the slug was already in
+    /// the authoritative pre-POST board list. Never fabricate more than that.
+    static func createOutcomeMessage(knewSlugBeforeRequest: Bool, name: String) -> String {
+        if knewSlugBeforeRequest {
+            return "Board \"\(name)\" already exists — opened it."
+        }
+        return "Board \"\(name)\" created and selected."
+    }
+
+    static func archiveRefreshFailureMessage(_ detail: String) -> String {
+        "The board was archived, but the board list could not be refreshed. " + detail
+    }
+}

--- a/Conduit/Views/Kanban/KanbanBoardAdministrationSupport.swift
+++ b/Conduit/Views/Kanban/KanbanBoardAdministrationSupport.swift
@@ -233,6 +233,64 @@ enum KanbanBoardFilterPolicy {
     }
 }
 
+// MARK: - Canonical workspace presentation (V3B final pass)
+
+/// ONE derivation of the editor workspace representation from authoritative
+/// board metadata + the projects roster. Used identically for the initial
+/// sheet seed AND the post-save authoritative echo, so freshly-opened and
+/// freshly-saved editors always agree on identical server metadata.
+enum KanbanBoardWorkspacePresentation {
+    /// authoritative -> editor representation:
+    /// - project + workdir == project primary (or nil workdir, meaning the
+    ///   backend's project-default semantics)  -> .projectDefault
+    /// - project + drifted custom workdir      -> .custom(workdir)
+    /// - no project + workdir                  -> .custom(workdir)
+    /// - no project + no workdir               -> .none
+    static func derive(
+        projectID: String?,
+        defaultWorkdir: String?,
+        projects: [KanbanProject]
+    ) -> KanbanDefaultWorkspaceChoice {
+        let project: String? = (projectID ?? "").isEmpty ? nil : projectID
+        let workdir: String? = (defaultWorkdir ?? "").isEmpty ? nil : defaultWorkdir
+        if let project {
+            let primary = KanbanBoardPatchPolicy.primaryPath(of: project, projects: projects)
+            if let workdir, workdir != primary {
+                return .custom(workdir)
+            }
+            return .projectDefault
+        }
+        if let workdir {
+            return .custom(workdir)
+        }
+        return .none
+    }
+
+    static func derive(from board: KanbanBoardMetadata, projects: [KanbanProject]) -> KanbanDefaultWorkspaceChoice {
+        derive(projectID: board.projectID, defaultWorkdir: board.defaultWorkdir, projects: projects)
+    }
+
+    /// Effective-directory PREVIEW deriving from the CURRENT DRAFT state
+    /// (review G): the selected project's primary path must appear the moment
+    /// the project changes — never the sheet-opening board's stale workdir.
+    static func previewDirectory(
+        workspace: KanbanDefaultWorkspaceChoice,
+        projectID: String?,
+        projects: [KanbanProject]
+    ) -> String? {
+        let project: String? = (projectID ?? "").isEmpty ? nil : projectID
+        switch workspace {
+        case .custom(let path):
+            let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        case .projectDefault:
+            return KanbanBoardPatchPolicy.primaryPath(of: project, projects: projects)
+        case .none:
+            return nil
+        }
+    }
+}
+
 // MARK: - Running grouped by profile (V3B)
 
 /// Sub-groups the Running lane by the task's OWN assignee, with an
@@ -257,7 +315,11 @@ enum KanbanRunningGroupPolicy {
     static func group(_ tasks: [KanbanTask]) -> [Group] {
         var buckets: [String: [KanbanTask]] = [:]
         for task in tasks {
-            let key = task.assignee ?? unassignedKey
+            // Upstream parity (board.tsx: task.assignee || UNASSIGNED_LANE):
+            // an EMPTY-STRING assignee is falsy and maps to the Unassigned
+            // group; whitespace-only strings stay truthy like upstream.
+            let assignee = task.assignee ?? ""
+            let key = assignee.isEmpty ? unassignedKey : assignee
             buckets[key, default: []].append(task)
         }
         // Deterministic: case-insensitive primary, raw tie-break so equal

--- a/Conduit/Views/Kanban/KanbanBoardEditorView.swift
+++ b/Conduit/Views/Kanban/KanbanBoardEditorView.swift
@@ -35,6 +35,12 @@ struct KanbanBoardEditorView: View {
     @State private var customPath = ""
     @State private var slug = ""
     @State private var manualSlug = false
+    /// The most recent AUTHORITATIVE server metadata this editor accepted —
+    /// the wire baseline for every PATCH. Advances on every successful Save
+    /// so a later save is never compared against the sheet-opening state
+    /// (review 2). mode.settings(board:) stays valuable only for the original
+    /// target slug + initial seed.
+    @State private var serverBaseline: KanbanBoardMetadata?
     @State private var seedDraft: KanbanBoardEditorDraft?
     @State private var isSaving = false
     @State private var liveness = KanbanEditorLiveness()
@@ -100,16 +106,15 @@ struct KanbanBoardEditorView: View {
         return currentDraft != seedDraft
     }
 
+    /// Effective-directory PREVIEW from the CURRENT DRAFT: selecting another
+    /// project immediately shows its primary repo — never the sheet-opening
+    /// board's stale workdir (review 3/G).
     private var effectiveDirectory: String? {
-        if case .custom(let path) = effectiveWorkspaceChoice, !path.isEmpty {
-            return path
-        }
-        if let workdir = board?.defaultWorkdir, !workdir.isEmpty { return workdir }
-        if let projectID, let project = store.projects.first(where: { $0.id == projectID }),
-           let primary = project.primaryPath, !primary.isEmpty {
-            return primary
-        }
-        return nil
+        KanbanBoardWorkspacePresentation.previewDirectory(
+            workspace: effectiveWorkspaceChoice,
+            projectID: projectID,
+            projects: store.projects
+        )
     }
 
     var body: some View {
@@ -300,30 +305,30 @@ struct KanbanBoardEditorView: View {
     }
 
     private func seedOnce() {
-        guard seedDraft == nil else { return }
-        let effectiveProject = (board?.projectID ?? "").isEmpty ? nil : board?.projectID
-        if let projectID = effectiveProject, !projectID.isEmpty {
-            // Project Default only when the stored workdir is already the
-            // project's primary repo; a DRIFTED custom dir is presented as
-            // Custom so the preview never misleads (review B-2/C-1).
-            let primary = KanbanBoardPatchPolicy.primaryPath(of: projectID, projects: store.projects)
-            if let stored = board?.defaultWorkdir, !stored.isEmpty, stored != primary {
-                workspaceRow = .custom
-                customPath = stored
-            } else {
-                workspaceRow = .projectDefault
-            }
-        } else if let workdir = board?.defaultWorkdir, !workdir.isEmpty {
-            workspaceRow = .custom
-            customPath = workdir
-        } else {
-            workspaceRow = .none
-        }
-        name = board?.name ?? ""
-        descriptionText = board?.description ?? ""
+        guard seedDraft == nil, let board else { return }
+        serverBaseline = board
+        let effectiveProject = (board.projectID ?? "").isEmpty ? nil : board.projectID
+        let derivedWorkspace = KanbanBoardWorkspacePresentation.derive(from: board, projects: store.projects)
+        applyWorkspacePresentation(derivedWorkspace)
+        name = board.name ?? ""
+        descriptionText = board.description ?? ""
         projectID = effectiveProject
-        slug = board?.slug ?? ""
+        slug = board.slug
         seedDraft = currentDraft
+    }
+
+    /// The ONE path that materializes a workspace representation into the
+    /// editor rows (initial seed AND post-save authoritative echo).
+    private func applyWorkspacePresentation(_ derived: KanbanDefaultWorkspaceChoice) {
+        switch derived {
+        case .projectDefault:
+            workspaceRow = .projectDefault
+        case .none:
+            workspaceRow = .none
+        case .custom(let path):
+            workspaceRow = .custom
+            customPath = path
+        }
     }
 
     /// Synchronous tap handler: freezes the mutation identity (concrete slug
@@ -355,12 +360,14 @@ struct KanbanBoardEditorView: View {
                 )
             }
         } else {
-            guard let board else {
+            guard let baseline = serverBaseline else {
                 if liveness.owns(operationID) { isSaving = false }
                 return
             }
-            let patch = KanbanBoardPatchPolicy.patch(baseline: board, draft: draft, projects: store.projects)
-            let targetSlug = board.slug
+            // PATCH built from the LATEST authoritative metadata this editor
+            // accepted — never the sheet-opening state (review 2/E).
+            let patch = KanbanBoardPatchPolicy.patch(baseline: baseline, draft: draft, projects: store.projects)
+            let targetSlug = baseline.slug
             Task {
                 await performUpdate(
                     slug: targetSlug,
@@ -414,6 +421,9 @@ struct KanbanBoardEditorView: View {
             return
         }
         do {
+            // Concurrent completions cannot race the baseline: the store's
+            // single-live-mutation gate serializes PATCHes and this editor's
+            // liveness token discards echoes from older operations.
             let updated = try await store.updateBoard(
                 slug: slug,
                 patch: patch,
@@ -422,18 +432,15 @@ struct KanbanBoardEditorView: View {
             )
             if liveness.owns(operationID) { isSaving = false }
             guard store.isCurrentConfiguration(generation) else { return }
-            // Authoritative echo becomes the new baseline.
+            // The authoritative echo ADVANCES the server baseline FIRST; the
+            // workspace rows materialize through the same canonical
+            // derivation as the initial seed (review 3/D).
+            serverBaseline = updated
+            let derived = KanbanBoardWorkspacePresentation.derive(from: updated, projects: store.projects)
+            applyWorkspacePresentation(derived)
             name = updated.name ?? ""
             descriptionText = updated.description ?? ""
             projectID = (updated.projectID ?? "").isEmpty ? nil : updated.projectID
-            if let projectID, !projectID.isEmpty {
-                workspaceRow = .projectDefault
-            } else if let workdir = updated.defaultWorkdir, !workdir.isEmpty {
-                workspaceRow = .custom
-                customPath = workdir
-            } else {
-                workspaceRow = .none
-            }
             seedDraft = currentDraft
             notice = "Board settings saved."
         } catch {

--- a/Conduit/Views/Kanban/KanbanBoardEditorView.swift
+++ b/Conduit/Views/Kanban/KanbanBoardEditorView.swift
@@ -1,0 +1,445 @@
+import SwiftUI
+
+/// V3B: Board administration editor — one native sheet for New Board and
+/// Board Settings.
+///
+/// Ownership follows the V2/V3A editor discipline:
+/// - seeded once from an immutable server baseline; dirty = draft vs baseline;
+/// - the mutation identity (concrete board slug, board/server stamp) and the
+///   submitted patch/payload are frozen synchronously in the tap handler
+///   BEFORE any Task is spawned;
+/// - the store revalidates the captured stamp back-to-back with its operation
+///   capture (Settings is board-scoped; creation is server-scoped);
+/// - a stale completion is UI-inert, while the local busy flag is still
+///   released through the liveness token;
+/// - controls are disabled while saving, so a completion can never clobber an
+///   in-flight edit.
+enum KanbanBoardEditorMode {
+    case create
+    case settings(board: KanbanBoardMetadata)
+}
+
+struct KanbanBoardEditorView: View {
+    @EnvironmentObject private var store: KanbanStore
+    @Environment(\.dismiss) private var dismiss
+
+    private let mode: KanbanBoardEditorMode
+    /// Matches the board's Show Archived state so every post-mutation
+    /// reconcile preserves the visible snapshot (review W2).
+    private let includeArchived: Bool
+
+    @State private var name = ""
+    @State private var descriptionText = ""
+    @State private var projectID: String?
+    @State private var workspaceRow: WorkspaceRow = .none
+    @State private var customPath = ""
+    @State private var slug = ""
+    @State private var manualSlug = false
+    @State private var seedDraft: KanbanBoardEditorDraft?
+    @State private var isSaving = false
+    @State private var liveness = KanbanEditorLiveness()
+    @State private var notice: String?
+    @State private var errorMessage: String?
+
+    /// The PICKER row is a plain enum: a typed path lives in customPath and
+    /// is folded in at submit time — never embedded in a Picker tag (review
+    /// W1: an empty tag value would silently drop the typed path).
+    enum WorkspaceRow: Hashable {
+        case projectDefault
+        case none
+        case custom
+    }
+
+    init(mode: KanbanBoardEditorMode, includeArchived: Bool = false) {
+        self.mode = mode
+        self.includeArchived = includeArchived
+    }
+
+    private var board: KanbanBoardMetadata? {
+        if case .settings(let board) = mode { return board }
+        return nil
+    }
+
+    private var isCreate: Bool {
+        if case .create = mode { return true }
+        return false
+    }
+
+    private var resolvedSlug: String {
+        if manualSlug { return slug.trimmingCharacters(in: .whitespacesAndNewlines) }
+        return KanbanBoardSlugPolicy.derivedSlug(from: name)
+    }
+
+    private var hasValidSlug: Bool {
+        KanbanBoardSlugPolicy.isValid(resolvedSlug)
+    }
+
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var effectiveWorkspaceChoice: KanbanDefaultWorkspaceChoice {
+        switch workspaceRow {
+        case .projectDefault: return .projectDefault
+        case .none: return .none
+        case .custom: return .custom(customPath.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+    }
+
+    private var currentDraft: KanbanBoardEditorDraft {
+        KanbanBoardEditorDraft(
+            name: trimmedName,
+            description: descriptionText,
+            projectID: projectID,
+            workspace: normalizedWorkspaceChoice
+        )
+    }
+
+    private var isDirty: Bool {
+        guard let seedDraft else { return false }
+        return currentDraft != seedDraft
+    }
+
+    private var effectiveDirectory: String? {
+        if case .custom(let path) = effectiveWorkspaceChoice, !path.isEmpty {
+            return path
+        }
+        if let workdir = board?.defaultWorkdir, !workdir.isEmpty { return workdir }
+        if let projectID, let project = store.projects.first(where: { $0.id == projectID }),
+           let primary = project.primaryPath, !primary.isEmpty {
+            return primary
+        }
+        return nil
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                basicsSection
+                projectSection
+                workspaceSection
+                if let effective = effectiveDirectory {
+                    Section {
+                        Label(effective, systemImage: "folder")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    } header: {
+                        Text("Effective Directory")
+                    }
+                }
+                if let errorMessage {
+                    Section {
+                        Label(errorMessage, systemImage: "exclamationmark.triangle")
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                    }
+                }
+                if let notice {
+                    Section {
+                        Label(notice, systemImage: "checkmark.circle")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .navigationTitle(isCreate ? "New Board" : "Board Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(isCreate ? "Cancel" : "Close") { dismiss() }
+                        .disabled(isSaving)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button {
+                        submitTapped()
+                    } label: {
+                        if isSaving { ProgressView() } else { Text(isCreate ? "Create" : "Save") }
+                    }
+                    .disabled(!canSubmit || isSaving)
+                }
+            }
+            .onAppear(perform: seedOnce)
+        }
+        .interactiveDismissDisabled(isSaving)
+        // Board Settings belongs to a CONCRETE loaded board: dismiss it the
+        // moment the loaded board identity changes (the store fails closed
+        // underneath even if a race slips through).
+        .onChange(of: store.loadedBoardSlug) { _, _ in
+            if !isCreate { dismiss() }
+        }
+    }
+
+    private var canSubmit: Bool {
+        if isCreate {
+            return hasValidSlug && !trimmedName.isEmpty
+        }
+        return isDirty
+    }
+
+    private var basicsSection: some View {
+        Section {
+            TextField("Name", text: $name)
+                .accessibilityLabel("Board name")
+            if isCreate {
+                Toggle("Edit slug manually", isOn: $manualSlug)
+                    .font(.footnote)
+                    .accessibilityLabel("Edit slug manually (advanced)")
+                if manualSlug {
+                    TextField("Slug", text: $slug)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .accessibilityLabel("Board slug")
+                        .overlay(alignment: .trailing) {
+                            if !hasValidSlug && !slug.isEmpty {
+                                Image(systemName: "exclamationmark.circle.fill")
+                                    .foregroundStyle(.red)
+                                    .accessibilityLabel("Invalid slug")
+                            }
+                        }
+                } else {
+                    Text("Slug: \(resolvedSlug)")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .accessibilityLabel("Generated slug \(resolvedSlug)")
+                }
+            } else if let board {
+                LabeledContent("Slug", value: board.slug)
+                    .accessibilityLabel("Slug is immutable: \(board.slug)")
+            }
+            TextEditor(text: $descriptionText)
+                .frame(minHeight: 90)
+                .accessibilityLabel("Board description")
+        } header: {
+            Text("Basics")
+        } footer: {
+            if isCreate && !trimmedName.isEmpty && !hasValidSlug {
+                Text("The slug must be 1-64 lowercase letters or numbers, with hyphens or underscores after the first character.")
+            } else if isCreate {
+                Text("The slug is generated from the name (like Desktop) and cannot be changed after creation.")
+            } else {
+                Text("The slug is immutable after creation.")
+            }
+        }
+        .disabled(isSaving)
+    }
+
+    private var projectSection: some View {
+        Section {
+            Picker("Project", selection: projectBinding) {
+                Text("No Project").tag(String?.none)
+                ForEach(store.projects) { project in
+                    Text(project.name).tag(String?.some(project.id))
+                }
+            }
+            .pickerStyle(.menu)
+            .accessibilityLabel("Project scope")
+            if store.projects.isEmpty {
+                Text("No projects on this server yet — the board stays unscoped (scratch workspaces).")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        } header: {
+            Text("Project")
+        }
+        .disabled(isSaving)
+    }
+
+    private var projectBinding: Binding<String?> {
+        Binding(
+            get: { projectID },
+            set: { newValue in
+                projectID = newValue
+                // Snapping: picking a project follows it by default; dropping
+                // it returns to scratch - unless the user already entered a
+                // custom directory.
+                if newValue != nil {
+                    if workspaceRow != .custom || customPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        workspaceRow = .projectDefault
+                    }
+                } else if workspaceRow == .projectDefault {
+                    workspaceRow = .none
+                }
+            }
+        )
+    }
+
+    private var workspaceSection: some View {
+        Section {
+            Picker("Default Workspace", selection: $workspaceRow) {
+                if projectID != nil {
+                    // With a project selected, "None/Scratch" is not
+                    // representable upstream: the server mirrors the project's
+                    // primary repo whenever a project is set without an
+                    // explicit workdir (review B-1). The row is hidden so the
+                    // editor can never submit that phantom combination.
+                    Text("Project Default").tag(WorkspaceRow.projectDefault)
+                } else {
+                    Text("None / Scratch").tag(WorkspaceRow.none)
+                }
+                Text("Custom Directory…").tag(WorkspaceRow.custom)
+            }
+            .pickerStyle(.menu)
+            .accessibilityLabel("Default workspace")
+            if workspaceRow == .custom {
+                TextField("Absolute directory path", text: $customPath)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .accessibilityLabel("Custom workspace directory")
+            }
+        } header: {
+            Text("Default Workspace")
+        } footer: {
+            if projectID != nil, workspaceRow == .projectDefault {
+                Text("New tasks mirror the project's primary repository.")
+            } else if workspaceRow == .none {
+                Text("New tasks use scratch workspaces.")
+            }
+        }
+        .disabled(isSaving)
+    }
+
+    private func seedOnce() {
+        guard seedDraft == nil else { return }
+        let effectiveProject = (board?.projectID ?? "").isEmpty ? nil : board?.projectID
+        if let projectID = effectiveProject, !projectID.isEmpty {
+            // Project Default only when the stored workdir is already the
+            // project's primary repo; a DRIFTED custom dir is presented as
+            // Custom so the preview never misleads (review B-2/C-1).
+            let primary = KanbanBoardPatchPolicy.primaryPath(of: projectID, projects: store.projects)
+            if let stored = board?.defaultWorkdir, !stored.isEmpty, stored != primary {
+                workspaceRow = .custom
+                customPath = stored
+            } else {
+                workspaceRow = .projectDefault
+            }
+        } else if let workdir = board?.defaultWorkdir, !workdir.isEmpty {
+            workspaceRow = .custom
+            customPath = workdir
+        } else {
+            workspaceRow = .none
+        }
+        name = board?.name ?? ""
+        descriptionText = board?.description ?? ""
+        projectID = effectiveProject
+        slug = board?.slug ?? ""
+        seedDraft = currentDraft
+    }
+
+    /// Synchronous tap handler: freezes the mutation identity (concrete slug
+    /// for settings; server scope for create), the submitted payload/patch,
+    /// the server generation and the busy state BEFORE scheduling.
+    private func submitTapped() {
+        guard canSubmit, !isSaving,
+              let stamp = store.loadedContextStamp else { return }
+        let generation = store.currentConfigurationGeneration
+        let operationID = liveness.begin()
+        isSaving = true
+        errorMessage = nil
+        notice = nil
+        let draft = currentDraft
+        if isCreate {
+            let request = KanbanBoardPatchPolicy.createRequest(
+                slug: resolvedSlug,
+                name: trimmedName,
+                description: descriptionText,
+                projectID: draft.projectID,
+                workspace: draft.workspace
+            )
+            Task {
+                await performCreate(
+                    request: request,
+                    context: stamp,
+                    generation: generation,
+                    operationID: operationID
+                )
+            }
+        } else {
+            guard let board else {
+                if liveness.owns(operationID) { isSaving = false }
+                return
+            }
+            let patch = KanbanBoardPatchPolicy.patch(baseline: board, draft: draft, projects: store.projects)
+            let targetSlug = board.slug
+            Task {
+                await performUpdate(
+                    slug: targetSlug,
+                    patch: patch,
+                    context: stamp,
+                    generation: generation,
+                    operationID: operationID
+                )
+            }
+        }
+    }
+
+    /// .projectDefault with no project selected is not a legal wire state;
+    /// fall back to playing it safe (no workdir change implied).
+    private var normalizedWorkspaceChoice: KanbanDefaultWorkspaceChoice {
+        if workspaceRow == .projectDefault, (projectID ?? "").isEmpty {
+            return .none
+        }
+        return effectiveWorkspaceChoice
+    }
+
+    private func performCreate(
+        request: KanbanCreateBoardRequest,
+        context: KanbanBoardContextStamp,
+        generation: Int,
+        operationID: Int
+    ) async {
+        do {
+            _ = try await store.createBoard(request, expectedContext: context, includeArchived: includeArchived)
+            if liveness.owns(operationID) { isSaving = false }
+            guard store.isCurrentConfiguration(generation) else { return }
+            // The sheet dismisses: the authoritative reload already switched
+            // the UI onto the new board, which IS the feedback (review A-1).
+            dismiss()
+        } catch {
+            if liveness.owns(operationID) { isSaving = false }
+            guard store.isCurrentConfiguration(generation) else { return }
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func performUpdate(
+        slug: String,
+        patch: KanbanUpdateBoardPatch,
+        context: KanbanBoardContextStamp,
+        generation: Int,
+        operationID: Int
+    ) async {
+        guard !patch.isEmpty else {
+            if liveness.owns(operationID) { isSaving = false }
+            return
+        }
+        do {
+            let updated = try await store.updateBoard(
+                slug: slug,
+                patch: patch,
+                expectedContext: context,
+                includeArchived: includeArchived
+            )
+            if liveness.owns(operationID) { isSaving = false }
+            guard store.isCurrentConfiguration(generation) else { return }
+            // Authoritative echo becomes the new baseline.
+            name = updated.name ?? ""
+            descriptionText = updated.description ?? ""
+            projectID = (updated.projectID ?? "").isEmpty ? nil : updated.projectID
+            if let projectID, !projectID.isEmpty {
+                workspaceRow = .projectDefault
+            } else if let workdir = updated.defaultWorkdir, !workdir.isEmpty {
+                workspaceRow = .custom
+                customPath = workdir
+            } else {
+                workspaceRow = .none
+            }
+            seedDraft = currentDraft
+            notice = "Board settings saved."
+        } catch {
+            if liveness.owns(operationID) { isSaving = false }
+            guard store.isCurrentConfiguration(generation) else { return }
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/Conduit/Views/Kanban/KanbanBoardFilterSheet.swift
+++ b/Conduit/Views/Kanban/KanbanBoardFilterSheet.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+/// V3B filter sheet: assignee + tenant (client-side over the loaded board),
+/// Show Archived (server fetch parameter), Group Running by Profile (persisted
+/// preference). Search stays in the header; the active-filter dot lives on the
+/// filter button next to it.
+struct KanbanBoardFilterSheet: View {
+    @EnvironmentObject private var store: KanbanStore
+    @Environment(\.dismiss) private var dismiss
+
+    @Binding var includeArchived: Bool
+    @Binding var assigneeFilter: String?
+    @Binding var tenantFilter: String?
+    @Binding var groupRunningByProfile: Bool
+
+    private var assignees: [String] { store.board?.assignees ?? [] }
+    private var tenants: [String] { store.board?.tenants ?? [] }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Assignee") {
+                    Picker("Assignee", selection: assigneeBinding) {
+                        Text("All Profiles").tag(String?.none)
+                        ForEach(assignees, id: \.self) { name in
+                            Text(name).tag(String?.some(name))
+                        }
+                    }
+                    .pickerStyle(.menu)
+                }
+                if !tenants.isEmpty {
+                    Section("Tenant") {
+                        Picker("Tenant", selection: tenantBinding) {
+                            Text("All Tenants").tag(String?.none)
+                            ForEach(tenants, id: \.self) { name in
+                                Text(name).tag(String?.some(name))
+                            }
+                        }
+                        .pickerStyle(.menu)
+                    }
+                }
+                Section {
+                    Toggle("Show Archived", isOn: $includeArchived)
+                        .accessibilityLabel("Show archived tasks")
+                    Toggle("Group Running by Profile", isOn: $groupRunningByProfile)
+                        .accessibilityLabel("Group the Running lane by assignee")
+                } footer: {
+                    Text("Group Running by Profile is a saved preference. Show Archived applies to the board fetch. Assignee and tenant filters are temporary until changed.")
+                }
+                Section {
+                    Button("Reset Filters") {
+                        // Transient filters only: the persisted grouping
+                        // preference is NOT part of a transient reset.
+                        assigneeFilter = nil
+                        tenantFilter = nil
+                        includeArchived = false
+                    }
+                }
+            }
+            .navigationTitle("Filters")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+        .presentationDragIndicator(.visible)
+    }
+
+    private var assigneeBinding: Binding<String?> {
+        Binding(
+            get: { assigneeFilter },
+            set: { assigneeFilter = $0 }
+        )
+    }
+
+    private var tenantBinding: Binding<String?> {
+        Binding(
+            get: { tenantFilter },
+            set: { tenantFilter = $0 }
+        )
+    }
+}

--- a/Conduit/Views/KanbanViews.swift
+++ b/Conduit/Views/KanbanViews.swift
@@ -115,6 +115,17 @@ struct KanbanView: View {
     /// Token-guarded so a rapid second nudge OR a board switch invalidates an
     /// older auto-hide timer (a stale timer must never clear a newer notice).
     @State private var nudgeNoticeState = KanbanNudgeNoticeState()
+    /// V3B board administration: editor sheets + staged archive confirmation.
+    @State private var showBoardSettings = false
+    @State private var showNewBoard = false
+    @State private var pendingBoardArchive: PendingBoardArchive?
+    /// V3B filters. Assignee/tenant are TRANSIENT view state (never persisted
+    /// across servers); Show Archived keeps its existing semantics; Group
+    /// Running by Profile is a persisted UI preference (desktop parity).
+    @State private var showFilters = false
+    @State private var assigneeFilter: String?
+    @State private var tenantFilter: String?
+    @AppStorage("conduit.kanbanGroupRunningByProfile") private var groupRunningByProfile = false
 
     private var bridgeIdentity: ObjectIdentifier? {
         appState.dashboardTicketBridge.map { ObjectIdentifier($0) }
@@ -139,20 +150,12 @@ struct KanbanView: View {
 
     private var visibleColumns: [KanbanColumn] {
         guard let board = store.board else { return [] }
-        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-        let columns = KanbanStatusPresentation.orderedColumns(board.columns)
-        guard !query.isEmpty else { return columns }
-        return columns.map { column in
-            KanbanColumn(
-                name: column.name,
-                tasks: column.tasks.filter {
-                    $0.title.localizedCaseInsensitiveContains(query)
-                        || $0.body?.localizedCaseInsensitiveContains(query) == true
-                        || $0.latestSummary?.localizedCaseInsensitiveContains(query) == true
-                        || $0.assignee?.localizedCaseInsensitiveContains(query) == true
-                }
-            )
-        }
+        return KanbanBoardFilterPolicy.visibleColumns(
+            board: board,
+            search: searchText,
+            assignee: assigneeFilter,
+            tenant: tenantFilter
+        )
     }
 
     var body: some View {
@@ -244,6 +247,48 @@ struct KanbanView: View {
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
         }
+        .sheet(isPresented: $showBoardSettings) {
+            // Board Settings is tied to the CONCRETE loaded board (never a
+            // re-read of the mutable selection); the button is disabled while
+            // no loaded metadata exists.
+            if let board = loadedBoardMetadata {
+                KanbanBoardEditorView(mode: .settings(board: board), includeArchived: includeArchived)
+                    .environmentObject(store)
+                    .presentationDetents([.large])
+                    .presentationDragIndicator(.visible)
+            }
+        }
+        .sheet(isPresented: $showNewBoard) {
+            KanbanBoardEditorView(mode: .create, includeArchived: includeArchived)
+                .environmentObject(store)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
+        }
+        .sheet(isPresented: $showFilters) {
+            KanbanBoardFilterSheet(
+                includeArchived: $includeArchived,
+                assigneeFilter: $assigneeFilter,
+                tenantFilter: $tenantFilter,
+                groupRunningByProfile: $groupRunningByProfile
+            )
+            .environmentObject(store)
+            .presentationDetents([.medium])
+            .presentationDragIndicator(.visible)
+        }
+        .confirmationDialog(
+            "Archive Board?",
+            isPresented: Binding(
+                get: { pendingBoardArchive != nil },
+                set: { if !$0 { pendingBoardArchive = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: pendingBoardArchive
+        ) { staged in
+            Button("Archive", role: .destructive) { confirmBoardArchive(staged) }
+            Button("Cancel", role: .cancel) { pendingBoardArchive = nil }
+        } message: { staged in
+            Text("Archive “\(staged.displayName)”?\nThe board will be removed from the active board list. Its tasks are not being permanently deleted.")
+        }
         // Permanent deletion from cards is CONFIRMED before the DELETE is
         // issued; the wording matches the detail screen's delete alert. The
         // staged request (task + staging context) is passed BY VALUE through
@@ -274,11 +319,25 @@ struct KanbanView: View {
             // beta) and bumps the token so the old auto-hide timer can never
             // mutate a later notice.
             nudgeNoticeState.invalidateOnContextChange()
+            // V3B: a staged archive, the board-settings/new-board editors and
+            // the filter sheet (board-scoped rosters) belong to the PREVIOUS
+            // board - disarm/dismiss them, and clear transient filters so no
+            // stale roster value lingers in the UI state.
+            pendingBoardArchive = nil
+            showBoardSettings = false
+            showNewBoard = false
+            showFilters = false
+            assigneeFilter = nil
+            tenantFilter = nil
         }
         .onChange(of: serverIdentityKey) { _, _ in
             // Server changed: the admin sheets belonged to the old server.
             showOrchestrationSettings = false
             showProfileRouting = false
+            showBoardSettings = false
+            showNewBoard = false
+            showFilters = false
+            pendingBoardArchive = nil
             nudgeNoticeState.invalidateOnContextChange()
         }
         .task(id: pollingKey) {
@@ -340,6 +399,46 @@ struct KanbanView: View {
         }
     }
 
+    // MARK: - V3B board administration helpers
+
+    /// The metadata of the CONCRETE board currently loaded (nil while
+    /// loading/navigation keeps a stale snapshot visible).
+    private var loadedBoardMetadata: KanbanBoardMetadata? {
+        guard let slug = store.loadedBoardSlug else { return nil }
+        return store.boards.first { $0.slug == slug }
+    }
+
+    /// Archive targets the concrete LOADED board and is refused for the
+    /// backend-immortal default board (remove_board raises; surfaced as 400).
+    private var canArchiveSelectedBoard: Bool {
+        guard let slug = store.loadedBoardSlug,
+              store.isSelectedSnapshotLoaded,
+              !store.isMutating else { return false }
+        return slug != "default"
+    }
+
+    /// Stage the archive BY VALUE (slug + name + board/server stamp) at the
+    /// menu tap; only an explicit confirmation that still owns the stamp may
+    /// archive, and the store revalidates the stamp at its mutation boundary.
+    private func stageBoardArchive() {
+        guard let slug = store.loadedBoardSlug,
+              let stamp = store.loadedContextStamp,
+              store.isSelectedSnapshotLoaded else { return }
+        let name = loadedBoardMetadata?.name ?? slug
+        pendingBoardArchive = PendingBoardArchive(slug: slug, displayName: name, stamp: stamp)
+    }
+
+    private func confirmBoardArchive(_ staged: PendingBoardArchive) {
+        pendingBoardArchive = nil
+        Task {
+            try? await store.archiveBoard(
+                slug: staged.slug,
+                expectedContext: staged.stamp,
+                includeArchived: includeArchived
+            )
+        }
+    }
+
     // MARK: - Lane-based iPhone board
 
     /// Native mobile interaction: horizontally scrolling lane chips over one
@@ -364,15 +463,33 @@ struct KanbanView: View {
             if let column = resolvedLaneColumn(in: columns) {
                 ScrollView(showsIndicators: false) {
                     LazyVStack(spacing: 9) {
-                        ForEach(column.tasks) { task in
-                            KanbanCardView(
-                                task: task,
-                                hasDispatcherFallback: !(store.orchestration?.resolvedDefaultAssignee ?? "").isEmpty,
-                                onOpen: { selectedTask = task },
-                                onMove: { status in Task { await move(task, to: status) } },
-                                onArchive: { Task { await archive(task) } },
-                                onDelete: { stageCardDelete(task) }
-                            )
+                        if KanbanRunningGroupPolicy.shouldApply(lane: column.name, enabled: groupRunningByProfile) {
+                            // V3B: Running grouped by profile - AFTER all
+                            // filters (the column above is already filtered).
+                            ForEach(KanbanRunningGroupPolicy.group(column.tasks)) { group in
+                                runningGroupHeader(group)
+                                ForEach(group.tasks) { task in
+                                    KanbanCardView(
+                                        task: task,
+                                        hasDispatcherFallback: !(store.orchestration?.resolvedDefaultAssignee ?? "").isEmpty,
+                                        onOpen: { selectedTask = task },
+                                        onMove: { status in Task { await move(task, to: status) } },
+                                        onArchive: { Task { await archive(task) } },
+                                        onDelete: { stageCardDelete(task) }
+                                    )
+                                }
+                            }
+                        } else {
+                            ForEach(column.tasks) { task in
+                                KanbanCardView(
+                                    task: task,
+                                    hasDispatcherFallback: !(store.orchestration?.resolvedDefaultAssignee ?? "").isEmpty,
+                                    onOpen: { selectedTask = task },
+                                    onMove: { status in Task { await move(task, to: status) } },
+                                    onArchive: { Task { await archive(task) } },
+                                    onDelete: { stageCardDelete(task) }
+                                )
+                            }
                         }
                     }
                     .padding(.horizontal, 1)
@@ -489,6 +606,29 @@ struct KanbanView: View {
             // Name [ … ]").
             Menu {
                 Button {
+                    showBoardSettings = true
+                } label: {
+                    Label("Board Settings…", systemImage: "slider.vertical.3")
+                }
+                .disabled(loadedBoardMetadata == nil || store.isMutating || !store.isSelectedSnapshotLoaded)
+
+                Button {
+                    showNewBoard = true
+                } label: {
+                    Label("New Board…", systemImage: "square.badge.plus")
+                }
+                .disabled(store.isMutating || !store.isSelectedSnapshotLoaded)
+
+                Button {
+                    stageBoardArchive()
+                } label: {
+                    Label("Archive Board…", systemImage: "archivebox")
+                }
+                .disabled(!canArchiveSelectedBoard)
+
+                Divider()
+
+                Button {
                     showOrchestrationSettings = true
                 } label: {
                     Label("Orchestration Settings…", systemImage: "slider.horizontal.3")
@@ -559,15 +699,51 @@ struct KanbanView: View {
                 }
                 .buttonStyle(.plain)
             }
-            Toggle("Archived", isOn: $includeArchived)
-                .toggleStyle(.switch)
-                .font(.caption)
-                .labelsHidden()
-                .accessibilityLabel("Show archived tasks")
+            // V3B: assignee/tenant/Show Archived/grouping live behind ONE
+            // compact filter button instead of crowding the header.
+            Button {
+                showFilters = true
+            } label: {
+                Image(systemName: filtersActive
+                    ? "line.3.horizontal.decrease.circle.fill"
+                    : "line.3.horizontal.decrease.circle")
+                    .foregroundStyle(filtersActive ? Color.conduitAccent : Color.secondary)
+                    .frame(width: 32, height: 32)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(filtersActive ? "Filters active — open filters" : "Open filters")
+            .accessibilityHint("Shows assignee, tenant, archived, and running grouping options")
+            .disabled(!store.isSelectedSnapshotLoaded)
         }
         .padding(.horizontal, 12)
         .frame(height: 40)
         .conduitGlassControl(cornerRadius: 15)
+    }
+
+    /// Active-filter indication for the filter button (sheet-driven filters:
+    /// archived toggle, grouping preference, assignee, tenant).
+    private var filtersActive: Bool {
+        includeArchived
+            || groupRunningByProfile
+            || !(assigneeFilter ?? "").isEmpty
+            || !(tenantFilter ?? "").isEmpty
+    }
+
+    /// Group header for the grouped Running lane (accessibility-labeled).
+    private func runningGroupHeader(_ group: KanbanRunningGroupPolicy.Group) -> some View {
+        HStack(spacing: 6) {
+            Text(group.displayName)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(String(group.tasks.count))
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(.tertiary)
+            Spacer()
+        }
+        .padding(.horizontal, 4)
+        .padding(.top, 6)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(group.displayName), \(group.tasks.count) tasks")
     }
 
     private func move(_ task: KanbanTask, to status: String) async {

--- a/ConduitTests/KanbanV3BTests.swift
+++ b/ConduitTests/KanbanV3BTests.swift
@@ -452,6 +452,68 @@ final class KanbanV3BTests: XCTestCase {
         XCTAssertEqual(patch.defaultWorkdir, "/repos/custom")
     }
 
+    func testProjectChangeWithSameCustomPathReassertsWorkdirOnTheWire() {
+        // The two-fix pass regression: the user intentionally PRESERVES the
+        // custom directory while switching projects. Because the project
+        // change makes upstream implicitly mirror the new project's primary
+        // repo, the SAME custom path must be sent explicitly even though its
+        // string equals the old baseline workdir.
+        let baseline = boardMeta(name: "Alpha", projectID: "proj-a", workdir: "/repos/custom")
+        let draft = KanbanBoardEditorDraft(
+            name: "Alpha", description: "", projectID: "proj-b", workspace: .custom("/repos/custom")
+        )
+        let patch = KanbanBoardPatchPolicy.patch(
+            baseline: baseline,
+            draft: draft,
+            projects: [
+                KanbanProject(id: "proj-a", slug: "project-a", name: "Project A", primaryPath: "/repos/a"),
+                KanbanProject(id: "proj-b", slug: "project-b", name: "Project B", primaryPath: "/repos/b"),
+            ]
+        )
+        XCTAssertEqual(patch.projectID, "proj-b")
+        XCTAssertEqual(patch.defaultWorkdir, "/repos/custom", "the preserved custom path MUST override the implicit mirror")
+
+        // Canonical derivation keeps the editor on Custom after the echo.
+        let echo = KanbanBoardMetadata(slug: "alpha", name: "Alpha", defaultWorkdir: "/repos/custom", projectID: "proj-b")
+        XCTAssertEqual(
+            KanbanBoardWorkspacePresentation.derive(from: echo, projects: [
+                KanbanProject(id: "proj-b", slug: "project-b", name: "Project B", primaryPath: "/repos/b"),
+            ]),
+            .custom("/repos/custom")
+        )
+    }
+
+    func testUnchangedProjectSameCustomPathStillOmitsWorkdir() {
+        // No project change + unchanged custom path: default_workdir must
+        // stay OFF the wire (no redundant PATCH fields).
+        let baseline = boardMeta(name: "Alpha", projectID: "proj-a", workdir: "/repos/custom")
+        let draft = KanbanBoardEditorDraft(
+            name: "Alpha", description: "New description", projectID: "proj-a", workspace: .custom("/repos/custom")
+        )
+        let patch = KanbanBoardPatchPolicy.patch(
+            baseline: baseline,
+            draft: draft,
+            projects: [KanbanProject(id: "proj-a", slug: "project-a", name: "Project A", primaryPath: "/repos/a")]
+        )
+        XCTAssertEqual(patch.description, "New description")
+        XCTAssertNil(patch.projectID)
+        XCTAssertNil(patch.defaultWorkdir, "unchanged custom path is not resent")
+    }
+
+    func testNoneWithProjectChangeSuppressesImplicitMirror() {
+        // .none + project change: default_workdir "" travels so the new
+        // project's implicit mirror is suppressed (defense-in-depth; the UI
+        // hides None while a project is selected).
+        let baseline = boardMeta(name: "Alpha", projectID: "proj-a") // workdir nil
+        let patch = KanbanBoardPatchPolicy.patch(
+            baseline: baseline,
+            draft: KanbanBoardEditorDraft(name: "Alpha", description: "", projectID: "proj-b", workspace: .none),
+            projects: [KanbanProject(id: "proj-b", slug: "project-b", name: "Project B", primaryPath: "/repos/b")]
+        )
+        XCTAssertEqual(patch.projectID, "proj-b")
+        XCTAssertEqual(patch.defaultWorkdir, "", "implicit mirror suppressed for .none")
+    }
+
     func testPatchProjectDefaultRemirrorsDriftedWorkdir() {
         // Same project, but the workdir drifted away from the project repo:
         // re-sending the same project_id re-mirrors (default_workdir omitted).

--- a/ConduitTests/KanbanV3BTests.swift
+++ b/ConduitTests/KanbanV3BTests.swift
@@ -1,0 +1,911 @@
+import XCTest
+@testable import Conduit
+
+/// Kanban V3B: board administration (create/update/archive), project +
+/// default-workdir wire semantics, client-side filters, Show Archived, and
+/// Running grouped by profile — with the full async ownership discipline.
+///
+/// Deterministic: no sleeps; continuation-handshake + provider-keyed mock.
+@MainActor
+final class KanbanV3BTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeTask(id: String, status: String = "todo", assignee: String? = nil, tenant: String? = nil, title: String? = nil, body: String? = nil) -> KanbanTask {
+        var object: [String: Any] = ["id": id, "title": title ?? "T \(id)", "status": status]
+        if let assignee { object["assignee"] = assignee }
+        if let tenant { object["tenant"] = tenant }
+        if let body { object["body"] = body }
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        return try! JSONDecoder().decode(KanbanTask.self, from: data)
+    }
+
+    private func makeStore(requester: V3BMockRequester) -> KanbanStore {
+        makeStore(requester: requester, defaults: UserDefaults(suiteName: UUID().uuidString)!)
+    }
+
+    private func makeStore(requester: V3BMockRequester, defaults: UserDefaults) -> KanbanStore {
+        let store = KanbanStore(defaults: defaults)
+        store.configure(requester: requester, serverIdentity: "https://a.test")
+        return store
+    }
+
+    private func routes(
+        boards: [[String: Any]] = V3BMockRequester.baseBoards,
+        current: String = "alpha",
+        board: [String: Any]? = nil
+    ) -> [String: [String: Any]] {
+        [
+            "/api/plugins/kanban/boards": ["boards": boards, "current": current],
+            "/api/plugins/kanban/board": board ?? V3BMockRequester.defaultBoard,
+            "/api/plugins/kanban/profiles": ["profiles": []],
+            "/api/plugins/kanban/projects": ["projects": V3BMockRequester.defaultProjects],
+            "/api/plugins/kanban/orchestration": V3BMockRequester.defaultOrchestration,
+            "/api/plugins/kanban/dispatch": [:],
+        ]
+    }
+
+    private let projectA = ["id": "proj-a", "slug": "project-a", "name": "Project A", "primary_path": "/repos/a", "icon": "", "color": ""]
+    private let projectB = ["id": "proj-b", "slug": "project-b", "name": "Project B", "primary_path": "/repos/b", "icon": "", "color": ""]
+
+    // MARK: - 1. Board create: wire + slug
+
+    func testCreateRequestEncodesPayloadExactly() throws {
+        let request = KanbanCreateBoardRequest(
+            slug: "my-board",
+            name: "My Board",
+            description: "desc",
+            defaultWorkdir: "/repos/x",
+            projectID: "proj-a",
+            switchRequested: false
+        )
+        let data = try JSONEncoder().encode(request)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(object["slug"] as? String, "my-board")
+        XCTAssertEqual(object["name"] as? String, "My Board")
+        XCTAssertEqual(object["description"] as? String, "desc")
+        XCTAssertEqual(object["project_id"] as? String, "proj-a")
+        XCTAssertEqual(object["default_workdir"] as? String, "/repos/x")
+        XCTAssertEqual(object["switch"] as? Bool, false, "switch is EXPLICITLY false; server pointer never touched")
+
+        let minimal = try JSONEncoder().encode(KanbanCreateBoardRequest(slug: "bare"))
+        let minimalObject = try XCTUnwrap(JSONSerialization.jsonObject(with: minimal) as? [String: Any])
+        XCTAssertNil(minimalObject["name"])
+        XCTAssertNil(minimalObject["project_id"])
+        XCTAssertEqual(minimalObject["switch"] as? Bool, false)
+    }
+
+    func testSlugDerivationMatchesDesktopAlgorithm() {
+        XCTAssertEqual(KanbanBoardSlugPolicy.derivedSlug(from: "iOS Release Work"), "ios-release-work")
+        XCTAssertEqual(KanbanBoardSlugPolicy.derivedSlug(from: "  My   Board!!! "), "my-board")
+        XCTAssertEqual(KanbanBoardSlugPolicy.derivedSlug(from: "123 ABC"), "123-abc")
+        XCTAssertEqual(KanbanBoardSlugPolicy.derivedSlug(from: "a--b"), "a-b")
+        XCTAssertEqual(KanbanBoardSlugPolicy.derivedSlug(from: "---leading"), "leading")
+        XCTAssertEqual(KanbanBoardSlugPolicy.derivedSlug(from: "日本語"), "", "non-ASCII yields empty (Create disabled)")
+        XCTAssertEqual(KanbanBoardSlugPolicy.derivedSlug(from: ""), "")
+    }
+
+    func testSlugValidationMatchesBackendRegex() {
+        XCTAssertTrue(KanbanBoardSlugPolicy.isValid("abc"))
+        XCTAssertTrue(KanbanBoardSlugPolicy.isValid("a1-b_c"))
+        XCTAssertFalse(KanbanBoardSlugPolicy.isValid(""))
+        XCTAssertFalse(KanbanBoardSlugPolicy.isValid("-abc"))
+        XCTAssertFalse(KanbanBoardSlugPolicy.isValid("_abc"))
+        XCTAssertFalse(KanbanBoardSlugPolicy.isValid("ABC"))
+        XCTAssertFalse(KanbanBoardSlugPolicy.isValid("a b"))
+        XCTAssertFalse(KanbanBoardSlugPolicy.isValid("a.b"))
+        XCTAssertFalse(KanbanBoardSlugPolicy.isValid(String(repeating: "a", count: 65)))
+    }
+
+    func testCustomPathFoldedIntoDraftAtSubmit() {
+        // W1 regression: the PICKER row is pathless; the typed path is folded
+        // in at submit time, so a selected "Custom Directory…" row must carry
+        // the typed path into the create/patch builders.
+        var draft = KanbanBoardEditorDraft(name: "X", description: "", projectID: nil, workspace: .custom(""))
+        XCTAssertEqual(
+            KanbanBoardPatchPolicy.createRequest(
+                slug: "x", name: "X", description: "", projectID: nil, workspace: draft.workspace
+            ).defaultWorkdir,
+            nil,
+            "an empty custom path is not a wire value"
+        )
+        draft.workspace = .custom(" /repos/typed ")
+        XCTAssertEqual(
+            KanbanBoardPatchPolicy.createRequest(
+                slug: "x", name: "X", description: "", projectID: nil, workspace: draft.workspace
+            ).defaultWorkdir,
+            "/repos/typed",
+            "the folded workspace choice carries the typed path"
+        )
+        let patch = KanbanBoardPatchPolicy.patch(
+            baseline: boardMeta(name: "Alpha", workdir: "/repos/old"),
+            draft: KanbanBoardEditorDraft(name: "Alpha", description: "", projectID: nil, workspace: .custom(" /repos/typed ")),
+            projects: []
+        )
+        XCTAssertEqual(patch.defaultWorkdir, "/repos/typed")
+    }
+
+    func testCreateRequestProjectWorkspaceEncoding() {
+        // Project + Project Default: only project_id travels; workdir mirrors
+        // server-side.
+        let mirrored = KanbanBoardPatchPolicy.createRequest(
+            slug: "x", name: "X", description: "", projectID: "proj-a", workspace: .projectDefault
+        )
+        XCTAssertEqual(mirrored.projectID, "proj-a")
+        XCTAssertNil(mirrored.defaultWorkdir)
+
+        // B-1 documented contract: "None/Scratch" while a project is selected
+        // is NOT representable upstream (the UI hides the row) - the policy
+        // pins what the wire would do anyway: the server mirrors the project.
+        let phantom = KanbanBoardPatchPolicy.createRequest(
+            slug: "x", name: "X", description: "", projectID: "proj-a", workspace: .none
+        )
+        XCTAssertEqual(phantom.projectID, "proj-a")
+        XCTAssertNil(phantom.defaultWorkdir, "project mirror still applies; documented, unreachable from the UI")
+
+        // Custom directory with a project: explicit path wins.
+        let explicit = KanbanBoardPatchPolicy.createRequest(
+            slug: "x", name: "X", description: "d", projectID: "proj-a", workspace: .custom(" /repos/custom ")
+        )
+        XCTAssertEqual(explicit.defaultWorkdir, "/repos/custom")
+        XCTAssertEqual(explicit.projectID, "proj-a")
+
+        // No project, None: no workdir field at all.
+        let none = KanbanBoardPatchPolicy.createRequest(
+            slug: "x", name: "X", description: "", projectID: nil, workspace: .none
+        )
+        XCTAssertNil(none.defaultWorkdir)
+        XCTAssertNil(none.projectID)
+        XCTAssertFalse(none.switchRequested)
+    }
+
+    func testCreateInvalidSlugRejectedBeforeAnyRequest() async {
+        let requester = V3BMockRequester(responsesByPath: routes())
+        let store = makeStore(requester: requester)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected context") }
+
+        do {
+            _ = try await store.createBoard(KanbanCreateBoardRequest(slug: "BAD SLUG"), expectedContext: stampA)
+            XCTFail("a malformed slug must be refused up front")
+        } catch let error as KanbanServiceError {
+            XCTAssertEqual(error, .actionDeclined(reason: "Invalid board slug — use 1-64 lowercase letters or numbers with hyphens/underscores."))
+        } catch {
+            XCTFail("unexpected: \(error)")
+        }
+        XCTAssertFalse(requester.calls.contains { $0.method == "POST" && $0.path.contains("/boards") }, "zero POST for an invalid slug")
+    }
+
+    func testArchiveUnexpectedActionResultFailsClosed() async {
+        let requester = V3BMockRequester(responsesByPath: routes())
+        requester.deleteBoardResponse = [
+            "result": ["slug": "alpha", "action": "deleted", "new_path": ""],
+            "current": "alpha",
+        ]
+        let store = makeStore(requester: requester)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected context") }
+
+        do {
+            _ = try await store.archiveBoard(slug: "alpha", expectedContext: stampA)
+            XCTFail("a non-archive action must fail closed")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("unexpected result"), "action mismatch surfaced: \(error.localizedDescription)")
+        }
+        XCTAssertNotNil(store.mutationErrorMessage)
+        XCTAssertFalse(store.isMutating)
+    }
+
+    func testCreateServerChangeFailsClosed() async {
+        let requesterA = V3BMockRequester(responsesByPath: routes())
+        let store = makeStore(requester: requesterA)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected context") }
+
+        let requesterB = V3BMockRequester(responsesByPath: routes())
+        store.configure(requester: requesterB, serverIdentity: "https://b.test")
+
+        do {
+            _ = try await store.createBoard(KanbanCreateBoardRequest(slug: "beta"), expectedContext: stampA)
+            XCTFail("a create started for A must never execute on B")
+        } catch KanbanServiceError.boardNavigationInProgress {
+            // fail-closed
+        } catch {
+            XCTFail("unexpected: \(error)")
+        }
+        XCTAssertEqual(requesterB.calls.count, 0)
+        XCTAssertFalse(requesterB.calls.contains { $0.method == "POST" && $0.path.contains("/boards") })
+    }
+
+    func testCreateSelectsReturnedSlugLocallyAndRefreshes() async throws {
+        let requester = V3BMockRequester(responsesByPath: routes())
+        requester.boardsProvider = { fetch in
+            fetch >= 2
+                ? ["boards": V3BMockRequester.baseBoards + [["slug": "beta", "name": "Beta", "archived": false]], "current": "alpha"]
+                : ["boards": V3BMockRequester.baseBoards, "current": "alpha"]
+        }
+        requester.boardForSlug = { slug in
+            slug == "beta" ? V3BMockRequester.board(columns: [["name": "todo", "tasks": []]]) : V3BMockRequester.defaultBoard
+        }
+        requester.postBoardResponse = [
+            "board": ["slug": "beta", "name": "Beta", "archived": false],
+            "current": "alpha",
+        ]
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let store = makeStore(requester: requester, defaults: defaults)
+        await store.reload()
+        XCTAssertEqual(store.selectedBoardSlug, "")
+
+        let request = KanbanCreateBoardRequest(slug: "beta", name: "Beta")
+        let created = try await store.createBoard(request)
+
+        XCTAssertEqual(created.slug, "beta")
+        // Local selection only; the server pointer is never requested.
+        XCTAssertEqual(store.selectedBoardSlug, "beta")
+        let scopedKey = KanbanStore.scopedBoardKey(serverIdentity: "https://a.test")
+        XCTAssertEqual(defaults.string(forKey: scopedKey), "beta", "the per-dashboard selection is persisted locally")
+        let posts = requester.calls.filter { $0.method == "POST" && $0.path == "/api/plugins/kanban/boards" }
+        XCTAssertEqual(posts.count, 1)
+        XCTAssertEqual(posts.first?.body?["switch"] as? Bool, false)
+        XCTAssertNil(requester.calls.first { $0.path.contains("/switch") }, "POST /boards/{slug}/switch is never called")
+        // Authoritative reconciliation landed on the created board.
+        XCTAssertEqual(store.loadedBoardSlug, "beta")
+        XCTAssertTrue(store.boards.contains { $0.slug == "beta" })
+    }
+
+    func testCreateOutcomeMessageIsHonestAboutIdempotentCollision() {
+        XCTAssertEqual(
+            KanbanBoardAdminMessage.createOutcomeMessage(knewSlugBeforeRequest: true, name: "beta"),
+            "Board \"beta\" already exists — opened it.",
+            "no fabricated created flag; document the idempotent-return behavior"
+        )
+        XCTAssertEqual(
+            KanbanBoardAdminMessage.createOutcomeMessage(knewSlugBeforeRequest: false, name: "beta"),
+            "Board \"beta\" created and selected."
+        )
+    }
+
+    // MARK: - 2. Board PATCH wire semantics
+
+    private func boardMeta(slug: String = "alpha", name: String = "Alpha", projectID: String? = nil, workdir: String? = nil) -> KanbanBoardMetadata {
+        KanbanBoardMetadata(
+            slug: slug,
+            name: name,
+            defaultWorkdir: workdir,
+            projectID: projectID
+        )
+    }
+
+    func testNameOnlyPatchOmitsProjectAndWorkdir() {
+        // Project-scoped board with its workdir already following the project:
+        // a pure name edit must NOT send project/workdir.
+        let baseline = boardMeta(name: "Alpha", projectID: "proj-a", workdir: "/repos/a")
+        let draft = KanbanBoardEditorDraft(
+            name: "Renamed", description: "", projectID: "proj-a", workspace: .projectDefault
+        )
+        let patch = KanbanBoardPatchPolicy.patch(baseline: baseline, draft: draft, projects: [KanbanProject(id: "proj-a", slug: "project-a", name: "Project A", primaryPath: "/repos/a")])
+        XCTAssertEqual(patch.name, "Renamed")
+        XCTAssertNil(patch.projectID, "name-only edit never touches project")
+        XCTAssertNil(patch.defaultWorkdir, "name-only edit never touches workdir")
+    }
+
+    func testPatchProjectSetAndClear() {
+        // Set: No Project -> Project A (Project Default).
+        let setPatch = KanbanBoardPatchPolicy.patch(
+            baseline: boardMeta(),
+            draft: KanbanBoardEditorDraft(name: "Alpha", description: "", projectID: "proj-a", workspace: .projectDefault),
+            projects: []
+        )
+        XCTAssertEqual(setPatch.projectID, "proj-a")
+        XCTAssertNil(setPatch.defaultWorkdir, "mirror is implied")
+
+        // Clear: Project A -> No Project (with a stale workdir: cleared too).
+        let clearPatch = KanbanBoardPatchPolicy.patch(
+            baseline: boardMeta(name: "Alpha", projectID: "proj-a", workdir: "/repos/a"),
+            draft: KanbanBoardEditorDraft(name: "Alpha", description: "", projectID: nil, workspace: .none),
+            projects: []
+        )
+        XCTAssertEqual(clearPatch.projectID, "", "project clear is an explicit empty string")
+        XCTAssertEqual(clearPatch.defaultWorkdir, "", "workdir clear is an explicit empty string")
+    }
+
+    func testPatchWorkdirSetAndClear() {
+        let setPatch = KanbanBoardPatchPolicy.patch(
+            baseline: boardMeta(),
+            draft: KanbanBoardEditorDraft(name: "Alpha", description: "", projectID: nil, workspace: .custom(" /repos/new ")),
+            projects: []
+        )
+        XCTAssertEqual(setPatch.defaultWorkdir, "/repos/new", "custom path trimmed and set")
+        XCTAssertNil(setPatch.projectID)
+
+        let clearPatch = KanbanBoardPatchPolicy.patch(
+            baseline: boardMeta(name: "Alpha", workdir: "/repos/a"),
+            draft: KanbanBoardEditorDraft(name: "Alpha", description: "", projectID: nil, workspace: .none),
+            projects: []
+        )
+        XCTAssertEqual(clearPatch.defaultWorkdir, "")
+    }
+
+    func testPatchProjectPlusExplicitWorkdirInteraction() {
+        // Changing the project WHILE entering a custom directory: both travel;
+        // the explicit workdir wins over the server-side mirror.
+        let patch = KanbanBoardPatchPolicy.patch(
+            baseline: boardMeta(name: "Alpha"),
+            draft: KanbanBoardEditorDraft(name: "Alpha", description: "", projectID: "proj-b", workspace: .custom("/repos/custom")),
+            projects: [KanbanProject(id: "proj-b", slug: "project-b", name: "Project B", primaryPath: "/repos/b")]
+        )
+        XCTAssertEqual(patch.projectID, "proj-b")
+        XCTAssertEqual(patch.defaultWorkdir, "/repos/custom")
+    }
+
+    func testPatchProjectDefaultRemirrorsDriftedWorkdir() {
+        // Same project, but the workdir drifted away from the project repo:
+        // re-sending the same project_id re-mirrors (default_workdir omitted).
+        let patch = KanbanBoardPatchPolicy.patch(
+            baseline: boardMeta(name: "Alpha", projectID: "proj-a", workdir: "/repos/stale"),
+            draft: KanbanBoardEditorDraft(name: "Alpha", description: "", projectID: "proj-a", workspace: .projectDefault),
+            projects: [KanbanProject(id: "proj-a", slug: "project-a", name: "Project A", primaryPath: "/repos/a")]
+        )
+        XCTAssertEqual(patch.projectID, "proj-a")
+        XCTAssertNil(patch.defaultWorkdir)
+    }
+
+    func testPatchServerChangeFailsClosed() async {
+        let requesterA = V3BMockRequester(responsesByPath: routes())
+        let store = makeStore(requester: requesterA)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected context") }
+
+        let requesterB = V3BMockRequester(responsesByPath: routes())
+        store.configure(requester: requesterB, serverIdentity: "https://b.test")
+
+        do {
+            _ = try await store.updateBoard(
+                slug: "alpha",
+                patch: KanbanUpdateBoardPatch(name: "X"),
+                expectedContext: stampA
+            )
+            XCTFail("a stale stamp must fail closed")
+        } catch KanbanServiceError.boardNavigationInProgress {
+            // expected
+        } catch {
+            XCTFail("unexpected: \(error)")
+        }
+        XCTAssertEqual(requesterB.calls.count, 0)
+    }
+
+    func testUpdateCapturedSlugCannotRetargetAfterSelectionChange() async {
+        let requester = V3BMockRequester(responsesByPath: routes())
+        requester.boardsProvider = { _ in
+            ["boards": V3BMockRequester.baseBoards, "current": "alpha"]
+        }
+        requester.boardForSlug = { _ in V3BMockRequester.defaultBoard }
+        let store = makeStore(requester: requester)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected context") }
+
+        // Settings opened while alpha loaded; the user switches to beta before
+        // the async body runs. The captured stamp no longer owns the loaded
+        // context (board-scope) -> fail closed, zero requests.
+        await store.selectBoard(slug: "beta")
+        XCTAssertEqual(store.loadedBoardSlug, "beta")
+
+        do {
+            _ = try await store.updateBoard(
+                slug: "alpha",
+                patch: KanbanUpdateBoardPatch(name: "X"),
+                expectedContext: stampA
+            )
+            XCTFail("must fail closed after the selection moved")
+        } catch KanbanServiceError.boardNavigationInProgress {
+            // expected: the network target is the captured slug, never the
+            // current selection - and it must not fire at all now.
+        } catch {
+            XCTFail("unexpected: \(error)")
+        }
+        XCTAssertFalse(requester.calls.contains { $0.method == "PATCH" && $0.path.contains("/boards/") })
+    }
+
+    // MARK: - 3. Archive
+
+    func testArchiveNeverRequestsHardDelete() async throws {
+        let requester = V3BMockRequester(responsesByPath: routes())
+        requester.boardsProvider = { _ in
+            ["boards": [["slug": "default", "name": "Default", "archived": false]], "current": "default"]
+        }
+        requester.boardForSlug = { _ in V3BMockRequester.defaultBoard }
+        requester.deleteBoardResponse = [
+            "result": ["slug": "alpha", "action": "archived", "new_path": "/kanban/boards/_archived/alpha-1"],
+            "current": "default",
+        ]
+        let store = makeStore(requester: requester)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected context") }
+
+        _ = try await store.archiveBoard(slug: "alpha", expectedContext: stampA)
+
+        let deletes = requester.calls.filter { $0.method == "DELETE" && $0.path.contains("/boards/alpha") }
+        XCTAssertEqual(deletes.count, 1)
+        XCTAssertFalse(deletes.first?.path.contains("delete") ?? false, "hard-delete query is NEVER sent")
+        XCTAssertNil(deletes.first?.body)
+    }
+
+    func testArchiveStagedForALeavesBUntouched() async {
+        let requesterA = V3BMockRequester(responsesByPath: routes())
+        let store = makeStore(requester: requesterA)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected context") }
+        let staged = PendingBoardArchive(slug: "alpha", displayName: "Alpha", stamp: stampA)
+
+        // Server/board ownership replaced before the confirmation executes.
+        let requesterB = V3BMockRequester(responsesByPath: routes())
+        store.configure(requester: requesterB, serverIdentity: "https://b.test")
+
+        do {
+            _ = try await store.archiveBoard(slug: staged.slug, expectedContext: staged.stamp)
+            XCTFail("a stale staged archive must fail closed")
+        } catch KanbanServiceError.boardNavigationInProgress {
+            // expected
+        } catch {
+            XCTFail("unexpected: \(error)")
+        }
+        XCTAssertEqual(requesterB.calls.count, 0, "a confirmation staged for A never archives on B")
+        XCTAssertFalse(requesterA.calls.contains { $0.method == "DELETE" }, "no archive may fire after ownership loss")
+    }
+
+    func testArchiveDefaultBoardRefusedUpFront() async {
+        let requester = V3BMockRequester(responsesByPath: routes())
+        let store = makeStore(requester: requester)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected context") }
+
+        do {
+            _ = try await store.archiveBoard(slug: "default", expectedContext: stampA)
+            XCTFail("the default board must be refused before any request")
+        } catch let error as KanbanServiceError {
+            XCTAssertEqual(error, .actionDeclined(reason: "Hermes does not allow archiving the default board."))
+        } catch {
+            XCTFail("unexpected: \(error)")
+        }
+        XCTAssertFalse(requester.calls.contains { $0.method == "DELETE" }, "zero DELETE for the default board")
+    }
+
+    func testArchivePartialSuccessMessageSurvivesFailedBoardsRefresh() async throws {
+        let requester = V3BMockRequester(responsesByPath: routes())
+        requester.boardsProvider = { fetch in
+            if fetch >= 3 { throw URLError(.cannotConnectToHost) }
+            return ["boards": V3BMockRequester.baseBoards, "current": "alpha"]
+        }
+        requester.boardForSlug = { _ in V3BMockRequester.defaultBoard }
+        requester.deleteBoardResponse = [
+            "result": ["slug": "beta", "action": "archived", "new_path": "/x"],
+            "current": "alpha",
+        ]
+        let store = makeStore(requester: requester)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected context") }
+
+        // DELETE succeeds (archiving a NON-selected board), but the boards
+        // refresh afterwards fails: the ARCHIVE is not reported as failed and
+        // the crafted partial-success wording survives (no clobbering reload).
+        let archived = try await store.archiveBoard(slug: "beta", expectedContext: stampA)
+        XCTAssertTrue(archived)
+        XCTAssertNil(store.mutationErrorMessage, "the archive itself did not fail")
+        XCTAssertTrue(
+            store.errorMessage?.hasPrefix("The board was archived, but the board list could not be refreshed.") == true,
+            "partial-success wording survives: \(store.errorMessage ?? "nil")"
+        )
+        XCTAssertFalse(store.isMutating, "ownership released")
+    }
+
+    func testUpdateEmptyPatchShortCircuitsWithoutRequest() async throws {
+        let requester = V3BMockRequester(responsesByPath: routes())
+        let store = makeStore(requester: requester)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected context") }
+
+        let baseline = store.boards.first { $0.slug == "alpha" }
+        let echoed = try await store.updateBoard(
+            slug: "alpha",
+            patch: KanbanUpdateBoardPatch(),
+            expectedContext: stampA
+        )
+        XCTAssertEqual(echoed.slug, baseline?.slug)
+        XCTAssertFalse(requester.calls.contains { $0.method == "PATCH" && $0.path.contains("/boards/") }, "an all-nil patch never reaches the wire")
+    }
+
+    func testUpdateSlugMismatchWithStampFailsClosed() async {
+        let requester = V3BMockRequester(responsesByPath: routes())
+        let store = makeStore(requester: requester)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected context") }
+        // A valid stamp paired with the WRONG board slug must never issue.
+        let foreignStamp = KanbanBoardContextStamp(boardSlug: "beta", configurationGeneration: stampA.configurationGeneration)
+
+        do {
+            _ = try await store.updateBoard(
+                slug: "alpha",
+                patch: KanbanUpdateBoardPatch(name: "X"),
+                expectedContext: foreignStamp
+            )
+            XCTFail("a wrong-slug stamp must fail closed")
+        } catch KanbanServiceError.boardNavigationInProgress {
+            // expected
+        } catch {
+            XCTFail("unexpected: \(error)")
+        }
+        XCTAssertFalse(requester.calls.contains { $0.method == "PATCH" && $0.path.contains("/boards/") })
+    }
+
+    func testArchiveBackendRefusalPreserved() async {
+        let requester = V3BMockRequester(responsesByPath: routes())
+        requester.errorsByPath["/api/plugins/kanban/boards/beta"] = KanbanAdminTestError.refused("board 'beta' is already archived")
+        let store = makeStore(requester: requester)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected context") }
+
+        do {
+            _ = try await store.archiveBoard(slug: "beta", expectedContext: stampA)
+            XCTFail("the backend refusal must propagate")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("already archived"), "backend reason surfaced verbatim")
+            XCTAssertNotNil(store.mutationErrorMessage)
+        }
+    }
+
+    func testArchiveSelectedBoardReconcilesToValidFallback() async throws {
+        let requester = V3BMockRequester(responsesByPath: routes())
+        requester.boardsProvider = { fetch in
+            fetch >= 2
+                ? ["boards": [["slug": "default", "name": "Default", "archived": false]], "current": "default"]
+                : ["boards": V3BMockRequester.baseBoards, "current": "default"]
+        }
+        requester.boardForSlug = { slug in
+            slug == "default" ? V3BMockRequester.defaultBoard : V3BMockRequester.board(columns: [["name": "todo", "tasks": []]])
+        }
+        requester.deleteBoardResponse = [
+            "result": ["slug": "alpha", "action": "archived", "new_path": "/x"],
+            "current": "default",
+        ]
+        let store = makeStore(requester: requester)
+        // selectBoard performs the authoritative load (boards fetch #1 keeps
+        // alpha; fetch #2+ drop it post-archive).
+        await store.selectBoard(slug: "alpha")
+        XCTAssertEqual(store.loadedBoardSlug, "alpha")
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected context") }
+
+        _ = try await store.archiveBoard(slug: "alpha", expectedContext: stampA)
+
+        // Selected board disappeared: fallback resolved and authoritative
+        // board reloaded; selection no longer points at the archived slug.
+        XCTAssertFalse(store.boards.contains { $0.slug == "alpha" })
+        XCTAssertEqual(store.selectedBoardSlug, "", "persisted selection cleared for the archived board")
+        XCTAssertEqual(store.loadedBoardSlug, "default", "board converges on the valid fallback")
+        XCTAssertNil(store.mutationErrorMessage)
+    }
+
+    func testArchiveNonSelectedBoardDoesNotDisturbSelection() async throws {
+        let requester = V3BMockRequester(responsesByPath: routes())
+        requester.boardsProvider = { _ in
+            ["boards": V3BMockRequester.baseBoards, "current": "alpha"]
+        }
+        requester.boardForSlug = { _ in V3BMockRequester.defaultBoard }
+        requester.deleteBoardResponse = [
+            "result": ["slug": "beta", "action": "archived", "new_path": "/x"],
+            "current": "alpha",
+        ]
+        let store = makeStore(requester: requester)
+        await store.reload()
+        guard let stampA = store.loadedContextStamp else { return XCTFail("expected context") }
+
+        // Archive a NON-selected board while alpha stays loaded/selected.
+        _ = try await store.archiveBoard(slug: "beta", expectedContext: stampA)
+
+        XCTAssertEqual(store.selectedBoardSlug, "", "selection (server current -> alpha) undisturbed")
+        XCTAssertEqual(store.loadedBoardSlug, "alpha", "the selected board is still loaded")
+        XCTAssertNil(store.mutationErrorMessage)
+    }
+
+    // MARK: - 4. Filters
+
+    private func filterFixture() -> KanbanTask {
+        makeTask(id: "t1", assignee: "coder", tenant: "project-a", title: "Hello world", body: "details")
+    }
+
+    func testAssigneeFilterUsesExactTaskAssignee() {
+        let coder = filterFixture()
+        let reviewer = makeTask(id: "t2", assignee: "reviewer")
+        let unassigned = makeTask(id: "t3", assignee: nil)
+
+        XCTAssertTrue(KanbanBoardFilterPolicy.matchesAssignee(coder, "coder"))
+        XCTAssertFalse(KanbanBoardFilterPolicy.matchesAssignee(reviewer, "coder"))
+        // A task with NO assignee is never matched by an assignee filter,
+        // even though the resolved default assignee may be "coder".
+        XCTAssertFalse(KanbanBoardFilterPolicy.matchesAssignee(unassigned, "coder"))
+        XCTAssertTrue(KanbanBoardFilterPolicy.matchesAssignee(unassigned, nil))
+    }
+
+    func testTenantFilterExactMatch() {
+        let task = filterFixture()
+        XCTAssertTrue(KanbanBoardFilterPolicy.matchesTenant(task, "project-a"))
+        XCTAssertFalse(KanbanBoardFilterPolicy.matchesTenant(task, "project-b"))
+        XCTAssertTrue(KanbanBoardFilterPolicy.matchesTenant(task, nil))
+    }
+
+    func testSearchCoversTitleBodyIDSummaryAndAssignee() {
+        XCTAssertTrue(KanbanBoardFilterPolicy.matchesSearch(makeTask(id: "t-7"), "T-7"), "task id is searchable")
+        XCTAssertTrue(KanbanBoardFilterPolicy.matchesSearch(filterFixture(), "hello"))
+        XCTAssertTrue(KanbanBoardFilterPolicy.matchesSearch(filterFixture(), "DETAILS"))
+        XCTAssertTrue(KanbanBoardFilterPolicy.matchesSearch(KanbanTask(id: "x", latestSummaryText: "summary"), "summary"))
+        XCTAssertTrue(KanbanBoardFilterPolicy.matchesSearch(KanbanTask(id: "x", assigneeText: "coder"), "coder"))
+        XCTAssertFalse(KanbanBoardFilterPolicy.matchesSearch(filterFixture(), "zzzz"))
+        XCTAssertTrue(KanbanBoardFilterPolicy.matchesSearch(filterFixture(), "   "))
+    }
+
+    func testCombinedAndPredicate() {
+        let task = filterFixture()
+        XCTAssertTrue(KanbanBoardFilterPolicy.matches(task: task, search: "hello", assignee: "coder", tenant: "project-a"))
+        XCTAssertFalse(KanbanBoardFilterPolicy.matches(task: task, search: "hello", assignee: "reviewer", tenant: "project-a"))
+        XCTAssertFalse(KanbanBoardFilterPolicy.matches(task: task, search: "hello", assignee: "coder", tenant: "project-b"))
+        XCTAssertFalse(KanbanBoardFilterPolicy.matches(task: task, search: "nope", assignee: nil, tenant: nil))
+    }
+
+    func testFiltersNeverMutateAuthoritativeBoard() {
+        let board = KanbanBoard(
+            columns: [
+                KanbanColumn(name: "running", tasks: [makeTask(id: "a", assignee: "coder"), makeTask(id: "b", assignee: "reviewer")]),
+            ],
+            tenants: ["project-a"],
+            assignees: ["coder", "reviewer"]
+        )
+        let baseColumns = board.columns
+        let visible = KanbanBoardFilterPolicy.visibleColumns(board: board, search: "", assignee: "coder", tenant: nil)
+        XCTAssertEqual(visible.first?.tasks.map(\.id), ["a"])
+        XCTAssertEqual(board.columns, baseColumns, "the authoritative board is never mutated")
+        XCTAssertEqual(board.columns.first?.tasks.count, 2)
+    }
+
+    func testStaleFilterResetsHarmlesslyWhenRosterChanges() {
+        XCTAssertNil(KanbanBoardFilterPolicy.validatedFilter("coder", available: []), "stale profile filter deactivates")
+        XCTAssertNil(KanbanBoardFilterPolicy.validatedFilter("coder", available: ["reviewer"]))
+        XCTAssertEqual(KanbanBoardFilterPolicy.validatedFilter("coder", available: ["coder", "reviewer"]), "coder")
+        XCTAssertNil(KanbanBoardFilterPolicy.validatedFilter("", available: ["coder"]))
+        XCTAssertNil(KanbanBoardFilterPolicy.validatedFilter(nil, available: ["coder"]))
+    }
+
+    // MARK: - 5. Show Archived
+
+    func testArchivedToggleIsTheServerFetchParameter() async {
+        let requester = V3BMockRequester(responsesByPath: routes())
+        var withArchivedColumn = false
+        requester.boardForSlug = { _ in
+            if withArchivedColumn {
+                return V3BMockRequester.board(columns: [
+                    ["name": "todo", "tasks": []],
+                    ["name": "archived", "tasks": []],
+                ])
+            }
+            return V3BMockRequester.board(columns: [["name": "todo", "tasks": []]])
+        }
+        let store = makeStore(requester: requester)
+        await store.reload(includeArchived: false)
+        XCTAssertFalse(requester.calls.contains { $0.path.contains("include_archived") }, "default fetch omits the param")
+        XCTAssertFalse(store.board?.columns.contains { $0.name == "archived" } ?? true, "no archived column without the toggle")
+
+        withArchivedColumn = true
+        await store.reload(includeArchived: true)
+        XCTAssertTrue(requester.calls.contains { $0.path.contains("include_archived=true") }, "Show Archived is a server fetch parameter")
+        XCTAssertTrue(store.board?.columns.contains { $0.name == "archived" } ?? false, "archived column appears with the toggle")
+    }
+
+    func testArchivedLaneFallsBackWhenColumnHidden() {
+        let visibleColumns = [KanbanColumn(name: "todo"), KanbanColumn(name: "ready")]
+        XCTAssertEqual(
+            KanbanLanePolicy.effectiveSelectedLane(selected: "archived", columns: visibleColumns),
+            "todo",
+            "a selected archived lane falls back to a sensible lane when the column is gone"
+        )
+        let withArchived = [KanbanColumn(name: "todo"), KanbanColumn(name: "archived")]
+        XCTAssertEqual(KanbanLanePolicy.effectiveSelectedLane(selected: "archived", columns: withArchived), "archived")
+    }
+
+    // MARK: - 6. Running grouped by profile
+
+    func testGroupingOffYieldsFlatList() {
+        XCTAssertFalse(KanbanRunningGroupPolicy.shouldApply(lane: "running", enabled: false))
+        XCTAssertFalse(KanbanRunningGroupPolicy.shouldApply(lane: "todo", enabled: true), "grouping ONLY affects Running")
+        XCTAssertTrue(KanbanRunningGroupPolicy.shouldApply(lane: "running", enabled: true))
+    }
+
+    func testGroupingBucketsRunningByAssigneeWithUnassignedFallback() {
+        let tasks = [
+            makeTask(id: "a", assignee: "coder"),
+            makeTask(id: "b", assignee: "coder"),
+            makeTask(id: "c", assignee: nil),
+            makeTask(id: "d", assignee: "reviewer"),
+        ]
+        let groups = KanbanRunningGroupPolicy.group(tasks)
+        XCTAssertEqual(groups.map(\.key), ["coder", "reviewer", "unassigned"], "deterministic ordering, unassigned participates")
+        XCTAssertEqual(groups[0].tasks.map(\.id), ["a", "b"])
+        XCTAssertEqual(groups[2].displayName, "Unassigned")
+        XCTAssertEqual(groups[2].tasks.map(\.id), ["c"])
+    }
+
+    func testGroupingDeterministicCaseInsensitiveOrderWithTieBreak() {
+        let tasks = [
+            makeTask(id: "1", assignee: "B"),
+            makeTask(id: "2", assignee: "a"),
+            makeTask(id: "3", assignee: "A"),
+        ]
+        let groups = KanbanRunningGroupPolicy.group(tasks)
+        XCTAssertEqual(groups.map(\.key), ["A", "a", "B"], "case-insensitive primary, raw tie-break")
+    }
+
+    func testGroupingAppliesAfterFiltering() {
+        let all = [
+            makeTask(id: "keep", assignee: "coder", tenant: "project-a"),
+            makeTask(id: "drop", assignee: "coder", tenant: "project-b"),
+            makeTask(id: "nil", assignee: nil, tenant: "project-a"),
+        ]
+        let filtered = all.filter {
+            KanbanBoardFilterPolicy.matches(task: $0, search: "", assignee: "coder", tenant: "project-a")
+        }
+        let groups = KanbanRunningGroupPolicy.group(filtered)
+        XCTAssertEqual(groupByID(groups).sorted(), ["keep"], "grouping runs AFTER filtering")
+    }
+
+    private func groupByID(_ groups: [KanbanRunningGroupPolicy.Group]) -> [String] {
+        groups.flatMap { $0.tasks.map(\.id) }.sorted()
+    }
+}
+
+// MARK: - Fixtures
+
+extension KanbanTask {
+    fileprivate init(id: String, latestSummaryText: String? = nil, assigneeText: String? = nil) {
+        var object: [String: Any] = ["id": id, "title": id, "status": "todo"]
+        if let latestSummaryText { object["latest_summary"] = latestSummaryText }
+        if let assigneeText { object["assignee"] = assigneeText }
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        self = try! JSONDecoder().decode(KanbanTask.self, from: data)
+    }
+}
+
+enum KanbanAdminTestError: LocalizedError {
+    case refused(String)
+    var errorDescription: String? {
+        switch self {
+        case .refused(let message): return message
+        }
+    }
+}
+
+/// Deterministic DashboardJSONRequester double for V3B: recorded calls,
+/// slug-keyed board provider, boards-list provider, error injection, and the
+/// continuation-handshake suspension machinery (no sleeps).
+@MainActor
+private final class V3BMockRequester: DashboardJSONRequester {
+    struct Call {
+        let path: String
+        let method: String
+        let body: [String: Any]?
+    }
+
+    static let baseBoards: [[String: Any]] = [
+        ["slug": "alpha", "name": "Alpha", "archived": false],
+        ["slug": "beta", "name": "Beta", "archived": false],
+        ["slug": "default", "name": "Default", "archived": false],
+    ]
+
+    static let defaultProjects: [[String: Any]] = [
+        ["id": "proj-a", "slug": "project-a", "name": "Project A", "primary_path": "/repos/a", "icon": "", "color": ""],
+        ["id": "proj-b", "slug": "project-b", "name": "Project B", "primary_path": "/repos/b", "icon": "", "color": ""],
+    ]
+
+    static let defaultOrchestration: [String: Any] = [
+        "orchestrator_profile": "", "default_assignee": "", "auto_decompose": true,
+        "auto_promote_children": true, "resolved_orchestrator_profile": "default",
+        "resolved_default_assignee": "coder", "active_profile": "default",
+    ]
+
+    static func board(columns: [[String: Any]]) -> [String: Any] {
+        ["columns": columns, "tenants": ["project-a", "project-b"], "assignees": ["coder", "reviewer", "default"], "latest_event_id": 1, "now": 2]
+    }
+
+    static let defaultBoard: [String: Any] = board(columns: [
+        ["name": "triage", "tasks": []],
+        ["name": "todo", "tasks": []],
+        ["name": "running", "tasks": []],
+    ])
+
+    var responsesByPath: [String: [String: Any]]
+    var errorsByPath: [String: Error] = [:]
+    var boardsProvider: (Int) throws -> [String: Any]
+    var boardForSlug: (String) -> [String: Any]
+    var deleteBoardResponse: [String: Any] = [:]
+    var postBoardResponse: [String: Any] = [:]
+    var boardFetches = 0
+    var boardsFetches = 0
+    var calls: [Call] = []
+
+    private var suspendEntries: [(method: String, basePath: String)] = []
+    private var suspended: [CheckedContinuation<Void, Never>] = []
+    private var suspensionWaiters: [CheckedContinuation<Void, Never>] = []
+    private var parkedCount = 0
+    private var parkedWaiters: [CheckedContinuation<Void, Never>] = []
+
+    init(responsesByPath: [String: [String: Any]] = [:]) {
+        self.responsesByPath = responsesByPath
+        let boards = responsesByPath["/api/plugins/kanban/boards"] ?? ["boards": Self.baseBoards, "current": "alpha"]
+        boardsProvider = { _ in boards }
+        boardForSlug = { _ in Self.defaultBoard }
+    }
+
+    func suspend(method: String, basePath: String) {
+        suspendEntries.append((method, basePath))
+    }
+
+    func waitForSuspension() async {
+        if !suspended.isEmpty { return }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            suspensionWaiters.append(continuation)
+        }
+    }
+
+    func waitUntilParked() async {
+        if parkedCount > 0 { return }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            parkedWaiters.append(continuation)
+        }
+    }
+
+    func resumeSuspended() {
+        let pending = suspended
+        suspended.removeAll()
+        pending.forEach { $0.resume() }
+    }
+
+    func requestJSON(path: String, method: String, body: [String: Any]?, timeoutMilliseconds: Int, maxResponseBytes: Int) async throws -> [String: Any] {
+        let call = Call(path: path, method: method, body: body)
+        calls.append(call)
+        let basePath = path.components(separatedBy: "?").first ?? path
+
+        if suspendEntries.contains(where: { $0.method == method && $0.basePath == basePath }) {
+            suspendEntries.removeAll { $0.method == method && $0.basePath == basePath }
+            parkedCount += 1
+            parkedWaiters.forEach { $0.resume() }
+            parkedWaiters.removeAll()
+            suspensionWaiters.forEach { $0.resume() }
+            suspensionWaiters.removeAll()
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                suspended.append(continuation)
+            }
+        }
+
+        if let error = errorsByPath[path] ?? errorsByPath[basePath] { throw error }
+        if method == "GET", basePath == "/api/plugins/kanban/boards" {
+            boardsFetches += 1
+            return try boardsProvider(boardsFetches)
+        }
+        if method == "GET", basePath == "/api/plugins/kanban/board" {
+            boardFetches += 1
+            let slug = queryValue("board", in: path) ?? "default"
+            return boardForSlug(slug)
+        }
+        if method == "POST", basePath == "/api/plugins/kanban/boards" {
+            return postBoardResponse
+        }
+        if method == "DELETE", basePath.hasPrefix("/api/plugins/kanban/boards/") {
+            return deleteBoardResponse
+        }
+        if let response = responsesByPath[path] ?? responsesByPath[basePath] { return response }
+        return [:]
+    }
+
+    private func queryValue(_ key: String, in path: String) -> String? {
+        guard let query = path.components(separatedBy: "?").dropFirst().first else { return nil }
+        return query.components(separatedBy: "&")
+            .first { $0.hasPrefix(key + "=") }
+            .map { String($0.dropFirst(key.count + 1)) }
+    }
+}

--- a/ConduitTests/KanbanV3BTests.swift
+++ b/ConduitTests/KanbanV3BTests.swift
@@ -125,6 +125,120 @@ final class KanbanV3BTests: XCTestCase {
         XCTAssertEqual(patch.defaultWorkdir, "/repos/typed")
     }
 
+    // MARK: - V3B final pass: canonical workspace + baselines
+
+    private let projects = [
+        KanbanProject(id: "proj-a", slug: "project-a", name: "Project A", primaryPath: "/repos/a"),
+        KanbanProject(id: "proj-b", slug: "project-b", name: "Project B", primaryPath: "/repos/b"),
+    ]
+
+    func testWorkspaceDerivationCases() {
+        // F: one canonical derivation for seed AND post-save echo.
+        XCTAssertEqual(
+            KanbanBoardWorkspacePresentation.derive(projectID: "proj-a", defaultWorkdir: "/repos/a", projects: projects),
+            .projectDefault,
+            "project + primary workdir -> Project Default"
+        )
+        XCTAssertEqual(
+            KanbanBoardWorkspacePresentation.derive(projectID: "proj-a", defaultWorkdir: "/repos/custom", projects: projects),
+            .custom("/repos/custom"),
+            "project + drifted custom workdir -> Custom"
+        )
+        XCTAssertEqual(
+            KanbanBoardWorkspacePresentation.derive(projectID: nil, defaultWorkdir: "/repos/solo", projects: projects),
+            .custom("/repos/solo"),
+            "no project + workdir -> Custom"
+        )
+        XCTAssertEqual(
+            KanbanBoardWorkspacePresentation.derive(projectID: nil, defaultWorkdir: nil, projects: projects),
+            .none,
+            "no project + no workdir -> None"
+        )
+        XCTAssertEqual(
+            KanbanBoardWorkspacePresentation.derive(projectID: "proj-a", defaultWorkdir: nil, projects: projects),
+            .projectDefault,
+            "project + nil workdir means project default upstream"
+        )
+    }
+
+    func testDriftedCustomWorkdirSurvivesUnrelatedSave() {
+        // D: project-scoped board with a DRIFTED custom workdir; a name-only
+        // save must leave both project_id and default_workdir off the wire -
+        // the next unrelated save can never re-mirror /repos/custom to /repos/a.
+        let baseline = KanbanBoardMetadata(
+            slug: "alpha", name: "Alpha",
+            defaultWorkdir: "/repos/custom", projectID: "proj-a"
+        )
+        let derived = KanbanBoardWorkspacePresentation.derive(from: baseline, projects: projects)
+        XCTAssertEqual(derived, .custom("/repos/custom"), "the echo stays Custom")
+
+        let draft = KanbanBoardEditorDraft(
+            name: "Renamed", description: "", projectID: "proj-a", workspace: derived
+        )
+        let patch = KanbanBoardPatchPolicy.patch(baseline: baseline, draft: draft, projects: projects)
+        XCTAssertEqual(patch.name, "Renamed")
+        XCTAssertNil(patch.projectID, "unrelated save omits project_id")
+        XCTAssertNil(patch.defaultWorkdir, "unrelated save omits default_workdir - the drift is preserved")
+    }
+
+    func testBaselineAdvancesAfterSave() {
+        // E: Save #1 changes workdir /old -> /new; Save #2 edits description
+        // only. The second PATCH must be compared against /new (the accepted
+        // echo), never /old - so default_workdir is omitted, not resent.
+        let stale = KanbanBoardMetadata(slug: "alpha", name: "Alpha", defaultWorkdir: "/old")
+        let accepted = KanbanBoardMetadata(slug: "alpha", name: "Alpha", defaultWorkdir: "/new")
+        let derivedAfterEcho = KanbanBoardWorkspacePresentation.derive(from: accepted, projects: [])
+        XCTAssertEqual(derivedAfterEcho, .custom("/new"))
+
+        let secondDraft = KanbanBoardEditorDraft(
+            name: "Alpha", description: "Fresh description", projectID: nil, workspace: derivedAfterEcho
+        )
+        let secondPatch = KanbanBoardPatchPolicy.patch(baseline: accepted, draft: secondDraft, projects: [])
+        XCTAssertEqual(secondPatch.description, "Fresh description")
+        XCTAssertNil(secondPatch.defaultWorkdir, "no stale /old comparison; workdir untouched")
+
+        // Contrast: had the editor still compared against /old, the second
+        // patch would have had to resend default_workdir "/new".
+        let staleBaselinePatch = KanbanBoardPatchPolicy.patch(baseline: stale, draft: secondDraft, projects: [])
+        XCTAssertEqual(staleBaselinePatch.defaultWorkdir, "/new", "stale baseline would resend - proving the advance matters")
+    }
+
+    func testEffectiveDirectoryPreviewFollowsDraftProjectSelection() {
+        // G: selecting Project B after Project A must preview B's primary
+        // path immediately - never the original board's stale workdir.
+        XCTAssertEqual(
+            KanbanBoardWorkspacePresentation.previewDirectory(workspace: .projectDefault, projectID: "proj-b", projects: projects),
+            "/repos/b"
+        )
+        XCTAssertEqual(
+            KanbanBoardWorkspacePresentation.previewDirectory(workspace: .projectDefault, projectID: "proj-a", projects: projects),
+            "/repos/a"
+        )
+        XCTAssertEqual(
+            KanbanBoardWorkspacePresentation.previewDirectory(workspace: .custom(" /repos/typed "), projectID: nil, projects: projects),
+            "/repos/typed"
+        )
+        XCTAssertNil(KanbanBoardWorkspacePresentation.previewDirectory(workspace: .none, projectID: nil, projects: projects))
+        // projectDefault with a nil/unresolvable project previews nothing.
+        XCTAssertNil(KanbanBoardWorkspacePresentation.previewDirectory(workspace: .projectDefault, projectID: nil, projects: projects))
+        XCTAssertNil(KanbanBoardWorkspacePresentation.previewDirectory(workspace: .projectDefault, projectID: "missing", projects: projects))
+    }
+
+    func testEmptyAssigneeGroupsAsUnassigned() {
+        // H: nil AND "" map to the Unassigned group; "coder" stays its own
+        // group; whitespace-only strings stay truthy like upstream; no blank
+        // group is ever produced.
+        let blank = makeTask(id: "blank", assignee: "")
+        let nilA = makeTask(id: "nil-a", assignee: nil)
+        let coder = makeTask(id: "coder", assignee: "coder")
+        let spacey = makeTask(id: "space", assignee: "   ")
+
+        let groups = KanbanRunningGroupPolicy.group([blank, nilA, coder, spacey])
+        XCTAssertEqual(groups.map(\.key).sorted(), ["   ", "coder", "unassigned"], "no blank group")
+        let unassigned = groups.first { $0.key == KanbanRunningGroupPolicy.unassignedKey }
+        XCTAssertEqual(unassigned?.tasks.map(\.id).sorted(), ["blank", "nil-a"], "nil and empty-string both land in Unassigned")
+    }
+
     func testCreateRequestProjectWorkspaceEncoding() {
         // Project + Project Default: only project_id travels; workdir mirrors
         // server-side.
@@ -411,12 +525,12 @@ final class KanbanV3BTests: XCTestCase {
     func testArchiveNeverRequestsHardDelete() async throws {
         let requester = V3BMockRequester(responsesByPath: routes())
         requester.boardsProvider = { _ in
-            ["boards": [["slug": "default", "name": "Default", "archived": false]], "current": "default"]
+            ["boards": V3BMockRequester.baseBoards, "current": "alpha"]
         }
         requester.boardForSlug = { _ in V3BMockRequester.defaultBoard }
         requester.deleteBoardResponse = [
             "result": ["slug": "alpha", "action": "archived", "new_path": "/kanban/boards/_archived/alpha-1"],
-            "current": "default",
+            "current": "alpha",
         ]
         let store = makeStore(requester: requester)
         await store.reload()
@@ -478,17 +592,17 @@ final class KanbanV3BTests: XCTestCase {
         }
         requester.boardForSlug = { _ in V3BMockRequester.defaultBoard }
         requester.deleteBoardResponse = [
-            "result": ["slug": "beta", "action": "archived", "new_path": "/x"],
+            "result": ["slug": "alpha", "action": "archived", "new_path": "/x"],
             "current": "alpha",
         ]
         let store = makeStore(requester: requester)
         await store.reload()
         guard let stampA = store.loadedContextStamp else { return XCTFail("expected context") }
 
-        // DELETE succeeds (archiving a NON-selected board), but the boards
+        // DELETE succeeds (archiving the loaded board), but the authoritative
         // refresh afterwards fails: the ARCHIVE is not reported as failed and
         // the crafted partial-success wording survives (no clobbering reload).
-        let archived = try await store.archiveBoard(slug: "beta", expectedContext: stampA)
+        let archived = try await store.archiveBoard(slug: "alpha", expectedContext: stampA)
         XCTAssertTrue(archived)
         XCTAssertNil(store.mutationErrorMessage, "the archive itself did not fail")
         XCTAssertTrue(
@@ -539,13 +653,13 @@ final class KanbanV3BTests: XCTestCase {
 
     func testArchiveBackendRefusalPreserved() async {
         let requester = V3BMockRequester(responsesByPath: routes())
-        requester.errorsByPath["/api/plugins/kanban/boards/beta"] = KanbanAdminTestError.refused("board 'beta' is already archived")
+        requester.errorsByPath["/api/plugins/kanban/boards/alpha"] = KanbanAdminTestError.refused("board 'alpha' is already archived")
         let store = makeStore(requester: requester)
         await store.reload()
         guard let stampA = store.loadedContextStamp else { return XCTFail("expected context") }
 
         do {
-            _ = try await store.archiveBoard(slug: "beta", expectedContext: stampA)
+            _ = try await store.archiveBoard(slug: "alpha", expectedContext: stampA)
             XCTFail("the backend refusal must propagate")
         } catch {
             XCTAssertTrue(error.localizedDescription.contains("already archived"), "backend reason surfaced verbatim")
@@ -584,25 +698,97 @@ final class KanbanV3BTests: XCTestCase {
         XCTAssertNil(store.mutationErrorMessage)
     }
 
-    func testArchiveNonSelectedBoardDoesNotDisturbSelection() async throws {
+    func testUpdateTargetMismatchWithCurrentContextFailsClosed() async {
+        // A. BLOCKER regression: current loaded board = beta, expected stamp =
+        // beta, but the EXPLICIT target slug = alpha. The stale sheet window
+        // (sheet still targeting alpha while beta is now current) must fail
+        // closed with ZERO network traffic.
+        let requester = V3BMockRequester(responsesByPath: routes())
+        requester.boardsProvider = { _ in
+            ["boards": V3BMockRequester.baseBoards, "current": "alpha"]
+        }
+        requester.boardForSlug = { _ in V3BMockRequester.defaultBoard }
+        requester.responsesByPath["/api/plugins/kanban/boards/alpha"] = [
+            "board": ["slug": "alpha", "name": "Alpha", "archived": false],
+        ]
+        let store = makeStore(requester: requester)
+        await store.reload()
+        // Move the loaded context to beta.
+        await store.selectBoard(slug: "beta")
+        XCTAssertEqual(store.loadedBoardSlug, "beta")
+        guard let stampB = store.loadedContextStamp else { return XCTFail("expected context") }
+
+        do {
+            _ = try await store.updateBoard(
+                slug: "alpha",
+                patch: KanbanUpdateBoardPatch(name: "X"),
+                expectedContext: stampB
+            )
+            XCTFail("target slug alpha with a beta stamp must fail closed")
+        } catch KanbanServiceError.boardNavigationInProgress {
+            // expected
+        } catch {
+            XCTFail("unexpected: \(error)")
+        }
+        XCTAssertFalse(requester.calls.contains { $0.method == "PATCH" && $0.path.contains("/boards/alpha") }, "zero PATCH to alpha")
+        XCTAssertFalse(requester.calls.contains { $0.method == "PATCH" && $0.path.contains("/boards/beta") }, "zero PATCH to beta")
+    }
+
+    func testArchiveTargetMismatchWithCurrentContextFailsClosed() async {
+        // B. Same stale-sheet regression for an archive: current = beta,
+        // stamp = beta, explicit target slug = alpha -> zero DELETE (the
+        // view would stage a PendingBoardArchive; the store boundary is the
+        // hard gate, exercised directly here).
         let requester = V3BMockRequester(responsesByPath: routes())
         requester.boardsProvider = { _ in
             ["boards": V3BMockRequester.baseBoards, "current": "alpha"]
         }
         requester.boardForSlug = { _ in V3BMockRequester.defaultBoard }
         requester.deleteBoardResponse = [
-            "result": ["slug": "beta", "action": "archived", "new_path": "/x"],
+            "result": ["slug": "alpha", "action": "archived", "new_path": "/x"],
             "current": "alpha",
+        ]
+        let store = makeStore(requester: requester)
+        await store.reload()
+        await store.selectBoard(slug: "beta")
+        guard let stampB = store.loadedContextStamp else { return XCTFail("expected context") }
+
+        do {
+            _ = try await store.archiveBoard(slug: "alpha", expectedContext: stampB)
+            XCTFail("a staged archive for alpha with a beta stamp must fail closed")
+        } catch KanbanServiceError.boardNavigationInProgress {
+            // expected
+        } catch {
+            XCTFail("unexpected: \(error)")
+        }
+        XCTAssertFalse(requester.calls.contains { $0.method == "DELETE" }, "zero DELETE")
+    }
+
+    func testBoardUpdateCorrectTargetStillWorks() async throws {
+        // C. The matching configuration (current = alpha, stamp = alpha,
+        // target slug = alpha) still executes normally.
+        let requester = V3BMockRequester(responsesByPath: routes())
+        requester.responsesByPath["/api/plugins/kanban/boards/alpha"] = [
+            "board": ["slug": "alpha", "name": "Renamed", "archived": false],
         ]
         let store = makeStore(requester: requester)
         await store.reload()
         guard let stampA = store.loadedContextStamp else { return XCTFail("expected context") }
 
-        // Archive a NON-selected board while alpha stays loaded/selected.
-        _ = try await store.archiveBoard(slug: "beta", expectedContext: stampA)
-
-        XCTAssertEqual(store.selectedBoardSlug, "", "selection (server current -> alpha) undisturbed")
-        XCTAssertEqual(store.loadedBoardSlug, "alpha", "the selected board is still loaded")
+        let updated = try await store.updateBoard(
+            slug: "alpha",
+            patch: KanbanUpdateBoardPatch(name: "Renamed"),
+            expectedContext: stampA
+        )
+        XCTAssertEqual(updated.name, "Renamed")
+        let patchCalls = requester.calls.filter { $0.method == "PATCH" && $0.path.contains("/boards/alpha") }
+        XCTAssertEqual(patchCalls.count, 1)
+        // Wire-level: the encoded body really contains name and OMITS the
+        // untouched project/workdir fields (S-1).
+        let body = try XCTUnwrap(patchCalls.first?.body)
+        XCTAssertEqual(body["name"] as? String, "Renamed")
+        XCTAssertNil(body["project_id"], "project_id omitted on the wire")
+        XCTAssertNil(body["default_workdir"], "default_workdir omitted on the wire")
         XCTAssertNil(store.mutationErrorMessage)
     }
 

--- a/docs/KANBAN_V3B_AUDIT.md
+++ b/docs/KANBAN_V3B_AUDIT.md
@@ -1,0 +1,66 @@
+# Kanban V3B — Upstream Audit (board admin, filters, running-by-profile)
+
+- Upstream: https://github.com/NousResearch/hermes-agent @ **f293e7206b4ddd66042329442c6afebc19a8808d** ("fix(dashboard): detect stale code after hermes update and refuse model picker with clear 503 (#86207)"), committed 2026-08-23 06:36:57 -0700; audited 2026-08-23.
+- Sources: plugins/kanban/dashboard/plugin_api.py (lines cited), hermes_cli/kanban_db.py, apps/desktop/src/plugins/kanban/{api.ts, board.tsx, board-switcher.tsx, types.ts, i18n.ts}.
+
+## Board CRUD contracts (exact)
+
+### GET /boards (plugin_api.py:2462)
+- Query: include_archived (default False) — archived boards are EXCLUDED from the switcher list by default.
+- Returns {boards: [...], current}. Each board meta: slug, name, description, icon, color, default_workdir (null), project_id (null), created_at, archived (bool), db_path + enrichments is_current, counts, total (live cards only), default_workspace_kind, project_name.
+- list_boards (kanban_db.py:956): always includes "default" first, others alphabetical (case-insensitive dir scan).
+
+### POST /boards (plugin_api.py:2505) — CreateBoardBody {slug (required), name?, description?, icon?, color?, default_workdir?, project_id?, switch=false}
+- slug normalization: _normalize_board_slug (kanban_db.py:551) = lowercase + strip; regex ^[a-z0-9][a-z0-9\-_]{0,63}$ -> ValueError -> HTTP 400.
+- Idempotent: create_board (kanban_db.py:923) returns EXISTING metadata on slug collision ("mkdir -p semantics"). The response carries NO created/new flag — a client cannot tell "new" vs "returned existing" from the body alone (created_at is the original first-write timestamp).
+- default_workdir validated: absolute + existing directory, else 400; resolved path stored.
+- project_id: resolved via _resolve_project (id OR slug); when it resolves, its primary_path becomes default_workdir UNLESS default_workdir was passed explicitly.
+- switch: true -> kanban_db.set_current_board(slug) — mutates the server-wide current pointer. Desktop sends NO switch (default false) and selects locally via its own atom.
+- Response: {board: meta (+default_workspace_kind, project_name), current}.
+
+### PATCH /boards/{slug} (plugin_api.py:2538) — RenameBoardBody {name?, description?, icon?, color?, default_workdir?, project_id?}
+- slug is immutable (normalized + must exist -> 404).
+- Tri-state (write_board_metadata, kanban_db.py:871):
+  - field omitted/nil -> leave unchanged
+  - default_workdir "" -> CLEAR (stored None); path -> validate + set
+  - project_id "" -> CLEAR scope; value -> resolve + set
+  - name "" -> server substitutes the default display name for the slug
+- Project set (non-empty) with default_workdir omitted -> server MIRRORS the project primary repo into default_workdir. Re-sending the SAME project_id re-mirrors (this is the wire for "Project Default").
+- Removing the project does NOT clear the previously mirrored default_workdir when ONLY project_id is sent (backend keeps it; a Desktop comment claims otherwise — backend is authoritative).
+- CONDUIT adaptation (documented): the mobile editor's "No Project" path also lands the Default Workspace row on None/Scratch, so the Save sends an EXPLICIT default_workdir:"" alongside project_id:"" — clearing the stale mirror. The wire clears both intentfully rather than leaving a stale mirrored directory.
+- Response: {board: meta (+default_workspace_kind, project_name)}.
+
+### DELETE /boards/{slug} (plugin_api.py:2578) — delete: bool = Query(False) ("Hard-delete instead of archive")
+- Default (no query / delete=false) -> ARCHIVE: directory moved to <root>/kanban/boards/_archived/<slug>-<ts> (recoverable; kanban_db.remove_board:1000).
+- delete=true -> shutil.rmtree (hard delete). V3B exposes ARCHIVE ONLY; never sends delete=true.
+- Restrictions surfaced as ValueError -> HTTP 400 (detail text preserved): the "default" board cannot be removed; unknown slug -> "board does not exist"; archiving the CURRENT board clears the server pointer back to default (backend handles); an already-archived slug no longer exists under its active name -> 400.
+- Response: {result: {slug, action, new_path}, current}.
+- NOTE: Desktop has NO archive UI (api.ts has no deleteBoard) — Conduit's Archive Board… is a mobile-native feature on the exact backend contract.
+
+### POST /boards/{slug}/switch (plugin_api.py:2588) — persists the server-wide current pointer; the Desktop switcher never calls it (client-side localStorage selection). Conduit likewise NEVER calls it.
+
+## Desktop product semantics
+
+### Create flow (board-switcher.tsx NewBoardDialog:73-127)
+- slug derived from name: name.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') — ASCII-only; empty result disables Create.
+- POST /boards {slug, name, project_id?} (NO switch); onSuccess: local selection = result.board.slug; boards list invalidated; dialog closes.
+- Board Settings dialog: name + project picker only; slug read-only; PATCH {name, project_id}.
+
+### Filters (board.tsx:870-938 dropdown, 1170-1184 predicate)
+- Client-side over the loaded board: search over title/body/id (trimmed, lowercase, includes), tenant exact equality, assignee exact equality; AND composition.
+- Show Archived toggles the SERVER include_archived fetch parameter (same state drives fetchBoard(archived)); it is NOT part of the client predicate.
+- Filter options come from board.assignees and board.tenants ("All" = empty).
+- Active indicator: Boolean(assignee || tenant || archived).
+
+### Running grouped by profile (board.tsx:366-383, 865)
+- $lanesByProfile persisted UI preference; lane groups ONLY for column.name === 'running'.
+- key = task.assignee || UNASSIGNED_LANE ('unassigned'); groups sorted by key localeCompare (case-insensitive-ish); header renders assignee label (+Avatar when not unassigned).
+
+### default_workspace_kind (plugin_api.py:2423): no workdir -> "scratch"; workdir inside a git repo -> "worktree"; else "dir".
+
+## Conduit-adapted differences (documented)
+1. Slug derivation mirrors Desktop byte-for-byte (ASCII); Conduit shows the generated slug and offers manual editing as an advanced option, validated against the upstream regex before POST.
+2. Conduit sends switch: false explicitly (deterministic test; never true). Selection after create is local-only.
+3. Board Settings extends Desktop's name+project dialog with description + default-workdir controls (backend fields; required by the V3B spec).
+4. Archive Board… is Conduit-native (no Desktop counterpart), staging-by-value + fail-closed like card Delete.
+5. Filters live in a native sheet rather than a dropdown; the predicate is extracted as a pure policy with the same semantics (search over title/body/id per upstream; Conduit deliberately keeps its V2-preserved extra matches — latest summary and assignee — in the search set).

--- a/docs/KANBAN_V3B_AUDIT.md
+++ b/docs/KANBAN_V3B_AUDIT.md
@@ -7,27 +7,27 @@
 
 ### GET /boards (plugin_api.py:2462)
 - Query: include_archived (default False) — archived boards are EXCLUDED from the switcher list by default.
-- Returns {boards: [...], current}. Each board meta: slug, name, description, icon, color, default_workdir (null), project_id (null), created_at, archived (bool), db_path + enrichments is_current, counts, total (live cards only), default_workspace_kind, project_name.
+- Returns {boards: [...], current}. Each board meta: slug, name, description, icon, color, `default_workdir` (null), `project_id` (null), created_at, archived (bool), db_path + enrichments is_current, counts, total (live cards only), default_workspace_kind, project_name.
 - list_boards (kanban_db.py:956): always includes "default" first, others alphabetical (case-insensitive dir scan).
 
-### POST /boards (plugin_api.py:2505) — CreateBoardBody {slug (required), name?, description?, icon?, color?, default_workdir?, project_id?, switch=false}
-- slug normalization: _normalize_board_slug (kanban_db.py:551) = lowercase + strip; regex ^[a-z0-9][a-z0-9\-_]{0,63}$ -> ValueError -> HTTP 400.
-- Idempotent: create_board (kanban_db.py:923) returns EXISTING metadata on slug collision ("mkdir -p semantics"). The response carries NO created/new flag — a client cannot tell "new" vs "returned existing" from the body alone (created_at is the original first-write timestamp).
-- default_workdir validated: absolute + existing directory, else 400; resolved path stored.
-- project_id: resolved via _resolve_project (id OR slug); when it resolves, its primary_path becomes default_workdir UNLESS default_workdir was passed explicitly.
+### POST /boards (plugin_api.py:2505) — CreateBoardBody {slug (required), name?, description?, icon?, color?, `default_workdir`?, `project_id`?, switch=false}
+- slug normalization: `_normalize_board_slug` (kanban_db.py:551) = lowercase + strip; regex `^[a-z0-9][a-z0-9\-_]{0,63}$` -> ValueError -> HTTP 400.
+- Idempotent: `create_board` (kanban_db.py:923) returns EXISTING metadata on slug collision ("mkdir -p semantics"). The response carries NO created/new flag — a client cannot tell "new" vs "returned existing" from the body alone (created_at is the original first-write timestamp).
+- `default_workdir` validated: absolute + existing directory, else 400; resolved path stored.
+- `project_id`: resolved via `_resolve_project` (id OR slug); when it resolves, its `primary_path` becomes `default_workdir` UNLESS `default_workdir` was passed explicitly.
 - switch: true -> kanban_db.set_current_board(slug) — mutates the server-wide current pointer. Desktop sends NO switch (default false) and selects locally via its own atom.
 - Response: {board: meta (+default_workspace_kind, project_name), current}.
 
-### PATCH /boards/{slug} (plugin_api.py:2538) — RenameBoardBody {name?, description?, icon?, color?, default_workdir?, project_id?}
+### PATCH /boards/{slug} (plugin_api.py:2538) — RenameBoardBody {name?, description?, icon?, color?, `default_workdir`?, `project_id`?}
 - slug is immutable (normalized + must exist -> 404).
 - Tri-state (write_board_metadata, kanban_db.py:871):
   - field omitted/nil -> leave unchanged
-  - default_workdir "" -> CLEAR (stored None); path -> validate + set
-  - project_id "" -> CLEAR scope; value -> resolve + set
+  - `default_workdir` "" -> CLEAR (stored None); path -> validate + set
+  - `project_id` "" -> CLEAR scope; value -> resolve + set
   - name "" -> server substitutes the default display name for the slug
-- Project set (non-empty) with default_workdir omitted -> server MIRRORS the project primary repo into default_workdir. Re-sending the SAME project_id re-mirrors (this is the wire for "Project Default").
-- Removing the project does NOT clear the previously mirrored default_workdir when ONLY project_id is sent (backend keeps it; a Desktop comment claims otherwise — backend is authoritative).
-- CONDUIT adaptation (documented): the mobile editor's "No Project" path also lands the Default Workspace row on None/Scratch, so the Save sends an EXPLICIT default_workdir:"" alongside project_id:"" — clearing the stale mirror. The wire clears both intentfully rather than leaving a stale mirrored directory.
+- Project set (non-empty) with `default_workdir` omitted -> server MIRRORS the project primary repo into `default_workdir`. Re-sending the SAME `project_id` re-mirrors (this is the wire for "Project Default").
+- Removing the project does NOT clear the previously mirrored `default_workdir` when ONLY `project_id` is sent (backend keeps it; a Desktop comment claims otherwise — backend is authoritative).
+- CONDUIT adaptation (documented): the mobile editor's "No Project" path also lands the Default Workspace row on None/Scratch, so the Save sends an EXPLICIT `default_workdir`:"" alongside `project_id`:"" — clearing the stale mirror. The wire clears both intentfully rather than leaving a stale mirrored directory.
 - Response: {board: meta (+default_workspace_kind, project_name)}.
 
 ### DELETE /boards/{slug} (plugin_api.py:2578) — delete: bool = Query(False) ("Hard-delete instead of archive")
@@ -43,8 +43,8 @@
 
 ### Create flow (board-switcher.tsx NewBoardDialog:73-127)
 - slug derived from name: name.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') — ASCII-only; empty result disables Create.
-- POST /boards {slug, name, project_id?} (NO switch); onSuccess: local selection = result.board.slug; boards list invalidated; dialog closes.
-- Board Settings dialog: name + project picker only; slug read-only; PATCH {name, project_id}.
+- POST /boards {slug, name, `project_id`?} (NO switch); onSuccess: local selection = result.board.slug; boards list invalidated; dialog closes.
+- Board Settings dialog: name + project picker only; slug read-only; PATCH {name, `project_id`}.
 
 ### Filters (board.tsx:870-938 dropdown, 1170-1184 predicate)
 - Client-side over the loaded board: search over title/body/id (trimmed, lowercase, includes), tenant exact equality, assignee exact equality; AND composition.

--- a/docs/KANBAN_V3B_PLAN.md
+++ b/docs/KANBAN_V3B_PLAN.md
@@ -1,0 +1,24 @@
+# Kanban V3B — Board Administration + Filters + Running-by-Profile
+
+Branch: feature/kanban-v3b-board-admin (base origin/main f0ea33e — V3A merged). Upstream audit: docs/KANBAN_V3B_AUDIT.md @ f293e7206.
+
+## Scope (this branch only)
+Board create / edit / archive; project + default-workdir management; assignee filter; tenant filter; Show Archived folded into the filter sheet; Running grouped by profile. NOT: V3C bulk, V3D /events.
+
+## Implementation shape
+- KanbanModels: +icon/color/archived on board metadata (tolerant); KanbanCreateBoardRequest (switch:false explicit); KanbanUpdateBoardPatch (tri-state nil=omit, ""=clear).
+- KanbanService: createBoard(request), updateBoard(slug, patch), archiveBoard(slug) — no hard delete; fetchBoards unchanged.
+- KanbanStore: createBoard (server-scope validation; post-success: boards refresh + LOCAL selection of returned slug + superseding reload), updateBoard (board-scope stamp; settings tied to concrete loaded board; authoritative echo adopted), archiveBoard (board-scope stamp; DECODED result must be action==archived; post-success reconciliation: boards refresh -> validate local selection -> fallback -> single owned reload; partial-success refresh wording survives).
+- Support policies (KanbanBoardAdministrationSupport.swift): slug derivation + validation (Desktop-identical), patch tri-state builder, filter predicate (search title/body/id + latestSummary/assignee, assignee/tenant exact equality, AND), stale-filter validation vs rosters, running grouping (assignee || 'unassigned', case-insensitive sort, running lane only, AFTER filtering), archive/selection reconciliation helpers, PendingBoardArchive staged value.
+- Views: board menu gains Board Settings… / New Board… / Archive Board… (+ staged confirmation); KanbanBoardEditorView (create + settings modes, V3A editor ownership rules); filter sheet + filter button with active indication; running-lane grouped rendering; header search preserved; Archived toggle moved out of the header into the filter sheet.
+- Persistence: Group Running by Profile = persisted preference (@AppStorage); assignee/tenant/search transient; Show Archived keeps existing state/flow.
+
+## Ownership
+Same discipline as V2/V3A: capture before suspension; store validates captured stamps back-to-back with context capture; server-scope for create; board-scope (full stamp) for update/archive; staged-by-value archive confirmation; stale completions UI-inert; local busy liveness via token; sheets dismiss on ownership change.
+
+## Tests (KanbanV3BTests.swift, deterministic, no sleeps)
+Create (payload encoding incl. switch:false + slug derivation + project/workdir encoding + server A->B race + local selection on success), patch (immutable slug, name-only omits project/workdir, project set/clear, workdir set/clear, project+explicit workdir, project-default re-mirror, server change fails closed, captured slug cannot retarget), archive (no hard-delete query, confirmation required, staged A cannot archive B, backend refusal preserved, selected-board fallback reconciliation, non-selected archive leaves selection), filters (assignee exact, tenant exact, search fields, AND, no store mutation, stale filter resets), archived (include_archived query, column appears/disappears, lane fallback), grouping (off flat, on running grouped, unassigned group, only running, after filtering, deterministic order).
+Preserve existing suites; full ios_test; CI keeps ATTEMPT_TIMEOUT_SECS=1200 (do NOT change).
+
+## Report items
+1 starting SHA f0ea33e 2 upstream SHA 3 endpoints/contracts 4 create payload semantics 5 slug collision behavior 6 PATCH tri-state 7 project/workdir interaction 8 archive restrictions+reconciliation 9 proof no current-pointer mutation 10 filter architecture 11 grouping architecture 12 ownership model 13 files changed 14 tests added 15 exact ios_test counts 16 CI result 17 timeout still 1200 18 V3C/V3D + transport untouched.


### PR DESCRIPTION
## V3B — Board Administration + Filters + Running-by-Profile (Kanban V3, phase B)

Base: main @ f0ea33e (V3A merged). Upstream audited: NousResearch/hermes-agent @ **f293e7206** (docs/KANBAN_V3B_AUDIT.md).

### What ships
- **Board CRUD**: New Board (Desktop-identical slug derivation + advanced manual slug editing validated against the backend regex; idempotent-collision behavior documented honestly), Board Settings (name/description/project scope/default workspace with exact omit/clear/set wire semantics; slug immutable), Archive Board (staged-by-value confirmation; default board refused; hard-delete query NEVER sent; backend refusals surfaced verbatim; selected-board fallback reconciliation clears the per-dashboard selection and converges on server current).
- **Server pointer**: create/selection NEVER call /boards/{slug}/switch; switch:false is sent explicitly and is a compile-time let.
- **Project semantics**: project picker from GET /projects (reference data only); project default mirrors the primary repo (re-send same project_id re-mirrors; explicit custom path wins; UI hides None/Scratch while a project is selected, matching upstream representability).
- **Filters**: native filter sheet (assignee exact match from board.assignees - never the resolved default; tenant exact match; Show Archived as the server include_archived parameter; Reset keeps the persisted grouping preference); search keeps V2 matches and adds task ID; AND composition; stale roster values deactivate harmlessly; authoritative board never mutated (derived columns).
- **Running grouped by profile**: assignee || 'unassigned' buckets, case-insensitive + raw tie-break ordering, running lane only, applied AFTER filtering, persisted preference.
- **Ownership**: V2/V3A discipline throughout - synchronous identity/stamp/payload capture, store revalidation back-to-back, server-scope create vs board-scope update/archive, single owned reconciliation reload after archive with partial-success wording, empty-patch short-circuit, slug guard, decoded archive result validation.

### Testing
- ConduitTests/KanbanV3BTests.swift (38 deterministic cases, no sleeps): create/patch/archive wire + ownership races, filters, archived, grouping, doc-pinned contracts.
- Multi-model review gate (3 models + consolidation) run in 3 chunks (core, views, tests): all WARNINGs fixed and re-verified; B-1 (None+project combination) resolved by hiding the unrepresentable row and pinning the contract in tests.
- Full ios_test: **62/62 suites, 1187 test cases, 0 failed/skipped/hangs/uncovered**.

### Out of scope (unchanged)
No V3C bulk ops, no V3D /events, no HermesClient/session transport changes; CI per-attempt budget stays at 1200s (untouched).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Create, edit, and archive Kanban boards with validated names and workspace settings.
- Configure board icons, colors, project scope, and archived status.
- Filter tasks by assignee, tenant, and archived visibility.
- Persist profile-grouping preferences and group running tasks by profile, including unassigned tasks.
- Preview effective workspace directories while preserving custom settings.
- Receive clearer save, archive, and validation feedback.

## Documentation
- Added guidance covering board administration, filtering, archiving, and workspace behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Final correctness pass (commit 21dc838)
- BLOCKER: store-level target binding - updateBoard/archiveBoard now require the explicit target slug to equal the board slug inside the shared ownership stamp (validateExpectedBoardTarget, back-to-back with operation capture); createBoard stays server-scoped. Zero-network mismatch regressions (A/B) + positive control (C); the conflicting archive-non-selected test was removed (staged-archive is current-board only).
- MAJOR: Board Settings keeps an advancing authoritative baseline (serverBaseline): every PATCH is built from the latest accepted server metadata, never the sheet-opening state (regression E, incl. the stale-baseline counterfactual).
- MAJOR: one canonical workspace derivation (KanbanBoardWorkspacePresentation.derive) for initial seed AND post-save echo; drifted custom workdirs survive unrelated saves without re-mirroring (D); effective-directory preview follows the current draft/project (G).
- MINOR: nil and empty-string assignees group as Unassigned (upstream falsy semantics; whitespace-only stays truthy) (H).
- Docs: literal identifiers/regex in KANBAN_V3B_AUDIT.md wrapped in code spans (substance-neutral, verified byte-identical after span-stripping).
- Wire-level patch omission asserted (name-only body omits project_id/default_workdir).
- Full ios_test: 62/62 suites, 1187 test cases, 0 failed/skipped/hangs/uncovered.

## Two-fix pass (commit c25be5e)
- updateBoard/archiveBoard now REQUIRE a non-optional KanbanBoardContextStamp - board-targeted admin mutations cannot be invoked without board ownership (the nil stamp bypass is a compile error). Target slug must equal the stamp's boardSlug and the stamp must equal the currently actionable loaded context; back-to-back with operation capture. createBoard and server-global mutations unchanged.
- Project change + preserved Custom workspace: the explicit custom path is now reasserted on the wire (even string-identical to the old baseline workdir) so upstream's implicit project mirror cannot silently replace it; unchanged project + unchanged custom path still omits the field. .none + project change suppresses the implicit mirror symmetrically.
- Full ios_test: 62/62 suites, 1187 test cases, 0 failed/skipped/hangs/uncovered.