### PR TITLE
fix(profiles): make profile discovery monotonic and failure-tolerant

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -6546,15 +6546,25 @@ final class AppState: ObservableObject {
             // old connection must not overwrite the live list, and must not
             // repopulate a persisted cache that
             // prepareChatResumeForConnection(to:) already cleared with the
-            // previous server's profile names.
+            // previous server's profile names. Discarded silently — profile
+            // discovery has no retry loop to feed an error into.
             guard dashboardTicketBridge === bridge else { return }
             let values = response["profiles"] as? [Any] ?? []
             let names = values.compactMap { value -> String? in
                 if let name = value as? String { return name }
                 return (value as? [String: Any])?["name"] as? String
             }
-            profiles = orderedProfiles(names + ["default"])
-            defaults.set(profiles, forKey: knownProfilesKey)
+            // A 200 with no profile names is a degraded payload (dashboard
+            // mid-restart, partial deploy, proxy), not authoritative evidence
+            // that every profile vanished — Hermes always has `default`. The
+            // next line would otherwise collapse the picker and persist that
+            // degraded list over the complete cache, the exact bug this
+            // function exists to prevent, just via a 200 instead of an error.
+            let nextProfiles = names.isEmpty
+                ? orderedProfiles(profiles + [activeProfile, "default"])
+                : orderedProfiles(names + ["default"])
+            profiles = nextProfiles
+            defaults.set(nextProfiles, forKey: knownProfilesKey)
         } catch {
             guard dashboardTicketBridge === bridge else { return }
             // Profile discovery is additive and monotonic. A failed refresh

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -6625,21 +6625,28 @@ final class AppState: ObservableObject {
     /// that reconnect lands.
     private func adoptAuthoritativeFallbackProfile(_ fallback: String) {
         guard fallback != activeProfile else { return }
+        // A profile change replaces the voice gateway; any in-flight read
+        // aloud belongs to the outgoing profile (same as switchProfile).
+        messageReadAloudController.stop()
         flushPendingPresentationCache()
         sessions = []
         cronSessions = []
         archivedSessions = []
+        projects = []
+        supportsProjects = false
+        projectsLoading = false
         slashCommands = Self.builtInSlashCommands
-        // The in-memory transcript, streaming text, and reasoning state all
-        // belong to the deleted profile's session; the flush above already
-        // persisted them under that profile's namespace. Showing them under
-        // the fallback's restored session identity would mislabel them, and
-        // the unguarded presentation-cache writes on user actions would
-        // persist them there. Same reset set as the other hard boundaries
-        // (prepareChatResumeForConnection, sign-out).
         messages = []
         clearStreamingText()
         resetReasoningTurn()
+        // The next profile's approval mode is unknown until its first session
+        // snapshot arrives; don't let the deleted profile's approval floor or
+        // YOLO state leak across the re-home — neutralize to the safe display
+        // until the fallback profile resolves them (same neutralization as
+        // switchProfile).
+        runtime.approvalsMode = nil
+        runtime.yolo = false
+        lastReportedSessionYolo = nil
         // Drop the deleted profile's persisted local bookkeeping so a later
         // re-creation with the same name starts fresh instead of
         // resurrecting obsolete titles and pins.

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -755,6 +755,10 @@ final class AppState: ObservableObject {
     private let sessionTitleRecoveryTracker = SessionTitleRecoveryTracker()
     private let sessionRenameOperationsOverride: SessionRenameOperation.Operations?
     private let sessionCatalogLoaderOverride: ((Bool) async throws -> [SessionSummary])?
+    /// Test seam mirroring `sessionCatalogLoader`: overrides the dashboard
+    /// `/api/profiles` fetch inside `loadProfiles()` so success, failure, and
+    /// late-response ordering can be modeled without a live WebKit bridge.
+    private let profileDiscoveryLoaderOverride: (@MainActor () async throws -> [String: Any])?
     private var reconnectAttempts = 0
     /// Whether the UI scene is active. Backgrounded scene updates must
     /// complete within ~10s of wall clock before the watchdog kills the app
@@ -1006,6 +1010,7 @@ final class AppState: ObservableObject {
         },
         sessionRenameOperations: SessionRenameOperation.Operations? = nil,
         sessionCatalogLoader: ((Bool) async throws -> [SessionSummary])? = nil,
+        profileDiscoveryLoader: (@MainActor () async throws -> [String: Any])? = nil,
         reconnectScheduler: ChatResumeReconnectScheduler? = nil,
         reconnectExecutor: ChatResumeReconnectExecutor? = nil,
         chatResumeLifecycleOperations: ChatResumeLifecycleOperations = .live,
@@ -1025,6 +1030,7 @@ final class AppState: ObservableObject {
         self.clearSessionPresentationCache = clearSessionPresentationCache
         sessionRenameOperationsOverride = sessionRenameOperations
         sessionCatalogLoaderOverride = sessionCatalogLoader
+        profileDiscoveryLoaderOverride = profileDiscoveryLoader
         self.reconnectScheduler = reconnectScheduler ?? scheduleChatResumeReconnectTask
         self.reconnectExecutor = reconnectExecutor
         self.chatResumeLifecycleOperations = chatResumeLifecycleOperations
@@ -1057,6 +1063,16 @@ final class AppState: ObservableObject {
            let stored = try? JSONDecoder().decode([String: [String]].self, from: data) {
             pinnedSessionIDsByProfile = stored
         }
+        // Hydrate the visible profile list from the persisted known-profile
+        // cache before any discovery runs. A cold launch must not present an
+        // effectively empty list — starting from `[]` is what let a single
+        // failed /api/profiles refresh collapse the picker to one entry and
+        // persist that degraded list over the complete cache. The union also
+        // heals a cache a pre-fix build already degraded: `default` and the
+        // remembered active profile are re-added on first launch.
+        profiles = orderedProfiles(
+            (defaults.stringArray(forKey: knownProfilesKey) ?? []) + [activeProfile, "default"]
+        )
         restoreActiveSessionState(for: activeProfile)
         restorePinnedSessions(for: activeProfile)
         if shouldLoadSavedConnection {
@@ -6516,9 +6532,22 @@ final class AppState: ObservableObject {
     }
 
     func loadProfiles() async {
-        guard let dashboardTicketBridge else { return }
+        guard let bridge = dashboardTicketBridge else { return }
         do {
-            let response = try await dashboardTicketBridge.requestJSON(path: "/api/profiles")
+            let response: [String: Any]
+            if let profileDiscoveryLoaderOverride {
+                response = try await profileDiscoveryLoaderOverride()
+            } else {
+                response = try await bridge.requestJSON(path: "/api/profiles")
+            }
+            // Commit gate, same identity pattern as the dashboard catalog
+            // loader: a bridge swapped mid-request (server change, re-login,
+            // disconnect) makes this response foreign. A late reply from an
+            // old connection must not overwrite the live list, and must not
+            // repopulate a persisted cache that
+            // prepareChatResumeForConnection(to:) already cleared with the
+            // previous server's profile names.
+            guard dashboardTicketBridge === bridge else { return }
             let values = response["profiles"] as? [Any] ?? []
             let names = values.compactMap { value -> String? in
                 if let name = value as? String { return name }
@@ -6527,10 +6556,19 @@ final class AppState: ObservableObject {
             profiles = orderedProfiles(names + ["default"])
             defaults.set(profiles, forKey: knownProfilesKey)
         } catch {
-            // Profile discovery is additive. A working chat must not be
-            // replaced by an error just because an older dashboard lacks it.
-            if profiles.isEmpty { profiles = orderedProfiles([activeProfile]) }
-            defaults.set(profiles, forKey: knownProfilesKey)
+            guard dashboardTicketBridge === bridge else { return }
+            // Profile discovery is additive and monotonic. A failed refresh
+            // (bridge still loading, dashboard restart, transient 5xx) must
+            // never shrink the visible list or overwrite a complete persisted
+            // cache with a degraded fallback — that degradation is exactly
+            // how a known profile "disappeared" from the picker until the
+            // next successful discovery or a logout/login cycle. Union with
+            // the current list so the active profile and the `default`
+            // invariant are always represented, then persist the union (a
+            // no-op write when the cache is already complete).
+            let merged = orderedProfiles(profiles + [activeProfile, "default"])
+            profiles = merged
+            defaults.set(merged, forKey: knownProfilesKey)
         }
     }
 
@@ -8550,6 +8588,13 @@ final class AppState: ObservableObject {
         self.isVoiceEnabled = isVoiceEnabled
         if let transcriptionMode { voiceTranscriptionMode = transcriptionMode }
         if let appleSpeechAvailability { self.appleSpeechAvailability = appleSpeechAvailability }
+    }
+
+    /// Test-only: installs a dashboard bridge (and nothing else) so profile
+    /// discovery can exercise its bridge-identity commit gate — modeled
+    /// connection swaps — without the voice capability snapshot plumbing.
+    func installDashboardTicketBridgeForTesting(_ bridge: DashboardTicketBridge) {
+        dashboardTicketBridge = bridge
     }
 
     private func loadVoiceProfilePreferences(profile: String) -> VoiceProfilePreferences {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -6572,9 +6572,21 @@ final class AppState: ObservableObject {
             // empty-payload paths already union `activeProfile` in, so only
             // this branch can need the correction.
             if !names.isEmpty, !nextProfiles.contains(activeProfile) {
+                // orderedProfiles always unions "default" into a non-empty
+                // names list, so the fallback is unconditionally "default";
+                // the contains-check stays as cheap defense-in-depth against
+                // a future change to that union invariant.
                 adoptAuthoritativeFallbackProfile(
                     nextProfiles.contains("default") ? "default" : nextProfiles[0]
                 )
+                // The abandoned profile-scoped connect/reconnect work can no
+                // longer commit (its identity fences now fail), so converge
+                // the transport onto the corrected profile. Fire-and-forget:
+                // never awaited inside discovery, and idempotent — the next
+                // discovery contains the fallback and will not re-adopt.
+                if isConnected {
+                    Task { await reconnect() }
+                }
             }
         } catch {
             guard dashboardTicketBridge === bridge else { return }
@@ -6598,17 +6610,19 @@ final class AppState: ObservableObject {
     /// fallback using the same local hard-boundary sequence as the forward
     /// profile transition in `connect(with:profile:)`: flush the outgoing
     /// transcript under its presentation-cache namespace, clear the
-    /// profile-scoped catalogs, fence-flip the identity, restore the
+    /// profile-scoped catalogs and transcript, fence-flip the identity,
+    /// prune the deleted profile's persisted bookkeeping, restore the
     /// fallback's remembered session/pinned state, and persist the
     /// correction under `activeProfileKey`.
     ///
     /// Deliberately NOT the interactive `switchProfile(to:reusing:)` flow:
     /// that re-resolves the whole connection and would nest reconnects and
-    /// capability loads inside this discovery call site. The currently
-    /// connected client keeps serving until the next natural reconnect,
-    /// which will target the corrected profile; catalog reads are filtered
-    /// and path-prefixed by the explicit profile, so no cross-profile
-    /// transcript or cache state leaks in the meantime.
+    /// capability loads inside this discovery call site. Callers schedule a
+    /// fire-and-forget `reconnect()` when the transport is live so the
+    /// client converges onto the corrected profile; every catalog read is
+    /// filtered and path-prefixed by the explicit profile, so no
+    /// cross-profile transcript or cache state leaks in the window before
+    /// that reconnect lands.
     private func adoptAuthoritativeFallbackProfile(_ fallback: String) {
         guard fallback != activeProfile else { return }
         flushPendingPresentationCache()
@@ -6616,6 +6630,23 @@ final class AppState: ObservableObject {
         cronSessions = []
         archivedSessions = []
         slashCommands = Self.builtInSlashCommands
+        // The in-memory transcript, streaming text, and reasoning state all
+        // belong to the deleted profile's session; the flush above already
+        // persisted them under that profile's namespace. Showing them under
+        // the fallback's restored session identity would mislabel them, and
+        // the unguarded presentation-cache writes on user actions would
+        // persist them there. Same reset set as the other hard boundaries
+        // (prepareChatResumeForConnection, sign-out).
+        messages = []
+        clearStreamingText()
+        resetReasoningTurn()
+        // Drop the deleted profile's persisted local bookkeeping so a later
+        // re-creation with the same name starts fresh instead of
+        // resurrecting obsolete titles and pins.
+        activeSessionTitlesByProfile.removeValue(forKey: activeProfile)
+        pinnedSessionIDsByProfile.removeValue(forKey: activeProfile)
+        persistActiveSessionTitles()
+        persistPinnedSessions()
         setActiveProfile(fallback)
         restoreActiveSessionState(for: fallback)
         restorePinnedSessions(for: fallback)

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -6565,6 +6565,17 @@ final class AppState: ObservableObject {
                 : orderedProfiles(names + ["default"])
             profiles = nextProfiles
             defaults.set(nextProfiles, forKey: knownProfilesKey)
+            // A non-empty response is authoritative: if the server no longer
+            // knows the active profile (deleted externally), re-home onto a
+            // valid fallback instead of leaving `activeProfile ∉ profiles` —
+            // a state the profile picker cannot represent. The degraded and
+            // empty-payload paths already union `activeProfile` in, so only
+            // this branch can need the correction.
+            if !names.isEmpty, !nextProfiles.contains(activeProfile) {
+                adoptAuthoritativeFallbackProfile(
+                    nextProfiles.contains("default") ? "default" : nextProfiles[0]
+                )
+            }
         } catch {
             guard dashboardTicketBridge === bridge else { return }
             // Profile discovery is additive and monotonic. A failed refresh
@@ -6580,6 +6591,35 @@ final class AppState: ObservableObject {
             profiles = merged
             defaults.set(merged, forKey: knownProfilesKey)
         }
+    }
+
+    /// Authoritative discovery reported a server that no longer contains the
+    /// active profile (e.g. it was deleted externally). Re-home onto a valid
+    /// fallback using the same local hard-boundary sequence as the forward
+    /// profile transition in `connect(with:profile:)`: flush the outgoing
+    /// transcript under its presentation-cache namespace, clear the
+    /// profile-scoped catalogs, fence-flip the identity, restore the
+    /// fallback's remembered session/pinned state, and persist the
+    /// correction under `activeProfileKey`.
+    ///
+    /// Deliberately NOT the interactive `switchProfile(to:reusing:)` flow:
+    /// that re-resolves the whole connection and would nest reconnects and
+    /// capability loads inside this discovery call site. The currently
+    /// connected client keeps serving until the next natural reconnect,
+    /// which will target the corrected profile; catalog reads are filtered
+    /// and path-prefixed by the explicit profile, so no cross-profile
+    /// transcript or cache state leaks in the meantime.
+    private func adoptAuthoritativeFallbackProfile(_ fallback: String) {
+        guard fallback != activeProfile else { return }
+        flushPendingPresentationCache()
+        sessions = []
+        cronSessions = []
+        archivedSessions = []
+        slashCommands = Self.builtInSlashCommands
+        setActiveProfile(fallback)
+        restoreActiveSessionState(for: fallback)
+        restorePinnedSessions(for: fallback)
+        defaults.set(fallback, forKey: activeProfileKey)
     }
 
     /// Hermes blocks a clarify/approval prompt for only ~5 minutes server-side

--- a/ConduitTests/ProfileDiscoveryTests.swift
+++ b/ConduitTests/ProfileDiscoveryTests.swift
@@ -195,10 +195,12 @@ final class ProfileDiscoveryTests: XCTestCase {
     }
 
     func testLateResponseAfterServerChangeDoesNotRepopulateProfileState() async throws {
+        // Seeded before AppState init: the stored dashboard URL is where a
+        // cold launch's baseline server identity is captured from.
+        defaults.set("https://one.example", forKey: "conduit.dashboardURL")
         seedKnownProfiles(["default", "one-only"], activeProfile: "default")
         let gate = ProfileResponseGate()
         let appState = makeAppState(profileDiscoveryLoader: { try await gate.wait() })
-        appState.rememberDashboardURL("https://one.example")
         appState.installDashboardTicketBridgeForTesting(makeBridge("https://one.example"))
 
         let discovery = Task { await appState.loadProfiles() }
@@ -217,10 +219,10 @@ final class ProfileDiscoveryTests: XCTestCase {
     }
 
     func testLateFailureAfterServerChangeDoesNotRepopulateProfileState() async throws {
+        defaults.set("https://one.example", forKey: "conduit.dashboardURL")
         seedKnownProfiles(["default", "one-only"], activeProfile: "default")
         let gate = ProfileResponseGate()
         let appState = makeAppState(profileDiscoveryLoader: { try await gate.wait() })
-        appState.rememberDashboardURL("https://one.example")
         appState.installDashboardTicketBridgeForTesting(makeBridge("https://one.example"))
 
         let discovery = Task { await appState.loadProfiles() }

--- a/ConduitTests/ProfileDiscoveryTests.swift
+++ b/ConduitTests/ProfileDiscoveryTests.swift
@@ -273,13 +273,15 @@ final class ProfileDiscoveryTests: XCTestCase {
         seedKnownProfiles(["default", "profile2"], activeProfile: "profile2")
         // Stale per-profile bookkeeping and catalog state belonging to the
         // deleted profile, used to probe the hard-boundary side effects.
+        // Titles are stored as a UserDefaults dictionary; pins as JSON data,
+        // each mirroring its production persistence representation.
+        defaults.set(
+            ["profile2": "old title"],
+            forKey: "conduit.activeSessionTitlesByProfile.v1"
+        )
         defaults.set(
             try JSONEncoder().encode(["profile2": ["pin-1"], "default": []]),
             forKey: "conduit.pinnedSessionIdsByProfile.v1"
-        )
-        defaults.set(
-            try JSONEncoder().encode(["profile2": "old title"]),
-            forKey: "conduit.activeSessionTitlesByProfile.v1"
         )
         let appState = makeAppState(profileDiscoveryLoader: {
             ["profiles": ["profile3", "default"]]
@@ -299,6 +301,10 @@ final class ProfileDiscoveryTests: XCTestCase {
                 lineageRootId: nil
             )
         ]
+        // Stale runtime floor owned by the deleted profile; the re-home must
+        // neutralize it exactly like switchProfile does.
+        appState.runtime.approvalsMode = "off"
+        appState.runtime.yolo = true
 
         await appState.loadProfiles()
 
@@ -323,6 +329,13 @@ final class ProfileDiscoveryTests: XCTestCase {
             defaults.dictionary(forKey: "conduit.activeSessionTitlesByProfile.v1") as? [String: String],
             [:]
         )
+        // The deleted profile's runtime approval floor and YOLO state do not
+        // survive the re-home, and no stale Projects state rides along.
+        XCTAssertNil(appState.runtime.approvalsMode)
+        XCTAssertFalse(appState.runtime.yolo)
+        XCTAssertTrue(appState.projects.isEmpty)
+        XCTAssertFalse(appState.supportsProjects)
+        XCTAssertFalse(appState.projectsLoading)
     }
 
     func testAuthoritativeResponseContainingActiveProfileKeepsItWithoutReset() async throws {

--- a/ConduitTests/ProfileDiscoveryTests.swift
+++ b/ConduitTests/ProfileDiscoveryTests.swift
@@ -271,10 +271,34 @@ final class ProfileDiscoveryTests: XCTestCase {
 
     func testAuthoritativeResponseRemovingActiveProfileRehomesToDefault() async throws {
         seedKnownProfiles(["default", "profile2"], activeProfile: "profile2")
+        // Stale per-profile bookkeeping and catalog state belonging to the
+        // deleted profile, used to probe the hard-boundary side effects.
+        defaults.set(
+            try JSONEncoder().encode(["profile2": ["pin-1"], "default": []]),
+            forKey: "conduit.pinnedSessionIdsByProfile.v1"
+        )
+        defaults.set(
+            try JSONEncoder().encode(["profile2": "old title"]),
+            forKey: "conduit.activeSessionTitlesByProfile.v1"
+        )
         let appState = makeAppState(profileDiscoveryLoader: {
             ["profiles": ["profile3", "default"]]
         })
         appState.installDashboardTicketBridgeForTesting(makeBridge("https://one.example"))
+        appState.sessions = [
+            SessionSummary(
+                id: "profile2-session",
+                alternateIds: [],
+                title: "profile2-session",
+                model: "Hermes",
+                updatedLabel: "now",
+                profile: "profile2",
+                source: .chat,
+                isActive: false,
+                isArchived: false,
+                lineageRootId: nil
+            )
+        ]
 
         await appState.loadProfiles()
 
@@ -284,6 +308,21 @@ final class ProfileDiscoveryTests: XCTestCase {
         XCTAssertEqual(appState.profiles, ["default", "profile3"])
         XCTAssertEqual(appState.activeProfile, "default")
         XCTAssertEqual(defaults.string(forKey: Self.activeProfileKey), "default")
+        // Hard-boundary side effects: the deleted profile's catalog state is
+        // cleared, its persisted bookkeeping is pruned so a later
+        // re-creation starts fresh, and the fallback's state is restored.
+        XCTAssertTrue(appState.sessions.isEmpty)
+        XCTAssertEqual(appState.activeSessionTitle, "New conversation")
+        // persistPinnedSessions stores JSON data, mirroring the init load.
+        let persistedPins = try JSONDecoder().decode(
+            [String: [String]].self,
+            from: defaults.data(forKey: "conduit.pinnedSessionIdsByProfile.v1") ?? Data()
+        )
+        XCTAssertEqual(persistedPins, ["default": []])
+        XCTAssertEqual(
+            defaults.dictionary(forKey: "conduit.activeSessionTitlesByProfile.v1") as? [String: String],
+            [:]
+        )
     }
 
     func testAuthoritativeResponseContainingActiveProfileKeepsItWithoutReset() async throws {

--- a/ConduitTests/ProfileDiscoveryTests.swift
+++ b/ConduitTests/ProfileDiscoveryTests.swift
@@ -1,0 +1,255 @@
+import XCTest
+@testable import Conduit
+
+/// Regression coverage for the disappearing-profile bug: a transient
+/// `/api/profiles` failure must never shrink the visible profile list or
+/// overwrite the persisted known-profile cache, and a late response from a
+/// replaced connection must not commit stale profile state.
+@MainActor
+final class ProfileDiscoveryTests: XCTestCase {
+
+    private static let knownProfilesKey = "conduit.knownProfiles.v1"
+    private static let activeProfileKey = "conduit.activeProfile"
+
+    private enum DiscoveryError: Error {
+        case transient
+    }
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "ProfileDiscoveryTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeAppState(
+        profileDiscoveryLoader: (@MainActor () async throws -> [String: Any])? = nil
+    ) -> AppState {
+        AppState(
+            defaults: defaults,
+            loadSavedConnection: false,
+            profileDiscoveryLoader: profileDiscoveryLoader
+        )
+    }
+
+    private func makeBridge(_ baseURL: String) -> DashboardTicketBridge {
+        DashboardTicketBridge(
+            baseURL: baseURL,
+            pendingRequests: DashboardTicketBridgePendingRequests(),
+            readinessPollAttempts: 0,
+            readinessPollInterval: .milliseconds(1)
+        )
+    }
+
+    private func seedKnownProfiles(_ knownProfiles: [String]?, activeProfile: String) {
+        if let knownProfiles {
+            defaults.set(knownProfiles, forKey: Self.knownProfilesKey)
+        }
+        defaults.set(activeProfile, forKey: Self.activeProfileKey)
+    }
+
+    private func assertPersistedKnownProfiles(
+        _ expected: [String]?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(
+            defaults.stringArray(forKey: Self.knownProfilesKey),
+            expected,
+            file: file,
+            line: line
+        )
+    }
+
+    // MARK: - Initialization hydration
+
+    func testInitHydratesProfilesFromPersistedKnownProfileCache() {
+        seedKnownProfiles(["default", "profile2"], activeProfile: "profile2")
+
+        let appState = makeAppState()
+
+        XCTAssertEqual(appState.profiles, ["default", "profile2"])
+    }
+
+    func testInitHydrationReaddsDefaultToDegradedLegacyCache() {
+        // A pre-fix build could persist a degraded one-entry cache; hydration
+        // must heal it with the `default` invariant instead of trusting it.
+        seedKnownProfiles(["profile2"], activeProfile: "profile2")
+
+        let appState = makeAppState()
+
+        XCTAssertEqual(appState.profiles, ["default", "profile2"])
+    }
+
+    // MARK: - Discovery failure must never shrink the known set
+
+    func testDiscoveryFailurePreservesCompleteCacheWhenActiveIsSecondProfile() async throws {
+        seedKnownProfiles(["default", "profile2"], activeProfile: "profile2")
+        let appState = makeAppState(profileDiscoveryLoader: { throw DiscoveryError.transient })
+        appState.installDashboardTicketBridgeForTesting(makeBridge("https://one.example"))
+
+        await appState.loadProfiles()
+
+        XCTAssertEqual(appState.profiles, ["default", "profile2"])
+        assertPersistedKnownProfiles(["default", "profile2"])
+    }
+
+    func testDiscoveryFailurePreservesCompleteCacheWhenActiveIsDefault() async throws {
+        seedKnownProfiles(["default", "profile2"], activeProfile: "default")
+        let appState = makeAppState(profileDiscoveryLoader: { throw DiscoveryError.transient })
+        appState.installDashboardTicketBridgeForTesting(makeBridge("https://one.example"))
+
+        await appState.loadProfiles()
+
+        XCTAssertEqual(appState.profiles, ["default", "profile2"])
+        assertPersistedKnownProfiles(["default", "profile2"])
+    }
+
+    func testDiscoveryFailureWithoutCachePresentsMinimumSetAndLaterSuccessConverges() async throws {
+        seedKnownProfiles(nil, activeProfile: "profile2")
+        let appState = makeAppState(profileDiscoveryLoader: { throw DiscoveryError.transient })
+        appState.installDashboardTicketBridgeForTesting(makeBridge("https://one.example"))
+
+        await appState.loadProfiles()
+
+        XCTAssertEqual(appState.profiles, ["default", "profile2"])
+        assertPersistedKnownProfiles(["default", "profile2"])
+
+        // The fallback must not corrupt future discovery: the next successful
+        // refresh still establishes the server's list without a re-login.
+        let recoveredState = makeAppState(profileDiscoveryLoader: {
+            ["profiles": ["profile2", "default", "profile3"]]
+        })
+        recoveredState.installDashboardTicketBridgeForTesting(makeBridge("https://one.example"))
+
+        await recoveredState.loadProfiles()
+
+        XCTAssertEqual(recoveredState.profiles, ["default", "profile2", "profile3"])
+        assertPersistedKnownProfiles(["default", "profile2", "profile3"])
+    }
+
+    // MARK: - Successful discovery
+
+    func testDiscoverySuccessRefreshesVisibleListAndPersistedCache() async throws {
+        seedKnownProfiles(["default"], activeProfile: "default")
+        let appState = makeAppState(profileDiscoveryLoader: {
+            ["profiles": ["profile2", "default"]]
+        })
+        appState.installDashboardTicketBridgeForTesting(makeBridge("https://one.example"))
+
+        await appState.loadProfiles()
+
+        XCTAssertEqual(appState.profiles, ["default", "profile2"])
+        assertPersistedKnownProfiles(["default", "profile2"])
+    }
+
+    func testTransientFailureThenSuccessConvergesWithoutRelogin() async throws {
+        seedKnownProfiles(["default", "profile2"], activeProfile: "profile2")
+        var shouldFail = true
+        let appState = makeAppState(profileDiscoveryLoader: {
+            if shouldFail { throw DiscoveryError.transient }
+            return ["profiles": ["profile2", "default"]]
+        })
+        appState.installDashboardTicketBridgeForTesting(makeBridge("https://one.example"))
+
+        await appState.loadProfiles()
+        XCTAssertEqual(appState.profiles, ["default", "profile2"])
+
+        shouldFail = false
+        await appState.loadProfiles()
+
+        XCTAssertEqual(appState.profiles, ["default", "profile2"])
+        assertPersistedKnownProfiles(["default", "profile2"])
+    }
+
+    // MARK: - Stale responses from replaced connections
+
+    func testLateResponseFromReplacedBridgeDoesNotCommit() async throws {
+        seedKnownProfiles(["default", "profile2"], activeProfile: "profile2")
+        let gate = ProfileResponseGate()
+        let appState = makeAppState(profileDiscoveryLoader: { try await gate.wait() })
+        appState.installDashboardTicketBridgeForTesting(makeBridge("https://one.example"))
+
+        let discovery = Task { await appState.loadProfiles() }
+        await gate.waitUntilEntered()
+
+        // The connection is replaced (server change / re-login) while the old
+        // request is still in flight; its late success must be discarded.
+        appState.installDashboardTicketBridgeForTesting(makeBridge("https://two.example"))
+        gate.resume(.success(["profiles": ["default", "profile2", "stale-only"]]))
+        await discovery.value
+
+        XCTAssertEqual(appState.profiles, ["default", "profile2"])
+        assertPersistedKnownProfiles(["default", "profile2"])
+    }
+
+    func testLateResponseAfterServerChangeDoesNotRepopulateProfileState() async throws {
+        defaults.set("https://one.example", forKey: "conduit.dashboardURL")
+        seedKnownProfiles(["default", "one-only"], activeProfile: "default")
+        let gate = ProfileResponseGate()
+        let appState = makeAppState(profileDiscoveryLoader: { try await gate.wait() })
+        appState.rememberDashboardURL("https://one.example")
+        appState.installDashboardTicketBridgeForTesting(makeBridge("https://one.example"))
+
+        let discovery = Task { await appState.loadProfiles() }
+        await gate.waitUntilEntered()
+
+        // Reconnecting to a different Hermes server wipes the server-scoped
+        // profile state and swaps the dashboard bridge; the old server's late
+        // response must not repopulate either.
+        XCTAssertTrue(appState.prepareChatResumeForConnection(to: "https://two.example"))
+        appState.installDashboardTicketBridgeForTesting(makeBridge("https://two.example"))
+        gate.resume(.success(["profiles": ["default", "one-only"]]))
+        await discovery.value
+
+        XCTAssertTrue(appState.profiles.isEmpty)
+        assertPersistedKnownProfiles(nil)
+    }
+}
+
+/// Result-carrying suspension gate for driving `loadProfiles()` through a
+/// controlled response window. All access is MainActor-confined, matching the
+/// AppState and test isolation.
+@MainActor
+private final class ProfileResponseGate {
+    private var responseContinuation: CheckedContinuation<[String: Any], Error>?
+    private var heldResponse: Result<[String: Any], Error>?
+    private var enteredContinuations: [CheckedContinuation<Void, Never>] = []
+    private var enterCount = 0
+
+    func wait() async throws -> [String: Any] {
+        enterCount += 1
+        let waiters = enteredContinuations
+        enteredContinuations = []
+        waiters.forEach { $0.resume() }
+        if let heldResponse {
+            return try heldResponse.get()
+        }
+        return try await withCheckedThrowingContinuation { responseContinuation = $0 }
+    }
+
+    func waitUntilEntered() async {
+        guard enterCount == 0 else { return }
+        await withCheckedContinuation { enteredContinuations.append($0) }
+    }
+
+    func resume(_ result: Result<[String: Any], Error>) {
+        if let continuation = responseContinuation {
+            responseContinuation = nil
+            continuation.resume(with: result)
+        } else {
+            heldResponse = result
+        }
+    }
+}

--- a/ConduitTests/ProfileDiscoveryTests.swift
+++ b/ConduitTests/ProfileDiscoveryTests.swift
@@ -195,7 +195,6 @@ final class ProfileDiscoveryTests: XCTestCase {
     }
 
     func testLateResponseAfterServerChangeDoesNotRepopulateProfileState() async throws {
-        defaults.set("https://one.example", forKey: "conduit.dashboardURL")
         seedKnownProfiles(["default", "one-only"], activeProfile: "default")
         let gate = ProfileResponseGate()
         let appState = makeAppState(profileDiscoveryLoader: { try await gate.wait() })
@@ -215,6 +214,53 @@ final class ProfileDiscoveryTests: XCTestCase {
 
         XCTAssertTrue(appState.profiles.isEmpty)
         assertPersistedKnownProfiles(nil)
+    }
+
+    func testLateFailureAfterServerChangeDoesNotRepopulateProfileState() async throws {
+        seedKnownProfiles(["default", "one-only"], activeProfile: "default")
+        let gate = ProfileResponseGate()
+        let appState = makeAppState(profileDiscoveryLoader: { try await gate.wait() })
+        appState.rememberDashboardURL("https://one.example")
+        appState.installDashboardTicketBridgeForTesting(makeBridge("https://one.example"))
+
+        let discovery = Task { await appState.loadProfiles() }
+        await gate.waitUntilEntered()
+
+        // The failure branch carries the same commit gate: without it, a late
+        // error from the old connection would "recover" by repopulating the
+        // just-wiped state with the previous server-era minimum set.
+        XCTAssertTrue(appState.prepareChatResumeForConnection(to: "https://two.example"))
+        appState.installDashboardTicketBridgeForTesting(makeBridge("https://two.example"))
+        gate.resume(.failure(DiscoveryError.transient))
+        await discovery.value
+
+        XCTAssertTrue(appState.profiles.isEmpty)
+        assertPersistedKnownProfiles(nil)
+    }
+
+    func testDegenerateEmptySuccessKeepsKnownProfiles() async throws {
+        seedKnownProfiles(["default", "profile2"], activeProfile: "profile2")
+        let appState = makeAppState(profileDiscoveryLoader: {
+            ["profiles": []]
+        })
+        appState.installDashboardTicketBridgeForTesting(makeBridge("https://one.example"))
+
+        // A 200 whose payload lists no profiles (dashboard mid-restart,
+        // partial deploy) is degraded, not authoritative: it must not shrink
+        // the known set or persist a degraded cache.
+        await appState.loadProfiles()
+
+        XCTAssertEqual(appState.profiles, ["default", "profile2"])
+        assertPersistedKnownProfiles(["default", "profile2"])
+
+        // Same for a payload missing the key entirely.
+        let missingKeyState = makeAppState(profileDiscoveryLoader: { [:] })
+        missingKeyState.installDashboardTicketBridgeForTesting(makeBridge("https://one.example"))
+
+        await missingKeyState.loadProfiles()
+
+        XCTAssertEqual(missingKeyState.profiles, ["default", "profile2"])
+        assertPersistedKnownProfiles(["default", "profile2"])
     }
 }
 

--- a/ConduitTests/ProfileDiscoveryTests.swift
+++ b/ConduitTests/ProfileDiscoveryTests.swift
@@ -255,7 +255,9 @@ final class ProfileDiscoveryTests: XCTestCase {
         XCTAssertEqual(appState.profiles, ["default", "profile2"])
         assertPersistedKnownProfiles(["default", "profile2"])
 
-        // Same for a payload missing the key entirely.
+        // Same for a payload missing the key entirely. Seeded explicitly so
+        // this half does not depend on state the first half persisted.
+        seedKnownProfiles(["default", "profile2"], activeProfile: "profile2")
         let missingKeyState = makeAppState(profileDiscoveryLoader: { [:] })
         missingKeyState.installDashboardTicketBridgeForTesting(makeBridge("https://one.example"))
 
@@ -263,6 +265,72 @@ final class ProfileDiscoveryTests: XCTestCase {
 
         XCTAssertEqual(missingKeyState.profiles, ["default", "profile2"])
         assertPersistedKnownProfiles(["default", "profile2"])
+    }
+
+    // MARK: - Authoritative success re-homes a deleted active profile
+
+    func testAuthoritativeResponseRemovingActiveProfileRehomesToDefault() async throws {
+        seedKnownProfiles(["default", "profile2"], activeProfile: "profile2")
+        let appState = makeAppState(profileDiscoveryLoader: {
+            ["profiles": ["profile3", "default"]]
+        })
+        appState.installDashboardTicketBridgeForTesting(makeBridge("https://one.example"))
+
+        await appState.loadProfiles()
+
+        // The server's list is authoritative (profile2 was deleted
+        // externally); the active profile must transition to a valid
+        // fallback instead of lingering outside the visible list.
+        XCTAssertEqual(appState.profiles, ["default", "profile3"])
+        XCTAssertEqual(appState.activeProfile, "default")
+        XCTAssertEqual(defaults.string(forKey: Self.activeProfileKey), "default")
+    }
+
+    func testAuthoritativeResponseContainingActiveProfileKeepsItWithoutReset() async throws {
+        seedKnownProfiles(["default", "profile2"], activeProfile: "profile2")
+        let appState = makeAppState(profileDiscoveryLoader: {
+            ["profiles": ["profile3", "default", "profile2"]]
+        })
+        appState.installDashboardTicketBridgeForTesting(makeBridge("https://one.example"))
+        // Probe for an unnecessary reset: profile-scoped catalog state
+        // installed under the still-valid active profile must survive.
+        appState.sessions = [
+            SessionSummary(
+                id: "profile2-session",
+                alternateIds: [],
+                title: "profile2-session",
+                model: "Hermes",
+                updatedLabel: "now",
+                profile: "profile2",
+                source: .chat,
+                isActive: false,
+                isArchived: false,
+                lineageRootId: nil
+            )
+        ]
+
+        await appState.loadProfiles()
+
+        XCTAssertEqual(appState.profiles, ["default", "profile2", "profile3"])
+        XCTAssertEqual(appState.activeProfile, "profile2")
+        XCTAssertEqual(defaults.string(forKey: Self.activeProfileKey), "profile2")
+        XCTAssertEqual(appState.sessions.count, 1)
+    }
+
+    func testAuthoritativeResponseDeletingNonActiveProfilePropagates() async throws {
+        seedKnownProfiles(["default", "profile2"], activeProfile: "default")
+        let appState = makeAppState(profileDiscoveryLoader: {
+            ["profiles": ["default"]]
+        })
+        appState.installDashboardTicketBridgeForTesting(makeBridge("https://one.example"))
+
+        await appState.loadProfiles()
+
+        // Authoritative deletions still propagate; the active profile is
+        // unaffected because it remains server-valid.
+        XCTAssertEqual(appState.profiles, ["default"])
+        XCTAssertEqual(appState.activeProfile, "default")
+        assertPersistedKnownProfiles(["default"])
     }
 }
 


### PR DESCRIPTION
## Symptom

App Store build (~140) report: a user with two Hermes profiles intermittently sees only one of them. The missing profile cannot be selected; logout/login restores both; after some time one may vanish again; sometimes both spontaneously reappear.

## Root cause

Two defects combined destructively:

1. `AppState.init` never restored the persisted `conduit.knownProfiles.v1` cache into `profiles`, so every cold launch started the visible list empty.
2. `loadProfiles()`'s catch handler replaced `profiles` with `[activeProfile]` whenever it was empty **and persisted that degraded list over the complete cache**.

So one transient `/api/profiles` failure (bridge still loading, dashboard restart, flaky link) collapsed the picker to a single profile — whichever was active — and clobbered the good cache. The inverse direction (losing profile 2 vs losing Default) depends only on which profile was remembered as active. A later successful discovery explains the spontaneous recovery.

## Fix

Profile discovery is now **monotonic and failure-tolerant**:

- **Init hydration** — `AppState.init` seeds the visible list with `orderedProfiles(persisted cache ∪ activeProfile ∪ "default")` before any discovery runs. As a side effect this heals caches a pre-fix build already degraded (`default` and the active profile are re-added on first launch).
- **Failure path** — a failed refresh commits `orderedProfiles(current ∪ activeProfile ∪ "default")` instead of `[activeProfile]`, and persists only that union. It can add, never shrink, and never overwrites a complete cache.
- **Degenerate success** (review finding) — a 200 with empty/missing `profiles` (dashboard mid-restart, partial deploy) routes through the same monotonic merge instead of collapsing to `["default"]`. A genuinely reduced server list (non-empty names) still replaces authoritatively, so server-side deletions still propagate.
- **Stale-response protection** — both commit paths capture `dashboardTicketBridge` before awaiting and discard the outcome if the bridge was swapped mid-request (server change, re-login, disconnect). This reuses the app's existing bridge-identity commit-gate pattern (same as the dashboard catalog loader, `AppState.swift:6018`). A late reply from an old connection can neither overwrite live state nor repopulate a cache the server-identity wipe already cleared.

### Server-identity scoping

Not re-namespaced. `prepareChatResumeForConnection(to:)` already wipes `profiles` and `knownProfilesKey` when the normalized server identity changes, which prevents profile names from server A appearing while connected to server B. Remaining limitation (documented in code): between init hydration and the identity check the previous server's names briefly exist in memory; the picker is unreachable pre-connection and the window is never persisted.

### Non-goals (unchanged by this PR)

Profile switching semantics, transcript reconciliation, presentation cache, YOLO bookkeeping, session hydration (#106), auth flow — all untouched. This is a narrow discovery/persistence fix.

## Tests

New `ConduitTests/ProfileDiscoveryTests.swift` (11 tests) via a `profileDiscoveryLoader` init seam (mirrors `sessionCatalogLoader`) plus a test-only bridge installer to model connection swaps:

- init hydrates the persisted cache; heals a degraded legacy cache
- discovery failure preserves the complete cache (active = profile2 and active = Default)
- no-cache fallback presents `["default", active]` and a later success converges
- successful discovery refreshes the visible list and persisted cache
- transient failure → success converges without relogin
- late success/failure from a replaced bridge is discarded (MainActor gate suspends the loader mid-flight)
- late success/failure after a server change repopulates nothing
- degenerate empty payloads (empty array / missing key) keep known profiles

## Verification

- Focused: `ProfileDiscoveryTests` 11/11 pass (Mac build host, iPhone 17 Pro).
- Full `ConduitTests` suite: **1426/1426, 0 failures** (1415 baseline + 11 new), including all profile-switch, YOLO, and cross-profile cache regression suites.
- `git diff --check` clean; no lint tooling configured in the repo.
- Caveat: the local `ConduitUITests` runner failed to bootstrap ("Timed out waiting for AX loaded notification") — the known simulator AX wedge. It reproduced identically on the pre-fix commit, the post-fix commit, and in isolation, so it is environmental and unrelated to this diff; branch CI will cover the UI target.

## Review

Local multi-model review (three reviewers, parallel): **APPROVE × 3, zero blockers**. Both WARNING-class findings were adopted (degenerate empty-success guard; the reviewer NIT suggesting removal of the dashboard-URL test seed proved incorrect and was reverted with an explanatory comment — the seed is what feeds `initialChatResumeServerIdentity` at init).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved visible profiles when discovery temporarily fails, returns no profiles, or encounters delayed responses.
  * Restored saved profiles during app launch, including recovery of incomplete legacy profile data.
  * Kept active and default profiles available when discovery results are unavailable.
  * Automatically switched to a fallback profile if the active profile was deleted externally and reconnected when needed.
  * Applied profile removals correctly when confirmed by authoritative discovery results.

* **Tests**
  * Added coverage for profile loading, recovery, refreshes, connection changes, failures, and empty responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->