### PR TITLE
ci: shard XCTest suite into parallel lanes with per-lane retry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,12 @@ jobs:
     needs: shard-check
     runs-on: macos-26
     # Outer emergency bound only: setup + one build (900 s) + up to two
-    # 10-minute attempts + a worst-case erase/reboot reset must all fit, so a
-    # wedged lane can still use its in-script retry. The real watchdog is
-    # per-attempt inside scripts/ci-run-tests.sh
+    # 10-minute attempts + a worst-case erase/reboot reset must all fit with
+    # real slack, so a wedged lane can always finish its in-script retry
+    # under a script-level diagnosis instead of a truncating job kill. The
+    # real watchdog is per-attempt inside scripts/ci-run-tests.sh
     # (ATTEMPT_TIMEOUT_SECS, defaulted to 600 s for unit shards).
-    timeout-minutes: 45
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:
@@ -95,10 +96,10 @@ jobs:
     needs: shard-check
     runs-on: macos-26
     # Outer emergency bound only: setup + one build (900 s) + up to two
-    # 20-minute attempts + a worst-case erase/reboot reset (per-attempt
-    # watchdog defaults to 1200 s for the ui lane — XCUITest lanes are
-    # inherently slower than unit shards).
-    timeout-minutes: 65
+    # 20-minute attempts + a worst-case erase/reboot reset must all fit with
+    # real slack (per-attempt watchdog defaults to 1200 s for the ui lane —
+    # XCUITest lanes are inherently slower than unit shards).
+    timeout-minutes: 70
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,26 +6,53 @@ on:
   pull_request:
     branches: [main]
 
-# Cancel superseded runs on the same PR/branch
+# Cancel superseded runs: one group per PR number (pull_request events) or per
+# branch ref (push events). Different PRs and different branches therefore
+# never cancel one another.
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
 
-jobs:
-  test:
-    name: Build & Test
-    runs-on: macos-26
-    # Outer emergency limit only — wedge detection lives in
-    # scripts/ci-run-tests.sh (per-attempt wall-clock budget, temporarily
-    # defaulted to 20 min as a cold-run ceiling). Headroom is tight when a
-    # second full-length attempt is needed; the 45-min cap remains the
-    # ultimate bound, and it exists for the residual cases the budget cannot
-    # reach (e.g. a wedged CoreSimulatorService blocking simctl itself).
-    timeout-minutes: 45
+env:
+  # Known simulator, used directly as the xcodebuild destination — no
+  # `simctl list` enumeration on the happy path. Name-only (no OS pin)
+  # tracks the newest iOS runtime on the runner image. macos-26 images ship
+  # the iPhone 17 family; if an image refresh renames devices, override here
+  # (failure steps dump the full device list to pick a new name from).
+  SIMULATOR_NAME: "iPhone 17 Pro"
 
+jobs:
+  # Cheap guard before spending macOS minutes: every test class must be
+  # assigned to exactly one lane in scripts/test-shards.txt.
+  shard-check:
+    name: Shard coverage check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - name: Verify shard assignments
+        run: bash scripts/check-test-shards.sh
+
+  # Unit tests: four static shards of ConduitTests run concurrently. One
+  # slow/flaky shard resets and retries ITSELF only — the other shards'
+  # results are kept (fail-fast: false).
+  unit:
+    name: Unit tests — shard ${{ matrix.shard }}
+    needs: shard-check
+    runs-on: macos-26
+    # Outer emergency bound only: setup + one build (900 s) + up to two
+    # 10-minute attempts + a worst-case erase/reboot reset must all fit, so a
+    # wedged lane can still use its in-script retry. The real watchdog is
+    # per-attempt inside scripts/ci-run-tests.sh
+    # (ATTEMPT_TIMEOUT_SECS, defaulted to 600 s for unit shards).
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [a, b, c, d]
     steps:
       - uses: actions/checkout@v7
 
@@ -38,54 +65,66 @@ jobs:
       - name: Generate Xcode project
         run: xcodegen generate
 
-      - name: List available simulators
-        run: xcrun simctl list devices available
+      - name: Run unit-test shard ${{ matrix.shard }}
+        # build-for-testing once, then test-without-building with a
+        # per-attempt watchdog; a retry resets the simulator and re-runs ONLY
+        # this shard against the already-built products.
+        run: bash scripts/ci-run-tests.sh "unit-${{ matrix.shard }}"
 
-      - name: Pick simulator
+      - name: Dump simulator state (failure diagnostics)
+        if: failure()
         run: |
-          set -euo pipefail
-          # macOS images change available devices across versions, so avoid
-          # hardcoding a simulator model that may not exist on the runner.
-          SIMULATOR=$(xcrun simctl list devices available -j | \
-            python3 -c "
-          import json, sys
-          data = json.load(sys.stdin)
-          for runtime, devices in data['devices'].items():
-              if 'iOS' not in runtime:
-                  continue
-              for device in devices:
-                  if 'iPhone' in device['name']:
-                      print(device['udid'])
-                      sys.exit(0)
-          sys.exit(1)
-          ")
-
-          if [ -z "$SIMULATOR" ]; then
-            echo "::error::No iPhone simulator found"
-            exit 1
-          fi
-
-          echo "Using simulator UDID: $SIMULATOR"
-          echo "SIMULATOR=$SIMULATOR" >> "$GITHUB_ENV"
-
-      - name: Run tests
-        # scripts/ci-run-tests.sh owns the retry loop. Each attempt gets its
-        # own wall-clock budget (default 1200 s = 20 min, a temporary
-        # cold-run ceiling; healthy runs take 7-13 min) so a hung test or
-        # wedged simulator is killed and retried instead of stalling until
-        # the 45-min job timeout — which remains the outer emergency limit,
-        # not the wedge-detection mechanism. See the script header for the
-        # exact worst-case caveat. The script also boots the simulator before
-        # every attempt, streams raw xcodebuild output into this step's log,
-        # and leaves per-attempt logs + any partial .xcresult bundles for the
-        # upload step below.
-        run: bash scripts/ci-run-tests.sh
+          xcrun simctl list runtimes available || true
+          xcrun simctl list devices available
 
       - name: Upload test results on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: TestResults.xcresult
+          name: test-results-unit-${{ matrix.shard }}
+          path: |
+            TestResults.xcresult
+            TestResults-retry.xcresult
+            ci-logs/
+          if-no-files-found: ignore
+
+  # UI tests: a dedicated lane so ConduitUITests instability can never force
+  # the unit-test shards to rerun (and vice versa).
+  ui:
+    name: UI tests
+    needs: shard-check
+    runs-on: macos-26
+    # Outer emergency bound only: setup + one build (900 s) + up to two
+    # 20-minute attempts + a worst-case erase/reboot reset (per-attempt
+    # watchdog defaults to 1200 s for the ui lane — XCUITest lanes are
+    # inherently slower than unit shards).
+    timeout-minutes: 65
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app
+
+      - name: Install xcodegen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
+      - name: Run UI tests
+        run: bash scripts/ci-run-tests.sh ui
+
+      - name: Dump simulator state (failure diagnostics)
+        if: failure()
+        run: |
+          xcrun simctl list runtimes available || true
+          xcrun simctl list devices available
+
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-ui
           path: |
             TestResults.xcresult
             TestResults-retry.xcresult

--- a/ConduitTests/SettledMessageIsolationTests.swift
+++ b/ConduitTests/SettledMessageIsolationTests.swift
@@ -64,7 +64,13 @@ final class SettledMessageIsolationTests: XCTestCase {
         )
     }
 
