### PR TITLE
fix(voice): align STT provider identity, gating, and timeout with Hermes upstream

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -8534,16 +8534,22 @@ final class AppState: ObservableObject {
     /// aloud / voice conversation mutual exclusion can be exercised with
     /// mock controllers. `readAloudGatewayBridge` is set to the same bridge
     /// so a mock read aloud gateway installed on the controller counts as
-    /// current and is not replaced by a real one at tap time.
+    /// current and is not replaced by a real one at tap time. Pass
+    /// `transcriptionMode` / `appleSpeechAvailability` to pin the route the
+    /// capability checks consult; nil leaves the current value.
     func installVoiceCapabilityStateForTesting(
         bridge: DashboardTicketBridge,
         snapshot: VoiceCapabilitySnapshot,
-        isVoiceEnabled: Bool
+        isVoiceEnabled: Bool,
+        transcriptionMode: VoiceTranscriptionMode? = nil,
+        appleSpeechAvailability: AppleSpeechRecognitionAvailability? = nil
     ) {
         dashboardTicketBridge = bridge
         readAloudGatewayBridge = bridge
         voiceCapabilitySnapshot = snapshot
         self.isVoiceEnabled = isVoiceEnabled
+        if let transcriptionMode { voiceTranscriptionMode = transcriptionMode }
+        if let appleSpeechAvailability { self.appleSpeechAvailability = appleSpeechAvailability }
     }
 
     private func loadVoiceProfilePreferences(profile: String) -> VoiceProfilePreferences {

--- a/Conduit/Voice/HermesVoiceConfigurationService.swift
+++ b/Conduit/Voice/HermesVoiceConfigurationService.swift
@@ -26,6 +26,12 @@ struct VoiceProviderReadiness: Equatable, Identifiable {
     /// The gateway's own picker row label. Provider selection is submitted
     /// under this name so Hermes — not Conduit — owns the row→config mapping.
     let displayName: String
+    /// Structured marker for the managed Nous route, set once at parse time
+    /// from upstream semantics (`managed_nous_feature` for the row's kind, or
+    /// the legacy managed-row label). Selection writes for these rows are
+    /// server-owned: when the toolset provider endpoint is unavailable they
+    /// must fail closed, never fall back to a raw config write of "nous".
+    let isManagedNous: Bool
     let requiredCredentials: [VoiceCredentialStatus]
 }
 
@@ -139,8 +145,10 @@ final class HermesVoiceConfigurationService: ObservableObject {
             sttReadiness: try? stt.get(),
             ttsReadiness: try? tts.get(),
             environment: try? environment.get(),
-            sttEndpointAvailable: (try? stt.get()) != nil,
-            ttsEndpointAvailable: (try? tts.get()) != nil
+            // STT toolset readiness is intentionally NOT passed to the
+            // parser: it cannot influence transcription capability, only the
+            // picker population and diagnostics built from its rows.
+            ttsToolsetConfigAvailable: (try? tts.get()) != nil
         )
         snapshot = parsed
         // Toolset config was added after some public gateways. Its absence is
@@ -160,23 +168,58 @@ final class HermesVoiceConfigurationService: ObservableObject {
     func saveProvider(_ provider: String, kind: VoiceProviderDescriptor.Kind) async -> Bool {
         let providers = kind == .stt ? snapshot.sttProviders : snapshot.ttsProviders
         guard let row = providers.first(where: { $0.descriptor.id == provider })?.readiness else {
-            // Schema-only provider (gateway without toolset readiness): the
-            // raw ID is a plain vendor config value, safe to write directly.
-            let saved = await save(value: provider, for: "\(kind.rawValue).provider")
-            if saved { await reload() }
-            return saved
+            // Schema-only provider (gateway without toolset readiness). The
+            // raw ID is a plain vendor config value, safe to write directly —
+            // except the canonical managed Nous ID, whose meaning is
+            // server-owned and never written raw.
+            guard provider.lowercased() != "nous" else {
+                errorMessage = "Hermes must translate this managed selection; its provider endpoint is unavailable."
+                return false
+            }
+            return await saveVendorSelection(provider, kind: kind)
         }
         if await saveProviderSelection(rowName: row.displayName, kind: kind) { return true }
-        // The toolset endpoint failed. Managed "Nous Subscription" must fall
-        // out loud — writing "nous" raw is only meaningful on gateways whose
-        // provider endpoint translates the row. Vendor rows carry IDs that
-        // ARE the config values upstream persists, so their legacy write
-        // stays safe.
-        guard row.displayName.lowercased() != "nous subscription" else { return false }
+        // The toolset endpoint failed. Managed Nous rows must fail closed:
+        // "nous" is only meaningful on gateways whose provider endpoint
+        // translates the row, so it is never raw-written through the legacy
+        // config fallback. Vendor rows carry IDs that ARE the config values
+        // upstream persists, so their legacy write stays safe.
+        guard !row.isManagedNous else { return false }
         errorMessage = nil
-        let saved = await save(value: provider, for: "\(kind.rawValue).provider")
-        if saved { await reload() }
-        return saved
+        return await saveVendorSelection(provider, kind: kind)
+    }
+
+    /// Legacy provider-selection fallback for gateways whose toolset provider
+    /// endpoint is unavailable. Writes the section atomically the way
+    /// upstream's single-provider selection model expects: the vendor value
+    /// lands in `<section>.provider` and any stale `use_gateway`
+    /// gateway-routing intent is removed — a leftover `use_gateway: true`
+    /// would override the user's fresh BYOK selection on legacy runtimes.
+    /// Like the other config editors, this is a full-document GET→PUT, so a
+    /// concurrent profile-config edit from another writer could be clobbered;
+    /// the single-writer UI flow makes that a deliberate, pre-existing
+    /// trade-off rather than a new one.
+    private func saveVendorSelection(_ vendor: String, kind: VoiceProviderDescriptor.Kind) async -> Bool {
+        let sectionKey = kind.rawValue
+        guard var config = try? await requester.requestJSON(path: profilePath("/api/config"), method: "GET", body: nil) else {
+            errorMessage = "Could not load voice settings to save this change."
+            return false
+        }
+        var section = config[sectionKey] as? [String: Any] ?? [:]
+        section["provider"] = vendor
+        section.removeValue(forKey: "use_gateway")
+        config[sectionKey] = section
+        do {
+            _ = try await requester.requestJSON(
+                path: profilePath("/api/config"), method: "PUT",
+                body: ["config": config]
+            )
+            await reload()
+            return true
+        } catch {
+            errorMessage = "Could not save \(sectionKey).provider: \(error.localizedDescription)"
+            return false
+        }
     }
 
     private func saveProviderSelection(rowName: String, kind: VoiceProviderDescriptor.Kind) async -> Bool {
@@ -299,8 +342,7 @@ enum VoiceConfigurationParser {
         sttReadiness: [String: Any]?,
         ttsReadiness: [String: Any]?,
         environment: [String: Any]?,
-        sttEndpointAvailable: Bool,
-        ttsEndpointAvailable: Bool
+        ttsToolsetConfigAvailable: Bool
     ) -> VoiceConfigurationSnapshot {
         let selectedSTT = nestedString(config, "stt.provider") ?? "local"
         let selectedTTS = nestedString(config, "tts.provider") ?? "edge"
@@ -315,24 +357,21 @@ enum VoiceConfigurationParser {
 
         let stt = sttIDs.map { id in providerConfiguration(id: id, kind: .stt, readiness: readiness, credentials: credentials) }
         let tts = ttsIDs.map { id in providerConfiguration(id: id, kind: .tts, readiness: readiness, credentials: credentials) }
-        let noVoiceSurface = !sttEndpointAvailable && !ttsEndpointAvailable
         let sttEnabled = nestedBool(config, "stt.enabled") ?? true
         let selectedTTSReady = selectedProviderIsReady(tts, selectedID: selectedTTS)
-        // Hermes Desktop gates dictation on the profile config alone
-        // (stt.enabled != false) and lets the real transcription attempt
-        // surface provider/auth problems. Picker readiness stays diagnostic:
-        // it cannot model every runtime credential source (stt.openai.api_key,
-        // VOICE_TOOLS_OPENAI_KEY, OPENAI_API_KEY, managed Nous sign-in), so a
-        // needs_auth/needs_keys row must never preemptively disable the mic.
-        let supportsTranscription = sttEndpointAvailable && sttEnabled
-        let supportsSpeech = ttsEndpointAvailable && selectedTTSReady
+        // Hermes Desktop's dictation principle: once the profile config is
+        // loaded, `stt.enabled != false` is the only capability gate. The
+        // toolset readiness response is picker/diagnostic surface — its
+        // availability says nothing about POST /api/audio/transcribe, and its
+        // metadata cannot model every runtime credential source
+        // (stt.openai.api_key, VOICE_TOOLS_OPENAI_KEY, OPENAI_API_KEY,
+        // managed Nous sign-in). A real endpoint problem surfaces from the
+        // actual transcription attempt.
+        let supportsTranscription = sttEnabled
+        let supportsSpeech = ttsToolsetConfigAvailable && selectedTTSReady
         let unavailableReason: String?
-        if noVoiceSurface {
-            unavailableReason = "This Hermes gateway does not provide voice endpoints. Text chat remains available."
-        } else if !sttEnabled {
+        if !sttEnabled {
             unavailableReason = "Speech-to-text is disabled for this Hermes profile."
-        } else if !sttEndpointAvailable {
-            unavailableReason = "This Hermes gateway does not expose a speech-to-text endpoint."
         } else if !supportsSpeech {
             unavailableReason = "The selected text-to-speech provider is not ready for this profile."
         } else {
@@ -367,7 +406,7 @@ enum VoiceConfigurationParser {
             (id == "xiaomi_mimo" && credential.key == "MIMO_API_KEY")
         }
         return .init(descriptor: descriptor, fields: fields, readiness: row.map {
-            .init(id: $0.id, kind: $0.kind, status: $0.status, isActive: $0.isActive, displayName: $0.displayName, requiredCredentials: required)
+            .init(id: $0.id, kind: $0.kind, status: $0.status, isActive: $0.isActive, displayName: $0.displayName, isManagedNous: $0.isManagedNous, requiredCredentials: required)
         })
     }
 
@@ -476,7 +515,10 @@ enum VoiceConfigurationParser {
             if let text = row["status"] as? String { status = text }
             else if let object = row["status"] as? [String: Any] { status = object["state"] as? String ?? object["label"] as? String ?? "Unknown" }
             else { status = "Unknown" }
-            return .init(id: id, kind: kind, status: status, isActive: row["is_active"] as? Bool ?? false, displayName: row["name"] as? String ?? id, requiredCredentials: credentials)
+            // providerID resolves to "nous" only for the managed route (the
+            // managed feature marker or the legacy managed-row label), so the
+            // canonical ID doubles as the structured managed marker.
+            return .init(id: id, kind: kind, status: status, isActive: row["is_active"] as? Bool ?? false, displayName: row["name"] as? String ?? id, isManagedNous: id == "nous", requiredCredentials: credentials)
         }
     }
 

--- a/Conduit/Voice/HermesVoiceConfigurationService.swift
+++ b/Conduit/Voice/HermesVoiceConfigurationService.swift
@@ -23,6 +23,9 @@ struct VoiceProviderReadiness: Equatable, Identifiable {
     let kind: VoiceProviderDescriptor.Kind
     let status: String
     let isActive: Bool
+    /// The gateway's own picker row label. Provider selection is submitted
+    /// under this name so Hermes — not Conduit — owns the row→config mapping.
+    let displayName: String
     let requiredCredentials: [VoiceCredentialStatus]
 }
 
@@ -147,10 +150,58 @@ final class HermesVoiceConfigurationService: ObservableObject {
         }
     }
 
+    /// Provider selection follows the Hermes client contract: when the row
+    /// came from the toolset readiness matrix, its display name is submitted
+    /// to the toolset provider endpoint and the GATEWAY owns the config write
+    /// (managed "Nous Subscription" rows become `stt.provider = nous` on
+    /// current Hermes and the gateway-intent equivalent on older ones).
+    /// Writing a Conduit-side ID such as "nous" directly would corrupt the
+    /// profile config on gateways that predate that value.
     func saveProvider(_ provider: String, kind: VoiceProviderDescriptor.Kind) async -> Bool {
+        let providers = kind == .stt ? snapshot.sttProviders : snapshot.ttsProviders
+        guard let row = providers.first(where: { $0.descriptor.id == provider })?.readiness else {
+            // Schema-only provider (gateway without toolset readiness): the
+            // raw ID is a plain vendor config value, safe to write directly.
+            let saved = await save(value: provider, for: "\(kind.rawValue).provider")
+            if saved { await reload() }
+            return saved
+        }
+        if await saveProviderSelection(rowName: row.displayName, kind: kind) { return true }
+        // The toolset endpoint failed. Managed "Nous Subscription" must fall
+        // out loud — writing "nous" raw is only meaningful on gateways whose
+        // provider endpoint translates the row. Vendor rows carry IDs that
+        // ARE the config values upstream persists, so their legacy write
+        // stays safe.
+        guard row.displayName.lowercased() != "nous subscription" else { return false }
+        errorMessage = nil
         let saved = await save(value: provider, for: "\(kind.rawValue).provider")
         if saved { await reload() }
         return saved
+    }
+
+    private func saveProviderSelection(rowName: String, kind: VoiceProviderDescriptor.Kind) async -> Bool {
+        do {
+            let response = try await requester.requestJSON(
+                path: profilePath("/api/tools/toolsets/\(kind.rawValue)/provider"),
+                method: "PUT",
+                body: ["provider": rowName]
+            )
+            if let error = response["error"] as? String, !error.isEmpty {
+                errorMessage = "Could not select \(rowName): \(error)"
+                return false
+            }
+            await reload()
+            if response["needs_nous_auth"] as? Bool == true {
+                // The write landed; Hermes is flagging that the managed route
+                // still needs sign-in. Diagnostic, never a silent failure.
+                let feature = kind == .stt ? "speech-to-text" : "speech"
+                errorMessage = "Hermes saved this selection, but the Nous subscription needs sign-in before \(feature) can use it."
+            }
+            return true
+        } catch {
+            errorMessage = "Could not select \(rowName): \(error.localizedDescription)"
+            return false
+        }
     }
 
     func save(value: String, for key: String) async -> Bool {
@@ -266,17 +317,22 @@ enum VoiceConfigurationParser {
         let tts = ttsIDs.map { id in providerConfiguration(id: id, kind: .tts, readiness: readiness, credentials: credentials) }
         let noVoiceSurface = !sttEndpointAvailable && !ttsEndpointAvailable
         let sttEnabled = nestedBool(config, "stt.enabled") ?? true
-        let selectedSTTReady = selectedProviderIsReady(stt, selectedID: selectedSTT)
         let selectedTTSReady = selectedProviderIsReady(tts, selectedID: selectedTTS)
-        let supportsTranscription = sttEndpointAvailable && sttEnabled && selectedSTTReady
+        // Hermes Desktop gates dictation on the profile config alone
+        // (stt.enabled != false) and lets the real transcription attempt
+        // surface provider/auth problems. Picker readiness stays diagnostic:
+        // it cannot model every runtime credential source (stt.openai.api_key,
+        // VOICE_TOOLS_OPENAI_KEY, OPENAI_API_KEY, managed Nous sign-in), so a
+        // needs_auth/needs_keys row must never preemptively disable the mic.
+        let supportsTranscription = sttEndpointAvailable && sttEnabled
         let supportsSpeech = ttsEndpointAvailable && selectedTTSReady
         let unavailableReason: String?
         if noVoiceSurface {
             unavailableReason = "This Hermes gateway does not provide voice endpoints. Text chat remains available."
-        } else if !supportsTranscription {
-            unavailableReason = sttEnabled
-                ? "The selected speech-to-text provider is not ready for this profile."
-                : "Speech-to-text is disabled for this Hermes profile."
+        } else if !sttEnabled {
+            unavailableReason = "Speech-to-text is disabled for this Hermes profile."
+        } else if !sttEndpointAvailable {
+            unavailableReason = "This Hermes gateway does not expose a speech-to-text endpoint."
         } else if !supportsSpeech {
             unavailableReason = "The selected text-to-speech provider is not ready for this profile."
         } else {
@@ -311,14 +367,33 @@ enum VoiceConfigurationParser {
             (id == "xiaomi_mimo" && credential.key == "MIMO_API_KEY")
         }
         return .init(descriptor: descriptor, fields: fields, readiness: row.map {
-            .init(id: $0.id, kind: $0.kind, status: $0.status, isActive: $0.isActive, requiredCredentials: required)
+            .init(id: $0.id, kind: $0.kind, status: $0.status, isActive: $0.isActive, displayName: $0.displayName, requiredCredentials: required)
         })
     }
 
+    /// Display catalog matching Hermes' current STT picker. Providers outside
+    /// this table (plugin rows such as StepFun/Xiaomi MiMo, or future
+    /// gateways) fall back to a generated descriptor and still work.
     static func catalogDescriptor(id: String, kind: VoiceProviderDescriptor.Kind) -> VoiceProviderDescriptor? {
         switch (id, kind) {
         case ("local", .stt):
             return .init(id: id, displayName: "Local", kind: kind, models: ["tiny", "base", "small", "medium", "large-v3"], supportsStreaming: false)
+        case ("nous", .stt), ("openai", .stt):
+            // The managed Nous route resolves models from the same
+            // OpenAI-compatible catalog as the direct key.
+            return .init(id: id, displayName: id == "nous" ? "Nous Subscription" : "OpenAI", kind: kind, models: ["whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe", "gpt-transcribe"], supportsStreaming: false)
+        case ("groq", .stt):
+            return .init(id: id, displayName: "Groq", kind: kind, models: ["whisper-large-v3-turbo", "whisper-large-v3", "distil-whisper-large-v3-en"], supportsStreaming: false)
+        case ("xai", .stt):
+            return .init(id: id, displayName: "xAI", kind: kind, supportsStreaming: false)
+        case ("elevenlabs", .stt):
+            return .init(id: id, displayName: "ElevenLabs Scribe", kind: kind, supportsStreaming: false)
+        case ("deepinfra", .stt):
+            return .init(id: id, displayName: "DeepInfra", kind: kind, supportsStreaming: false)
+        case ("nous", .tts):
+            return .init(id: id, displayName: "Nous Subscription", kind: kind, supportsStreaming: true)
+        case ("openai", .tts):
+            return .init(id: id, displayName: "OpenAI", kind: kind, supportsStreaming: true)
         case ("stepfun", .stt):
             return .init(id: id, displayName: "StepFun", kind: kind, models: ["stepaudio-2.5-asr", "step-asr"], supportsStreaming: false)
         case ("stepfun", .tts):
@@ -332,10 +407,15 @@ enum VoiceConfigurationParser {
     }
 
     static func typedFields(id: String, kind: VoiceProviderDescriptor.Kind) -> [VoiceTypedField] {
-        let root = "\(kind.rawValue).\(id)"
+        // The managed Nous selection shares the vendor's config section
+        // upstream (Hermes resolves stt.nous through stt.openai), so its
+        // editors must read and write the vendor keys.
+        let root = id == "nous" ? "\(kind.rawValue).openai" : "\(kind.rawValue).\(id)"
+        // Hermes keys the ElevenLabs STT model `stt.elevenlabs.model_id`.
+        let modelKey = kind == .stt && id == "elevenlabs" ? "model_id" : "model"
         let defaultModel = id == "local" && kind == .stt ? "base" : ""
         var shared = [
-            VoiceTypedField(key: "\(root).model", label: "Model", help: "You can enter any installed model identifier.", kind: .text, defaultValue: defaultModel),
+            VoiceTypedField(key: "\(root).\(modelKey)", label: "Model", help: "You can enter any installed model identifier.", kind: .text, defaultValue: defaultModel),
             VoiceTypedField(key: "\(root).language", label: "Language", help: "Leave blank for automatic language detection.", kind: .text, defaultValue: "")
         ]
         if kind == .tts {
@@ -396,25 +476,36 @@ enum VoiceConfigurationParser {
             if let text = row["status"] as? String { status = text }
             else if let object = row["status"] as? [String: Any] { status = object["state"] as? String ?? object["label"] as? String ?? "Unknown" }
             else { status = "Unknown" }
-            return .init(id: id, kind: kind, status: status, isActive: row["is_active"] as? Bool ?? false, requiredCredentials: credentials)
+            return .init(id: id, kind: kind, status: status, isActive: row["is_active"] as? Bool ?? false, displayName: row["name"] as? String ?? id, requiredCredentials: credentials)
         }
     }
 
-    /// Hermes' current toolset response includes `tts_provider` but older and
-    /// current STT responses can omit `stt_provider`, leaving only the picker
-    /// display name. Normalize those names back to config keys so Conduit never
-    /// writes a label such as "Local Whisper" into `stt.provider`.
+    /// Hermes' toolset response keys each row by its picker label; only TTS
+    /// rows additionally carry a `tts_provider` config key. Normalize rows to
+    /// the provider IDs Hermes itself writes into `stt.provider`/`tts.provider`
+    /// so Conduit never conflates two different routes.
+    ///
+    /// The managed "Nous Subscription" row is its own selection upstream:
+    /// current Hermes writes `stt.provider = "nous"` (serviced by the
+    /// OpenAI-compatible implementation through the managed gateway) while the
+    /// direct "OpenAI" row writes `stt.provider = "openai"` with the user's
+    /// own key. The two must stay distinct — the row's vendor field, when
+    /// present, names the shared implementation, not the selection — so the
+    /// managed flags decide identity before any vendor field is read.
     private static func providerID(for row: [String: Any], kind: VoiceProviderDescriptor.Kind) -> String? {
+        let name = (row["name"] as? String ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if row["managed_nous_feature"] as? String == kind.rawValue || name.lowercased() == "nous subscription" {
+            return "nous"
+        }
         if kind == .stt, let id = row["stt_provider"] as? String, !id.isEmpty { return id }
         if kind == .tts, let id = row["tts_provider"] as? String, !id.isEmpty { return id }
-        guard let name = row["name"] as? String, !name.isEmpty else { return nil }
-        if kind == .stt {
-            switch name.lowercased() {
-            case "local whisper": return "local"
-            case "nous subscription", "openai": return "openai"
-            case "elevenlabs scribe": return "elevenlabs"
-            default: break
-            }
+        guard !name.isEmpty else { return nil }
+        switch name.lowercased() {
+        case "local whisper": return "local"
+        case "openai", "openai tts": return "openai"
+        case "elevenlabs scribe": return "elevenlabs"
+        case "microsoft edge tts": return "edge"
+        default: break
         }
         return name
             .components(separatedBy: CharacterSet.alphanumerics.inverted)

--- a/Conduit/Voice/HermesVoiceGateway.swift
+++ b/Conduit/Voice/HermesVoiceGateway.swift
@@ -7,6 +7,25 @@ import Foundation
 
 @MainActor
 final class HermesVoiceGateway: VoiceGatewayService {
+    /// Mirrors Hermes Desktop's transcription request policy
+    /// (apps/desktop/src/api/system.ts): remote providers and long recordings
+    /// regularly exceed short request ceilings, so every request gets a
+    /// generous floor that scales with the payload and clamps at a cap.
+    static let transcriptionMinimumRequestTimeoutMilliseconds = 180_000
+    static let transcriptionMaximumRequestTimeoutMilliseconds = 600_000
+    /// The payload is the base64 audio data URL itself, so its length tracks
+    /// clip size; 0.1ms per character budgets roughly 2s of timeout per 1s of
+    /// audio before the cap clamps it.
+    static let transcriptionTimeoutMillisecondsPerDataURLCharacter = 0.1
+
+    static func transcriptionRequestTimeoutMilliseconds(dataURLCharacterCount: Int) -> Int {
+        let estimated = max(
+            transcriptionMinimumRequestTimeoutMilliseconds,
+            Int(ceil(Double(dataURLCharacterCount) * transcriptionTimeoutMillisecondsPerDataURLCharacter))
+        )
+        return min(transcriptionMaximumRequestTimeoutMilliseconds, estimated)
+    }
+
     let profile: String
     private let bridge: DashboardTicketBridge
     private let baseURL: String
@@ -23,7 +42,9 @@ final class HermesVoiceGateway: VoiceGatewayService {
             path: "/api/audio/transcribe" + profileQuery,
             method: "POST",
             body: ["data_url": audio.dataURL, "mime_type": "audio/wav"],
-            timeoutMilliseconds: 90_000
+            timeoutMilliseconds: Self.transcriptionRequestTimeoutMilliseconds(
+                dataURLCharacterCount: audio.dataURL.utf8.count
+            )
         )
         if let error = response["error"] as? String, !error.isEmpty { throw DashboardTicketBridgeError.requestFailed(error) }
         guard let rawTranscript = response["transcript"] as? String ?? response["text"] as? String else {

--- a/Conduit/Voice/HermesVoiceGateway.swift
+++ b/Conduit/Voice/HermesVoiceGateway.swift
@@ -14,8 +14,9 @@ final class HermesVoiceGateway: VoiceGatewayService {
     static let transcriptionMinimumRequestTimeoutMilliseconds = 180_000
     static let transcriptionMaximumRequestTimeoutMilliseconds = 600_000
     /// The payload is the base64 audio data URL itself, so its length tracks
-    /// clip size; 0.1ms per character budgets roughly 2s of timeout per 1s of
-    /// audio before the cap clamps it.
+    /// clip size. Conduit records 16kHz mono 16-bit WAV (~42.7k base64
+    /// characters per second of audio), so 0.1ms per character budgets ~4.3s
+    /// of timeout per 1s of audio before the cap clamps it.
     static let transcriptionTimeoutMillisecondsPerDataURLCharacter = 0.1
 
     static func transcriptionRequestTimeoutMilliseconds(dataURLCharacterCount: Int) -> Int {
@@ -38,12 +39,15 @@ final class HermesVoiceGateway: VoiceGatewayService {
     }
 
     func transcribe(_ audio: VoiceCapturedAudio) async throws -> String {
+        // Base64 encoding is expensive for long recordings — build the data
+        // URL once and reuse it for both the payload and the timeout budget.
+        let dataURL = audio.dataURL
         let response = try await bridge.requestJSON(
             path: "/api/audio/transcribe" + profileQuery,
             method: "POST",
-            body: ["data_url": audio.dataURL, "mime_type": "audio/wav"],
+            body: ["data_url": dataURL, "mime_type": "audio/wav"],
             timeoutMilliseconds: Self.transcriptionRequestTimeoutMilliseconds(
-                dataURLCharacterCount: audio.dataURL.utf8.count
+                dataURLCharacterCount: dataURL.utf8.count
             )
         )
         if let error = response["error"] as? String, !error.isEmpty { throw DashboardTicketBridgeError.requestFailed(error) }

--- a/ConduitTests/AppStateVoiceCapabilityTests.swift
+++ b/ConduitTests/AppStateVoiceCapabilityTests.swift
@@ -1,0 +1,128 @@
+//
+//  AppStateVoiceCapabilityTests.swift
+//  Conduit
+//
+//  AppState-level voice capability gating: Hermes transcription availability
+//  follows the profile config and the live transcription attempt — never the
+//  provider picker's readiness metadata — while the Apple on-device route
+//  stays gated only by its own permission/availability checks.
+//
+
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class AppStateVoiceCapabilityTests: XCTestCase {
+    /// The Reddit reproduction at the AppState layer: with the selected
+    /// OpenAI provider ready (and the parser keeping the Nous Subscription
+    /// row's needs_auth state on its own row), the composer mic stays usable.
+    func testReadySelectedTranscriptionKeepsVoiceConversationAvailable() {
+        let appState = makeAppState(
+            snapshot: VoiceCapabilitySnapshot(
+                isGatewayConnected: true,
+                supportsTranscription: true,
+                supportsSpeech: true,
+                unavailableReason: nil
+            )
+        )
+
+        XCTAssertNil(appState.voiceUnavailableReason)
+        XCTAssertTrue(appState.canStartVoiceConversation)
+    }
+
+    func testDisabledHermesTranscriptionStillBlocksVoiceConversation() {
+        let appState = makeAppState(
+            snapshot: VoiceCapabilitySnapshot(
+                isGatewayConnected: true,
+                supportsTranscription: false,
+                supportsSpeech: true,
+                unavailableReason: "Speech-to-text is disabled for this Hermes profile."
+            )
+        )
+
+        XCTAssertEqual(appState.voiceUnavailableReason, "Speech-to-text is disabled for this Hermes profile.")
+        XCTAssertFalse(appState.canStartVoiceConversation)
+    }
+
+    /// The Apple on-device route must not consult Hermes provider readiness:
+    /// a profile with no ready Hermes STT still allows on-device dictation.
+    func testAppleOnDeviceModeDoesNotConsultHermesTranscriptionReadiness() {
+        let appState = makeAppState(
+            snapshot: VoiceCapabilitySnapshot(
+                isGatewayConnected: true,
+                supportsTranscription: false,
+                supportsSpeech: true,
+                unavailableReason: nil
+            ),
+            transcriptionMode: .appleOnDevice,
+            appleSpeechAvailability: .ready(localeIdentifier: "en-US")
+        )
+
+        XCTAssertNil(appState.voiceUnavailableReason)
+        XCTAssertTrue(appState.canStartVoiceConversation)
+    }
+
+    /// Independence cuts both ways: the Apple route is still gated by its own
+    /// Speech Recognition permission state, not by Hermes metadata.
+    func testAppleOnDeviceModeStillHonorsItsOwnPermissionGate() {
+        let appState = makeAppState(
+            snapshot: VoiceCapabilitySnapshot(
+                isGatewayConnected: true,
+                supportsTranscription: true,
+                supportsSpeech: true,
+                unavailableReason: nil
+            ),
+            transcriptionMode: .appleOnDevice,
+            appleSpeechAvailability: .permissionDenied
+        )
+
+        XCTAssertEqual(
+            appState.voiceUnavailableReason,
+            "Allow Speech Recognition in iOS Settings to use on-device transcription."
+        )
+    }
+
+    /// Uncertainty on the Apple route (permission not yet granted) does not
+    /// block the mic — only an outright denial or unsupported locale does.
+    func testApplePermissionRequiredDoesNotBlockVoiceConversation() {
+        let appState = makeAppState(
+            snapshot: VoiceCapabilitySnapshot(
+                isGatewayConnected: true,
+                supportsTranscription: false,
+                supportsSpeech: true,
+                unavailableReason: nil
+            ),
+            transcriptionMode: .appleOnDevice,
+            appleSpeechAvailability: .permissionRequired(localeIdentifier: "en-US")
+        )
+
+        XCTAssertNil(appState.voiceUnavailableReason)
+        XCTAssertTrue(appState.canStartVoiceConversation)
+    }
+
+    private func makeAppState(
+        snapshot: VoiceCapabilitySnapshot,
+        transcriptionMode: VoiceTranscriptionMode = .hermes,
+        appleSpeechAvailability: AppleSpeechRecognitionAvailability = .ready(localeIdentifier: "en-US")
+    ) -> AppState {
+        let suite = "AppStateVoiceCapabilityTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Failed to create test UserDefaults suite")
+        }
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suite)
+        }
+
+        let appState = AppState(defaults: defaults, loadSavedConnection: false)
+        appState.connection = HermesConnection(baseUrl: "https://example.com", ticket: "test-ticket")
+        appState.isConnected = true
+        appState.installVoiceCapabilityStateForTesting(
+            bridge: DashboardTicketBridge(baseURL: "https://example.com"),
+            snapshot: snapshot,
+            isVoiceEnabled: true,
+            transcriptionMode: transcriptionMode,
+            appleSpeechAvailability: appleSpeechAvailability
+        )
+        return appState
+    }
+}

--- a/ConduitTests/HermesVoiceConfigurationServiceTests.swift
+++ b/ConduitTests/HermesVoiceConfigurationServiceTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Conduit
 
+@MainActor
 final class HermesVoiceConfigurationServiceTests: XCTestCase {
     func testParserUsesSchemaProvidersAndProfileConfig() {
         let snapshot = VoiceConfigurationParser.parse(
@@ -88,7 +89,9 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
         XCTAssertEqual(snapshot.credentials, [
             .init(key: "STEPFUN_API_KEY", isSet: false, description: "StepFun API key")
         ])
-        XCTAssertFalse(snapshot.capability.supportsTranscription)
+        // Readiness is diagnostic: needs_keys surfaces in Settings but the
+        // real transcription attempt is what reports the missing key.
+        XCTAssertTrue(snapshot.capability.supportsTranscription)
     }
 
     func testLocalWhisperReadinessUsesCanonicalProviderAndVisibleDefaultModel() {
@@ -122,5 +125,331 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
         XCTAssertEqual(snapshot.sttProviders.first?.descriptor.displayName, "Local")
         XCTAssertEqual(snapshot.sttProviders.first?.fields.first(where: { $0.key == "stt.local.model" })?.defaultValue, "base")
         XCTAssertTrue(snapshot.capability.supportsTranscription)
+    }
+
+    // MARK: - Nous Subscription vs direct OpenAI (Reddit-reported regression)
+
+    /// Rows shaped exactly like the upstream toolset payload: STT rows carry
+    /// only a picker `name` — no `stt_provider` field. The managed Nous row
+    /// and the direct OpenAI row must become distinct provider identities and
+    /// each must keep its own readiness status.
+    func testNousSubscriptionAndDirectOpenAIRemainDistinctProviders() {
+        let snapshot = VoiceConfigurationParser.parse(
+            profile: "default",
+            schema: nil,
+            config: ["stt": ["enabled": true, "provider": "openai"], "tts": ["provider": "edge"]],
+            sttReadiness: [
+                "providers": [
+                    ["name": "Nous Subscription", "status": "needs_auth", "is_active": false],
+                    ["name": "OpenAI", "status": "ready", "is_active": true]
+                ]
+            ],
+            ttsReadiness: ["providers": []],
+            environment: [:],
+            sttEndpointAvailable: true,
+            ttsEndpointAvailable: true
+        )
+
+        XCTAssertEqual(snapshot.sttProviders.map(\.descriptor.id), ["nous", "openai"])
+        XCTAssertEqual(snapshot.sttProviders.first { $0.descriptor.id == "nous" }?.readiness?.status, "needs_auth")
+        XCTAssertEqual(snapshot.sttProviders.first { $0.descriptor.id == "openai" }?.readiness?.status, "ready")
+        // Selection attaches to the row it names — never the managed row.
+        XCTAssertEqual(snapshot.sttProviders.first { $0.descriptor.id == "openai" }?.readiness?.isActive, true)
+        XCTAssertEqual(snapshot.sttProviders.first { $0.descriptor.id == "nous" }?.readiness?.displayName, "Nous Subscription")
+    }
+
+    /// The Reddit reproduction: OpenAI selected and ready, Nous Subscription
+    /// logged out. The direct route must not inherit the managed row's
+    /// needs_auth state and transcription must stay available.
+    func testDirectOpenAIIsNotDisabledBecauseNousSubscriptionNeedsAuth() {
+        let snapshot = VoiceConfigurationParser.parse(
+            profile: "default",
+            schema: nil,
+            config: ["stt": ["enabled": true, "provider": "openai"], "tts": ["provider": "edge"]],
+            sttReadiness: [
+                "providers": [
+                    ["name": "Nous Subscription", "status": "needs_auth", "is_active": false],
+                    ["name": "OpenAI", "status": "ready", "is_active": true]
+                ]
+            ],
+            ttsReadiness: [
+                "providers": [["name": "Microsoft Edge TTS", "tts_provider": "edge", "status": "ready", "is_active": true]]
+            ],
+            environment: [:],
+            sttEndpointAvailable: true,
+            ttsEndpointAvailable: true
+        )
+
+        XCTAssertTrue(snapshot.capability.supportsTranscription)
+        XCTAssertNil(snapshot.capability.unavailableReason)
+    }
+
+    /// Readiness is a diagnostic: needs_keys on the selected provider must
+    /// still surface in Settings, but it must not preemptively disable the
+    /// mic — the real transcription attempt reports the provider error.
+    func testNeedsKeysReadinessStaysDiagnosticAndDoesNotDisableTranscription() {
+        let snapshot = VoiceConfigurationParser.parse(
+            profile: "default",
+            schema: nil,
+            config: ["stt": ["enabled": true, "provider": "openai"], "tts": ["provider": "edge"]],
+            sttReadiness: [
+                "providers": [
+                    ["name": "Nous Subscription", "status": "needs_auth", "is_active": false],
+                    ["name": "OpenAI", "status": "needs_keys", "is_active": true]
+                ]
+            ],
+            ttsReadiness: [
+                "providers": [["name": "Microsoft Edge TTS", "tts_provider": "edge", "status": "ready", "is_active": true]]
+            ],
+            environment: [:],
+            sttEndpointAvailable: true,
+            ttsEndpointAvailable: true
+        )
+
+        XCTAssertEqual(snapshot.sttProviders.first { $0.descriptor.id == "openai" }?.readiness?.status, "needs_keys")
+        XCTAssertTrue(snapshot.capability.supportsTranscription)
+    }
+
+    func testDisabledSTTConfigStillDisablesHermesTranscription() {
+        let snapshot = VoiceConfigurationParser.parse(
+            profile: "default",
+            schema: nil,
+            config: ["stt": ["enabled": false, "provider": "openai"], "tts": ["provider": "edge"]],
+            sttReadiness: [
+                "providers": [["name": "OpenAI", "status": "ready", "is_active": true]]
+            ],
+            ttsReadiness: [
+                "providers": [["name": "Microsoft Edge TTS", "tts_provider": "edge", "status": "ready", "is_active": true]]
+            ],
+            environment: [:],
+            sttEndpointAvailable: true,
+            ttsEndpointAvailable: true
+        )
+
+        XCTAssertFalse(snapshot.capability.supportsTranscription)
+        XCTAssertEqual(snapshot.capability.unavailableReason, "Speech-to-text is disabled for this Hermes profile.")
+    }
+
+    /// Normalization against Hermes' current STT picker catalog: every row
+    /// name maps to the provider ID Hermes writes into stt.provider, and the
+    /// managed TTS row stays distinct from the direct OpenAI TTS row even
+    /// though both rows' vendor field says "openai".
+    func testCurrentUpstreamPickerCatalogMapsToCanonicalProviderIDs() {
+        let snapshot = VoiceConfigurationParser.parse(
+            profile: "default",
+            schema: nil,
+            config: ["stt": ["provider": "local"], "tts": ["provider": "edge"]],
+            sttReadiness: [
+                "providers": [
+                    ["name": "Local Whisper", "status": "ready", "is_active": true],
+                    // Managed flag must outrank the vendor stt_provider field.
+                    ["name": "Nous Subscription", "stt_provider": "openai", "requires_nous_auth": true, "managed_nous_feature": "stt", "status": "needs_auth", "is_active": false],
+                    ["name": "OpenAI", "status": "needs_keys", "is_active": false],
+                    ["name": "Groq", "status": "ready", "is_active": false],
+                    ["name": "xAI", "status": "ready", "is_active": false],
+                    ["name": "ElevenLabs Scribe", "status": "needs_keys", "is_active": false],
+                    ["name": "DeepInfra", "status": "needs_keys", "is_active": false]
+                ]
+            ],
+            ttsReadiness: [
+                "providers": [
+                    ["name": "Nous Subscription", "tts_provider": "openai", "requires_nous_auth": true, "managed_nous_feature": "tts", "status": "needs_auth", "is_active": false],
+                    ["name": "OpenAI TTS", "tts_provider": "openai", "status": "needs_keys", "is_active": false]
+                ]
+            ],
+            environment: [:],
+            sttEndpointAvailable: true,
+            ttsEndpointAvailable: true
+        )
+
+        XCTAssertEqual(
+            snapshot.sttProviders.map(\.descriptor.id),
+            ["local", "nous", "openai", "groq", "xai", "elevenlabs", "deepinfra"]
+        )
+        XCTAssertEqual(
+            snapshot.ttsProviders.map(\.descriptor.id),
+            ["nous", "openai", "edge"]
+        )
+        XCTAssertEqual(snapshot.sttProviders.first { $0.descriptor.id == "nous" }?.descriptor.displayName, "Nous Subscription")
+        XCTAssertEqual(snapshot.sttProviders.first { $0.descriptor.id == "openai" }?.descriptor.displayName, "OpenAI")
+    }
+
+    /// The managed Nous selection resolves model/language through the vendor
+    /// config section upstream, so its editors must target stt.openai.* keys.
+    func testManagedNousFieldEditorsTargetVendorConfigKeys() {
+        let fields = VoiceConfigurationParser.typedFields(id: "nous", kind: .stt)
+        XCTAssertTrue(fields.contains { $0.key == "stt.openai.model" })
+        XCTAssertTrue(fields.contains { $0.key == "stt.openai.language" })
+        let elevenlabs = VoiceConfigurationParser.typedFields(id: "elevenlabs", kind: .stt)
+        XCTAssertTrue(elevenlabs.contains { $0.key == "stt.elevenlabs.model_id" })
+    }
+
+    // MARK: - Provider selection save path
+
+    /// Row-backed providers must be selected through the gateway's toolset
+    /// provider endpoint under the row's display name — Hermes owns the
+    /// row→config mapping (managed rows become `stt.provider = nous` on
+    /// current gateways and the gateway-intent equivalent on older ones).
+    /// Conduit must never write a Conduit-side ID such as "nous" itself.
+    func testProviderSelectionSubmitsRowNameToGatewayEndpoint() async {
+        let requester = MockVoiceConfigurationRequester()
+        requester.routes = [
+            "/api/config": ["stt": ["enabled": true, "provider": "openai"], "tts": ["provider": "edge"]],
+            "/api/tools/toolsets/stt/config": [
+                "providers": [
+                    ["name": "Nous Subscription", "status": "needs_auth", "is_active": false],
+                    ["name": "OpenAI", "status": "ready", "is_active": true]
+                ]
+            ],
+            "/api/tools/toolsets/tts/config": ["providers": []],
+            "/api/tools/toolsets/stt/provider": ["ok": true]
+        ]
+        let service = HermesVoiceConfigurationService(requester: requester, profile: "default")
+        await service.reload()
+
+        let saved = await service.saveProvider("nous", kind: .stt)
+
+        XCTAssertTrue(saved)
+        let providerPUT = requester.recorded.first {
+            $0.method == "PUT" && $0.path == "/api/tools/toolsets/stt/provider"
+        }
+        XCTAssertEqual(providerPUT?.body as? [String: String], ["provider": "Nous Subscription"])
+        XCTAssertFalse(requester.recorded.contains { $0.method == "PUT" && $0.path == "/api/config" })
+    }
+
+    /// Schema-only providers (gateways without toolset readiness) keep the
+    /// legacy direct config write: their raw IDs are plain vendor values.
+    func testSchemaOnlyProviderSelectionFallsBackToDirectConfigWrite() async {
+        let requester = MockVoiceConfigurationRequester()
+        requester.routes = [
+            "/api/config": ["stt": ["enabled": true, "provider": "stepfun"], "tts": ["provider": "stepfun"]],
+            "/api/tools/toolsets/stt/config": ["providers": []],
+            "/api/tools/toolsets/tts/config": ["providers": []]
+        ]
+        let service = HermesVoiceConfigurationService(requester: requester, profile: "default")
+        await service.reload()
+
+        let saved = await service.saveProvider("stepfun", kind: .stt)
+
+        XCTAssertTrue(saved)
+        XCTAssertTrue(requester.recorded.contains { $0.method == "PUT" && $0.path == "/api/config" })
+        XCTAssertFalse(requester.recorded.contains { $0.path == "/api/tools/toolsets/stt/provider" })
+        XCTAssertEqual(service.snapshot.selectedSTTProvider, "stepfun")
+    }
+
+    /// A managed-row selection on a signed-out account still saves — Hermes
+    /// writes the selection and flags the missing entitlement, which Conduit
+    /// surfaces as a notice instead of hiding it.
+    func testManagedSelectionSurfacesNeedsAuthNoticeFromGateway() async {
+        let requester = MockVoiceConfigurationRequester()
+        requester.routes = [
+            "/api/config": ["stt": ["enabled": true, "provider": "openai"], "tts": ["provider": "edge"]],
+            "/api/tools/toolsets/stt/config": [
+                "providers": [
+                    ["name": "Nous Subscription", "status": "needs_auth", "is_active": false],
+                    ["name": "OpenAI", "status": "ready", "is_active": true]
+                ]
+            ],
+            "/api/tools/toolsets/tts/config": ["providers": []],
+            "/api/tools/toolsets/stt/provider": ["ok": true, "needs_nous_auth": true, "feature": "stt"]
+        ]
+        let service = HermesVoiceConfigurationService(requester: requester, profile: "default")
+        await service.reload()
+
+        let saved = await service.saveProvider("nous", kind: .stt)
+
+        XCTAssertTrue(saved)
+        XCTAssertNotNil(service.errorMessage)
+    }
+
+    /// The managed row must fail loud when the gateway's provider endpoint is
+    /// unavailable — a direct `stt.provider = "nous"` write is only valid on
+    /// gateways whose endpoint translates the row, never as a fallback.
+    func testManagedRowSelectionFailsLoudWithoutProviderEndpoint() async {
+        let requester = MockVoiceConfigurationRequester()
+        requester.routes = [
+            "/api/config": ["stt": ["enabled": true, "provider": "openai"], "tts": ["provider": "edge"]],
+            "/api/tools/toolsets/stt/config": [
+                "providers": [
+                    ["name": "Nous Subscription", "status": "needs_auth", "is_active": false],
+                    ["name": "OpenAI", "status": "ready", "is_active": true]
+                ]
+            ],
+            "/api/tools/toolsets/tts/config": ["providers": []]
+        ]
+        let service = HermesVoiceConfigurationService(requester: requester, profile: "default")
+        await service.reload()
+
+        let saved = await service.saveProvider("nous", kind: .stt)
+
+        XCTAssertFalse(saved)
+        XCTAssertNotNil(service.errorMessage)
+        XCTAssertFalse(requester.recorded.contains { $0.method == "PUT" && $0.path == "/api/config" })
+    }
+
+    /// Vendor rows carry IDs that are valid config values upstream, so when
+    /// the provider endpoint is unreachable their selection degrades to the
+    /// legacy direct write instead of failing outright.
+    func testVendorRowSelectionFallsBackToDirectConfigWriteWhenEndpointMissing() async {
+        let requester = MockVoiceConfigurationRequester()
+        requester.routes = [
+            "/api/config": ["stt": ["enabled": true, "provider": "openai"], "tts": ["provider": "edge"]],
+            "/api/tools/toolsets/stt/config": [
+                "providers": [
+                    ["name": "Nous Subscription", "status": "needs_auth", "is_active": false],
+                    ["name": "OpenAI", "status": "ready", "is_active": true]
+                ]
+            ],
+            "/api/tools/toolsets/tts/config": ["providers": []]
+        ]
+        let service = HermesVoiceConfigurationService(requester: requester, profile: "default")
+        await service.reload()
+
+        let saved = await service.saveProvider("openai", kind: .stt)
+
+        XCTAssertTrue(saved)
+        XCTAssertTrue(requester.recorded.contains { $0.method == "PUT" && $0.path == "/api/config" })
+        XCTAssertEqual(service.snapshot.selectedSTTProvider, "openai")
+    }
+
+    /// Row-backed TTS selection uses the same gateway contract on the tts
+    /// toolset: the row's display name, not a Conduit-side ID.
+    func testTTSRowSelectionSubmitsRowNameToGatewayEndpoint() async {
+        let requester = MockVoiceConfigurationRequester()
+        requester.routes = [
+            "/api/config": ["stt": ["provider": "local"], "tts": ["provider": "edge"]],
+            "/api/tools/toolsets/stt/config": ["providers": []],
+            "/api/tools/toolsets/tts/config": [
+                "providers": [
+                    ["name": "Nous Subscription", "tts_provider": "openai", "requires_nous_auth": true, "managed_nous_feature": "tts", "status": "needs_auth", "is_active": false],
+                    ["name": "OpenAI TTS", "tts_provider": "openai", "status": "needs_keys", "is_active": false]
+                ]
+            ],
+            "/api/tools/toolsets/tts/provider": ["ok": true]
+        ]
+        let service = HermesVoiceConfigurationService(requester: requester, profile: "default")
+        await service.reload()
+
+        let saved = await service.saveProvider("nous", kind: .tts)
+
+        XCTAssertTrue(saved)
+        let providerPUT = requester.recorded.first {
+            $0.method == "PUT" && $0.path == "/api/tools/toolsets/tts/provider"
+        }
+        XCTAssertEqual(providerPUT?.body as? [String: String], ["provider": "Nous Subscription"])
+    }
+}
+
+@MainActor
+private final class MockVoiceConfigurationRequester: VoiceConfigurationRequesting {
+    var routes: [String: [String: Any]] = [:]
+    private(set) var recorded: [(path: String, method: String, body: [String: Any]?)] = []
+
+    func requestJSON(path: String, method: String, body: [String: Any]?) async throws -> [String: Any] {
+        recorded.append((path: path, method: method, body: body))
+        guard let response = routes[path] else {
+            throw DashboardTicketBridgeError.requestFailed("No mock response for \(path)")
+        }
+        return response
     }
 }

--- a/ConduitTests/HermesVoiceConfigurationServiceTests.swift
+++ b/ConduitTests/HermesVoiceConfigurationServiceTests.swift
@@ -22,8 +22,7 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
                 "MIMO_API_KEY": ["is_set": true, "redacted_value": "mi…123"],
                 "STEPFUN_API_KEY": ["is_set": false, "redacted_value": NSNull()]
             ],
-            sttEndpointAvailable: true,
-            ttsEndpointAvailable: true
+            ttsToolsetConfigAvailable: true
         )
 
         XCTAssertEqual(snapshot.profile, "research")
@@ -42,13 +41,42 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
             config: ["stt": [String: Any](), "tts": [String: Any]()],
             sttReadiness: nil, ttsReadiness: nil,
             environment: ["MIMO_API_KEY": ["is_set": true, "redacted_value": "should-not-be-copied", "description": "MiMo key"]],
-            sttEndpointAvailable: false, ttsEndpointAvailable: false
+            ttsToolsetConfigAvailable: false
         )
 
         XCTAssertEqual(snapshot.credentials, [.init(key: "MIMO_API_KEY", isSet: true, description: "MiMo key")])
-        XCTAssertFalse(snapshot.capability.supportsTranscription)
+        // Profile config loaded with no stt.enabled=false: the missing
+        // toolset readiness surface cannot disable Hermes transcription —
+        // only TTS remains unconfirmed (no readiness rows to vouch for it).
+        XCTAssertTrue(snapshot.capability.supportsTranscription)
         XCTAssertFalse(snapshot.capability.supportsSpeech)
-        XCTAssertEqual(snapshot.capability.unavailableReason, "This Hermes gateway does not provide voice endpoints. Text chat remains available.")
+        XCTAssertEqual(snapshot.capability.unavailableReason, "The selected text-to-speech provider is not ready for this profile.")
+    }
+
+    /// Toolset readiness metadata is picker/diagnostic surface only: when
+    /// /api/tools/toolsets/stt/config is unavailable but the profile config
+    /// loads, Hermes transcription stays attemptable and the unavailable
+    /// reason must not claim the audio endpoint is absent.
+    func testMissingToolsetReadinessDoesNotDisableHermesTranscription() {
+        let snapshot = VoiceConfigurationParser.parse(
+            profile: "default",
+            schema: nil,
+            config: ["stt": ["enabled": true, "provider": "openai"], "tts": ["provider": "edge"]],
+            sttReadiness: nil,
+            ttsReadiness: nil,
+            environment: [:],
+            ttsToolsetConfigAvailable: false
+        )
+
+        XCTAssertTrue(snapshot.capability.supportsTranscription)
+        XCTAssertNotEqual(
+            snapshot.capability.unavailableReason,
+            "This Hermes gateway does not expose a speech-to-text endpoint."
+        )
+        XCTAssertNotEqual(
+            snapshot.capability.unavailableReason,
+            "This Hermes gateway does not provide voice endpoints. Text chat remains available."
+        )
     }
 
     func testXiaomiCatalogContainsDocumentedBuiltInVoicesAndManualField() {
@@ -82,8 +110,7 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
             ],
             ttsReadiness: ["providers": []],
             environment: [:],
-            sttEndpointAvailable: true,
-            ttsEndpointAvailable: true
+            ttsToolsetConfigAvailable: true
         )
 
         XCTAssertEqual(snapshot.credentials, [
@@ -117,8 +144,7 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
                 ]]
             ],
             environment: [:],
-            sttEndpointAvailable: true,
-            ttsEndpointAvailable: true
+            ttsToolsetConfigAvailable: true
         )
 
         XCTAssertEqual(snapshot.sttProviders.map(\.descriptor.id), ["local"])
@@ -146,8 +172,7 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
             ],
             ttsReadiness: ["providers": []],
             environment: [:],
-            sttEndpointAvailable: true,
-            ttsEndpointAvailable: true
+            ttsToolsetConfigAvailable: true
         )
 
         XCTAssertEqual(snapshot.sttProviders.map(\.descriptor.id), ["nous", "openai"])
@@ -176,8 +201,7 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
                 "providers": [["name": "Microsoft Edge TTS", "tts_provider": "edge", "status": "ready", "is_active": true]]
             ],
             environment: [:],
-            sttEndpointAvailable: true,
-            ttsEndpointAvailable: true
+            ttsToolsetConfigAvailable: true
         )
 
         XCTAssertTrue(snapshot.capability.supportsTranscription)
@@ -202,8 +226,7 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
                 "providers": [["name": "Microsoft Edge TTS", "tts_provider": "edge", "status": "ready", "is_active": true]]
             ],
             environment: [:],
-            sttEndpointAvailable: true,
-            ttsEndpointAvailable: true
+            ttsToolsetConfigAvailable: true
         )
 
         XCTAssertEqual(snapshot.sttProviders.first { $0.descriptor.id == "openai" }?.readiness?.status, "needs_keys")
@@ -222,8 +245,7 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
                 "providers": [["name": "Microsoft Edge TTS", "tts_provider": "edge", "status": "ready", "is_active": true]]
             ],
             environment: [:],
-            sttEndpointAvailable: true,
-            ttsEndpointAvailable: true
+            ttsToolsetConfigAvailable: true
         )
 
         XCTAssertFalse(snapshot.capability.supportsTranscription)
