### PR TITLE
fix(resume): bound WS message size and prefer compact session.resume (#106)

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2664,14 +2664,17 @@ final class AppState: ObservableObject {
             // response; the HTTP endpoint reads the timestamped rows from
             // state.db and hydrates the conversation instead.
             let bridge = dashboardTicketBridge
-            // Request the compact projection only when a history source can
-            // hydrate the transcript without a second round trip: a dashboard
-            // bridge that is ready to serve requests, or a test seam standing
-            // in for one. A cold bridge resumes with the transcript carried in
-            // the RPC response, exactly as pre-compact builds did — and so do
-            // the legacy fallbacks below (gateway without the history route),
-            // whose response size is bounded only by the socket limit.
-            let compactResume = chatResumeLifecycleOperations.persistedTranscript != nil || bridge?.isReady == true
+            // Prefer the compact projection whenever a history source exists
+            // to hydrate the transcript — the dashboard bridge, or a test seam
+            // standing in for one. A cold bridge does not change the flavor:
+            // requestJSON's bounded readiness poll (30 × 100 ms) waits for the
+            // page inside the concurrent transcript fetch, so the compact
+            // resume is never delayed by that wait, and a bridge still not
+            // usable afterwards degrades to the single legacy resume. The
+            // legacy resume — cold bridge, gateway without the history route —
+            // carries the transcript in the RPC response, whose size is
+            // bounded by the socket limit (the pre-compact behavior).
+            let compactResume = chatResumeLifecycleOperations.persistedTranscript != nil || bridge != nil
             async let resumedSession = openChatResumeSession(
                 sessionId,
                 using: client,
@@ -2680,8 +2683,7 @@ final class AppState: ObservableObject {
             async let transcriptOutcome = persistedTranscriptOutcome(
                 sessionId: sessionId,
                 profile: profile,
-                using: bridge,
-                enabled: compactResume
+                using: bridge
             )
 
             var result = try await resumedSession
@@ -6088,12 +6090,8 @@ final class AppState: ObservableObject {
     private func persistedTranscriptOutcome(
         sessionId: String,
         profile: String,
-        using bridge: DashboardTicketBridge?,
-        enabled: Bool
+        using bridge: DashboardTicketBridge?
     ) async -> PersistedTranscriptOutcome {
-        // The caller passes `enabled` false when the resume already carries
-        // the transcript (no hydration needed), so no history request runs.
-        guard enabled else { return .unavailable }
         let fetchOutcome: PersistedTranscriptFetchOutcome
         if let persistedTranscript = chatResumeLifecycleOperations.persistedTranscript {
             fetchOutcome = await persistedTranscript(sessionId, profile)
@@ -6104,21 +6102,13 @@ final class AppState: ObservableObject {
                     path: sessionMessagesPath(sessionId: sessionId, profile: profile)
                 ))
             } catch {
-                // Older gateways can omit the endpoint, and a freshly created
-                // (or reloading) bridge is not ready to serve requests yet.
-                // Both leave the resume without a usable history source, so
-                // the legacy resume that carries the transcript remains a
-                // safe fallback in those cases; unrelated failures must
-                // surface instead. Note the bridge caps REST response size
-                // (DataURLLimits.maxJSONResponseBytes), so an oversized
-                // transcript also surfaces here rather than silently
+                // requestJSON's readiness poll is the bounded wait for a cold
+                // or reloading bridge; whatever it raises is classified with
+                // the seam-sourced failures below. Note the bridge caps REST
+                // response size (DataURLLimits.maxJSONResponseBytes), so an
+                // oversized transcript also lands here rather than silently
                 // degrading the resume.
-                if Self.historySourceIsUnavailable(error) {
-                    sessionCatalogLog.debug("Persisted transcript endpoint unavailable for \(sessionId, privacy: .public)")
-                    return .unavailable
-                }
-                sessionCatalogLog.debug("Persisted transcript unavailable for \(sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)")
-                return .failed(error)
+                fetchOutcome = .failed(error)
             }
         }
 
@@ -6126,6 +6116,17 @@ final class AppState: ObservableObject {
         case .unavailable:
             return .unavailable
         case .failed(let error):
+            // One classification for both the bridge fetch and the seam:
+            // structural endpoint gaps, a bridge that never became ready
+            // inside its bounded poll, and transient transport trouble
+            // (429, 5xx, status-0 WebKit/network failures, request timeouts)
+            // degrade to the single legacy resume; authentication and every
+            // other failure must surface instead of silently degrading.
+            if Self.historySourceIsUnavailable(error) {
+                sessionCatalogLog.debug("Persisted transcript unavailable for \(sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                return .unavailable
+            }
+            sessionCatalogLog.debug("Persisted transcript failed for \(sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)")
             return .failed(error)
         case .payload(let response):
             // The dashboard server returns `messages`; the API-server variant
@@ -6146,17 +6147,29 @@ final class AppState: ObservableObject {
         }
     }
 
-    /// A history source that is structurally absent (404/410/501 from the
-    /// history route) or not currently usable (the bridge's WebKit page is
-    /// still loading or reloading) cannot hydrate the transcript right now,
-    /// so the legacy resume is the correct fallback. Every other failure is
-    /// transient or environmental (network, auth, server error) and must
-    /// propagate instead of silently degrading the resume.
+    /// Classifies a history-fetch failure for the resume fallback. Everything
+    /// that leaves the resume without a usable transcript *right now*
+    /// degrades to the single legacy resume:
+    ///
+    ///  - structural endpoint gaps — 404/410 (the gateway predates the
+    ///    messages route);
+    ///  - a bridge that did not become ready within its bounded readiness
+    ///    poll, or a request that outlived its deadline (both funnel into
+    ///    `.notReady` by the bridge's error contract);
+    ///  - transient transport trouble — HTTP 408/429, any 5xx (which
+    ///    subsumes 501), and status 0 (WebKit-level network/abort failures,
+    ///    including response caps).
+    ///
+    /// Client-originated request/bridge timeouts always arrive through one of
+    /// the status-0/`.notReady` funnels above; other authentication (401/403 →
+    /// `.signInRequired`) and every unlisted error is a real failure that must
+    /// propagate instead of silently degrading the resume into a fallback.
     nonisolated static func historySourceIsUnavailable(_ error: Error) -> Bool {
         if case DashboardTicketBridgeError.notReady = error { return true }
         guard case let DashboardTicketBridgeError.http(status, _) = error else { return false }
         switch status {
-        case 404, 410, 501: return true
+        case 0, 404, 408, 410, 429: return true
+        case 500...599: return true
         default: return false
         }
     }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -30,7 +30,8 @@ struct ChatResumeLifecycleOperations {
     var connectClient: (@MainActor (HermesClient) async throws -> Void)?
     var loadCatalog: (@MainActor (HermesClient, Bool) async throws -> [SessionSummary])?
     var mintTicket: (@MainActor (String) async throws -> String)?
-    var openSession: (@MainActor (HermesClient, String) async throws -> SessionResumeResult)?
+    var openSession: (@MainActor (HermesClient, String, Bool) async throws -> SessionResumeResult)?
+    var persistedTranscript: (@MainActor (String, String) async -> PersistedTranscriptFetchOutcome)?
     var branchSession: (@MainActor (
         HermesClient,
         String,
@@ -66,7 +67,8 @@ struct ChatResumeLifecycleOperations {
         connectClient: (@MainActor (HermesClient) async throws -> Void)? = nil,
         loadCatalog: (@MainActor (HermesClient, Bool) async throws -> [SessionSummary])? = nil,
         mintTicket: (@MainActor (String) async throws -> String)? = nil,
-        openSession: (@MainActor (HermesClient, String) async throws -> SessionResumeResult)? = nil,
+        openSession: (@MainActor (HermesClient, String, Bool) async throws -> SessionResumeResult)? = nil,
+        persistedTranscript: (@MainActor (String, String) async -> PersistedTranscriptFetchOutcome)? = nil,
         branchSession: (@MainActor (
             HermesClient,
             String,
@@ -102,6 +104,7 @@ struct ChatResumeLifecycleOperations {
         self.loadCatalog = loadCatalog
         self.mintTicket = mintTicket
         self.openSession = openSession
+        self.persistedTranscript = persistedTranscript
         self.branchSession = branchSession
         self.setSessionTitle = setSessionTitle
         self.refreshContext = refreshContext
@@ -120,6 +123,33 @@ struct ChatResumeLifecycleOperations {
     }
 
     static let live = ChatResumeLifecycleOperations()
+}
+
+/// Raw result of fetching a session's persisted history — the dashboard
+/// messages endpoint's JSON payload exactly as returned, still to be parsed
+/// by AppState's production normalizer path.
+enum PersistedTranscriptFetchOutcome {
+    case payload([String: Any])
+    /// No usable history source: no dashboard bridge, or the gateway predates
+    /// the messages endpoint. The caller falls back to the resume RPC that
+    /// carries the transcript itself.
+    case unavailable
+    /// An unrelated history failure (network, authentication, unexpected
+    /// payload). It must surface to the caller instead of silently degrading
+    /// the resume into a fallback.
+    case failed(Error)
+}
+
+/// Parsed readiness of the persisted transcript for a resume reconciliation.
+enum PersistedTranscriptOutcome {
+    case hydrated(PersistedSessionTranscript)
+    case unavailable
+    case failed(Error)
+}
+
+struct PersistedSessionTranscript {
+    let resolvedSessionId: String?
+    let messages: [ChatMessage]
 }
 
 struct ComposerSubmissionContext: Equatable {
@@ -763,11 +793,6 @@ final class AppState: ObservableObject {
         /// catalog. Empty or unusable responses must remain mergeable with
         /// the previous snapshot instead of evicting it.
         let isAuthoritative: Bool
-    }
-
-    private struct PersistedSessionTranscript {
-        let resolvedSessionId: String?
-        let messages: [ChatMessage]
     }
 
     private struct TitleGenerationSettings {
@@ -2634,22 +2659,69 @@ final class AppState: ObservableObject {
 
         do {
             // Match Hermes Desktop: fetch the durable transcript and resume the
-            // live runtime concurrently. `session.resume` intentionally uses a
-            // compact projection which omits persisted timestamps, while the
-            // HTTP endpoint reads the timestamped rows from state.db.
+            // live runtime concurrently. The compact resume (`omit_messages`)
+            // keeps the whole persisted transcript out of the WebSocket
+            // response; the HTTP endpoint reads the timestamped rows from
+            // state.db and hydrates the conversation instead.
             let bridge = dashboardTicketBridge
+            // Request the compact projection only when a history source can
+            // hydrate the transcript without a second round trip: a dashboard
+            // bridge that is ready to serve requests, or a test seam standing
+            // in for one. A cold bridge resumes with the transcript carried in
+            // the RPC response, exactly as pre-compact builds did — and so do
+            // the legacy fallbacks below (gateway without the history route),
+            // whose response size is bounded only by the socket limit.
+            let compactResume = chatResumeLifecycleOperations.persistedTranscript != nil || bridge?.isReady == true
             async let resumedSession = openChatResumeSession(
                 sessionId,
-                using: client
+                using: client,
+                compact: compactResume
             )
-            async let persistedTranscript = dashboardSessionTranscript(
+            async let transcriptOutcome = persistedTranscriptOutcome(
                 sessionId: sessionId,
                 profile: profile,
-                using: bridge
+                using: bridge,
+                enabled: compactResume
             )
 
-            let result = try await resumedSession
-            let transcript = await persistedTranscript
+            var result = try await resumedSession
+            var transcript: PersistedSessionTranscript?
+            if compactResume {
+                switch await transcriptOutcome {
+                case .hydrated(let persisted):
+                    // The endpoint may resolve a runtime ID to its stored
+                    // session ID; only rows belonging to this session may
+                    // hydrate the transcript. A foreign identity means the
+                    // history source is unusable for this resume — request
+                    // the transcript through the resume RPC instead.
+                    if transcriptMatchesSession(
+                        persisted,
+                        requestedSessionId: sessionId,
+                        resumedSessionId: result.sessionId
+                    ) {
+                        transcript = persisted
+                    } else {
+                        result = try await openChatResumeSession(
+                            sessionId,
+                            using: client,
+                            compact: false
+                        )
+                    }
+                case .unavailable:
+                    // No usable history source (missing bridge, or a gateway
+                    // predating the messages endpoint): re-resume carrying
+                    // the transcript, exactly as pre-compact builds did.
+                    result = try await openChatResumeSession(
+                        sessionId,
+                        using: client,
+                        compact: false
+                    )
+                case .failed(let error):
+                    // An unrelated history failure must not be papered over by
+                    // a legacy resume that would hide it: surface it instead.
+                    throw error
+                }
+            }
             guard automaticChatResumeWorkIsCurrent(
                     automaticWorkToken,
                     syncOperationID: automaticSyncOperationID
@@ -2691,9 +2763,16 @@ final class AppState: ObservableObject {
                     sessionIDs: [sessionId, result.sessionId, transcript.resolvedSessionId].compactMap { $0 }
                 )
             }
-            let shouldUsePersistedTranscript = !result.snapshot.hasLiveProjection
-                && transcriptMatches
-                && (transcript.map { !$0.messages.isEmpty || result.messages.isEmpty } ?? false)
+            // A compact resume ships no persisted transcript, so the REST rows
+            // are the durable base even while a turn is live: the in-flight
+            // projection rides on top through the streaming bubble, matching
+            // Desktop's cache-as-base rendering. A resume that carried
+            // messages keeps the historical precedence where a live projection
+            // wins over the REST read.
+            let resumeCarriedTranscript = !result.messages.isEmpty
+            let shouldUsePersistedTranscript = transcriptMatches
+                && (transcript.map { !$0.messages.isEmpty || !resumeCarriedTranscript } ?? false)
+                && (!result.snapshot.hasLiveProjection || !resumeCarriedTranscript)
             let presentationResult: SessionResumeResult
             if let transcript, shouldUsePersistedTranscript {
                 presentationResult = SessionResumeResult(
@@ -2862,12 +2941,16 @@ final class AppState: ObservableObject {
 
     private func openChatResumeSession(
         _ sessionID: String,
-        using client: HermesClient
+        using client: HermesClient,
+        compact: Bool
     ) async throws -> SessionResumeResult {
         if let openSession = chatResumeLifecycleOperations.openSession {
-            return try await openSession(client, sessionID)
+            return try await openSession(client, sessionID, compact)
         }
-        return try await client.openSession(sessionID)
+        if compact {
+            return try await client.openSession(sessionID)
+        }
+        return try await client.openSessionLegacy(sessionID)
     }
 
     private func refreshChatResumeContext(
@@ -5995,36 +6078,86 @@ final class AppState: ObservableObject {
             .caseInsensitiveCompare(rhs.trimmingCharacters(in: .whitespacesAndNewlines)) == .orderedSame
     }
 
-    /// Mirrors Hermes Desktop's `/api/sessions/{id}/messages` prefetch. The
-    /// dashboard server returns `messages`; the API-server variant returns
-    /// `data`, so accept both public Hermes response shapes.
-    private func dashboardSessionTranscript(
+    /// Mirrors Hermes Desktop's `/api/sessions/{id}/messages` prefetch:
+    /// fetches the session's persisted transcript through the dashboard
+    /// history route (or the test seam standing in for it) and parses it with
+    /// the production normalizer path. The typed outcome lets the resume
+    /// reconciliation distinguish a missing history source — which triggers
+    /// the legacy full-transcript resume — from an unrelated failure, which
+    /// must surface instead of silently degrading.
+    private func persistedTranscriptOutcome(
         sessionId: String,
         profile: String,
-        using bridge: DashboardTicketBridge?
-    ) async -> PersistedSessionTranscript? {
-        guard let bridge else { return nil }
+        using bridge: DashboardTicketBridge?,
+        enabled: Bool
+    ) async -> PersistedTranscriptOutcome {
+        // The caller passes `enabled` false when the resume already carries
+        // the transcript (no hydration needed), so no history request runs.
+        guard enabled else { return .unavailable }
+        let fetchOutcome: PersistedTranscriptFetchOutcome
+        if let persistedTranscript = chatResumeLifecycleOperations.persistedTranscript {
+            fetchOutcome = await persistedTranscript(sessionId, profile)
+        } else {
+            guard let bridge else { return .unavailable }
+            do {
+                fetchOutcome = .payload(try await bridge.requestJSON(
+                    path: sessionMessagesPath(sessionId: sessionId, profile: profile)
+                ))
+            } catch {
+                // Older gateways can omit the endpoint, and a freshly created
+                // (or reloading) bridge is not ready to serve requests yet.
+                // Both leave the resume without a usable history source, so
+                // the legacy resume that carries the transcript remains a
+                // safe fallback in those cases; unrelated failures must
+                // surface instead. Note the bridge caps REST response size
+                // (DataURLLimits.maxJSONResponseBytes), so an oversized
+                // transcript also surfaces here rather than silently
+                // degrading the resume.
+                if Self.historySourceIsUnavailable(error) {
+                    sessionCatalogLog.debug("Persisted transcript endpoint unavailable for \(sessionId, privacy: .public)")
+                    return .unavailable
+                }
+                sessionCatalogLog.debug("Persisted transcript unavailable for \(sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                return .failed(error)
+            }
+        }
 
-        do {
-            let response = try await bridge.requestJSON(
-                path: sessionMessagesPath(sessionId: sessionId, profile: profile)
-            )
+        switch fetchOutcome {
+        case .unavailable:
+            return .unavailable
+        case .failed(let error):
+            return .failed(error)
+        case .payload(let response):
+            // The dashboard server returns `messages`; the API-server variant
+            // returns `data`, so accept both public Hermes response shapes.
             let rawMessages = ["messages", "data", "_array"]
                 .compactMap { response[$0] as? [Any] }
                 .first
-            guard let rawMessages else { return nil }
+            guard let rawMessages else {
+                return .failed(HermesError.invalidResponse)
+            }
 
             let resolvedSessionId = (response["session_id"] as? String)
                 ?? (response["sessionId"] as? String)
-            return PersistedSessionTranscript(
+            return .hydrated(PersistedSessionTranscript(
                 resolvedSessionId: resolvedSessionId,
                 messages: MessageNormalizer.normalizeMessages(rawMessages.map(AnyCodable.from))
-            )
-        } catch {
-            // Older gateways can omit the endpoint. The compact resume path and
-            // presentation cache remain a safe fallback in that case.
-            sessionCatalogLog.debug("Persisted transcript unavailable for \(sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)")
-            return nil
+            ))
+        }
+    }
+
+    /// A history source that is structurally absent (404/410/501 from the
+    /// history route) or not currently usable (the bridge's WebKit page is
+    /// still loading or reloading) cannot hydrate the transcript right now,
+    /// so the legacy resume is the correct fallback. Every other failure is
+    /// transient or environmental (network, auth, server error) and must
+    /// propagate instead of silently degrading the resume.
+    nonisolated static func historySourceIsUnavailable(_ error: Error) -> Bool {
+        if case DashboardTicketBridgeError.notReady = error { return true }
+        guard case let DashboardTicketBridgeError.http(status, _) = error else { return false }
+        switch status {
+        case 404, 410, 501: return true
+        default: return false
         }
     }
 

--- a/Conduit/Services/DashboardTicketBridge.swift
+++ b/Conduit/Services/DashboardTicketBridge.swift
@@ -122,11 +122,15 @@ enum DashboardCookiePersistence {
 enum DashboardTicketBridgeError: LocalizedError {
     case notReady
     case signInRequired
+    /// Local/dashboard-message failures that never produced an HTTP status
+    /// (request encoding, ticket-mint details). HTTP failures travel as
+    /// `.http(status:detail:)` instead.
     case requestFailed(String)
     /// Non-auth HTTP failure carrying the gateway's status code, so callers
-    /// can recognize structural gaps (404/410/501 — e.g. a gateway without
-    /// the session-messages endpoint) and fall back deliberately instead of
-    /// treating them like transient server errors.
+    /// can recognize structural gaps (404/410 — e.g. a gateway without the
+    /// session-messages endpoint) and transient trouble (429/5xx/408, status
+    /// 0) and fall back deliberately instead of treating them like unrelated
+    /// server errors.
     case http(status: Int, detail: String)
 
     var errorDescription: String? {
@@ -195,9 +199,7 @@ final class DashboardTicketBridge: NSObject {
     let webView: WKWebView
     let cloudflareAccess: CloudflareAccessCredentials?
 
-    /// Readable so callers can pick a request strategy up front (e.g. skip a
-    /// compact resume that would depend on this bridge) without mutating it.
-    private(set) var isReady = false
+    private var isReady = false
     /// Whether the current dashboard page load has terminally failed (as
     /// opposed to still being in flight on a slow link). Retry logic only
     /// reloads a failed load — restarting an in-progress one would abort a

--- a/Conduit/Services/DashboardTicketBridge.swift
+++ b/Conduit/Services/DashboardTicketBridge.swift
@@ -123,6 +123,11 @@ enum DashboardTicketBridgeError: LocalizedError {
     case notReady
     case signInRequired
     case requestFailed(String)
+    /// Non-auth HTTP failure carrying the gateway's status code, so callers
+    /// can recognize structural gaps (404/410/501 — e.g. a gateway without
+    /// the session-messages endpoint) and fall back deliberately instead of
+    /// treating them like transient server errors.
+    case http(status: Int, detail: String)
 
     var errorDescription: String? {
         switch self {
@@ -132,6 +137,8 @@ enum DashboardTicketBridgeError: LocalizedError {
             return "Dashboard sign-in has expired."
         case .requestFailed(let message):
             return message
+        case .http(_, let detail):
+            return detail
         }
     }
 }
@@ -188,7 +195,9 @@ final class DashboardTicketBridge: NSObject {
     let webView: WKWebView
     let cloudflareAccess: CloudflareAccessCredentials?
 
-    private var isReady = false
+    /// Readable so callers can pick a request strategy up front (e.g. skip a
+    /// compact resume that would depend on this bridge) without mutating it.
+    private(set) var isReady = false
     /// Whether the current dashboard page load has terminally failed (as
     /// opposed to still being in flight on a slow link). Retry logic only
     /// reloads a failed load — restarting an in-progress one would abort a
@@ -795,7 +804,7 @@ extension DashboardTicketBridge: WKScriptMessageHandler {
             return
         }
         let detail = payload["error"] as? String ?? "Dashboard request failed (\(status))."
-        continuation.resume(throwing: DashboardTicketBridgeError.requestFailed(detail))
+        continuation.resume(throwing: DashboardTicketBridgeError.http(status: status, detail: detail))
     }
 }
 

--- a/Conduit/Services/HermesClient.swift
+++ b/Conduit/Services/HermesClient.swift
@@ -426,6 +426,11 @@ final class HermesClient: ObservableObject {
     static let requestTimeout: TimeInterval = 30
     static let promptSubmitTimeout: TimeInterval = 180 // 3 minutes
     static let titleGenerationTimeout: TimeInterval = 90
+    /// The legacy full-transcript resume is the RPC most likely to carry the
+    /// largest payload over the slowest connections (issue #106 follow-up),
+    /// so it gets a bounded-but-generous budget instead of the ordinary
+    /// request timeout.
+    static let legacyResumeTimeout: TimeInterval = 60
 
     init(
         connection: HermesConnection,
@@ -781,9 +786,16 @@ final class HermesClient: ObservableObject {
     /// Resume variant that carries the persisted transcript inside the RPC
     /// response. Used when compact resume cannot be hydrated (missing bridge,
     /// a gateway without the history endpoint, or history rows that resolved
-    /// to a foreign session).
+    /// to a foreign session). Its response is the largest ordinary payload in
+    /// the app, so it uses the dedicated `legacyResumeTimeout`.
     func openSessionLegacy(_ sessionId: String) async throws -> SessionResumeResult {
         try await resumeSession(sessionId, omitMessages: false)
+    }
+
+    /// Compact responses are tiny, so they ride the ordinary request budget;
+    /// the legacy transcript response gets the generous bounded budget.
+    static func resumeTimeout(omitMessages: Bool) -> TimeInterval {
+        omitMessages ? requestTimeout : legacyResumeTimeout
     }
 
     private func resumeSession(_ sessionId: String, omitMessages: Bool) async throws -> SessionResumeResult {
@@ -795,7 +807,11 @@ final class HermesClient: ObservableObject {
         if omitMessages {
             params["omit_messages"] = true
         }
-        let result = try await rpc("session.resume", params: params)
+        let result = try await rpc(
+            "session.resume",
+            params: params,
+            timeout: Self.resumeTimeout(omitMessages: omitMessages)
+        )
         let object = result.objectValue ?? [:]
         let resolvedId = object["session_id"]?.stringValue ?? sessionId
         let messages = MessageNormalizer.normalizeMessages(

--- a/Conduit/Services/HermesClient.swift
+++ b/Conduit/Services/HermesClient.swift
@@ -18,6 +18,10 @@
 //    controls.
 //  - Use resumed.messages from session.resume RPC, including any in-flight
 //    transcript state, rather than deriving liveness from message roles.
+//    Since the compact resume (issue #106) the default openSession suppresses
+//    that transcript (omit_messages) and AppState hydrates the persisted rows
+//    over REST; openSessionLegacy is the variant whose response still carries
+//    the messages.
 //  - Do NOT merge gateway RPC session.list into the UI list — it reads from
 //    the main DB containing ALL profiles. Use profile-scoped endpoint only.
 //
@@ -336,6 +340,15 @@ protocol HermesWebSocketTransport: AnyObject {
 /// Production transport: one `URLSession` per socket, delegate-driven
 /// handshake. Behaviour is identical to the client's pre-seam connect().
 final class URLSessionWebSocketTransport: HermesWebSocketTransport {
+    /// Explicit incoming-message bound for the production socket. URLSession's
+    /// own default (1 MiB) closes the connection with close code 1009 as soon
+    /// as a single WebSocket message exceeds it, which is how resuming a large
+    /// session — one huge `session.resume` frame — used to kill Conduit's
+    /// connection in a reconnect loop (issue #106). 4 MiB comfortably covers
+    /// legitimate control payloads while staying bounded; the compact resume
+    /// keeps transcript-sized payloads off the socket entirely.
+    static let maximumMessageSize = 4 * 1024 * 1024
+
     private var session: URLSession?
     private var delegate: WebSocketOpenDelegate?
 
@@ -352,7 +365,9 @@ final class URLSessionWebSocketTransport: HermesWebSocketTransport {
         let session = URLSession(configuration: config, delegate: delegate, delegateQueue: nil)
         self.session = session
         self.delegate = delegate
-        return session.webSocketTask(with: request)
+        let task = session.webSocketTask(with: request)
+        task.maximumMessageSize = Self.maximumMessageSize
+        return task
     }
 
     func invalidate() {
@@ -751,12 +766,36 @@ final class HermesClient: ObservableObject {
         _ = try await rpc("session.list", params: nil, timeout: 8)
     }
 
+    /// Resumes a session with the compact projection: `omit_messages` asks
+    /// the gateway to suppress the persisted transcript copy in the response
+    /// (`messages: []`) because the caller hydrates it through the
+    /// authenticated REST history route, exactly like Hermes Desktop. Older
+    /// gateways read `session.resume` params loosely and simply ignore the
+    /// unknown flag, degrading to the historical full response. AppState owns
+    /// the REST hydration and falls back to `openSessionLegacy` when no
+    /// usable history source exists.
     func openSession(_ sessionId: String) async throws -> SessionResumeResult {
-        let result = try await rpc("session.resume", params: [
+        try await resumeSession(sessionId, omitMessages: true)
+    }
+
+    /// Resume variant that carries the persisted transcript inside the RPC
+    /// response. Used when compact resume cannot be hydrated (missing bridge,
+    /// a gateway without the history endpoint, or history rows that resolved
+    /// to a foreign session).
+    func openSessionLegacy(_ sessionId: String) async throws -> SessionResumeResult {
+        try await resumeSession(sessionId, omitMessages: false)
+    }
+
+    private func resumeSession(_ sessionId: String, omitMessages: Bool) async throws -> SessionResumeResult {
+        var params: [String: Any] = [
             "session_id": sessionId,
             "cols": 96,
             "source": "desktop"
-        ])
+        ]
+        if omitMessages {
+            params["omit_messages"] = true
+        }
+        let result = try await rpc("session.resume", params: params)
         let object = result.objectValue ?? [:]
         let resolvedId = object["session_id"]?.stringValue ?? sessionId
         let messages = MessageNormalizer.normalizeMessages(

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -12,7 +12,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 loadCatalog: { _, _ in [staleCatalog] },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     SessionResumeResult(
                         sessionId: sessionID,
                         messages: newerMessages,
@@ -76,7 +76,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let gates = SessionOpenGates(sessionIDs: sessionIDs)
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     await gates.suspend(sessionID)
                     return SessionResumeResult(
                         sessionId: sessionID,
@@ -127,7 +127,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 loadCatalog: { _, _ in [active] },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     await openGate.suspend()
                     return SessionResumeResult(
                         sessionId: sessionID,
@@ -188,7 +188,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 loadCatalog: { _, _ in [active] },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     await openGate.suspend()
                     return SessionResumeResult(
                         sessionId: sessionID,
@@ -230,7 +230,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 loadCatalog: { _, _ in [active] },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     await openGate.suspend()
                     return SessionResumeResult(
                         sessionId: sessionID,
@@ -300,7 +300,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 loadCatalog: { _, _ in [active] },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     await openGate.suspend()
                     return SessionResumeResult(
                         sessionId: sessionID,
@@ -351,7 +351,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 loadCatalog: { _, _ in [active] },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     await openGate.suspend()
                     return SessionResumeResult(
                         sessionId: sessionID,
@@ -410,7 +410,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 loadCatalog: { _, _ in [active] },
-                openSession: { _, _ in
+                openSession: { _, _, _ in
                     await openGate.suspend()
                     return SessionResumeResult(
                         sessionId: "runtime-a",
@@ -470,7 +470,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 loadCatalog: { _, _ in [previous] },
-                openSession: { _, _ in
+                openSession: { _, _, _ in
                     return SessionResumeResult(
                         sessionId: resumedSessionID,
                         messages: [],
@@ -511,7 +511,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let openGate = ControlledSuspension()
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     await openGate.suspend()
                     return SessionResumeResult(
                         sessionId: sessionID,
@@ -545,7 +545,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let secondGate = ControlledSuspension()
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     if sessionID == "stored-b" {
                         await firstGate.suspend()
                     } else {
@@ -603,7 +603,7 @@ final class AppStateChatResumeTests: XCTestCase {
                     await secondCatalogGate.suspend()
                     return [self.session("stored-c")]
                 },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     SessionResumeResult(
                         sessionId: sessionID,
                         messages: sessionID == "stored-c" ? secondMessages : firstMessages,
@@ -688,7 +688,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 loadCatalog: { _, _ in [self.session("stored-a")] },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     SessionResumeResult(
                         sessionId: sessionID,
                         messages: transcript,
@@ -742,7 +742,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 loadCatalog: { _, _ in [self.session("stored-a")] },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     SessionResumeResult(
                         sessionId: sessionID,
                         messages: transcript,
@@ -1004,7 +1004,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 loadCatalog: { _, _ in [self.session("stored-a")] },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     SessionResumeResult(
                         sessionId: sessionID,
                         messages: transcript,
@@ -1060,7 +1060,7 @@ final class AppStateChatResumeTests: XCTestCase {
                     }
                     return [self.session("stored-current")]
                 },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     if sessionID == "stored-current" {
                         await newerOpenGate.suspend()
                     }
@@ -1173,7 +1173,7 @@ final class AppStateChatResumeTests: XCTestCase {
                     }
                     return [self.session("stored-current")]
                 },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     SessionResumeResult(
                         sessionId: sessionID,
                         messages: sessionID == "stored-current" ? currentMessages : staleMessages,
@@ -1218,7 +1218,7 @@ final class AppStateChatResumeTests: XCTestCase {
     func testAuthoritativeEmptyTranscriptSettlesFromScopedRevisionZeroLayout() async {
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     SessionResumeResult(
                         sessionId: sessionID,
                         messages: [],
@@ -1276,7 +1276,7 @@ final class AppStateChatResumeTests: XCTestCase {
         )
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     SessionResumeResult(
                         sessionId: sessionID,
                         messages: authoritativeMessages,
@@ -1345,7 +1345,7 @@ final class AppStateChatResumeTests: XCTestCase {
                     await notificationCatalogGate.suspend()
                     return [self.session("stored-b")]
                 },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     SessionResumeResult(
                         sessionId: sessionID,
                         messages: sessionID == "stored-c" ? messagesC : messagesB,
@@ -1623,7 +1623,7 @@ final class AppStateChatResumeTests: XCTestCase {
                     }
                     return [active]
                 },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     openedSessionIDs.append(sessionID)
                     return SessionResumeResult(
                         sessionId: sessionID,
@@ -1690,7 +1690,7 @@ final class AppStateChatResumeTests: XCTestCase {
                     return [active]
                 },
                 mintTicket: { _ in "refreshed-ticket" },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     openCount += 1
                     if openCount == 1 {
                         await openGate.suspend()
@@ -1759,7 +1759,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 loadCatalog: { _, _ in [] },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     SessionResumeResult(
                         sessionId: sessionID,
                         messages: messages,
@@ -1805,7 +1805,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 loadCatalog: { _, _ in [] },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     SessionResumeResult(
                         sessionId: sessionID,
                         messages: newMessages,
@@ -1860,7 +1860,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let gate = ControlledSuspension()
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     await gate.suspend()
                     return SessionResumeResult(
                         sessionId: sessionID,
@@ -1916,7 +1916,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 loadCatalog: { _, _ in [] },
-                openSession: { _, _ in throw ControlledLifecycleError.failed },
+                openSession: { _, _, _ in throw ControlledLifecycleError.failed },
                 branchSession: { _, _, _, _, _ in
                     (sessionId: "branch-runtime", storedSessionId: "branch-stored", profile: "default")
                 },
@@ -1961,7 +1961,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 loadCatalog: { _, _ in [] },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     if sessionID == "branch-runtime" {
                         await branchGate.suspend()
                     }
@@ -2780,7 +2780,7 @@ final class AppStateChatResumeTests: XCTestCase {
                     loadCatalogCount += 1
                     return [destination]
                 },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     openSessionCount += 1
                     return SessionResumeResult(
                         sessionId: sessionID,
@@ -2944,7 +2944,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 loadCatalog: { _, _ in [origin] },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     openedSessionIDs.append(sessionID)
                     return SessionResumeResult(
                         sessionId: "runtime-recovered",
@@ -2991,7 +2991,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 loadCatalog: { _, _ in [origin] },
-                openSession: { _, _ in
+                openSession: { _, _, _ in
                     SessionResumeResult(
                         sessionId: "runtime-recovered",
                         messages: [],
@@ -3170,7 +3170,7 @@ final class AppStateChatResumeTests: XCTestCase {
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 loadCatalog: { _, _ in [origin] },
-                openSession: { _, _ in
+                openSession: { _, _, _ in
                     SessionResumeResult(
                         sessionId: "runtime-recovered",
                         messages: [],
@@ -3301,7 +3301,7 @@ final class AppStateChatResumeTests: XCTestCase {
                     }
                     return "profile-ticket"
                 },
-                openSession: { client, sessionID in
+                openSession: { client, sessionID, _ in
                     let profile = client.profile ?? "default"
                     openedProfiles.append(profile)
                     return SessionResumeResult(

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -1661,7 +1661,11 @@ final class AppStateChatResumeTests: XCTestCase {
         await connecting.value
 
         XCTAssertEqual(catalogLoadCount, 2)
-        XCTAssertEqual(openedSessionIDs, [active.id])
+        // The dashboard bridge created by connect() is cold, so the resume
+        // begins compact (omit_messages) and — the bridge never becoming
+        // ready inside the bounded readiness poll — degrades to exactly one
+        // legacy resume for the same session (issue #106 follow-up).
+        XCTAssertEqual(openedSessionIDs, [active.id, active.id])
         XCTAssertEqual(harness.appState.activeSessionId, active.id)
         XCTAssertEqual(harness.appState.messages, restoredMessages)
         XCTAssertTrue(harness.appState.isConnected)

--- a/ConduitTests/AppStateReasoningStreamTests.swift
+++ b/ConduitTests/AppStateReasoningStreamTests.swift
@@ -480,7 +480,7 @@ final class AppStateReasoningStreamTests: XCTestCase {
             ChatMessage(id: "new-1", role: .assistant, content: "Other session", timestamp: "1")
         ]
         let state = makeAppState(lifecycleOperations: ChatResumeLifecycleOperations(
-            openSession: { _, sessionID in
+            openSession: { _, sessionID, _ in
                 SessionResumeResult(
                     sessionId: sessionID,
                     messages: replacementMessages,

--- a/ConduitTests/ChatReturnSurfaceTests.swift
+++ b/ConduitTests/ChatReturnSurfaceTests.swift
@@ -346,7 +346,7 @@ final class ChatReturnSurfaceTests: XCTestCase {
                     return [self.session("stored-a")]
                 },
                 mintTicket: { _ in throw ReturnSurfaceTestError.mintUnavailable },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     SessionResumeResult(
                         sessionId: sessionID,
                         messages: [
@@ -412,7 +412,7 @@ final class ChatReturnSurfaceTests: XCTestCase {
         let harness = makeHarness(
             surface: .sessions,
             lifecycleOperations: ChatResumeLifecycleOperations(
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     SessionResumeResult(
                         sessionId: sessionID,
                         messages: [

--- a/ConduitTests/CompactResumeTranscriptTests.swift
+++ b/ConduitTests/CompactResumeTranscriptTests.swift
@@ -1,0 +1,477 @@
+import XCTest
+@testable import Conduit
+
+/// Regression coverage for issue #106: large sessions resume reliably because
+/// the WebSocket transport carries a bounded, explicit `maximumMessageSize`
+/// and `session.resume` requests the compact projection (`omit_messages`),
+/// hydrating the persisted transcript through the existing dashboard history
+/// route. The compatibility fallback (history source unavailable → legacy
+/// full-transcript resume) is exercised, and unrelated history failures must
+/// surface instead of hiding behind that fallback.
+@MainActor
+final class CompactResumeTranscriptTests: XCTestCase {
+
+    private enum FixtureError: Error {
+        case unusableSuite
+    }
+
+    @MainActor
+    private final class ResumeCallRecorder {
+        private(set) var calls: [(sessionID: String, compact: Bool)] = []
+        func record(sessionID: String, compact: Bool) {
+            calls.append((sessionID, compact))
+        }
+    }
+
+    // MARK: - Transcript hydration
+
+    func testCompactResumeHydratesPersistedTranscriptFromHistoryPayload() async throws {
+        let recorder = ResumeCallRecorder()
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let harness = try makeHarness(
+            openSession: { _, sessionID, compact in
+                recorder.record(sessionID: sessionID, compact: compact)
+                return SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],  // compact projection: transcript omitted
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                // Raw history payload exactly as the dashboard messages
+                // endpoint returns it; the production normalizer parses it.
+                .payload([
+                    "session_id": "stored-a",
+                    "messages": [
+                        [
+                            "id": 1,
+                            "role": "user",
+                            "content": "Find the transcript.",
+                            "timestamp": "2026-09-01T10:00:00Z"
+                        ],
+                        [
+                            "id": 2,
+                            "role": "assistant",
+                            "content": "",
+                            "timestamp": "2026-09-01T10:00:04Z",
+                            "tool_calls": [[
+                                "id": "call_1",
+                                "type": "function",
+                                "function": [
+                                    "name": "read_file",
+                                    "arguments": "{\"path\": \"/tmp/transcript.md\"}"
+                                ]
+                            ]]
+                        ],
+                        [
+                            "id": 3,
+                            "role": "tool",
+                            "tool_call_id": "call_1",
+                            "content": "file body",
+                            "timestamp": "2026-09-01T10:00:05Z"
+                        ],
+                        [
+                            "id": 4,
+                            "role": "assistant",
+                            "content": "Here it is.",
+                            "timestamp": "2026-09-01T10:00:06Z"
+                        ]
+                    ]
+                ])
+            }
+        )
+        harness.appState.sessions = [active]
+
+        let opened = await harness.appState.openSession("stored-a")
+
+        XCTAssertTrue(opened)
+        XCTAssertEqual(recorder.calls.map { $0.compact }, [true])
+
+        // The visible conversation is the persisted transcript, parsed by the
+        // production normalizer: user row, tool card with input and output,
+        // and the final reply — not just array counts.
+        XCTAssertEqual(harness.appState.messages.map { $0.role }, [.user, .tool, .assistant])
+        XCTAssertEqual(harness.appState.messages[0].content, "Find the transcript.")
+        XCTAssertEqual(harness.appState.messages[0].timestamp, "2026-09-01T10:00:00Z")
+        XCTAssertEqual(harness.appState.messages[1].tool?.name, "read_file")
+        XCTAssertEqual(harness.appState.messages[1].tool?.input, "{\"path\": \"/tmp/transcript.md\"}")
+        XCTAssertEqual(harness.appState.messages[1].tool?.output, "file body")
+        XCTAssertEqual(harness.appState.messages[2].content, "Here it is.")
+        XCTAssertEqual(harness.appState.messages[2].timestamp, "2026-09-01T10:00:06Z")
+    }
+
+    // MARK: - Live projection preservation
+
+    func testCompactResumeKeepsRunningInflightProjectionOnPersistedBase() async throws {
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let persistedPrefix = "Streaming the report now."
+        let inflightText = persistedPrefix + " The numbers section is next."
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],  // compact projection: transcript omitted
+                    snapshot: SessionRuntimeSnapshot(
+                        object: ["running": .bool(true)],
+                        inflight: .object(["assistant": .string(inflightText)])
+                    )
+                )
+            },
+            persistedTranscript: { _, _ in
+                .payload([
+                    "session_id": "stored-a",
+                    "messages": [
+                        [
+                            "id": 1,
+                            "role": "user",
+                            "content": "Write the report.",
+                            "timestamp": "2026-09-01T10:00:00Z"
+                        ],
+                        [
+                            "id": 2,
+                            "role": "assistant",
+                            "content": persistedPrefix,
+                            "timestamp": "2026-09-01T10:00:10Z"
+                        ]
+                    ]
+                ])
+            }
+        )
+        harness.appState.sessions = [active]
+
+        let opened = await harness.appState.openSession("stored-a")
+
+        XCTAssertTrue(opened)
+        // The persisted conversation stays visible while the turn is live,
+        // and the in-flight projection rides the live bubble as exactly the
+        // unpersisted continuation — no duplicated prefix row.
+        XCTAssertEqual(harness.appState.messages.map { $0.role }, [.user, .assistant])
+        XCTAssertEqual(harness.appState.messages[1].content, persistedPrefix)
+        XCTAssertEqual(harness.appState.messages[1].timestamp, "2026-09-01T10:00:10Z")
+        // Publish the authoritative streaming buffer into the test projection.
+        harness.appState.showSidebar = true
+        harness.appState.showSidebar = false
+        XCTAssertEqual(harness.appState.streamingText, "The numbers section is next.")
+        XCTAssertFalse(
+            harness.appState.messages.contains { $0.content.contains("The numbers section is next.") },
+            "The inflight continuation must ride the live bubble, not duplicate into rows"
+        )
+    }
+
+    // MARK: - Large-session regression
+
+    func testLargeSessionResumeShipsNoTranscriptOverWebSocket() async throws {
+        // A transcript whose ordinary (non-compact) resume payload exceeds the
+        // old 1 MiB URLSessionWebSocketTask default. The invariant under test:
+        // such a session resumes deterministically without that giant payload
+        // ever needing to traverse the WebSocket — no live multi-megabyte
+        // transfer is involved.
+        let filler = String(repeating: "x", count: 3_000)
+        var rows: [[String: Any]] = []
+        for index in 0..<200 {
+            let minute = String(format: "%02d", index % 60)
+            rows.append([
+                "id": index * 2,
+                "role": "user",
+                "content": "Prompt \(index) \(filler)",
+                "timestamp": "2026-09-01T10:\(minute):00Z"
+            ])
+            rows.append([
+                "id": index * 2 + 1,
+                "role": "assistant",
+                "content": "Reply \(index) \(filler)",
+                "timestamp": "2026-09-01T10:\(minute):05Z"
+            ])
+        }
+        let payloadBytes = try JSONSerialization
+            .data(withJSONObject: ["session_id": "stored-a", "messages": rows])
+            .count
+        XCTAssertGreaterThan(
+            payloadBytes,
+            1_048_576,
+            "The fixture must represent a session whose legacy resume frame would exceed the old default limit"
+        )
+
+        let recorder = ResumeCallRecorder()
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let harness = try makeHarness(
+            openSession: { _, sessionID, compact in
+                recorder.record(sessionID: sessionID, compact: compact)
+                return SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in .payload(["session_id": "stored-a", "messages": rows]) }
+        )
+        harness.appState.sessions = [active]
+
+        let opened = await harness.appState.openSession("stored-a")
+
+        XCTAssertTrue(opened)
+        XCTAssertEqual(
+            recorder.calls.map { $0.compact },
+            [true],
+            "The large session must resume compactly with the transcript hydrated from history"
+        )
+        XCTAssertEqual(harness.appState.messages.count, 400)
+        XCTAssertEqual(harness.appState.messages.first?.content, "Prompt 0 \(filler)")
+        XCTAssertEqual(harness.appState.messages.first?.timestamp, "2026-09-01T10:00:00Z")
+        XCTAssertEqual(harness.appState.messages.last?.content, "Reply 199 \(filler)")
+        XCTAssertEqual(harness.appState.messages.last?.timestamp, "2026-09-01T10:19:05Z")
+    }
+
+    // MARK: - Compatibility fallback
+
+    func testUnavailableHistorySourceFallsBackToLegacyResume() async throws {
+        let recorder = ResumeCallRecorder()
+        let legacyMessages = [
+            ChatMessage(
+                id: "legacy-1",
+                role: .user,
+                content: "Legacy persisted prompt",
+                timestamp: "2026-09-01T09:00:00Z"
+            ),
+            ChatMessage(
+                id: "legacy-2",
+                role: .assistant,
+                content: "Legacy persisted reply",
+                timestamp: "2026-09-01T09:00:05Z"
+            )
+        ]
+        let active = session("stored-gateway-old")
+        let harness = try makeHarness(
+            openSession: { _, sessionID, compact in
+                recorder.record(sessionID: sessionID, compact: compact)
+                if compact {
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                }
+                return SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: legacyMessages,
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                // The gateway predates the session-messages endpoint.
+                .unavailable
+            }
+        )
+        harness.appState.sessions = [active]
+
+        let opened = await harness.appState.openSession("stored-gateway-old")
+
+        XCTAssertTrue(opened)
+        XCTAssertEqual(
+            recorder.calls.map { $0.compact },
+            [true, false],
+            "The unsupported history source must trigger exactly one legacy re-resume"
+        )
+        XCTAssertEqual(
+            harness.appState.messages.map { $0.content },
+            ["Legacy persisted prompt", "Legacy persisted reply"]
+        )
+    }
+
+    func testLegacyFallbackHydratesSessionExceedingTransportBound() async throws {
+        // The issue-sanctioned legacy fallback (history source unavailable)
+        // must deterministically hydrate a transcript far larger than the new
+        // 4 MiB socket bound as well: the durable rows arrive through the
+        // fallback resume, and the assertion proves the fixture really is
+        // bigger than the transport bound without pushing traffic over a
+        // live WebSocket.
+        let filler = String(repeating: "x", count: 10_000)
+        let recorder = ResumeCallRecorder()
+        let count = 450
+        let legacyMessages: [ChatMessage] = (0..<count).map { index in
+            ChatMessage(
+                id: "big-\(index)",
+                role: index.isMultiple(of: 2) ? .user : .assistant,
+                content: "Row \(index) \(filler)",
+                timestamp: "2026-09-01T10:\(String(format: "%02d", index % 60)):00Z"
+            )
+        }
+        let payloadBytes = legacyMessages
+            .reduce(0) { $0 + $1.content.utf8.count }
+        XCTAssertGreaterThan(payloadBytes, 4 * 1024 * 1024, "The fixture must exceed the new transport bound")
+
+        let active = session("stored-gateway-old")
+        let harness = try makeHarness(
+            openSession: { _, sessionID, compact in
+                recorder.record(sessionID: sessionID, compact: compact)
+                if compact {
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                }
+                return SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: legacyMessages,
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in .unavailable }
+        )
+        harness.appState.sessions = [active]
+
+        let opened = await harness.appState.openSession("stored-gateway-old")
+
+        XCTAssertTrue(opened)
+        XCTAssertEqual(recorder.calls.map { $0.compact }, [true, false])
+        XCTAssertEqual(harness.appState.messages.count, count)
+        XCTAssertEqual(harness.appState.messages.first?.content, "Row 0 \(filler)")
+        XCTAssertEqual(harness.appState.messages.last?.content, "Row \(count - 1) \(filler)")
+    }
+
+    func testHistoryFailureSurfacesWithoutLegacyFallback() async throws {
+        let recorder = ResumeCallRecorder()
+        let active = session("stored-a")
+        let harness = try makeHarness(
+            openSession: { _, sessionID, compact in
+                recorder.record(sessionID: sessionID, compact: compact)
+                return SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                // An unrelated authentication failure on the history source.
+                .failed(DashboardTicketBridgeError.signInRequired)
+            }
+        )
+        harness.appState.sessions = [active]
+
+        let opened = await harness.appState.openSession("stored-a")
+
+        XCTAssertFalse(opened, "A history authentication failure must surface, not hide behind a legacy resume")
+        XCTAssertEqual(
+            recorder.calls.map { $0.compact },
+            [true],
+            "No silent legacy fallback may run for unrelated history failures"
+        )
+        XCTAssertTrue(
+            harness.appState.errorMessage?.contains("Dashboard sign-in has expired.") == true,
+            "The surfaced error should name the actual history failure, got: \(harness.appState.errorMessage ?? "nil")"
+        )
+    }
+
+    func testMalformedHistoryPayloadSurfacesWithoutLegacyFallback() async throws {
+        let recorder = ResumeCallRecorder()
+        let active = session("stored-a")
+        let harness = try makeHarness(
+            openSession: { _, sessionID, compact in
+                recorder.record(sessionID: sessionID, compact: compact)
+                return SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                // A 200 response without the expected messages array.
+                .payload(["session_id": "stored-a"])
+            }
+        )
+        harness.appState.sessions = [active]
+
+        let opened = await harness.appState.openSession("stored-a")
+
+        XCTAssertFalse(opened, "A malformed history payload must surface, not hide behind a legacy resume")
+        XCTAssertEqual(recorder.calls.map { $0.compact }, [true])
+        XCTAssertFalse(
+            harness.appState.errorMessage?.isEmpty ?? true,
+            "The parse failure should be visible to the user"
+        )
+    }
+
+    // MARK: - Unavailable-source classification
+
+    func testHistorySourceUnavailableClassificationMatchesOnlyUsableSourceGaps() {
+        // Structural endpoint gaps and a not-yet-usable bridge fall back to
+        // the legacy resume…
+        XCTAssertTrue(AppState.historySourceIsUnavailable(
+            DashboardTicketBridgeError.http(status: 404, detail: "Not Found")
+        ))
+        XCTAssertTrue(AppState.historySourceIsUnavailable(
+            DashboardTicketBridgeError.http(status: 410, detail: "Gone")
+        ))
+        XCTAssertTrue(AppState.historySourceIsUnavailable(
+            DashboardTicketBridgeError.http(status: 501, detail: "Not Implemented")
+        ))
+        XCTAssertTrue(AppState.historySourceIsUnavailable(DashboardTicketBridgeError.notReady))
+        // …while transient or environmental failures do not.
+        XCTAssertFalse(AppState.historySourceIsUnavailable(
+            DashboardTicketBridgeError.http(status: 500, detail: "Internal error")
+        ))
+        XCTAssertFalse(AppState.historySourceIsUnavailable(
+            DashboardTicketBridgeError.http(status: 0, detail: "network failure")
+        ))
+        XCTAssertFalse(AppState.historySourceIsUnavailable(DashboardTicketBridgeError.signInRequired))
+        XCTAssertFalse(AppState.historySourceIsUnavailable(
+            DashboardTicketBridgeError.requestFailed("Dashboard request failed (500).")
+        ))
+    }
+
+    // MARK: - Harness
+
+    private func makeHarness(
+        openSession: @escaping @MainActor (HermesClient, String, Bool) async throws -> SessionResumeResult,
+        persistedTranscript: (@MainActor (String, String) async -> PersistedTranscriptFetchOutcome)? = nil
+    ) throws -> (appState: AppState, defaults: UserDefaults) {
+        let suite = "CompactResumeTranscriptTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            throw FixtureError.unusableSuite
+        }
+        addTeardownBlock { defaults.removePersistentDomain(forName: suite) }
+        let cacheSuite = suite + ".cache"
+        guard let cacheDefaults = UserDefaults(suiteName: cacheSuite) else {
+            throw FixtureError.unusableSuite
+        }
+        addTeardownBlock { cacheDefaults.removePersistentDomain(forName: cacheSuite) }
+
+        let store = ChatResumeStore(defaults: defaults)
+        let appState = AppState(
+            defaults: defaults,
+            chatResumeCoordinator: ChatResumeCoordinator(store: store),
+            recoverySequence: ChatResumeRecoverySequence(),
+            loadSavedConnection: false,
+            clearSessionPresentationCache: {},
+            chatResumeLifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: openSession,
+                persistedTranscript: persistedTranscript,
+                refreshContext: { _, _ in }
+            ),
+            sessionPresentationCache: SessionPresentationCache(defaults: cacheDefaults)
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        appState.connection = connection
+        appState.client = HermesClient(connection: connection, profile: "default")
+        return (appState, defaults)
+    }
+
+    private func session(
+        _ id: String,
+        alternateIDs: [String] = []
+    ) -> SessionSummary {
+        SessionSummary(
+            id: id,
+            alternateIds: alternateIDs,
+            title: id,
+            model: "Hermes",
+            updatedLabel: "now",
+            profile: "default",
+            source: .chat,
+            isActive: false,
+            isArchived: false,
+            lineageRootId: nil
+        )
+    }
+}

--- a/ConduitTests/CompactResumeTranscriptTests.swift
+++ b/ConduitTests/CompactResumeTranscriptTests.swift
@@ -278,13 +278,199 @@ final class CompactResumeTranscriptTests: XCTestCase {
         )
     }
 
-    func testLegacyFallbackHydratesSessionExceedingTransportBound() async throws {
-        // The issue-sanctioned legacy fallback (history source unavailable)
-        // must deterministically hydrate a transcript far larger than the new
-        // 4 MiB socket bound as well: the durable rows arrive through the
-        // fallback resume, and the assertion proves the fixture really is
-        // bigger than the transport bound without pushing traffic over a
-        // live WebSocket.
+    /// Drives one reconciliation against a history source that fails with
+    /// `failure` and asserts the transient-failure contract: the session
+    /// still opens via exactly one legacy resume, and the fallback can never
+    /// cascade (the legacy call itself never triggers a second one).
+    private func assertTransientHistoryFailureFallsBackExactlyOnce(
+        _ failure: Error,
+        expectedLegacyContent: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let recorder = ResumeCallRecorder()
+        let active = session("stored-transient")
+        let harness = try makeHarness(
+            openSession: { _, sessionID, compact in
+                recorder.record(sessionID: sessionID, compact: compact)
+                if compact {
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                }
+                return SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: [
+                        ChatMessage(
+                            id: "legacy-1",
+                            role: .assistant,
+                            content: expectedLegacyContent,
+                            timestamp: "2026-09-01T08:00:00Z"
+                        )
+                    ],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in .failed(failure) }
+        )
+        harness.appState.sessions = [active]
+
+        let opened = await harness.appState.openSession("stored-transient")
+
+        XCTAssertTrue(opened, "\(failure) must fall back instead of failing the resume", file: file, line: line)
+        XCTAssertEqual(
+            recorder.calls.map { $0.compact },
+            [true, false],
+            "\(failure) must trigger exactly one legacy resume",
+            file: file,
+            line: line
+        )
+        XCTAssertEqual(
+            harness.appState.messages.map { $0.content },
+            [expectedLegacyContent],
+            file: file,
+            line: line
+        )
+    }
+
+    func testTransientHistoryFailuresFallBackExactlyOnce() async throws {
+        // 429 / 5xx / status-0 WebKit failures / bridge readiness-timeout are
+        // temporary availability problems: preserve session access through
+        // exactly one legacy resume instead of failing the restore.
+        let transientFailures: [Error] = [
+            DashboardTicketBridgeError.http(status: 429, detail: "Too Many Requests"),
+            DashboardTicketBridgeError.http(status: 500, detail: "Internal error"),
+            DashboardTicketBridgeError.http(status: 503, detail: "Service Unavailable"),
+            DashboardTicketBridgeError.http(status: 0, detail: "Failed to fetch"),
+            DashboardTicketBridgeError.notReady,
+        ]
+        for failure in transientFailures {
+            try await assertTransientHistoryFailureFallsBackExactlyOnce(
+                failure,
+                expectedLegacyContent: "Legacy transcript"
+            )
+        }
+    }
+
+    func testStructuralHistoryEndpointGapsFallBackExactlyOnce() async throws {
+        // Gateways predating the history endpoint fall back cleanly as well.
+        for status in [404, 410, 501] {
+            try await assertTransientHistoryFailureFallsBackExactlyOnce(
+                DashboardTicketBridgeError.http(status: status, detail: "missing endpoint"),
+                expectedLegacyContent: "Legacy transcript"
+            )
+        }
+    }
+
+    func testDelayedHistoryHydrationAvoidsLegacyResume() async throws {
+        // A history source that is not usable at the instant reconciliation
+        // starts but becomes usable inside the bounded readiness window
+        // hydrates normally — the legacy resume must not fire.
+        let recorder = ResumeCallRecorder()
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let harness = try makeHarness(
+            openSession: { _, sessionID, compact in
+                recorder.record(sessionID: sessionID, compact: compact)
+                return SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                try? await Task.sleep(for: .milliseconds(150))
+                return .payload([
+                    "session_id": "stored-a",
+                    "messages": [[
+                        "id": 1,
+                        "role": "user",
+                        "content": "Late hydration",
+                        "timestamp": "2026-09-01T10:00:00Z"
+                    ]]
+                ])
+            }
+        )
+        harness.appState.sessions = [active]
+
+        let opened = await harness.appState.openSession("stored-a")
+
+        XCTAssertTrue(opened)
+        XCTAssertEqual(
+            recorder.calls.map { $0.compact },
+            [true],
+            "Hydration that succeeds inside the bounded window must not trigger the legacy resume"
+        )
+        XCTAssertEqual(harness.appState.messages.first?.content, "Late hydration")
+    }
+
+    func testColdDashboardBridgeStillBeginsWithCompactResume() async throws {
+        // Regression for the cold-launch hole: a dashboard bridge that exists
+        // but is not ready yet must NOT push the resume onto the legacy
+        // full-transcript path immediately. The resume begins compact, the
+        // transcript fetch waits inside requestJSON's bounded readiness poll,
+        // and a bridge that never becomes usable degrades to exactly one
+        // legacy resume. A modern gateway therefore never receives a legacy
+        // full-transcript request just because the bridge was cold.
+        let recorder = ResumeCallRecorder()
+        let active = session("stored-cold")
+        let harness = try makeHarness(
+            openSession: { _, sessionID, compact in
+                recorder.record(sessionID: sessionID, compact: compact)
+                return SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: [
+                        ChatMessage(
+                            id: "restored",
+                            role: .assistant,
+                            content: "Restored",
+                            timestamp: "1"
+                        )
+                    ],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            additionalOperations: { ops in
+                ops.connectClient = { _ in }
+                ops.loadCatalog = { _, _ in [active] }
+                ops.loadProfiles = {}
+                ops.loadBusyInputMode = { _ in }
+                ops.loadProfileDisplayPreferences = {}
+                ops.loadSlashCommands = {}
+            }
+        )
+        harness.coordinator.rememberSessionID(active.id, for: "default")
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+
+        await harness.appState.connect(
+            with: HermesConnection(baseUrl: "https://one.example", ticket: "cold-ticket")
+        )
+
+        XCTAssertTrue(harness.appState.isConnected)
+        XCTAssertEqual(
+            recorder.calls.map { $0.compact },
+            [true, false],
+            "A cold bridge must begin compact and fall back to at most one legacy resume"
+        )
+        XCTAssertEqual(harness.appState.messages.map { $0.content }, ["Restored"])
+    }
+
+    func testLegacyFallbackMergeHandlesLargeTranscriptAtAppStateLevel() async throws {
+        // AppState-merge-level scope ONLY: this injects a large transcript
+        // through the lifecycle seam, bypassing HermesClient, JSON-RPC
+        // serialization, and URLSessionWebSocketTask entirely. It proves the
+        // reconciliation and merge layers handle a big transcript without
+        // duplication — it makes NO claim about transport size.
+        //
+        // Transport bound: a legacy resume response larger than the 4 MiB
+        // `URLSessionWebSocketTask.maximumMessageSize` cannot traverse the
+        // socket at all (verified by
+        // HermesClientTests/testProductionTransportRaisesWebSocketMessageLimit).
+        // The supported path for transcripts of that scale is the compact
+        // resume + REST hydration
+        // (testLargeSessionResumeShipsNoTranscriptOverWebSocket).
         let filler = String(repeating: "x", count: 10_000)
         let recorder = ResumeCallRecorder()
         let count = 450
@@ -296,9 +482,11 @@ final class CompactResumeTranscriptTests: XCTestCase {
                 timestamp: "2026-09-01T10:\(String(format: "%02d", index % 60)):00Z"
             )
         }
+        // The fixture is deliberately large so any row loss or duplication in
+        // the merge path is observable at scale.
         let payloadBytes = legacyMessages
             .reduce(0) { $0 + $1.content.utf8.count }
-        XCTAssertGreaterThan(payloadBytes, 4 * 1024 * 1024, "The fixture must exceed the new transport bound")
+        XCTAssertGreaterThan(payloadBytes, 4 * 1024 * 1024)
 
         let active = session("stored-gateway-old")
         let harness = try makeHarness(
@@ -394,29 +582,41 @@ final class CompactResumeTranscriptTests: XCTestCase {
 
     // MARK: - Unavailable-source classification
 
-    func testHistorySourceUnavailableClassificationMatchesOnlyUsableSourceGaps() {
-        // Structural endpoint gaps and a not-yet-usable bridge fall back to
-        // the legacy resume…
+    func testHistorySourceUnavailableClassification() {
+        // Structural endpoint gaps fall back to the legacy resume…
+        for status in [404, 410, 501] {
+            XCTAssertTrue(
+                AppState.historySourceIsUnavailable(
+                    DashboardTicketBridgeError.http(status: status, detail: "missing")
+                ),
+                "status \(status) must be classified as unavailable"
+            )
+        }
+        // …as do transient availability problems: rate limiting, any 5xx,
+        // status-0 WebKit/network failures, and a bridge (or request) that
+        // outlived its bounded readiness strategy.
         XCTAssertTrue(AppState.historySourceIsUnavailable(
-            DashboardTicketBridgeError.http(status: 404, detail: "Not Found")
+            DashboardTicketBridgeError.http(status: 429, detail: "Too Many Requests")
         ))
+        for status in [500, 502, 503, 504] {
+            XCTAssertTrue(
+                AppState.historySourceIsUnavailable(
+                    DashboardTicketBridgeError.http(status: status, detail: "server error")
+                ),
+                "status \(status) must be classified as unavailable"
+            )
+        }
         XCTAssertTrue(AppState.historySourceIsUnavailable(
-            DashboardTicketBridgeError.http(status: 410, detail: "Gone")
-        ))
-        XCTAssertTrue(AppState.historySourceIsUnavailable(
-            DashboardTicketBridgeError.http(status: 501, detail: "Not Implemented")
+            DashboardTicketBridgeError.http(status: 0, detail: "Failed to fetch")
         ))
         XCTAssertTrue(AppState.historySourceIsUnavailable(DashboardTicketBridgeError.notReady))
-        // …while transient or environmental failures do not.
-        XCTAssertFalse(AppState.historySourceIsUnavailable(
-            DashboardTicketBridgeError.http(status: 500, detail: "Internal error")
-        ))
-        XCTAssertFalse(AppState.historySourceIsUnavailable(
-            DashboardTicketBridgeError.http(status: 0, detail: "network failure")
-        ))
+        // Authentication and unclassified failures must surface instead.
         XCTAssertFalse(AppState.historySourceIsUnavailable(DashboardTicketBridgeError.signInRequired))
         XCTAssertFalse(AppState.historySourceIsUnavailable(
-            DashboardTicketBridgeError.requestFailed("Dashboard request failed (500).")
+            DashboardTicketBridgeError.http(status: 400, detail: "Bad Request")
+        ))
+        XCTAssertFalse(AppState.historySourceIsUnavailable(
+            DashboardTicketBridgeError.requestFailed("Could not encode dashboard request.")
         ))
     }
 
@@ -424,8 +624,9 @@ final class CompactResumeTranscriptTests: XCTestCase {
 
     private func makeHarness(
         openSession: @escaping @MainActor (HermesClient, String, Bool) async throws -> SessionResumeResult,
-        persistedTranscript: (@MainActor (String, String) async -> PersistedTranscriptFetchOutcome)? = nil
-    ) throws -> (appState: AppState, defaults: UserDefaults) {
+        persistedTranscript: (@MainActor (String, String) async -> PersistedTranscriptFetchOutcome)? = nil,
+        additionalOperations: (inout ChatResumeLifecycleOperations) -> Void = { _ in }
+    ) throws -> (appState: AppState, coordinator: ChatResumeCoordinator, defaults: UserDefaults) {
         let suite = "CompactResumeTranscriptTests.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suite) else {
             throw FixtureError.unusableSuite
@@ -437,24 +638,25 @@ final class CompactResumeTranscriptTests: XCTestCase {
         }
         addTeardownBlock { cacheDefaults.removePersistentDomain(forName: cacheSuite) }
 
-        let store = ChatResumeStore(defaults: defaults)
+        var operations = ChatResumeLifecycleOperations(
+            openSession: openSession,
+            persistedTranscript: persistedTranscript
+        )
+        additionalOperations(&operations)
+        let coordinator = ChatResumeCoordinator(store: ChatResumeStore(defaults: defaults))
         let appState = AppState(
             defaults: defaults,
-            chatResumeCoordinator: ChatResumeCoordinator(store: store),
+            chatResumeCoordinator: coordinator,
             recoverySequence: ChatResumeRecoverySequence(),
             loadSavedConnection: false,
             clearSessionPresentationCache: {},
-            chatResumeLifecycleOperations: ChatResumeLifecycleOperations(
-                openSession: openSession,
-                persistedTranscript: persistedTranscript,
-                refreshContext: { _, _ in }
-            ),
+            chatResumeLifecycleOperations: operations,
             sessionPresentationCache: SessionPresentationCache(defaults: cacheDefaults)
         )
         let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
         appState.connection = connection
         appState.client = HermesClient(connection: connection, profile: "default")
-        return (appState, defaults)
+        return (appState, coordinator, defaults)
     }
 
     private func session(

--- a/ConduitTests/CrossProfilePresentationCacheTests.swift
+++ b/ConduitTests/CrossProfilePresentationCacheTests.swift
@@ -148,7 +148,7 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
                 (client.profile ?? "default") == "work" ? workCatalog : []
             },
             mintTicket: { _ in "profile-ticket" },
-            openSession: { client, sessionID in
+            openSession: { client, sessionID, _ in
                 SessionResumeResult(
                     sessionId: sessionID,
                     messages: openMessages(client),
@@ -339,7 +339,7 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
                 connectClient: { _ in },
                 loadCatalog: { _, _ in [self.session(fixtures.session.id, profile: "work")] },
                 mintTicket: { _ in "connect-ticket" },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     SessionResumeResult(
                         sessionId: sessionID,
                         messages: fixtures.messages,
@@ -397,7 +397,7 @@ final class CrossProfilePresentationCacheTests: XCTestCase {
                 connectClient: { _ in throw ForcedSwitchFailure() },
                 loadCatalog: { _, _ in [self.session(fixtures.session.id, profile: "work")] },
                 mintTicket: { _ in "profile-ticket" },
-                openSession: { _, sessionID in
+                openSession: { _, sessionID, _ in
                     SessionResumeResult(
                         sessionId: sessionID,
                         messages: fixtures.messages,

--- a/ConduitTests/HermesClientTests.swift
+++ b/ConduitTests/HermesClientTests.swift
@@ -176,7 +176,157 @@ final class HermesClientTests: XCTestCase {
         client.disconnect()
     }
 
+    // MARK: - session.resume transport bound (issue #106)
+
+    func testProductionTransportRaisesWebSocketMessageLimit() {
+        // URLSessionWebSocketTask's platform default receive limit closes the
+        // socket with close code 1009 as soon as a single message exceeds it,
+        // which is how resuming large sessions used to disconnect Conduit in
+        // a loop. The production transport must install the explicit bounded
+        // 4 MiB limit on the real socket.
+        let transport = URLSessionWebSocketTransport()
+        defer { transport.invalidate() }
+        let request = URLRequest(url: URL(string: "wss://gateway.example/api/ws")!)
+        let socket = transport.makeSocket(
+            request: request,
+            onOpen: { _ in },
+            onCloseBeforeOpen: { _ in }
+        )
+
+        let task = socket as? URLSessionWebSocketTask
+        XCTAssertNotNil(task, "The production transport must produce a URLSessionWebSocketTask")
+        XCTAssertEqual(task?.maximumMessageSize, URLSessionWebSocketTransport.maximumMessageSize)
+        XCTAssertEqual(URLSessionWebSocketTransport.maximumMessageSize, 4 * 1024 * 1024)
+        XCTAssertNotEqual(
+            URLSessionWebSocketTransport.maximumMessageSize,
+            1_048_576,
+            "The limit must not remain at the platform default"
+        )
+    }
+
+    func testOpenSessionRequestsCompactResumeWithoutTranscriptPayload() async throws {
+        let transport = FakeTransport()
+        let socket = FakeSocket()
+        transport.nextSocket = { socket }
+        let client = makeClient(transport: transport)
+        let connectTask = Task { try? await client.connect() }
+        transport.open(socket)
+        try await awaitCompletion(of: connectTask, "connect() to complete after the handshake")
+
+        let sent = Gate()
+        socket.onSend = { sent.signal() }
+        let openTask = Task<SessionResumeResult, Error> { try await client.openSession("sess-large") }
+        try await sent.wait("the session.resume request to be sent")
+
+        let request = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(try XCTUnwrap(socket.sentTexts.last).utf8)) as? [String: Any]
+        )
+        XCTAssertEqual(request["method"] as? String, "session.resume")
+        let params = try XCTUnwrap(request["params"] as? [String: Any])
+        XCTAssertEqual(params["session_id"] as? String, "sess-large")
+        XCTAssertEqual(
+            params["omit_messages"] as? Bool,
+            true,
+            "The compact resume must ask the gateway to omit the persisted transcript"
+        )
+        XCTAssertEqual(params["cols"] as? Int, 96)
+        XCTAssertEqual(params["source"] as? String, "desktop")
+
+        let id = try XCTUnwrap(request["id"] as? Int)
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": [
+                "session_id": "sess-large",
+                "messages": [Any](),
+                "info": ["running": false]
+            ]
+        ]
+        socket.deliver(String(data: try JSONSerialization.data(withJSONObject: response), encoding: .utf8)!)
+
+        let result = try await awaitResult(of: openTask, "the compact session.resume response")
+        XCTAssertTrue(result.messages.isEmpty, "The compact response must carry no transcript")
+        XCTAssertEqual(result.sessionId, "sess-large")
+        client.disconnect()
+    }
+
+    func testOpenSessionLegacyCarriesTranscriptInResponse() async throws {
+        let transport = FakeTransport()
+        let socket = FakeSocket()
+        transport.nextSocket = { socket }
+        let client = makeClient(transport: transport)
+        let connectTask = Task { try? await client.connect() }
+        transport.open(socket)
+        try await awaitCompletion(of: connectTask, "connect() to complete after the handshake")
+
+        let sent = Gate()
+        socket.onSend = { sent.signal() }
+        let openTask = Task<SessionResumeResult, Error> { try await client.openSessionLegacy("sess-full") }
+        try await sent.wait("the legacy session.resume request to be sent")
+
+        let request = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(try XCTUnwrap(socket.sentTexts.last).utf8)) as? [String: Any]
+        )
+        let params = try XCTUnwrap(request["params"] as? [String: Any])
+        XCTAssertEqual(params["session_id"] as? String, "sess-full")
+        XCTAssertNil(params["omit_messages"], "The legacy resume must not suppress the transcript")
+
+        let id = try XCTUnwrap(request["id"] as? Int)
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": [
+                "session_id": "sess-full",
+                "messages": [
+                    ["role": "user", "content": "Hello", "timestamp": "2026-09-01T10:00:00Z"],
+                    ["role": "assistant", "content": "Hi there", "timestamp": "2026-09-01T10:00:05Z"]
+                ],
+                "info": ["running": false]
+            ]
+        ]
+        socket.deliver(String(data: try JSONSerialization.data(withJSONObject: response), encoding: .utf8)!)
+
+        let result = try await awaitResult(of: openTask, "the legacy session.resume response")
+        XCTAssertEqual(result.messages.map({ $0.role }), [.user, .assistant])
+        XCTAssertEqual(result.messages.first?.content, "Hello")
+        XCTAssertEqual(result.messages.first?.timestamp, "2026-09-01T10:00:00Z")
+        client.disconnect()
+    }
+
     // MARK: - Helpers
+
+    private final class ResultBox<T>: @unchecked Sendable {
+        var value: Result<T, Error>?
+    }
+
+    /// Bounded wait for a spawned throwing task, returning its result. The
+    /// Task-side counterpart of `Gate.wait`: a wedged phase fails the
+    /// test naming `phase` instead of suspending forever.
+    private func awaitResult<T>(
+        of task: Task<T, Error>,
+        _ phase: String,
+        timeout: TimeInterval = 10,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws -> T {
+        let finished = Gate()
+        let box = ResultBox<T>()
+        let watcher = Task<Void, Never>.detached(priority: .userInitiated) {
+            do {
+                box.value = .success(try await task.value)
+            } catch {
+                box.value = .failure(error)
+            }
+            finished.signal()
+        }
+        defer { watcher.cancel() }
+        try await finished.wait(phase, timeout: timeout, file: file, line: line)
+        guard let stored = box.value else {
+            XCTFail("Expected a result for \(phase)", file: file, line: line)
+            throw TestSyncTimedOut(phase: phase)
+        }
+        return try stored.get()
+    }
 
     private func makeClient(transport: FakeTransport) -> HermesClient {
         HermesClient(
@@ -309,6 +459,10 @@ private final class FakeSocket: HermesWebSocket {
     private(set) var resumed = false
     var onResume: (() -> Void)?
     var onReceivePending: (() -> Void)?
+    private(set) var sentTexts: [String] = []
+    /// Signalled after each outbound text frame so tests can await the
+    /// JSON-RPC request before answering it.
+    var onSend: (() -> Void)?
 
     private var receiveContinuation: CheckedContinuation<URLSessionWebSocketTask.Message, Error>?
 
@@ -329,6 +483,10 @@ private final class FakeSocket: HermesWebSocket {
     }
 
     func send(_ message: URLSessionWebSocketTask.Message, completionHandler: @escaping @Sendable (Error?) -> Void) {
+        if case .string(let text) = message {
+            sentTexts.append(text)
+            onSend?()
+        }
         completionHandler(nil)
     }
 

--- a/ConduitTests/HermesClientTests.swift
+++ b/ConduitTests/HermesClientTests.swift
@@ -204,6 +204,18 @@ final class HermesClientTests: XCTestCase {
         )
     }
 
+    func testLegacyResumeUsesDedicatedTimeoutBudget() {
+        // The legacy full-transcript resume carries the largest ordinary
+        // payload in the app, so it gets the bounded-but-generous 60 s
+        // budget; the compact resume rides the ordinary 30 s request
+        // timeout (issue #106 follow-up).
+        XCTAssertEqual(HermesClient.resumeTimeout(omitMessages: true), HermesClient.requestTimeout)
+        XCTAssertEqual(HermesClient.requestTimeout, 30)
+        XCTAssertEqual(HermesClient.resumeTimeout(omitMessages: false), HermesClient.legacyResumeTimeout)
+        XCTAssertEqual(HermesClient.legacyResumeTimeout, 60)
+        XCTAssertGreaterThan(HermesClient.legacyResumeTimeout, HermesClient.requestTimeout)
+    }
+
     func testOpenSessionRequestsCompactResumeWithoutTranscriptPayload() async throws {
         let transport = FakeTransport()
         let socket = FakeSocket()

--- a/ConduitTests/SessionYoloPersistenceTests.swift
+++ b/ConduitTests/SessionYoloPersistenceTests.swift
@@ -229,7 +229,7 @@ final class SessionYoloPersistenceTests: XCTestCase {
         let openGate = SessionYoloResumeGate()
         let operations = ChatResumeLifecycleOperations(
             loadCatalog: { _, _ in [self.session("session-a")] },
-            openSession: { _, sessionID in
+            openSession: { _, sessionID, _ in
                 await openGate.suspend()
                 return SessionResumeResult(
                     sessionId: sessionID,
@@ -282,7 +282,7 @@ final class SessionYoloPersistenceTests: XCTestCase {
         let recorder = YoloSetCallRecorder()
         let operations = ChatResumeLifecycleOperations(
             loadCatalog: { _, _ in [self.session("session-a")] },
-            openSession: { _, sessionID in
+            openSession: { _, sessionID, _ in
                 await openGate.suspend()
                 return SessionResumeResult(
                     sessionId: sessionID,
@@ -340,7 +340,7 @@ final class SessionYoloPersistenceTests: XCTestCase {
         let openGate = SessionYoloResumeGate()
         let operations = ChatResumeLifecycleOperations(
             loadCatalog: { _, _ in [self.session("session-a")] },
-            openSession: { _, sessionID in
+            openSession: { _, sessionID, _ in
                 await openGate.suspend()
                 return SessionResumeResult(
                     sessionId: sessionID,
@@ -485,7 +485,7 @@ final class SessionYoloPersistenceTests: XCTestCase {
         let recorder = YoloSetCallRecorder()
         let operations = ChatResumeLifecycleOperations(
             loadCatalog: { _, _ in [self.session("session-a")] },
-            openSession: { _, sessionID in
+            openSession: { _, sessionID, _ in
                 SessionResumeResult(
                     sessionId: sessionID,
                     messages: [],
@@ -523,7 +523,7 @@ final class SessionYoloPersistenceTests: XCTestCase {
         let recorder = YoloSetCallRecorder()
         let operations = ChatResumeLifecycleOperations(
             loadCatalog: { _, _ in [self.session("session-a")] },
-            openSession: { _, sessionID in
+            openSession: { _, sessionID, _ in
                 SessionResumeResult(
                     sessionId: sessionID,
                     messages: [],
@@ -561,7 +561,7 @@ final class SessionYoloPersistenceTests: XCTestCase {
         let recorder = YoloSetCallRecorder()
         let operations = ChatResumeLifecycleOperations(
             loadCatalog: { _, _ in [self.session("session-a")] },
-            openSession: { _, sessionID in
+            openSession: { _, sessionID, _ in
                 SessionResumeResult(
                     sessionId: sessionID,
                     messages: [],
@@ -598,7 +598,7 @@ final class SessionYoloPersistenceTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suite) }
         let operations = ChatResumeLifecycleOperations(
             loadCatalog: { _, _ in [self.session("session-a")] },
-            openSession: { _, sessionID in
+            openSession: { _, sessionID, _ in
                 SessionResumeResult(
                     sessionId: sessionID,
                     messages: [],
@@ -641,7 +641,7 @@ final class SessionYoloPersistenceTests: XCTestCase {
         let recorder = YoloSetCallRecorder()
         let operations = ChatResumeLifecycleOperations(
             loadCatalog: { _, _ in [self.session("session-a")] },
-            openSession: { _, sessionID in
+            openSession: { _, sessionID, _ in
                 SessionResumeResult(
                     sessionId: sessionID,
                     messages: [],
@@ -731,7 +731,7 @@ final class SessionYoloPersistenceTests: XCTestCase {
         let recorder = YoloSetCallRecorder()
         let operations = ChatResumeLifecycleOperations(
             loadCatalog: { _, _ in [self.session("session-a")] },
-            openSession: { _, sessionID in
+            openSession: { _, sessionID, _ in
                 SessionResumeResult(
                     sessionId: sessionID,
                     messages: [],
@@ -858,7 +858,7 @@ final class SessionYoloPersistenceTests: XCTestCase {
         let recorder = YoloSetCallRecorder()
         let operations = ChatResumeLifecycleOperations(
             loadCatalog: { _, _ in [self.session("session-a")] },
-            openSession: { _, sessionID in
+            openSession: { _, sessionID, _ in
                 SessionResumeResult(
                     sessionId: sessionID,
                     messages: [],
@@ -899,7 +899,7 @@ final class SessionYoloPersistenceTests: XCTestCase {
         let openGate = SessionYoloResumeGate()
         let operations = ChatResumeLifecycleOperations(
             loadCatalog: { _, _ in [self.session("session-a")] },
-            openSession: { _, sessionID in
+            openSession: { _, sessionID, _ in
                 await openGate.suspend()
                 return SessionResumeResult(
                     sessionId: sessionID,
@@ -959,7 +959,7 @@ final class SessionYoloPersistenceTests: XCTestCase {
         let recorder = YoloSetCallRecorder()
         let operations = ChatResumeLifecycleOperations(
             loadCatalog: { _, _ in [self.session("session-a")] },
-            openSession: { _, sessionID in
+            openSession: { _, sessionID, _ in
                 await openGate.suspend()
                 return SessionResumeResult(
                     sessionId: sessionID,
@@ -1014,7 +1014,7 @@ final class SessionYoloPersistenceTests: XCTestCase {
         let recorder = YoloSetCallRecorder()
         let operations = ChatResumeLifecycleOperations(
             loadCatalog: { _, _ in [self.session("session-a")] },
-            openSession: { _, sessionID in
+            openSession: { _, sessionID, _ in
                 SessionResumeResult(
                     sessionId: sessionID,
                     messages: [],
@@ -1087,7 +1087,7 @@ final class SessionYoloPersistenceTests: XCTestCase {
         let recorder = YoloSetCallRecorder()
         let operations = ChatResumeLifecycleOperations(
             loadCatalog: { _, _ in [self.session("session-a")] },
-            openSession: { _, sessionID in
+            openSession: { _, sessionID, _ in
                 await openGate.suspend()
                 return SessionResumeResult(
                     sessionId: sessionID,
@@ -1163,7 +1163,7 @@ final class SessionYoloPersistenceTests: XCTestCase {
             connectClient: { _ in },
             loadCatalog: { _, _ in [] },
             mintTicket: { _ in "profile-ticket" },
-            openSession: { _, sessionID in
+            openSession: { _, sessionID, _ in
                 SessionResumeResult(
                     sessionId: sessionID,
                     messages: [],
@@ -1244,7 +1244,7 @@ final class SessionYoloPersistenceTests: XCTestCase {
                 (client.profile ?? "default") == "work" ? [] : [self.session("persisted-a", alternateIDs: ["runtime-a"])]
             },
             mintTicket: { _ in "profile-ticket" },
-            openSession: { _, sessionID in
+            openSession: { _, sessionID, _ in
                 // Resume snapshots always report the gateway's forgotten
                 // flag; they never park - only the toggle RPC does.
                 recorder.record(sessionID, false)

--- a/ConduitTests/YoloProfileSwitchBookkeepingTests.swift
+++ b/ConduitTests/YoloProfileSwitchBookkeepingTests.swift
@@ -82,7 +82,7 @@ final class YoloProfileSwitchBookkeepingTests: XCTestCase {
             connectClient: { _ in },
             loadCatalog: { _, _ in [] },
             mintTicket: { _ in "profile-ticket" },
-            openSession: { _, sessionID in
+            openSession: { _, sessionID, _ in
                 SessionResumeResult(
                     sessionId: sessionID,
                     messages: [],
@@ -220,7 +220,7 @@ final class YoloProfileSwitchBookkeepingTests: XCTestCase {
             connectClient: { _ in },
             loadCatalog: { _, _ in [] },
             mintTicket: { _ in "profile-ticket" },
-            openSession: { _, sessionID in
+            openSession: { _, sessionID, _ in
                 SessionResumeResult(
                     sessionId: sessionID,
                     messages: [],


### PR DESCRIPTION
Fixes #106.

## Root cause

Two compounding problems on large sessions:

1. `URLSessionWebSocketTask` closed the connection with **1009 / message too big** as soon as a single incoming frame exceeded its platform-default (~1 MiB) `maximumMessageSize` — `URLSessionWebSocketTransport.makeSocket` never raised it.
2. `session.resume` shipped the **entire persisted transcript** in one frame, so opening a deep conversation reliably exceeded that limit → disconnect → tight reconnect loop (the blinking New Chat icon from the issue's gateway logs).

Upstream contract verified in NousResearch/hermes-agent: the gateway reads `omit_messages` via loose `params.get(...)` (`"messages": [] if omit_messages else …`), and Hermes Desktop sends `cols: 96, omit_messages: true`, hydrating the transcript over the authenticated REST route with the live projection rendered on top.

## Changes

- **Transport bound (defense-in-depth, kept unconditionally):** the production socket gets an explicit bounded `maximumMessageSize` of **4 MiB**. Not unbounded; transcript-sized payloads stay off the socket entirely via compact resume.
- **Compact resume:** `HermesClient.openSession` sends `omit_messages: true`. `AppState.reconcile` selects compact only when a **ready** history source exists (dashboard bridge `isReady`, or the test seam); a cold bridge or no bridge performs exactly one legacy resume, identical to pre-change behavior.
- **Hydration through the existing path:** the durable transcript still comes from the dashboard `/api/sessions/{id}/messages` route, parsed by the same production `MessageNormalizer` path; merge semantics (presentation cache, pending decision restoration, inflight projection via the streaming bubble, buffered-event dedup, YOLO/approvals/aliases, profile-switch ownership guards) are untouched.
- **Narrow compatibility fallback:** when the history source is *structurally unavailable* (404/410/501 — e.g. a gateway predating the endpoint), *not ready yet* (`notReady`), or resolves rows to a **foreign session identity**, Conduit performs exactly **one** legacy full-transcript re-resume (`openSessionLegacy`, no `omit_messages`). Older gateways also ignore the unknown flag outright (loose `params` reading upstream), a second safety net.
- **Failures surface:** auth (`signInRequired`), server errors, network failures, and malformed payloads **fail the resume loudly** instead of silently degrading — no broad fallback concealment.
- `DashboardTicketBridgeError` gained a typed `.http(status:detail:)` case so the unsupported-endpoint condition is recognized without string matching; `isReady` became `private(set)`.

## Compatibility notes

- Compact resume is **readiness-gated** rather than unconditional: gateways without the history endpoint (and cold bridges) take the legacy single-resume path, so their behavior is byte-identical to today's.
- Disclosed assumption: old gateways are assumed to ignore unknown `session.resume` params — verified against upstream handler sources (`params: dict` + `.get`). A hypothetical strictly-validating old gateway would fail loudly (JSON-RPC error surfaced), not loop.

## Known window (reviewed, accepted)

The legacy fallback required for gateways without a history source carries the transcript in the RPC response, whose size is bounded only by the 4 MiB socket limit — same as pre-change builds. This is the issue-sanctioned "one legacy resume" and cannot be avoided without violating the fallback requirement; it is documented in code and covered by a deterministic >4 MiB fallback regression test.

## Tests

New `CompactResumeTranscriptTests` (8): compact request + real-normalizer hydration, running-turn inflight preservation without duplication, deterministic large-session (>1 MiB old default) compact resume, unavailable→legacy fallback (asserts exactly one legacy re-resume), **>4 MiB legacy fallback hydration**, auth-failure and malformed-payload surfacing without fallback, and unavailable-source classification. `HermesClientTests` +3: 4 MiB transport limit on the real task, compact request params, legacy request params. `ChatResumeLifecycleOperations.openSession` seam gained the flavor flag (56 closures updated).

## Validation

- Focused suites + all session-resume/reconciliation suites: **pass**
- **Full Conduit suite via `ios_test`: 69/69 units, 9/9 batches, no hangs, no uncovered suites**
- Release-configuration simulator build: **BUILD SUCCEEDED**
- Pre-push multi-model review gate: **APPROVE WITH NITS, 0 blockers** (2 findings adjudicated above, nits applied)

🤖 Generated with Claude Code

---

## Follow-up (7433f07): review-findings hardening

Closes the remaining reliability gaps from the first review round without changing the architecture.

**Cold bridge readiness.** A bridge that exists but is not ready yet no longer selects the legacy full-transcript path. Compact resume always begins whenever a history source exists; `requestJSON`'s existing bounded readiness poll (30 × 100 ms) waits *inside the concurrent transcript fetch*, so the WebSocket resume is never delayed by the wait. A bridge that becomes usable within the window hydrates normally (no legacy resume); one that does not degrades to exactly one legacy resume. A >4 MiB session on a modern gateway therefore no longer immediately goes out as a full-transcript request that cannot fit the socket bound.

**History failure routing.** Exactly one legacy resume for: 404/410 (structural endpoint gap), 408/429/5xx (transient HTTP), status 0 (WebKit-level network/abort failures, including the 24 MiB response cap), and bridge readiness/deadline timeouts (`.notReady`). Surfaced, never concealed: 401/403 (`.signInRequired`), malformed successful payloads, and any unclassified error. Classification is centralized in `AppState.historySourceIsUnavailable(_:)` and applies identically to the bridge fetch and the test seam.

**Fallback is exactly once.** Structurally: one compact `openChatResumeSession` call, then a straight-line `switch` with a single legacy call site and a throwing failure path that never re-enters; every fallback test asserts `[true, false]` (and no test can observe a third call).

**Legacy resume timeout.** Dedicated `legacyResumeTimeout = 60 s` via `resumeTimeout(omitMessages:)` (compact keeps the ordinary 30 s budget), pinned by `testLegacyResumeUsesDedicatedTimeoutBudget`.

**>4 MiB test corrected.** The former `testLegacyFallbackHydratesSessionExceedingTransportBound` injected messages through the AppState seam — bypassing HermesClient, JSON-RPC, and URLSession — while implying transport coverage. Renamed to `testLegacyFallbackMergeHandlesLargeTranscriptAtAppStateLevel` with explicit scope documentation: it now asserts only AppState merge behavior, and states that a legacy WebSocket response > 4 MiB cannot traverse the socket (the supported large-transcript path is compact resume + REST hydration). The real-transport 4 MiB test and the compact large-session regression remain.

**Tests added/updated:** transient-failure fallback loop (429/500/503/0/`notReady`), structural-gap loop (404/410/501), delayed-hydration success avoids legacy resume, cold-bridge compact-first via the real `connect()` flow, timeout budget pin, expanded classification matrix (incl. 408), and the updated cold-bridge expectation in the existing viewport-cancellation connect test.

**Validation:** focused suites pass; full Conduit suite **69/69 units, 9/9 batches** via `ios_test`; `plan-tests.py validate` OK; pre-push multi-model review gate on the full two-commit diff: **APPROVE WITH NITS, 0 blockers (3/3 reviewers)** — warnings addressed (timeout test pin, 408 classification), nits applied (isReady widening reverted, doc corrections).