-    /// Hosts an AssistantBubble row in a retained, live window.
+    /// Hosts an AssistantBubble row in a retained, live window. The Dynamic
+    /// Type environment is PINNED: on a freshly booted CI simulator the
+    /// hosting window's content-size category resolves asynchronously, and a
+    /// late trait-sync transaction inside a measurement window would
+    /// otherwise read as a spurious settled re-evaluation (the same failure
+    /// mode testDynamicTypeChangeReOpensSettledContentGate was hardened
+    /// against).
     private func mountRow(
         message: ChatMessage,
         appState: AppState,
@@ -75,7 +81,8 @@ final class SettledMessageIsolationTests: XCTestCase {
             readAloudController: appState.messageReadAloudController,
             gatewayResolver: resolver
         )
-        .environmentObject(appState))
+        .environmentObject(appState)
+        .environment(\.sizeCategory, .large))
         let host = UIHostingController(rootView: row)
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
         window.rootViewController = host
@@ -94,23 +101,35 @@ final class SettledMessageIsolationTests: XCTestCase {
 
         let host = mountRow(message: message, appState: appState, resolver: resolver)
 
-        // Baseline: the initial mount performed the expensive work.
-        let initialMarkdownBodies = TranscriptPerf.settledMarkdownTextBodyEvaluations
+        // Baseline: the initial mount performed the expensive work — and let
+        // its full commit (including trait-sync follow-up transactions) land
+        // BEFORE arming the measurement window, exactly like
+        // testDynamicTypeChangeReOpensSettledContentGate. A zero-interval
+        // run-loop tick observes only what flushed synchronously, so a late
+        // first-mount transaction on a slow/cold runner otherwise lands
+        // inside the window and reads as a spurious re-evaluation.
+        drainUntil(2.0) { TranscriptPerf.settledMarkdownTextBodyEvaluations > 0 }
         let initialSTVUpdates = TranscriptPerf.selectableTextViewUpdateCalls
-        XCTAssertGreaterThan(initialMarkdownBodies, 0, "initial mount must render the markdown")
+        XCTAssertGreaterThan(TranscriptPerf.settledMarkdownTextBodyEvaluations, 0, "initial mount must render the markdown")
 
         // Simulate a streaming tick: the parent re-creates the row with
-        // IDENTICAL inputs (equal message value, same resolver identity).
+        // IDENTICAL inputs (equal message value, same resolver identity,
+        // same pinned Dynamic Type environment).
         TranscriptPerf.reset()
         host.rootView = AnyView(AssistantBubble(
             message: message,
             readAloudController: appState.messageReadAloudController,
             gatewayResolver: resolver
         )
-        .environmentObject(appState))
+        .environmentObject(appState)
+        .environment(\.sizeCategory, .large))
         host.view.setNeedsLayout()
         host.view.layoutIfNeeded()
-        RunLoop.current.run(until: Date())
+
+        // Give any (incorrect) re-evaluation time to surface before
+        // asserting; draining past the re-creation commit makes the
+        // stay-at-zero assertion meaningful instead of vacuously passing.
+        drainUntil(1.0) { TranscriptPerf.settledMarkdownTextBodyEvaluations > 0 }
 
         XCTAssertEqual(
             TranscriptPerf.settledMarkdownTextBodyEvaluations, 0,
@@ -140,10 +159,11 @@ final class SettledMessageIsolationTests: XCTestCase {
             readAloudController: appState.messageReadAloudController,
             gatewayResolver: resolver
         )
-        .environmentObject(appState))
+        .environmentObject(appState)
+        .environment(\.sizeCategory, .large))
         host.view.setNeedsLayout()
         host.view.layoutIfNeeded()
-        RunLoop.current.run(until: Date())
+        drainUntil(2.0) { TranscriptPerf.settledMarkdownTextBodyEvaluations > 0 }
 
         XCTAssertGreaterThan(
             TranscriptPerf.settledMarkdownTextBodyEvaluations, 0,
@@ -169,10 +189,11 @@ final class SettledMessageIsolationTests: XCTestCase {
             readAloudController: appState.messageReadAloudController,
             gatewayResolver: resolverB
         )
-        .environmentObject(appState))
+        .environmentObject(appState)
+        .environment(\.sizeCategory, .large))
         host.view.setNeedsLayout()
         host.view.layoutIfNeeded()
