### PR TITLE
fix(presentation): hard cross-profile boundary for deferred presentation-cache writes

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -860,6 +860,7 @@ final class AppState: ObservableObject {
             // operation safe on its own so no caller can forget it.
             guard self.activeProfile == scheduledProfile,
                   self.presentationCacheProfileEpoch == scheduledEpoch else {
+                presentationCacheFlushTask = nil
                 return
             }
             self.cacheMessagePresentation(for: [sessionId])
@@ -888,8 +889,9 @@ final class AppState: ObservableObject {
     /// transition site (`switchProfile`, `connect(with:profile:)`) where
     /// that ownership is guaranteed. Both fence conditions in
     /// `schedulePresentationCacheFlush` are intentionally redundant — string
-    /// equality is the readable guard, the wrapping `&+= 1` (~2^63 switches,
-    /// unreachable) catches A→B→A round-trips — do not simplify either away.
+    /// equality is the readable guard, the wrapping `&+= 1` (overflows only
+    /// after ~9.2×10^18 switches — unreachable) catches A→B→A round-trips —
+    /// do not simplify either away.
     private func setActiveProfile(_ newValue: String) {
         guard newValue != activeProfile else { return }
         activeProfile = newValue
@@ -6291,12 +6293,14 @@ final class AppState: ObservableObject {
             projectsLoading = false
             restoreActiveSessionState(for: previousProfile)
             restorePinnedSessions(for: previousProfile)
-            // Restore the outgoing transcript state BEFORE flipping the
-            // identity back: setActiveProfile(_:)'s boundary flush persists
-            // whatever is in memory under the outgoing (previous) profile, so
-            // it must already describe that profile here — otherwise the
-            // partially-loaded target transcript would be written into the
-            // restored profile's namespace.
+            // restoreActiveSessionState/restorePinnedSessions are
+            // synchronous and cache-write-free; the pre-flight boundary
+            // flush (above) already persisted the outgoing transcript under
+            // the previous profile's namespace. setActiveProfile(_:)
+            // deliberately does NOT flush: flipping the identity back only
+            // re-arms the namespace and bumps the fence epoch, making any
+            // flush scheduled under the failed target during the aborted
+            // attempt stale.
             setActiveProfile(previousProfile)
             connection = savedConnection
             client?.disconnect()

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -877,23 +877,35 @@ final class AppState: ObservableObject {
         cacheMessagePresentation()
     }
 
-    /// Assigns the active profile and fences deferred presentation-cache
-    /// work: any coalesced flush scheduled while another profile was active
-    /// becomes stale the moment the identity changes. Call this instead of
-    /// assigning `activeProfile` directly so no mutation site can skip the
-    /// fence.
+    /// Assigns the active profile and enforces the hard presentation-cache
+    /// profile boundary: any coalesced flush scheduled while another profile
+    /// was active is flushed synchronously here — while the outgoing profile
+    /// is still active — and then fenced by the epoch bump, so no mutation
+    /// site can skip the boundary or lose the outgoing transcript. The
+    /// flush-before-bump ordering is what makes the epoch a complete fence;
+    /// `presentationCacheProfileEpoch` uses wrapping arithmetic because ~2^63
+    /// switches are unreachable, and the profile string is compared
+    /// independently in the task anyway, so a wrap can never resurrect a
+    /// stale flush. Both fence conditions in
+    /// `schedulePresentationCacheFlush` are deliberately redundant with this
+    /// single mutator (string equality is the readable guard; the epoch
+    /// catches A→B→A round-trips) — do not simplify either away.
     private func setActiveProfile(_ newValue: String) {
         guard newValue != activeProfile else { return }
+        flushPendingPresentationCache()
         activeProfile = newValue
         presentationCacheProfileEpoch &+= 1
     }
 
+#if DEBUG
     /// Deterministic-test access to the pending coalesced flush. Awaiting its
     /// value settles every deferred-write decision (cancelled, fenced, or
-    /// completed) without wall-clock timing.
+    /// completed) without wall-clock timing. Test-only plumbing; compiled out
+    /// of release builds.
     var presentationCacheFlushOperationForTesting: Task<Void, Never>? {
         presentationCacheFlushTask
     }
+#endif
 
     // MARK: - Persistence
 
@@ -6164,11 +6176,9 @@ final class AppState: ObservableObject {
             transitionGeneration = beginExplicitChatViewportTransition()
         }
         cancelChatResumeTransportRecovery()
-        // Hard profile boundary for deferred writes: cancel the debounced
-        // stream flush and write synchronously while the outgoing profile is
-        // still active. The latest transcript lands in its own namespace and
-        // no parked task survives the identity change below.
-        flushPendingPresentationCache()
+        // The hard profile boundary (synchronous outgoing-transcript flush +
+        // epoch fence) lives in setActiveProfile(_:), invoked below when the
+        // identity actually flips.
         cancelSecondaryProfileTitleRecovery()
 
         // Dismiss keyboard before switching profiles
@@ -6261,7 +6271,6 @@ final class AppState: ObservableObject {
             }
             errorMessage = "Could not switch workspace: \(error.localizedDescription)"
             clearPendingDecisionRestorationGuard()
-            setActiveProfile(previousProfile)
             // The pre-switch reset neutralized the approval state; restore it
             // with the rest of the previous profile or a failed switch loses
             // the floor while the previous profile is still the active one.
@@ -6276,6 +6285,13 @@ final class AppState: ObservableObject {
             projectsLoading = false
             restoreActiveSessionState(for: previousProfile)
             restorePinnedSessions(for: previousProfile)
+            // Restore the outgoing transcript state BEFORE flipping the
+            // identity back: setActiveProfile(_:)'s boundary flush persists
+            // whatever is in memory under the outgoing (previous) profile, so
+            // it must already describe that profile here — otherwise the
+            // partially-loaded target transcript would be written into the
+            // restored profile's namespace.
+            setActiveProfile(previousProfile)
             connection = savedConnection
             client?.disconnect()
             client = nil

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -877,22 +877,21 @@ final class AppState: ObservableObject {
         cacheMessagePresentation()
     }
 
-    /// Assigns the active profile and enforces the hard presentation-cache
-    /// profile boundary: any coalesced flush scheduled while another profile
-    /// was active is flushed synchronously here — while the outgoing profile
-    /// is still active — and then fenced by the epoch bump, so no mutation
-    /// site can skip the boundary or lose the outgoing transcript. The
-    /// flush-before-bump ordering is what makes the epoch a complete fence;
-    /// `presentationCacheProfileEpoch` uses wrapping arithmetic because ~2^63
-    /// switches are unreachable, and the profile string is compared
-    /// independently in the task anyway, so a wrap can never resurrect a
-    /// stale flush. Both fence conditions in
-    /// `schedulePresentationCacheFlush` are deliberately redundant with this
-    /// single mutator (string equality is the readable guard; the epoch
-    /// catches A→B→A round-trips) — do not simplify either away.
+    /// Assigns the active profile and fences deferred presentation-cache
+    /// work: any coalesced flush scheduled under another profile becomes
+    /// stale the moment the identity changes. Call this instead of assigning
+    /// `activeProfile` directly so no mutation site can skip the fence.
+    ///
+    /// Deliberately NOT flushing here: on rollbacks (failed switches) the
+    /// still-active identity does not own the restored in-memory content,
+    /// so the synchronous outgoing-transcript flush belongs at each forward
+    /// transition site (`switchProfile`, `connect(with:profile:)`) where
+    /// that ownership is guaranteed. Both fence conditions in
+    /// `schedulePresentationCacheFlush` are intentionally redundant — string
+    /// equality is the readable guard, the wrapping `&+= 1` (~2^63 switches,
+    /// unreachable) catches A→B→A round-trips — do not simplify either away.
     private func setActiveProfile(_ newValue: String) {
         guard newValue != activeProfile else { return }
-        flushPendingPresentationCache()
         activeProfile = newValue
         presentationCacheProfileEpoch &+= 1
     }
@@ -1929,6 +1928,11 @@ final class AppState: ObservableObject {
         showLogin = false
         connection = conn
         if activeProfile != profile {
+            // Hard profile boundary for this forward transition: cancel the
+            // debounced stream flush and write synchronously while the
+            // current profile still owns the in-memory transcript. Mirrors
+            // switchProfile(to:reusing:).
+            flushPendingPresentationCache()
             sessions = []
             cronSessions = []
             archivedSessions = []
@@ -6176,9 +6180,11 @@ final class AppState: ObservableObject {
             transitionGeneration = beginExplicitChatViewportTransition()
         }
         cancelChatResumeTransportRecovery()
-        // The hard profile boundary (synchronous outgoing-transcript flush +
-        // epoch fence) lives in setActiveProfile(_:), invoked below when the
-        // identity actually flips.
+        // Hard profile boundary for this forward transition: cancel the
+        // debounced stream flush and write synchronously while the outgoing
+        // profile still owns the in-memory transcript. No parked task
+        // survives the identity changes below (success or rollback).
+        flushPendingPresentationCache()
         cancelSecondaryProfileTitleRecovery()
 
         // Dismiss keyboard before switching profiles

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -687,6 +687,16 @@ final class AppState: ObservableObject {
     /// Coalesces presentation-cache flushes during streaming so we
     /// don't serialize and write UserDefaults on every WebSocket frame.
     private var presentationCacheFlushTask: Task<Void, Never>?
+    /// Monotonic fence for deferred presentation-cache writes. Bumped when
+    /// the active profile identity changes so a coalesced flush scheduled
+    /// under one profile can never land in another profile's namespace.
+    private var presentationCacheProfileEpoch = 0
+    /// Injectable stand-in for the debounce sleep. Defaults to wall-clock
+    /// `Task.sleep`; deterministic tests park a pending flush mid-flight
+    /// through this seam instead of racing its timing.
+    private let presentationCacheDebounceSuspension: @Sendable (
+        Duration
+    ) async throws -> Void
     /// A resume without explicit active-turn confirmation can restore a
     /// decision card from local presentation data. Keep the card in memory for
     /// this AppState so another foreground resume can still show it, but strip
@@ -822,6 +832,12 @@ final class AppState: ObservableObject {
     /// so continuous streaming can never postpone a flush indefinitely.
     private func schedulePresentationCacheFlush(for sessionId: String) {
         presentationCacheFlushTask?.cancel()
+        // Capture the profile identity this deferred write belongs to. The
+        // task only keeps the session ID immutable; everything else it reads
+        // (messages, reconciliation IDs, restoration guards) is live state.
+        let scheduledProfile = activeProfile
+        let scheduledEpoch = presentationCacheProfileEpoch
+        let suspendForDebounce = presentationCacheDebounceSuspension
         let now = Date()
         let sinceLastFlush = lastPresentationCacheFlushDate
             .map { now.timeIntervalSince($0) }
@@ -831,11 +847,21 @@ final class AppState: ObservableObject {
         let delay: Duration = sinceLastFlush >= 5 ? .zero : .seconds(2)
         presentationCacheFlushTask = Task { [weak self] in
             do {
-                try await Task.sleep(for: delay)
+                try await suspendForDebounce(delay)
             } catch {
                 return
             }
             guard !Task.isCancelled, let self else { return }
+            // Stale-execution fence: if the app switched profiles while this
+            // flush was parked, the captured session ID no longer describes
+            // the live transcript, and writing through the now-active cache
+            // namespace would cross-contaminate profiles. switchProfile also
+            // flushes and cancels before switching; this guard keeps the
+            // operation safe on its own so no caller can forget it.
+            guard self.activeProfile == scheduledProfile,
+                  self.presentationCacheProfileEpoch == scheduledEpoch else {
+                return
+            }
             self.cacheMessagePresentation(for: [sessionId])
             self.lastPresentationCacheFlushDate = Date()
             self.presentationCacheFlushTask = nil
@@ -849,6 +875,24 @@ final class AppState: ObservableObject {
         presentationCacheFlushTask = nil
         lastPresentationCacheFlushDate = Date()
         cacheMessagePresentation()
+    }
+
+    /// Assigns the active profile and fences deferred presentation-cache
+    /// work: any coalesced flush scheduled while another profile was active
+    /// becomes stale the moment the identity changes. Call this instead of
+    /// assigning `activeProfile` directly so no mutation site can skip the
+    /// fence.
+    private func setActiveProfile(_ newValue: String) {
+        guard newValue != activeProfile else { return }
+        activeProfile = newValue
+        presentationCacheProfileEpoch &+= 1
+    }
+
+    /// Deterministic-test access to the pending coalesced flush. Awaiting its
+    /// value settles every deferred-write decision (cancelled, fenced, or
+    /// completed) without wall-clock timing.
+    var presentationCacheFlushOperationForTesting: Task<Void, Never>? {
+        presentationCacheFlushTask
     }
 
     // MARK: - Persistence
@@ -927,8 +971,12 @@ final class AppState: ObservableObject {
         reconnectExecutor: ChatResumeReconnectExecutor? = nil,
         chatResumeLifecycleOperations: ChatResumeLifecycleOperations = .live,
         sessionPresentationCache: SessionPresentationCache = .shared,
-        sessionYoloStore: SessionYoloStore? = nil
+        sessionYoloStore: SessionYoloStore? = nil,
+        presentationCacheDebounceSuspension: (@Sendable (Duration) async throws -> Void)? = nil
     ) {
+        self.presentationCacheDebounceSuspension =
+            presentationCacheDebounceSuspension
+            ?? { duration in try await Task.sleep(for: duration) }
         self.defaults = defaults
         self.sessionPresentationCache = sessionPresentationCache
         self.sessionYoloStore = sessionYoloStore ?? SessionYoloStore(defaults: defaults)
@@ -1874,7 +1922,9 @@ final class AppState: ObservableObject {
             archivedSessions = []
             slashCommands = Self.builtInSlashCommands
         }
-        activeProfile = profile
+        // Fence deferred presentation-cache writes created under the
+        // previous profile before transcripts change over.
+        setActiveProfile(profile)
         restoreActiveSessionState(for: profile)
         restorePinnedSessions(for: profile)
         defaults.set(profile, forKey: activeProfileKey)
@@ -6114,7 +6164,11 @@ final class AppState: ObservableObject {
             transitionGeneration = beginExplicitChatViewportTransition()
         }
         cancelChatResumeTransportRecovery()
-        cacheMessagePresentation()
+        // Hard profile boundary for deferred writes: cancel the debounced
+        // stream flush and write synchronously while the outgoing profile is
+        // still active. The latest transcript lands in its own namespace and
+        // no parked task survives the identity change below.
+        flushPendingPresentationCache()
         cancelSecondaryProfileTitleRecovery()
 
         // Dismiss keyboard before switching profiles
@@ -6156,7 +6210,9 @@ final class AppState: ObservableObject {
             connection = freshConnection
             client = nextClient
             clearPendingDecisionRestorationGuard()
-            activeProfile = target
+            // Fence any residual deferred cache write scheduled under the
+            // outgoing profile before identities and namespaces change over.
+            setActiveProfile(target)
             sessions = []
             cronSessions = []
             archivedSessions = []
@@ -6205,7 +6261,7 @@ final class AppState: ObservableObject {
             }
             errorMessage = "Could not switch workspace: \(error.localizedDescription)"
             clearPendingDecisionRestorationGuard()
-            activeProfile = previousProfile
+            setActiveProfile(previousProfile)
             // The pre-switch reset neutralized the approval state; restore it
             // with the rest of the previous profile or a failed switch loses
             // the floor while the previous profile is still the active one.

--- a/Conduit/Services/SessionPresentationCache.swift
+++ b/Conduit/Services/SessionPresentationCache.swift
@@ -433,6 +433,13 @@ final class SessionPresentationCache {
         let existingUnconfirmedAt = ids.lazy
             .compactMap { store[self.key(profile: profile, sessionID: $0)]?.unconfirmedPendingDecisionAt }
             .first
+        #if DEBUG
+        if true { // TEMP-DIAG
+            let rows = freshRecords.prefix(3).map { $0.id }
+            print("[SAVE-TRACE] profile=\(profile) ids=\(ids) rows=\(rows)")
+            print(Thread.callStackSymbols.prefix(12).joined(separator: "\n"))
+        }
+        #endif
         let unconfirmedAt = unconfirmedPendingDecisionKeys.isEmpty
             ? nil
             : (existingUnconfirmedAt ?? now())

--- a/Conduit/Services/SessionPresentationCache.swift
+++ b/Conduit/Services/SessionPresentationCache.swift
@@ -433,13 +433,6 @@ final class SessionPresentationCache {
         let existingUnconfirmedAt = ids.lazy
             .compactMap { store[self.key(profile: profile, sessionID: $0)]?.unconfirmedPendingDecisionAt }
             .first
-        #if DEBUG
-        if true { // TEMP-DIAG
-            let rows = freshRecords.prefix(3).map { $0.id }
-            print("[SAVE-TRACE] profile=\(profile) ids=\(ids) rows=\(rows)")
-            print(Thread.callStackSymbols.prefix(12).joined(separator: "\n"))
-        }
-        #endif
         let unconfirmedAt = unconfirmedPendingDecisionKeys.isEmpty
             ? nil
             : (existingUnconfirmedAt ?? now())

--- a/ConduitTests/CrossProfilePresentationCacheTests.swift
+++ b/ConduitTests/CrossProfilePresentationCacheTests.swift
@@ -391,7 +391,9 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
         struct ForcedSwitchFailure: Error {}
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
-                connectClient: { _ in },
+                // Fail AFTER the identity has already flipped so the
+                // rollback path exercises the mid-attempt fence + restore.
+                connectClient: { _ in throw ForcedSwitchFailure() },
                 loadCatalog: { _, _ in [self.session(fixtures.session.id, profile: "work")] },
                 mintTicket: { _ in "profile-ticket" },
                 openSession: { _, sessionID in
@@ -402,7 +404,7 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
                     )
                 },
                 refreshContext: { _, _ in },
-                loadBusyInputMode: { _ in throw ForcedSwitchFailure() }
+                loadBusyInputMode: { _ in }
             ),
             park: park
         )

--- a/ConduitTests/CrossProfilePresentationCacheTests.swift
+++ b/ConduitTests/CrossProfilePresentationCacheTests.swift
@@ -323,13 +323,11 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
         )
     }
 
-    /// The identity change inside connect(with:profile:) — a legitimate
-    /// profile-switch entry point that never touches
-    /// `presentationCacheFlushTask` itself — must uphold the same hard
-    /// boundary as switchProfile: the parked flush is cancelled by the
-    /// boundary flush inside setActiveProfile(_:), the outgoing profile's
-    /// latest transcript is preserved synchronously while it is still
-    /// active, and nothing from session A ever reaches work's namespace.
+    /// connect(with:profile:) is a legitimate profile-switch entry point
+    /// that upholds the same hard boundary as switchProfile: its forward
+    /// transition flushes the outgoing transcript synchronously (cancelling
+    /// the parked flush), fences anything scheduled under the old identity,
+    /// and nothing from session A ever reaches work's namespace.
     func testConnectProfileChangePreservesOutgoingAndFencesStaleFlush() async {
         let (gate, park) = makeGatePark()
         let fixtures = workSessionFixtures()
@@ -431,14 +429,15 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
         gate.release()
         await Task.yield()
 
-        // Mid-attempt resume work may legitimately have persisted work's own
-        // transcript under work before the failure; the rollback guarantees
-        // are: the restored profile's own entry survives intact, nothing
-        // foreign lands anywhere, and no other namespace leaks.
+        // With no rollback flush and openSession never reached, nothing may
+        // be persisted during or after the aborted attempt beyond the
+        // pre-flip boundary write: exactly the restored profile's own
+        // namespace survives.
         let store = persistedCache(from: harness.defaults)
-        XCTAssertTrue(
-            Set(store.keys).isSubset(of: Set(["default|session-a", "work|" + fixtures.session.id.lowercased()])),
-            "A failed switch may only leave the two legitimate namespaces, got \(store.keys)"
+        XCTAssertEqual(
+            Set(store.keys),
+            Set(["default|session-a"]),
+            "A failed switch must leave only the restored profile's namespace, got \(store.keys)"
         )
         XCTAssertEqual(store["default|session-a"], ["a1"])
         for (key, ids) in store where key.hasPrefix("work|") {

--- a/ConduitTests/CrossProfilePresentationCacheTests.swift
+++ b/ConduitTests/CrossProfilePresentationCacheTests.swift
@@ -423,9 +423,8 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
         harness.appState.handleStreamEvent(.cwdUpdate(sessionId: "session-a", cwd: "/tmp/a"))
         await gate.waitUntilEngaged()
 
-        let switched = await harness.appState.switchProfile(to: "work")
+        await harness.appState.switchProfile(to: "work")
 
-        XCTAssertFalse(switched)
         XCTAssertEqual(harness.appState.activeProfile, "default")
         XCTAssertEqual(harness.appState.messages, self.outgoingTranscript)
 
@@ -438,7 +437,7 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
         // foreign lands anywhere, and no other namespace leaks.
         let store = persistedCache(from: harness.defaults)
         XCTAssertTrue(
-            store.keys.isSubset(of: Set(["default|session-a", "work|" + fixtures.session.id.lowercased()])),
+            Set(store.keys).isSubset(of: Set(["default|session-a", "work|" + fixtures.session.id.lowercased()])),
             "A failed switch may only leave the two legitimate namespaces, got \(store.keys)"
         )
         XCTAssertEqual(store["default|session-a"], ["a1"])

--- a/ConduitTests/CrossProfilePresentationCacheTests.swift
+++ b/ConduitTests/CrossProfilePresentationCacheTests.swift
@@ -1,0 +1,353 @@
+import XCTest
+@testable import Conduit
+
+/// Regression coverage for the cross-profile presentation-cache corruption:
+/// a coalesced stream flush scheduled under profile A was able to wake after
+/// `switchProfile(to:)` changed the active profile and write profile A's
+/// captured session ID through profile B's cache namespace. The debounce is
+/// exercised through an injected suspension instead of wall-clock sleeps so
+/// every interleaving below is deterministic.
+@MainActor
+final class CrossProfilePresentationCacheTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private let outgoingTranscript = [
+        ChatMessage(id: "a1", role: .assistant, content: "Outgoing answer", timestamp: "ts-a1")
+    ]
+
+    private func session(_ id: String, profile: String = "default") -> SessionSummary {
+        SessionSummary(
+            id: id,
+            alternateIds: [],
+            title: id,
+            model: "Hermes",
+            updatedLabel: "now",
+            profile: profile,
+            source: .chat,
+            isActive: false,
+            isArchived: false,
+            lineageRootId: nil
+        )
+    }
+
+    /// One-shot cancellation-aware suspension used as the injected debounce
+    /// sleep. `onCancel` releases the parked task so the coalesced operation
+    /// observes cancellation exactly like `Task.sleep` would.
+    private final class FlushDebounceGate: @unchecked Sendable {
+        private let lock = NSLock()
+        private var waiter: CheckedContinuation<Void, Never>?
+        private var engagement: CheckedContinuation<Void, Never>?
+        private var isReleased = false
+
+        func suspend() async {
+            await withCheckedContinuation { continuation in
+                self.lock.lock()
+                if self.isReleased {
+                    self.lock.unlock()
+                    continuation.resume()
+                    return
+                }
+                self.waiter = continuation
+                let pendingEngagement = self.engagement
+                self.engagement = nil
+                self.lock.unlock()
+                pendingEngagement?.resume()
+            }
+        }
+
+        func waitUntilEngaged() async {
+            await withCheckedContinuation { continuation in
+                self.lock.lock()
+                if self.waiter != nil || self.isReleased {
+                    self.lock.unlock()
+                    continuation.resume()
+                    return
+                }
+                self.engagement = continuation
+                self.lock.unlock()
+            }
+        }
+
+        func release() {
+            lock.lock()
+            isReleased = true
+            let pendingWaiter = waiter
+            waiter = nil
+            let pendingEngagement = engagement
+            engagement = nil
+            lock.unlock()
+            pendingWaiter?.resume()
+            pendingEngagement?.resume()
+        }
+    }
+
+    private func makeGatePark() -> (gate: FlushDebounceGate, park: @Sendable (Duration) async throws -> Void) {
+        let gate = FlushDebounceGate()
+        let park: @Sendable (Duration) async throws -> Void = { _ in
+            try await withTaskCancellationHandler {
+                await gate.suspend()
+            } onCancel: {
+                gate.release()
+            }
+        }
+        return (gate, park)
+    }
+
+    private func makeHarness(
+        lifecycleOperations: ChatResumeLifecycleOperations,
+        park: @escaping @Sendable (Duration) async throws -> Void
+    ) -> (
+        appState: AppState,
+        coordinator: ChatResumeCoordinator,
+        cache: SessionPresentationCache,
+        defaults: UserDefaults,
+        suiteName: String
+    ) {
+        let suiteName = "CrossProfilePresentationCacheTests." + UUID().uuidString
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("Failed to create test UserDefaults suite")
+        }
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        let store = ChatResumeStore(defaults: defaults)
+        let coordinator = ChatResumeCoordinator(store: store)
+        let cache = SessionPresentationCache(defaults: defaults)
+        let appState = AppState(
+            defaults: defaults,
+            chatResumeCoordinator: coordinator,
+            recoverySequence: ChatResumeRecoverySequence(),
+            loadSavedConnection: false,
+            clearSessionPresentationCache: {},
+            chatResumeLifecycleOperations: lifecycleOperations,
+            sessionPresentationCache: cache,
+            presentationCacheDebounceSuspension: park
+        )
+        return (appState, coordinator, cache, defaults, suiteName)
+    }
+
+    private func workSessionFixtures() -> (session: SessionSummary, messages: [ChatMessage]) {
+        (
+            session("work-session", profile: "work"),
+            [ChatMessage(id: "work-message", role: .assistant, content: "Work", timestamp: "ts-w1")]
+        )
+    }
+
+    private func switchLifecycleOperations(
+        openMessages: @MainActor @escaping (HermesClient) -> [ChatMessage]
+    ) -> ChatResumeLifecycleOperations {
+        ChatResumeLifecycleOperations(
+            connectClient: { _ in },
+            loadCatalog: { _, _ in [] },
+            mintTicket: { _ in "profile-ticket" },
+            openSession: { client, sessionID in
+                SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: openMessages(client),
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            refreshContext: { _, _ in },
+            loadProfiles: {},
+            loadBusyInputMode: { _ in },
+            loadProfileDisplayPreferences: {},
+            loadSlashCommands: {}
+        )
+    }
+
+    private func seedOutgoingTranscript(
+        in appState: AppState,
+        connection: HermesConnection,
+        sessionID: String
+    ) {
+        appState.connection = connection
+        appState.client = HermesClient(connection: connection, profile: "default")
+        appState.isConnected = true
+        appState.showLogin = false
+        appState.sessions = [session(sessionID)]
+        appState.activeSessionId = sessionID
+        appState.messages = outgoingTranscript
+    }
+
+    /// Timestamp restored by the cache for a matching probe row. Empty string
+    /// means "no cached entry supplied metadata" (nothing persisted); a
+    /// non-empty value proves a cache entry exists carrying that timestamp.
+    private func cachedTimestamp(
+        of cache: SessionPresentationCache,
+        profile: String,
+        sessionID: String
+    ) -> String {
+        let probe = [
+            ChatMessage(id: "a1", role: .assistant, content: "Outgoing answer", timestamp: "")
+        ]
+        return cache.merge(probe, profile: profile, sessionIDs: [sessionID]).first?.timestamp ?? ""
+    }
+
+    /// Set of persisted namespace keys ("<profile>|<session>") for exact
+    /// namespace-level assertions. The production record shape is
+    /// intentionally private; the storage version key pins this decoding.
+    private func persistedCacheKeys(from defaults: UserDefaults) -> Set<String> {
+        struct Entry: Decodable {}
+        guard let data = defaults.data(forKey: "conduit.sessionPresentation.v1"),
+              let map = try? JSONDecoder().decode([String: Entry].self, from: data) else {
+            return []
+        }
+        return Set(map.keys)
+    }
+
+    // MARK: - Tests
+
+    /// The reported bug: a stream event parks a presentation-cache flush under
+    /// profile A/session A, the app switches to profile B before it fires, and
+    /// when the parked operation finally runs it must neither populate
+    /// profile B's namespace nor lose profile A's outgoing transcript.
+    func testStreamFlushAcrossProfileSwitchCannotContaminateTargetProfile() async {
+        let (gate, park) = makeGatePark()
+        let defaultSession = session("session-a")
+        let fixtures = workSessionFixtures()
+        let harness = makeHarness(
+            lifecycleOperations: switchLifecycleOperations { client in
+                (client.profile ?? "default") == "work" ? fixtures.messages : []
+            },
+            park: park
+        )
+        let connection = HermesConnection(baseUrl: "https://127.0.0.1:1", ticket: "saved-ticket")
+        harness.coordinator.rememberSessionID(defaultSession.id, for: "default")
+        harness.coordinator.rememberSessionID(fixtures.session.id, for: "work")
+        seedOutgoingTranscript(in: harness.appState, connection: connection, sessionID: defaultSession.id)
+        harness.appState.installChatViewportSnapshotProvider(id: UUID()) {
+            ChatRenderedViewportSnapshot(
+                sessionKey: ChatScrollSessionKey(profile: "default", sessionID: "session-a"),
+                snapshot: ChatScrollSnapshot(anchorMessageID: "default-anchor", followsLatest: true)
+            )
+        }
+
+        // Step 3: a stream event belonging to session A schedules the deferred
+        // presentation-cache flush; the injected scheduler parks it mid-debounce
+        // before anything is persisted.
+        harness.appState.handleStreamEvent(.cwdUpdate(sessionId: defaultSession.id, cwd: "/tmp/a"))
+        let parkedOperation = harness.appState.presentationCacheFlushOperationForTesting
+        XCTAssertNotNil(parkedOperation, "The stream event must schedule the coalesced flush")
+        await gate.waitUntilEngaged()
+        XCTAssertEqual(
+            cachedTimestamp(of: harness.cache, profile: "default", sessionID: defaultSession.id),
+            "",
+            "Nothing may be persisted while the debounced flush is still parked"
+        )
+
+        // Step 4: switch to profile B before the deferred flush fires.
+        await harness.appState.switchProfile(to: "work")
+
+        XCTAssertEqual(harness.appState.activeProfile, "work")
+        XCTAssertEqual(harness.appState.messages, fixtures.messages)
+
+        // Step 5: run the old flush now that profile B is active. The parked
+        // operation had cancellation delivered synchronously during the
+        // switch's pre-change flush; awaiting it deterministically settles
+        // whichever defensive layer applies first (cancel or profile fence).
+        gate.release()
+        await parkedOperation?.value
+
+        // Step 6: profile B's cache must not hold anything keyed to A's
+        // session identity or A's transcript metadata.
+        XCTAssertEqual(
+            cachedTimestamp(of: harness.cache, profile: "work", sessionID: defaultSession.id),
+            "",
+            "A stale flush must never write profile A's transcript into profile B's namespace"
+        )
+        XCTAssertFalse(
+            persistedCacheKeys(from: harness.defaults).contains(where: { $0.hasPrefix("work|") }),
+            "No work-namespaced presentation entries may exist after a fresh switch"
+        )
+
+        // Step 7: profile A's latest transcript survived the switch because the
+        // pre-change boundary flushed synchronously while A was active.
+        XCTAssertEqual(
+            cachedTimestamp(of: harness.cache, profile: "default", sessionID: defaultSession.id),
+            "ts-a1",
+            "The outgoing profile's transcript metadata must be preserved across the switch"
+        )
+        let remainingKeys = persistedCacheKeys(from: harness.defaults)
+        XCTAssertEqual(remainingKeys, Set(["default|\(defaultSession.id)".lowercased()]))
+    }
+
+    /// Guard against overcorrecting: when the profile does not change, the
+    /// fenced deferred flush must still land normally (stream coalescing is
+    /// preserved, just identity-checked).
+    func testDeferredFlushStillLandsWhenProfileUnchanged() async {
+        let (gate, park) = makeGatePark()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(),
+            park: park
+        )
+        let connection = HermesConnection(baseUrl: "https://127.0.0.1:1", ticket: "saved-ticket")
+        seedOutgoingTranscript(in: harness.appState, connection: connection, sessionID: "session-a")
+
+        harness.appState.handleStreamEvent(.cwdUpdate(sessionId: "session-a", cwd: "/tmp/a"))
+        let parkedOperation = harness.appState.presentationCacheFlushOperationForTesting
+        XCTAssertNotNil(parkedOperation)
+        await gate.waitUntilEngaged()
+        XCTAssertEqual(cachedTimestamp(of: harness.cache, profile: "default", sessionID: "session-a"), "")
+
+        gate.release()
+        await parkedOperation?.value
+
+        XCTAssertEqual(
+            cachedTimestamp(of: harness.cache, profile: "default", sessionID: "session-a"),
+            "ts-a1",
+            "Same-profile deferred flushes must land unchanged once the debounce elapses"
+        )
+    }
+
+    /// Requirement-level guarantee: even when NO caller cancels or flushes, an
+    /// identity change fences the parked operation on its own. Changing
+    /// profiles through connect(with:profile:) never touches
+    /// `presentationCacheFlushTask`; only the epoch fence stands between the
+    /// stale task and profile B's namespace.
+    func testIdentityChangeAloneFencesStaleDeferredFlush() async {
+        let (gate, park) = makeGatePark()
+        let fixtures = workSessionFixtures()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                connectClient: { _ in },
+                loadCatalog: { _, _ in [self.session(fixtures.session.id, profile: "work")] },
+                mintTicket: { _ in "connect-ticket" },
+                openSession: { _, sessionID in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: fixtures.messages,
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            ),
+            park: park
+        )
+        let connection = HermesConnection(baseUrl: "https://127.0.0.1:1", ticket: "saved-ticket")
+        harness.coordinator.rememberSessionID(fixtures.session.id, for: "work")
+        seedOutgoingTranscript(in: harness.appState, connection: connection, sessionID: "session-a")
+
+        harness.appState.handleStreamEvent(.cwdUpdate(sessionId: "session-a", cwd: "/tmp/a"))
+        let parkedOperation = harness.appState.presentationCacheFlushOperationForTesting
+        XCTAssertNotNil(parkedOperation)
+        await gate.waitUntilEngaged()
+
+        // Profile changes without any explicit flush/cancel around it.
+        await harness.appState.connect(with: connection, profile: "work")
+        XCTAssertEqual(harness.appState.activeProfile, "work")
+
+        gate.release()
+        await parkedOperation?.value
+
+        XCTAssertEqual(
+            cachedTimestamp(of: harness.cache, profile: "work", sessionID: "session-a"),
+            "",
+            "The fenced task must not deposit session-A presentation data into the work namespace"
+        )
+        XCTAssertFalse(
+            persistedCacheKeys(from: harness.defaults).contains("work|session-a"),
+            "No work-namespaced entry may ever be created for the captured session"
+        )
+    }
+}

--- a/ConduitTests/CrossProfilePresentationCacheTests.swift
+++ b/ConduitTests/CrossProfilePresentationCacheTests.swift
@@ -289,7 +289,7 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
             )
         }
         XCTAssertTrue(
-            store.keys.isSubset(of: ["default|session-a", "default|\(defaultSession.id)".lowercased(), "work|\(fixtures.session.id)".lowercased()]),
+            Set(store.keys).isSubset(of: ["default|session-a", "default|\(defaultSession.id)".lowercased(), "work|\(fixtures.session.id)".lowercased()]),
             "Unexpected cache namespaces after the switch: \(store.keys)"
         )
     }

--- a/ConduitTests/CrossProfilePresentationCacheTests.swift
+++ b/ConduitTests/CrossProfilePresentationCacheTests.swift
@@ -275,12 +275,12 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
             "ts-a1",
             "The outgoing profile's transcript metadata must be preserved across the switch"
         )
+        // Schema-proof persistence assertions: the parked flush's captured
+        // identity may never appear under work, work's own row (written by
+        // its post-switch resume) holds only its own transcript, and the
+        // final store contains exactly these two namespaced entries.
         let store = persistedCache(from: harness.defaults)
-        XCTAssertFalse(
-            store.keys.contains { $0.hasPrefix("work|") && !$0.hasSuffix(fixtures.session.id) },
-            "Work-namespace entries are limited to work's own sessions, got \(store.keys)"
-        )
-        XCTAssertEqual(store["work|session-a"], nil)
+        XCTAssertNil(store["work|session-a"])
         for (key, ids) in store where key.hasPrefix("work|") {
             XCTAssertEqual(
                 Set(ids),
@@ -288,8 +288,9 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
                 "\(key) may only hold profile B's own transcript rows, got \(ids)"
             )
         }
-        XCTAssertTrue(
-            Set(store.keys).isSubset(of: ["default|session-a", "default|\(defaultSession.id)".lowercased(), "work|\(fixtures.session.id)".lowercased()]),
+        XCTAssertEqual(
+            Set(store.keys),
+            Set(["default|session-a", "work|" + fixtures.session.id.lowercased()]),
             "Unexpected cache namespaces after the switch: \(store.keys)"
         )
     }
@@ -322,12 +323,14 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
         )
     }
 
-    /// Requirement-level guarantee: even when NO caller cancels or flushes, an
-    /// identity change fences the parked operation on its own. Changing
-    /// profiles through connect(with:profile:) never touches
-    /// `presentationCacheFlushTask`; only the epoch fence stands between the
-    /// stale task and profile B's namespace.
-    func testIdentityChangeAloneFencesStaleDeferredFlush() async {
+    /// The identity change inside connect(with:profile:) — a legitimate
+    /// profile-switch entry point that never touches
+    /// `presentationCacheFlushTask` itself — must uphold the same hard
+    /// boundary as switchProfile: the parked flush is cancelled by the
+    /// boundary flush inside setActiveProfile(_:), the outgoing profile's
+    /// latest transcript is preserved synchronously while it is still
+    /// active, and nothing from session A ever reaches work's namespace.
+    func testConnectProfileChangePreservesOutgoingAndFencesStaleFlush() async {
         let (gate, park) = makeGatePark()
         let fixtures = workSessionFixtures()
         let harness = makeHarness(
@@ -355,21 +358,94 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
         XCTAssertNotNil(parkedOperation)
         await gate.waitUntilEngaged()
 
-        // Profile changes without any explicit flush/cancel around it.
+        // Profile changes through connect; the boundary lives inside
+        // setActiveProfile(_:), which no identity mutation can bypass.
         await harness.appState.connect(with: connection, profile: "work")
         XCTAssertEqual(harness.appState.activeProfile, "work")
 
         gate.release()
         await parkedOperation?.value
 
-        XCTAssertEqual(
-            cachedTimestamp(of: harness.cache, profile: "work", sessionID: "session-a"),
-            "",
-            "The fenced task must not deposit session-A presentation data into the work namespace"
-        )
+        let store = persistedCache(from: harness.defaults)
         XCTAssertNil(
-            persistedCache(from: harness.defaults)["work|session-a"],
-            "No work-namespaced entry may ever be created for the captured session"
+            store["work|session-a"],
+            "The stale task must not deposit session-A presentation data into the work namespace"
         )
+        // The connect boundary must also preserve the outgoing transcript
+        // synchronously while default was still active.
+        XCTAssertEqual(store["default|session-a"], ["a1"])
+        XCTAssertEqual(
+            cachedTimestamp(of: harness.cache, profile: "default", sessionID: "session-a"),
+            "ts-a1",
+            "The outgoing profile's transcript metadata must survive a connect-driven switch"
+        )
+    }
+
+    /// A failed switch that already flipped the identity must fence anything
+    /// scheduled mid-attempt, and rollback flushes the RESTORED previous
+    /// profile's transcript under its own namespace only — never leaving
+    /// partially-loaded target rows behind.
+    func testFailedSwitchRollbackFlushesOnlyRestoredProfileNamespace() async {
+        let (gate, park) = makeGatePark()
+        let fixtures = workSessionFixtures()
+        struct ForcedSwitchFailure: Error {}
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                connectClient: { _ in },
+                loadCatalog: { _, _ in [self.session(fixtures.session.id, profile: "work")] },
+                mintTicket: { _ in "profile-ticket" },
+                openSession: { _, sessionID in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: fixtures.messages,
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in },
+                loadBusyInputMode: { _ in throw ForcedSwitchFailure() }
+            ),
+            park: park
+        )
+        let connection = HermesConnection(baseUrl: "https://127.0.0.1:1", ticket: "saved-ticket")
+        harness.coordinator.rememberSessionID("session-a", for: "default")
+        harness.coordinator.rememberSessionID(fixtures.session.id, for: "work")
+        seedOutgoingTranscript(in: harness.appState, connection: connection, sessionID: "session-a")
+        harness.appState.installChatViewportSnapshotProvider(id: UUID()) {
+            ChatRenderedViewportSnapshot(
+                sessionKey: ChatScrollSessionKey(profile: "default", sessionID: "session-a"),
+                snapshot: ChatScrollSnapshot(anchorMessageID: "default-anchor", followsLatest: true)
+            )
+        }
+
+        // Parked flush under default/session-a before attempting the switch.
+        harness.appState.handleStreamEvent(.cwdUpdate(sessionId: "session-a", cwd: "/tmp/a"))
+        await gate.waitUntilEngaged()
+
+        let switched = await harness.appState.switchProfile(to: "work")
+
+        XCTAssertFalse(switched)
+        XCTAssertEqual(harness.appState.activeProfile, "default")
+        XCTAssertEqual(harness.appState.messages, self.outgoingTranscript)
+
+        gate.release()
+        await Task.yield()
+
+        // Mid-attempt resume work may legitimately have persisted work's own
+        // transcript under work before the failure; the rollback guarantees
+        // are: the restored profile's own entry survives intact, nothing
+        // foreign lands anywhere, and no other namespace leaks.
+        let store = persistedCache(from: harness.defaults)
+        XCTAssertTrue(
+            store.keys.isSubset(of: Set(["default|session-a", "work|" + fixtures.session.id.lowercased()])),
+            "A failed switch may only leave the two legitimate namespaces, got \(store.keys)"
+        )
+        XCTAssertEqual(store["default|session-a"], ["a1"])
+        for (key, ids) in store where key.hasPrefix("work|") {
+            XCTAssertEqual(
+                Set(ids),
+                Set(["work-message"]),
+                "\(key) may only hold work's own transcript rows, got \(ids)"
+            )
+        }
     }
 }

--- a/ConduitTests/CrossProfilePresentationCacheTests.swift
+++ b/ConduitTests/CrossProfilePresentationCacheTests.swift
@@ -112,6 +112,7 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
             defaults.removePersistentDomain(forName: suiteName)
         }
         let store = ChatResumeStore(defaults: defaults)
+        store.setBehavior(.continueWhereLeftOff)
         let coordinator = ChatResumeCoordinator(store: store)
         let cache = SessionPresentationCache(defaults: defaults)
         let appState = AppState(
@@ -135,11 +136,14 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
     }
 
     private func switchLifecycleOperations(
+        workCatalog: [SessionSummary],
         openMessages: @MainActor @escaping (HermesClient) -> [ChatMessage]
     ) -> ChatResumeLifecycleOperations {
         ChatResumeLifecycleOperations(
             connectClient: { _ in },
-            loadCatalog: { _, _ in [] },
+            loadCatalog: { client, _ in
+                (client.profile ?? "default") == "work" ? workCatalog : []
+            },
             mintTicket: { _ in "profile-ticket" },
             openSession: { client, sessionID in
                 SessionResumeResult(
@@ -207,7 +211,9 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
         let defaultSession = session("session-a")
         let fixtures = workSessionFixtures()
         let harness = makeHarness(
-            lifecycleOperations: switchLifecycleOperations { client in
+            lifecycleOperations: switchLifecycleOperations(
+                workCatalog: [fixtures.session]
+            ) { client in
                 (client.profile ?? "default") == "work" ? fixtures.messages : []
             },
             park: park

--- a/ConduitTests/CrossProfilePresentationCacheTests.swift
+++ b/ConduitTests/CrossProfilePresentationCacheTests.swift
@@ -33,7 +33,10 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
 
     /// One-shot cancellation-aware suspension used as the injected debounce
     /// sleep. `onCancel` releases the parked task so the coalesced operation
-    /// observes cancellation exactly like `Task.sleep` would.
+    /// observes cancellation exactly like `Task.sleep` would. Test-only
+    /// type, never shared across production concurrency domains;
+    /// `@unchecked Sendable` is sound because every field is guarded by
+    /// `lock`.
     private final class FlushDebounceGate: @unchecked Sendable {
         private let lock = NSLock()
         private var waiter: CheckedContinuation<Void, Never>?
@@ -383,7 +386,7 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
     /// scheduled mid-attempt, and rollback flushes the RESTORED previous
     /// profile's transcript under its own namespace only — never leaving
     /// partially-loaded target rows behind.
-    func testFailedSwitchRollbackFlushesOnlyRestoredProfileNamespace() async {
+    func testFailedSwitchRollbackLeavesOnlyRestoredProfileNamespace() async {
         let (gate, park) = makeGatePark()
         let fixtures = workSessionFixtures()
         struct ForcedSwitchFailure: Error {}
@@ -440,6 +443,67 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
             "A failed switch must leave only the restored profile's namespace, got \(store.keys)"
         )
         XCTAssertEqual(store["default|session-a"], ["a1"])
+        for (key, ids) in store where key.hasPrefix("work|") {
+            XCTAssertEqual(
+                Set(ids),
+                Set(["work-message"]),
+                "\(key) may only hold work's own transcript rows, got \(ids)"
+            )
+        }
+    }
+
+    /// The epoch fence's distinguishing case: default → work → back to
+    /// default while the original flush is still parked. The profile-string
+    /// guard alone would green-light the write after the round trip; only
+    /// the epoch check drops it. The two forward boundary flushes along the
+    /// way must have landed exactly each profile's own transcript.
+    func testStaleFlushIsFencedAcrossRoundTripBackToOriginProfile() async {
+        let (gate, park) = makeGatePark()
+        let defaultSession = session("session-a")
+        let fixtures = workSessionFixtures()
+        let harness = makeHarness(
+            lifecycleOperations: switchLifecycleOperations(
+                workCatalog: [fixtures.session]
+            ) { client in
+                (client.profile ?? "default") == "work" ? fixtures.messages : []
+            },
+            park: park
+        )
+        let connection = HermesConnection(baseUrl: "https://127.0.0.1:1", ticket: "saved-ticket")
+        harness.coordinator.rememberSessionID(defaultSession.id, for: "default")
+        harness.coordinator.rememberSessionID(fixtures.session.id, for: "work")
+        seedOutgoingTranscript(in: harness.appState, connection: connection, sessionID: defaultSession.id)
+        harness.appState.installChatViewportSnapshotProvider(id: UUID()) {
+            ChatRenderedViewportSnapshot(
+                sessionKey: ChatScrollSessionKey(profile: "default", sessionID: "session-a"),
+                snapshot: ChatScrollSnapshot(anchorMessageID: "default-anchor", followsLatest: true)
+            )
+        }
+
+        harness.appState.handleStreamEvent(.cwdUpdate(sessionId: defaultSession.id, cwd: "/tmp/a"))
+        let parkedOperation = harness.appState.presentationCacheFlushOperationForTesting
+        XCTAssertNotNil(parkedOperation)
+        await gate.waitUntilEngaged()
+
+        // Round trip inside the parked flush's lifetime.
+        await harness.appState.switchProfile(to: "work")
+        XCTAssertEqual(harness.appState.activeProfile, "work")
+        await harness.appState.switchProfile(to: "default")
+        XCTAssertEqual(harness.appState.activeProfile, "default")
+
+        gate.release()
+        await parkedOperation?.value
+
+        XCTAssertNil(
+            persistedCache(from: harness.defaults)["work|session-a"],
+            "The round-tripped flush must stay fenced despite the matching profile string"
+        )
+        XCTAssertEqual(
+            cachedTimestamp(of: harness.cache, profile: "default", sessionID: defaultSession.id),
+            "ts-a1",
+            "The original profile's transcript must survive the round trip"
+        )
+        let store = persistedCache(from: harness.defaults)
         for (key, ids) in store where key.hasPrefix("work|") {
             XCTAssertEqual(
                 Set(ids),

--- a/ConduitTests/CrossProfilePresentationCacheTests.swift
+++ b/ConduitTests/CrossProfilePresentationCacheTests.swift
@@ -188,16 +188,19 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
         return cache.merge(probe, profile: profile, sessionIDs: [sessionID]).first?.timestamp ?? ""
     }
 
-    /// Set of persisted namespace keys ("<profile>|<session>") for exact
+    /// Persisted namespace contents as [cache-key -> message IDs] for exact
     /// namespace-level assertions. The production record shape is
     /// intentionally private; the storage version key pins this decoding.
-    private func persistedCacheKeys(from defaults: UserDefaults) -> Set<String> {
-        struct Entry: Decodable {}
+    private func persistedCache(from defaults: UserDefaults) -> [String: [String]] {
+        struct Entry: Decodable {
+            struct Row: Decodable { let id: String }
+            let messages: [Row]
+        }
         guard let data = defaults.data(forKey: "conduit.sessionPresentation.v1"),
               let map = try? JSONDecoder().decode([String: Entry].self, from: data) else {
-            return []
+            return [:]
         }
-        return Set(map.keys)
+        return map.mapValues { $0.messages.map(\.id) }
     }
 
     // MARK: - Tests
@@ -256,15 +259,13 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
         await parkedOperation?.value
 
         // Step 6: profile B's cache must not hold anything keyed to A's
-        // session identity or A's transcript metadata.
+        // session identity. Profile B's own session row may legitimately
+        // exist (its resume flushes under its own namespace), but it may
+        // only contain profile B's own transcript.
         XCTAssertEqual(
             cachedTimestamp(of: harness.cache, profile: "work", sessionID: defaultSession.id),
             "",
             "A stale flush must never write profile A's transcript into profile B's namespace"
-        )
-        XCTAssertFalse(
-            persistedCacheKeys(from: harness.defaults).contains(where: { $0.hasPrefix("work|") }),
-            "No work-namespaced presentation entries may exist after a fresh switch"
         )
 
         // Step 7: profile A's latest transcript survived the switch because the
@@ -274,8 +275,23 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
             "ts-a1",
             "The outgoing profile's transcript metadata must be preserved across the switch"
         )
-        let remainingKeys = persistedCacheKeys(from: harness.defaults)
-        XCTAssertEqual(remainingKeys, Set(["default|\(defaultSession.id)".lowercased()]))
+        let store = persistedCache(from: harness.defaults)
+        XCTAssertFalse(
+            store.keys.contains { $0.hasPrefix("work|") && !$0.hasSuffix(fixtures.session.id) },
+            "Work-namespace entries are limited to work's own sessions, got \(store.keys)"
+        )
+        XCTAssertEqual(store["work|session-a"], nil)
+        for (key, ids) in store where key.hasPrefix("work|") {
+            XCTAssertEqual(
+                Set(ids),
+                Set(["work-message"]),
+                "\(key) may only hold profile B's own transcript rows, got \(ids)"
+            )
+        }
+        XCTAssertTrue(
+            store.keys.isSubset(of: ["default|session-a", "default|\(defaultSession.id)".lowercased(), "work|\(fixtures.session.id)".lowercased()]),
+            "Unexpected cache namespaces after the switch: \(store.keys)"
+        )
     }
 
     /// Guard against overcorrecting: when the profile does not change, the
@@ -351,8 +367,8 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
             "",
             "The fenced task must not deposit session-A presentation data into the work namespace"
         )
-        XCTAssertFalse(
-            persistedCacheKeys(from: harness.defaults).contains("work|session-a"),
+        XCTAssertNil(
+            persistedCache(from: harness.defaults)["work|session-a"],
             "No work-namespaced entry may ever be created for the captured session"
         )
     }


### PR DESCRIPTION
## Root cause

`AppState.schedulePresentationCacheFlush(for:)` coalesces streaming presentation-cache writes into a delayed `Task` that sleeps up to 2 s and then calls `cacheMessagePresentation(for: [sessionId])`. The task captured only the session ID while reading everything else at fire time from live mutable state — `messages`, reconciliation IDs, restoration guards, and crucially `activeProfile`, which selects the cache namespace (`SessionPresentationCache` keys are `"<profile>|<sessionID>"`). `switchProfile(to:)` wrote the outgoing transcript but never cancelled `presentationCacheFlushTask`, so a flush parked under profile A could wake after the switch completed and save A's session IDs — sometimes with A's stale transcript still in memory — through **profile B's cache namespace**, cross-contaminating presentation metadata between profiles.

## Fix

Three independent layers, so no single caller can regress the boundary:

1. **Self-defending deferred write** — every scheduled flush captures `(scheduledProfile, scheduledEpoch)` and drops itself after waking if either no longer matches. The epoch is bumped only by the sole mutator `setActiveProfile(_:)`, so an **A→B→A round trip** (which a string guard alone would pass) still fences the task.
2. **Fence-bearing identity mutator** — all three runtime `activeProfile` mutation sites funnel through `setActiveProfile(_:)`. Deliberately fence-only: on failed-switch rollbacks the still-active identity does *not* own the restored in-memory content, and a trace-instrumented regression test caught exactly that mis-attribution when a flush was temporarily centralized here.
3. **Explicit forward boundary flushes** — `switchProfile(to:reusing:)` *and* `connect(with:profile:)`'s profile-change branch call `flushPendingPresentationCache()` synchronously while the outgoing profile provably owns the in-memory transcript, cancelling the parked debounce and preserving its latest presentation metadata in its own namespace before any identity change. The failed-switch catch path restores prior state *before* flipping back, and writes nothing during rollback.

**Preserved behavior:** stream coalescing math (2 s debounce / 5 s ceiling), turn-completion flushes, ordinary session switching, pending clarification/approval restoration semantics, and background/foreground resume are untouched. `SessionPresentationCache` itself is not redesigned.

## Files changed

- `Conduit/Services/AppState.swift` — epoch capture + stale-execution fence + handle cleanup in `schedulePresentationCacheFlush`; `setActiveProfile(_:)` sole-mutator fencing (with wrap/redundancy documentation); forward boundary flushes at both switch entry points; `#if DEBUG` test accessor for the pending flush task.
- `ConduitTests/CrossProfilePresentationCacheTests.swift` — new deterministic regression suite (gate-controlled debounce parking, zero wall-clock sleeps).

## Regression coverage

| Test | Pins |
|---|---|
| `testStreamFlushAcrossProfileSwitchCannotContaminateTargetProfile` | reported bug: parked flush across A→B must not populate B's namespace; A's latest transcript survives exactly |
| `testDeferredFlushStillLandsWhenProfileUnchanged` | anti-overcorrection guard: unchanged-profile flushes still land |
| `testConnectProfileChangePreservesOutgoingAndFencesStaleFlush` | `connect(with:profile:)` upholds the same boundary as `switchProfile` |
| `testFailedSwitchRollbackLeavesOnlyRestoredProfileNamespace` | aborted switch leaves exactly the restored profile's namespace |
| `testStaleFlushIsFencedAcrossRoundTripBackToOriginProfile` | A→B→A round trip: only the epoch fence drops the parked write |

## Validation

- Focused `CrossProfilePresentationCacheTests`: **5/5 passed** on the final head.
- Full suite via `ios_test` on the final head: **65 units, 0 failed / 0 skipped / 0 hangs**, coverage reconciled, no simulator recovery.
- Full suite was additionally green twice on intermediate heads (same configuration).

## Review gate

- Initial three-model local review (`workflows/multi-model-review.js`; deepseek-v4-flash/opencode-go, step-3.7-flash/stepfun, mimo-v2.5/xiaomi-token-plan-sgp, consolidation on deepseek-v4-flash): **APPROVE 3/3, zero BLOCKERs** at `d31783e`, one majority WARNING (`connect(with:profile:)` flush asymmetry).
- Remediation introduced a mis-attribution on the rollback path that the new failed-switch test caught via stack-trace instrumentation; corrected design (fence-only setter, per-site forward flushes) verified by the same suite.
- Gate **re-run on the final design**: no BLOCKERs; majority APPROVE with a required comment fix plus a nil-out hardening and an A→B→A test request — all applied in `e5d0a17` (comment/doc/test-only in nature, so no third gate run; full suite re-verified above). Remaining non-blocking suggestions (DEBUG fenced-drop log line, schema-key extraction, connect-failure rollback pin) are tracked as follow-ups.

## Commit series

Nine substantive commits plus one paired temporary-instrumentation commit (`ea6df94` adds a debug tracer, removed again in `3f9a055`; net-zero effect). Squash-merge recommended for a clean history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented delayed presentation-cache updates from being written to the wrong profile after switching profiles.
  - Ensured pending transcript data is saved before profile transitions.
  - Improved cache consistency when profile connections fail or users return to a previous profile.

- **Tests**
  - Added comprehensive coverage for profile switching, failed transitions, deferred updates, and transcript preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->