### PR TITLE
fix(chat): drop Hermes Recent Summary compaction records at the history boundary

### DIFF
--- a/Conduit/Services/HermesClient.swift
+++ b/Conduit/Services/HermesClient.swift
@@ -1664,8 +1664,8 @@ enum MessageNormalizer {
     private static let priorContextWrapperHeader =
         "[PRIOR CONTEXT — for reference only; not a new message]"
 
-    /// Hermes emits two generations of compaction headers, and the reload
-    /// path can drop the `_compressed_summary` flag while keeping the
+    /// Hermes emits multiple generations of compaction headers, and the
+    /// reload path can drop the `_compressed_summary` flag while keeping the
     /// recognizable text. Match case-insensitively like the other Hermes
     /// bracketed notices, anchored at the start of the content so ordinary
     /// discussion of "context compaction" is never mistaken for a summary.
@@ -1680,6 +1680,7 @@ enum MessageNormalizer {
         let head = content[headStart...].prefix(32).lowercased()
         return head.hasPrefix("[context compaction")
             || head.hasPrefix("[context summary]:")
+            || head.hasPrefix("[recent summary (")
     }
 
     /// Normalizes the gateway's native clarification event. Current Hermes

--- a/ConduitTests/MessageNormalizerTests.swift
+++ b/ConduitTests/MessageNormalizerTests.swift
@@ -1170,11 +1170,163 @@ final class MessageNormalizerTests: XCTestCase {
         XCTAssertTrue(MessageNormalizer.hasCompactionSummaryPrefix(
             "\n\t  [context summary]: legacy opening\n" + hugeTail
         ))
+        XCTAssertTrue(MessageNormalizer.hasCompactionSummaryPrefix(
+            "[Recent Summary (d0, node 342)]\n" + hugeTail
+        ))
+        // The Recent Summary anchor includes the opening parenthesis, so a
+        // different bracketed notice with the same words stays visible.
+        XCTAssertFalse(MessageNormalizer.hasCompactionSummaryPrefix(
+            "[Recent Summary quoted without the node anchor]?\n" + hugeTail
+        ))
         XCTAssertFalse(MessageNormalizer.hasCompactionSummaryPrefix(
             "Can you explain how context compaction works?\n" + hugeTail
         ))
         XCTAssertFalse(MessageNormalizer.hasCompactionSummaryPrefix("   \n\t"))
         XCTAssertFalse(MessageNormalizer.hasCompactionSummaryPrefix(""))
+    }
+
+    // MARK: - Hermes "Recent Summary" headers (third compaction generation)
+
+    func testPersistedRecentSummaryHeaderIsOmittedForUserRecord() {
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(101),
+                "role": .string("user"),
+                "content": .string("[Recent Summary (d0, node 342)]\nEarlier the user asked about the deploy pipeline.")
+            ])
+        ])
+
+        XCTAssertTrue(messages.isEmpty)
+    }
+
+    func testPersistedRecentSummaryHeaderIsOmittedRegardlessOfRole() {
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(102),
+                "role": .string("assistant"),
+                "content": .string("[Recent Summary (d0, node 342)]\nSummary of the assistant's prior turns.")
+            ])
+        ])
+
+        XCTAssertTrue(messages.isEmpty)
+    }
+
+    func testRecentSummaryHeaderWithLeadingWhitespaceIsOmitted() {
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(103),
+                "role": .string("user"),
+                "content": .string("   \n\t[Recent Summary (d0, node 342)]\nSummary follows.")
+            ])
+        ])
+
+        XCTAssertTrue(messages.isEmpty)
+    }
+
+    func testRecentSummaryHeaderAcceptsArbitraryDepthAndNodeNumbers() {
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(104),
+                "role": .string("user"),
+                "content": .string("[Recent Summary (d1, node 17)]\nSummary A.")
+            ]),
+            .object([
+                "id": .number(105),
+                "role": .string("assistant"),
+                "content": .string("[Recent Summary (d12, node 9001)]\nSummary B.")
+            ])
+        ])
+
+        XCTAssertTrue(messages.isEmpty)
+    }
+
+    func testRecentSummaryHeaderIsCaseInsensitive() {
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(106),
+                "role": .string("user"),
+                "content": .string("[recent summary (d0, node 342)]\nSummary follows.")
+            ])
+        ])
+
+        XCTAssertTrue(messages.isEmpty)
+    }
+
+    func testOrdinaryRecentSummaryDiscussionIsNotHidden() {
+        let content = "Can you explain what [Recent Summary (d0, node 342)] means?"
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(107),
+                "role": .string("user"),
+                "content": .string(content)
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .user)
+        XCTAssertEqual(messages[0].content, content)
+    }
+
+    func testRecentSummaryMentionLaterInMessageIsNotHidden() {
+        // Detection stays start-anchored: a header quoted later inside a
+        // normal message belongs to the user's own text.
+        let content = "My transcript shows a header like\n"
+            + "[Recent Summary (d0, node 342)]\n"
+            + "mid-session — what produces it?"
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(108),
+                "role": .string("user"),
+                "content": .string(content)
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .user)
+        XCTAssertEqual(messages[0].content, content)
+    }
+
+    func testLargeRecentSummaryNeverReachesChatMessages() {
+        // A multi-megabyte Recent Summary must be dropped by the bounded
+        // prefix check alone — no flag, no merged delimiter in the body —
+        // so it never reaches the Markdown/UI rendering pipeline.
+        let hugeSummary = "[Recent Summary (d2, node 1188)]\n"
+            + String(repeating: "The session covered implementation details and open questions. ", count: 30_000)
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(109),
+                "role": .string("user"),
+                "content": .string(hugeSummary)
+            ]),
+            .object([
+                "id": .number(110),
+                "role": .string("assistant"),
+                "content": .string("Still here after the recent summary was dropped.")
+            ])
+        ])
+
+        XCTAssertEqual(messages.map(\.role), [.assistant])
+        XCTAssertEqual(messages.first?.content, "Still here after the recent summary was dropped.")
+    }
+
+    func testMergedRecentSummaryBehindWrapperNeverReachesChatMessages() {
+        // Second compaction: a merged row whose retained prefix is itself a
+        // generation-3 summary must be dropped after the delimiter split,
+        // not kept as a visible bubble above the newest summary.
+        let merged = "[PRIOR CONTEXT — for reference only; not a new message]\n"
+            + "[Recent Summary (d0, node 342)]\n"
+            + "Earlier turns, compacted.\n"
+            + "[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]\n"
+            + "Newest compacted turns."
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(111),
+                "role": .string("user"),
+                "content": .string(merged)
+            ])
+        ])
+
+        XCTAssertTrue(messages.isEmpty)
     }
 
     func testInterruptedIdenticalCorrectionDoesNotCreateASecondUserBubble() {


### PR DESCRIPTION
## Summary

Follow-up to #86. Hermes introduced a third generation of context-compaction header, persisted as ordinary transcript records with conversational roles (often `user`):

```
[Recent Summary (d0, node 342)]
```

PR #86's normalizer recognized only the two older header formats, so these records passed through normalization, inherited the persisted role, and rendered as large user bubbles on session resume. This PR extends the existing detection in place — no new filtering path, no view-layer changes, no role reclassification.

## Root cause

`MessageNormalizer.hasCompactionSummaryPrefix` (Conduit/Services/HermesClient.swift) classified only `[CONTEXT COMPACTION ...` and `[CONTEXT SUMMARY]:` prefixes plus the `_compressed_summary` flag and the merged-record delimiter. The new header format was unrecognized format drift, not a removed fix — the PR #86 filtering was verified intact before this change.

## Fix

One anchor added to the existing bounded, start-anchored, case-insensitive prefix helper:

- leading whitespace is skipped by index, then only the first 32 characters are compared (lowercased), so a multi-megabyte summary is never copied or tail-scanned
- new anchor `[recent summary (` — the opening parenthesis is the invariant discriminator; depth/node numbering is arbitrary and never hard-coded
- role-independent: filtering happens in `visibleContentRemovingCompaction` before any `ChatMessage` exists, for conversational roles; the tool-output exemption is untouched
- the merged-delimiter path re-validates its retained prefix through the same helper, so double-compaction rows whose older prefix is a Recent Summary are dropped too

## Tests

9 new focused regression tests in `MessageNormalizerTests` (plus the existing PR #86 suite, unchanged and green):

- user-role Recent Summary omitted; assistant-role also omitted (role independence)
- leading whitespace accepted (`"   \n\t[Recent Summary ...]"`)
- arbitrary depth/node numbers (`(d1, node 17)`, `(d12, node 9001)`)
- case-insensitive header
- ordinary user discussion mentioning the header is NOT hidden (start-anchor)
- header quoted later inside a normal message is NOT hidden
- multi-megabyte payload dropped during normalization, never reaching Markdown/rendering
- merged record whose retained prefix (behind the `[PRIOR CONTEXT …]` wrapper) is a gen-3 summary is omitted after the delimiter split
- bounded-head helper test extended: positive for the new format + a negative pinning that `[Recent Summary` without the parenthesis anchor stays visible

## Verification

- `ios_test` run `20260829-010710-a143`: MessageNormalizerTests, AppStateChatResumeTests, SessionPresentationCacheTests, HermesClientTests — **passed**, 0 failures, 0 uncovered
- `ios_test` run `20260829-013445-c664`: MessageNormalizerTests re-run after the last test addition — **passed**
- Pre-push multi-model review gate (`workflows/multi-model-review.js`): **APPROVE 3/3** (deepseek-v4-flash, step-3.7-flash, mimo-v2.5; consolidated on deepseek-v4-flash) — 0 BLOCKER, 0 WARNING; the one adopted SUGGESTION (merged-delimiter gen-3 test) is included in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of persisted Hermes compaction summaries across multiple header formats.
  * Added support for variations in capitalization, spacing, metadata values, and large summaries.
  * Prevented incorrectly removing ordinary content or summaries mentioned later in a message.

* **Tests**
  * Expanded coverage for summary detection and omission behavior across supported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->