-        RunLoop.current.run(until: Date())
+        drainUntil(2.0) { TranscriptPerf.settledMarkdownTextBodyEvaluations > 0 }
 
         XCTAssertGreaterThan(
             TranscriptPerf.settledMarkdownTextBodyEvaluations, 0,

--- a/scripts/check-test-shards.sh
+++ b/scripts/check-test-shards.sh
@@ -39,8 +39,11 @@ scan_classes() {
     | sed -E 's/^.*class[[:space:]]+([A-Za-z_][A-Za-z0-9_]*).*$/\1/' \
     | sort -u
 }
-unit_dir_classes="$(scan_classes "$ROOT/ConduitTests")"
-ui_dir_classes="$(scan_classes "$ROOT/ConduitUITests")"
+# Tolerate scan "failure" (grep exits 1 on zero matches, and with pipefail
+# that surfaces here): the -z "$on_disk" guard below owns the diagnostic, so
+# a renamed/empty target directory must not abort under set -e first.
+unit_dir_classes="$(scan_classes "$ROOT/ConduitTests" || true)"
+ui_dir_classes="$(scan_classes "$ROOT/ConduitUITests" || true)"
 on_disk="$(printf '%s\n%s\n' "$unit_dir_classes" "$ui_dir_classes" | sort -u)"
 
 if [ -z "$on_disk" ]; then
@@ -50,7 +53,9 @@ fi
 # 2. Assignments declared in the shard file. CRLF-normalized first so a
 #    Windows-authored checkout cannot poison class names with a trailing \r.
 shard_data="$(tr -d '\r' < "$SHARD_FILE")"
-malformed="$(printf '%s\n' "$shard_data" | awk '!/^[[:space:]]*(#|$)/ && NF != 2 {print NR": "$0}')"
+# Actions parses only the first physical line of a ::error:: annotation, so
+# the pipeline collapses embedded newlines into one ';'-joined line.
+malformed="$(printf '%s\n' "$shard_data" | awk '!/^[[:space:]]*(#|$)/ && NF != 2 {print NR": "$0}' | tr '\n' ';')"
 if [ -n "$malformed" ]; then
   die "malformed lines in test-shards.txt (expected '<lane> <ClassName>'): $malformed"
 fi

--- a/scripts/check-test-shards.sh
+++ b/scripts/check-test-shards.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# Shard-membership guard for CI.
+#
+# Every XCTestCase subclass under ConduitTests/ and ConduitUITests/ must be
+# assigned to exactly one lane in scripts/test-shards.txt. Without this check
+# a newly added test class would silently run in NO shard and lose coverage.
+#
+# Also enforces lane/target consistency against the ON-DISK target directory
+# (not just the class-name suffix): classes under ConduitUITests/ must be in
+# the 'ui' lane, unit lanes must only contain ConduitTests classes, and every
+# lane the workflow expects (unit-a..unit-d, ui) must be non-empty.
+#
+# Needs only bash + grep + awk (runs on ubuntu, macOS, and git-bash).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SHARD_FILE="$SCRIPT_DIR/test-shards.txt"
+
+fail=0
+
+die() {
+  echo "::error::$1"
+  fail=1
+}
+
+# 1. XCTest classes on disk, discovered PER TARGET DIRECTORY so lane
+#    assignment can be verified against where a class really lives (not just
+#    its name). Only direct XCTestCase subclass declarations of the form
+#    "class Foo: XCTestCase" on a single line are matched — the convention in
+#    this repo; helper classes inside test files subclass app protocols
+#    (services, URLProtocol, …), and the ':' anchor keeps anything that merely
+#    mentions XCTestCase elsewhere (e.g. MyXCTestCaseHelper) from matching.
+class_re='class[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[^;{]*:[[:space:]]*XCTestCase'
+scan_classes() {
+  grep -rhoE "$class_re" "$1" --include='*.swift' \
+    | sed -E 's/^.*class[[:space:]]+([A-Za-z_][A-Za-z0-9_]*).*$/\1/' \
+    | sort -u
+}
+unit_dir_classes="$(scan_classes "$ROOT/ConduitTests")"
+ui_dir_classes="$(scan_classes "$ROOT/ConduitUITests")"
+on_disk="$(printf '%s\n%s\n' "$unit_dir_classes" "$ui_dir_classes" | sort -u)"
+
+if [ -z "$on_disk" ]; then
+  die "no XCTestCase subclasses found under ConduitTests/ or ConduitUITests/ — checker regex broken?"
+fi
+
+# 2. Assignments declared in the shard file. CRLF-normalized first so a
+#    Windows-authored checkout cannot poison class names with a trailing \r.
+shard_data="$(tr -d '\r' < "$SHARD_FILE")"
+malformed="$(printf '%s\n' "$shard_data" | awk '!/^[[:space:]]*(#|$)/ && NF != 2 {print NR": "$0}')"
+if [ -n "$malformed" ]; then
+  die "malformed lines in test-shards.txt (expected '<lane> <ClassName>'): $malformed"
+fi
+
+assignments="$(printf '%s\n' "$shard_data" | awk '!/^[[:space:]]*(#|$)/ {print $1, $2}')"
+if [ -z "$assignments" ]; then
+  die "no assignments found in test-shards.txt"
+fi
+
+# 3. Every class on disk must be assigned exactly once.
+declared="$(printf '%s\n' "$assignments" | awk '{print $2}' | sort)"
+duplicates="$(printf '%s\n' "$declared" | uniq -d)"
+if [ -n "$duplicates" ]; then
+  die "classes assigned to more than one lane: $(echo "$duplicates" | tr '\n' ' ')"
+fi
+
+missing="$(comm -13 <(printf '%s\n' "$declared") <(printf '%s\n' "$on_disk"))"
+if [ -n "$missing" ]; then
+  die "test classes missing from test-shards.txt (add them to a lane): $(echo "$missing" | tr '\n' ' ')"
+fi
+
+stale="$(comm -23 <(printf '%s\n' "$declared") <(printf '%s\n' "$on_disk"))"
+if [ -n "$stale" ]; then
+  die "test-shards.txt lists classes that no longer exist (remove or rename): $(echo "$stale" | tr '\n' ' ')"
+fi
+
+# 4. Lane/target consistency, verified against the ON-DISK target directory
+#    (the real source of truth), not merely the class-name suffix: a
+#    ConduitTests class assigned to 'ui' (or vice versa) fails here before it
+#    can burn a macOS build on a wrong-target -only-testing identifier.
+known_lanes="unit-a unit-b unit-c unit-d ui"
+while read -r lane cls; do
+  case " $known_lanes " in
+    *" $lane "*) ;;
+    *) die "unknown lane '$lane' in test-shards.txt (expected: $known_lanes)"; continue ;;
+  esac
+  case "$lane" in
+    ui) want_dir="ConduitUITests"; want_list="$ui_dir_classes" ;;
+    *)  want_dir="ConduitTests";  want_list="$unit_dir_classes" ;;
+  esac
+  if ! printf '%s\n' "$want_list" | grep -Fxq -- "$cls"; then
+    die "class $cls is assigned to lane '$lane' but does not live under $want_dir/"
+  fi
+done <<EOF
+$assignments
+EOF
+
+# 5. Every lane the CI matrix expects must be non-empty (an empty lane would
+#    fail at runtime; catch it here with a clearer message).
+total_in_lane=0
+for lane in $known_lanes; do
+  count="$(printf '%s\n' "$shard_data" | awk -v l="$lane" '$1 == l {n++} END {print n+0}')"
+  if [ "$count" -eq 0 ]; then
+    die "lane '$lane' has no classes assigned"
+  fi
+  total_in_lane=$(( total_in_lane + count ))
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "shard check FAILED"
+  exit 1
+fi
+
+echo "shard check OK: $(printf '%s\n' "$on_disk" | wc -l | tr -d ' ') test classes fully assigned"
+printf '%s\n' "$shard_data" | awk '!/^[[:space:]]*(#|$)/ {c[$1]++} END {for (l in c) printf "  %s: %d classes\n", l, c[l]}' | sort

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -212,16 +212,64 @@ run_with_deadline() {
   wait "$runner"
 }
 
+# Bound a short-lived command with a wall-clock deadline. The reset path's
+# simctl calls can hang on a wedged CoreSimulatorService — precisely the state
+# the erase escalation targets — so they must not silently consume the job
+# cap. stdout+stderr are captured into $BOUNDED_OUTPUT; the return value is
+# the command's status, or 124 when the deadline killed it.
+BOUNDED_OUTPUT=""
+bounded_run() {
+  local budget="$1"
+  shift
+  local outfile="$LOG_DIR/bounded-$$.log"
+  local runner status grace
+  BOUNDED_OUTPUT=""
+  set -m
+  "$@" >"$outfile" 2>&1 &
+  runner=$!
+  set +m
+  local deadline=$(( $(date +%s) + budget ))
+  while kill -0 "$runner" 2>/dev/null; do
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      echo "::warning::bounded command exceeded its ${budget}s budget: $*"
+      kill -TERM -- "-$runner" 2>/dev/null || kill -TERM "$runner" 2>/dev/null || true
+      grace=3
+      while [ "$grace" -gt 0 ] && kill -0 "$runner" 2>/dev/null; do
+        sleep 1
+        grace=$(( grace - 1 ))
+      done
+      kill -KILL -- "-$runner" 2>/dev/null || kill -KILL "$runner" 2>/dev/null || true
+      wait "$runner" 2>/dev/null
+      rm -f "$outfile"
+      return 124
+    fi
+    sleep 2
+  done
+  status=0
+  wait "$runner" || status=$?
+  BOUNDED_OUTPUT="$(cat "$outfile" 2>/dev/null)"
+  rm -f "$outfile"
+  return "$status"
+}
+
 # Resolve the UDID of the device the destination names. Only used on the RETRY
 # path (erase/boot need one concrete device; simctl cannot take a name that
 # exists on multiple runtimes). Picks the newest iOS runtime that has a device
 # named $SIMULATOR_NAME — matching how xcodebuild resolves a name-only
 # destination. Runtime keys embed the version (…SimRuntime.iOS-26-5); the
