### PR TITLE
feat(chat): add chat-only text size preference (#85)

### DIFF
--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -739,6 +739,7 @@ private struct ChatSettingsDetail: View {
             ),
             trailingSection: AnyView(
                 VStack(spacing: 14) {
+                    ChatTextSizeSettings()
                     ComposerReturnKeySettings()
                     DeviceHapticsSettings()
                 }
@@ -757,6 +758,61 @@ private struct ChatSettingsDetail: View {
         .init(key: "display.memory_notifications", label: "Self-improvement updates", help: "Choose whether Conduit follows Hermes, always shows, or never shows maintenance updates.", control: .labeledOptions([(value: "default", label: "Use Hermes default"), (value: "on", label: "Always show"), (value: "off", label: "Never show")], defaultValue: "default")),
         .init(key: "agent.image_input_mode", label: "Image attachments", help: "How Hermes supplies images to a model.", control: .options(["auto", "native", "text"], defaultValue: "auto")),
     ]
+}
+
+/// Local, device-only chat text-size preference (issue #85). Stored in
+/// UserDefaults via @AppStorage with the same lifetime as
+/// ComposerReturnKey — never part of the Hermes profile configuration and
+/// never synchronized anywhere. A five-position stepped slider: the change
+/// is live (the visible transcript re-renders as the slider moves), there
+/// is no Save button, and `Default` keeps today's appearance.
+private struct ChatTextSizeSettings: View {
+    @AppStorage(ChatTypography.preferenceKey) private var chatTextSizeRaw = ChatTypography.defaultSize.rawValue
+
+    private var selected: ChatTextSize {
+        ChatTypography.resolve(rawValue: chatTextSizeRaw)
+    }
+
+    var body: some View {
+        ConduitSettingsSection(
+            title: "Chat text size",
+            symbol: "textformat.size",
+            tint: .conduitAura
+        ) {
+            Text("Readable conversation content only — messages, lists, tables, and code. Buttons, timestamps, and the rest of the interface keep their size, and iOS Dynamic Type still applies on top.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("A")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
+                    Spacer()
+                    Text("A")
+                        .font(.system(size: 22, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
+                }
+                Slider(
+                    value: Binding(
+                        get: { Double(selected.rawValue) },
+                        set: { chatTextSizeRaw = Int($0.rounded()) }
+                    ),
+                    in: 0...Double(ChatTextSize.allCases.count - 1),
+                    step: 1
+                )
+                .tint(.conduitAccent)
+                .accessibilityLabel("Chat text size")
+                .accessibilityValue(selected.displayName)
+                .accessibilityHint("Five steps from smallest to largest. Applies to conversation text immediately.")
+                Text(selected.displayName)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            }
+        }
+    }
 }
 
 /// Local, device-only composer input preference. Stored in UserDefaults via

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -1409,6 +1409,11 @@ struct SystemBubble: View {
     }
 }
 
+/// Review activity summary. Intentionally OUTSIDE the chat text-size
+/// preference (issue #85): these status/activity cards — like tool cards —
+/// are not ordinary transcript Markdown and keep their fixed typography.
+/// (Of the system-message surfaces, only `SystemBubble`'s Markdown body
+/// follows `ChatTypography`.)
 private struct ReviewSummaryCard: View {
     let activity: ReviewActivity
     let timestamp: String
@@ -1489,6 +1494,9 @@ private struct ReviewSummaryCard: View {
     }
 }
 
+/// Model-change summary. Intentionally OUTSIDE the chat text-size
+/// preference (issue #85) — a status/activity card with fixed typography;
+/// see ReviewSummaryCard.
 private struct ModelChangeSummaryCard: View {
     let model: String
     let provider: String

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -96,6 +96,18 @@ struct ChatView: View {
         viewport.renderedScrollScope
     }
 
+    /// The chat-only text-size preference (issue #85). Local, device-only
+    /// @AppStorage like ComposerReturnKey — never synced to Hermes or the
+    /// profile. Injected once here so every transcript Markdown path
+    /// (settled, streaming, large-document, tables, code) resolves the same
+    /// typography, while non-chat subtrees keep the `.default` environment
+    /// value and today's appearance.
+    @AppStorage(ChatTypography.preferenceKey) private var chatTextSizeRaw = ChatTypography.defaultSize.rawValue
+
+    private var chatTextSize: ChatTextSize {
+        ChatTypography.resolve(rawValue: chatTextSizeRaw)
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             // Message list
@@ -115,6 +127,7 @@ struct ChatView: View {
             // Composer + control bar
             ComposerBar()
         }
+        .environment(\.chatTextSize, chatTextSize)
         .background(Color.clear)
         .overlay(alignment: .top) {
             if appState.isOpeningNotificationSession {
@@ -881,6 +894,7 @@ struct UserBubble: View {
     let message: ChatMessage
     let gatewayResolver: GatewayMediaDataURLResolver?
     @Environment(\.sizeCategory) private var sizeCategory
+    @Environment(\.chatTextSize) private var chatTextSize
 
     var body: some View {
         HStack {
@@ -889,7 +903,8 @@ struct UserBubble: View {
                 UserMessageContent(
                     message: message,
                     gatewayResolver: gatewayResolver,
-                    sizeCategory: sizeCategory
+                    sizeCategory: sizeCategory,
+                    chatTextSize: chatTextSize
                 )
                     .equatable()
 
@@ -903,17 +918,23 @@ struct UserBubble: View {
 /// Settled user-row content: Markdown plus attachment previews. Equatable
 /// over the message and the stable gateway resolver so streaming publishes
 /// cannot re-evaluate it (same contract as
-/// SettledAssistantMessageContent).
-private struct UserMessageContent: View, Equatable {
+/// SettledAssistantMessageContent). Internal (not private) so the gate
+/// contract is directly testable.
+struct UserMessageContent: View, Equatable {
     let message: ChatMessage
     let gatewayResolver: GatewayMediaDataURLResolver?
     /// Explicit Dynamic Type input — see SettledAssistantMessageContent.
     let sizeCategory: ContentSizeCategory
+    /// Explicit chat text-size input (issue #85): a preference change must
+    /// re-open the gate and re-render, while ordinary streaming publishes —
+    /// which leave both explicit inputs equal — keep the isolation.
+    let chatTextSize: ChatTextSize
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.message == rhs.message
             && lhs.gatewayResolver === rhs.gatewayResolver
             && lhs.sizeCategory == rhs.sizeCategory
+            && lhs.chatTextSize == rhs.chatTextSize
     }
 
     var body: some View {
@@ -1162,6 +1183,11 @@ struct SettledAssistantMessageContent: View, Equatable {
     /// UIKit trait collections, layout direction through TextKit — and do
     /// not require body re-evaluation.
     let sizeCategory: ContentSizeCategory
+    /// Explicit chat text-size input (issue #85): equality describes every
+    /// typography input, so a preference change re-opens the gate and
+    /// re-renders (the render cache keys on the chat-size identity), while
+    /// unrelated streaming publishes — equal inputs — stay gated.
+    let chatTextSize: ChatTextSize
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.message == rhs.message
@@ -1169,6 +1195,7 @@ struct SettledAssistantMessageContent: View, Equatable {
             && lhs.avatarURL == rhs.avatarURL
             && lhs.gatewayResolver === rhs.gatewayResolver
             && lhs.sizeCategory == rhs.sizeCategory
+            && lhs.chatTextSize == rhs.chatTextSize
     }
 
     var body: some View {
@@ -1308,6 +1335,7 @@ struct AssistantBubble: View {
     let gatewayResolver: GatewayMediaDataURLResolver?
     @EnvironmentObject var appState: AppState
     @Environment(\.sizeCategory) private var sizeCategory
+    @Environment(\.chatTextSize) private var chatTextSize
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -1316,7 +1344,8 @@ struct AssistantBubble: View {
                 displayName: appState.profileDisplayName(appState.activeProfile),
                 avatarURL: appState.profileAvatarURL(for: appState.activeProfile),
                 gatewayResolver: gatewayResolver,
-                sizeCategory: sizeCategory
+                sizeCategory: sizeCategory,
+                chatTextSize: chatTextSize
             )
             .equatable()
 
@@ -1501,13 +1530,16 @@ private struct ModelChangeSummaryCard: View {
 
 /// Settled reasoning-row content, gated the same way as assistant/user
 /// content: identical presentation inputs skip body evaluation during
-/// unrelated AppState publishes.
-private struct SettledThinkingCardContent: View, Equatable {
+/// unrelated AppState publishes. Internal (not private) so the gate
+/// contract is directly testable.
+struct SettledThinkingCardContent: View, Equatable {
     let message: ChatMessage
     let displayName: String
     let avatarURL: URL?
     /// Explicit Dynamic Type input — see SettledAssistantMessageContent.
     let sizeCategory: ContentSizeCategory
+    /// Explicit chat text-size input — see SettledAssistantMessageContent.
+    let chatTextSize: ChatTextSize
     @State private var expanded = false
 
     static func == (lhs: Self, rhs: Self) -> Bool {
@@ -1515,6 +1547,7 @@ private struct SettledThinkingCardContent: View, Equatable {
             && lhs.displayName == rhs.displayName
             && lhs.avatarURL == rhs.avatarURL
             && lhs.sizeCategory == rhs.sizeCategory
+            && lhs.chatTextSize == rhs.chatTextSize
     }
 
     var body: some View {
@@ -1527,7 +1560,7 @@ private struct SettledThinkingCardContent: View, Equatable {
             DisclosureGroup(isExpanded: $expanded) {
                 SelectableTextView(
                     text: message.content,
-                    font: .preferredFont(forTextStyle: .callout),
+                    font: ChatTypography.font(for: .thinking, chatSize: chatTextSize),
                     textColor: .secondaryLabel
                 )
                     .padding(.top, 4)
@@ -1553,6 +1586,7 @@ struct ThinkingCard: View {
     let message: ChatMessage
     @EnvironmentObject var appState: AppState
     @Environment(\.sizeCategory) private var sizeCategory
+    @Environment(\.chatTextSize) private var chatTextSize
 
     var body: some View {
         if appState.displayPreferences.showReasoning, !message.content.isEmpty {
@@ -1560,7 +1594,8 @@ struct ThinkingCard: View {
                 message: message,
                 displayName: appState.profileDisplayName(appState.activeProfile),
                 avatarURL: appState.profileAvatarURL(for: appState.activeProfile),
-                sizeCategory: sizeCategory
+                sizeCategory: sizeCategory,
+                chatTextSize: chatTextSize
             )
             .equatable()
         }

--- a/Conduit/Views/Components/ChatTypography.swift
+++ b/Conduit/Views/Components/ChatTypography.swift
@@ -157,13 +157,6 @@ enum ChatTypography {
         scaledFont(baseFont(for: role, compatibleWith: traits), chatSize: chatSize)
     }
 
-    /// The point size of a role's resolved font — for the few SwiftUI-native
-    /// Text/Image sites inside transcript content (list markers) that cannot
-    /// take a UIFont directly. Reads the live system size at call time.
-    static func pointSize(for role: Role, chatSize: ChatTextSize) -> CGFloat {
-        font(for: role, chatSize: chatSize).pointSize
-    }
-
     /// The unscaled (Dynamic Type only) base font for a role. Kept separate
     /// so `Default` resolution is exactly the historical font.
     static func baseFont(

--- a/Conduit/Views/Components/ChatTypography.swift
+++ b/Conduit/Views/Components/ChatTypography.swift
@@ -1,0 +1,230 @@
+//
+//  ChatTypography.swift
+//  Conduit
+//
+//  Central authority for transcript-content typography (issue #85).
+//
+//  The chat text-size preference is a local, device-only presentation
+//  setting backed by UserDefaults via @AppStorage (the same pattern as
+//  ComposerReturnKey). It is never synchronized to Hermes, profiles, the
+//  gateway, or any backend configuration.
+//
+//  The selected size is a FIRST-CLASS rendering input that AUGMENTS — never
+//  replaces — iOS Dynamic Type: every transcript font resolves as
+//
+//      system Dynamic Type size × Conduit chat text scale
+//
+//  so `Default` renders byte-identically to the pre-feature transcript at
+//  the user's current system text size, and accessibility text sizing keeps
+//  working at every position. All five values stay monotonically ordered
+//  and preserve the visual hierarchy (headings above body above captions;
+//  code stays monospaced) because the scale multiplies already-hierarchical
+//  Dynamic Type fonts.
+//
+//  Only readable message/transcript content resolves fonts through this
+//  type. Interface chrome — timestamps, identity labels, copy/branch/
+//  read-aloud buttons, navigation, Settings, composer controls, selection
+//  chrome, tool/status cards — keeps its existing typography.
+//
+//  Mermaid and KaTeX previews render inside WKWebView with their own HTML/CSS
+//  and intentionally keep their internal size; the surrounding source cards
+//  DO use this typography (see RenderCard/MarkupPreviewSheet/GuardedSourceCard).
+//
+
+import SwiftUI
+import UIKit
+
+/// The stepped chat text-size preference. The enum POSITION (raw value) is
+/// what persists — the scale factors live in `ChatTypography` so they can be
+/// tuned later without migrating stored preferences.
+enum ChatTextSize: Int, CaseIterable, Equatable {
+    case smallest = 0
+    case smaller
+    case `default`
+    case larger
+    case largest
+
+    /// Relative scale applied on top of the current system Dynamic Type size.
+    var scale: CGFloat {
+        switch self {
+        case .smallest: 0.85
+        case .smaller: 0.925
+        case .default: 1.00
+        case .larger: 1.125
+        case .largest: 1.25
+        }
+    }
+
+    /// Human-readable name, used by the Settings slider's accessibility value.
+    var displayName: String {
+        switch self {
+        case .smallest: "Smallest"
+        case .smaller: "Smaller"
+        case .default: "Default"
+        case .larger: "Larger"
+        case .largest: "Largest"
+        }
+    }
+
+    /// Stable identity for typography-sensitive caches (render cache, table
+    /// measurement, flow-chunk memos, code-slice identity). A different
+    /// position MUST produce a different identity so no cache can serve
+    /// attributed output laid out at another size.
+    var cacheIdentity: String { String(rawValue) }
+}
+
+/// Sole authority for transcript-content font resolution. Both UIKit
+/// (UIFont-returning) and SwiftUI (point-size/CGFloat-returning) consumers
+/// resolve through here so settled Markdown, streaming Markdown, tables,
+/// code, large documents, and source cards agree at the selected size.
+enum ChatTypography {
+    /// Local, device-only preference key. Namespaced like ComposerReturnKey.
+    static let preferenceKey = "conduit.chatTextSize"
+
+    /// Initial/fallback value: existing users keep today's appearance.
+    static let defaultSize: ChatTextSize = .default
+
+    // MARK: Preference resolution
+
+    /// Safe resolution of a persisted raw value: a missing or out-of-range
+    /// value falls back to `.default` instead of trapping or clamping.
+    static func resolve(rawValue: Int?) -> ChatTextSize {
+        guard let rawValue, let size = ChatTextSize(rawValue: rawValue) else { return .default }
+        return size
+    }
+
+    /// Reads the stored preference through UserDefaults (what @AppStorage
+    /// uses), so the app and tests agree on one resolution path.
+    static func stored(in defaults: UserDefaults = .standard) -> ChatTextSize {
+        resolve(rawValue: defaults.object(forKey: preferenceKey) as? Int)
+    }
+
+    // MARK: Semantic roles
+
+    /// Transcript-content roles. Each maps to the same base Dynamic Type
+    /// style the renderer used before this abstraction existed, so
+    /// `.default` preserves today's exact appearance.
+    enum Role: Equatable {
+        /// Paragraphs, list items, quotes (with caller-applied styling
+        /// handled here), callout bodies, columns, streaming text.
+        case body
+        /// Markdown headings by level (1...n).
+        case heading(level: Int)
+        /// Quote text — italic, like today.
+        case quote
+        /// Table header cells — bold caption.
+        case tableHeader
+        /// Table body cells.
+        case tableBody
+        /// Readable reasoning/thinking text.
+        case thinking
+        /// Fenced code blocks — monospaced.
+        case blockCode
+        /// Source text shown around rich Markdown previews (Mermaid/LaTeX
+        /// render cards, guarded oversized sources) — monospaced caption.
+        case sourceCode
+    }
+
+    // MARK: Scale
+
+    static func scale(for size: ChatTextSize) -> CGFloat { size.scale }
+
+    /// Scales an already-resolved (Dynamic Type aware) font. The descriptor
+    /// — family, weight, symbolic traits — is preserved; only the point
+    /// size grows or shrinks.
+    static func scaledFont(_ base: UIFont, chatSize: ChatTextSize) -> UIFont {
+        guard chatSize != .default else { return base }
+        return base.withSize(base.pointSize * chatSize.scale)
+    }
+
+    /// Scales a fixed layout dimension (e.g. list-marker column widths) so
+    /// chrome-adjacent content geometry keeps up with the text it hosts.
+    static func dimension(_ value: CGFloat, chatSize: ChatTextSize) -> CGFloat {
+        value * chatSize.scale
+    }
+
+    // MARK: Font resolution
+
+    /// Resolves a role's font at the selected chat size. The optional trait
+    /// collection makes Dynamic Type behavior unit-testable; production
+    /// call sites pass nil and resolve against the current system setting
+    /// (identical to the pre-feature `UIFont.preferredFont` calls).
+    static func font(
+        for role: Role,
+        chatSize: ChatTextSize,
+        compatibleWith traits: UITraitCollection? = nil
+    ) -> UIFont {
+        scaledFont(baseFont(for: role, compatibleWith: traits), chatSize: chatSize)
+    }
+
+    /// The point size of a role's resolved font — for the few SwiftUI-native
+    /// Text/Image sites inside transcript content (list markers) that cannot
+    /// take a UIFont directly. Reads the live system size at call time.
+    static func pointSize(for role: Role, chatSize: ChatTextSize) -> CGFloat {
+        font(for: role, chatSize: chatSize).pointSize
+    }
+
+    /// The unscaled (Dynamic Type only) base font for a role. Kept separate
+    /// so `Default` resolution is exactly the historical font.
+    static func baseFont(
+        for role: Role,
+        compatibleWith traits: UITraitCollection? = nil
+    ) -> UIFont {
+        switch role {
+        case .body:
+            return preferred(.body, traits)
+        case .heading(let level):
+            return preferred(headingStyle(for: level), traits).withTraits(.traitBold)
+        case .quote:
+            return preferred(.body, traits).withTraits(.traitItalic)
+        case .tableHeader:
+            return preferred(.caption1, traits).withTraits(.traitBold)
+        case .tableBody:
+            return preferred(.footnote, traits)
+        case .thinking:
+            return preferred(.callout, traits)
+        case .blockCode:
+            return .monospacedSystemFont(ofSize: preferred(.footnote, traits).pointSize, weight: .regular)
+        case .sourceCode:
+            return .monospacedSystemFont(ofSize: preferred(.caption1, traits).pointSize, weight: .regular)
+        }
+    }
+
+    /// Dynamic Type text style for a Markdown heading level — the same
+    /// mapping MarkdownHeading has always used (h1 → title2 … h4+ →
+    /// subheadline), bold applied above.
+    static func headingStyle(for level: Int) -> UIFont.TextStyle {
+        switch level {
+        case 1: .title2
+        case 2: .title3
+        case 3: .headline
+        default: .subheadline
+        }
+    }
+
+    private static func preferred(_ style: UIFont.TextStyle, _ traits: UITraitCollection?) -> UIFont {
+        if let traits {
+            return UIFont.preferredFont(forTextStyle: style, compatibleWith: traits)
+        }
+        return UIFont.preferredFont(forTextStyle: style)
+    }
+}
+
+// MARK: - Environment
+
+/// Environment propagation of the selected chat text size. The default is
+/// `.default` — subtrees that never receive the injection (Settings,
+/// Kanban, previews, tests) keep rendering exactly as before, which is what
+/// keeps this a chat-only preference rather than an app-wide one.
+private struct ChatTextSizeEnvironmentKey: EnvironmentKey {
+    static let defaultValue: ChatTextSize = .default
+}
+
+extension EnvironmentValues {
+    /// The transcript typography this subtree renders content with. Injected
+    /// at the chat root; read by MarkdownText and friends.
+    var chatTextSize: ChatTextSize {
+        get { self[ChatTextSizeEnvironmentKey.self] }
+        set { self[ChatTextSizeEnvironmentKey.self] = newValue }
+    }
+}

--- a/Conduit/Views/Components/MarkdownLargeDocumentView.swift
+++ b/Conduit/Views/Components/MarkdownLargeDocumentView.swift
@@ -1018,6 +1018,17 @@ struct LargeCodeSliceHighlightState {
         invalidateIfIdentityChanged(to: passIdentity)
         highlighted = text
     }
+
+    /// The highlighted result eligible for display under `identity` — nil
+    /// unless the stored result belongs to EXACTLY that identity. This is
+    /// the render-time final guard: between an identity change and the
+    /// `onChange` invalidation there is one body evaluation where the
+    /// stored result still carries the previous identity, and it must
+    /// never be mounted under the new one (the view renders the plain
+    /// path at the current font instead).
+    func highlightedText(for identity: String) -> NSAttributedString? {
+        displayedIdentity == identity ? highlighted : nil
+    }
 }
 
 /// One bounded slice of a large code block: plain monospaced text
@@ -1047,7 +1058,12 @@ private struct LargeCodeSliceView: View {
 
     var body: some View {
         Group {
-            if let highlighted = highlightState.highlighted {
+            // Render-time final guard: the highlighted attributed string is
+            // mounted ONLY while its recorded identity exactly matches the
+            // live sliceIdentity. In the one body evaluation between an
+            // identity change and onChange delivery, the mismatch routes to
+            // the plain-text path at the current font instead.
+            if let highlighted = highlightState.highlightedText(for: sliceIdentity) {
                 SelectableTextView(
                     attributedText: highlighted,
                     font: font,
@@ -1084,8 +1100,8 @@ private struct LargeCodeSliceView: View {
             // staleness protections are `.task(id:)` cancellation (fires on
             // any identity change) and the synchronous `onChange`
             // invalidation above; the snapshot comparison plus the
-            // MainActor-confined continuation keep the record path single
-            //turn and auditable.
+            // MainActor-confined continuation keep the record path to a
+            // single turn, auditable in one place.
             let passIdentity = sliceIdentity
             let highlightedResult = await SyntaxHighlighter.highlightAsync(
                 currentSource,
@@ -1094,7 +1110,11 @@ private struct LargeCodeSliceView: View {
             // Everything from here on runs on the main actor (the .task
             // closure inherits this MainActor view's context), so the state
             // write below is a single main-actor mutation.
-            guard !Task.isCancelled, sliceIdentity == passIdentity, !highlightedResult.characters.isEmpty else { return }
+            // The empty-result check is defensive (a non-empty source always
+            // yields a non-empty result today); an empty outcome falls back
+            // to the plain path instead of mounting an empty text view.
+            guard !Task.isCancelled, sliceIdentity == passIdentity,
+                  !highlightedResult.characters.isEmpty else { return }
             // Convergence + record in one state write (see syncAndStore).
             let bridged = SelectableTextView.bridge(
                 highlightedResult,

--- a/Conduit/Views/Components/MarkdownLargeDocumentView.swift
+++ b/Conduit/Views/Components/MarkdownLargeDocumentView.swift
@@ -640,8 +640,9 @@ private struct LargeDocumentPreparingView: View {
 
 /// Memoizes a flow chunk's attributed string so unrelated body
 /// re-evaluations never re-run the Foundation parses. The memo identity is
-/// explicit: Dynamic Type category (fonts bake into the string) and the
-/// accent-surface flag (colors bake in).
+/// explicit: Dynamic Type category (fonts bake into the string), the
+/// selected chat text size (fonts bake into the string — issue #85), and
+/// the accent-surface flag (colors bake in).
 ///
 /// Invariant for the remaining inputs: `foregroundStyle` is tied 1:1 to
 /// `usesAccentSurface` at every call site (`.primary`/`false` and
@@ -653,6 +654,7 @@ private struct LargeDocumentPreparingView: View {
 final class LargeFlowChunkBox {
     private var cachedText: NSAttributedString?
     private var cachedCategory: UIContentSizeCategory?
+    private var cachedChatTextSize: ChatTextSize?
     private var cachedUsesAccentSurface: Bool?
 
     @MainActor
@@ -661,10 +663,12 @@ final class LargeFlowChunkBox {
         references: MarkdownReferenceContext,
         foregroundStyle: Color,
         usesAccentSurface: Bool,
-        contentCategory: UIContentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        contentCategory: UIContentSizeCategory = UIApplication.shared.preferredContentSizeCategory,
+        chatTextSize: ChatTextSize = .default
     ) -> NSAttributedString? {
         if let cachedText,
            cachedCategory == contentCategory,
+           cachedChatTextSize == chatTextSize,
            cachedUsesAccentSurface == usesAccentSurface {
             return cachedText
         }
@@ -673,10 +677,12 @@ final class LargeFlowChunkBox {
             references: references,
             foregroundStyle: foregroundStyle,
             usesAccentSurface: usesAccentSurface,
-            newestCharacterOpacities: []
+            newestCharacterOpacities: [],
+            chatTextSize: chatTextSize
         )
         cachedText = text
         cachedCategory = contentCategory
+        cachedChatTextSize = chatTextSize
         cachedUsesAccentSurface = usesAccentSurface
         return text
     }
@@ -697,6 +703,7 @@ struct LargeFlowChunkView: View {
     let selectionSegment: MarkdownSelectionSegmentDescriptor?
 
     @Environment(\.sizeCategory) private var sizeCategory
+    @Environment(\.chatTextSize) private var chatTextSize
 
     /// Per-view memo box: identity comes from the enclosing ForEach index
     /// (keyed by source identity), so it survives re-evaluations and dies
@@ -709,11 +716,12 @@ struct LargeFlowChunkView: View {
             references: references,
             foregroundStyle: foregroundStyle,
             usesAccentSurface: usesAccentSurface,
-            contentCategory: UIContentSizeCategory(sizeCategory)
+            contentCategory: UIContentSizeCategory(sizeCategory),
+            chatTextSize: chatTextSize
         ) {
             SelectableTextView(
                 attributedText: attributed,
-                font: .preferredFont(forTextStyle: .body),
+                font: ChatTypography.font(for: .body, chatSize: chatTextSize),
                 textColor: usesAccentSurface ? .white : UIColor(foregroundStyle),
                 lineSpacing: 4,
                 linkColor: usesAccentSurface ? .white : .link,
@@ -958,6 +966,21 @@ struct LargeCodeBlockView: View {
     }
 }
 
+/// Stable identity for a large-code slice's highlight+presentation pass.
+/// Extracted so the cache-invalidation contract is unit-testable: a chat
+/// text-size change MUST produce a different identity (the highlighted
+/// attributed string bakes the pass's default font in when bridged), while
+/// everything else staying equal keeps the previous identity.
+enum LargeCodeSliceIdentity {
+    static func identity(
+        source: String,
+        sizeCategory: ContentSizeCategory,
+        chatTextSize: ChatTextSize
+    ) -> String {
+        "\(source.hashValue)-\(sizeCategory)-chat:\(chatTextSize.cacheIdentity)"
+    }
+}
+
 /// One bounded slice of a large code block: plain monospaced text
 /// immediately, tokenized highlighting swapped in when the off-main pass
 /// completes. Each slice is independently selectable.
@@ -969,13 +992,18 @@ private struct LargeCodeSliceView: View {
 
     @State private var highlighted: NSAttributedString?
     @Environment(\.sizeCategory) private var sizeCategory
+    @Environment(\.chatTextSize) private var chatTextSize
 
     private var font: UIFont {
-        .monospacedSystemFont(ofSize: UIFont.preferredFont(forTextStyle: .footnote).pointSize, weight: .regular)
+        ChatTypography.font(for: .blockCode, chatSize: chatTextSize)
     }
 
     private var sliceIdentity: String {
-        "\(source.hashValue)-\(sizeCategory)"
+        LargeCodeSliceIdentity.identity(
+            source: source,
+            sizeCategory: sizeCategory,
+            chatTextSize: chatTextSize
+        )
     }
 
     var body: some View {

--- a/Conduit/Views/Components/MarkdownLargeDocumentView.swift
+++ b/Conduit/Views/Components/MarkdownLargeDocumentView.swift
@@ -981,6 +981,45 @@ enum LargeCodeSliceIdentity {
     }
 }
 
+/// One large-code slice's highlighted result together with the slice
+/// identity it was produced under. A typography/source identity change
+/// invalidates the stored highlighted result immediately (issue #85 review
+/// fix): its baked font attributes belong to the old size, so the view must
+/// fall back to plain text at the new font while the replacement highlight
+/// pass runs — an old-size highlighted string must never stay mounted
+/// during the transition.
+///
+/// Deliberately a VALUE type: the view holds it in `@State`, and SwiftUI
+/// only observes writes through the state wrapper — a reference type
+/// mutated in place would never trigger the swap-in/invalidation renders.
+struct LargeCodeSliceHighlightState {
+    private(set) var highlighted: NSAttributedString?
+    /// The slice identity the currently stored result belongs to.
+    private(set) var displayedIdentity: String?
+
+    /// Invalidates the stored highlighted result when the slice identity
+    /// changed. Returns true when a stored result was invalidated.
+    @discardableResult
+    mutating func invalidateIfIdentityChanged(to newIdentity: String) -> Bool {
+        guard displayedIdentity != newIdentity else { return false }
+        displayedIdentity = newIdentity
+        guard highlighted != nil else { return false }
+        highlighted = nil
+        return true
+    }
+
+    /// Convergence + record for a completed highlight pass in ONE mutation
+    /// (one `@State` write → one render): syncs the tracked identity to the
+    /// completed pass and stores the result. The view's live
+    /// `sliceIdentity == passIdentity` guard is the outer stale protection;
+    /// a pass that lost an identity race is cancelled or refused before
+    /// reaching here.
+    mutating func syncAndStore(_ text: NSAttributedString, passIdentity: String) {
+        invalidateIfIdentityChanged(to: passIdentity)
+        highlighted = text
+    }
+}
+
 /// One bounded slice of a large code block: plain monospaced text
 /// immediately, tokenized highlighting swapped in when the off-main pass
 /// completes. Each slice is independently selectable.
@@ -990,7 +1029,7 @@ private struct LargeCodeSliceView: View {
     let usesAccentSurface: Bool
     var maximumNumberOfLines: Int = 0
 
-    @State private var highlighted: NSAttributedString?
+    @State private var highlightState = LargeCodeSliceHighlightState()
     @Environment(\.sizeCategory) private var sizeCategory
     @Environment(\.chatTextSize) private var chatTextSize
 
@@ -1008,7 +1047,7 @@ private struct LargeCodeSliceView: View {
 
     var body: some View {
         Group {
-            if let highlighted {
+            if let highlighted = highlightState.highlighted {
                 SelectableTextView(
                     attributedText: highlighted,
                     font: font,
@@ -1027,6 +1066,13 @@ private struct LargeCodeSliceView: View {
                 )
             }
         }
+        // A typography/source identity change must never keep the previous
+        // highlighted attributed string mounted: clear it synchronously so
+        // the plain path renders at the new font while highlighting
+        // recomputes.
+        .onChange(of: sliceIdentity) { _, newIdentity in
+            highlightState.invalidateIfIdentityChanged(to: newIdentity)
+        }
         .task(id: sliceIdentity) {
             // Accent-surface (user-bubble) code never highlights, matching
             // the ordinary ChatCodeBlock behavior.
@@ -1034,21 +1080,29 @@ private struct LargeCodeSliceView: View {
             let currentSource = source
             let currentLanguage = language
             let currentFont = font
-            // Snapshot the identity the pass started under; comparing
-            // against the live property is what actually drops stale
-            // results when the view was re-created mid-pass.
+            // Snapshot the identity the pass started under. The authoritative
+            // staleness protections are `.task(id:)` cancellation (fires on
+            // any identity change) and the synchronous `onChange`
+            // invalidation above; the snapshot comparison plus the
+            // MainActor-confined continuation keep the record path single
+            //turn and auditable.
             let passIdentity = sliceIdentity
             let highlightedResult = await SyntaxHighlighter.highlightAsync(
                 currentSource,
                 language: currentLanguage
             )
-            guard !Task.isCancelled, sliceIdentity == passIdentity else { return }
-            self.highlighted = SelectableTextView.bridge(
+            // Everything from here on runs on the main actor (the .task
+            // closure inherits this MainActor view's context), so the state
+            // write below is a single main-actor mutation.
+            guard !Task.isCancelled, sliceIdentity == passIdentity, !highlightedResult.characters.isEmpty else { return }
+            // Convergence + record in one state write (see syncAndStore).
+            let bridged = SelectableTextView.bridge(
                 highlightedResult,
                 defaultFont: currentFont,
                 defaultColor: .label,
                 linkColor: .link
             )
+            highlightState.syncAndStore(bridged, passIdentity: passIdentity)
         }
     }
 }

--- a/Conduit/Views/Components/MarkdownText.swift
+++ b/Conduit/Views/Components/MarkdownText.swift
@@ -33,6 +33,12 @@ struct MarkdownText: View {
     /// snapshot that would be dead the moment the next delta arrives.
     var isStreaming: Bool = false
 
+    /// The selected chat text size (issue #85): a first-class rendering
+    /// input, injected at the chat root. Streaming and settled content read
+    /// the same value, so the whole stream stays at one size. The
+    /// `.default` environment default keeps non-chat subtrees untouched.
+    @Environment(\.chatTextSize) private var chatTextSize
+
     var body: some View {
         // Path fork is centralized here: ordinary messages keep the exact
         // fast cached path below; pathological ones (see
@@ -58,7 +64,8 @@ struct MarkdownText: View {
             recognizesGatewayMedia: gatewayMediaDataURL != nil,
             foregroundStyle: foregroundStyle,
             usesAccentSurface: usesAccentSurface,
-            isStreaming: isStreaming
+            isStreaming: isStreaming,
+            chatTextSize: chatTextSize
         )
         let selectionSegments = rendering.selectableText == nil
             ? MarkdownSelectionSegmentPlan.descriptors(for: rendering.blocks)
@@ -72,7 +79,7 @@ struct MarkdownText: View {
                         to: baseText,
                         baseColor: usesAccentSurface ? .white : UIColor(foregroundStyle)
                     ),
-                    font: .preferredFont(forTextStyle: .body),
+                    font: ChatTypography.font(for: .body, chatSize: chatTextSize),
                     textColor: usesAccentSurface ? .white : UIColor(foregroundStyle),
                     lineSpacing: 4,
                     linkColor: usesAccentSurface ? .white : .link
@@ -218,7 +225,7 @@ private final class MarkdownSelectionHighlightView: UIView {
 /// exact pathological Markdown this bounding exists for used to re-walk
 /// every table's cells on each SwiftUI body re-evaluation just to
 /// rediscover the same budget (see MarkdownRichContentPolicy).
-private final class MarkdownRendering {
+final class MarkdownRendering {
     let blocks: [MarkdownBlock]
     /// The message's link reference definitions; block views need them to
     /// resolve reference-style links when re-parsing each fragment.
@@ -249,7 +256,7 @@ private final class MarkdownRendering {
 /// style so settled messages render from cache and only genuinely new content
 /// pays for parsing. Streaming-tail fades stay per-frame but are applied to a
 /// copy of the cached base rather than triggering a rebuild.
-private enum MarkdownRenderCache {
+enum MarkdownRenderCache {
     private static let cache: NSCache<NSString, MarkdownRendering> = {
         let cache = NSCache<NSString, MarkdownRendering>()
         cache.countLimit = 256
@@ -263,7 +270,8 @@ private enum MarkdownRenderCache {
         recognizesGatewayMedia: Bool,
         foregroundStyle: Color,
         usesAccentSurface: Bool,
-        isStreaming: Bool
+        isStreaming: Bool,
+        chatTextSize: ChatTextSize
     ) -> MarkdownRendering {
         // `foregroundStyle` is deliberately absent from the key: only two
         // values are ever passed (.primary / .white), each uniquely tied to
@@ -277,14 +285,18 @@ private enum MarkdownRenderCache {
             "MarkdownRenderCache keys on usesAccentSurface, not foregroundStyle; a new style needs an explicit key token."
         )
 
-        // Fonts resolve against the current Dynamic Type size, so a size change
-        // must miss the cache rather than serve stale metrics. Reading
-        // preferredContentSizeCategory touches UIApplication.shared, hence the
-        // @MainActor isolation on this function.
+        // Fonts resolve against the current Dynamic Type size AND the
+        // selected chat text size (issue #85), so either change must miss the
+        // cache rather than serve stale metrics. The chat-size identity is
+        // the persisted enum position, so re-tuning the scale factors later
+        // needs no cache migration. Reading preferredContentSizeCategory
+        // touches UIApplication.shared, hence the @MainActor isolation on
+        // this function.
         let key = [
             recognizesGatewayMedia ? "1" : "0",
             usesAccentSurface ? "1" : "0",
             UIApplication.shared.preferredContentSizeCategory.rawValue,
+            chatTextSize.cacheIdentity,
             source
         ].joined(separator: "|") as NSString
 
@@ -298,7 +310,8 @@ private enum MarkdownRenderCache {
                 references: document.references,
                 foregroundStyle: foregroundStyle,
                 usesAccentSurface: usesAccentSurface,
-                newestCharacterOpacities: []
+                newestCharacterOpacities: [],
+                chatTextSize: chatTextSize
             )
         )
         // While streaming, `source` changes every frame, so a cached entry is
@@ -373,11 +386,15 @@ enum MarkdownSelectionFormatter {
         references: MarkdownReferenceContext = .empty,
         foregroundStyle: Color,
         usesAccentSurface: Bool,
-        newestCharacterOpacities: [Double]
+        newestCharacterOpacities: [Double],
+        chatTextSize: ChatTextSize = .default
     ) -> NSAttributedString? {
         guard !blocks.isEmpty, blocks.allSatisfy(\.isSelectableFlowBlock) else { return nil }
 
-        let bodyFont = UIFont.preferredFont(forTextStyle: .body)
+        // All fonts resolve through ChatTypography (issue #85): the selected
+        // chat size scales ON TOP of the current Dynamic Type size, and
+        // `.default` reproduces the historical fonts exactly.
+        let bodyFont = ChatTypography.font(for: .body, chatSize: chatTextSize)
         let textColor = usesAccentSurface ? UIColor.white : UIColor(foregroundStyle)
         let linkColor = usesAccentSurface ? UIColor.white : UIColor.link
         let result = NSMutableAttributedString()
@@ -390,7 +407,8 @@ enum MarkdownSelectionFormatter {
                 textColor: textColor,
                 linkColor: linkColor,
                 usesAccentSurface: usesAccentSurface,
-                foregroundStyle: foregroundStyle
+                foregroundStyle: foregroundStyle,
+                chatTextSize: chatTextSize
             ) else {
                 return nil
             }
@@ -418,14 +436,15 @@ enum MarkdownSelectionFormatter {
         textColor: UIColor,
         linkColor: UIColor,
         usesAccentSurface: Bool,
-        foregroundStyle: Color
+        foregroundStyle: Color,
+        chatTextSize: ChatTextSize
     ) -> NSAttributedString? {
         switch block {
         case .heading(let level, let text):
             return inline(
                 text,
                 references: references,
-                font: headingFont(level),
+                font: headingFont(level, chatTextSize: chatTextSize),
                 textColor: textColor,
                 linkColor: linkColor
             )
@@ -441,7 +460,8 @@ enum MarkdownSelectionFormatter {
                 bodyFont: bodyFont,
                 textColor: textColor,
                 linkColor: linkColor,
-                markerColor: usesAccentSurface ? .white : UIColor(Color.conduitAccent)
+                markerColor: usesAccentSurface ? .white : UIColor(Color.conduitAccent),
+                chatTextSize: chatTextSize
             )
 
         case .orderedList(let items):
@@ -452,7 +472,8 @@ enum MarkdownSelectionFormatter {
                 bodyFont: bodyFont,
                 textColor: textColor,
                 linkColor: linkColor,
-                markerColor: usesAccentSurface ? .white : UIColor(Color.conduitAccent)
+                markerColor: usesAccentSurface ? .white : UIColor(Color.conduitAccent),
+                chatTextSize: chatTextSize
             )
 
         case .quote(let lines):
@@ -460,7 +481,7 @@ enum MarkdownSelectionFormatter {
             let quoteColor = usesAccentSurface
                 ? UIColor.white.withAlphaComponent(0.90)
                 : UIColor(foregroundStyle).withAlphaComponent(0.90)
-            let quoteFont = bodyFont.withTraits(.traitItalic)
+            let quoteFont = ChatTypography.font(for: .quote, chatSize: chatTextSize)
 
             for (index, line) in lines.enumerated() {
                 if index > 0 {
@@ -490,7 +511,8 @@ enum MarkdownSelectionFormatter {
         bodyFont: UIFont,
         textColor: UIColor,
         linkColor: UIColor,
-        markerColor: UIColor
+        markerColor: UIColor,
+        chatTextSize: ChatTextSize
     ) -> NSAttributedString {
         let result = NSMutableAttributedString()
         let markerFont = bodyFont.withTraits(.traitBold)
@@ -539,8 +561,8 @@ enum MarkdownSelectionFormatter {
         return SelectableTextView.bridge(attributed, defaultFont: font, defaultColor: textColor, linkColor: linkColor)
     }
 
-    private static func headingFont(_ level: Int) -> UIFont {
-        MarkdownHeading.font(for: level)
+    private static func headingFont(_ level: Int, chatTextSize: ChatTextSize) -> UIFont {
+        MarkdownHeading.font(for: level, chatTextSize: chatTextSize)
     }
 
     /// Applies the streaming-tail fade to a copy, leaving the shared cached
@@ -603,13 +625,16 @@ enum MarkdownTableAlignment {
 /// Shared heading font logic used by both MarkdownSelectionFormatter
 /// and MarkdownBlockView to prevent divergence.
 enum MarkdownHeading {
+    /// Heading font at the selected chat text size. The style mapping and
+    /// bold trait live in ChatTypography so the SwiftUI block renderer and
+    /// the attributed-string formatter can never diverge.
+    static func font(for level: Int, chatTextSize: ChatTextSize) -> UIFont {
+        ChatTypography.font(for: .heading(level: level), chatSize: chatTextSize)
+    }
+
+    /// Historical entry point: today's typography at the default chat size.
     static func font(for level: Int) -> UIFont {
-        switch level {
-        case 1: UIFont.preferredFont(forTextStyle: .title2).withTraits(.traitBold)
-        case 2: UIFont.preferredFont(forTextStyle: .title3).withTraits(.traitBold)
-        case 3: UIFont.preferredFont(forTextStyle: .headline).withTraits(.traitBold)
-        default: UIFont.preferredFont(forTextStyle: .subheadline).withTraits(.traitBold)
-        }
+        font(for: level, chatTextSize: .default)
     }
 }
 
@@ -622,6 +647,7 @@ struct MarkdownBlockView: View {
     let selectionCoordinator: MarkdownSelectionCoordinator?
     let selectionSegments: [MarkdownSelectionSegmentDescriptor]
     let newestCharacterOpacities: [Double]
+    @Environment(\.chatTextSize) private var chatTextSize
 
     var body: some View {
         switch block {
@@ -787,7 +813,7 @@ struct MarkdownBlockView: View {
     }
 
     private func headingFont(_ level: Int) -> UIFont {
-        MarkdownHeading.font(for: level)
+        MarkdownHeading.font(for: level, chatTextSize: chatTextSize)
     }
 
     private var blockDescriptor: MarkdownSelectionSegmentDescriptor? {
@@ -893,7 +919,9 @@ private struct InlineMarkdown: View {
     let source: String
     let foregroundStyle: Color
     let usesAccentSurface: Bool
-    var font: UIFont = .preferredFont(forTextStyle: .body)
+    /// Explicit role font (headings, table cells); nil resolves the body
+    /// role through ChatTypography at the selected chat text size.
+    var font: UIFont?
     var lineSpacing: CGFloat = 0
     var maximumNumberOfLines: Int = 0
     var textAlignment: NSTextAlignment = .natural
@@ -902,6 +930,11 @@ private struct InlineMarkdown: View {
     var selectionSegment: MarkdownSelectionSegmentDescriptor?
     var trailingCharacterOpacities: [Double] = []
     @Environment(\.markdownReferences) private var references
+    @Environment(\.chatTextSize) private var chatTextSize
+
+    private var effectiveFont: UIFont {
+        font ?? ChatTypography.font(for: .body, chatSize: chatTextSize)
+    }
 
     private var attributed: AttributedString {
         InlineMarkdownContent.attributed(
@@ -915,7 +948,7 @@ private struct InlineMarkdown: View {
     var body: some View {
         SelectableTextView(
             attributedText: attributed,
-            font: font,
+            font: effectiveFont,
             textColor: usesAccentSurface ? .white : UIColor(foregroundStyle),
             lineSpacing: lineSpacing,
             maximumNumberOfLines: maximumNumberOfLines,
@@ -937,6 +970,21 @@ private struct MarkdownList: View {
     let selectionCoordinator: MarkdownSelectionCoordinator?
     let selectionSegments: [MarkdownSelectionSegmentDescriptor]
     var trailingCharacterOpacities: [Double] = []
+    @Environment(\.chatTextSize) private var chatTextSize
+    @Environment(\.sizeCategory) private var sizeCategory
+
+    /// Marker glyphs resolve Dynamic Type through the environment category
+    /// (rather than a size frozen at body-evaluation time), so a system
+    /// text-size change re-resolves them wherever the list re-evaluates.
+    private var markerFont: UIFont {
+        ChatTypography.font(
+            for: .body,
+            chatSize: chatTextSize,
+            compatibleWith: UITraitCollection(
+                preferredContentSizeCategory: UIContentSizeCategory(sizeCategory)
+            )
+        )
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 7) {
@@ -945,15 +993,16 @@ private struct MarkdownList: View {
                 HStack(alignment: .firstTextBaseline, spacing: 9) {
                     if let task {
                         Image(systemName: task.complete ? "checkmark.square.fill" : "square")
+                            .font(.system(size: markerFont.pointSize))
                             .foregroundStyle(task.complete
                                              ? (usesAccentSurface ? Color.white : Color.conduitAccent)
                                              : (usesAccentSurface ? Color.white.opacity(0.82) : Color.secondary))
-                            .frame(width: 16, alignment: .trailing)
+                            .frame(width: ChatTypography.dimension(16, chatSize: chatTextSize), alignment: .trailing)
                     } else {
                         Text(ordered ? "\(index + 1)." : "•")
-                            .font(.body.weight(.semibold))
+                            .font(.system(size: markerFont.pointSize, weight: .semibold))
                             .foregroundStyle(usesAccentSurface ? Color.white.opacity(0.92) : Color.conduitAccent)
-                            .frame(width: ordered ? 24 : 12, alignment: .trailing)
+                            .frame(width: ChatTypography.dimension(ordered ? 24 : 12, chatSize: chatTextSize), alignment: .trailing)
                     }
                     InlineMarkdown(
                         source: task?.text ?? item,
@@ -979,6 +1028,7 @@ private struct MarkdownQuote: View {
     let selectionCoordinator: MarkdownSelectionCoordinator?
     let selectionSegments: [MarkdownSelectionSegmentDescriptor]
     var trailingCharacterOpacities: [Double] = []
+    @Environment(\.chatTextSize) private var chatTextSize
 
     private var callout: (kind: String, text: String)? {
         guard let first = lines.first, let marker = MarkdownParser.calloutMarker(first.text) else { return nil }
@@ -1012,7 +1062,7 @@ private struct MarkdownQuote: View {
                             source: line.text,
                             foregroundStyle: foregroundStyle.opacity(0.90),
                             usesAccentSurface: usesAccentSurface,
-                            font: UIFont.preferredFont(forTextStyle: .body).withTraits(.traitItalic),
+                            font: ChatTypography.font(for: .quote, chatSize: chatTextSize),
                             lineSpacing: 3,
                             selectionCoordinator: selectionCoordinator,
                             selectionSegment: selectionSegments.indices.contains(index) ? selectionSegments[index] : nil,
@@ -1146,18 +1196,23 @@ enum MarkdownTableLayout {
         headers: [String],
         rows: [[String]],
         availableWidth: CGFloat,
-        references: MarkdownReferenceContext = .empty
+        references: MarkdownReferenceContext = .empty,
+        chatTextSize: ChatTextSize = .default
     ) -> [CGFloat] {
         let columnCount = max(headers.count, rows.map(\.count).max() ?? 0)
         guard columnCount > 0 else { return [] }
 
-        // Fonts resolve against the current Dynamic Type size, so the widths
-        // key on the content category just like MarkdownRenderCache, on the
-        // viewport width that feeds the fit-or-shrink decision, and on the
-        // reference definitions (they change how cell source measures).
+        // Fonts resolve against the current Dynamic Type size AND the
+        // selected chat text size (issue #85), so the widths key on the
+        // content category just like MarkdownRenderCache, on the chat-size
+        // identity, on the viewport width that feeds the fit-or-shrink
+        // decision, and on the reference definitions (they change how cell
+        // source measures). A chat-size change must never serve stale
+        // measurements from the previous size.
         let key = (
             [
                 UIApplication.shared.preferredContentSizeCategory.rawValue,
+                chatTextSize.cacheIdentity,
                 String(format: "%.1f", availableWidth),
                 references.definitionsMarkdown
             ]
@@ -1167,8 +1222,8 @@ enum MarkdownTableLayout {
 
         if let cached = cache.object(forKey: key) as? [CGFloat] { return cached }
 
-        let headerFont = UIFont.preferredFont(forTextStyle: .caption1).withTraits(.traitBold)
-        let bodyFont = UIFont.preferredFont(forTextStyle: .footnote)
+        let headerFont = ChatTypography.font(for: .tableHeader, chatSize: chatTextSize)
+        let bodyFont = ChatTypography.font(for: .tableBody, chatSize: chatTextSize)
 
         var ideals = [CGFloat](repeating: 0, count: columnCount)
         for (index, header) in headers.enumerated() {
@@ -1271,7 +1326,9 @@ private struct MarkdownTableWidthProbe: View {
     }
 }
 
-private struct MarkdownTable: View {
+/// The ordinary (non-paged) table presentation. Internal (not private) so
+/// the chat-size wiring into column measurement is directly testable.
+struct MarkdownTable: View {
     let headers: [String]
     let alignments: [MarkdownTableAlignment]
     let rows: [[String]]
@@ -1287,13 +1344,15 @@ private struct MarkdownTable: View {
     /// later, once the width is known.
     @State private var availableWidth: CGFloat = 0
     @Environment(\.markdownReferences) private var references
+    @Environment(\.chatTextSize) private var chatTextSize
 
     private var columnWidths: [CGFloat] {
         MarkdownTableLayout.columnWidths(
             headers: headers,
             rows: rows,
             availableWidth: availableWidth,
-            references: references
+            references: references,
+            chatTextSize: chatTextSize
         )
     }
 
@@ -1357,6 +1416,7 @@ struct MarkdownTableRowView: View {
     let usesAccentSurface: Bool
     let selectionCoordinator: MarkdownSelectionCoordinator?
     let segmentFor: (Int) -> MarkdownSelectionSegmentDescriptor?
+    @Environment(\.chatTextSize) private var chatTextSize
 
     var body: some View {
         HStack(spacing: 0) {
@@ -1368,9 +1428,10 @@ struct MarkdownTableRowView: View {
                     source: cell,
                     foregroundStyle: foregroundStyle,
                     usesAccentSurface: usesAccentSurface,
-                    font: isHeader
-                        ? UIFont.preferredFont(forTextStyle: .caption1).withTraits(.traitBold)
-                        : UIFont.preferredFont(forTextStyle: .footnote),
+                    font: ChatTypography.font(
+                        for: isHeader ? .tableHeader : .tableBody,
+                        chatSize: chatTextSize
+                    ),
                     textAlignment: alignments.indices.contains(index) ? alignments[index].nsText : .natural,
                     // The exact shared column width — a single-value range keeps
                     // the cell's measured/committed height deterministic from the
@@ -1417,6 +1478,7 @@ struct LargeMarkdownTable: View {
     /// cap-and-scroll fallback re-resolves a frame later.
     @State private var availableWidth: CGFloat = 0
     @Environment(\.markdownReferences) private var references
+    @Environment(\.chatTextSize) private var chatTextSize
 
     init(
         headers: [String],
@@ -1458,7 +1520,8 @@ struct LargeMarkdownTable: View {
                 $0.map { MarkdownLargeDocumentPolicy.boundedDisplayText($0, maxBytes: ceiling) }
             },
             availableWidth: availableWidth,
-            references: references
+            references: references,
+            chatTextSize: chatTextSize
         )
     }
 
@@ -1539,6 +1602,7 @@ struct GuardedSourceCard: View {
     let guardBytes: Int
 
     @State private var copied = false
+    @Environment(\.chatTextSize) private var chatTextSize
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -1553,7 +1617,7 @@ struct GuardedSourceCard: View {
             }
             SelectableTextView(
                 text: String(source.prefix(2_000)),
-                font: .monospacedSystemFont(ofSize: UIFont.preferredFont(forTextStyle: .caption1).pointSize, weight: .regular),
+                font: ChatTypography.font(for: .sourceCode, chatSize: chatTextSize),
                 textColor: .label,
                 maximumNumberOfLines: 5
             )
@@ -1940,6 +2004,13 @@ struct ChatCodeBlock: View {
     var selectionCoordinator: MarkdownSelectionCoordinator?
     var selectionSegment: MarkdownSelectionSegmentDescriptor?
     @State private var copied = false
+    @Environment(\.chatTextSize) private var chatTextSize
+
+    /// Code content scales with the chat text size (issue #85); the
+    /// language label and Copy button above stay interface chrome.
+    private var codeFont: UIFont {
+        ChatTypography.font(for: .blockCode, chatSize: chatTextSize)
+    }
 
     private var normalizedLanguage: String { MarkdownLanguage.normalized(language) }
 
@@ -1968,7 +2039,7 @@ struct ChatCodeBlock: View {
                     if usesAccentSurface {
                         SelectableTextView(
                             text: source,
-                            font: .monospacedSystemFont(ofSize: UIFont.preferredFont(forTextStyle: .footnote).pointSize, weight: .regular),
+                            font: codeFont,
                             textColor: UIColor.white.withAlphaComponent(0.96),
                             lineSpacing: 3,
                             wrapsLines: false,
@@ -1978,7 +2049,7 @@ struct ChatCodeBlock: View {
                     } else {
                         SelectableTextView(
                             attributedText: SyntaxHighlighter.highlight(source, language: normalizedLanguage),
-                            font: .monospacedSystemFont(ofSize: UIFont.preferredFont(forTextStyle: .footnote).pointSize, weight: .regular),
+                            font: codeFont,
                             textColor: .label,
                             lineSpacing: 3,
                             wrapsLines: false,
@@ -2034,6 +2105,7 @@ private struct RenderCard: View {
     let actionTitle: String
     let actionIcon: String
     let action: () -> Void
+    @Environment(\.chatTextSize) private var chatTextSize
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -2050,7 +2122,7 @@ private struct RenderCard: View {
                 .tint(.conduitAccent)
             SelectableTextView(
                 text: source,
-                font: .monospacedSystemFont(ofSize: UIFont.preferredFont(forTextStyle: .caption1).pointSize, weight: .regular),
+                font: ChatTypography.font(for: .sourceCode, chatSize: chatTextSize),
                 textColor: .label,
                 maximumNumberOfLines: 5
             )
@@ -2072,6 +2144,7 @@ private struct MarkupPreview: Identifiable {
 private struct MarkupPreviewSheet: View {
     let preview: MarkupPreview
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.chatTextSize) private var chatTextSize
 
     var body: some View {
         NavigationStack {
@@ -2082,7 +2155,7 @@ private struct MarkupPreviewSheet: View {
                 ScrollView(.horizontal, showsIndicators: false) {
                     SelectableTextView(
                         text: preview.source,
-                        font: .monospacedSystemFont(ofSize: UIFont.preferredFont(forTextStyle: .caption1).pointSize, weight: .regular),
+                        font: ChatTypography.font(for: .sourceCode, chatSize: chatTextSize),
                         textColor: .label,
                         wrapsLines: false
                     )
@@ -2574,6 +2647,10 @@ enum SyntaxHighlighter {
         return cache
     }()
 
+    /// NOTE: deliberately NOT keyed on the chat text size (issue #85): the
+    /// tokenizer bakes colors only — fonts are applied when the result is
+    /// bridged into an NSAttributedString with a caller-supplied default
+    /// font — so one highlighted value serves every typography.
     static func highlight(_ source: String, language: String) -> AttributedString {
         let key = "\(language)|\(source)" as NSString
         if let cached = cache.object(forKey: key) { return cached.value }

--- a/ConduitTests/ChatTextSelectionTests.swift
+++ b/ConduitTests/ChatTextSelectionTests.swift
@@ -5,6 +5,66 @@ import SwiftUI
 
 final class ChatTextSelectionTests: XCTestCase {
     @MainActor
+    func testSelectionGeometryTracksTypographyReflow() throws {
+        // Issue #85: a chat text-size change reflows transcript text; the
+        // selection geometry (caret rects) must track the reflowed layout
+        // instead of reporting stale positions from the previous font, and
+        // the selection itself must survive the reflow.
+        let textView = SelectableTextView.makeTextView()
+        let sample = "line one for the probe\nline two for the probe\nline three for the probe\nline four for the probe"
+        textView.attributedText = NSAttributedString(
+            string: sample,
+            attributes: [.font: UIFont.systemFont(ofSize: 12)]
+        )
+        textView.frame = CGRect(x: 0, y: 0, width: 220, height: 400)
+        textView.setNeedsLayout()
+        textView.layoutIfNeeded()
+
+        let selection = NSRange(location: (sample as NSString).length - 12, length: 10)
+        textView.selectedRange = selection
+        let smallRange = try XCTUnwrap(textView.selectedTextRange)
+        let smallEndCaret = textView.caretRect(for: smallRange.end)
+        let smallFittedHeight = textView.sizeThatFits(
+            CGSize(width: 220, height: 10_000)
+        ).height
+
+        // Reflow at the larger chat size (same text, larger font). UITextKit
+        // resets the selection on text replacement, so the same range is
+        // re-applied — what the app effectively does when the coordinator
+        // re-resolves the selection against the reflowed layout.
+        textView.attributedText = NSAttributedString(
+            string: sample,
+            attributes: [.font: UIFont.systemFont(ofSize: 20)]
+        )
+        textView.setNeedsLayout()
+        textView.layoutIfNeeded()
+        textView.selectedRange = selection
+
+        XCTAssertEqual(textView.selectedRange.length, selection.length,
+                       "the selection must remain expressible after the reflow")
+        let largeRange = try XCTUnwrap(textView.selectedTextRange)
+        let largeStart = textView.caretRect(for: largeRange.start)
+        let largeEnd = textView.caretRect(for: largeRange.end)
+        let largeFittedHeight = textView.sizeThatFits(
+            CGSize(width: 220, height: 10_000)
+        ).height
+
+        XCTAssertGreaterThan(largeFittedHeight, smallFittedHeight,
+                             "the larger typography must actually reflow the content")
+        XCTAssertGreaterThan(
+            abs(largeEnd.minY - smallEndCaret.minY), 0.5,
+            "the selection endpoint must track the reflowed layout, not the previous font's geometry"
+        )
+        for (label, rect) in [("start", largeStart), ("end", largeEnd)] {
+            XCTAssertGreaterThan(rect.height, 0, "\(label) caret must stay non-degenerate after the reflow")
+            XCTAssertGreaterThanOrEqual(rect.minX, 0, "\(label) caret must stay inside the container")
+            XCTAssertGreaterThanOrEqual(rect.minY, 0, "\(label) caret must stay inside the container")
+            XCTAssertLessThanOrEqual(rect.maxY, largeFittedHeight + 1,
+                                     "\(label) caret must not point past the reflowed content")
+        }
+    }
+
+    @MainActor
     func testSelectableTextViewDefaultsToNoSelectionCoordinatorHooks() {
         let view = SelectableTextView(text: "plain text")
 

--- a/ConduitTests/ChatTypographyTests.swift
+++ b/ConduitTests/ChatTypographyTests.swift
@@ -490,10 +490,12 @@ final class ChatTypographyTests: XCTestCase {
     /// Review-gate WARNING coverage, mounted at the view level: after the
     /// highlight pass completes the mounted preview slice renders tokenized
     /// at the CURRENT size, and after a chat-size identity change it must
-    /// re-render at the NEW size — a SwiftUI-invisible state mutation (the
-    /// in-place-mutation blocker) would leave the old-size tokens mounted
-    /// forever, which this test fails on. (Exercises the collapsed preview
-    /// slice path; the expanded path shares the same state object.)
+    /// re-render at the NEW size. The stricter render-eligibility invariant
+    /// (highlighted content from a previous identity is never renderable
+    /// under the current one) is enforced by the view's identity guard and
+    /// pinned by testHighlightedResultIsOnlyEligibleForItsOwnIdentity.
+    /// (Exercises the collapsed preview slice path; the expanded slices use
+    /// the same state type and guard.)
     @MainActor
     func testLargeCodeSliceTypographyFollowsIdentityChange() throws {
         let emitter = ChatSizeEmitter()
@@ -614,6 +616,41 @@ final class ChatTypographyTests: XCTestCase {
         // display churn while only unrelated inputs move).
         XCTAssertFalse(state.invalidateIfIdentityChanged(to: "B"))
         XCTAssertEqual(state.highlighted?.string, "retry")
+    }
+
+    /// Render-eligibility invariant (review fix): a highlighted result is
+    /// renderable ONLY under the identity it was produced for. This covers
+    /// the one body evaluation between an identity change and onChange
+    /// delivery — a result from a previous identity must never be mounted
+    /// under the live identity; the view renders plain text instead.
+    @MainActor
+    func testHighlightedResultIsOnlyEligibleForItsOwnIdentity() {
+        var state = LargeCodeSliceHighlightState()
+
+        // Live identity A, result stored under A: eligible.
+        state.invalidateIfIdentityChanged(to: "A")
+        state.syncAndStore(NSAttributedString(string: "a-tokens"), passIdentity: "A")
+        XCTAssertEqual(
+            state.highlightedText(for: "A")?.string, "a-tokens",
+            "the result is eligible under its own identity"
+        )
+
+        // Live identity B, stored result still from A: NOT eligible — the
+        // render-time guard routes the view to the plain-text path.
+        XCTAssertNil(
+            state.highlightedText(for: "B"),
+            "a result from a previous identity must never be renderable under the current one"
+        )
+
+        // Once invalidation lands (onChange), B has no stored result either.
+        state.invalidateIfIdentityChanged(to: "B")
+        XCTAssertNil(state.highlighted)
+        XCTAssertNil(state.highlightedText(for: "B"))
+
+        // A result stored under B is eligible under B and nowhere else.
+        state.syncAndStore(NSAttributedString(string: "b-tokens"), passIdentity: "B")
+        XCTAssertEqual(state.highlightedText(for: "B")?.string, "b-tokens")
+        XCTAssertNil(state.highlightedText(for: "A"))
     }
 
     // MARK: - Settled-row Equatable gates

--- a/ConduitTests/ChatTypographyTests.swift
+++ b/ConduitTests/ChatTypographyTests.swift
@@ -14,10 +14,26 @@
 //  side so any accidental app-wide scaling surfaces as a failure.
 //
 
+import Combine
 import SwiftUI
 import UIKit
 import XCTest
 @testable import Conduit
+
+/// Drives the chat-size environment for mounted-view tests so a test can
+/// flip the preference after mount (exactly what the Settings slider does).
+private final class ChatSizeEmitter: ObservableObject {
+    @Published var chatSize: ChatTextSize = .default
+}
+
+private struct ChatSizeInjector<Content: View>: View {
+    @ObservedObject var emitter: ChatSizeEmitter
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        content().environment(\.chatTextSize, emitter.chatSize)
+    }
+}
 
 final class ChatTypographyTests: XCTestCase {
 
@@ -433,6 +449,173 @@ final class ChatTypographyTests: XCTestCase {
         )
     }
 
+    private func largeHighlightedSource() -> String {
+        // Cross the large-code threshold so LargeCodeBlockView slices the
+        // source into highlighted slices.
+        let line = "let value = compute(\"token\", 42) // comment continuation\n"
+        var source = ""
+        while source.utf8.count < MarkdownLargeDocumentPolicy.codeBlockThresholdBytes + 2_000 {
+            source += line
+        }
+        return source
+    }
+
+    /// Distinct foreground colors in one attributed string — the plain
+    /// rendering path carries exactly one; tokenized highlighting carries
+    /// several.
+    private func distinctForegroundColors(of attributed: NSAttributedString) -> Int {
+        var colors = Set<UIColor>()
+        attributed.enumerateAttribute(
+            .foregroundColor,
+            in: NSRange(location: 0, length: attributed.length),
+            options: []
+        ) { value, _, _ in
+            if let color = value as? UIColor { colors.insert(color) }
+        }
+        return colors.count
+    }
+
+    private func allFontSizes(of attributed: NSAttributedString) -> Set<CGFloat> {
+        var sizes = Set<CGFloat>()
+        attributed.enumerateAttribute(
+            .font,
+            in: NSRange(location: 0, length: attributed.length),
+            options: []
+        ) { value, _, _ in
+            if let font = value as? UIFont { sizes.insert(font.pointSize) }
+        }
+        return sizes
+    }
+
+    /// Review-gate WARNING coverage, mounted at the view level: after the
+    /// highlight pass completes the mounted preview slice renders tokenized
+    /// at the CURRENT size, and after a chat-size identity change it must
+    /// re-render at the NEW size — a SwiftUI-invisible state mutation (the
+    /// in-place-mutation blocker) would leave the old-size tokens mounted
+    /// forever, which this test fails on. (Exercises the collapsed preview
+    /// slice path; the expanded path shares the same state object.)
+    @MainActor
+    func testLargeCodeSliceTypographyFollowsIdentityChange() throws {
+        let emitter = ChatSizeEmitter()
+        let source = largeHighlightedSource()
+        let view = ChatSizeInjector(emitter: emitter) {
+            LargeCodeBlockView(
+                source: source,
+                language: "swift",
+                usesAccentSurface: false
+            )
+        }
+
+        let host = UIHostingController(rootView: view)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.isHidden = false
+        defer {
+            window.isHidden = true
+            window.rootViewController = nil
+        }
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+
+        func pump(_ seconds: TimeInterval) {
+            let deadline = Date().addingTimeInterval(seconds)
+            while Date() < deadline {
+                RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+                host.view.setNeedsLayout()
+                host.view.layoutIfNeeded()
+            }
+        }
+
+        func codeAttributedStrings() -> [NSAttributedString] {
+            allTextViewsDeep(in: host.view)
+                .compactMap { ($0 as? UITextView)?.attributedText }
+                .filter { $0.length > 0 }
+        }
+
+        // Wait for the first highlight pass: some slice must render
+        // tokenized (multiple token colors).
+        pump(4.0)
+        var tokenizedColors = 0
+        var oldSizes = Set<CGFloat>()
+        for attributed in codeAttributedStrings() {
+            let colors = distinctForegroundColors(of: attributed)
+            if colors >= 2 {
+                tokenizedColors = max(tokenizedColors, colors)
+                oldSizes.formUnion(allFontSizes(of: attributed))
+            }
+        }
+        XCTAssertGreaterThanOrEqual(tokenizedColors, 2,
+                                    "the first highlight pass must render tokenized slices")
+        XCTAssertFalse(oldSizes.isEmpty)
+
+        // Change the preference the way the Settings slider does. Every
+        // mounted slice must end up at the NEW size — the old-size tokens
+        // may appear only transiently, never persist.
+        emitter.chatSize = .largest
+        pump(4.0)
+
+        let newSize = ChatTypography.font(for: .blockCode, chatSize: .largest).pointSize
+        let attributedStrings = codeAttributedStrings()
+        XCTAssertFalse(attributedStrings.isEmpty, "slices must stay mounted after the size change")
+        for attributed in attributedStrings {
+            let sizes = allFontSizes(of: attributed)
+            XCTAssertFalse(
+                sizes.contains { size in
+                    oldSizes.contains { abs(size - $0) < 0.01 }
+                },
+                "no mounted slice may keep the previous size's fonts after the identity change"
+            )
+            for size in sizes {
+                XCTAssertEqual(size, newSize, accuracy: 0.5,
+                               "every slice must render at the selected chat size")
+            }
+        }
+    }
+
+    // MARK: - Large-code highlight invalidation (review-gate fix)
+
+    /// A typography/source identity change must invalidate the stored
+    /// highlighted attributed string immediately — the view falls back to
+    /// plain text at the new font while the replacement pass runs. Stale
+    /// passes are refused by the view's live `sliceIdentity ==
+    /// passIdentity` guard before the state is ever touched; this test pins
+    /// the state machine's own contract underneath that guard.
+    @MainActor
+    func testHighlightStateInvalidatesDisplayedResultOnIdentityChange() {
+        var state = LargeCodeSliceHighlightState()
+        let oldSizeResult = NSAttributedString(
+            string: "old",
+            attributes: [.font: UIFont.systemFont(ofSize: 10)]
+        )
+
+        // First pass for identity A: sync the identity, then record.
+        XCTAssertFalse(state.invalidateIfIdentityChanged(to: "A"), "nothing is stored yet")
+        state.syncAndStore(oldSizeResult, passIdentity: "A")
+        XCTAssertEqual(state.highlighted?.string, "old")
+        XCTAssertEqual(state.displayedIdentity, "A")
+
+        // The identity changes (chat size / Dynamic Type / source): the
+        // old-size result must drop immediately.
+        XCTAssertTrue(state.invalidateIfIdentityChanged(to: "B"))
+        XCTAssertNil(state.highlighted, "the stale highlighted result must not stay mounted")
+
+        // The replacement pass for the new identity converges + stores in
+        // one mutation. (A stale pass is refused by the view's live
+        // `sliceIdentity == passIdentity` guard before this is ever
+        // reached, so it can never resurrect a superseded result.)
+        state.syncAndStore(NSAttributedString(string: "new"), passIdentity: "B")
+        XCTAssertEqual(state.highlighted?.string, "new")
+
+        // Same-identity re-store (a retried pass) is fine.
+        state.syncAndStore(NSAttributedString(string: "retry"), passIdentity: "B")
+        XCTAssertEqual(state.highlighted?.string, "retry")
+
+        // An unchanged identity is a no-op (no needless invalidation, no
+        // display churn while only unrelated inputs move).
+        XCTAssertFalse(state.invalidateIfIdentityChanged(to: "B"))
+        XCTAssertEqual(state.highlighted?.string, "retry")
+    }
+
     // MARK: - Settled-row Equatable gates
 
     private func assistantMessage() -> ChatMessage {
@@ -535,23 +718,34 @@ final class ChatTypographyTests: XCTestCase {
             let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
             window.rootViewController = host
             window.isHidden = false
-            host.view.setNeedsLayout()
-            host.view.layoutIfNeeded()
-            // The width probe settles a frame after the first layout pass.
-            let settled = XCTestExpectation(description: "width probe settles")
-            DispatchQueue.main.async { settled.fulfill() }
-            wait(for: [settled], timeout: 2)
-            host.view.setNeedsLayout()
-            host.view.layoutIfNeeded()
-
             defer {
                 window.isHidden = true
                 window.rootViewController = nil
             }
 
-            let textViews = allTextViewsDeep(in: host.view).compactMap { $0 as? UITextView }
-            XCTAssertFalse(textViews.isEmpty, "mounted table must contain text views")
-            return textViews.map { $0.frame.width }.sorted()
+            // The width probe's state lands through SwiftUI preference/
+            // state propagation, which can need more than one layout pass
+            // under CI load. Re-layout and re-check within a bounded number
+            // of passes until the mounted widths are usable and stable —
+            // no arbitrary sleeps, no reliance on a single main-queue hop.
+            var previous: [CGFloat] = []
+            var settledWidths: [CGFloat]?
+            for _ in 0..<10 {
+                host.view.setNeedsLayout()
+                host.view.layoutIfNeeded()
+                let widths = allTextViewsDeep(in: host.view)
+                    .compactMap { ($0 as? UITextView)?.frame.width }
+                    .sorted()
+                if !widths.isEmpty, widths.allSatisfy({ $0 > 0 }), widths == previous {
+                    settledWidths = widths
+                    break
+                }
+                previous = widths
+                RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+            }
+            let widths = try XCTUnwrap(settledWidths, "table widths never settled")
+            XCTAssertFalse(widths.isEmpty, "mounted table must contain text views")
+            return widths
         }
 
         let atDefault = try mountedTextViewWidths(chatTextSize: .default)

--- a/ConduitTests/ChatTypographyTests.swift
+++ b/ConduitTests/ChatTypographyTests.swift
@@ -1,0 +1,569 @@
+//
+//  ChatTypographyTests.swift
+//  ConduitTests
+//
+//  Regression coverage for the chat-only text-size preference (issue #85):
+//  preference persistence, centralized typography resolution, typography-
+//  sensitive cache identities (render cache, table measurement, flow-chunk
+//  memos, code-slice identity), and the settled-row Equatable gates.
+//
+//  Scope note: interface chrome (timestamps, buttons, navigation, Settings,
+//  composer, selection handles) intentionally does NOT resolve through
+//  ChatTypography — that exclusion is a code-review invariant, not something
+//  the unit harness can observe; the font-level tests here pin the content
+//  side so any accidental app-wide scaling surfaces as a failure.
+//
+
+import SwiftUI
+import UIKit
+import XCTest
+@testable import Conduit
+
+final class ChatTypographyTests: XCTestCase {
+
+    // MARK: - Preference model
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: ChatTypography.preferenceKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: ChatTypography.preferenceKey)
+        super.tearDown()
+    }
+
+    func testPreferenceDefaultsToDefaultWithNoStoredValue() {
+        // A missing key must resolve to the default position so existing
+        // users keep today's transcript appearance after updating.
+        XCTAssertNil(UserDefaults.standard.object(forKey: ChatTypography.preferenceKey))
+        XCTAssertEqual(ChatTypography.stored(), .default)
+        XCTAssertEqual(ChatTypography.resolve(rawValue: nil), .default)
+    }
+
+    func testAllFivePersistedValuesRoundTrip() {
+        for size in ChatTextSize.allCases {
+            UserDefaults.standard.set(size.rawValue, forKey: ChatTypography.preferenceKey)
+            XCTAssertEqual(ChatTypography.stored(), size, "rawValue `\(size.rawValue)` must round-trip")
+        }
+    }
+
+    func testInvalidPersistedValuesFallBackSafely() {
+        for invalid in [-1, 5, 99, Int.min, Int.max] {
+            UserDefaults.standard.set(invalid, forKey: ChatTypography.preferenceKey)
+            XCTAssertEqual(
+                ChatTypography.stored(),
+                .default,
+                "out-of-range rawValue \(invalid) must fall back to .default"
+            )
+        }
+        // Non-integer storage reads as "no valid Int" too.
+        UserDefaults.standard.set("nonsense", forKey: ChatTypography.preferenceKey)
+        XCTAssertEqual(ChatTypography.stored(), .default)
+    }
+
+    func testCacheIdentitiesAreDistinctPerPosition() {
+        let identities = Set(ChatTextSize.allCases.map(\.cacheIdentity))
+        XCTAssertEqual(identities.count, ChatTextSize.allCases.count,
+                       "each position needs its own cache identity so no cache can cross sizes")
+    }
+
+    // MARK: - Typography resolution
+
+    func testScaleFactorsMatchSpecification() {
+        let expected: [ChatTextSize: CGFloat] = [
+            .smallest: 0.85,
+            .smaller: 0.925,
+            .default: 1.00,
+            .larger: 1.125,
+            .largest: 1.25
+        ]
+        for (size, factor) in expected {
+            XCTAssertEqual(ChatTypography.scale(for: size), factor, accuracy: 0.0001,
+                           "\(size) scale must match the documented factor")
+        }
+    }
+
+    func testDefaultResolvesExactlyTodayTypography() {
+        let roles: [ChatTypography.Role] = [
+            .body, .heading(level: 1), .heading(level: 3), .quote,
+            .tableHeader, .tableBody, .thinking, .blockCode, .sourceCode
+        ]
+        for role in roles {
+            let resolved = ChatTypography.font(for: role, chatSize: .default)
+            let base = ChatTypography.baseFont(for: role)
+            XCTAssertEqual(resolved.pointSize, base.pointSize, accuracy: 0.001,
+                           "\(role) at .default must be the historical font")
+            XCTAssertEqual(resolved.fontDescriptor, base.fontDescriptor,
+                           "\(role) at .default must preserve the historical descriptor")
+        }
+    }
+
+    func testSizesAreMonotonicAcrossAllRoles() {
+        let ordered = ChatTextSize.allCases.sorted { $0.rawValue < $1.rawValue }
+        let roles: [ChatTypography.Role] = [
+            .body, .heading(level: 1), .heading(level: 4), .quote,
+            .tableHeader, .tableBody, .thinking, .blockCode, .sourceCode
+        ]
+        for role in roles {
+            var previous: CGFloat = -1
+            for size in ordered {
+                let pointSize = ChatTypography.font(for: role, chatSize: size).pointSize
+                XCTAssertGreaterThan(pointSize, previous,
+                                     "\(role) must strictly grow across positions at \(size)")
+                previous = pointSize
+            }
+        }
+    }
+
+    func testSystemDynamicTypeStillAffectsResolvedFonts() {
+        // The chat scale must AUGMENT Dynamic Type, never replace it: at a
+        // fixed chat size, a larger system category still yields larger fonts.
+        let small = UITraitCollection(preferredContentSizeCategory: .small)
+        let huge = UITraitCollection(preferredContentSizeCategory: .extraExtraExtraLarge)
+        for size in ChatTextSize.allCases {
+            for role in [ChatTypography.Role.body, .heading(level: 2), .tableBody] {
+                let atSmall = ChatTypography.font(for: role, chatSize: size, compatibleWith: small)
+                let atHuge = ChatTypography.font(for: role, chatSize: size, compatibleWith: huge)
+                XCTAssertGreaterThan(
+                    atHuge.pointSize, atSmall.pointSize,
+                    "\(role) at chat size \(size) must still respond to Dynamic Type"
+                )
+            }
+        }
+        // And the augmentation composes: largest system + largest chat is
+        // exactly 1.25x the largest system font.
+        let base = ChatTypography.font(for: .body, chatSize: .default, compatibleWith: huge)
+        let scaled = ChatTypography.font(for: .body, chatSize: .largest, compatibleWith: huge)
+        XCTAssertEqual(scaled.pointSize, base.pointSize * 1.25, accuracy: 0.001)
+    }
+
+    func testSemanticHierarchyRemainsIntactAtEverySize() {
+        for size in ChatTextSize.allCases {
+            func font(_ role: ChatTypography.Role) -> UIFont {
+                ChatTypography.font(for: role, chatSize: size)
+            }
+            let h1 = font(.heading(level: 1))
+            let h2 = font(.heading(level: 2))
+            let h3 = font(.heading(level: 3))
+            let h4 = font(.heading(level: 4))
+            let body = font(.body)
+            let tableBody = font(.tableBody)
+
+            XCTAssertGreaterThan(h1.pointSize, h2.pointSize)
+            XCTAssertGreaterThan(h2.pointSize, h3.pointSize)
+            XCTAssertGreaterThan(h3.pointSize, h4.pointSize)
+            // h3 keeps today's relationship to body: same size, heavier trait.
+            XCTAssertEqual(h3.pointSize, body.pointSize, accuracy: 0.001)
+            XCTAssertTrue(h3.fontDescriptor.symbolicTraits.contains(.traitBold),
+                          "a heading must still look like a heading (bold) at \(size)")
+            XCTAssertGreaterThan(body.pointSize, tableBody.pointSize)
+
+            // Code stays monospaced at every size.
+            for codeRole in [ChatTypography.Role.blockCode, .sourceCode] {
+                let codeFont = font(codeRole)
+                XCTAssertEqual(
+                    codeFont.fontName,
+                    UIFont.monospacedSystemFont(ofSize: 10, weight: .regular).fontName,
+                    "\(codeRole) must stay monospaced at \(size)"
+                )
+            }
+            XCTAssertTrue(font(.tableHeader).fontDescriptor.symbolicTraits.contains(.traitBold),
+                          "table header must stay bold at \(size)")
+            XCTAssertTrue(font(.quote).fontDescriptor.symbolicTraits.contains(.traitItalic),
+                          "quote must stay italic at \(size)")
+        }
+    }
+
+    // MARK: - Markdown render cache
+
+    private let cacheFixtureSource = """
+    ## Cached typography probe
+
+    A paragraph with **bold**, *italic*, `code`, and a [link](https://example.com).
+    """
+
+    @MainActor
+    func testRenderCacheSeparatesChatSizes() throws {
+        func firstFontSize(_ rendering: MarkdownRendering) throws -> CGFloat {
+            let attributed = try XCTUnwrap(rendering.selectableText)
+            let font = try XCTUnwrap(attributed.attribute(.font, at: 0, effectiveRange: nil) as? UIFont)
+            return font.pointSize
+        }
+
+        let atDefault = MarkdownRenderCache.rendering(
+            source: cacheFixtureSource,
+            recognizesGatewayMedia: false,
+            foregroundStyle: .primary,
+            usesAccentSurface: false,
+            isStreaming: false,
+            chatTextSize: .default
+        )
+        let atLargest = MarkdownRenderCache.rendering(
+            source: cacheFixtureSource,
+            recognizesGatewayMedia: false,
+            foregroundStyle: .primary,
+            usesAccentSurface: false,
+            isStreaming: false,
+            chatTextSize: .largest
+        )
+        XCTAssertFalse(atDefault === atLargest,
+                       "a chat-size change must never reuse the other size's rendering")
+        XCTAssertGreaterThan(try firstFontSize(atLargest), try firstFontSize(atDefault),
+                             "the rebuilt rendering must carry the larger fonts")
+
+        // Returning to the earlier size must hit the original cached entry
+        // again — both directions stay cached, nothing stale is served.
+        let backToDefault = MarkdownRenderCache.rendering(
+            source: cacheFixtureSource,
+            recognizesGatewayMedia: false,
+            foregroundStyle: .primary,
+            usesAccentSurface: false,
+            isStreaming: false,
+            chatTextSize: .default
+        )
+        XCTAssertTrue(backToDefault === atDefault,
+                      "returning to a previously rendered size must reuse that size's cache entry")
+    }
+
+    @MainActor
+    func testStreamingAndSettledConvergeOnOneTypography() throws {
+        // Stable chunks (isStreaming: false) and the live tail
+        // (isStreaming: true) resolve through the same ChatTypography value,
+        // so a mid-stream preference change moves BOTH pieces together.
+        func firstFontSize(isStreaming: Bool, chatTextSize: ChatTextSize) throws -> CGFloat {
+            let rendering = MarkdownRenderCache.rendering(
+                source: cacheFixtureSource,
+                recognizesGatewayMedia: false,
+                foregroundStyle: .primary,
+                usesAccentSurface: false,
+                isStreaming: isStreaming,
+                chatTextSize: chatTextSize
+            )
+            let attributed = try XCTUnwrap(rendering.selectableText)
+            let font = try XCTUnwrap(attributed.attribute(.font, at: 0, effectiveRange: nil) as? UIFont)
+            return font.pointSize
+        }
+
+        let settled = try firstFontSize(isStreaming: false, chatTextSize: .larger)
+        let streaming = try firstFontSize(isStreaming: true, chatTextSize: .larger)
+        XCTAssertEqual(streaming, settled, accuracy: 0.001,
+                       "streaming and settled content must resolve identical fonts")
+
+        let settledDefault = try firstFontSize(isStreaming: false, chatTextSize: .default)
+        XCTAssertGreaterThan(settled, settledDefault)
+    }
+
+    // MARK: - Selection formatter fonts
+
+    func testFormatterScalesAllInlineRuns() throws {
+        let blocks = MarkdownParser.parse("A **bold** run, *italic*, `code`, and plain.")
+        func fontSizes(at size: ChatTextSize) throws -> [CGFloat] {
+            let attributed = try XCTUnwrap(MarkdownSelectionFormatter.attributedText(
+                for: blocks,
+                foregroundStyle: .primary,
+                usesAccentSurface: false,
+                newestCharacterOpacities: [],
+                chatTextSize: size
+            ))
+            var sizes: [CGFloat] = []
+            attributed.enumerateAttribute(.font, in: NSRange(location: 0, length: attributed.length), options: []) { value, _, _ in
+                if let font = value as? UIFont { sizes.append(font.pointSize) }
+            }
+            return sizes
+        }
+
+        let baseline = try fontSizes(at: .default)
+        let scaled = try fontSizes(at: .larger)
+        XCTAssertEqual(baseline.count, scaled.count)
+        for (index, baseSize) in baseline.enumerated() {
+            XCTAssertEqual(scaled[index], baseSize * 1.125, accuracy: 0.01,
+                           "every run (bold, italic, code, plain) must scale proportionally")
+        }
+    }
+
+    func testFormatterDefaultMatchesUnscaledPreferredFont() throws {
+        let blocks = MarkdownParser.parse("Plain paragraph for the baseline probe.")
+        let attributed = try XCTUnwrap(MarkdownSelectionFormatter.attributedText(
+            for: blocks,
+            foregroundStyle: .primary,
+            usesAccentSurface: false,
+            newestCharacterOpacities: [],
+            chatTextSize: .default
+        ))
+        let font = try XCTUnwrap(attributed.attribute(.font, at: 0, effectiveRange: nil) as? UIFont)
+        XCTAssertEqual(font.pointSize, UIFont.preferredFont(forTextStyle: .body).pointSize, accuracy: 0.001)
+    }
+
+    func testSelectionContentIsSizeInvariant() throws {
+        // Selection works on character ranges; the typography change must
+        // not alter the string the ranges point into.
+        let blocks = MarkdownParser.parse("## Head\n\nOne **two** three.")
+        let small = try XCTUnwrap(MarkdownSelectionFormatter.attributedText(
+            for: blocks, foregroundStyle: .primary, usesAccentSurface: false,
+            newestCharacterOpacities: [], chatTextSize: .smallest
+        ))
+        let large = try XCTUnwrap(MarkdownSelectionFormatter.attributedText(
+            for: blocks, foregroundStyle: .primary, usesAccentSurface: false,
+            newestCharacterOpacities: [], chatTextSize: .largest
+        ))
+        XCTAssertEqual(small.string, large.string)
+        XCTAssertEqual(small.length, large.length)
+    }
+
+    // MARK: - Large-document flow chunk memo
+
+    @MainActor
+    func testFlowChunkBoxInvalidatesOnChatTextSizeChange() {
+        let box = LargeFlowChunkBox()
+        let blocks: [MarkdownBlock] = [.paragraph("Large-document chunk typography probe.")]
+
+        let atDefault = box.attributedText(
+            blocks: blocks, references: .empty,
+            foregroundStyle: .primary, usesAccentSurface: false,
+            contentCategory: .large, chatTextSize: .default
+        )
+        let cachedDefault = box.attributedText(
+            blocks: blocks, references: .empty,
+            foregroundStyle: .primary, usesAccentSurface: false,
+            contentCategory: .large, chatTextSize: .default
+        )
+        XCTAssertTrue(atDefault === cachedDefault, "same chat size must reuse the memoized string")
+
+        let atLargest = box.attributedText(
+            blocks: blocks, references: .empty,
+            foregroundStyle: .primary, usesAccentSurface: false,
+            contentCategory: .large, chatTextSize: .largest
+        )
+        XCTAssertFalse(atDefault === atLargest,
+                       "a chat-size change must rebuild the memoized chunk")
+        if let oldFont = atDefault?.attribute(.font, at: 0, effectiveRange: nil) as? UIFont,
+           let newFont = atLargest?.attribute(.font, at: 0, effectiveRange: nil) as? UIFont {
+            XCTAssertGreaterThan(newFont.pointSize, oldFont.pointSize)
+        } else {
+            XCTFail("flow chunk strings must carry fonts")
+        }
+
+        let backToDefault = box.attributedText(
+            blocks: blocks, references: .empty,
+            foregroundStyle: .primary, usesAccentSurface: false,
+            contentCategory: .large, chatTextSize: .default
+        )
+        // The box is a single-slot memo: returning to the earlier size
+        // legitimately REBUILDS (the .largest entry replaced it) — the
+        // contract is that it rebuilds to the original size's metrics and
+        // never serves the other size's string.
+        XCTAssertFalse(backToDefault === atLargest,
+                       "the previous size's string must not be served at the original size")
+        if let originalFont = atDefault?.attribute(.font, at: 0, effectiveRange: nil) as? UIFont,
+           let rebuiltFont = backToDefault?.attribute(.font, at: 0, effectiveRange: nil) as? UIFont {
+            XCTAssertEqual(rebuiltFont.pointSize, originalFont.pointSize, accuracy: 0.001,
+                           "the rebuilt memo must carry the original size's typography")
+        } else {
+            XCTFail("flow chunk strings must carry fonts")
+        }
+    }
+
+    // MARK: - Table measurement identity
+
+    @MainActor
+    func testTableMeasurementChangesWithChatSize() {
+        // Wide cells exercise the measurement (not the fixed caps): the
+        // fonts grow, so the ideal cell widths grow too.
+        let headers = ["Column One", "Column Two"]
+        let rows = [["measured content driver", "second driver value"]]
+
+        let atDefault = MarkdownTableLayout.columnWidths(
+            headers: headers, rows: rows,
+            availableWidth: 390, chatTextSize: .default
+        )
+        let atLargest = MarkdownTableLayout.columnWidths(
+            headers: headers, rows: rows,
+            availableWidth: 390, chatTextSize: .largest
+        )
+        XCTAssertEqual(atDefault.count, atLargest.count)
+        for (old, new) in zip(atDefault, atLargest) {
+            XCTAssertGreaterThan(new, old,
+                                 "larger chat text must measure wider cells — no stale widths")
+        }
+
+        // Back to the first size: the original measurements again (exact
+        // equality proves the cache served the right identity).
+        let backToDefault = MarkdownTableLayout.columnWidths(
+            headers: headers, rows: rows,
+            availableWidth: 390, chatTextSize: .default
+        )
+        XCTAssertEqual(backToDefault, atDefault)
+
+        // Narrow table: tiny content stays a valid two-column layout.
+        let tiny = MarkdownTableLayout.columnWidths(
+            headers: ["A", "B"], rows: [["1", "2"]],
+            availableWidth: 390, chatTextSize: .default
+        )
+        let tinyLarge = MarkdownTableLayout.columnWidths(
+            headers: ["A", "B"], rows: [["1", "2"]],
+            availableWidth: 390, chatTextSize: .largest
+        )
+        XCTAssertEqual(tiny.count, 2)
+        XCTAssertEqual(tinyLarge.count, 2)
+    }
+
+    // MARK: - Large/sliced code identity
+
+    func testLargeCodeSliceIdentityIncludesChatSize() {
+        let category = ContentSizeCategory.large
+        let base = LargeCodeSliceIdentity.identity(source: "let x = 1", sizeCategory: category, chatTextSize: .default)
+
+        XCTAssertEqual(base, LargeCodeSliceIdentity.identity(source: "let x = 1", sizeCategory: category, chatTextSize: .default),
+                       "identical inputs must keep one identity")
+        for size in ChatTextSize.allCases where size != .default {
+            XCTAssertNotEqual(
+                base,
+                LargeCodeSliceIdentity.identity(source: "let x = 1", sizeCategory: category, chatTextSize: size),
+                "a chat-size change must invalidate the slice's highlight pass"
+            )
+        }
+        XCTAssertNotEqual(
+            base,
+            LargeCodeSliceIdentity.identity(source: "let y = 2", sizeCategory: category, chatTextSize: .default)
+        )
+        XCTAssertNotEqual(
+            base,
+            LargeCodeSliceIdentity.identity(source: "let x = 1", sizeCategory: .extraExtraLarge, chatTextSize: .default)
+        )
+    }
+
+    // MARK: - Settled-row Equatable gates
+
+    private func assistantMessage() -> ChatMessage {
+        ChatMessage(
+            id: "m1",
+            role: .assistant,
+            content: "Settled **assistant** body for the gate probe.",
+            timestamp: "2026-01-01T00:00:00Z"
+        )
+    }
+
+    private func userMessage() -> ChatMessage {
+        ChatMessage(
+            id: "m2",
+            role: .user,
+            content: "Settled user body for the gate probe.",
+            timestamp: "2026-01-01T00:00:01Z"
+        )
+    }
+
+    func testSettledAssistantGateReOpensOnChatSizeChange() {
+        let message = assistantMessage()
+        let baseline = SettledAssistantMessageContent(
+            message: message, displayName: "Hermes", avatarURL: nil,
+            gatewayResolver: nil, sizeCategory: .large, chatTextSize: .default
+        )
+        let sameInputs = SettledAssistantMessageContent(
+            message: message, displayName: "Hermes", avatarURL: nil,
+            gatewayResolver: nil, sizeCategory: .large, chatTextSize: .default
+        )
+        XCTAssertEqual(baseline, sameInputs,
+                       "identical inputs (the ordinary streaming publish) must stay gated")
+
+        let resized = SettledAssistantMessageContent(
+            message: message, displayName: "Hermes", avatarURL: nil,
+            gatewayResolver: nil, sizeCategory: .large, chatTextSize: .larger
+        )
+        XCTAssertNotEqual(baseline, resized,
+                          "a chat text-size change must re-open the settled gate")
+    }
+
+    func testSettledUserGateReOpensOnChatSizeChange() {
+        let message = userMessage()
+        let baseline = UserMessageContent(
+            message: message, gatewayResolver: nil,
+            sizeCategory: .large, chatTextSize: .default
+        )
+        XCTAssertEqual(baseline, UserMessageContent(
+            message: message, gatewayResolver: nil,
+            sizeCategory: .large, chatTextSize: .default
+        ))
+
+        XCTAssertNotEqual(baseline, UserMessageContent(
+            message: message, gatewayResolver: nil,
+            sizeCategory: .large, chatTextSize: .smallest
+        ))
+    }
+
+    func testSettledThinkingGateReOpensOnChatSizeChange() {
+        let message = assistantMessage()
+        let baseline = SettledThinkingCardContent(
+            message: message, displayName: "Hermes", avatarURL: nil,
+            sizeCategory: .large, chatTextSize: .default
+        )
+        XCTAssertEqual(baseline, SettledThinkingCardContent(
+            message: message, displayName: "Hermes", avatarURL: nil,
+            sizeCategory: .large, chatTextSize: .default
+        ))
+        XCTAssertNotEqual(baseline, SettledThinkingCardContent(
+            message: message, displayName: "Hermes", avatarURL: nil,
+            sizeCategory: .large, chatTextSize: .largest
+        ))
+    }
+
+    // MARK: - Ordinary table view wiring (review-gate integration)
+
+    /// Regression for the review-gate BLOCKER: the ordinary MarkdownTable
+    /// must pass the selected chat size into MarkdownTableLayout, so columns
+    /// are measured at the same size the cells render at. Mounting the view
+    /// is the only way to observe that wiring — a direct columnWidths call
+    /// with an explicit argument cannot catch a missed argument at the call
+    /// site inside the view.
+    @MainActor
+    func testOrdinaryTableViewWiresChatSizeIntoColumnWidths() throws {
+        func mountedTextViewWidths(chatTextSize: ChatTextSize) throws -> [CGFloat] {
+            let table = MarkdownTable(
+                headers: ["Column One", "Column Two"],
+                alignments: [.leading, .leading],
+                rows: [["measured content driver", "second driver value"]],
+                foregroundStyle: .primary,
+                usesAccentSurface: false,
+                selectionCoordinator: nil,
+                blockIndex: 0,
+                selectionSegments: []
+            )
+            .environment(\.markdownReferences, .empty)
+            .environment(\.chatTextSize, chatTextSize)
+
+            let host = UIHostingController(rootView: table)
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+            window.rootViewController = host
+            window.isHidden = false
+            host.view.setNeedsLayout()
+            host.view.layoutIfNeeded()
+            // The width probe settles a frame after the first layout pass.
+            let settled = XCTestExpectation(description: "width probe settles")
+            DispatchQueue.main.async { settled.fulfill() }
+            wait(for: [settled], timeout: 2)
+            host.view.setNeedsLayout()
+            host.view.layoutIfNeeded()
+
+            defer {
+                window.isHidden = true
+                window.rootViewController = nil
+            }
+
+            let textViews = allTextViewsDeep(in: host.view).compactMap { $0 as? UITextView }
+            XCTAssertFalse(textViews.isEmpty, "mounted table must contain text views")
+            return textViews.map { $0.frame.width }.sorted()
+        }
+
+        let atDefault = try mountedTextViewWidths(chatTextSize: .default)
+        let atLargest = try mountedTextViewWidths(chatTextSize: .largest)
+        XCTAssertEqual(atDefault.count, atLargest.count)
+        XCTAssertGreaterThan(
+            atLargest.max() ?? 0, atDefault.max() ?? 0,
+            "the ordinary table's mounted columns must grow with the chat size"
+        )
+    }
+
+    private func allTextViewsDeep(in view: UIView) -> [UIView] {
+        view.subviews.flatMap { [$0] + allTextViewsDeep(in: $0) }
+    }
+}

--- a/ConduitTests/ChatViewportControllerTests.swift
+++ b/ConduitTests/ChatViewportControllerTests.swift
@@ -542,6 +542,10 @@ final class ChatViewportControllerTests: XCTestCase {
                 scrollCommands(effects).isEmpty,
                 "a typography reflow must not scroll a browsing user"
             )
+            XCTAssertNil(
+                browsing.pendingFollowCorrection,
+                "a relatch correction must never be scheduled while browsing"
+            )
         }
     }
 

--- a/ConduitTests/ChatViewportControllerTests.swift
+++ b/ConduitTests/ChatViewportControllerTests.swift
@@ -514,6 +514,37 @@ final class ChatViewportControllerTests: XCTestCase {
         )).isEmpty)
     }
 
+    func testChatTextSizeReflowDoesNotScrollWhileBrowsing() {
+        // Issue #85: changing the chat text size reflows the transcript and
+        // reaches the viewport ONLY as layout-metric ticks — it is never a
+        // transcript change (appState.messages is untouched) — so a user
+        // scrolled away from the bottom must not be thrown to the bottom
+        // when the rows resize under them.
+        var browsing = makeController(following: keyA)
+        _ = dragBegan(&browsing, sessionKey: keyA)
+        _ = browsing.userDragGestureEnded()
+
+        // The reflow lands as successive geometry ticks with the content
+        // bottom far below the viewport (rows grew taller). No tick may
+        // scroll a browsing user away-from-bottom. (A scheduled relatch
+        // correction dies silently in this mode — followCorrectionDue
+        // requires .followingLatest — so there is no second-order scroll
+        // path to guard here.)
+        for bottomMarkerMaxY: CGFloat in [1000, 1400, 2000] {
+            let effects = browsing.layoutMetricsChanged(
+                facts: layoutFacts(
+                    bottomMarkerMaxY: bottomMarkerMaxY,
+                    viewportMaxY: 800,
+                    scope: browsing.renderedScrollScope
+                )
+            )
+            XCTAssertTrue(
+                scrollCommands(effects).isEmpty,
+                "a typography reflow must not scroll a browsing user"
+            )
+        }
+    }
+
     func testLayoutTickNearBottomWhileBrowsingRelatchesWithoutScrolling() {
         var controller = makeController(following: keyA)
         _ = dragBegan(&controller, sessionKey: keyA)

--- a/ConduitTests/SettledMessageIsolationTests.swift
+++ b/ConduitTests/SettledMessageIsolationTests.swift
@@ -244,35 +244,40 @@ final class SettledMessageIsolationTests: XCTestCase {
             displayName: "Hermes",
             avatarURL: nil,
             gatewayResolver: resolver,
-            sizeCategory: .large
+            sizeCategory: .large,
+            chatTextSize: .default
         )
         let sameInputs = SettledAssistantMessageContent(
             message: markdownMessage(),
             displayName: "Hermes",
             avatarURL: nil,
             gatewayResolver: resolver,
-            sizeCategory: .large
+            sizeCategory: .large,
+            chatTextSize: .default
         )
         let differentResolver = SettledAssistantMessageContent(
             message: markdownMessage(),
             displayName: "Hermes",
             avatarURL: nil,
             gatewayResolver: otherResolver,
-            sizeCategory: .large
+            sizeCategory: .large,
+            chatTextSize: .default
         )
         let differentMessage = SettledAssistantMessageContent(
             message: markdownMessage(id: "m2"),
             displayName: "Hermes",
             avatarURL: nil,
             gatewayResolver: resolver,
-            sizeCategory: .large
+            sizeCategory: .large,
+            chatTextSize: .default
         )
         let differentSizeCategory = SettledAssistantMessageContent(
             message: markdownMessage(),
             displayName: "Hermes",
             avatarURL: nil,
             gatewayResolver: resolver,
-            sizeCategory: .extraExtraLarge
+            sizeCategory: .extraExtraLarge,
+            chatTextSize: .default
         )
 
         XCTAssertEqual(a, sameInputs, "equal message + same resolver identity must compare equal")


### PR DESCRIPTION
## Chat-only font size preference (issue #85)

Closes #85.

Adds a five-position stepped **chat text size** preference (Smallest · Smaller · Default · Larger · Largest) that reflows readable transcript content independently from the rest of the UI. Live update, no Save button, local device-only — never synced to Hermes, profiles, or the gateway.

### Design

**`ChatTypography` is the sole authority for transcript-content font resolution.** The selected size is a first-class rendering input that **augments** iOS Dynamic Type (`system Dynamic Type size × Conduit chat scale`), so `Default` renders exactly like today's transcript and accessibility text sizing keeps working at every position. Semantic roles (body, headings by level, quote, table header/body, thinking, block code, source cards) map to the same Dynamic Type styles the renderer used before — hierarchy and monospace/code treatment preserved.

### Coverage

- **Markdown paths:** settled user/assistant/partial/system Markdown, streaming (stable chunks + live tail converge), large documents (collapsed preview, expanded flow chunks, specialized callouts/columns), tables (ordinary + paged), block code, large/sliced code, and the source cards around Mermaid/KaTeX previews. The WebKit diagram/formula previews intentionally keep their internal size (documented in `ChatTypography.swift`).
- **Typography-sensitive caches all include the chat-size identity:** `MarkdownRenderCache` key, `MarkdownTableLayout` measurement key, `LargeFlowChunkBox` memo, `LargeCodeSliceIdentity` (highlight task identity). `SyntaxHighlighter` needs no key — it bakes colors only; fonts are applied at bridge time.
- **Equatable settled-row gates:** `UserMessageContent`, `SettledAssistantMessageContent`, and `SettledThinkingCardContent` carry an explicit `chatTextSize` input — a preference change re-opens the gate; ordinary streaming publishes keep the existing isolation.
- **Chrome untouched:** timestamps, identity labels, copy/branch/read-aloud buttons, navigation, Settings, composer, tool/status cards, selection handles.

### Settings

Settings → Chat gains a live five-position slider (device-only `@AppStorage`, same pattern as the Return-key preference): A–A scale labels, selected-value caption, `accessibilityLabel`/`accessibilityValue`/`accessibilityHint`.

### Tests

New `ChatTypographyTests` (14 tests): preference default/round-trip/invalid fallback, scale spec, `.default` ≡ legacy fonts, monotonic ordering, Dynamic Type augmentation via trait collections, hierarchy/monospace/traits at every size, render-cache size separation + return-hit, streaming/settled convergence, formatter run scaling, selection content invariance, flow-chunk memo invalidation, table measurement reflow, large-code-slice identity, all three Equatable gates, and a **view-level integration test** pinning the ordinary `MarkdownTable` → `MarkdownTableLayout` chat-size wiring (mounted column widths must grow with the selected size). `SettledMessageIsolationTests` adapted for the new gate parameter.

### Validation

- Full `ios_test` suite: **70/70 units passed** (69 pre-existing + new suite), zero failures, zero uncovered.
- Multi-model review gate ran on the branch diff; the one verified BLOCKER (ordinary `MarkdownTable` missing the measurement wiring — caught by review, missed by direct-call tests) and the list-marker Dynamic Type warning are fixed in this commit, plus the flagged slider-knob/test-newline nits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a device-only Chat text size setting with five size options.
  - Changes apply immediately without saving or profile synchronization.
  - Conversation text, headings, tables, quotes, lists, code blocks, and thinking content now follow the selected size.
  - Chat text sizing works alongside accessibility text-size settings.

- **Bug Fixes**
  - Preserved browsing position when text resizing reflows chat content.

- **Tests**
  - Added coverage for persistence, rendering, scaling, reflow, and cache updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->