### PR TITLE
feat(composer): optional hardware-keyboard Return-to-send in chat composer

### DIFF
--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -737,7 +737,12 @@ private struct ChatSettingsDetail: View {
                     ResponseBehaviorSettings(initialMode: busyInputMode, save: persistBusyInputMode)
                 }
             ),
-            trailingSection: AnyView(DeviceHapticsSettings())
+            trailingSection: AnyView(
+                VStack(spacing: 14) {
+                    ComposerReturnKeySettings()
+                    DeviceHapticsSettings()
+                }
+            )
         )
         .navigationTitle("Chat")
         .task { options = await loadOptions() }
@@ -752,6 +757,30 @@ private struct ChatSettingsDetail: View {
         .init(key: "display.memory_notifications", label: "Self-improvement updates", help: "Choose whether Conduit follows Hermes, always shows, or never shows maintenance updates.", control: .labeledOptions([(value: "default", label: "Use Hermes default"), (value: "on", label: "Always show"), (value: "off", label: "Never show")], defaultValue: "default")),
         .init(key: "agent.image_input_mode", label: "Image attachments", help: "How Hermes supplies images to a model.", control: .options(["auto", "native", "text"], defaultValue: "auto")),
     ]
+}
+
+/// Local, device-only composer input preference. Stored in UserDefaults via
+/// @AppStorage; never part of the Hermes profile configuration.
+private struct ComposerReturnKeySettings: View {
+    @AppStorage(ComposerReturnKey.preferenceKey) private var returnKeySends = false
+
+    var body: some View {
+        ConduitSettingsSection(
+            title: "Keyboard",
+            symbol: "keyboard",
+            tint: .conduitAura
+        ) {
+            Text("Press Return to send. Use Shift-Return for a new line.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            Text("Hardware keyboards only. The on-screen keyboard's Return key keeps inserting a new line.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            Toggle("Return key sends", isOn: $returnKeySends)
+                .tint(.conduitAccent)
+                .accessibilityHint("Applies to hardware keyboards only. The on-screen keyboard's Return key is unchanged.")
+        }
+    }
 }
 
 private struct DeviceHapticsSettings: View {

--- a/Conduit/Views/Components/ComposerBar.swift
+++ b/Conduit/Views/Components/ComposerBar.swift
@@ -32,6 +32,9 @@ struct ComposerBar: View {
     @State private var documentImportContext: AsyncAttachmentContext?
     @State private var attachmentGeneration: UInt64 = 0
     @State private var suppressNextTextChangeSuggestions = false
+    /// Local, device-only input preference. Defaults to off so existing
+    /// users keep Return inserting a newline after updating.
+    @AppStorage(ComposerReturnKey.preferenceKey) private var returnKeySends = false
     @Namespace private var glassNamespace
 
     struct AsyncAttachmentContext: Equatable {
@@ -332,7 +335,10 @@ struct ComposerBar: View {
                         onPastedImageError: { message in
                             handlePastedImageError(message, editorIdentity: currentEditorIdentity)
                         },
-                        editorIdentity: editorIdentity
+                        editorIdentity: editorIdentity,
+                        returnKeySends: returnKeySends,
+                        canSubmitFromReturn: ComposerReturnKey.canSubmit(action: action),
+                        onSubmitFromReturn: { submitFromReturnKey() }
                     )
                     .id(editorIdentity)
                     .padding(.horizontal, 5)
@@ -579,6 +585,16 @@ struct ComposerBar: View {
         .padding(.horizontal, 14)
         .padding(.top, 7)
         .padding(.bottom, 1)
+    }
+
+    /// Return-shortcut entry point. Invokes the exact same submission path
+    /// as the composer action button, but only for typed-message actions
+    /// (send/steer/interrupt): Return never acts as the stop-only control.
+    /// The gate is re-checked here so the existing composer action state —
+    /// not the text view — stays authoritative.
+    private func submitFromReturnKey() {
+        guard ComposerReturnKey.canSubmit(action: action) else { return }
+        submit()
     }
 
     private func submit() {

--- a/Conduit/Views/Components/ComposerBar.swift
+++ b/Conduit/Views/Components/ComposerBar.swift
@@ -337,6 +337,9 @@ struct ComposerBar: View {
                         },
                         editorIdentity: editorIdentity,
                         returnKeySends: returnKeySends,
+                        // May lag one render behind fast typing; the safe
+                        // failure mode is newline insertion, and
+                        // submitFromReturnKey() re-checks the live gate.
                         canSubmitFromReturn: ComposerReturnKey.canSubmit(action: action),
                         onSubmitFromReturn: { submitFromReturnKey() }
                     )
@@ -591,10 +594,14 @@ struct ComposerBar: View {
     /// as the composer action button, but only for typed-message actions
     /// (send/steer/interrupt): Return never acts as the stop-only control.
     /// The gate is re-checked here so the existing composer action state —
-    /// not the text view — stays authoritative.
-    private func submitFromReturnKey() {
-        guard ComposerReturnKey.canSubmit(action: action) else { return }
+    /// not the text view — stays authoritative. Reports whether the message
+    /// actually went out, so a declined shortcut press falls back to the
+    /// text view's default newline behavior instead of being swallowed.
+    @discardableResult
+    private func submitFromReturnKey() -> Bool {
+        guard ComposerReturnKey.canSubmit(action: action) else { return false }
         submit()
+        return true
     }
 
     private func submit() {

--- a/Conduit/Views/Components/ComposerPasteTextView.swift
+++ b/Conduit/Views/Components/ComposerPasteTextView.swift
@@ -193,8 +193,10 @@ final class ImagePasteTextView: UITextView {
     /// Ground-truth Shift state folded from the keyboard's own Shift press
     /// events. Some Bluetooth keyboards report chord modifiers with a lag on
     /// the event/key modifier surfaces, so the physical Shift press itself is
-    /// tracked as well.
-    private var hardwareShiftHeld = false
+    /// tracked as well. Left and right Shift are tracked independently so a
+    /// released key cannot clear a still-held second Shift.
+    private var heldShiftKeys: Set<UIKeyboardHIDUsage> = []
+    private var hardwareShiftHeld: Bool { !heldShiftKeys.isEmpty }
 
     override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
         foldHardwareShift(presses, pressed: true)
@@ -204,8 +206,9 @@ final class ImagePasteTextView: UITextView {
                 || Self.shiftIsPressed(event: event, key: returnPress.key)
             // Consume only the Return press, and only when the composer
             // actually acted. Every other case (setting off, Shift-Return,
-            // non-submittable composer, declined callback) is forwarded with
-            // the remaining presses so default text behavior is preserved.
+            // marked text / IME composition, non-submittable composer,
+            // declined callback) is forwarded with the remaining presses so
+            // UIKit's normal text-input behavior is preserved.
             if handleReturnKeyPress(shiftPressed: shiftPressed) {
                 forwarding.remove(returnPress)
             }
@@ -220,25 +223,59 @@ final class ImagePasteTextView: UITextView {
         super.pressesEnded(presses, with: event)
     }
 
-    /// Folds physical Shift presses into the tracked chord state.
+    override func pressesCancelled(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        // A cancelled sequence (e.g. the system ends chord tracking) must
+        // release tracked Shift state exactly like a normal key-up, or the
+        // shortcut would keep believing Shift is held.
+        foldHardwareShift(presses, pressed: false)
+        super.pressesCancelled(presses, with: event)
+    }
+
+    /// Folds physical Shift presses into the tracked chord state. Cancellations
+    /// are treated like key-ups: the press is no longer held either way.
     private func foldHardwareShift(_ presses: Set<UIPress>, pressed: Bool) {
-        for press in presses
-        where press.key?.keyCode == .keyboardLeftShift || press.key?.keyCode == .keyboardRightShift {
-            hardwareShiftHeld = pressed
-        }
+        heldShiftKeys = Self.updatedShiftState(
+            heldShiftKeys,
+            keyCodes: Set(presses.compactMap { $0.key?.keyCode }),
+            isPressed: pressed
+        )
+    }
+
+    /// Pure Shift-chord state transition over key codes, extracted so the
+    /// begin/end/cancel bookkeeping is unit-testable without synthesizing
+    /// UIPress events. Unknown key codes are ignored; cancellations and
+    /// key-ups both release their keys.
+    static func updatedShiftState(
+        _ held: Set<UIKeyboardHIDUsage>,
+        keyCodes: Set<UIKeyboardHIDUsage>,
+        isPressed: Bool
+    ) -> Set<UIKeyboardHIDUsage> {
+        let shiftCodes: Set<UIKeyboardHIDUsage> = [.keyboardLeftShift, .keyboardRightShift]
+        let touched = keyCodes.intersection(shiftCodes)
+        return isPressed ? held.union(touched) : held.subtracting(touched)
     }
 
     /// Applies the Return shortcut policy for one Return key press and
-    /// reports whether the press was consumed as a submit. Consumption
-    /// additionally requires the composer's callback to report that it
-    /// acted; anything else returns false so the caller forwards the press.
-    /// Internal so tests can drive the exact pressesBegan branch without
-    /// synthesizing UIPress or UIKey events (neither exposes an initializer).
+    /// reports whether the press was consumed as a submit. While the text
+    /// view holds IME marked text, Return belongs to the composition and the
+    /// shortcut always declines. Consumption additionally requires the
+    /// composer's callback to report that it acted; anything else returns
+    /// false so the caller forwards the press. Internal so tests can drive
+    /// the exact pressesBegan branch without synthesizing UIPress or UIKey
+    /// events (neither exposes an initializer).
     @discardableResult
     func handleReturnKeyPress(shiftPressed: Bool) -> Bool {
+        handleReturnKeyPress(shiftPressed: shiftPressed, hasMarkedText: markedTextRange != nil)
+    }
+
+    /// Test seam for the same decision path with the marked-text state passed
+    /// explicitly, since a live IME composition cannot be synthesized in unit
+    /// tests.
+    func handleReturnKeyPress(shiftPressed: Bool, hasMarkedText: Bool) -> Bool {
         let decision = ComposerReturnKey.decision(
             returnKeySends: returnKeySends,
             shiftPressed: shiftPressed,
+            hasMarkedText: hasMarkedText,
             canSubmit: canSubmitFromReturn
         )
         guard decision == .submit, let onSubmit = onSubmitFromReturn else { return false }

--- a/Conduit/Views/Components/ComposerPasteTextView.swift
+++ b/Conduit/Views/Components/ComposerPasteTextView.swift
@@ -204,6 +204,7 @@ final class ImagePasteTextView: UITextView {
         if let returnPress = presses.first(where: { Self.isReturnKeyPress($0) }) {
             let shiftPressed = hardwareShiftHeld
                 || Self.shiftIsPressed(event: event, key: returnPress.key)
+                || Self.shiftIsHeld(in: event?.allPresses ?? [])
             // Consume only the Return press, and only when the composer
             // actually acted. Every other case (setting off, Shift-Return,
             // marked text / IME composition, non-submittable composer,
@@ -220,6 +221,8 @@ final class ImagePasteTextView: UITextView {
 
     override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
         foldHardwareShift(presses, pressed: false)
+        // Forward the original set: UIKit tracks press lifecycle across the
+        // whole sequence, not just the keys this shortcut cares about.
         super.pressesEnded(presses, with: event)
     }
 
@@ -228,7 +231,27 @@ final class ImagePasteTextView: UITextView {
         // release tracked Shift state exactly like a normal key-up, or the
         // shortcut would keep believing Shift is held.
         foldHardwareShift(presses, pressed: false)
+        // Forward the original set: UIKit tracks press lifecycle across the
+        // whole sequence, not just the keys this shortcut cares about.
         super.pressesCancelled(presses, with: event)
+    }
+
+    /// Whether any currently-down Shift press exists anywhere in the press
+    /// event. Covers keyboards that deliver the Shift key-down in a separate,
+    /// later event than Return, where the per-press modifiers and the local
+    /// fold would not yet show the chord.
+    static func shiftIsHeld(in presses: Set<UIPress>) -> Bool {
+        presses.contains { press in
+            press.key?.keyCode == .keyboardLeftShift || press.key?.keyCode == .keyboardRightShift
+        }
+    }
+
+    override func resignFirstResponder() -> Bool {
+        // A focus change mid-chord means the key-up will go to a different
+        // responder; drop the tracked Shift so the next plain Return is not
+        // misread as Shift-Return.
+        heldShiftKeys.removeAll()
+        return super.resignFirstResponder()
     }
 
     /// Folds physical Shift presses into the tracked chord state. Cancellations

--- a/Conduit/Views/Components/ComposerPasteTextView.swift
+++ b/Conduit/Views/Components/ComposerPasteTextView.swift
@@ -36,8 +36,10 @@ struct ComposerPasteTextView: UIViewRepresentable {
     /// text view never approximates it.
     var canSubmitFromReturn: Bool = false
     /// Invoked on the main thread when a Return press classifies as submit.
+    /// Returns whether the composer actually acted: only then is the Return
+    /// press consumed; a declined action keeps the default text behavior.
     /// ComposerBar stays the owner of the actual send/steer/interrupt action.
-    var onSubmitFromReturn: (() -> Void)? = nil
+    var onSubmitFromReturn: (() -> Bool)? = nil
 
     func makeCoordinator() -> Coordinator { Coordinator(self) }
 
@@ -187,26 +189,51 @@ final class ImagePasteTextView: UITextView {
     // existing newline behavior untouched.
     var returnKeySends = false
     var canSubmitFromReturn = false
-    var onSubmitFromReturn: (() -> Void)?
+    var onSubmitFromReturn: (() -> Bool)?
+    /// Ground-truth Shift state folded from the keyboard's own Shift press
+    /// events. Some Bluetooth keyboards report chord modifiers with a lag on
+    /// the event/key modifier surfaces, so the physical Shift press itself is
+    /// tracked as well.
+    private var hardwareShiftHeld = false
 
     override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
-        if let returnPress = presses.first(where: { Self.isReturnKeyPress($0) }),
-           handleReturnKeyPress(
-               shiftPressed: Self.shiftIsPressed(event: event, key: returnPress.key)
-           ) {
-            // Consumed as a submit. Not forwarding to super is what prevents
-            // the newline from being inserted; every other case (setting off,
-            // Shift-Return, non-submittable composer) falls through to the
-            // default text behavior below.
-            return
+        foldHardwareShift(presses, pressed: true)
+        var forwarding = presses
+        if let returnPress = presses.first(where: { Self.isReturnKeyPress($0) }) {
+            let shiftPressed = hardwareShiftHeld
+                || Self.shiftIsPressed(event: event, key: returnPress.key)
+            // Consume only the Return press, and only when the composer
+            // actually acted. Every other case (setting off, Shift-Return,
+            // non-submittable composer, declined callback) is forwarded with
+            // the remaining presses so default text behavior is preserved.
+            if handleReturnKeyPress(shiftPressed: shiftPressed) {
+                forwarding.remove(returnPress)
+            }
         }
-        super.pressesBegan(presses, with: event)
+        if !forwarding.isEmpty {
+            super.pressesBegan(forwarding, with: event)
+        }
+    }
+
+    override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        foldHardwareShift(presses, pressed: false)
+        super.pressesEnded(presses, with: event)
+    }
+
+    /// Folds physical Shift presses into the tracked chord state.
+    private func foldHardwareShift(_ presses: Set<UIPress>, pressed: Bool) {
+        for press in presses
+        where press.key?.keyCode == .keyboardLeftShift || press.key?.keyCode == .keyboardRightShift {
+            hardwareShiftHeld = pressed
+        }
     }
 
     /// Applies the Return shortcut policy for one Return key press and
-    /// reports whether the press was consumed as a submit. Internal so tests
-    /// can drive the exact pressesBegan branch without synthesizing UIPress
-    /// or UIKey events (neither exposes an initializer).
+    /// reports whether the press was consumed as a submit. Consumption
+    /// additionally requires the composer's callback to report that it
+    /// acted; anything else returns false so the caller forwards the press.
+    /// Internal so tests can drive the exact pressesBegan branch without
+    /// synthesizing UIPress or UIKey events (neither exposes an initializer).
     @discardableResult
     func handleReturnKeyPress(shiftPressed: Bool) -> Bool {
         let decision = ComposerReturnKey.decision(
@@ -214,15 +241,18 @@ final class ImagePasteTextView: UITextView {
             shiftPressed: shiftPressed,
             canSubmit: canSubmitFromReturn
         )
-        guard decision == .submit else { return false }
-        onSubmitFromReturn?()
-        return true
+        guard decision == .submit, let onSubmit = onSubmitFromReturn else { return false }
+        return onSubmit()
     }
 
-    /// Pure keystroke classification, extracted so the key-code match is
-    /// unit-testable without hardware key events.
+    /// Pure keystroke classification for hardware Return presses. Covers the
+    /// main Return key plus the keypad/alternate Enter keys on extended
+    /// keyboards, so every physical Enter variant behaves consistently.
     static func isReturnKeyPress(_ press: UIPress) -> Bool {
-        press.key?.keyCode == .keyboardReturnOrEnter
+        guard let keyCode = press.key?.keyCode else { return false }
+        return keyCode == .keyboardReturnOrEnter
+            || keyCode == .keyboardReturn
+            || keyCode == .keypadEnter
     }
 
     /// Shift detection for a Return press. UIPressesEvent and UIKey can

--- a/Conduit/Views/Components/ComposerPasteTextView.swift
+++ b/Conduit/Views/Components/ComposerPasteTextView.swift
@@ -27,6 +27,17 @@ struct ComposerPasteTextView: UIViewRepresentable {
     let onPastedImage: (PastedImage) -> Void
     let onPastedImageError: (String) -> Void
     let editorIdentity: UUID
+    /// Hardware-keyboard Return behavior. When true, a plain Return press
+    /// submits through the composer action path; Shift-Return and every
+    /// non-submittable state keep the default newline insertion.
+    var returnKeySends: Bool = false
+    /// Live composer verdict on whether the Return shortcut may currently
+    /// fire. ComposerBar computes this from the existing action state; the
+    /// text view never approximates it.
+    var canSubmitFromReturn: Bool = false
+    /// Invoked on the main thread when a Return press classifies as submit.
+    /// ComposerBar stays the owner of the actual send/steer/interrupt action.
+    var onSubmitFromReturn: (() -> Void)? = nil
 
     func makeCoordinator() -> Coordinator { Coordinator(self) }
 
@@ -53,6 +64,9 @@ struct ComposerPasteTextView: UIViewRepresentable {
         }
         view.onPastedImage = onPastedImage
         view.onPastedImageError = onPastedImageError
+        view.returnKeySends = returnKeySends
+        view.canSubmitFromReturn = canSubmitFromReturn
+        view.onSubmitFromReturn = onSubmitFromReturn
         return view
     }
 
@@ -71,6 +85,9 @@ struct ComposerPasteTextView: UIViewRepresentable {
         }
         uiView.onPastedImage = onPastedImage
         uiView.onPastedImageError = onPastedImageError
+        uiView.returnKeySends = returnKeySends
+        uiView.canSubmitFromReturn = canSubmitFromReturn
+        uiView.onSubmitFromReturn = onSubmitFromReturn
         uiView.setNeedsLayout()
         if isFocused, !uiView.isFirstResponder { uiView.becomeFirstResponder() }
         if !isFocused, uiView.isFirstResponder { uiView.resignFirstResponder() }
@@ -136,6 +153,9 @@ struct ComposerPasteTextView: UIViewRepresentable {
                 textView.onContentHeightChange = nil
                 textView.onPastedImage = nil
                 textView.onPastedImageError = nil
+                textView.returnKeySends = false
+                textView.canSubmitFromReturn = false
+                textView.onSubmitFromReturn = nil
             }
             if textView.isFirstResponder {
                 textView.resignFirstResponder()
@@ -159,6 +179,59 @@ final class ImagePasteTextView: UITextView {
     var minimumReportedHeight: CGFloat = 44
     var maximumReportedHeight: CGFloat = 160
     private var lastReportedHeight: CGFloat = 0
+
+    // Hardware-keyboard Return shortcut. pressesBegan only classifies the
+    // keystroke; the send-vs-newline policy lives in ComposerReturnKey and
+    // the actual composer action stays in ComposerBar. The software
+    // keyboard's Return key does not produce UIPress events, so it keeps its
+    // existing newline behavior untouched.
+    var returnKeySends = false
+    var canSubmitFromReturn = false
+    var onSubmitFromReturn: (() -> Void)?
+
+    override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        if let returnPress = presses.first(where: { Self.isReturnKeyPress($0) }),
+           handleReturnKeyPress(
+               shiftPressed: Self.shiftIsPressed(event: event, key: returnPress.key)
+           ) {
+            // Consumed as a submit. Not forwarding to super is what prevents
+            // the newline from being inserted; every other case (setting off,
+            // Shift-Return, non-submittable composer) falls through to the
+            // default text behavior below.
+            return
+        }
+        super.pressesBegan(presses, with: event)
+    }
+
+    /// Applies the Return shortcut policy for one Return key press and
+    /// reports whether the press was consumed as a submit. Internal so tests
+    /// can drive the exact pressesBegan branch without synthesizing UIPress
+    /// or UIKey events (neither exposes an initializer).
+    @discardableResult
+    func handleReturnKeyPress(shiftPressed: Bool) -> Bool {
+        let decision = ComposerReturnKey.decision(
+            returnKeySends: returnKeySends,
+            shiftPressed: shiftPressed,
+            canSubmit: canSubmitFromReturn
+        )
+        guard decision == .submit else { return false }
+        onSubmitFromReturn?()
+        return true
+    }
+
+    /// Pure keystroke classification, extracted so the key-code match is
+    /// unit-testable without hardware key events.
+    static func isReturnKeyPress(_ press: UIPress) -> Bool {
+        press.key?.keyCode == .keyboardReturnOrEnter
+    }
+
+    /// Shift detection for a Return press. UIPressesEvent and UIKey can
+    /// report modifiers independently, so both sources are consulted; either
+    /// reporting Shift means the user wants a newline.
+    static func shiftIsPressed(event: UIPressesEvent?, key: UIKey?) -> Bool {
+        (event?.modifierFlags.contains(.shift) ?? false)
+            || (key?.modifierFlags.contains(.shift) ?? false)
+    }
 
     override init(frame: CGRect, textContainer: NSTextContainer?) {
         super.init(frame: frame, textContainer: textContainer)

--- a/Conduit/Views/Components/ComposerReturnKey.swift
+++ b/Conduit/Views/Components/ComposerReturnKey.swift
@@ -1,0 +1,49 @@
+//
+//  ComposerReturnKey.swift
+//  Conduit
+//
+//  Policy layer for the optional hardware-keyboard Return shortcut in the
+//  chat composer. The UIKit text view only classifies the keystroke (Return
+//  with or without Shift held); this type owns the send-vs-newline decision
+//  so it stays pure and unit-testable. ComposerBar remains the sole
+//  authority on which composer action is actually available.
+//
+
+import Foundation
+
+enum ComposerReturnKey {
+    /// Local, device-only input preference backed by UserDefaults via
+    /// @AppStorage. It is presentation/input state for this device and is
+    /// never synchronized to the Hermes profile or gateway.
+    static let preferenceKey = "conduit.composerReturnKeySends"
+
+    /// What the text view should do with one hardware Return press.
+    enum Decision: Equatable {
+        case submit
+        case insertNewline
+    }
+
+    /// Pure shortcut policy:
+    /// - With the preference off, Return keeps its default newline behavior.
+    /// - Shift-Return always inserts a newline, even when the shortcut is on.
+    /// - A non-submittable composer never swallows Return; it falls back to
+    ///   the default newline behavior instead.
+    static func decision(
+        returnKeySends: Bool,
+        shiftPressed: Bool,
+        canSubmit: Bool
+    ) -> Decision {
+        guard returnKeySends, !shiftPressed, canSubmit else { return .insertNewline }
+        return .submit
+    }
+
+    /// Whether the composer's currently valid action may be triggered from
+    /// Return. Only typed-message actions qualify. A running response with an
+    /// empty composer is stop-only; Return must never act as the Stop button.
+    static func canSubmit(action: ComposerAction) -> Bool {
+        switch action {
+        case .send, .steer, .interrupt: return true
+        case .stop, .unavailable: return false
+        }
+    }
+}

--- a/Conduit/Views/Components/ComposerReturnKey.swift
+++ b/Conduit/Views/Components/ComposerReturnKey.swift
@@ -26,14 +26,18 @@ enum ComposerReturnKey {
     /// Pure shortcut policy:
     /// - With the preference off, Return keeps its default newline behavior.
     /// - Shift-Return always inserts a newline, even when the shortcut is on.
+    /// - While multistage text input (IME) has marked text active, Return
+    ///   belongs to the composition (confirming candidates); the shortcut
+    ///   never fires and the press is left to UIKit's normal text input.
     /// - A non-submittable composer never swallows Return; it falls back to
     ///   the default newline behavior instead.
     static func decision(
         returnKeySends: Bool,
         shiftPressed: Bool,
+        hasMarkedText: Bool,
         canSubmit: Bool
     ) -> Decision {
-        guard returnKeySends, !shiftPressed, canSubmit else { return .insertNewline }
+        guard returnKeySends, !shiftPressed, !hasMarkedText, canSubmit else { return .insertNewline }
         return .submit
     }
 

--- a/ConduitTests/ComposerReturnKeyTests.swift
+++ b/ConduitTests/ComposerReturnKeyTests.swift
@@ -7,8 +7,9 @@
 //  UIKit text-view branch that consumes (or forwards) the Return press,
 //  and the default-off persistence of the preference. UIPress/UIKey have
 //  no public initializers, so the pressesBegan branch is exercised through
-//  the extracted handleReturnKeyPress(shiftPressed:) entry point with the
-//  key-code/modifier classification pinned separately.
+//  the extracted handleReturnKeyPress(shiftPressed:) entry point, with the
+//  modifier classification pinned directly and consumption additionally
+//  gated on the composer's callback reporting that it acted.
 //
 
 import Foundation
@@ -83,7 +84,7 @@ final class ComposerReturnKeyTests: XCTestCase {
         view.returnKeySends = true
         view.canSubmitFromReturn = true
         var submitCount = 0
-        view.onSubmitFromReturn = { submitCount += 1 }
+        view.onSubmitFromReturn = { submitCount += 1; return true }
 
         XCTAssertTrue(view.handleReturnKeyPress(shiftPressed: false))
         XCTAssertEqual(submitCount, 1)
@@ -94,7 +95,7 @@ final class ComposerReturnKeyTests: XCTestCase {
         view.returnKeySends = true
         view.canSubmitFromReturn = true
         var submitCount = 0
-        view.onSubmitFromReturn = { submitCount += 1 }
+        view.onSubmitFromReturn = { submitCount += 1; return true }
 
         // A false return means the press was not consumed and falls through
         // to the default newline insertion.
@@ -107,7 +108,7 @@ final class ComposerReturnKeyTests: XCTestCase {
         view.returnKeySends = true
         view.canSubmitFromReturn = false
         var submitCount = 0
-        view.onSubmitFromReturn = { submitCount += 1 }
+        view.onSubmitFromReturn = { submitCount += 1; return true }
 
         XCTAssertFalse(view.handleReturnKeyPress(shiftPressed: false))
         XCTAssertEqual(submitCount, 0)
@@ -118,10 +119,40 @@ final class ComposerReturnKeyTests: XCTestCase {
         view.returnKeySends = false
         view.canSubmitFromReturn = true
         var submitCount = 0
-        view.onSubmitFromReturn = { submitCount += 1 }
+        view.onSubmitFromReturn = { submitCount += 1; return true }
 
         XCTAssertFalse(view.handleReturnKeyPress(shiftPressed: false))
         XCTAssertEqual(submitCount, 0)
+    }
+
+    func testDeclinedComposerCallbackForwardsPressInsteadOfConsuming() {
+        // Even when the policy classifies submit, a declined composer action
+        // must report the press as NOT consumed so pressesBegan forwards it
+        // and the default newline insertion still happens.
+        let view = ImagePasteTextView()
+        view.returnKeySends = true
+        view.canSubmitFromReturn = true
+        var submitCount = 0
+        view.onSubmitFromReturn = { submitCount += 1; return false }
+
+        XCTAssertFalse(view.handleReturnKeyPress(shiftPressed: false))
+        XCTAssertEqual(submitCount, 1)
+    }
+
+    func testMissingCallbackReportsPressAsNotConsumed() {
+        // Defensive: with no callback wired (plain UITextView-style use),
+        // a submit classification must not report consumption.
+        let view = ImagePasteTextView()
+        view.returnKeySends = true
+        view.canSubmitFromReturn = true
+
+        XCTAssertFalse(view.handleReturnKeyPress(shiftPressed: false))
+    }
+
+    func testShiftClassificationIsFalseWhenNoEventAndNoKey() {
+        // Pins the nil-safety of the modifier sources: with neither the
+        // presses event nor the key reporting modifiers, Shift is not held.
+        XCTAssertFalse(ImagePasteTextView.shiftIsPressed(event: nil, key: nil))
     }
 
     func testTextViewDefaultsPreserveLegacyReturnBehavior() {

--- a/ConduitTests/ComposerReturnKeyTests.swift
+++ b/ConduitTests/ComposerReturnKeyTests.swift
@@ -35,14 +35,14 @@ final class ComposerReturnKeyTests: XCTestCase {
     func testSettingOffPlainReturnInsertsNewline() {
         // Existing users must keep the default: Return never submits.
         XCTAssertEqual(
-            ComposerReturnKey.decision(returnKeySends: false, shiftPressed: false, canSubmit: true),
+            ComposerReturnKey.decision(returnKeySends: false, shiftPressed: false, hasMarkedText: false, canSubmit: true),
             .insertNewline
         )
     }
 
     func testSettingOnPlainReturnWithSubmittableComposerSubmits() {
         XCTAssertEqual(
-            ComposerReturnKey.decision(returnKeySends: true, shiftPressed: false, canSubmit: true),
+            ComposerReturnKey.decision(returnKeySends: true, shiftPressed: false, hasMarkedText: false, canSubmit: true),
             .submit
         )
     }
@@ -50,7 +50,7 @@ final class ComposerReturnKeyTests: XCTestCase {
     func testSettingOnShiftReturnInsertsNewline() {
         // Shift-Return must never send, even with a submittable composer.
         XCTAssertEqual(
-            ComposerReturnKey.decision(returnKeySends: true, shiftPressed: true, canSubmit: true),
+            ComposerReturnKey.decision(returnKeySends: true, shiftPressed: true, hasMarkedText: false, canSubmit: true),
             .insertNewline
         )
     }
@@ -59,7 +59,18 @@ final class ComposerReturnKeyTests: XCTestCase {
         // Synchronizing, disabled, stop-only, or empty states must not get
         // Return swallowed: fall back to the default newline behavior.
         XCTAssertEqual(
-            ComposerReturnKey.decision(returnKeySends: true, shiftPressed: false, canSubmit: false),
+            ComposerReturnKey.decision(returnKeySends: true, shiftPressed: false, hasMarkedText: false, canSubmit: false),
+            .insertNewline
+        )
+    }
+
+    func testSettingOnPlainReturnWithMarkedTextInsertsNewline() {
+        // IME composition owns Return while marked text is active (Japanese/
+        // Chinese candidates confirm on Return). The shortcut must decline
+        // even with everything else favorable, leaving the key to UIKit's
+        // normal multistage text input.
+        XCTAssertEqual(
+            ComposerReturnKey.decision(returnKeySends: true, shiftPressed: false, hasMarkedText: true, canSubmit: true),
             .insertNewline
         )
     }
@@ -155,6 +166,23 @@ final class ComposerReturnKeyTests: XCTestCase {
         XCTAssertFalse(ImagePasteTextView.shiftIsPressed(event: nil, key: nil))
     }
 
+    func testMarkedTextForwardsReturnInsteadOfSubmitting() {
+        // IME composition: with marked text active, a plain Return on a
+        // submittable composer must NOT submit and must report the press as
+        // NOT consumed, so pressesBegan forwards it to UIKit's normal
+        // text-input handling (candidate confirmation). A live IME session
+        // cannot be synthesized in unit tests, so the marked-text state is
+        // passed through the same decision seam pressesBegan uses.
+        let view = ImagePasteTextView()
+        view.returnKeySends = true
+        view.canSubmitFromReturn = true
+        var submitCount = 0
+        view.onSubmitFromReturn = { submitCount += 1; return true }
+
+        XCTAssertFalse(view.handleReturnKeyPress(shiftPressed: false, hasMarkedText: true))
+        XCTAssertEqual(submitCount, 0)
+    }
+
     func testTextViewDefaultsPreserveLegacyReturnBehavior() {
         // Fresh text views (and every existing construction site that does
         // not know about the shortcut) must behave exactly as before.
@@ -178,6 +206,49 @@ final class ComposerReturnKeyTests: XCTestCase {
         XCTAssertFalse(view.returnKeySends)
         XCTAssertFalse(view.canSubmitFromReturn)
         XCTAssertNil(view.onSubmitFromReturn)
+    }
+
+    // MARK: - Held-Shift chord state (begin / end / cancel)
+
+    func testCancelledShiftPressReleasesTrackedState() {
+        // pressesCancelled must clear a held Shift exactly like pressesEnded,
+        // or the shortcut would keep believing Shift is held after the system
+        // cancels the press sequence.
+        var held = ImagePasteTextView.updatedShiftState(
+            [],
+            keyCodes: [.keyboardLeftShift],
+            isPressed: true
+        )
+        XCTAssertEqual(held, [.keyboardLeftShift])
+
+        held = ImagePasteTextView.updatedShiftState(held, keyCodes: [.keyboardLeftShift], isPressed: false)
+        XCTAssertTrue(held.isEmpty)
+    }
+
+    func testSecondShiftSurvivesReleasingOneKey() {
+        // Left and right Shift are tracked independently: releasing one while
+        // the other is still physically held keeps the chord active.
+        var held = ImagePasteTextView.updatedShiftState(
+            [],
+            keyCodes: [.keyboardLeftShift, .keyboardRightShift],
+            isPressed: true
+        )
+        XCTAssertEqual(held, [.keyboardLeftShift, .keyboardRightShift])
+
+        held = ImagePasteTextView.updatedShiftState(held, keyCodes: [.keyboardLeftShift], isPressed: false)
+        XCTAssertEqual(held, [.keyboardRightShift])
+    }
+
+    func testShiftStateIgnoresNonShiftKeyCodes() {
+        var held = ImagePasteTextView.updatedShiftState(
+            [],
+            keyCodes: [.keyboardA, .keyboardReturnOrEnter],
+            isPressed: true
+        )
+        XCTAssertTrue(held.isEmpty)
+
+        held = ImagePasteTextView.updatedShiftState(held, keyCodes: [.keyboardA], isPressed: false)
+        XCTAssertTrue(held.isEmpty)
     }
 
     // MARK: - Preference default and persistence

--- a/ConduitTests/ComposerReturnKeyTests.swift
+++ b/ConduitTests/ComposerReturnKeyTests.swift
@@ -1,0 +1,171 @@
+//
+//  ComposerReturnKeyTests.swift
+//  ConduitTests
+//
+//  Covers the optional hardware-keyboard Return shortcut in the chat
+//  composer: the pure decision policy, the composer-action gate, the
+//  UIKit text-view branch that consumes (or forwards) the Return press,
+//  and the default-off persistence of the preference. UIPress/UIKey have
+//  no public initializers, so the pressesBegan branch is exercised through
+//  the extracted handleReturnKeyPress(shiftPressed:) entry point with the
+//  key-code/modifier classification pinned separately.
+//
+
+import Foundation
+import SwiftUI
+import UIKit
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class ComposerReturnKeyTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: ComposerReturnKey.preferenceKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: ComposerReturnKey.preferenceKey)
+        super.tearDown()
+    }
+
+    // MARK: - Decision policy
+
+    func testSettingOffPlainReturnInsertsNewline() {
+        // Existing users must keep the default: Return never submits.
+        XCTAssertEqual(
+            ComposerReturnKey.decision(returnKeySends: false, shiftPressed: false, canSubmit: true),
+            .insertNewline
+        )
+    }
+
+    func testSettingOnPlainReturnWithSubmittableComposerSubmits() {
+        XCTAssertEqual(
+            ComposerReturnKey.decision(returnKeySends: true, shiftPressed: false, canSubmit: true),
+            .submit
+        )
+    }
+
+    func testSettingOnShiftReturnInsertsNewline() {
+        // Shift-Return must never send, even with a submittable composer.
+        XCTAssertEqual(
+            ComposerReturnKey.decision(returnKeySends: true, shiftPressed: true, canSubmit: true),
+            .insertNewline
+        )
+    }
+
+    func testSettingOnPlainReturnWithNonSubmittableComposerInsertsNewline() {
+        // Synchronizing, disabled, stop-only, or empty states must not get
+        // Return swallowed: fall back to the default newline behavior.
+        XCTAssertEqual(
+            ComposerReturnKey.decision(returnKeySends: true, shiftPressed: false, canSubmit: false),
+            .insertNewline
+        )
+    }
+
+    // MARK: - Composer action gate
+
+    func testReturnCanSubmitOnlyForTypedMessageActions() {
+        XCTAssertTrue(ComposerReturnKey.canSubmit(action: .send))
+        XCTAssertTrue(ComposerReturnKey.canSubmit(action: .steer))
+        XCTAssertTrue(ComposerReturnKey.canSubmit(action: .interrupt))
+        // A running response with an empty composer is stop-only; Return
+        // must never act as the Stop button.
+        XCTAssertFalse(ComposerReturnKey.canSubmit(action: .stop))
+        // Synchronizing/reconnecting/unsupported gateways are unavailable.
+        XCTAssertFalse(ComposerReturnKey.canSubmit(action: .unavailable))
+    }
+
+    // MARK: - Text view press branch
+
+    func testTextViewConsumesPlainReturnAsSubmitWhenEnabledAndSubmittable() {
+        let view = ImagePasteTextView()
+        view.returnKeySends = true
+        view.canSubmitFromReturn = true
+        var submitCount = 0
+        view.onSubmitFromReturn = { submitCount += 1 }
+
+        XCTAssertTrue(view.handleReturnKeyPress(shiftPressed: false))
+        XCTAssertEqual(submitCount, 1)
+    }
+
+    func testTextViewShiftReturnNeverSubmits() {
+        let view = ImagePasteTextView()
+        view.returnKeySends = true
+        view.canSubmitFromReturn = true
+        var submitCount = 0
+        view.onSubmitFromReturn = { submitCount += 1 }
+
+        // A false return means the press was not consumed and falls through
+        // to the default newline insertion.
+        XCTAssertFalse(view.handleReturnKeyPress(shiftPressed: true))
+        XCTAssertEqual(submitCount, 0)
+    }
+
+    func testTextViewReturnDoesNotSubmitWhenComposerCannotAct() {
+        let view = ImagePasteTextView()
+        view.returnKeySends = true
+        view.canSubmitFromReturn = false
+        var submitCount = 0
+        view.onSubmitFromReturn = { submitCount += 1 }
+
+        XCTAssertFalse(view.handleReturnKeyPress(shiftPressed: false))
+        XCTAssertEqual(submitCount, 0)
+    }
+
+    func testTextViewReturnKeepsLegacyNewlineBehaviorWhenSettingOff() {
+        let view = ImagePasteTextView()
+        view.returnKeySends = false
+        view.canSubmitFromReturn = true
+        var submitCount = 0
+        view.onSubmitFromReturn = { submitCount += 1 }
+
+        XCTAssertFalse(view.handleReturnKeyPress(shiftPressed: false))
+        XCTAssertEqual(submitCount, 0)
+    }
+
+    func testTextViewDefaultsPreserveLegacyReturnBehavior() {
+        // Fresh text views (and every existing construction site that does
+        // not know about the shortcut) must behave exactly as before.
+        let view = ImagePasteTextView()
+        XCTAssertFalse(view.returnKeySends)
+        XCTAssertFalse(view.canSubmitFromReturn)
+        XCTAssertNil(view.onSubmitFromReturn)
+    }
+
+    func testRepresentableDefaultsPreserveLegacyReturnBehavior() {
+        var storedText = ""
+        let view = ComposerPasteTextView(
+            text: Binding(get: { storedText }, set: { storedText = $0 }),
+            isFocused: .constant(false),
+            measuredHeight: .constant(44),
+            enabled: true,
+            onPastedImage: { _ in },
+            onPastedImageError: { _ in },
+            editorIdentity: UUID()
+        )
+        XCTAssertFalse(view.returnKeySends)
+        XCTAssertFalse(view.canSubmitFromReturn)
+        XCTAssertNil(view.onSubmitFromReturn)
+    }
+
+    // MARK: - Preference default and persistence
+
+    func testPreferenceDefaultsToOffWithNoStoredValue() {
+        UserDefaults.standard.removeObject(forKey: ComposerReturnKey.preferenceKey)
+
+        // @AppStorage in ComposerBar and the Chat settings row reads through
+        // UserDefaults; a missing key must resolve to the `false` default so
+        // existing users never gain send-on-Return after updating.
+        XCTAssertNil(UserDefaults.standard.object(forKey: ComposerReturnKey.preferenceKey))
+        XCTAssertFalse(UserDefaults.standard.bool(forKey: ComposerReturnKey.preferenceKey))
+    }
+
+    func testPreferenceRestoresStoredValue() {
+        UserDefaults.standard.set(true, forKey: ComposerReturnKey.preferenceKey)
+        XCTAssertTrue(UserDefaults.standard.bool(forKey: ComposerReturnKey.preferenceKey))
+
+        UserDefaults.standard.set(false, forKey: ComposerReturnKey.preferenceKey)
+        XCTAssertFalse(UserDefaults.standard.bool(forKey: ComposerReturnKey.preferenceKey))
+    }
+}

--- a/scripts/test-shards.txt
+++ b/scripts/test-shards.txt
@@ -29,6 +29,7 @@ unit-a ChatTitleScrollTests
 unit-a ChatViewFollowCorrectionTests
 unit-a ChatViewportControllerTests
 unit-a ComposerPasteTextViewTests
+unit-a ComposerReturnKeyTests
 unit-a InterfaceOrientationTests
 unit-a MarkdownFallbackTests
 unit-a MarkdownLargeDocumentTests


### PR DESCRIPTION
## Summary

Adds an opt-in **Chat → Keyboard → "Return key sends"** setting (default **off**) for hardware keyboards on iPad:

- **Setting ON:** plain hardware-keyboard **Return** submits through the exact same composer action path as the existing Send/action button (send / steer / interrupt — never stop). **Shift-Return** always inserts a newline.
- **Setting OFF:** behavior is byte-for-byte unchanged — Return inserts a newline; sending stays on the composer action button. Existing users see no change after updating (default false).

## Behavior matrix

| Composer state | Return (setting ON) | Shift-Return |
|---|---|---|
| idle + text/attachments | send (button's path) | newline |
| running + typed text | steer / interrupt (per busy-input mode) | newline |
| running, empty composer (stop-only) | newline — Return never acts as Stop | newline |
| synchronizing / reconnecting / unsupported | newline (gate closed) | newline |
| setting OFF, any state | newline (legacy) | newline |

## Implementation

- **`Conduit/Views/Components/ComposerReturnKey.swift` (new):** small pure decision layer — `decision(returnKeySends:shiftPressed:canSubmit:)` and `canSubmit(action:)` (send/steer/interrupt → true; stop/unavailable → false) — plus the preference key. Kept narrow on purpose: no composer state machine lives here.
- **`Conduit/Views/Components/ComposerPasteTextView.swift`:** `ImagePasteTextView.pressesBegan` is the only Return interception point. It classifies hardware Return presses (`UIPress.key.keyCode`: `keyboardReturnOrEnter`, `keyboardReturn`, `keypadEnter`) and consumes **only the Return press, and only when** the setting is on, the composer gate is open, **and** the composer's callback reports it acted — everything else forwards to `super`, preserving default newline behavior. Shift is detected from the press event, the key's modifiers, **and** direct tracking of physical Shift presses (hardens against Bluetooth keyboards whose chord modifiers can lag). Software keyboards never emit `UIPress` (they deliver `insertText("\n")` via the text-input protocol), so they are untouched by design — no `shouldChangeTextIn`, `returnKeyType`, or `submitLabel` hooks were used.
- **`Conduit/Views/Components/ComposerBar.swift`:** owns everything action-related. `@AppStorage(ComposerReturnKey.preferenceKey)` (default `false`), passes `canSubmitFromReturn: ComposerReturnKey.canSubmit(action: action)` computed from the existing composer action state, and `submitFromReturnKey()` re-checks the live gate before invoking the existing `submit()` — the identical path as the action button (haptics, draft collapse, `appState.submitComposer`). No send/attachment/draft/slash logic is duplicated in the text view.
- **`Conduit/Views/AuxiliaryViews.swift`:** new "Keyboard" section on the existing Chat settings page with the toggle and copy that states the hardware-keyboard scope explicitly.

## Persistence

Local, device-only preference: `UserDefaults` key `conduit.composerReturnKeySends` via `@AppStorage`. Default `false`, survives relaunch, takes effect without a reconnect, and is **never sent to the Hermes gateway**.

## Tests

New `ConduitTests/ComposerReturnKeyTests.swift` (16 tests): decision matrix (off+Return, on+Return, Shift-Return, non-submittable), action gate, press-consume/forward branch including the declined-callback fallback and missing-callback safety, modifier nil-classification, text view + representable legacy defaults, preference default-off, and persistence.

`ios_test` on an isolated Mac worktree at the same base commit (14d6603), all **0 uncovered**:

- `20260828-005725-8544` — ComposerReturnKeyTests + ComposerPasteTextViewTests + TurnStateTests: **passed**
- `20260828-005837-817b` — ComposerDraftStoreTests + ChatReturnSurfaceTests + HapticsTests + ChatTextSelectionTests + InteractionHapticsTests: **passed**
- `20260828-012649-3f92` (after review-gate fixes) — same three suites as the first run: **passed**

Full app + test targets build cleanly in every run.

## Review gate

Mandatory multi-model review (deepseek-v4-flash, step-3.7-flash, mimo-v2.5; consolidation on deepseek-v4-flash): consolidated **APPROVE** (2/3, one REQUEST CHANGES), **zero BLOCKERs**. The single dual-reviewer WARNING — whole-press-set consumption could drop chorded key presses, and Shift modifier reporting can lag on split-report Bluetooth keyboards — was fixed in 664b2d3: only the Return press is consumed and only when the composer acted, with physical Shift presses tracked directly. Reviewer suggestions S1 (keypad/alternate Enter treated as Return), S2 (declined-callback + shift-classification tests), and S3 (staleness comment, safe failure mode) are included.

## Caveats

- Software keyboard Return keeps inserting a newline even with the setting on; the settings copy states this explicitly.
- The gate freshness matches the action button (render-time state) and is re-checked live at press time; the stale-window failure mode is newline insertion, never an accidental send.
- Held/auto-repeated Return is inert after a submit: the composer clears synchronously, leaving a stop-only state the gate declines.

Image paste, drafts, attachments, slash suggestions, chat scrolling, session switching, and all backend behavior are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to send messages by pressing Return on a hardware keyboard.
  * Return inserts a new line by default, or when Shift is held.
  * The setting is device-specific and available in Chat settings with explanatory accessibility guidance.

* **Bug Fixes**
  * Preserved normal newline behavior when message submission is unavailable or unsuccessful.

* **Tests**
  * Added coverage for Return-key submission, Shift-Return behavior, defaults, and fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->