-# major is two-digit, so plain lexical `sort -r` is safe.
+# newest pick compares MAJOR.MINOR NUMERICALLY (a plain lexical sort would
+# rank iOS-26-10 older than iOS-26-9 once minors go double-digit).
 simulator_udid() {
   local json runtime udid
-  json=$(xcrun simctl list devices available -j 2>/dev/null) || return 1
-  for runtime in $(printf '%s\n' "$json" | jq -r '.devices | keys[]' | grep 'SimRuntime\.iOS' | sort -r); do
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "::warning::jq not found on runner — cannot resolve simulator UDID for the targeted erase/boot; degrading to xcodebuild-managed boot"
+    return 1
+  fi
+  if ! bounded_run 60 xcrun simctl list devices available -j; then
+    return 1
+  fi
+  json="$BOUNDED_OUTPUT"
+  for runtime in $(printf '%s\n' "$json" | jq -r '.devices | keys[]' | grep 'SimRuntime\.iOS' | awk -F'iOS-' '{split($2, a, "-"); printf "%04d.%03d %s\n", a[1] + 0, a[2] + 0, $0}' | sort -rn | awk '{print $2}'); do
     udid=$(printf '%s\n' "$json" | jq -r --arg rt "$runtime" --arg n "$SIMULATOR_NAME" \
       '.devices[$rt][]? | select(.name == $n) | .udid' | head -n 1)
     if [ -n "$udid" ]; then
@@ -239,21 +287,26 @@ simulator_udid() {
 reset_and_boot_simulator() {
   local erase="${1:-0}"
   local udid
-  xcrun simctl shutdown all >/dev/null 2>&1 || true
+  # Every simctl call below is deadline-bounded: a wedged
+  # CoreSimulatorService must cost a bounded warning, not the whole job cap.
+  # On any bound/degrade the retry still happens — xcodebuild boots the
+  # destination itself.
+  bounded_run 60 xcrun simctl shutdown all >/dev/null 2>&1 || true
   if [ "$erase" -eq 1 ]; then
     echo "::warning::previous attempt timed out — erasing simulator before retry"
     if udid=$(simulator_udid); then
-      xcrun simctl erase "$udid" >/dev/null 2>&1 || true
+      bounded_run 180 xcrun simctl erase "$udid" >/dev/null 2>&1 || true
     else
       echo "::warning::could not resolve simulator UDID for erase — retrying without erase"
     fi
   fi
   sleep 3
   if udid=$(simulator_udid); then
-    xcrun simctl boot "$udid" 2>/dev/null || true
+    bounded_run 60 xcrun simctl boot "$udid" >/dev/null 2>&1 || true
     # Wait for a complete boot before handing the device to xcodebuild; a
-    # half-booted simulator wedges tests.
-    xcrun simctl bootstatus "$udid" -b -t 180 || true
+    # half-booted simulator wedges tests. bootstatus bounds itself with
+    # -t 180; the outer bound catches bootstatus itself hanging.
+    bounded_run 200 xcrun simctl bootstatus "$udid" -b -t 180 >/dev/null 2>&1 || true
   else
     echo "::warning::could not resolve simulator UDID — letting xcodebuild boot the destination itself"
   fi

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -1,57 +1,121 @@
 #!/usr/bin/env bash
 #
-# Full-suite test runner with a per-attempt wall-clock budget.
+# Sharded CI test runner: build once, then run ONE test lane with a
+# per-attempt wall-clock budget and retry-without-rebuilding.
 #
-# WHY THIS EXISTS: a single hung async test (or a wedged simulator) makes
-# xcodebuild emit no output and never exit. Without a per-attempt deadline the
-# retry loop below can never advance — the 45-minute job timeout kills the job
-# instead, attempt 2 never runs, and no diagnostics survive (CI run #328).
+# WHY THIS EXISTS: CI used to run the entire XCTest universe as one
+# monolithic `xcodebuild test`. As the suite grew, a single hung async test or
+# wedged simulator hit the attempt budget and forced a FULL-SUITE rerun on a
+# reset simulator — the dominant CI cost. This runner instead executes a
+# single lane (see scripts/test-shards.txt), and the workflow runs the lanes
+# as parallel jobs, so:
+#   - a timeout or flaky run retries only the current lane;
+#   - the other lanes' results are never thrown away (fail-fast: false);
+#   - retries re-use the already-built test products: the lane runs
+#     `build-for-testing` exactly once and every attempt (including retries)
+#     is `test-without-building`. A runtime retry NEVER rebuilds.
 #
-# Contract:
-#   - Runs the full suite up to 2 times. Exit 0 = some attempt passed.
-#     Exit 1 = every attempt failed or timed out.
-#   - Each attempt gets ATTEMPT_TIMEOUT_SECS (default 1200 = 20 min; healthy
-#     runs finish in 7-13 min). The 20-minute value is a temporary cold-run
-#     ceiling intended to prevent healthy-but-slow first attempts from being
-#     killed at 16 minutes and forcing an expensive simulator erase/retry. The
-#     workflow's 45-minute job timeout remains the ultimate bound, so in the
-#     pathological case a second full-length attempt may not receive its entire
-#     nominal 20-minute budget. The intent is: prefer one 17-20 minute
-#     successful cold attempt over killing it at 16 minutes + erase/reboot +
-#     warm retry. A timed-out attempt is killed by process group and its status
-#     flows through the retry loop exactly like a test failure.
-#   - The simulator is explicitly booted (shutdown → boot → bootstatus) before
-#     EVERY attempt, including the first.
-#   - After a TIMED-OUT attempt the retry erases the dedicated simulator before
-#     rebooting: the deadline kill removes xcodebuild's process group, but
-#     services inside the simulator (e.g. the pasteboard daemon) can stay
-#     wedged in ways a plain reboot does not clear. Ordinary failures keep the
-#     fast shutdown→boot reset.
-#   - Raw xcodebuild logs land in ci-logs/ and stream into the step log; any
-#     partial .xcresult bundles are left on disk for the artifact upload.
+# Usage:
+#   scripts/ci-run-tests.sh <lane>       lane: unit-a|unit-b|unit-c|unit-d|ui
 #
-# Required env:
-#   SIMULATOR            UDID of the iOS simulator to test against.
+# Phases:
+#   1. build-for-testing     — exactly once; NO retry (build failures are
+#                              deterministic; retrying cannot help and a
+#                              simulator reset would not fix them).
+#                              Budget: BUILD_TIMEOUT_SECS.
+#   2. test-without-building — up to ATTEMPTS attempts, each with budget
+#                              ATTEMPT_TIMEOUT_SECS. Before a RETRY attempt the
+#                              simulator is reset; after a TIMED-OUT attempt
+#                              that reset escalates to an erase (the deadline
+#                              kill removes xcodebuild's process group, but
+#                              services inside the simulator — e.g. the
+#                              pasteboard daemon — can stay wedged in ways a
+#                              plain reboot does not clear).
+#
+# Simulator handling:
+#   xcodebuild always uses the known SIMULATOR_DESTINATION directly — the
+#   happy path never pays for `simctl list` enumeration. A concrete UDID is
+#   resolved (one JSON query) only on the RETRY path, because the targeted
+#   erase/boot needs one device and simctl cannot disambiguate a device name
+#   that exists on several runtimes.
+#
 # Optional env:
-#   ATTEMPT_TIMEOUT_SECS per-attempt budget in seconds (default 1200).
-#   ATTEMPTS             max attempts (default 2).
+#   SIMULATOR_NAME        simulator device name (default: iPhone 17 Pro).
+#                         Composed into the xcodebuild destination; override
+#                         when a runner-image refresh renames devices.
+#   SIMULATOR_OS          optional OS pin appended to the destination.
+#   ATTEMPT_TIMEOUT_SECS  per-test-attempt budget; default 600 s (10 min) for
+#                         unit shards, 1200 s (20 min) for the ui lane.
+#   BUILD_TIMEOUT_SECS    build-for-testing budget; default 900 s.
+#   ATTEMPTS              max test attempts; default 2.
+#
+# Raw xcodebuild logs land in ci-logs/ and stream into the step log; partial
+# .xcresult bundles are left on disk for the failure-only artifact upload.
 #
 # Bash 3.2 compatible (GitHub macOS runners default to /bin/bash).
 
 set -uo pipefail
 
-SIMULATOR="${SIMULATOR:-}"
-# TEMPORARY ceiling (Kanban V3 merge): raise/revert via this default.
-# TODO(kanban-v3): revert to 960 once the cold-run page-ceiling work
-# (see header comment) is no longer needed.
-ATTEMPT_TIMEOUT_SECS="${ATTEMPT_TIMEOUT_SECS:-1200}"
-ATTEMPTS="${ATTEMPTS:-2}"
+LANE="${1:-}"
+case "$LANE" in
+  ui)        TEST_TARGET="ConduitUITests" ;;
+  unit-*)    TEST_TARGET="ConduitTests" ;;
+  *)
+    echo "::error::usage: $0 <lane> (unit-a|unit-b|unit-c|unit-d|ui); got '$LANE'"
+    exit 1
+    ;;
+esac
 
