### PR TITLE
fix(chat): honor Hermes display projection on persisted transcript rows

### DIFF
--- a/Conduit/Models/Models.swift
+++ b/Conduit/Models/Models.swift
@@ -171,6 +171,12 @@ struct ChatMessage: Identifiable, Equatable {
     var approval: ApprovalActivity?
     var attachments: [Attachment]?
     var code: String?
+    /// Canonical Hermes `display_kind` when the persisted row arrived with
+    /// explicit synthetic-timeline projection (`model_switch`, `auto_continue`,
+    /// …). Nil for ordinary rows. Normalization already reduced the row to its
+    /// final display role/content; this only lets the timeline UI style the
+    /// notice without re-deriving it from text.
+    let displayKind: String?
 
     // Non-codable because it contains closures in some uses; serialization
     // is handled by the gateway, not by us. We construct these from RPC results.
@@ -188,7 +194,8 @@ struct ChatMessage: Identifiable, Equatable {
         clarify: ClarifyActivity? = nil,
         approval: ApprovalActivity? = nil,
         attachments: [Attachment]? = nil,
-        code: String? = nil
+        code: String? = nil,
+        displayKind: String? = nil
     ) {
         self.id = id
         self.role = role
@@ -203,6 +210,7 @@ struct ChatMessage: Identifiable, Equatable {
         self.approval = approval
         self.attachments = attachments
         self.code = code
+        self.displayKind = displayKind
     }
 }
 

--- a/Conduit/Services/HermesClient.swift
+++ b/Conduit/Services/HermesClient.swift
@@ -1700,20 +1700,16 @@ enum MessageNormalizer {
     }
 
     /// `display_content` is the authoritative visible payload whenever the
-    /// field exists — including an explicit empty string, which must never
-    /// fall back to the physical carrier. A JSON null is treated as absent:
-    /// no current Hermes write path emits one, and a broken projection should
-    /// not silently hide a genuine message. Non-textual scalars (a stray
-    /// bool/number) are malformed rather than an intentional empty
-    /// projection, so they degrade to the physical carrier too.
+    /// field exists — including an explicit empty string, JSON null, or an
+    /// odd scalar, all of which resolve to authoritative empty text rather
+    /// than a fallback. Field presence is the authority boundary: once the
+    /// field exists, the physical carrier must never resurface, because a
+    /// malformed projection falling back to physical content could expose
+    /// model-facing internal rows. Nil return therefore means exactly
+    /// "field absent".
     private static func projectedDisplayContent(in obj: [String: AnyCodable]) -> String? {
         guard let value = obj["display_content"] else { return nil }
-        switch value {
-        case .string, .array, .object:
-            return extractContent(value)
-        default:
-            return nil
-        }
+        return extractContent(value)
     }
 
     /// `display_metadata` may arrive as a JSON object (current servers) or as
@@ -1732,9 +1728,13 @@ enum MessageNormalizer {
     }
 
     /// Upstream persists `task_count` on `async_delegation_complete` rows so
-    /// clients can phrase the completion notice.
+    /// clients can phrase the completion notice. The count goes through
+    /// `doubleValue` + `Int(exactly:)` so non-representable numbers (1e100,
+    /// NaN, fractional) degrade to the generic notice instead of trapping
+    /// normalization — malformed metadata must never fail hydration.
     private static func delegationCompleteNotice(metadata: AnyCodable?) -> String {
-        guard let taskCount = displayMetadataObject(metadata)?["task_count"]?.intValue,
+        guard let count = displayMetadataObject(metadata)?["task_count"]?.doubleValue,
+              let taskCount = Int(exactly: count),
               taskCount > 0 else {
             return "Background agent work finished"
         }
@@ -1753,12 +1753,11 @@ enum MessageNormalizer {
         systemNotice: String?,
         rawVisible: String
     ) -> String {
-        let projectedNotice: String? = {
-            guard let projected, !projected.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-                return nil
-            }
-            return projected
-        }()
+        // `projected` is non-nil only when the `display_content` field
+        // exists, and its value — including an explicit empty string — is
+        // authoritative: trimming an empty projection back into absence
+        // would fall through to canned labels or the physical carrier,
+        // which must never resurface.
         switch kind {
         case .hidden:
             // Defense in depth: hidden rows are dropped before content work.
@@ -1770,8 +1769,8 @@ enum MessageNormalizer {
             // model-change card detection and keeps that presentation. A
             // marker the card regex cannot parse is still model scaffold, so
             // it degrades to the canned label rather than rendering raw.
-            if let projectedNotice {
-                return projectedNotice
+            if let projected {
+                return projected
             }
             if let modelChange {
                 return "[Model has been changed to \(modelChange.provider)/\(modelChange.model)]"
@@ -1780,16 +1779,22 @@ enum MessageNormalizer {
         case .personalitySwitch:
             // The physical marker embeds the full persona prompt; surface a
             // canned label instead, like Hermes Desktop does.
-            return projectedNotice ?? "Personality changed"
+            return projected ?? "Personality changed"
         case .autoContinue:
-            return projectedNotice ?? "Resumed interrupted turn"
+            return projected ?? "Resumed interrupted turn"
         case .asyncDelegationComplete:
-            return projectedNotice ?? delegationCompleteNotice(metadata: metadata)
+            return projected ?? delegationCompleteNotice(metadata: metadata)
         case .internalNotification:
             // The row content is the operational notice itself (wake events,
-            // background completions); show it as a system notice, with a
-            // `[System: …]` wrapper stripped when present.
-            let visible = projectedNotice ?? systemNotice ?? rawVisible
+            // background completions); show it as a system notice. An
+            // explicit projection — including an empty one — is authoritative
+            // and rendered verbatim; the canned label is only for rows that
+            // have no projection at all, and the `[System: …]` strip applies
+            // only to that no-projection fallback.
+            if let projected {
+                return projected
+            }
+            let visible = systemNotice ?? rawVisible
             return visible.isEmpty ? "System notification" : visible
         }
     }

--- a/Conduit/Services/HermesClient.swift
+++ b/Conduit/Services/HermesClient.swift
@@ -1247,6 +1247,25 @@ extension AnyCodable {
 
 // MARK: - Message Normalization
 
+/// Hermes' persisted display-projection contract. Some model-facing records —
+/// model switches, personality pivots, auto-continuations, background-agent
+/// completions, internal wake notices — are persisted as `role=user` rows so
+/// strict OpenAI-compatible providers accept them mid-history, while
+/// `display_kind` tells clients they are not human-authored messages and
+/// `display_content` overrides the physical `content` with the text that
+/// should actually be visible. The recognized values mirror Hermes Desktop's
+/// transcript hydration; an unrecognized value is deliberately given no
+/// display semantics so a future kind can never delete or reinterpret an
+/// ordinary visible row.
+private enum HermesDisplayKind: String {
+    case hidden
+    case modelSwitch = "model_switch"
+    case personalitySwitch = "personality_switch"
+    case autoContinue = "auto_continue"
+    case asyncDelegationComplete = "async_delegation_complete"
+    case internalNotification = "internal_notification"
+}
+
 enum MessageNormalizer {
 
     static func normalizeProjects(_ payload: AnyCodable, profile: String?) -> [ProjectSummary] {
@@ -1474,6 +1493,19 @@ enum MessageNormalizer {
                 ?? dataMessage
                 ?? [:]
             let obj = envelope.merging(nested) { _, nestedValue in nestedValue }
+
+            // Hermes' display projection is resolved before any content work.
+            // A hidden row is pure model-facing scaffolding (compaction
+            // handoffs, interrupted-turn checkpoints) that can be
+            // multi-megabyte, so it is dropped before Markdown, compaction
+            // scans, reasoning extraction, or tool interpretation — and
+            // regardless of its physical role.
+            let displayKind = HermesDisplayKind(
+                rawValue: (obj["display_kind"]?.stringValue ?? "")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+            if displayKind == .hidden { continue }
+
             let rawRole = (obj["role"]?.stringValue ?? obj["type"]?.stringValue ?? "").lowercased()
             let isToolResult = rawRole == "tool" || rawRole.contains("tool_result") || rawRole.contains("tool-result")
             var role: MessageRole
@@ -1493,28 +1525,68 @@ enum MessageNormalizer {
                 ?? obj["message_id"]?.descriptiveStringValue
                 ?? String(index)
 
+            // `display_content` replaces the physical payload for
+            // conversational rows. Tool results keep their legacy handling:
+            // upstream only ever projects conversational rows, and a tool
+            // output that merely contains display-like fields must not be
+            // rewritten. The `??` keeps the physical carrier un-extracted
+            // whenever a projection exists.
+            let projectedContent = isToolResult ? nil : projectedDisplayContent(in: obj)
             let extractedContent = isToolResult
                 ? extractToolOutput(obj)
-                : extractContent(obj["content"] ?? obj["text"] ?? .null)
+                : projectedContent ?? extractContent(obj["content"] ?? obj["text"] ?? .null)
             // Compaction bookkeeping is removed before role/system/runtime
             // normalization so no summary text — standalone or merged onto a
             // real prompt — can reach a ChatMessage and the renderer.
-            guard let rawContent = visibleContentRemovingCompaction(
-                from: obj,
-                content: extractedContent,
-                isToolResult: isToolResult
-            ) else {
+            //
+            // With an explicit display projection the physical carrier is
+            // never scanned and the projected text is never re-judged: the
+            // legacy delimiter search, the `_compressed_summary` flag, and
+            // the summary-prefix guard cannot discard authentic
+            // `display_content` (ordering matters here — the compatibility
+            // filters are only for rows lacking display metadata).
+            let rawContent: String?
+            if let projected = projectedContent {
+                rawContent = projected
+            } else {
+                rawContent = visibleContentRemovingCompaction(
+                    from: obj,
+                    content: extractedContent,
+                    isToolResult: isToolResult
+                )
+            }
+            guard let rawContent else {
                 continue
             }
             let modelChange = modelChangeActivity(fromText: rawContent)
             let systemNotice = systemNoticeText(fromText: rawContent)
-            if modelChange != nil || systemNotice != nil { role = .system }
+            // A known synthetic display kind never renders as a human turn,
+            // even when its persisted role is `user` and its text matches no
+            // legacy marker. Unknown kinds keep ordinary normalization.
+            if modelChange != nil || systemNotice != nil || (displayKind != nil && !isToolResult) {
+                role = .system
+            }
             let userContent: (content: String, rawContent: String?, attachments: [Attachment]?) = role == .user
                 ? splitUserImageReferences(rawContent, messageId: id)
                 : (content: rawContent, rawContent: nil, attachments: nil)
-            let content = modelChange.map {
-                "[Model has been changed to \($0.provider)/\($0.model)]"
-            } ?? systemNotice ?? userContent.content
+            let content: String
+            if let displayKind, !isToolResult {
+                // `displayKind` is non-nil here only for the known synthetic
+                // timeline kinds: hidden rows were already dropped and
+                // unknown values fail raw-value decoding above.
+                content = timelineNoticeContent(
+                    for: displayKind,
+                    projected: projectedContent,
+                    metadata: obj["display_metadata"],
+                    modelChange: modelChange,
+                    systemNotice: systemNotice,
+                    rawVisible: rawContent
+                )
+            } else {
+                content = modelChange.map {
+                    "[Model has been changed to \($0.provider)/\($0.model)]"
+                } ?? systemNotice ?? userContent.content
+            }
 
             let reasoning = role == .assistant ? extractContent(obj["reasoning"] ?? obj["reasoning_content"] ?? .null) : nil
             // This deliberately follows Desktop's persisted-transcript parser:
@@ -1584,7 +1656,12 @@ enum MessageNormalizer {
                 ))
             }
 
-            let review = role == .system ? reviewActivity(from: obj, eventSessionId: nil) : nil
+            // Timeline-projected rows are never self-improvement reviews, and
+            // skipping detection also keeps their physical carrier
+            // un-extracted.
+            let review = role == .system && displayKind == nil
+                ? reviewActivity(from: obj, eventSessionId: nil)
+                : nil
             let base = ChatMessage(
                 id: id,
                 role: role,
@@ -1594,7 +1671,8 @@ enum MessageNormalizer {
                 author: extractAuthor(obj),
                 reasoning: nil,
                 review: review,
-                attachments: userContent.attachments
+                attachments: userContent.attachments,
+                displayKind: displayKind?.rawValue
             )
 
             // External session history occasionally includes a role-less
@@ -1619,6 +1697,101 @@ enum MessageNormalizer {
         }
 
         return collapseDuplicateInterruptCorrections(in: messages)
+    }
+
+    /// `display_content` is the authoritative visible payload whenever the
+    /// field exists — including an explicit empty string, which must never
+    /// fall back to the physical carrier. A JSON null is treated as absent:
+    /// no current Hermes write path emits one, and a broken projection should
+    /// not silently hide a genuine message. Non-textual scalars (a stray
+    /// bool/number) are malformed rather than an intentional empty
+    /// projection, so they degrade to the physical carrier too.
+    private static func projectedDisplayContent(in obj: [String: AnyCodable]) -> String? {
+        guard let value = obj["display_content"] else { return nil }
+        switch value {
+        case .string, .array, .object:
+            return extractContent(value)
+        default:
+            return nil
+        }
+    }
+
+    /// `display_metadata` may arrive as a JSON object (current servers) or as
+    /// unparsed JSON text (older backends). Anything malformed degrades to
+    /// nil so a bad sidecar can never fail session normalization.
+    private static func displayMetadataObject(_ value: AnyCodable?) -> [String: AnyCodable]? {
+        guard let value else { return nil }
+        if let object = value.objectValue { return object }
+        guard let text = value.stringValue,
+              let data = text.data(using: .utf8),
+              let parsed = try? JSONSerialization.jsonObject(with: data),
+              let object = parsed as? [String: Any] else {
+            return nil
+        }
+        return object.mapValues { AnyCodable.from($0) }
+    }
+
+    /// Upstream persists `task_count` on `async_delegation_complete` rows so
+    /// clients can phrase the completion notice.
+    private static func delegationCompleteNotice(metadata: AnyCodable?) -> String {
+        guard let taskCount = displayMetadataObject(metadata)?["task_count"]?.intValue,
+              taskCount > 0 else {
+            return "Background agent work finished"
+        }
+        return taskCount == 1 ? "1 background agent finished" : "\(taskCount) background agents finished"
+    }
+
+    /// Final visible text for a row Hermes tags with a known synthetic
+    /// display kind. These rows are timeline events — Hermes Desktop renders
+    /// canned labels for them — so the physical scaffold text is never shown
+    /// unless an explicit `display_content` projection supplies better copy.
+    private static func timelineNoticeContent(
+        for kind: HermesDisplayKind,
+        projected: String?,
+        metadata: AnyCodable?,
+        modelChange: (model: String, provider: String)?,
+        systemNotice: String?,
+        rawVisible: String
+    ) -> String {
+        let projectedNotice: String? = {
+            guard let projected, !projected.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return nil
+            }
+            return projected
+        }()
+        switch kind {
+        case .hidden:
+            // Defense in depth: hidden rows are dropped before content work.
+            // Never echo the physical carrier if that invariant ever breaks.
+            return "Hidden system event"
+        case .modelSwitch:
+            // An explicit projection outranks the marker-derived card text;
+            // without one, the persisted marker matches Conduit's existing
+            // model-change card detection and keeps that presentation. A
+            // marker the card regex cannot parse is still model scaffold, so
+            // it degrades to the canned label rather than rendering raw.
+            if let projectedNotice {
+                return projectedNotice
+            }
+            if let modelChange {
+                return "[Model has been changed to \(modelChange.provider)/\(modelChange.model)]"
+            }
+            return "Model changed"
+        case .personalitySwitch:
+            // The physical marker embeds the full persona prompt; surface a
+            // canned label instead, like Hermes Desktop does.
+            return projectedNotice ?? "Personality changed"
+        case .autoContinue:
+            return projectedNotice ?? "Resumed interrupted turn"
+        case .asyncDelegationComplete:
+            return projectedNotice ?? delegationCompleteNotice(metadata: metadata)
+        case .internalNotification:
+            // The row content is the operational notice itself (wake events,
+            // background completions); show it as a system notice, with a
+            // `[System: …]` wrapper stripped when present.
+            let visible = projectedNotice ?? systemNotice ?? rawVisible
+            return visible.isEmpty ? "System notification" : visible
+        }
     }
 
     static func modelChangeActivity(fromText text: String) -> (model: String, provider: String)? {

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -1369,7 +1369,11 @@ struct SystemBubble: View {
     let message: ChatMessage
 
     private var isRuntimeNotice: Bool {
-        MessageNormalizer.systemNoticeText(fromText: message.rawContent ?? message.content) != nil
+        // Rows Hermes projected onto the timeline via `display_kind` are
+        // runtime notices by construction, even though their projected text
+        // (e.g. "Resumed interrupted turn") matches no legacy marker.
+        message.displayKind != nil
+            || MessageNormalizer.systemNoticeText(fromText: message.rawContent ?? message.content) != nil
     }
 
     var body: some View {

--- a/ConduitTests/CompactResumeTranscriptTests.swift
+++ b/ConduitTests/CompactResumeTranscriptTests.swift
@@ -100,6 +100,123 @@ final class CompactResumeTranscriptTests: XCTestCase {
         XCTAssertEqual(harness.appState.messages[2].timestamp, "2026-09-01T10:00:06Z")
     }
 
+    // MARK: - Hermes display projection on the reload path
+
+    /// Regression for the transcript-leak finding: the REST history route
+    /// returns the physical persisted rows plus display-projection metadata,
+    /// and several synthetic row families (model switches, auto-continues,
+    /// hidden compaction carriers) ride as `role=user`. The compact-resume
+    /// hydration must apply Hermes' display contract so none of them become
+    /// human-authored user bubbles after a session reload.
+    func testCompactResumeAppliesDisplayProjectionToSyntheticRows() async throws {
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let modelSwitchMarker = "[System: The active model for this chat has changed to GLM-5.3-Flash via provider zai. From this point forward, use this runtime metadata when answering questions about what model/provider is active.]"
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],  // compact projection: transcript omitted
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                // Raw history payload exactly as the dashboard messages
+                // endpoint returns it, including a hidden scaffolding row, an
+                // auto-continue pivot, and a display_content compaction
+                // carrier alongside the genuine conversation.
+                .payload([
+                    "session_id": "stored-a",
+                    "messages": [
+                        [
+                            "id": 1,
+                            "role": "user",
+                            "content": "Ship the release.",
+                            "timestamp": "2026-09-01T10:00:00Z"
+                        ],
+                        [
+                            "id": 2,
+                            "role": "user",
+                            "content": "INTERNAL MODEL SCAFFOLD — do not render",
+                            "display_kind": "hidden",
+                            "timestamp": "2026-09-01T10:00:01Z"
+                        ],
+                        [
+                            "id": 3,
+                            "role": "user",
+                            "content": "[System note: Your previous turn was interrupted mid-run. Continuing from the checkpoint.]",
+                            "display_kind": "auto_continue",
+                            "timestamp": "2026-09-01T10:00:02Z"
+                        ],
+                        [
+                            "id": 4,
+                            "role": "user",
+                            "content": "Pull the logs before triage.\n\n"
+                                + "[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]\n\n"
+                                + "[CONTEXT COMPACTION 12:04]\nCompacted prior turns.",
+                            "display_content": "Pull the logs before triage.",
+                            "timestamp": "2026-09-01T10:00:03Z"
+                        ],
+                        [
+                            "id": 5,
+                            "role": "user",
+                            "content": modelSwitchMarker,
+                            "display_kind": "model_switch",
+                            "timestamp": "2026-09-01T10:00:04Z"
+                        ],
+                        [
+                            "id": 6,
+                            "role": "assistant",
+                            "content": "Shipping it now.",
+                            "timestamp": "2026-09-01T10:00:05Z"
+                        ]
+                    ]
+                ])
+            }
+        )
+        harness.appState.sessions = [active]
+
+        let opened = await harness.appState.openSession("stored-a")
+
+        XCTAssertTrue(opened)
+
+        // The genuine conversation survives, the hidden row disappears, the
+        // auto-continue and model-switch pivots become timeline events, and
+        // the display_content carrier shows its projected ask instead of the
+        // physical compaction payload.
+        XCTAssertEqual(
+            harness.appState.messages.map { $0.role },
+            [.user, .system, .user, .system, .assistant]
+        )
+        XCTAssertEqual(
+            harness.appState.messages.map { $0.content },
+            [
+                "Ship the release.",
+                "Resumed interrupted turn",
+                "Pull the logs before triage.",
+                "[Model has been changed to zai/GLM-5.3-Flash]",
+                "Shipping it now."
+            ]
+        )
+        // No synthetic row may end up authored as the human user.
+        XCTAssertEqual(
+            harness.appState.messages.filter { $0.role == .user }.map { $0.content },
+            ["Ship the release.", "Pull the logs before triage."]
+        )
+        XCTAssertFalse(
+            harness.appState.messages.contains { $0.content.contains("INTERNAL MODEL SCAFFOLD") }
+                || harness.appState.messages.contains { $0.content.contains("COMPACTION") }
+                || harness.appState.messages.contains { $0.content.contains("System note") },
+            "No model-facing scaffold text may reach the visible transcript"
+        )
+        // The model-switch row keeps the card presentation ChatView derives
+        // from rawContent.
+        XCTAssertNotNil(
+            MessageNormalizer.modelChangeActivity(
+                fromText: harness.appState.messages[3].rawContent ?? harness.appState.messages[3].content
+            )
+        )
+    }
+
     // MARK: - Live projection preservation
 
     func testCompactResumeKeepsRunningInflightProjectionOnPersistedBase() async throws {

--- a/ConduitTests/HermesClientTests.swift
+++ b/ConduitTests/HermesClientTests.swift
@@ -305,6 +305,69 @@ final class HermesClientTests: XCTestCase {
         client.disconnect()
     }
 
+    func testLegacyResumeAppliesDisplayProjectionToPersistedRows() async throws {
+        // REST hydration and the legacy `session.resume` transcript must
+        // enforce the same Hermes display contract: synthetic rows tagged
+        // with `display_kind` never become human user bubbles, and hidden
+        // scaffolding disappears entirely.
+        let transport = FakeTransport()
+        let socket = FakeSocket()
+        transport.nextSocket = { socket }
+        let client = makeClient(transport: transport)
+        let connectTask = Task { try? await client.connect() }
+        transport.open(socket)
+        try await awaitCompletion(of: connectTask, "connect() to complete after the handshake")
+
+        let sent = Gate()
+        socket.onSend = { sent.signal() }
+        let openTask = Task<SessionResumeResult, Error> { try await client.openSessionLegacy("sess-display") }
+        try await sent.wait("the legacy session.resume request to be sent")
+
+        let request = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(try XCTUnwrap(socket.sentTexts.last).utf8)) as? [String: Any]
+        )
+        let id = try XCTUnwrap(request["id"] as? Int)
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": [
+                "session_id": "sess-display",
+                "messages": [
+                    ["role": "user", "content": "Ship the release.", "timestamp": "2026-09-01T10:00:00Z"],
+                    [
+                        "role": "user",
+                        "content": "INTERNAL MODEL SCAFFOLD — do not render",
+                        "display_kind": "hidden",
+                        "timestamp": "2026-09-01T10:00:01Z"
+                    ],
+                    [
+                        "role": "user",
+                        "content": "[System note: Your previous turn was interrupted mid-run. Continuing.]",
+                        "display_kind": "auto_continue",
+                        "timestamp": "2026-09-01T10:00:02Z"
+                    ],
+                    [
+                        "role": "user",
+                        "content": "Background delegation report scaffold",
+                        "display_kind": "async_delegation_complete",
+                        "display_metadata": ["task_count": 2],
+                        "timestamp": "2026-09-01T10:00:03Z"
+                    ]
+                ],
+                "info": ["running": false]
+            ]
+        ]
+        socket.deliver(String(data: try JSONSerialization.data(withJSONObject: response), encoding: .utf8)!)
+
+        let result = try await awaitResult(of: openTask, "the legacy session.resume response")
+        XCTAssertEqual(result.messages.map({ $0.role }), [.user, .system, .system])
+        XCTAssertEqual(
+            result.messages.map { $0.content },
+            ["Ship the release.", "Resumed interrupted turn", "2 background agents finished"]
+        )
+        client.disconnect()
+    }
+
     // MARK: - Helpers
 
     private final class ResultBox<T>: @unchecked Sendable {

--- a/ConduitTests/MessageNormalizerTests.swift
+++ b/ConduitTests/MessageNormalizerTests.swift
@@ -1710,6 +1710,7 @@ final class MessageNormalizerTests: XCTestCase {
             .object(["task_count": .string("two")]),
             .object(["task_count": .number(0)]),
             .object(["task_count": .number(-1)]),
+            .object(["task_count": .number(2.5)]),
             .null
         ]
         for (index, metadata) in variants.enumerated() {
@@ -1858,21 +1859,93 @@ final class MessageNormalizerTests: XCTestCase {
         XCTAssertTrue(messages.isEmpty)
     }
 
-    func testMalformedScalarDisplayContentDegradesToPhysicalCarrier() {
-        // Only a textual projection is authoritative; a stray scalar is
-        // malformed rather than an intentional empty projection.
+    func testMalformedScalarDisplayContentNeverFallsBackToPhysicalCarrier() {
+        // Field presence is the authority boundary: a stray scalar is an
+        // explicit (odd) projection resolving to empty text, never a reason
+        // to reveal the physical carrier.
         let messages = MessageNormalizer.normalizeMessages([
             .object([
                 "id": .number(341),
                 "role": .string("user"),
-                "content": .string("Genuine ask."),
-                "display_content": .number(5)
+                "content": .string("DO NOT SHOW PHYSICAL"),
+                "display_content": .number(42)
             ])
         ])
 
         XCTAssertEqual(messages.count, 1)
         XCTAssertEqual(messages[0].role, .user)
-        XCTAssertEqual(messages[0].content, "Genuine ask.")
+        XCTAssertEqual(messages[0].content, "")
+        XCTAssertFalse(
+            messages.contains { $0.content.contains("DO NOT SHOW PHYSICAL") },
+            "The physical content must never resurface behind a malformed projection"
+        )
+    }
+
+    func testExplicitNullDisplayContentNeverFallsBackToPhysicalContent() {
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(342),
+                "role": .string("user"),
+                "content": .string("DO NOT SHOW PHYSICAL"),
+                "display_content": .null
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .user)
+        XCTAssertEqual(messages[0].content, "")
+        XCTAssertFalse(
+            messages.contains { $0.content.contains("DO NOT SHOW PHYSICAL") },
+            "An explicit null projection must not expose the physical content"
+        )
+    }
+
+    func testExplicitEmptyProjectionOnTimelineKindRemainsAuthoritative() {
+        // For synthetic kinds an empty projection must not be trimmed back
+        // into absence: that would substitute canned labels or fall through
+        // to the physical synthetic payload.
+        let rows: [(Double, String, String)] = [
+            (343, "internal_notification", "DO NOT SHOW PHYSICAL"),
+            (344, "auto_continue", "AUTO CONTINUE INTERNAL SCAFFOLD"),
+            (346, "model_switch", "DO NOT SHOW PHYSICAL"),
+            (347, "personality_switch", "DO NOT SHOW PHYSICAL"),
+            (348, "async_delegation_complete", "DO NOT SHOW PHYSICAL")
+        ]
+        for (id, kind, carrier) in rows {
+            let messages = MessageNormalizer.normalizeMessages([
+                .object([
+                    "id": .number(id),
+                    "role": .string("user"),
+                    "content": .string(carrier),
+                    "display_kind": .string(kind),
+                    "display_content": .string("")
+                ])
+            ])
+
+            XCTAssertEqual(messages.count, 1, kind)
+            XCTAssertEqual(messages[0].role, .system, kind)
+            XCTAssertEqual(messages[0].content, "", kind)
+            XCTAssertFalse(
+                messages.contains { $0.content.contains(carrier) },
+                "\(kind): the physical payload must never resurface"
+            )
+        }
+    }
+
+    func testHugeTaskCountDegradesToGenericNoticeWithoutTrapping() {
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(345),
+                "role": .string("user"),
+                "content": .string("Background delegation report scaffold"),
+                "display_kind": .string("async_delegation_complete"),
+                "display_metadata": .object(["task_count": .number(1e100)])
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .system)
+        XCTAssertEqual(messages[0].content, "Background agent work finished")
     }
 
     private func message(

--- a/ConduitTests/MessageNormalizerTests.swift
+++ b/ConduitTests/MessageNormalizerTests.swift
@@ -1353,6 +1353,528 @@ final class MessageNormalizerTests: XCTestCase {
         XCTAssertEqual(messages.last?.content, "Response interrupted by a user correction.")
     }
 
+    // MARK: - Hermes display projection (display_kind / display_content)
+
+    /// Hermes persists some model-facing rows as `role=user` for provider
+    /// history semantics while `display_kind`/`display_content` tell clients
+    /// how they must actually be presented. Conduit must honor that contract
+    /// at the normalization boundary instead of mapping the physical role
+    /// straight onto a human user bubble.
+
+    func testHiddenUserRowIsDroppedEntirely() {
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(301),
+                "role": .string("user"),
+                "content": .string("INTERNAL MODEL SCAFFOLD"),
+                "display_kind": .string("hidden")
+            ])
+        ])
+
+        XCTAssertTrue(messages.isEmpty)
+    }
+
+    func testHiddenAssistantRowIsDroppedEntirely() {
+        // Hiding is a property of the row, not of its physical role.
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(302),
+                "role": .string("assistant"),
+                "content": .string("Interrupted-turn checkpoint payload"),
+                "display_kind": .string("hidden")
+            ])
+        ])
+
+        XCTAssertTrue(messages.isEmpty)
+    }
+
+    func testHiddenRowWithDisplayContentIsStillDropped() {
+        // Explicit hiding wins over any projection: upstream only co-locates
+        // these when the row must not be shown at all.
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(303),
+                "role": .string("user"),
+                "content": .string("internal carrier"),
+                "display_content": .string("Supposedly visible"),
+                "display_kind": .string("hidden")
+            ])
+        ])
+
+        XCTAssertTrue(messages.isEmpty)
+    }
+
+    func testHiddenRowIsDroppedBeforeLargeBodyIsProcessed() {
+        // The hidden verdict must come from the metadata alone — a
+        // multi-megabyte model-facing body is never scanned or copied.
+        let hugeBody = "[CONTEXT COMPACTION 12:04]\n"
+            + String(repeating: "Compacted scaffold body. ", count: 30_000)
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(304),
+                "role": .string("user"),
+                "content": .string(hugeBody),
+                "display_kind": .string("hidden")
+            ]),
+            .object([
+                "id": .number(305),
+                "role": .string("assistant"),
+                "content": .string("Neighbor row survives.")
+            ])
+        ])
+
+        XCTAssertEqual(messages.map(\.content), ["Neighbor row survives."])
+    }
+
+    func testDisplayContentOverridesPhysicalCarrier() {
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(306),
+                "role": .string("user"),
+                "content": .string("internal summary scaffold\n\nREAL ASK"),
+                "display_content": .string("REAL ASK")
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .user)
+        XCTAssertEqual(messages[0].content, "REAL ASK")
+        XCTAssertFalse(messages[0].content.contains("scaffold"))
+    }
+
+    func testDisplayContentWinsOverCompactionCarrierWithoutDroppingTheRow() {
+        // Ordering: the physical content contains a legacy compaction
+        // delimiter, but the explicit projection is authoritative — the row
+        // must present the projected prompt, not be discarded wholesale.
+        let carrier = "Pull the logs before triage.\n\n"
+            + "[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]\n\n"
+            + "[CONTEXT COMPACTION 12:04]\n"
+            + String(repeating: "Summary body. ", count: 2_000)
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(307),
+                "role": .string("user"),
+                "content": .string(carrier),
+                "display_content": .string("Pull the logs before triage.")
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .user)
+        XCTAssertEqual(messages[0].content, "Pull the logs before triage.")
+    }
+
+    func testDisplayContentWinsOverCompressedSummaryFlag() {
+        // The REST projection keeps `_compressed_summary` metadata on a
+        // recovered carrier row; the flag must not discard the projected ask.
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(308),
+                "role": .string("user"),
+                "content": .string("Summary of prior turns."),
+                "metadata": .object(["_compressed_summary": .bool(true)]),
+                "display_content": .string("The actual recovered ask.")
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].content, "The actual recovered ask.")
+    }
+
+    func testDisplayContentWinsEvenWhenProjectedTextStartsWithACompactionHeader() {
+        // The compatibility filters never re-judge projected text: only rows
+        // lacking display metadata are subject to the summary-prefix guard.
+        let projected = "[CONTEXT COMPACTION 12:04]\nServer-declared visible text."
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(330),
+                "role": .string("user"),
+                "content": .string("physical carrier"),
+                "display_content": .string(projected)
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .user)
+        XCTAssertEqual(messages[0].content, projected)
+    }
+
+    func testExplicitEmptyDisplayContentNeverFallsBackToPhysicalContent() {
+        // Field presence — not a non-empty value — makes the projection
+        // authoritative. The genuinely empty row follows the existing
+        // empty-message rules, but the physical carrier must never reappear.
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(309),
+                "role": .string("user"),
+                "content": .string("DO NOT SHOW ME"),
+                "display_content": .string("")
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .user)
+        XCTAssertEqual(messages[0].content, "")
+        XCTAssertFalse(
+            messages.contains { $0.content.contains("DO NOT SHOW ME") },
+            "The physical content must never resurface behind an empty projection"
+        )
+    }
+
+    func testAutoContinueKindProjectsToSystemTimelineNotice() {
+        let scaffold = "[System note: Your previous turn was interrupted mid-run. Resuming from the last checkpoint.]"
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(310),
+                "role": .string("user"),
+                "content": .string(scaffold),
+                "display_kind": .string("auto_continue")
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .system)
+        XCTAssertEqual(messages[0].displayKind, "auto_continue")
+        XCTAssertEqual(messages[0].content, "Resumed interrupted turn")
+        XCTAssertFalse(messages[0].content.contains("System note"))
+    }
+
+    func testModelSwitchKindKeepsExistingModelChangePresentation() {
+        // The persisted marker rides as role=user; display_kind makes the
+        // timeline outcome explicit while the existing model-change card
+        // detection (driven by rawContent in ChatView) keeps working.
+        let marker = "[System: The active model for this chat has changed to GLM-5.3-Flash via provider zai. From this point forward, use this runtime metadata when answering questions about what model/provider is active.]"
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(311),
+                "role": .string("user"),
+                "content": .string(marker),
+                "display_kind": .string("model_switch")
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .system)
+        XCTAssertEqual(messages[0].displayKind, "model_switch")
+        XCTAssertEqual(messages[0].content, "[Model has been changed to zai/GLM-5.3-Flash]")
+        XCTAssertNotNil(
+            MessageNormalizer.modelChangeActivity(fromText: messages[0].rawContent ?? messages[0].content),
+            "ChatView's model-change card detection must still fire for the projected row"
+        )
+    }
+
+    func testModelSwitchKindWithUnrecognizedTextFallsBackToCannedNotice() {
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(312),
+                "role": .string("user"),
+                "content": .string("model runtime pivot"),
+                "display_kind": .string("model_switch")
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .system)
+        XCTAssertEqual(messages[0].content, "Model changed")
+    }
+
+    func testModelSwitchKindPrefersExplicitDisplayContentOverMarkerCard() {
+        // When Hermes explicitly projects display content onto a model_switch
+        // row, that copy is authoritative even over the marker-derived card.
+        let marker = "[System: The active model for this chat has changed to GLM-5.3-Flash via provider zai. From this point forward, use this runtime metadata when answering questions about what model/provider is active.]"
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(331),
+                "role": .string("user"),
+                "content": .string(marker),
+                "display_content": .string("Switched to GLM-5.3-Flash via zai."),
+                "display_kind": .string("model_switch")
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .system)
+        XCTAssertEqual(messages[0].content, "Switched to GLM-5.3-Flash via zai.")
+    }
+
+    func testKnownKindOnAssistantRowStillProjectsToTimeline() {
+        // Upstream only ever tags user rows, but the projection is a property
+        // of the row: a known synthetic kind never stays a human turn.
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(332),
+                "role": .string("assistant"),
+                "content": .string("[System note: Your previous turn was interrupted mid-run.]"),
+                "display_kind": .string("auto_continue")
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .system)
+        XCTAssertEqual(messages[0].content, "Resumed interrupted turn")
+    }
+
+    func testDisplayKindMatchingToleratesSurroundingWhitespaceOnly() {
+        // Whitespace around the canonical value is trimmed; case is matched
+        // exactly like Hermes Desktop, so casing drift stays conservative.
+        let trimmed = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(333),
+                "role": .string("user"),
+                "content": .string("scaffold"),
+                "display_kind": .string("  hidden  ")
+            ])
+        ])
+        let wrongCase = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(334),
+                "role": .string("assistant"),
+                "content": .string("Visible assistant text"),
+                "display_kind": .string("Hidden")
+            ])
+        ])
+
+        XCTAssertTrue(trimmed.isEmpty)
+        XCTAssertEqual(wrongCase.count, 1)
+        XCTAssertEqual(wrongCase[0].role, .assistant)
+    }
+
+    func testPersonalitySwitchKindProjectsToTimelineNoticeWithoutPersonaScaffold() {
+        let marker = "[System: The user has changed the assistant's personality. From this point forward, adopt the following persona and respond accordingly: You are a terse pirate first mate.]"
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(313),
+                "role": .string("user"),
+                "content": .string(marker),
+                "display_kind": .string("personality_switch")
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .system)
+        XCTAssertEqual(messages[0].displayKind, "personality_switch")
+        XCTAssertEqual(messages[0].content, "Personality changed")
+        XCTAssertFalse(messages[0].content.contains("pirate"))
+    }
+
+    func testAsyncDelegationCompleteUsesObjectMetadataTaskCount() {
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(314),
+                "role": .string("user"),
+                "content": .string("Background delegation report scaffold"),
+                "display_kind": .string("async_delegation_complete"),
+                "display_metadata": .object(["task_count": .number(2)])
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .system)
+        XCTAssertEqual(messages[0].content, "2 background agents finished")
+        XCTAssertFalse(messages[0].content.contains("scaffold"))
+    }
+
+    func testAsyncDelegationCompleteUsesSingularForOneTask() {
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(315),
+                "role": .string("user"),
+                "content": .string("Background delegation report scaffold"),
+                "display_kind": .string("async_delegation_complete"),
+                "display_metadata": .object(["task_count": .number(1)])
+            ])
+        ])
+
+        XCTAssertEqual(messages[0].content, "1 background agent finished")
+    }
+
+    func testAsyncDelegationCompleteParsesJSONStringMetadata() {
+        // Older backends serve display_metadata as unparsed JSON text.
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(316),
+                "role": .string("user"),
+                "content": .string("Background delegation report scaffold"),
+                "display_kind": .string("async_delegation_complete"),
+                "display_metadata": .string("{\"task_count\": 3, \"failed_count\": 0}")
+            ])
+        ])
+
+        XCTAssertEqual(messages[0].content, "3 background agents finished")
+    }
+
+    func testAsyncDelegationCompleteMalformedMetadataDegradesToGenericNotice() {
+        let variants: [AnyCodable] = [
+            .string("{definitely not json"),
+            .array([.number(1), .number(2)]),
+            .object(["task_count": .string("two")]),
+            .object(["task_count": .number(0)]),
+            .object(["task_count": .number(-1)]),
+            .null
+        ]
+        for (index, metadata) in variants.enumerated() {
+            let messages = MessageNormalizer.normalizeMessages([
+                .object([
+                    "id": .number(Double(320 + index)),
+                    "role": .string("user"),
+                    "content": .string("Background delegation report scaffold"),
+                    "display_kind": .string("async_delegation_complete"),
+                    "display_metadata": metadata
+                ])
+            ])
+
+            XCTAssertEqual(messages.count, 1, "variant \(index) must still produce its notice")
+            XCTAssertEqual(messages[0].role, .system, "variant \(index) must not stay a user bubble")
+            XCTAssertEqual(
+                messages[0].content,
+                "Background agent work finished",
+                "variant \(index) must degrade to the generic label"
+            )
+        }
+    }
+
+    func testInternalNotificationKindNeverRendersAsHumanUser() {
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(324),
+                "role": .string("user"),
+                "content": .string("Background watch fired: nightly build finished."),
+                "display_kind": .string("internal_notification")
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .system)
+        XCTAssertEqual(messages[0].displayKind, "internal_notification")
+        XCTAssertEqual(messages[0].content, "Background watch fired: nightly build finished.")
+    }
+
+    func testInternalNotificationKindStripsSystemWrapper() {
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(325),
+                "role": .string("user"),
+                "content": .string("[System: Resume wake-up notice for the scheduled task.]"),
+                "display_kind": .string("internal_notification")
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .system)
+        XCTAssertEqual(messages[0].content, "Resume wake-up notice for the scheduled task.")
+    }
+
+    func testUnknownDisplayKindPreservesTheRowConservatively() {
+        // A future kind must neither crash normalization nor delete or
+        // reinterpret an otherwise ordinary visible row.
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(326),
+                "role": .string("assistant"),
+                "content": .string("Visible assistant text"),
+                "display_kind": .string("future_kind")
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .assistant)
+        XCTAssertEqual(messages[0].content, "Visible assistant text")
+        XCTAssertNil(messages[0].displayKind)
+    }
+
+    func testUnknownDisplayKindStillHonorsDisplayContent() {
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(327),
+                "role": .string("user"),
+                "content": .string("physical carrier"),
+                "display_content": .string("Projected ask"),
+                "display_kind": .string("future_kind")
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .user)
+        XCTAssertEqual(messages[0].content, "Projected ask")
+    }
+
+    func testToolRowsKeepLegacyHandlingAgainstDisplayFields() {
+        // A tool row carrying display-shaped fields must not be rewritten:
+        // upstream only ever projects conversational rows, so the tool card
+        // keeps its own output exactly.
+        let output = "grep results:\n[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]\nmatched 3 lines"
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(328),
+                "role": .string("tool"),
+                "tool_call_id": .string("call-301"),
+                "tool_name": .string("run_grep"),
+                "content": .string(output),
+                "display_content": .string("Tampered projection"),
+                "display_kind": .string("model_switch")
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .tool)
+        XCTAssertEqual(messages[0].tool?.output, output)
+        XCTAssertEqual(messages[0].tool?.name, "run_grep")
+        XCTAssertNil(messages[0].displayKind)
+    }
+
+    func testHiddenToolRowIsStillDropped() {
+        // Hiding is explicit presentation semantics for the row and applies
+        // regardless of physical role — the same rule the gateway's resume
+        // projection applies to every role.
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(329),
+                "role": .string("tool"),
+                "tool_call_id": .string("call-302"),
+                "tool_name": .string("read_file"),
+                "content": .string("internal checkpoint payload"),
+                "display_kind": .string("hidden")
+            ])
+        ])
+
+        XCTAssertTrue(messages.isEmpty)
+    }
+
+    func testKindRowWithoutProjectionYieldsToLegacyCompactionFilter() {
+        // Precedence pin: a synthetic row lacking display_content still goes
+        // through the legacy filters, so a pure summary carrier is dropped
+        // whole instead of being replaced by the canned notice.
+        let carrier = "[CONTEXT COMPACTION 12:04]\n"
+            + String(repeating: "Summary body. ", count: 2_000)
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(340),
+                "role": .string("user"),
+                "content": .string(carrier),
+                "display_kind": .string("auto_continue")
+            ])
+        ])
+
+        XCTAssertTrue(messages.isEmpty)
+    }
+
+    func testMalformedScalarDisplayContentDegradesToPhysicalCarrier() {
+        // Only a textual projection is authoritative; a stray scalar is
+        // malformed rather than an intentional empty projection.
+        let messages = MessageNormalizer.normalizeMessages([
+            .object([
+                "id": .number(341),
+                "role": .string("user"),
+                "content": .string("Genuine ask."),
+                "display_content": .number(5)
+            ])
+        ])
+
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, .user)
+        XCTAssertEqual(messages[0].content, "Genuine ask.")
+    }
+
     private func message(
         id: Double,
         role: String,


### PR DESCRIPTION
## Summary

Persisted Hermes rows can ride as `role=user` for provider-history semantics while `display_kind` / `display_content` / `display_metadata` tell clients how to actually present them. Conduit mapped the physical role straight onto the UI role and ignored those fields, so synthetic rows — model switches, auto-continues, hidden compaction handoffs, delegation completions — leaked as human user bubbles after a session reload. The leak became prominent on the compact-resume path because `GET /api/sessions/{id}/messages` returns the raw persisted rows, unlike `session.resume`, whose server-side projection filters them.

Conduit-only fix (no `NousResearch/hermes-agent` changes), implemented at the shared normalization boundary so both the REST hydration and the legacy `session.resume` transcript enforce the same contract. Semantics mirror Hermes Desktop/TUI hydration, verified against the installed v0.20.6 upstream source.

## Contract handling

- **`display_kind=hidden`** — row dropped before any content work, regardless of physical role; multi-megabyte model-facing scaffolding is never scanned or copied.
- **`display_content`** — field PRESENCE is the authority boundary: any existing value (string, explicit empty string, JSON null, odd scalar, array, object) resolves via the existing coercion and is authoritative, so a malformed projection can never fall back and expose the physical carrier. The carrier is never extracted when a projection exists, and the legacy compaction filters never re-judge projected text.
- **Known synthetic kinds** — forced system/timeline presentation, never a user bubble:
  - `model_switch` → existing model-change card when the persisted marker matches, canned "Model changed" otherwise; an explicit `display_content` outranks the card.
  - `personality_switch` → "Personality changed" (the persona prompt embedded in the marker is never rendered).
  - `auto_continue` → "Resumed interrupted turn".
  - `async_delegation_complete` → "N background agent(s) finished" from `display_metadata.task_count`; "Background agent work finished" when metadata is missing/malformed. Metadata arrives as object, JSON text, array, or garbage — none can fail normalization.
  - `internal_notification` → the operational notice text, with a `[System: …]` wrapper stripped.
- **Unknown kinds** — ordinary normalization, conservatively preserved (no deletion, no reinterpretation).
- **Tool rows** — legacy handling preserved; only `hidden` drops them, matching the gateway's own resume projection.
- **Legacy #86/#108 compaction filters** — untouched and still applied to every row lacking display metadata (ordering guarantees they can never discard authentic `display_content`).

## Model / UI

`ChatMessage` gains one optional field, `displayKind: String?`, for projection provenance; `SystemBubble` styles those rows as runtime notices. Everything else is reduced to final display role/content during normalization — no parallel message model.

## Out of scope (deliberately unchanged)

Rows persisted without display metadata (e.g. the forensically-tracked updater handoff, `role=user, display_kind=NULL`) remain as-is: without trustworthy metadata they are indistinguishable from genuine user pastes, and prose heuristics are out of scope. Those need the upstream tagging fix.

## Tests

- 26 new `MessageNormalizerTests` covering every contract rule plus precedence/edge pins (hidden × role × display_content, carrier-vs-projection ordering, compaction-flag vs projection, JSON-string/malformed metadata, unknown kinds, tool-row safety).
- `CompactResumeTranscriptTests.testCompactResumeAppliesDisplayProjectionToSyntheticRows` — realistic REST history payload driven through the actual `AppState.openSession` compact hydration: the exact reload path that exposed the bug.
- `HermesClientTests.testLegacyResumeAppliesDisplayProjectionToPersistedRows` — same contract through the real `session.resume` RPC path (REST/legacy parity).
- Full suite green: **1,366 ConduitTests + 6 ConduitUITests, 0 failures**. Required suites: MessageNormalizerTests 96 (26 new), CompactResumeTranscriptTests 13 (+1), HermesClientTests 11 (+1), AppStateChatResumeTests 83, SessionPresentationCacheTests 43.

## Review

Multi-model review cycle (3 reviewers) run before push. First-round findings — projected-text prefix guard, review-activity carrier extraction, model_switch projection precedence, non-positive `task_count` — were fixed and re-reviewed; the final round returned unanimous APPROVE, and its remaining suggestions are applied in this commit.

A follow-up hardening pass (a79c24b) tightened three edge semantics per external review: `task_count` converts via `doubleValue` + `Int(exactly:)` with a `> 0` requirement (1e100/NaN/fractional degrade to the generic notice, never trap); `display_content` presence is the authority boundary (explicit null/bool/number resolve to authoritative empty — the physical carrier can never resurface); and all five synthetic timeline kinds render an explicit empty projection verbatim instead of trimming it back into absence. The 3-reviewer round on that pass caught one blocker (the internal_notification arm still substituted a canned label for an empty projection), which was fixed as prescribed and confirmation-approved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved transcript rendering using persisted display projections.
  * Hidden timeline entries are now omitted automatically.
  * Synthetic events, such as resumed turns, model changes, and delegation completion, appear as clear system timeline notices.
  * Displayed content now takes precedence over underlying stored payloads when available.
  * Runtime notices receive consistent system-message presentation.

* **Bug Fixes**
  * Improved handling of malformed, unknown, and non-text display content while preserving usable transcript data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
