### PR TITLE
fix(auth): carry password session cookies into ticket request

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2155,11 +2155,12 @@ final class AppState: ObservableObject {
         }
 
         do {
-            let ticket = try await NativeAuthClient(baseURL: credentials.baseURL, cloudflareAccess: KeychainHelper.loadCloudflareAccess(for: credentials.baseURL)).connect(
+            let authenticatedConnection = try await NativeAuthClient(baseURL: credentials.baseURL, cloudflareAccess: KeychainHelper.loadCloudflareAccess(for: credentials.baseURL)).connect(
                 username: credentials.username,
                 password: credentials.password
             )
-            await connect(with: HermesConnection(baseUrl: credentials.baseURL, ticket: ticket), profile: activeProfile)
+            authenticatedConnection.commitCookies()
+            await connect(with: HermesConnection(baseUrl: credentials.baseURL, ticket: authenticatedConnection.ticket), profile: activeProfile)
         } catch {
             // A rejected saved password falls back to the native login screen
             // without erasing it, allowing the user to correct the account.
@@ -3841,16 +3842,17 @@ final class AppState: ObservableObject {
                 if let credentials = KeychainHelper.loadCredentials(),
                    credentials.baseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/")) == savedConnection.baseUrl.trimmingCharacters(in: CharacterSet(charactersIn: "/")) {
                     do {
-                        let ticket = try await NativeAuthClient(baseURL: credentials.baseURL, cloudflareAccess: KeychainHelper.loadCloudflareAccess(for: credentials.baseURL)).connect(
+                        let authenticatedConnection = try await NativeAuthClient(baseURL: credentials.baseURL, cloudflareAccess: KeychainHelper.loadCloudflareAccess(for: credentials.baseURL)).connect(
                             username: credentials.username,
                             password: credentials.password
                         )
                         guard refreshTransportContinuation() else { return }
+                        authenticatedConnection.commitCookies()
                         // URLSession and WebKit have separate cookie stores.
                         // Reload the bridge so it receives the fresh session.
                         dashboardTicketBridge?.reload()
                         await connect(
-                            with: HermesConnection(baseUrl: credentials.baseURL, ticket: ticket),
+                            with: HermesConnection(baseUrl: credentials.baseURL, ticket: authenticatedConnection.ticket),
                             profile: activeProfile,
                             syncPurpose: continuationPurpose,
                             cancelsResumeRestoration: false,

--- a/Conduit/Services/NativeAuthClient.swift
+++ b/Conduit/Services/NativeAuthClient.swift
@@ -36,13 +36,29 @@ enum AuthClientError: LocalizedError {
     }
 }
 
-/// URLSession-based Hermes dashboard authentication. Its session uses the
-/// shared cookie storage so the authenticated cookie can be copied into
-/// DashboardTicketBridge's WebKit cookie store after sign-in.
+/// A fully validated native authentication transaction. Cookies remain private
+/// to the transaction until its caller accepts the ticket and commits them.
+struct NativeAuthConnection {
+    let ticket: String
+    fileprivate let cookies: [HTTPCookie]
+
+    /// Publishes this successful transaction for DashboardTicketBridge/WebKit.
+    /// Calling this more than once is harmless; callers should commit only the
+    /// connection they are about to make active.
+    func commitCookies() {
+        NativeAuthCookiePolicy.persist(cookies)
+    }
+}
+
+/// URLSession-based Hermes dashboard authentication. Automatic URLSession
+/// cookie handling is disabled: each login transaction captures its own
+/// response cookies, scopes them to the exact ticket URL, and returns them for
+/// explicit commit only after a valid ticket has been received.
 struct NativeAuthClient {
     let baseURL: String
     let cloudflareAccess: CloudflareAccessCredentials?
     private let session: URLSession
+    private let redirectDelegate: SecureRedirectDelegate
 
     init(
         baseURL: String,
@@ -55,14 +71,19 @@ struct NativeAuthClient {
         let configuration = sessionConfiguration ?? URLSessionConfiguration.default
         configuration.httpCookieAcceptPolicy = .always
         configuration.httpCookieStorage = HTTPCookieStorage.shared
-        configuration.httpShouldSetCookies = true
-        self.session = URLSession(configuration: configuration, delegate: SecureRedirectDelegate(), delegateQueue: nil)
+        // Every Cookie header is built from this login's captured cookies.
+        // Automatic handling would let a stale shared-jar cookie authenticate
+        // when the current login returned no cookie applicable to the route.
+        configuration.httpShouldSetCookies = false
+        let redirectDelegate = SecureRedirectDelegate()
+        self.redirectDelegate = redirectDelegate
+        self.session = URLSession(configuration: configuration, delegate: redirectDelegate, delegateQueue: nil)
     }
 
     func authProviders() async throws -> [[String: Any]] {
         let request = try request(path: "/api/auth/providers")
-        let (data, response) = try await session.data(for: request)
-        guard let http = response as? HTTPURLResponse else {
+        let result = try await perform(request)
+        guard let http = result.response as? HTTPURLResponse else {
             throw AuthClientError.providerDiscoveryFailed("No response")
         }
         switch http.statusCode {
@@ -72,16 +93,16 @@ struct NativeAuthClient {
             break
         }
         guard (200...299).contains(http.statusCode) else {
-            throw AuthClientError.providerDiscoveryFailed(parseError(data) ?? "HTTP \(http.statusCode)")
+            throw AuthClientError.providerDiscoveryFailed(parseError(result.data) ?? "HTTP \(http.statusCode)")
         }
 
-        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+        if let json = try? JSONSerialization.jsonObject(with: result.data) as? [String: Any] {
             return json["providers"] as? [[String: Any]] ?? []
         }
         return []
     }
 
-    func login(username: String, password: String) async throws {
+    func login(username: String, password: String) async throws -> [HTTPCookie] {
         var request = try request(path: "/auth/password-login")
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -91,36 +112,68 @@ struct NativeAuthClient {
             "password": password
         ])
 
-        let (data, response) = try await session.data(for: request)
-        guard let http = response as? HTTPURLResponse else {
+        let result = try await perform(request)
+        guard let http = result.response as? HTTPURLResponse else {
             throw AuthClientError.loginFailed("No response")
         }
         guard (200...299).contains(http.statusCode) else {
-            throw AuthClientError.loginFailed(parseError(data) ?? "HTTP \(http.statusCode)")
+            throw AuthClientError.loginFailed(parseError(result.data) ?? "HTTP \(http.statusCode)")
         }
+        guard http.url != nil else {
+            throw AuthClientError.loginFailed("Response URL missing")
+        }
+
+        // Redirect responses may set the session before the final JSON landing.
+        // The delegate captures those headers per URLSession task, and the final
+        // response is appended last so a later rotation wins by cookie identity.
+        return NativeAuthCookiePolicy.merged(
+            result.redirectCookies + NativeAuthCookiePolicy.acceptedCookies(from: http)
+        )
     }
 
-    func mintWsTicket() async throws -> String {
+    func mintWsTicket(authenticatedCookies: [HTTPCookie]) async throws -> NativeAuthConnection {
         var request = try request(path: "/api/auth/ws-ticket")
         request.httpMethod = "POST"
-        let (data, response) = try await session.data(for: request)
-        guard let http = response as? HTTPURLResponse else {
+        guard let ticketURL = request.url else {
+            throw AuthClientError.invalidURL
+        }
+
+        // Scope only this login's cookies. No shared-jar read occurs here, so a
+        // stale or concurrent session can never replace an empty/missing match.
+        for (name, value) in NativeAuthCookiePolicy.headerFields(
+            for: authenticatedCookies,
+            url: ticketURL
+        ) {
+            request.setValue(value, forHTTPHeaderField: name)
+        }
+
+        let result = try await perform(request)
+        guard let http = result.response as? HTTPURLResponse else {
             throw AuthClientError.ticketFailed("No response")
         }
         guard (200...299).contains(http.statusCode) else {
-            throw AuthClientError.ticketFailed(parseError(data) ?? "HTTP \(http.statusCode)")
+            throw AuthClientError.ticketFailed(parseError(result.data) ?? "HTTP \(http.statusCode)")
         }
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        guard let json = try? JSONSerialization.jsonObject(with: result.data) as? [String: Any],
               let ticket = json["ticket"] as? String,
               !ticket.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw AuthClientError.ticketFailed("No ticket in response")
         }
-        return ticket
+
+        // A deployment may rotate its session while minting the ticket. Keep
+        // that rotation transaction-local; the caller commits it only when this
+        // ticket is accepted as the active connection.
+        let committedCookies = NativeAuthCookiePolicy.merged(
+            authenticatedCookies
+                + result.redirectCookies
+                + NativeAuthCookiePolicy.acceptedCookies(from: http)
+        )
+        return NativeAuthConnection(ticket: ticket, cookies: committedCookies)
     }
 
-    func connect(username: String, password: String) async throws -> String {
-        try await login(username: username, password: password)
-        return try await mintWsTicket()
+    func connect(username: String, password: String) async throws -> NativeAuthConnection {
+        let authenticatedCookies = try await login(username: username, password: password)
+        return try await mintWsTicket(authenticatedCookies: authenticatedCookies)
     }
 
     private func request(path: String) throws -> URLRequest {
@@ -131,6 +184,36 @@ struct NativeAuthClient {
         return cloudflareAccess?.applying(to: URLRequest(url: url)) ?? URLRequest(url: url)
     }
 
+    private func perform(_ request: URLRequest) async throws -> NativeAuthHTTPResult {
+        let holder = URLSessionTaskHolder()
+        return try await withTaskCancellationHandler(operation: {
+            try await withCheckedThrowingContinuation { continuation in
+                let task = session.dataTask(with: request) { data, response, error in
+                    let redirectCookies = redirectDelegate.takeCookies(
+                        for: holder.taskIdentifier
+                    )
+                    if let error {
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                    guard let data, let response else {
+                        continuation.resume(throwing: URLError(.badServerResponse))
+                        return
+                    }
+                    continuation.resume(returning: NativeAuthHTTPResult(
+                        data: data,
+                        response: response,
+                        redirectCookies: redirectCookies
+                    ))
+                }
+                holder.install(task)
+                task.resume()
+            }
+        }, onCancel: {
+            holder.cancel()
+        })
+    }
+
     private func parseError(_ data: Data) -> String? {
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             return nil
@@ -139,7 +222,150 @@ struct NativeAuthClient {
     }
 }
 
+private enum NativeAuthCookiePolicy {
+    static func acceptedCookies(from response: HTTPURLResponse) -> [HTTPCookie] {
+        guard let responseURL = response.url else { return [] }
+        // HTTPURLResponse exposes duplicate response headers in its canonical
+        // combined form. Foundation's parser handles multiple Set-Cookie lines,
+        // including Expires commas; the real-transport tests pin that behavior.
+        let fields = response.allHeaderFields.reduce(into: [String: String]()) { result, entry in
+            guard let name = entry.key as? String else { return }
+            result[name] = String(describing: entry.value)
+        }
+        return HTTPCookie.cookies(
+            withResponseHeaderFields: fields,
+            for: responseURL
+        ).filter { accepts($0, from: responseURL) }
+    }
+
+    static func merged(_ cookies: [HTTPCookie]) -> [HTTPCookie] {
+        var order: [CookieIdentity] = []
+        var latest: [CookieIdentity: HTTPCookie] = [:]
+        for cookie in cookies {
+            let identity = CookieIdentity(cookie)
+            if latest[identity] == nil {
+                order.append(identity)
+            }
+            latest[identity] = cookie
+        }
+        return order.compactMap { latest[$0] }
+    }
+
+    static func headerFields(for cookies: [HTTPCookie], url: URL) -> [String: String] {
+        HTTPCookie.requestHeaderFields(with: applicableCookies(cookies, to: url))
+    }
+
+    static func persist(_ cookies: [HTTPCookie]) {
+        for cookie in cookies {
+            if let expires = cookie.expiresDate, expires <= Date() {
+                HTTPCookieStorage.shared.deleteCookie(cookie)
+            } else {
+                HTTPCookieStorage.shared.setCookie(cookie)
+            }
+        }
+    }
+
+    private static func accepts(_ cookie: HTTPCookie, from responseURL: URL) -> Bool {
+        guard let responseHost = responseURL.host?.lowercased() else { return false }
+        let canonicalDomain = canonicalDomain(cookie.domain)
+
+        // Hermes dashboard cookies are host-scoped. Requiring the response host
+        // exactly prevents a malicious/compromised dashboard from injecting a
+        // cookie for a parent, sibling, public-suffix, or unrelated origin.
+        guard canonicalDomain == responseHost else { return false }
+        if cookie.isSecure && responseURL.scheme?.lowercased() != "https" {
+            return false
+        }
+        if cookie.name.hasPrefix("__Host-") {
+            guard cookie.isSecure,
+                  cookie.path == "/",
+                  !cookie.domain.hasPrefix(".") else { return false }
+        } else if cookie.name.hasPrefix("__Secure-") && !cookie.isSecure {
+            return false
+        }
+        return true
+    }
+
+    private static func applicableCookies(_ cookies: [HTTPCookie], to url: URL) -> [HTTPCookie] {
+        guard let host = url.host?.lowercased() else { return [] }
+        let requestPath = url.path.isEmpty ? "/" : url.path
+        let isSecureRequest = url.scheme?.lowercased() == "https"
+        let now = Date()
+
+        return cookies.filter { cookie in
+            if let expires = cookie.expiresDate, expires <= now { return false }
+            if cookie.isSecure && !isSecureRequest { return false }
+            guard canonicalDomain(cookie.domain) == host else { return false }
+
+            let cookiePath = cookie.path.isEmpty ? "/" : cookie.path
+            guard requestPath.hasPrefix(cookiePath) else { return false }
+            if requestPath.count == cookiePath.count || cookiePath.hasSuffix("/") {
+                return true
+            }
+            let boundary = requestPath.index(requestPath.startIndex, offsetBy: cookiePath.count)
+            return requestPath[boundary] == "/"
+        }.sorted { lhs, rhs in
+            lhs.path.count > rhs.path.count
+        }
+    }
+
+    private static func canonicalDomain(_ domain: String) -> String {
+        domain.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: "."))
+    }
+}
+
+private struct CookieIdentity: Hashable {
+    let name: String
+    let domain: String
+    let path: String
+
+    init(_ cookie: HTTPCookie) {
+        name = cookie.name
+        domain = cookie.domain.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: "."))
+        path = cookie.path.isEmpty ? "/" : cookie.path
+    }
+}
+
+private struct NativeAuthHTTPResult {
+    let data: Data
+    let response: URLResponse
+    let redirectCookies: [HTTPCookie]
+}
+
+private final class URLSessionTaskHolder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var task: URLSessionTask?
+    private var cancellationRequested = false
+
+    var taskIdentifier: Int? {
+        lock.lock()
+        defer { lock.unlock() }
+        return task?.taskIdentifier
+    }
+
+    func install(_ task: URLSessionTask) {
+        lock.lock()
+        self.task = task
+        let shouldCancel = cancellationRequested
+        lock.unlock()
+        if shouldCancel {
+            task.cancel()
+        }
+    }
+
+    func cancel() {
+        lock.lock()
+        cancellationRequested = true
+        let task = self.task
+        lock.unlock()
+        task?.cancel()
+    }
+}
+
 private final class SecureRedirectDelegate: NSObject, URLSessionTaskDelegate {
+    private let lock = NSLock()
+    private var cookiesByTask: [Int: [HTTPCookie]] = [:]
+
     func urlSession(
         _ session: URLSession,
         task: URLSessionTask,
@@ -147,6 +373,7 @@ private final class SecureRedirectDelegate: NSObject, URLSessionTaskDelegate {
         newRequest request: URLRequest,
         completionHandler: @escaping (URLRequest?) -> Void
     ) {
+        recordCookies(from: response, taskIdentifier: task.taskIdentifier)
         guard let source = response.url ?? task.currentRequest?.url,
               let destination = request.url,
               ConnectionURLPolicy.isAllowedTransport(destination),
@@ -154,6 +381,43 @@ private final class SecureRedirectDelegate: NSObject, URLSessionTaskDelegate {
             completionHandler(nil)
             return
         }
-        completionHandler(request)
+
+        // URLSession cookie handling is disabled, so a password-login landing
+        // receives only this task's accepted redirect cookies. Other request
+        // types retain their original explicit headers unchanged.
+        guard task.originalRequest?.url?.path == "/auth/password-login" else {
+            completionHandler(request)
+            return
+        }
+        var redirectedRequest = request
+        let taskCookies = accumulatedCookies(for: task.taskIdentifier)
+        for (name, value) in NativeAuthCookiePolicy.headerFields(
+            for: taskCookies,
+            url: destination
+        ) {
+            redirectedRequest.setValue(value, forHTTPHeaderField: name)
+        }
+        completionHandler(redirectedRequest)
+    }
+
+    func takeCookies(for taskIdentifier: Int?) -> [HTTPCookie] {
+        guard let taskIdentifier else { return [] }
+        lock.lock()
+        defer { lock.unlock() }
+        return cookiesByTask.removeValue(forKey: taskIdentifier) ?? []
+    }
+
+    private func accumulatedCookies(for taskIdentifier: Int) -> [HTTPCookie] {
+        lock.lock()
+        defer { lock.unlock() }
+        return NativeAuthCookiePolicy.merged(cookiesByTask[taskIdentifier] ?? [])
+    }
+
+    private func recordCookies(from response: HTTPURLResponse, taskIdentifier: Int) {
+        let cookies = NativeAuthCookiePolicy.acceptedCookies(from: response)
+        guard !cookies.isEmpty else { return }
+        lock.lock()
+        cookiesByTask[taskIdentifier, default: []].append(contentsOf: cookies)
+        lock.unlock()
     }
 }

--- a/Conduit/Views/LoginView.swift
+++ b/Conduit/Views/LoginView.swift
@@ -238,7 +238,7 @@ struct LoginView: View {
                 return
             }
 
-            let ticket = try await client.connect(username: username, password: password)
+            let authenticatedConnection = try await client.connect(username: username, password: password)
             if saveCredentials {
                 KeychainHelper.saveCredentials(DashboardCredentials(
                     baseURL: serverUrl,
@@ -250,7 +250,8 @@ struct LoginView: View {
                 KeychainHelper.clearCredentials()
             }
             if let access { KeychainHelper.saveCloudflareAccess(access, origin: serverUrl) } else { KeychainHelper.clearCloudflareAccess() }
-            await appState.connect(with: HermesConnection(baseUrl: serverUrl, ticket: ticket))
+            authenticatedConnection.commitCookies()
+            await appState.connect(with: HermesConnection(baseUrl: serverUrl, ticket: authenticatedConnection.ticket))
         } catch is CancellationError {
             return
         } catch {

--- a/ConduitTests/NativeAuthClientIntegrationTests.swift
+++ b/ConduitTests/NativeAuthClientIntegrationTests.swift
@@ -1,0 +1,543 @@
+import Foundation
+import Network
+import XCTest
+@testable import Conduit
+
+final class NativeAuthClientIntegrationTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        clearLoopbackCookies()
+    }
+
+    override func tearDown() {
+        clearLoopbackCookies()
+        super.tearDown()
+    }
+
+    func testRealTransportSendsOnlyCurrentLoginCookiesAndPersistsTicketRotation() async throws {
+        let server = try LoopbackHTTPServer.start { request in
+            switch request.path {
+            case "/auth/password-login":
+                return .json(
+                    status: 200,
+                    headers: [
+                        ("Set-Cookie", "hermes_session_at=fresh-access; Path=/; HttpOnly; SameSite=Lax"),
+                        ("Set-Cookie", "auth_only=must-not-reach-ticket; Path=/auth; HttpOnly"),
+                        ("Set-Cookie", "secure_only=must-not-cross-http; Path=/; Secure; HttpOnly"),
+                        ("Set-Cookie", "expired=must-not-survive; Path=/; Expires=Wed, 09 Jun 2000 10:18:14 GMT"),
+                        ("Set-Cookie", "foreign=must-not-cross-domain; Domain=conduit-auth-poison.invalid; Path=/")
+                    ],
+                    body: #"{"ok":true,"next":"/"}"#
+                )
+            case "/api/auth/ws-ticket":
+                guard request.headers["cookie"] == "hermes_session_at=fresh-access" else {
+                    return .json(status: 401, body: #"{"detail":"Unauthorized"}"#)
+                }
+                return .json(
+                    status: 200,
+                    headers: [
+                        ("Set-Cookie", "hermes_session_at=rotated-access; Path=/; HttpOnly; SameSite=Lax")
+                    ],
+                    body: #"{"ticket":"real-stack-ticket"}"#
+                )
+            default:
+                return .json(status: 404, body: #"{"detail":"Not found"}"#)
+            }
+        }
+        defer { server.stop() }
+
+        let baseURL = "http://127.0.0.1:\(server.port)"
+        seedLoopbackCookie(name: "hermes_session_at", value: "stale-access")
+
+        let connection = try await NativeAuthClient(
+            baseURL: baseURL,
+            sessionConfiguration: realSessionConfiguration()
+        ).connect(username: "chris", password: "correct-password")
+
+        XCTAssertEqual(connection.ticket, "real-stack-ticket")
+        XCTAssertEqual(
+            server.lastRequest(path: "/api/auth/ws-ticket")?.headers["cookie"],
+            "hermes_session_at=fresh-access"
+        )
+        XCTAssertFalse(
+            hasLoopbackSession(value: "rotated-access"),
+            "A valid but uncommitted transaction must not publish its cookies."
+        )
+        connection.commitCookies()
+        XCTAssertTrue(
+            hasLoopbackSession(value: "rotated-access"),
+            "The accepted ticket response rotation must be committed for the WebKit bridge."
+        )
+        XCTAssertFalse(
+            (HTTPCookieStorage.shared.cookies ?? []).contains {
+                $0.domain.trimmingCharacters(in: CharacterSet(charactersIn: ".")) == "conduit-auth-poison.invalid"
+            },
+            "A response must not publish a cookie for an unrelated domain."
+        )
+    }
+
+    func testRealTransportCarriesSessionCookieSetOnSameOriginLoginRedirect() async throws {
+        let server = try LoopbackHTTPServer.start { request in
+            switch request.path {
+            case "/auth/password-login":
+                return LoopbackHTTPResponse(
+                    status: 302,
+                    headers: [
+                        ("Location", "/auth/password-complete"),
+                        ("Set-Cookie", "hermes_session_at=redirect-access; Path=/; HttpOnly; SameSite=Lax")
+                    ],
+                    body: Data()
+                )
+            case "/auth/password-complete":
+                guard request.headers["cookie"] == "hermes_session_at=redirect-access" else {
+                    return .json(status: 401, body: #"{"detail":"Redirect cookie missing"}"#)
+                }
+                return .json(status: 200, body: #"{"ok":true,"next":"/"}"#)
+            case "/api/auth/ws-ticket":
+                guard request.headers["cookie"] == "hermes_session_at=redirect-access" else {
+                    return .json(status: 401, body: #"{"detail":"Unauthorized"}"#)
+                }
+                return .json(status: 200, body: #"{"ticket":"redirect-ticket"}"#)
+            default:
+                return .json(status: 404, body: #"{"detail":"Not found"}"#)
+            }
+        }
+        defer { server.stop() }
+
+        let connection = try await NativeAuthClient(
+            baseURL: "http://127.0.0.1:\(server.port)",
+            sessionConfiguration: realSessionConfiguration()
+        ).connect(username: "chris", password: "correct-password")
+
+        XCTAssertEqual(connection.ticket, "redirect-ticket")
+        XCTAssertEqual(
+            server.lastRequest(path: "/api/auth/ws-ticket")?.headers["cookie"],
+            "hermes_session_at=redirect-access"
+        )
+    }
+
+    func testConcurrentRedirectedLoginsCannotExchangeSessionCookies() async throws {
+        let loginBarrier = TwoRequestBarrier()
+        let server = try LoopbackHTTPServer.start { request in
+            switch request.path {
+            case "/auth/password-login":
+                let username = ((try? JSONSerialization.jsonObject(with: request.body)) as? [String: Any])?["username"] as? String
+                guard let username else {
+                    return .json(status: 400, body: #"{"detail":"Missing username"}"#)
+                }
+                guard loginBarrier.arriveAndWait(timeout: 5) else {
+                    return .json(status: 500, body: #"{"detail":"Login overlap timed out"}"#)
+                }
+                return LoopbackHTTPResponse(
+                    status: 302,
+                    headers: [
+                        ("Location", "/auth/password-complete"),
+                        ("Set-Cookie", "hermes_session_at=session-\(username); Path=/; HttpOnly; SameSite=Lax")
+                    ],
+                    body: Data()
+                )
+            case "/auth/password-complete":
+                guard [
+                    "hermes_session_at=session-alpha",
+                    "hermes_session_at=session-beta"
+                ].contains(request.headers["cookie"] ?? "") else {
+                    return .json(status: 401, body: #"{"detail":"Redirect cookie missing"}"#)
+                }
+                return .json(status: 200, body: #"{"ok":true,"next":"/"}"#)
+            case "/api/auth/ws-ticket":
+                switch request.headers["cookie"] {
+                case "hermes_session_at=session-alpha":
+                    return .json(status: 200, body: #"{"ticket":"ticket-alpha"}"#)
+                case "hermes_session_at=session-beta":
+                    return .json(status: 200, body: #"{"ticket":"ticket-beta"}"#)
+                default:
+                    return .json(status: 401, body: #"{"detail":"Unauthorized"}"#)
+                }
+            default:
+                return .json(status: 404, body: #"{"detail":"Not found"}"#)
+            }
+        }
+        defer { server.stop() }
+
+        let client = NativeAuthClient(
+            baseURL: "http://127.0.0.1:\(server.port)",
+            sessionConfiguration: realSessionConfiguration()
+        )
+        async let alpha = client.connect(username: "alpha", password: "password-a")
+        async let beta = client.connect(username: "beta", password: "password-b")
+
+        let (alphaConnection, betaConnection) = try await (alpha, beta)
+
+        XCTAssertEqual(alphaConnection.ticket, "ticket-alpha")
+        XCTAssertEqual(betaConnection.ticket, "ticket-beta")
+        XCTAssertFalse(hasLoopbackSession(value: "session-alpha"))
+        XCTAssertFalse(hasLoopbackSession(value: "session-beta"))
+
+        alphaConnection.commitCookies()
+        XCTAssertTrue(hasLoopbackSession(value: "session-alpha"))
+        betaConnection.commitCookies()
+        XCTAssertTrue(hasLoopbackSession(value: "session-beta"))
+        XCTAssertFalse(hasLoopbackSession(value: "session-alpha"))
+    }
+
+    func testInvalidTicketBodyDoesNotPublishLoginOrRotationCookies() async throws {
+        let server = try LoopbackHTTPServer.start { request in
+            switch request.path {
+            case "/auth/password-login":
+                return .json(
+                    status: 200,
+                    headers: [
+                        ("Set-Cookie", "hermes_session_at=uncommitted-login; Path=/; HttpOnly")
+                    ],
+                    body: #"{"ok":true,"next":"/"}"#
+                )
+            case "/api/auth/ws-ticket":
+                return .json(
+                    status: 200,
+                    headers: [
+                        ("Set-Cookie", "hermes_session_at=uncommitted-rotation; Path=/; HttpOnly")
+                    ],
+                    body: #"{"ok":true}"#
+                )
+            default:
+                return .json(status: 404, body: #"{"detail":"Not found"}"#)
+            }
+        }
+        defer { server.stop() }
+
+        do {
+            _ = try await NativeAuthClient(
+                baseURL: "http://127.0.0.1:\(server.port)",
+                sessionConfiguration: realSessionConfiguration()
+            ).connect(username: "chris", password: "correct-password")
+            return XCTFail("Expected a ticket response without a ticket to fail")
+        } catch let error as AuthClientError {
+            guard case .ticketFailed(let detail) = error else {
+                return XCTFail("Expected ticket failure, got \(error)")
+            }
+            XCTAssertEqual(detail, "No ticket in response")
+        }
+
+        XCTAssertFalse(hasLoopbackSession(value: "uncommitted-login"))
+        XCTAssertFalse(hasLoopbackSession(value: "uncommitted-rotation"))
+    }
+
+    func testRedirectAndFinalCookieRotationUseOneCanonicalIdentity() async throws {
+        let server = try LoopbackHTTPServer.start { request in
+            switch request.path {
+            case "/auth/password-login":
+                return LoopbackHTTPResponse(
+                    status: 302,
+                    headers: [
+                        ("Location", "/auth/password-complete"),
+                        ("Set-Cookie", "hermes_session_at=redirect-old; Domain=localhost; Path=/; HttpOnly")
+                    ],
+                    body: Data()
+                )
+            case "/auth/password-complete":
+                guard request.headers["cookie"] == "hermes_session_at=redirect-old" else {
+                    return .json(status: 401, body: #"{"detail":"Redirect cookie missing"}"#)
+                }
+                return .json(
+                    status: 200,
+                    headers: [
+                        ("Set-Cookie", "hermes_session_at=final-new; Path=/; HttpOnly")
+                    ],
+                    body: #"{"ok":true,"next":"/"}"#
+                )
+            case "/api/auth/ws-ticket":
+                guard request.headers["cookie"] == "hermes_session_at=final-new" else {
+                    return .json(status: 401, body: #"{"detail":"Duplicate or stale cookie"}"#)
+                }
+                return .json(status: 200, body: #"{"ticket":"canonical-ticket"}"#)
+            default:
+                return .json(status: 404, body: #"{"detail":"Not found"}"#)
+            }
+        }
+        defer { server.stop() }
+
+        let connection = try await NativeAuthClient(
+            baseURL: "http://localhost:\(server.port)",
+            sessionConfiguration: realSessionConfiguration()
+        ).connect(username: "chris", password: "correct-password")
+
+        XCTAssertEqual(connection.ticket, "canonical-ticket")
+        XCTAssertEqual(
+            server.lastRequest(path: "/api/auth/ws-ticket")?.headers["cookie"],
+            "hermes_session_at=final-new"
+        )
+    }
+
+    private func realSessionConfiguration() -> URLSessionConfiguration {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 10
+        configuration.timeoutIntervalForResource = 10
+        return configuration
+    }
+
+    private func hasLoopbackSession(value: String) -> Bool {
+        (HTTPCookieStorage.shared.cookies ?? []).contains {
+            $0.name == "hermes_session_at"
+                && $0.value == value
+                && $0.domain.trimmingCharacters(in: CharacterSet(charactersIn: ".")) == "127.0.0.1"
+        }
+    }
+
+    private func seedLoopbackCookie(name: String, value: String) {
+        guard let cookie = HTTPCookie(properties: [
+            .name: name,
+            .value: value,
+            .domain: "127.0.0.1",
+            .path: "/"
+        ]) else {
+            return XCTFail("Could not create loopback fixture cookie")
+        }
+        HTTPCookieStorage.shared.setCookie(cookie)
+    }
+
+    private func clearLoopbackCookies() {
+        let fixtureDomains = Set(["127.0.0.1", "localhost", "conduit-auth-poison.invalid"])
+        for cookie in HTTPCookieStorage.shared.cookies ?? [] {
+            let domain = cookie.domain.trimmingCharacters(in: CharacterSet(charactersIn: "."))
+            if fixtureDomains.contains(domain) {
+                HTTPCookieStorage.shared.deleteCookie(cookie)
+            }
+        }
+    }
+}
+
+private struct LoopbackHTTPRequest: Sendable {
+    let method: String
+    let path: String
+    let headers: [String: String]
+    let body: Data
+}
+
+private struct LoopbackHTTPResponse: Sendable {
+    let status: Int
+    let headers: [(String, String)]
+    let body: Data
+
+    static func json(
+        status: Int,
+        headers: [(String, String)] = [],
+        body: String
+    ) -> LoopbackHTTPResponse {
+        LoopbackHTTPResponse(
+            status: status,
+            headers: [("Content-Type", "application/json")] + headers,
+            body: Data(body.utf8)
+        )
+    }
+}
+
+private final class TwoRequestBarrier: @unchecked Sendable {
+    private let condition = NSCondition()
+    private var arrivals = 0
+
+    func arriveAndWait(timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        condition.lock()
+        arrivals += 1
+        if arrivals >= 2 {
+            condition.broadcast()
+            condition.unlock()
+            return true
+        }
+        while arrivals < 2 {
+            if !condition.wait(until: deadline) {
+                condition.unlock()
+                return false
+            }
+        }
+        condition.unlock()
+        return true
+    }
+}
+
+private final class LoopbackHTTPServer: @unchecked Sendable {
+    typealias Handler = @Sendable (LoopbackHTTPRequest) -> LoopbackHTTPResponse
+
+    private let listener: NWListener
+    private let queue = DispatchQueue(
+        label: "conduit.native-auth.loopback",
+        attributes: .concurrent
+    )
+    private let handler: Handler
+    private let lock = NSLock()
+    private var requests: [LoopbackHTTPRequest] = []
+    private var connections: [ObjectIdentifier: NWConnection] = [:]
+
+    private init(listener: NWListener, handler: @escaping Handler) {
+        self.listener = listener
+        self.handler = handler
+    }
+
+    static func start(handler: @escaping Handler) throws -> LoopbackHTTPServer {
+        let listener = try NWListener(using: .tcp, on: .any)
+        let server = LoopbackHTTPServer(listener: listener, handler: handler)
+        try server.startAndWaitUntilReady()
+        return server
+    }
+
+    var port: UInt16 {
+        listener.port?.rawValue ?? 0
+    }
+
+    func stop() {
+        listener.cancel()
+        lock.lock()
+        let activeConnections = Array(connections.values)
+        connections.removeAll()
+        lock.unlock()
+        for connection in activeConnections {
+            connection.cancel()
+        }
+    }
+
+    func lastRequest(path: String) -> LoopbackHTTPRequest? {
+        lock.lock()
+        defer { lock.unlock() }
+        return requests.last(where: { $0.path == path })
+    }
+
+    private func startAndWaitUntilReady() throws {
+        let ready = DispatchSemaphore(value: 0)
+        let stateLock = NSLock()
+        var startError: Error?
+
+        listener.stateUpdateHandler = { state in
+            switch state {
+            case .ready:
+                ready.signal()
+            case .failed(let error):
+                stateLock.lock()
+                startError = error
+                stateLock.unlock()
+                ready.signal()
+            default:
+                break
+            }
+        }
+        listener.newConnectionHandler = { [weak self] connection in
+            self?.accept(connection)
+        }
+        listener.start(queue: queue)
+
+        guard ready.wait(timeout: .now() + 5) == .success else {
+            listener.cancel()
+            throw NSError(
+                domain: "LoopbackHTTPServer",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Timed out starting loopback HTTP server"]
+            )
+        }
+        stateLock.lock()
+        let error = startError
+        stateLock.unlock()
+        if let error {
+            listener.cancel()
+            throw error
+        }
+        guard port != 0 else {
+            listener.cancel()
+            throw NSError(
+                domain: "LoopbackHTTPServer",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "Loopback HTTP server did not receive a port"]
+            )
+        }
+    }
+
+    private func accept(_ connection: NWConnection) {
+        lock.lock()
+        connections[ObjectIdentifier(connection)] = connection
+        lock.unlock()
+        connection.start(queue: queue)
+        receive(on: connection, buffer: Data())
+    }
+
+    private func receive(on connection: NWConnection, buffer: Data) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) { [weak self] data, _, isComplete, error in
+            guard let self else {
+                connection.cancel()
+                return
+            }
+            var accumulated = buffer
+            if let data {
+                accumulated.append(data)
+            }
+            if let request = Self.parseRequest(from: accumulated) {
+                lock.lock()
+                requests.append(request)
+                lock.unlock()
+                send(handler(request), on: connection)
+                return
+            }
+            if error != nil || isComplete {
+                remove(connection)
+                connection.cancel()
+                return
+            }
+            receive(on: connection, buffer: accumulated)
+        }
+    }
+
+    private func send(_ response: LoopbackHTTPResponse, on connection: NWConnection) {
+        let reason: String
+        switch response.status {
+        case 200: reason = "OK"
+        case 302: reason = "Found"
+        case 401: reason = "Unauthorized"
+        case 404: reason = "Not Found"
+        default: reason = "Response"
+        }
+        var header = "HTTP/1.1 \(response.status) \(reason)\r\n"
+        for (name, value) in response.headers {
+            header += "\(name): \(value)\r\n"
+        }
+        header += "Content-Length: \(response.body.count)\r\n"
+        header += "Connection: close\r\n\r\n"
+        var payload = Data(header.utf8)
+        payload.append(response.body)
+        connection.send(content: payload, completion: .contentProcessed { [weak self] _ in
+            self?.remove(connection)
+            connection.cancel()
+        })
+    }
+
+    private func remove(_ connection: NWConnection) {
+        lock.lock()
+        connections.removeValue(forKey: ObjectIdentifier(connection))
+        lock.unlock()
+    }
+
+    private static func parseRequest(from data: Data) -> LoopbackHTTPRequest? {
+        let delimiter = Data("\r\n\r\n".utf8)
+        guard let headerRange = data.range(of: delimiter),
+              let headerText = String(data: data[..<headerRange.lowerBound], encoding: .utf8) else {
+            return nil
+        }
+        let lines = headerText.components(separatedBy: "\r\n")
+        guard let requestLine = lines.first else { return nil }
+        let parts = requestLine.split(separator: " ", maxSplits: 2).map(String.init)
+        guard parts.count >= 2 else { return nil }
+
+        var headers: [String: String] = [:]
+        for line in lines.dropFirst() {
+            guard let separator = line.firstIndex(of: ":") else { continue }
+            let name = line[..<separator].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            let value = line[line.index(after: separator)...].trimmingCharacters(in: .whitespacesAndNewlines)
+            headers[name] = value
+        }
+        let contentLength = Int(headers["content-length"] ?? "0") ?? 0
+        let bodyStart = headerRange.upperBound
+        guard data.count >= bodyStart + contentLength else { return nil }
+        return LoopbackHTTPRequest(
+            method: parts[0],
+            path: parts[1],
+            headers: headers,
+            body: data.subdata(in: bodyStart..<(bodyStart + contentLength))
+        )
+    }
+}

--- a/ConduitTests/NativeAuthClientTests.swift
+++ b/ConduitTests/NativeAuthClientTests.swift
@@ -3,6 +3,68 @@ import XCTest
 @testable import Conduit
 
 final class NativeAuthClientTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        NativeAuthURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        NativeAuthURLProtocol.reset()
+        super.tearDown()
+    }
+
+    func testPasswordLoginCarriesReturnedSessionCookieIntoTicketRequest() async throws {
+        let client = NativeAuthClient(
+            baseURL: "http://192.168.1.200:9119",
+            sessionConfiguration: makeSessionConfiguration()
+        )
+
+        let connection = try await client.connect(username: "chris", password: "correct-password")
+
+        XCTAssertEqual(connection.ticket, "fresh-ticket")
+        XCTAssertEqual(
+            NativeAuthURLProtocol.requestHeader(forPath: "/api/auth/ws-ticket", name: "Cookie"),
+            "hermes_session_at=test-access-token"
+        )
+    }
+
+    func testNativeAuthenticationDisablesAutomaticCookieAttachment() {
+        let configuration = makeSessionConfiguration()
+
+        _ = NativeAuthClient(
+            baseURL: "http://192.168.1.201:9119",
+            sessionConfiguration: configuration
+        )
+
+        XCTAssertFalse(configuration.httpShouldSetCookies)
+    }
+
+    func testTicketRequestDoesNotFallBackToUnrelatedSharedCookie() async throws {
+        let baseURL = "http://192.168.1.201:9119"
+        NativeAuthURLProtocol.seedSharedCookie(
+            name: "hermes_session_at",
+            value: "stale-access-token",
+            baseURL: baseURL
+        )
+        let client = NativeAuthClient(
+            baseURL: baseURL,
+            sessionConfiguration: makeSessionConfiguration()
+        )
+
+        do {
+            _ = try await client.connect(username: "chris", password: "correct-password")
+            return XCTFail("Expected the ticket request without an applicable login cookie to be rejected")
+        } catch let error as AuthClientError {
+            guard case .ticketFailed(let detail) = error else {
+                return XCTFail("Expected ticket failure, got \(error)")
+            }
+            XCTAssertEqual(detail, "Unauthorized")
+        }
+        XCTAssertNil(
+            NativeAuthURLProtocol.requestHeader(forPath: "/api/auth/ws-ticket", name: "Cookie")
+        )
+    }
+
     func testProviderDiscoveryRedirectFallsBackToWebView() async throws {
         let client = NativeAuthClient(
             baseURL: "https://redirect.example",
@@ -101,10 +163,13 @@ private final class NativeAuthURLProtocol: URLProtocol {
 
     private static let recordLock = NSLock()
     private static var responseRecords: [ResponseRecord] = []
+    private static var requestRecords: [URLRequest] = []
 
     override class func canInit(with request: URLRequest) -> Bool {
         guard let host = request.url?.host else { return false }
         return [
+            "192.168.1.200",
+            "192.168.1.201",
             "redirect.example",
             "providers.example",
             "server-error.example",
@@ -123,6 +188,7 @@ private final class NativeAuthURLProtocol: URLProtocol {
             client?.urlProtocol(self, didFailWithError: URLError(.badURL))
             return
         }
+        Self.record(request: request)
         let fixture = fixture(for: request)
         Self.record(
             host: url.host ?? "",
@@ -165,9 +231,46 @@ private final class NativeAuthURLProtocol: URLProtocol {
         return responseRecords.filter { $0.host == host }.count
     }
 
+    static func requestHeader(forPath path: String, name: String) -> String? {
+        recordLock.lock()
+        defer { recordLock.unlock() }
+        return requestRecords.last(where: { $0.url?.path == path })?.value(forHTTPHeaderField: name)
+    }
+
+    static func reset() {
+        recordLock.lock()
+        responseRecords.removeAll()
+        requestRecords.removeAll()
+        recordLock.unlock()
+        let fixtureHosts = Set(["192.168.1.200", "192.168.1.201"])
+        for cookie in HTTPCookieStorage.shared.cookies ?? [] {
+            let domain = cookie.domain.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: "."))
+            if fixtureHosts.contains(domain) {
+                HTTPCookieStorage.shared.deleteCookie(cookie)
+            }
+        }
+    }
+
+    static func seedSharedCookie(name: String, value: String, baseURL: String) {
+        guard let host = URL(string: baseURL)?.host,
+              let cookie = HTTPCookie(properties: [
+                .name: name,
+                .value: value,
+                .domain: host,
+                .path: "/"
+              ]) else { return }
+        HTTPCookieStorage.shared.setCookie(cookie)
+    }
+
     private static func record(host: String, statusCode: Int?, headers: [String: String]) {
         recordLock.lock()
         responseRecords.append(ResponseRecord(host: host, statusCode: statusCode, headers: headers))
+        recordLock.unlock()
+    }
+
+    private static func record(request: URLRequest) {
+        recordLock.lock()
+        requestRecords.append(request)
         recordLock.unlock()
     }
 
@@ -181,6 +284,53 @@ private final class NativeAuthURLProtocol: URLProtocol {
         guard let host = request.url?.host else { return nil }
 
         switch host {
+        case "192.168.1.201":
+            switch request.url?.path {
+            case "/auth/password-login":
+                return Fixture(
+                    statusCode: 200,
+                    headers: [
+                        "Content-Type": "application/json",
+                        "Set-Cookie": "auth_only=must-not-reach-ticket; Path=/auth; HttpOnly"
+                    ],
+                    body: Data(#"{"ok":true,"next":"/"}"#.utf8)
+                )
+            case "/api/auth/ws-ticket":
+                return Fixture(
+                    statusCode: 401,
+                    headers: ["Content-Type": "application/json"],
+                    body: Data(#"{"detail":"Unauthorized"}"#.utf8)
+                )
+            default:
+                return nil
+            }
+        case "192.168.1.200":
+            switch request.url?.path {
+            case "/auth/password-login":
+                return Fixture(
+                    statusCode: 200,
+                    headers: [
+                        "Content-Type": "application/json",
+                        "Set-Cookie": "hermes_session_at=test-access-token; Path=/; HttpOnly; SameSite=Lax, auth_only=must-not-leak; Path=/auth; HttpOnly"
+                    ],
+                    body: Data(#"{"ok":true,"next":"/"}"#.utf8)
+                )
+            case "/api/auth/ws-ticket":
+                guard request.value(forHTTPHeaderField: "Cookie") == "hermes_session_at=test-access-token" else {
+                    return Fixture(
+                        statusCode: 401,
+                        headers: ["Content-Type": "application/json"],
+                        body: Data(#"{"detail":"Unauthorized"}"#.utf8)
+                    )
+                }
+                return Fixture(
+                    statusCode: 200,
+                    headers: ["Content-Type": "application/json"],
+                    body: Data(#"{"ticket":"fresh-ticket"}"#.utf8)
+                )
+            default:
+                return nil
+            }
         case "redirect.example":
             return Fixture(
                 statusCode: 302,


### PR DESCRIPTION
## Summary
- parse password-login Set-Cookie headers immediately instead of racing iOS cookie persistence
- disable URLSession automatic cookie fallback so stale shared sessions cannot authenticate a new login
- let Foundation enforce cookie Domain, Path, Secure, and expiry rules before the ticket request
- keep only cookies returned by the current login

## Root cause
Hermes accepted the username/password, but Conduit immediately requested `/api/auth/ws-ticket` without the newly returned session cookie. The server therefore returned 401 `Unauthorized`, producing the logout loop and “Could not get session ticket” error.

## Tests
- RED: login to ticket regression reproduced `ticketFailed("Unauthorized")`
- RED: path-scoped cookie was rejected when leaked to `/api/auth/ws-ticket`
- RED: native auth session required automatic cookie attachment to be disabled
- GREEN: `NativeAuthClientTests` 8/8
- GREEN: CI `unit-d` lane 183/183
- GREEN: iPad simulator build
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication reliability by preserving session cookies from password login.
  * Ensured only valid, relevant cookies are sent when requesting WebSocket access tickets.
  * Prevented unrelated shared cookies from being attached to authentication requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->