@@ -258,8 +280,7 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
                 ]
             ],
             environment: [:],
-            sttEndpointAvailable: true,
-            ttsEndpointAvailable: true
+            ttsToolsetConfigAvailable: true
         )
 
         XCTAssertEqual(
@@ -318,11 +339,15 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
     }
 
     /// Schema-only providers (gateways without toolset readiness) keep the
-    /// legacy direct config write: their raw IDs are plain vendor values.
+    /// legacy direct config write: their raw IDs are plain vendor values, and
+    /// the section write strips any stale `use_gateway` intent.
     func testSchemaOnlyProviderSelectionFallsBackToDirectConfigWrite() async {
         let requester = MockVoiceConfigurationRequester()
         requester.routes = [
-            "/api/config": ["stt": ["enabled": true, "provider": "stepfun"], "tts": ["provider": "stepfun"]],
+            "/api/config": [
+                "stt": ["enabled": true, "provider": "stepfun", "use_gateway": true],
+                "tts": ["provider": "stepfun"]
+            ],
             "/api/tools/toolsets/stt/config": ["providers": []],
             "/api/tools/toolsets/tts/config": ["providers": []]
         ]
@@ -334,6 +359,10 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
         XCTAssertTrue(saved)
         XCTAssertTrue(requester.recorded.contains { $0.method == "PUT" && $0.path == "/api/config" })
         XCTAssertFalse(requester.recorded.contains { $0.path == "/api/tools/toolsets/stt/provider" })
+        let configPUT = requester.recorded.first { $0.method == "PUT" && $0.path == "/api/config" }
+        let writtenSection = (configPUT?.body?["config"] as? [String: Any])?["stt"] as? [String: Any]
+        XCTAssertEqual(writtenSection?["provider"] as? String, "stepfun")
+        XCTAssertNil(writtenSection?["use_gateway"])
         XCTAssertEqual(service.snapshot.selectedSTTProvider, "stepfun")
     }
 