-if [ -z "$SIMULATOR" ]; then
-  echo "::error::SIMULATOR (UDID) must be set"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SHARD_FILE="$SCRIPT_DIR/test-shards.txt"
+if [ ! -f "$SHARD_FILE" ]; then
+  echo "::error::shard membership file not found: $SHARD_FILE"
   exit 1
 fi
 
+# Lane membership comes from the readable shard file; each class becomes one
+# -only-testing:<target>/<class> argument.
+CLASSES=()
+while read -r lane cls; do
+  case "$lane" in ''|'#'*) continue ;; esac
+  # A lane with no class would generate a bogus -only-testing:<target>/ arg.
+  if [ -z "$cls" ]; then
+    echo "::error::malformed line in $SHARD_FILE: expected '<lane> <ClassName>'"
+    exit 1
+  fi
+  if [ "$lane" = "$LANE" ]; then
+    CLASSES+=("$cls")
+  fi
+done < <(tr -d '\r' < "$SHARD_FILE")
+
+if [ "${#CLASSES[@]}" -eq 0 ]; then
+  echo "::error::lane '$LANE' has no classes in $SHARD_FILE"
+  exit 1
+fi
+
+ONLY_TESTING=()
+for cls in "${CLASSES[@]}"; do
+  ONLY_TESTING+=("-only-testing:$TEST_TARGET/$cls")
+done
+echo "lane $LANE: ${#CLASSES[@]} classes from $TEST_TARGET"
+
+SIMULATOR_NAME="${SIMULATOR_NAME:-iPhone 17 Pro}"
+DESTINATION="platform=iOS Simulator,name=$SIMULATOR_NAME"
+if [ -n "${SIMULATOR_OS:-}" ]; then
+  DESTINATION="$DESTINATION,OS=$SIMULATOR_OS"
+fi
+echo "destination: $DESTINATION"
+
+case "$LANE" in
+  ui) DEFAULT_ATTEMPT_TIMEOUT=1200 ;;
+  *)  DEFAULT_ATTEMPT_TIMEOUT=600 ;;
+esac
+ATTEMPT_TIMEOUT_SECS="${ATTEMPT_TIMEOUT_SECS:-$DEFAULT_ATTEMPT_TIMEOUT}"
+BUILD_TIMEOUT_SECS="${BUILD_TIMEOUT_SECS:-900}"
+ATTEMPTS="${ATTEMPTS:-2}"
+
+PROJECT="Conduit.xcodeproj"
+SCHEME="Conduit"
 LOG_DIR="ci-logs"
 mkdir -p "$LOG_DIR"
 
@@ -60,27 +124,8 @@ mkdir -p "$LOG_DIR"
 # fresh runners (observed as a unit-test suite stalling forever inside its
 # first pasteboard touch). The pasteboard-mutating unit tests only need the
 # device-local pasteboard, so keep Simulator.app out of the path entirely.
+# Must happen before the device's pasteboard daemon first starts.
 defaults write com.apple.iphonesimulator PasteboardAutomaticSync -bool false
-
-# Boot the simulator to a known-clean state. All failures are tolerated: on a
-# fresh runner the device may already be shut down (or booted), and a wedged
-# device is exactly what this reset is here to clear. bootstatus is bounded
-# by -t; shutdown/boot themselves can in principle stall on a wedged
-# CoreSimulatorService — the job-level timeout is the backstop for that.
-reset_and_boot_simulator() {
-  # $1 = 1 erases the device before booting (used after a timed-out attempt).
-  local erase="${1:-0}"
-  xcrun simctl shutdown "$SIMULATOR" >/dev/null 2>&1 || true
-  if [ "$erase" -eq 1 ]; then
-    echo "::warning::previous attempt timed out — erasing simulator $SIMULATOR before retry"
-    xcrun simctl erase "$SIMULATOR" >/dev/null 2>&1 || true
-  fi
-  sleep 3
-  xcrun simctl boot "$SIMULATOR" 2>/dev/null || true
-  # Wait for a complete boot before handing the device to xcodebuild; a
-  # half-booted simulator wedges tests.
-  xcrun simctl bootstatus "$SIMULATOR" -b -t 180 || true
-}
 
 # Stream log lines not yet printed. $1 = log path, $2 = NAME of the caller's
 # variable holding the last printed line count (written back via printf -v).
@@ -100,44 +145,36 @@ stream_new_lines() {
   fi
 }
 
-# Run one xcodebuild attempt with a wall-clock deadline. Echoes the attempt's
-# exit status: xcodebuild's own status, or 124 when the deadline killed it.
-run_attempt() {
-  local attempt="$1"
-  local bundle="$2"
-  local log="$LOG_DIR/attempt-${attempt}.log"
+# Run `xcodebuild "$@"` with a wall-clock deadline. Streams the log into the
+# step log; returns xcodebuild's exit status, or 124 when the deadline killed
+# it. The caller owns the retry policy — this function never retries.
+run_with_deadline() {
+  local budget="$1"
+  local log="$2"
+  shift 2
+  local started deadline poll printed heartbeat timed_out now remaining runner grace
 
-  rm -rf "$bundle"
+  started=$(date +%s)
+  deadline=$(( started + budget ))
+  rm -f "$log"
 
   # Job control (set -m) puts this one background job into its own process
   # group so a deadline kill takes down xcodebuild AND its children (xctest,
   # simulator agents) without signalling this script itself.
   set -m
-  xcodebuild test \
-    -project Conduit.xcodeproj \
-    -scheme Conduit \
-    -destination "platform=iOS Simulator,id=$SIMULATOR" \
-    -configuration Debug \
-    -resultBundlePath "$bundle" \
-    CODE_SIGN_IDENTITY="" \
-    CODE_SIGNING_REQUIRED=NO \
-    CODE_SIGNING_ALLOWED=NO \
-    DEVELOPMENT_TEAM="" \
-    PROVISIONING_PROFILE_SPECIFIER="" \
-    >"$log" 2>&1 &
-  local runner=$!
+  xcodebuild "$@" >"$log" 2>&1 &
+  runner=$!
   set +m
 
   # Poll liveness, stream new output, and enforce the deadline. Sleeps never
   # cross the deadline, so the kill lands within one poll of the budget.
-  local deadline=$(( $(date +%s) + ATTEMPT_TIMEOUT_SECS ))
-  local poll=15
-  local printed=0
-  local heartbeat=0
-  local timed_out=0
+  poll=15
+  printed=0
+  heartbeat=0
+  timed_out=0
   while kill -0 "$runner" 2>/dev/null; do
-    local now=$(date +%s)
-    local remaining=$(( deadline - now ))
+    now=$(date +%s)
+    remaining=$(( deadline - now ))
     if [ "$remaining" -le 0 ]; then
       timed_out=1
       break
@@ -145,7 +182,7 @@ run_attempt() {
     stream_new_lines "$log" printed
     heartbeat=$(( heartbeat + 1 ))
     if [ "$(( heartbeat % 4 ))" -eq 0 ]; then
-      echo "… attempt ${attempt} still running ($(( ATTEMPT_TIMEOUT_SECS - remaining ))s elapsed, ${remaining}s of budget left)"
+      echo "… xcodebuild still running ($(( now - started ))s elapsed, ${remaining}s of budget left)"
     fi
     [ "$remaining" -lt "$poll" ] && poll="$remaining"
     sleep "$poll"
@@ -154,61 +191,145 @@ run_attempt() {
   stream_new_lines "$log" printed
 
   if [ "$timed_out" -eq 1 ]; then
-    echo "::error::Attempt ${attempt} exceeded its ${ATTEMPT_TIMEOUT_SECS}s budget — killing the xcodebuild process group (pid $runner)"
+    echo "::error::xcodebuild exceeded its ${budget}s budget — killing the process group (pid $runner)"
     # xcodebuild spawns children (xctest, simulator agents); TERM the whole
     # group so nothing is orphaned, give it a grace window, then KILL.
     kill -TERM -- "-$runner" 2>/dev/null || kill -TERM "$runner" 2>/dev/null || true
-    local grace=10
+    grace=10
     while [ "$grace" -gt 0 ] && kill -0 "$runner" 2>/dev/null; do
       sleep 1
       grace=$(( grace - 1 ))
     done
     kill -KILL -- "-$runner" 2>/dev/null || kill -KILL "$runner" 2>/dev/null || true
     wait "$runner" 2>/dev/null
-    # Diagnostics: whatever the (progressively written) result bundle holds
-    # stays on disk for the upload step; capture the device state and the
-    # wedge point in the log tail.
-    xcrun simctl list devices >"$LOG_DIR/simctl-devices-after-timeout-attempt-${attempt}.txt" 2>&1 || true
     ls -l "$log" || true
-    echo "---- last 200 log lines of the timed-out attempt ----"
+    echo "---- last 200 log lines of the timed-out invocation ----"
     tail -n 200 "$log" || true
-    echo "------------------------------------------------------"
+    echo "--------------------------------------------------------"
     return 124
   fi
 
   wait "$runner"
 }
 
+# Resolve the UDID of the device the destination names. Only used on the RETRY
+# path (erase/boot need one concrete device; simctl cannot take a name that
+# exists on multiple runtimes). Picks the newest iOS runtime that has a device
+# named $SIMULATOR_NAME — matching how xcodebuild resolves a name-only
+# destination. Runtime keys embed the version (…SimRuntime.iOS-26-5); the
+# major is two-digit, so plain lexical `sort -r` is safe.
+simulator_udid() {
+  local json runtime udid
+  json=$(xcrun simctl list devices available -j 2>/dev/null) || return 1
+  for runtime in $(printf '%s\n' "$json" | jq -r '.devices | keys[]' | grep 'SimRuntime\.iOS' | sort -r); do
+    udid=$(printf '%s\n' "$json" | jq -r --arg rt "$runtime" --arg n "$SIMULATOR_NAME" \
+      '.devices[$rt][]? | select(.name == $n) | .udid' | head -n 1)
+    if [ -n "$udid" ]; then
+      printf '%s\n' "$udid"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Reset the simulator to a known-clean state before a RETRY attempt.
+# $1 = 1 erases the device before booting (used after a timed-out attempt).
+# Failures are tolerated and degrade gracefully: on a wedged CoreSimulator
+# service the retry still happens — xcodebuild boots the destination itself.
+reset_and_boot_simulator() {
+  local erase="${1:-0}"
+  local udid
+  xcrun simctl shutdown all >/dev/null 2>&1 || true
+  if [ "$erase" -eq 1 ]; then
+    echo "::warning::previous attempt timed out — erasing simulator before retry"
+    if udid=$(simulator_udid); then
+      xcrun simctl erase "$udid" >/dev/null 2>&1 || true
+    else
+      echo "::warning::could not resolve simulator UDID for erase — retrying without erase"
+    fi
+  fi
+  sleep 3
+  if udid=$(simulator_udid); then
+    xcrun simctl boot "$udid" 2>/dev/null || true
+    # Wait for a complete boot before handing the device to xcodebuild; a
+    # half-booted simulator wedges tests.
+    xcrun simctl bootstatus "$udid" -b -t 180 || true
+  else
+    echo "::warning::could not resolve simulator UDID — letting xcodebuild boot the destination itself"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Phase 1: build the test products exactly once. No retry: build failures are
+# deterministic, and a simulator reset cannot fix them.
+# ---------------------------------------------------------------------------
+echo "::group::build-for-testing (budget ${BUILD_TIMEOUT_SECS}s)"
+build_status=0
+run_with_deadline "$BUILD_TIMEOUT_SECS" "$LOG_DIR/build.log" \
+  build-for-testing \
+  -project "$PROJECT" \
+  -scheme "$SCHEME" \
+  -destination "$DESTINATION" \
+  -configuration Debug \
+  CODE_SIGN_IDENTITY="" \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  DEVELOPMENT_TEAM="" \
+  PROVISIONING_PROFILE_SPECIFIER="" || build_status=$?
+echo "::endgroup::"
+
+if [ "$build_status" -ne 0 ]; then
+  echo "::error::build-for-testing failed (exit $build_status) — lane $LANE aborted; full log: $LOG_DIR/build.log"
+  exit 1
+fi
+echo "build-for-testing ok; test retries will reuse these products"
+
+# ---------------------------------------------------------------------------
+# Phase 2: run the lane with test-without-building. Every attempt — including
+# retries — uses the artifacts built above; a runtime retry never rebuilds.
+# ---------------------------------------------------------------------------
 erase_before_retry=0
 for attempt in $(seq 1 "$ATTEMPTS"); do
   if [ "$attempt" -eq 1 ]; then
     bundle="TestResults.xcresult"
+    # Fresh runner VMs start with devices shut down and clean; a blanket
+    # shutdown is cheap and guarantees xcodebuild cold-boots the destination.
+    # No simctl enumeration on the happy path.
+    xcrun simctl shutdown all >/dev/null 2>&1 || true
   else
     bundle="TestResults-retry.xcresult"
+    # A wedged or half-booted simulator is the one failure mode an in-test
+    # retry cannot clear; reset (and after a timeout, erase) before retrying.
+    echo "Resetting simulator before retry attempt $attempt"
+    reset_and_boot_simulator "$erase_before_retry"
   fi
 
-  # A wedged or half-booted simulator is the one failure mode in-test retries
-  # cannot clear; reset it before every attempt, including the first. After a
-  # timed-out attempt the reset escalates to an erase (see below).
-  echo "Booting simulator $SIMULATOR for attempt $attempt"
-  reset_and_boot_simulator "$erase_before_retry"
+  rm -rf "$bundle"
 
-  echo "::group::Test attempt $attempt (budget ${ATTEMPT_TIMEOUT_SECS}s)"
+  echo "::group::Test attempt $attempt for lane $LANE (budget ${ATTEMPT_TIMEOUT_SECS}s)"
   status=0
-  run_attempt "$attempt" "$bundle" || status=$?
+  run_with_deadline "$ATTEMPT_TIMEOUT_SECS" "$LOG_DIR/attempt-${attempt}.log" \
+    test-without-building \
+    -project "$PROJECT" \
+    -scheme "$SCHEME" \
+    -destination "$DESTINATION" \
+    -resultBundlePath "$bundle" \
+    "${ONLY_TESTING[@]}" || status=$?
   echo "::endgroup::"
 
   if [ "$status" -eq 0 ]; then
-    echo "tests passed on attempt $attempt"
+    echo "lane $LANE passed on attempt $attempt"
     exit 0
   fi
-  echo "tests failed on attempt $attempt (exit status $status)"
+  echo "lane $LANE failed on attempt $attempt (exit status $status)"
   # Only a deadline kill (124) escalates the next reset to an erase; ordinary
-  # test failures keep the fast shutdown→boot path.
+  # test failures keep the fast shutdown→boot path. Failure-only diagnostics:
+  # capture device state and leave the partial result bundle for upload.
   if [ "$status" -eq 124 ]; then
     erase_before_retry=1
+    xcrun simctl list devices > "$LOG_DIR/simctl-devices-after-timeout-attempt-${attempt}.txt" 2>&1 || true
   fi
 done
 
-echo "all $ATTEMPTS test attempts failed"
+echo "::error::all $ATTEMPTS attempts failed for lane $LANE"
 exit 1

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -76,7 +76,7 @@ fi
 # Lane membership comes from the readable shard file; each class becomes one
 # -only-testing:<target>/<class> argument.
 CLASSES=()
-while read -r lane cls; do
+while read -r lane cls _; do
   case "$lane" in ''|'#'*) continue ;; esac
   # A lane with no class would generate a bogus -only-testing:<target>/ arg.
   if [ -z "$cls" ]; then
@@ -217,6 +217,9 @@ run_with_deadline() {
 # the erase escalation targets — so they must not silently consume the job
 # cap. stdout+stderr are captured into $BOUNDED_OUTPUT; the return value is
 # the command's status, or 124 when the deadline killed it.
+# NOTE: BOUNDED_OUTPUT is set in the CALLER's shell — readable after a plain
+# call, but NOT across a $( ) subshell boundary (simulator_udid consumes it
+# inside its own). Keep that constraint in mind when adding call sites.
 BOUNDED_OUTPUT=""
 bounded_run() {
   local budget="$1"
@@ -240,6 +243,9 @@ bounded_run() {
       done
       kill -KILL -- "-$runner" 2>/dev/null || kill -KILL "$runner" 2>/dev/null || true
       wait "$runner" 2>/dev/null
+      # Best-effort: keep whatever the killed command already wrote so
+      # callers (e.g. timeout diagnostics) can preserve partial output.
+      BOUNDED_OUTPUT="$(cat "$outfile" 2>/dev/null)"
       rm -f "$outfile"
       return 124
     fi
@@ -291,22 +297,22 @@ reset_and_boot_simulator() {
   # CoreSimulatorService must cost a bounded warning, not the whole job cap.
   # On any bound/degrade the retry still happens — xcodebuild boots the
   # destination itself.
-  bounded_run 60 xcrun simctl shutdown all >/dev/null 2>&1 || true
+  bounded_run 60 xcrun simctl shutdown all || true
   if [ "$erase" -eq 1 ]; then
     echo "::warning::previous attempt timed out — erasing simulator before retry"
     if udid=$(simulator_udid); then
-      bounded_run 180 xcrun simctl erase "$udid" >/dev/null 2>&1 || true
+      bounded_run 180 xcrun simctl erase "$udid" || true
     else
       echo "::warning::could not resolve simulator UDID for erase — retrying without erase"
     fi
   fi
   sleep 3
   if udid=$(simulator_udid); then
-    bounded_run 60 xcrun simctl boot "$udid" >/dev/null 2>&1 || true
+    bounded_run 60 xcrun simctl boot "$udid" || true
     # Wait for a complete boot before handing the device to xcodebuild; a
     # half-booted simulator wedges tests. bootstatus bounds itself with
     # -t 180; the outer bound catches bootstatus itself hanging.
-    bounded_run 200 xcrun simctl bootstatus "$udid" -b -t 180 >/dev/null 2>&1 || true
+    bounded_run 200 xcrun simctl bootstatus "$udid" -b -t 180 || true
   else
     echo "::warning::could not resolve simulator UDID — letting xcodebuild boot the destination itself"
   fi
@@ -348,7 +354,7 @@ for attempt in $(seq 1 "$ATTEMPTS"); do
     # Fresh runner VMs start with devices shut down and clean; a blanket
     # shutdown is cheap and guarantees xcodebuild cold-boots the destination.
     # No simctl enumeration on the happy path.
-    xcrun simctl shutdown all >/dev/null 2>&1 || true
+    bounded_run 60 xcrun simctl shutdown all || true # bounded: a wedged CoreSimulatorService must not stall the lane before attempt 1
   else
     bundle="TestResults-retry.xcresult"
     # A wedged or half-booted simulator is the one failure mode an in-test
@@ -380,7 +386,23 @@ for attempt in $(seq 1 "$ATTEMPTS"); do
   # capture device state and leave the partial result bundle for upload.
   if [ "$status" -eq 124 ]; then
     erase_before_retry=1
-    xcrun simctl list devices > "$LOG_DIR/simctl-devices-after-timeout-attempt-${attempt}.txt" 2>&1 || true
+    # Best-effort failure-only diagnostics: this runs right after a
+    # simulator/test timeout — exactly when CoreSimulatorService is most
+    # likely unhealthy — so it is deadline-bounded and must never delay the
+    # shard-local retry. Partial output from a killed dump is preserved.
+    diag="$LOG_DIR/simctl-devices-after-timeout-attempt-${attempt}.txt"
+    diag_status=0
+    bounded_run 45 xcrun simctl list devices || diag_status=$?
+    # Always materialize the artifact (even an empty capture) so the failure
+    # bundle is consistent.
+    printf '%s\n' "${BOUNDED_OUTPUT:-<no output captured before failure/deadline>}" > "$diag"
+    if [ "$diag_status" -ne 0 ]; then
+      if [ "$diag_status" -eq 124 ]; then
+        echo "::warning::timeout diagnostic 'simctl list devices' did not complete within 45s — partial output in $diag; continuing to retry"
+      else
+        echo "::warning::timeout diagnostic 'simctl list devices' failed (exit $diag_status) — output in $diag; continuing to retry"
+      fi
+    fi
   fi
 done
 

--- a/scripts/test-shards.txt
+++ b/scripts/test-shards.txt
@@ -1,0 +1,99 @@
+# Test shard membership — source of truth for CI test lanes.
+#
+# Format (one assignment per line):
+#
+#   <lane> <XCTestCaseClassName>
+#
+# Lanes:
+#   unit-a .. unit-d   ConduitTests shards, run in parallel by the CI matrix
+#                      (jobs "unit (a)" .. "unit (d)").
+#   ui                 ConduitUITests, its own dedicated CI job.
+#
+# Blank lines and #-comments are ignored. Every XCTestCase subclass under
+# ConduitTests/ and ConduitUITests/ must appear EXACTLY ONCE —
+# scripts/check-test-shards.sh enforces this in CI (shard-check job), so a new
+# test class cannot silently run in no shard at all.
+#
+# Rebalancing: move a line to another lane and you are done — the runner
+# (scripts/ci-run-tests.sh) turns each lane into -only-testing:Target/Class
+# arguments mechanically. Keep roughly equal wall-clock per lane, not merely
+# equal class counts: heavy suites (Kanban*, MarkdownLargeDocument,
+# TranscriptPerformanceFixture, HermesClient, VoiceConversationController) are
+# deliberately spread so no single lane dominates.
+
+# --- unit-a: Markdown rendering, text selection, scrolling, layout ---------
+unit-a ChatMessageScrollTargetCacheIncrementalTests
+unit-a ChatScrollStateTests
+unit-a ChatTextSelectionTests
+unit-a ChatTitleScrollTests
+unit-a ChatViewFollowCorrectionTests
+unit-a ChatViewportControllerTests
+unit-a ComposerPasteTextViewTests
+unit-a InterfaceOrientationTests
+unit-a MarkdownFallbackTests
+unit-a MarkdownLargeDocumentTests
+unit-a MarkdownReferenceLinkTests
+unit-a MarkdownRichContentHostedTests
+unit-a MarkdownRichContentPolicyTests
+unit-a MarkdownSelectionCoordinatorTests
+unit-a MarkdownTableLayoutTests
+unit-a SelectableTextViewPresentationCacheTests
+unit-a TranscriptPerformanceFixtureTests
+
+# --- unit-b: app state, chat/session lifecycle, streaming ------------------
+unit-b AppStateChatResumeTests
+unit-b AppStateReadAloudTests
+unit-b AppStateReasoningStreamTests
+unit-b BufferedEventDeduplicationTests
+unit-b ChatResumeCoordinatorTests
+unit-b ChatResumePolicyTests
+unit-b ChatResumeStoreTests
+unit-b ChatReturnSurfaceTests
+unit-b ComposerDraftStoreTests
+unit-b CrossProfilePresentationCacheTests
+unit-b MessageReadAloudControllerTests
+unit-b MessageNormalizerTests
+unit-b SessionCatalogCacheTests
+unit-b SessionPresentationCacheTests
+unit-b SessionRenameTests
+unit-b SettledMessageIsolationTests
+unit-b StreamEventParserTests
+
+# --- unit-c: Kanban (incl. V2/V3) and Yolo profile bookkeeping -------------
+unit-c KanbanSelectionLayoutTests
+unit-c KanbanTests
+unit-c KanbanV2CorrectnessTests
+unit-c KanbanV2Tests
+unit-c KanbanV3ATests
+unit-c KanbanV3BTests
+unit-c KanbanV3CTests
+unit-c KanbanV3DTests
+unit-c ModelPickerTests
+unit-c SessionYoloPersistenceTests
+unit-c SessionYoloStoreTests
+unit-c TurnStateTests
+unit-c YoloProfileSwitchBookkeepingTests
+
+# --- unit-d: networking, security, dashboard, voice/wake, haptics ----------
+unit-d AnyCodableTests
+unit-d CloudflareAccessTests
+unit-d ConnectionURLPolicyOriginTests
+unit-d DashboardCookieClearingTests
+unit-d DashboardTicketBridgeTests
+unit-d HapticsEmissionTests
+unit-d HapticsTests
+unit-d HermesClientTests
+unit-d HermesVoiceConfigurationServiceTests
+unit-d InteractionHapticsTests
+unit-d NativeAuthClientTests
+unit-d ResponseHapticPolicyTests
+unit-d ResponseHapticStateTests
+unit-d SecurityBoundaryTests
+unit-d VoiceAudioSessionConfigurationTests
+unit-d VoiceConversationControllerTests
+unit-d WakeConfigurationStoreTests
+unit-d WakeLifecycleTests
+unit-d WakePhraseCompilerTests
+
+# --- ui: end-to-end XCUITest lane ------------------------------------------
+ui SelectionObserverUITests


### PR DESCRIPTION
## Problem

PR CI runs the entire XCTest universe as one monolithic `xcodebuild test`. As the suite grew (now 67 classes), this made one slow or wedged run extremely expensive: the first attempt could hit the 20-minute watchdog, the script then reset the simulator and **reran the entire suite**, and the job could burn most of its 45-minute budget. Simulator enumeration also ran two full `simctl list devices available` passes (+ a python picker) on every successful run.

Reference: #103 run 33115444518.

## What changed

- **Unit/UI split** — `ConduitTests` and `ConduitUITests` run as fully independent jobs. UI-test instability can never force unit tests to rerun (and vice versa).
- **4 static unit shards** — `strategy.fail-fast: false` matrix; one failed shard keeps the other shards' results.
- **Retry only the failed shard** — retry/reset/erase behavior is scoped to the failing lane by construction (each lane is its own job; the runner replays only that lane's `-only-testing` filters).
- **No rebuild on runtime retry** — each lane runs `xcodebuild build-for-testing` **exactly once**, then every attempt (including retries) is `xcodebuild test-without-building`. Build failures fail fast (no retry — deterministic).
- **Tightened, scoped watchdogs** — per-attempt: **600 s** unit shards / **1200 s** UI lane (down from the 1200 s monolithic ceiling); build 900 s. Job-level outer bounds 45/65 min are emergency limits sized to fit setup + one build + two attempts + a worst-case erase/reboot reset.
- **No happy-path simulator enumeration** — xcodebuild uses the known destination directly (`SIMULATOR_NAME=iPhone 17 Pro`, name-only so it tracks the newest runtime; env-overridable). A UDID is resolved via one `simctl list -j` query **only on the retry path** (erase/boot need a concrete device; device names are ambiguous across the image's multiple runtimes). Failure-only `if: failure()` steps dump runtimes + full device list.
- **Concurrency cancellation** — `group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`, `cancel-in-progress: true`; isolates PRs and branches from each other.
- **Shard coverage guard** — new `scripts/check-test-shards.sh` runs as a cheap ubuntu gate job: every `XCTestCase` subclass must be assigned to exactly one lane, verified against the **on-disk target directory** (not just name suffix); malformed lines, duplicate/missing assignments, unknown lanes, and empty matrix lanes all fail CI. Shard membership lives in the readable `scripts/test-shards.txt` — rebalancing is a one-line move.

## Shard structure

| Lane | Classes | Theme |
|---|---|---|
| unit-a | 17 | Markdown rendering, text selection/scrolling, layout (incl. the two perf-heavy suites) |
| unit-b | 17 | App state, chat/session lifecycle, streaming |
| unit-c | 13 | Kanban (V1/V2/V3A–D) + Yolo profile bookkeeping (newest, heaviest suites) |
| unit-d | 19 | Networking, security, dashboard, voice/wake, haptics |
| ui | 1 | `SelectionObserverUITests` (dedicated lane) |

## Tradeoffs

- Each of the 5 jobs performs its own `build-for-testing` (~5× build CPU across the matrix). Sharing one build artifact across runners was rejected for now per scope; each job's build is incremental-free but the wall-clock win dominates.
- Static shards need manual rebalancing; `test-shards.txt` + the CI guard make drift impossible to miss.
- Default simulator name is pinned to the macos-26 image generation and overridable via `SIMULATOR_NAME`; an image refresh that renames devices fails fast with full failure-only diagnostics to pick a new name.
- No `-parallel-testing-enabled` (tests may share defaults/stores), no DerivedData caching, no test skipped or removed — all 67 classes run exactly once across the lanes.

## Expected improvement

Typical PR wall-clock drops from ~20–45 min (monolithic, full-suite retry risk) to roughly **10–15 min** (setup + build + a ~2–4 min shard, slowest lane critical path), with UI tests running concurrently. A wedged shard now costs that shard one in-place retry instead of a full-suite rerun on a reset simulator.

## Validation

- `scripts/check-test-shards.sh`: 67/67 classes assigned exactly once (17/17/13/19/1); negative tests — unassigned class, duplicate assignment, misplaced class (target-directory check), emptied lane, malformed line, CRLF shard file — all behave correctly.
- `bash -n` on both scripts; workflow YAML parsed and structure verified; generated `-only-testing` identifiers checked per lane (correct `ConduitTests`/`ConduitUITests` prefixes, no UI leak into unit shards).

## Review gate

Local multi-model review (pinned: deepseek-v4-flash, step-3.7-flash, mimo-v2.5; consolidation deepseek-v4-flash): **APPROVE 2–1, zero BLOCKERs**. Consensus WARNINGs were fixed in this branch before push: job-timeout headroom (45/65 min), anchored XCTestCase discovery regex, directory-based lane/target verification, CRLF hardening. The remaining "runner not local" warning was verified as a reviewer misread (it is declared `local`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Test execution is now split across four parallel unit lanes and a dedicated UI lane.
  * Added validation to ensure all tests are assigned exactly once to the correct lane.
  * Improved test retries, timeout handling, simulator diagnostics, and failure artifacts.
* **Chores**
  * CI runs from separate branches and pull requests no longer cancel each other unexpectedly.
  * Simulator selection is more consistent across CI runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->