@@ -438,15 +467,153 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
         }
         XCTAssertEqual(providerPUT?.body as? [String: String], ["provider": "Nous Subscription"])
     }
+
+    /// When the toolset provider endpoint is unavailable, the legacy vendor
+    /// fallback must update the section atomically: write the vendor provider
+    /// AND remove stale `use_gateway` gateway-routing intent — a leftover
+    /// `use_gateway: true` would override the fresh BYOK selection on legacy
+    /// runtimes.
+    func testLegacyVendorFallbackRemovesStaleUseGatewayFromSTT() async throws {
+        let requester = MockVoiceConfigurationRequester()
+        requester.routes = [
+            "/api/config": [
+                "stt": ["provider": "openai", "use_gateway": true],
+                "tts": ["provider": "edge"]
+            ],
+            "/api/tools/toolsets/stt/config": [
+                "providers": [
+                    ["name": "Nous Subscription", "status": "needs_auth", "is_active": false],
+                    ["name": "OpenAI", "status": "ready", "is_active": true]
+                ]
+            ],
+            "/api/tools/toolsets/tts/config": ["providers": []]
+        ]
+        let service = HermesVoiceConfigurationService(requester: requester, profile: "default")
+        await service.reload()
+
+        let saved = await service.saveProvider("openai", kind: .stt)
+
+        XCTAssertTrue(saved)
+        let configPUT = requester.recorded.first { $0.method == "PUT" && $0.path == "/api/config" }
+        let writtenSection = try XCTUnwrap((configPUT?.body?["config"] as? [String: Any])?["stt"] as? [String: Any])
+        XCTAssertEqual(writtenSection["provider"] as? String, "openai")
+        XCTAssertNil(writtenSection["use_gateway"])
+    }
+
+    func testLegacyVendorFallbackRemovesStaleUseGatewayFromTTS() async throws {
+        let requester = MockVoiceConfigurationRequester()
+        requester.routes = [
+            "/api/config": [
+                "stt": ["provider": "local"],
+                "tts": ["provider": "openai", "use_gateway": true]
+            ],
+            "/api/tools/toolsets/stt/config": ["providers": []],
+            "/api/tools/toolsets/tts/config": [
+                "providers": [
+                    ["name": "Nous Subscription", "tts_provider": "openai", "requires_nous_auth": true, "managed_nous_feature": "tts", "status": "needs_auth", "is_active": false],
+                    ["name": "OpenAI TTS", "tts_provider": "openai", "status": "needs_keys", "is_active": false]
+                ]
+            ]
+        ]
+        let service = HermesVoiceConfigurationService(requester: requester, profile: "default")
+        await service.reload()
+
+        let saved = await service.saveProvider("openai", kind: .tts)
+
+        XCTAssertTrue(saved)
+        let configPUT = requester.recorded.first { $0.method == "PUT" && $0.path == "/api/config" }
+        let writtenSection = try XCTUnwrap((configPUT?.body?["config"] as? [String: Any])?["tts"] as? [String: Any])
+        XCTAssertEqual(writtenSection["provider"] as? String, "openai")
+        XCTAssertNil(writtenSection["use_gateway"])
+    }
+
+    /// If the legacy fallback's config PUT itself fails, the selection fails
+    /// loudly with an error message and nothing is reported as saved.
+    func testLegacyVendorFallbackFailsLoudWhenConfigPutFails() async {
+        let requester = MockVoiceConfigurationRequester()
+        requester.routes = [
+            "/api/config": ["stt": ["enabled": true, "provider": "openai"], "tts": ["provider": "edge"]],
+            "/api/tools/toolsets/stt/config": [
+                "providers": [
+                    ["name": "Nous Subscription", "status": "needs_auth", "is_active": false],
+                    ["name": "OpenAI", "status": "ready", "is_active": true]
+                ]
+            ],
+            "/api/tools/toolsets/tts/config": ["providers": []]
+        ]
+        requester.failingPUTPaths = ["/api/config"]
+        let service = HermesVoiceConfigurationService(requester: requester, profile: "default")
+        await service.reload()
+
+        let saved = await service.saveProvider("openai", kind: .stt)
+
+        XCTAssertFalse(saved)
+        XCTAssertTrue(service.errorMessage?.hasPrefix("Could not save stt.provider") ?? false)
+    }
+
+    /// Managed Nous identity is structural, not label-based: a managed row
+    /// with an unfamiliar display name must still fail closed when the
+    /// toolset provider endpoint is unavailable — never raw-write "nous"
+    /// through the legacy config fallback.
+    func testManagedNousRowWithUnfamiliarDisplayNameFailsClosed() async {
+        let requester = MockVoiceConfigurationRequester()
+        requester.routes = [
+            "/api/config": ["stt": ["enabled": true, "provider": "openai"], "tts": ["provider": "edge"]],
+            "/api/tools/toolsets/stt/config": [
+                "providers": [
+                    ["name": "Managed Speech", "managed_nous_feature": "stt", "stt_provider": "openai", "status": "needs_auth", "is_active": false]
+                ]
+            ],
+            "/api/tools/toolsets/tts/config": ["providers": []]
+        ]
+        let service = HermesVoiceConfigurationService(requester: requester, profile: "default")
+        await service.reload()
+
+        let nousRow = service.snapshot.sttProviders.first { $0.descriptor.id == "nous" }?.readiness
+        XCTAssertEqual(nousRow?.displayName, "Managed Speech")
+        XCTAssertEqual(nousRow?.isManagedNous, true)
+
+        let saved = await service.saveProvider("nous", kind: .stt)
+
+        XCTAssertFalse(saved)
+        XCTAssertNotNil(service.errorMessage)
+        XCTAssertFalse(requester.recorded.contains { $0.method == "PUT" && $0.path == "/api/config" })
+    }
+
+    /// A gateway whose toolset readiness endpoints are entirely unavailable
+    /// still exposes Hermes transcription once the profile config loads —
+    /// the readiness surface missing is a diagnostics limitation, not a
+    /// transcription capability limitation.
+    func testReloadCapabilitySurvivesUnavailableToolsetReadinessEndpoint() async {
+        let requester = MockVoiceConfigurationRequester()
+        requester.routes = [
+            "/api/config": ["stt": ["enabled": true, "provider": "openai"], "tts": ["provider": "edge"]]
+        ]
+        let service = HermesVoiceConfigurationService(requester: requester, profile: "default")
+
+        await service.reload()
+
+        XCTAssertTrue(service.snapshot.capability.supportsTranscription)
+        XCTAssertNotEqual(
+            service.snapshot.capability.unavailableReason,
+            "This Hermes gateway does not provide voice endpoints. Text chat remains available."
+        )
+    }
 }
 
 @MainActor
 private final class MockVoiceConfigurationRequester: VoiceConfigurationRequesting {
     var routes: [String: [String: Any]] = [:]
+    /// Paths whose PUT requests must fail (route-missing already fails GETs
+    /// and PUTs alike; this simulates a read-succeeds/write-fails gateway).
+    var failingPUTPaths: Set<String> = []
     private(set) var recorded: [(path: String, method: String, body: [String: Any]?)] = []
 
     func requestJSON(path: String, method: String, body: [String: Any]?) async throws -> [String: Any] {
         recorded.append((path: path, method: method, body: body))
+        if method == "PUT", failingPUTPaths.contains(path) {
+            throw DashboardTicketBridgeError.requestFailed("Mock PUT failure for \(path)")
+        }
         guard let response = routes[path] else {
             throw DashboardTicketBridgeError.requestFailed("No mock response for \(path)")
         }

--- a/ConduitTests/HermesVoiceGatewayTimeoutTests.swift
+++ b/ConduitTests/HermesVoiceGatewayTimeoutTests.swift
@@ -1,0 +1,65 @@
+//
+//  HermesVoiceGatewayTimeoutTests.swift
+//  Conduit
+//
+//  Pins the transcription request timeout policy against the upstream Hermes
+//  Desktop constants: every request gets at least the 180s floor, scales with
+//  the audio payload, and clamps at the 600s cap. The old fixed 90s ceiling
+//  truncated legitimate remote-provider transcriptions.
+//
+
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class HermesVoiceGatewayTimeoutTests: XCTestCase {
+    func testPolicyMatchesUpstreamDesktopConstants() {
+        XCTAssertEqual(HermesVoiceGateway.transcriptionMinimumRequestTimeoutMilliseconds, 180_000)
+        XCTAssertEqual(HermesVoiceGateway.transcriptionMaximumRequestTimeoutMilliseconds, 600_000)
+        XCTAssertEqual(HermesVoiceGateway.transcriptionTimeoutMillisecondsPerDataURLCharacter, 0.1)
+    }
+
+    func testShortRecordingsGetAtLeastTheNewMinimum() {
+        // A typical 10s clip (16kHz mono 16-bit ≈ 320KB → ~427k base64
+        // characters) would budget ~43s from the payload alone, but the 180s
+        // floor governs — well past the old 90s ceiling.
+        XCTAssertEqual(HermesVoiceGateway.transcriptionRequestTimeoutMilliseconds(dataURLCharacterCount: 0), 180_000)
+        XCTAssertEqual(HermesVoiceGateway.transcriptionRequestTimeoutMilliseconds(dataURLCharacterCount: 427_000), 180_000)
+    }
+
+    func testLargeRecordingsScaleUpward() {
+        // ~4M characters ≈ 3MB of audio → ~400s of budget: above the floor,
+        // below the cap. A band assertion keeps this free of float-ceil noise.
+        let scaled = HermesVoiceGateway.transcriptionRequestTimeoutMilliseconds(dataURLCharacterCount: 4_000_000)
+        XCTAssertTrue((400_000...400_100).contains(scaled), "Expected ~400s, got \(scaled)")
+
+        // Scaling is monotonic once above the floor.
+        let smaller = HermesVoiceGateway.transcriptionRequestTimeoutMilliseconds(dataURLCharacterCount: 2_000_000)
+        XCTAssertGreaterThan(scaled, smaller)
+        XCTAssertGreaterThanOrEqual(smaller, 180_000)
+    }
+
+    func testVeryLargeRecordingsAreBoundedByTheMaximum() {
+        XCTAssertEqual(
+            HermesVoiceGateway.transcriptionRequestTimeoutMilliseconds(dataURLCharacterCount: 1_000_000_000),
+            600_000
+        )
+        // No request is ever unbounded, and the conversion never traps.
+        XCTAssertEqual(
+            HermesVoiceGateway.transcriptionRequestTimeoutMilliseconds(dataURLCharacterCount: Int.max),
+            600_000
+        )
+        XCTAssertLessThanOrEqual(
+            HermesVoiceGateway.transcriptionRequestTimeoutMilliseconds(dataURLCharacterCount: Int.max / 2),
+            600_000
+        )
+    }
+
+    func testCapturedAudioDataURLFeedsThePolicy() {
+        let audio = VoiceCapturedAudio(wavData: Data(repeating: 0, count: 48), pcm16Data: Data(), sampleRate: 16_000, duration: 5)
+        XCTAssertEqual(
+            HermesVoiceGateway.transcriptionRequestTimeoutMilliseconds(dataURLCharacterCount: audio.dataURL.count),
+            180_000
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the confirmed voice/STT parity bug where Conduit showed **OpenAI STT as "Need Auth" and disabled the microphone** even though the connected Hermes runtime would transcribe successfully on the selected direct-OpenAI route.

### Root cause

Conduit's provider-readiness parser collapsed the upstream picker rows `"Nous Subscription"` and `"OpenAI"` into a single `openai` identity:

```swift
case "nous subscription", "openai": return "openai"
```

then attached readiness with a first-match `readiness.first { $0.id == id && $0.kind == kind }`. Because Hermes lists the Nous Subscription row first, the direct-OpenAI selection inherited the managed row's `needs_auth` status, and since `supportsTranscription` required the selected row to be `ready`, the composer microphone was disabled — the Reddit-reported regression.

### Upstream contract (verified against upstream main, 2026-08-30)

- Current Hermes writes **`stt.provider = "nous"`** for the managed "Nous Subscription" selection (serviced by the OpenAI-compatible implementation through the managed gateway, strictly — a local `OPENAI_API_KEY` must not override it) and **`stt.provider = "openai"`** for the direct BYOK row. Older gateways express the managed route as `openai` + `use_gateway: true`.
- STT toolset rows (`GET /api/tools/toolsets/stt/config`) carry only a display `name` — no `stt_provider` field. TTS rows add `tts_provider`, but the managed TTS row's vendor field also says `openai`, so the managed flags must decide identity.
- Upstream Desktop gates dictation on `stt.enabled != false` alone; provider/auth failures surface from the real transcription attempt. Readiness metadata is diagnostic.
- Desktop's transcription request timeout is `min(600_000ms, max(180_000ms, ceil(dataUrl.length × 0.1)))`.

## Changes

1. **Distinct provider identity** (`HermesVoiceConfigurationService`): readiness rows normalize to the provider IDs Hermes itself writes (`local`, `nous`, `openai`, `groq`, `xai`, `elevenlabs`, `deepinfra`), with managed flags outranking vendor fields. Both rows stay visible and correctly labeled in Settings ("Nous Subscription" vs "OpenAI"); Mistral STT is deliberately **not** re-exposed (upstream package quarantine).
2. **Readiness is diagnostic, not an authorization gate**: `supportsTranscription = sttEndpointAvailable && stt.enabled`, matching upstream Desktop. The mic is never disabled by `needs_auth`/`needs_keys`/`unknown` rows; real provider/auth errors surface from the actual `/api/audio/transcribe` call. `stt.enabled: false` remains authoritative. TTS readiness gating is unchanged.
3. **Gateway-owned provider selection**: row-backed selections are submitted by display name to `PUT /api/tools/toolsets/{stt,tts}/provider` (the upstream Desktop client contract, present in both gateway generations), so the server owns the row→config mapping. Managed "Nous Subscription" rows fail loud instead of ever writing `nous` raw; vendor rows fall back to the legacy direct config write. A `needs_nous_auth` response is surfaced as a notice, never a silent failure.
4. **Transcription timeout**: ported Desktop's policy exactly — `min(600s, max(180s, ceil(0.1ms per data-URL character)))` — replacing the fixed 90s ceiling that truncated legitimate remote-provider transcriptions. Cancellation is preserved.

## Deliberately out of scope

- **`GET /api/audio/voice-config` not consumed.** It resolves the runtime route (including credentials) for *client-direct* voice. Conduit always uses the relay endpoints, and `voice-config`'s own contract makes relay the floor, not an error — so its verdict adds nothing to capability. Parsing a credentials-bearing payload for diagnostics-only gains would expand the key-handling surface Conduit deliberately avoids (no credential persistence, no key logging). Absence on older gateways is also irrelevant since the endpoint is not required for the fix.
- **No TTS behavior change**: TTS readiness gating, providers, and the speak path are untouched (the split TTS rows now only carry correct, distinct diagnostics).
- **No voice UI redesign, no state-machine changes, no profile/session changes.**

## Tests

22 new focused tests (suite grew 1387 → 1409, all passing):

- **Reddit reproduction**: `testNousSubscriptionAndDirectOpenAIRemainDistinctProviders` / `testDirectOpenAIIsNotDisabledBecauseNousSubscriptionNeedsAuth` — exact fixture from the report; OpenAI must receive its own `ready` row and transcription stays available.
- `testNeedsKeysReadinessStaysDiagnosticAndDoesNotDisableTranscription`, `testDisabledSTTConfigStillDisablesHermesTranscription` (the `stt.enabled` authority is preserved).
- `testCurrentUpstreamPickerCatalogMapsToCanonicalProviderIDs` (full current catalog + managed-flag precedence over the vendor field, STT and TTS), `testManagedNousFieldEditorsTargetVendorConfigKeys` (managed route shares `stt.openai.*`; ElevenLabs uses `model_id`).
- Save-path contracts via mock requester: row-name submission to the toolset provider endpoint (STT + TTS), schema-only legacy fallback, managed fail-loud without the endpoint, vendor-row fallback, `needs_nous_auth` notice.
- `HermesVoiceGatewayTimeoutTests`: upstream constants, floor/scale/cap, monotonicity, no-trap extremes.
- `AppStateVoiceCapabilityTests`: ready snapshot keeps `canStartVoiceConversation`, `stt.enabled=false` still blocks, Apple on-device mode ignores Hermes STT readiness (both directions of independence, including `permissionRequired` vs `permissionDenied`).

Also updated two pre-existing tests that asserted the removed readiness-gating behavior.

## Verification

- Focused voice suites (config service, gateway timeout, AppState capability, controller, audio session): **green**.
- Full `ConduitTests` on the Mac build host (iPhone 17 Pro simulator): **1409 executed, 0 failures**.
- `git diff --check` clean. No repo lint tooling exists to run.

## Review gate

Three-model review cycle (DeepSeek V4 Flash / Step 3.7 Flash / MiMo V2.5): **3× APPROVE, zero blockers**. Applied endorsed suggestions: vendor-row legacy fallback for endpoint failure, `error`-key check on the provider PUT response, TTS display-name parity, `utf8.count` for the payload length, dead-switch cleanup, and the additional save-path/timeout/Apple-mode tests.

## Known upstream inconsistency (outside Conduit's control)

On older gateways the managed route's stored config value is `openai` + gateway intent, so after picking "Nous Subscription" the selected-provider highlight reflects the stored `openai` value even though the Nous row reports active. The write itself is correct on both generations; the display is honest about what the config holds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved voice provider setup with clearer provider names and expanded transcription provider options.
  * Added support for managed provider configurations and safer provider selection handling.
  * Transcription requests now allow more time for longer recordings, improving reliability.
* **Bug Fixes**
  * Voice availability now reflects actual transcription settings and live capability checks instead of provider readiness indicators alone.
  * Apple on-device transcription availability is evaluated independently using its own permissions and device support.
* **Tests**
  * Added coverage for voice capability gating, provider configuration, and transcription timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->