### PR TITLE
fix(chat): hydrate persisted transcripts as bounded tail-anchored pages

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -31,7 +31,17 @@ struct ChatResumeLifecycleOperations {
     var loadCatalog: (@MainActor (HermesClient, Bool) async throws -> [SessionSummary])?
     var mintTicket: (@MainActor (String) async throws -> String)?
     var openSession: (@MainActor (HermesClient, String, Bool) async throws -> SessionResumeResult)?
+    /// Seam for the initial persisted-history fetch. Receives BOTH the
+    /// bounded tail-page request and the legacy one-shot re-read (an echo
+    /// without the `order=latest` contract) — the query argument is built by
+    /// the production path builder and is not threaded through the seam, so
+    /// callables distinguish the two requests by call order (bounded first,
+    /// one-shot re-read second, at most once).
     var persistedTranscript: (@MainActor (String, String) async -> PersistedTranscriptFetchOutcome)?
+    /// Seam for older-page backfill requests only (`offset` = the window's
+    /// next offset). Distinct from `persistedTranscript` so backfill tests
+    /// never collide with initial-hydration fixtures.
+    var loadEarlierTranscriptPage: (@MainActor (String, String, Int) async -> PersistedTranscriptFetchOutcome)?
     var branchSession: (@MainActor (
         HermesClient,
         String,
@@ -69,6 +79,7 @@ struct ChatResumeLifecycleOperations {
         mintTicket: (@MainActor (String) async throws -> String)? = nil,
         openSession: (@MainActor (HermesClient, String, Bool) async throws -> SessionResumeResult)? = nil,
         persistedTranscript: (@MainActor (String, String) async -> PersistedTranscriptFetchOutcome)? = nil,
+        loadEarlierTranscriptPage: (@MainActor (String, String, Int) async -> PersistedTranscriptFetchOutcome)? = nil,
         branchSession: (@MainActor (
             HermesClient,
             String,
@@ -105,6 +116,7 @@ struct ChatResumeLifecycleOperations {
         self.mintTicket = mintTicket
         self.openSession = openSession
         self.persistedTranscript = persistedTranscript
+        self.loadEarlierTranscriptPage = loadEarlierTranscriptPage
         self.branchSession = branchSession
         self.setSessionTitle = setSessionTitle
         self.refreshContext = refreshContext
@@ -150,6 +162,10 @@ enum PersistedTranscriptOutcome {
 struct PersistedSessionTranscript {
     let resolvedSessionId: String?
     let messages: [ChatMessage]
+    /// Pagination echo of the response this transcript was parsed from.
+    /// Nil (or an echo without the `order=latest` tail contract) means the
+    /// backend served a one-shot full transcript.
+    var page: PersistedTranscriptPagination.PageInfo?
 }
 
 struct ComposerSubmissionContext: Equatable {
@@ -419,6 +435,11 @@ final class AppState: ObservableObject {
         }
     }
     @Published private(set) var activeSessionTitle = "New conversation"
+    /// Persisted-history pagination window of the active conversation.
+    /// Drives the "Load earlier messages" affordance; nil means the current
+    /// transcript is either a legacy one-shot hydration or not persisted-
+    /// history-backed at all, and no older pages exist to fetch.
+    @Published private(set) var persistedTranscriptWindow: PersistedTranscriptWindowState?
     @Published private(set) var isChatRefreshing = false
     @Published private(set) var chatResumeBehavior: ChatResumeBehavior = .continueWhereLeftOff
     @Published private(set) var chatReturnSurface: ChatReturnSurface = .conversation
@@ -1680,6 +1701,7 @@ final class AppState: ObservableObject {
         activeSessionId = nil
         activeSessionTitle = "New conversation"
         messages = []
+        persistedTranscriptWindow = nil
         clearStreamingText()
         resetReasoningTurn()
         activeSessionTitlesByProfile = [:]
@@ -2125,6 +2147,7 @@ final class AppState: ObservableObject {
         sessionCatalogCache.removeAll()
         pinnedSessionIDs = []
         messages = []
+        persistedTranscriptWindow = nil
         setActiveSessionState(id: nil, title: "New conversation")
         clearStreamingText()
         resetReasoningTurn()
@@ -2776,6 +2799,41 @@ final class AppState: ObservableObject {
                     resumedSessionId: result.sessionId
                 )
             } ?? false
+
+            // Persisted-history window bookkeeping. The window describes the
+            // REST-fetched display history only — runtime state above is
+            // untouched. A pagination echo carrying the `order=latest` tail
+            // contract opens the bounded window; a legacy one-shot hydration
+            // (or a hydration that failed the session-identity gate) leaves
+            // no window, because no older page exists to fetch.
+            //
+            // The refresh resets coverage to the fetched page even when the
+            // graft below kept older rows. The next backfills then retrace
+            // the backfilled prefix in page-sized increments, each deduped
+            // against held rows, until coverage catches up — harmless
+            // duplicate requests that self-correct, never gaps. Under-
+            // counting is the safe direction: trusting the prior coverage
+            // after a server-side rewrite could silently skip rows. A
+            // conversation that was already fully backfilled re-lights the
+            // affordance once and re-retires on its first terminal page.
+            //
+            // Capture the pre-reconcile transcript and window for the graft
+            // decision below before either is replaced.
+            let previousTranscriptMessages = messages
+            let priorWindow = persistedTranscriptWindow
+            if let transcript, transcriptMatches, let page = transcript.page,
+               page.honorsTailContract {
+                persistedTranscriptWindow = PersistedTranscriptWindowState(
+                    requestedSessionID: sessionId,
+                    profile: profile,
+                    pageSize: PersistedTranscriptPagination.pageSize,
+                    resolvedSessionID: transcript.resolvedSessionId ?? result.sessionId,
+                    nextOffset: page.rawReturned,
+                    canLoadEarlier: page.mayHaveOlderRows(fetchedRowCount: page.rawReturned)
+                )
+            } else {
+                persistedTranscriptWindow = nil
+            }
             if let transcript, transcriptMatches, result.snapshot.hasLiveProjection, !transcript.messages.isEmpty {
                 // Desktop keeps its live projection during an active turn. Seed
                 // the same durable presentation details first so the completed
@@ -2798,9 +2856,21 @@ final class AppState: ObservableObject {
                 && (!result.snapshot.hasLiveProjection || !resumeCarriedTranscript)
             let presentationResult: SessionResumeResult
             if let transcript, shouldUsePersistedTranscript {
+                // A re-reconciliation replaces only the newest page. Keep
+                // everything "Load earlier messages" already backfilled by
+                // re-anchoring the refreshed tail onto the older prefix;
+                // without this, any reconnect during a browsed long session
+                // would silently truncate the visible history back to one
+                // page.
+                let graftedTail = PersistedTranscriptWindow.grafting(
+                    refreshedTail: transcript.messages,
+                    ontoBackfilled: previousTranscriptMessages,
+                    window: priorWindowOwnsThisConversation(priorWindow, requestedSessionId: sessionId, profile: profile)
+                        ? priorWindow : nil
+                )
                 presentationResult = SessionResumeResult(
                     sessionId: result.sessionId,
-                    messages: transcript.messages,
+                    messages: graftedTail,
                     snapshot: result.snapshot
                 )
             } else {
@@ -2955,7 +3025,15 @@ final class AppState: ObservableObject {
                 return false
             }
             turnState = .reconnecting
-            errorMessage = "Failed to restore this conversation: \(error.localizedDescription)"
+            if case DashboardTicketBridgeError.oversizedResponse = error {
+                // A known-oversized one-shot history response from an old
+                // backend: retrying the same giant transcript over the
+                // bounded WebSocket is not a recovery. Surface the
+                // controlled compatibility error instead.
+                errorMessage = error.localizedDescription
+            } else {
+                errorMessage = "Failed to restore this conversation: \(error.localizedDescription)"
+            }
             settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
             chatResumeCoordinator.abandonPendingAutomaticSync()
             return false
@@ -3045,6 +3123,7 @@ final class AppState: ObservableObject {
             markChatViewportReplacement()
             setActiveSessionState(id: runtimeSessionID, title: "New conversation")
             messages = []
+            persistedTranscriptWindow = nil
             noteChatViewportTranscriptReplacement()
             clearStreamingText()
             activeAssistantMessageId = nil
@@ -4525,6 +4604,7 @@ final class AppState: ObservableObject {
         markChatViewportReplacement()
         setActiveSessionState(id: nil, title: "New conversation")
         messages = []
+        persistedTranscriptWindow = nil
         clearStreamingText()
         activeAssistantMessageId = nil
         resetReasoningTurn()
@@ -4603,6 +4683,7 @@ final class AppState: ObservableObject {
         let acceptedSessionIDs = knownSessionIDs(for: sessionId)
         setActiveSessionState(id: sessionId)
         messages = []
+        persistedTranscriptWindow = nil
         clearStreamingText()
         activeAssistantMessageId = nil
         resetReasoningTurn()
@@ -6109,30 +6190,25 @@ final class AppState: ObservableObject {
     /// reconciliation distinguish a missing history source — which triggers
     /// the legacy full-transcript resume — from an unrelated failure, which
     /// must surface instead of silently degrading.
+    ///
+    /// The request is explicitly bounded (tail-anchored page of
+    /// `PersistedTranscriptPagination.pageSize` rows) so the transport and
+    /// normalization cost of opening a conversation is bounded no matter how
+    /// large the session grew. A response that carries the `order=latest`
+    /// pagination echo answers under the paginated tail contract; one
+    /// without it is a legacy one-shot full transcript and hydrates as
+    /// before.
     private func persistedTranscriptOutcome(
         sessionId: String,
         profile: String,
         using bridge: DashboardTicketBridge?
     ) async -> PersistedTranscriptOutcome {
-        let fetchOutcome: PersistedTranscriptFetchOutcome
-        if let persistedTranscript = chatResumeLifecycleOperations.persistedTranscript {
-            fetchOutcome = await persistedTranscript(sessionId, profile)
-        } else {
-            guard let bridge else { return .unavailable }
-            do {
-                fetchOutcome = .payload(try await bridge.requestJSON(
-                    path: sessionMessagesPath(sessionId: sessionId, profile: profile)
-                ))
-            } catch {
-                // requestJSON's readiness poll is the bounded wait for a cold
-                // or reloading bridge; whatever it raises is classified with
-                // the seam-sourced failures below. Note the bridge caps REST
-                // response size (DataURLLimits.maxJSONResponseBytes), so an
-                // oversized transcript also lands here rather than silently
-                // degrading the resume.
-                fetchOutcome = .failed(error)
-            }
-        }
+        let fetchOutcome = await fetchPersistedHistoryPayload(
+            sessionId: sessionId,
+            profile: profile,
+            query: PersistedTranscriptPagination.tailQuery(offset: 0),
+            using: bridge
+        )
 
         switch fetchOutcome {
         case .unavailable:
@@ -6142,8 +6218,9 @@ final class AppState: ObservableObject {
             // structural endpoint gaps, a bridge that never became ready
             // inside its bounded poll, and transient transport trouble
             // (429, 5xx, status-0 WebKit/network failures, request timeouts)
-            // degrade to the single legacy resume; authentication and every
-            // other failure must surface instead of silently degrading.
+            // degrade to the single legacy resume; authentication, a known-
+            // oversized one-shot history response, and every other failure
+            // must surface instead of silently degrading.
             if Self.historySourceIsUnavailable(error) {
                 sessionCatalogLog.debug("Persisted transcript unavailable for \(sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)")
                 return .unavailable
@@ -6151,22 +6228,90 @@ final class AppState: ObservableObject {
             sessionCatalogLog.debug("Persisted transcript failed for \(sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)")
             return .failed(error)
         case .payload(let response):
-            // The dashboard server returns `messages`; the API-server variant
-            // returns `data`, so accept both public Hermes response shapes.
-            let rawMessages = ["messages", "data", "_array"]
-                .compactMap { response[$0] as? [Any] }
-                .first
-            guard let rawMessages else {
+            guard let rawMessages = Self.persistedMessageRows(in: response) else {
                 return .failed(HermesError.invalidResponse)
             }
+            let page = PersistedTranscriptPagination.parse(response, rawRowCount: rawMessages.count)
 
-            let resolvedSessionId = (response["session_id"] as? String)
-                ?? (response["sessionId"] as? String)
+            // A pagination echo WITHOUT the `order=latest` tail contract
+            // describes a backend that pages from the oldest end: honoring
+            // its offsets would walk the transcript forward from row zero
+            // and never reach the newest rows. Re-read one-shot — the exact
+            // request pre-pagination Conduit made — and treat the response
+            // as the legacy full transcript. Shape-detected from the echo,
+            // never version-sniffed, and performed at most once.
+            if let page, !page.honorsTailContract {
+                let oneShotOutcome = await fetchPersistedHistoryPayload(
+                    sessionId: sessionId,
+                    profile: profile,
+                    query: PersistedTranscriptPagination.legacyQuery,
+                    using: bridge
+                )
+                switch oneShotOutcome {
+                case .payload(let fullResponse):
+                    guard let fullRows = Self.persistedMessageRows(in: fullResponse) else {
+                        return .failed(HermesError.invalidResponse)
+                    }
+                    return .hydrated(PersistedSessionTranscript(
+                        resolvedSessionId: Self.resolvedSessionId(in: fullResponse) ?? Self.resolvedSessionId(in: response),
+                        messages: MessageNormalizer.normalizeMessages(fullRows.map(AnyCodable.from)),
+                        page: nil
+                    ))
+                case .unavailable:
+                    return .unavailable
+                case .failed(let error):
+                    if Self.historySourceIsUnavailable(error) {
+                        return .unavailable
+                    }
+                    return .failed(error)
+                }
+            }
+
+            // The dashboard server returns `messages`; the API-server variant
+            // returns `data`, so accept both public Hermes response shapes.
             return .hydrated(PersistedSessionTranscript(
-                resolvedSessionId: resolvedSessionId,
-                messages: MessageNormalizer.normalizeMessages(rawMessages.map(AnyCodable.from))
+                resolvedSessionId: Self.resolvedSessionId(in: response),
+                messages: MessageNormalizer.normalizeMessages(rawMessages.map(AnyCodable.from)),
+                page: page
             ))
         }
+    }
+
+    private func fetchPersistedHistoryPayload(
+        sessionId: String,
+        profile: String,
+        query: String,
+        using bridge: DashboardTicketBridge?
+    ) async -> PersistedTranscriptFetchOutcome {
+        if let persistedTranscript = chatResumeLifecycleOperations.persistedTranscript {
+            return await persistedTranscript(sessionId, profile)
+        }
+        guard let bridge else { return .unavailable }
+        do {
+            return .payload(try await bridge.requestJSON(
+                path: Self.sessionMessagesPath(sessionId: sessionId, profile: profile, query: query)
+            ))
+        } catch {
+            // requestJSON's readiness poll is the bounded wait for a cold
+            // or reloading bridge; whatever it raises is classified with
+            // the seam-sourced failures below. Note the bridge caps REST
+            // response size (DataURLLimits.maxJSONResponseBytes), so an
+            // oversized transcript also lands here rather than silently
+            // degrading the resume.
+            return .failed(error)
+        }
+    }
+
+    /// The dashboard server returns `messages`; the API-server variant
+    /// returns `data`, so accept both public Hermes response shapes.
+    nonisolated static func persistedMessageRows(in response: [String: Any]) -> [Any]? {
+        ["messages", "data", "_array"]
+            .compactMap { response[$0] as? [Any] }
+            .first
+    }
+
+    nonisolated static func resolvedSessionId(in response: [String: Any]) -> String? {
+        (response["session_id"] as? String) ?? (response["sessionId"] as? String)
     }
 
     /// Classifies a history-fetch failure for the resume fallback. Everything
@@ -6179,14 +6324,19 @@ final class AppState: ObservableObject {
     ///    poll, or a request that outlived its deadline (both funnel into
     ///    `.notReady` by the bridge's error contract);
     ///  - transient transport trouble — HTTP 408/429, any 5xx (which
-    ///    subsumes 501), and status 0 (WebKit-level network/abort failures,
-    ///    including response caps).
+    ///    subsumes 501), and status 0 (WebKit-level network/abort failures).
+    ///
+    /// A known-oversized one-shot history response is deliberately NOT
+    /// classified here: retrying the same giant transcript over the bounded
+    /// WebSocket is not a recovery, so the typed oversized condition
+    /// surfaces its controlled compatibility error instead.
     ///
     /// Client-originated request/bridge timeouts always arrive through one of
     /// the status-0/`.notReady` funnels above; other authentication (401/403 →
     /// `.signInRequired`) and every unlisted error is a real failure that must
     /// propagate instead of silently degrading the resume into a fallback.
     nonisolated static func historySourceIsUnavailable(_ error: Error) -> Bool {
+        if case DashboardTicketBridgeError.oversizedResponse = error { return false }
         if case DashboardTicketBridgeError.notReady = error { return true }
         guard case let DashboardTicketBridgeError.http(status, _) = error else { return false }
         switch status {
@@ -6196,9 +6346,192 @@ final class AppState: ObservableObject {
         }
     }
 
-    private func sessionMessagesPath(sessionId: String, profile: String) -> String {
+    /// Classifies a backfill failure for affordance retirement: only a
+    /// history source that is structurally gone retires "Load earlier
+    /// messages" — the endpoint disappeared (404/410), the bridge never
+    /// became ready, or the server is failing (5xx). Transient transport
+    /// trouble (408/429, status-0 WebKit failures) and every other failure
+    /// stay retryable through another explicit tap — a failed backfill never
+    /// loops on its own.
+    nonisolated static func historySourceIsStructurallyGone(_ error: Error) -> Bool {
+        if case DashboardTicketBridgeError.notReady = error { return true }
+        guard case let DashboardTicketBridgeError.http(status, _) = error else { return false }
+        switch status {
+        case 404, 410: return true
+        case 500...599: return true
+        default: return false
+        }
+    }
+
+    nonisolated static func sessionMessagesPath(
+        sessionId: String,
+        profile: String,
+        query: String
+    ) -> String {
         let encodedSessionId = sessionId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? sessionId
-        return dashboardPath("/api/sessions/\(encodedSessionId)/messages", profile: profile)
+        return DashboardPath.withProfile(
+            "/api/sessions/\(encodedSessionId)/messages\(query)",
+            profile: profile
+        )
+    }
+
+    private func priorWindowOwnsThisConversation(
+        _ window: PersistedTranscriptWindowState?,
+        requestedSessionId: String,
+        profile: String
+    ) -> Bool {
+        guard let window, window.profile == profile else { return false }
+        if window.requestedSessionID == requestedSessionId { return true }
+        // Alias-aware, exactly like the backfill ownership gate: the window
+        // may have been opened under a runtime ID while this reconcile runs
+        // under the catalog's stored ID (or vice versa).
+        return knownSessionIDs(for: requestedSessionId).contains(window.requestedSessionID)
+            || knownSessionIDs(for: window.requestedSessionID).contains(requestedSessionId)
+    }
+
+    /// Fetches the next older persisted-history page for the active
+    /// conversation and prepends it, keeping the user's visible position
+    /// stable (ChatView anchors the prepend through the viewport controller).
+    /// Strictly user-driven and single-flight: one explicit request at a
+    /// time, owned by the window identity captured at request time, and a
+    /// response from a session/profile that is no longer current is
+    /// discarded without touching state.
+    ///
+    /// Returns whether a prepend actually published — the view discharges
+    /// its viewport anchor when nothing landed, so an armed anchor can never
+    /// re-pin on some later unrelated transcript change.
+    @discardableResult
+    func loadEarlierMessages() async -> Bool {
+        guard let window = persistedTranscriptWindow,
+              window.canLoadEarlier,
+              !window.isLoadingEarlier,
+              persistedTranscriptWindowOwnershipIsCurrent(
+                requestedSessionId: window.requestedSessionID,
+                profile: window.profile
+              ) else {
+            return false
+        }
+        let requestSessionId = window.requestedSessionID
+        let profile = window.profile
+        let offset = window.nextOffset
+        var arming = window
+        arming.isLoadingEarlier = true
+        persistedTranscriptWindow = arming
+
+        let outcome = await fetchOlderTranscriptPage(
+            sessionId: requestSessionId,
+            profile: profile,
+            offset: offset
+        )
+
+        // Stale-response guard: the window must still be this exact
+        // request's window (same session, same profile, still loading, and
+        // no other fetch advanced it meanwhile). Anything else — session
+        // switch, profile switch, disconnect re-home — discards the page.
+        guard var current = persistedTranscriptWindow,
+              current.requestedSessionID == requestSessionId,
+              current.profile == profile,
+              current.isLoadingEarlier,
+              current.nextOffset == offset,
+              persistedTranscriptWindowOwnershipIsCurrent(
+                requestedSessionId: requestSessionId,
+                profile: profile
+              ) else {
+            return false
+        }
+        current.isLoadingEarlier = false
+        defer { persistedTranscriptWindow = current }
+
+        switch outcome {
+        case .payload(let response):
+            guard let rawRows = Self.persistedMessageRows(in: response) else {
+                // A malformed page is a backfill dead end, not a chat
+                // failure: stop offering older pages rather than erroring
+                // the already-hydrated conversation.
+                sessionCatalogLog.debug("Older-page backfill for \(requestSessionId, privacy: .public) returned a malformed payload; retiring the affordance")
+                current.canLoadEarlier = false
+                return false
+            }
+            let fetchedRowCount = rawRows.count
+            let page = PersistedTranscriptPagination.parse(response, rawRowCount: fetchedRowCount)
+            // Only pages still answering under the tail contract may splice
+            // into the transcript: a response whose echo lost `order=latest`
+            // carries oldest-anchored rows with unknown window semantics,
+            // and prepending them would break chronology. That response
+            // retires the affordance instead.
+            guard let page, page.honorsTailContract else {
+                sessionCatalogLog.debug("Older-page backfill for \(requestSessionId, privacy: .public) lost the tail contract; retiring the affordance")
+                current.canLoadEarlier = false
+                return false
+            }
+            var didPrepend = false
+            if fetchedRowCount > 0 {
+                let olderPage = MessageNormalizer.normalizeMessages(rawRows.map(AnyCodable.from))
+                if let merged = PersistedTranscriptWindow.prepending(olderPage, onto: messages) {
+                    messages = merged
+                    didPrepend = true
+                }
+            }
+            // A full page means older history may still exist; a short or
+            // empty page marks the transcript fully backfilled and retires
+            // the affordance. The offset advances by the fetched row count
+            // either way, which self-corrects drift: a page that deduped to
+            // nothing still moves the next request past the already-held
+            // rows.
+            current.nextOffset = offset + fetchedRowCount
+            current.canLoadEarlier = fetchedRowCount > 0
+                && page.mayHaveOlderRows(fetchedRowCount: fetchedRowCount)
+            return didPrepend
+        case .unavailable:
+            // The history source went away mid-conversation; there is no
+            // older page to offer.
+            current.canLoadEarlier = false
+            return false
+        case .failed(let error):
+            // Only a structurally gone history source retires the
+            // affordance; transient transport trouble stays retryable
+            // through another explicit tap — a failed backfill never loops
+            // on its own.
+            sessionCatalogLog.debug("Older-page backfill failed for \(requestSessionId, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            current.canLoadEarlier = !Self.historySourceIsStructurallyGone(error)
+            return false
+        }
+    }
+
+    private func fetchOlderTranscriptPage(
+        sessionId: String,
+        profile: String,
+        offset: Int
+    ) async -> PersistedTranscriptFetchOutcome {
+        if let loadEarlierTranscriptPage = chatResumeLifecycleOperations.loadEarlierTranscriptPage {
+            return await loadEarlierTranscriptPage(sessionId, profile, offset)
+        }
+        // Backfill never falls through to the initial-hydration seam: that
+        // seam cannot carry the offset, and a test wiring mistake would
+        // otherwise become a silent always-duplicate affordance.
+        guard let bridge = dashboardTicketBridge else { return .unavailable }
+        do {
+            return .payload(try await bridge.requestJSON(path: Self.sessionMessagesPath(
+                sessionId: sessionId,
+                profile: profile,
+                query: PersistedTranscriptPagination.tailQuery(offset: offset)
+            )))
+        } catch {
+            return .failed(error)
+        }
+    }
+
+    /// Ownership gate for the backfill: the window's session and profile
+    /// must still be the active conversation (alias-aware, since the
+    /// endpoint may resolve a runtime ID to its stored ID).
+    private func persistedTranscriptWindowOwnershipIsCurrent(
+        requestedSessionId: String,
+        profile: String
+    ) -> Bool {
+        guard profile == activeProfile, let activeId = activeSessionId else { return false }
+        if activeId == requestedSessionId { return true }
+        return knownSessionIDs(for: activeId).contains(requestedSessionId)
+            || knownSessionIDs(for: requestedSessionId).contains(activeId)
     }
 
     /// The endpoint may resolve a runtime ID to its stored session ID. Accept
@@ -6637,6 +6970,7 @@ final class AppState: ObservableObject {
         projectsLoading = false
         slashCommands = Self.builtInSlashCommands
         messages = []
+        persistedTranscriptWindow = nil
         clearStreamingText()
         resetReasoningTurn()
         // The next profile's approval mode is unknown until its first session

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2800,40 +2800,13 @@ final class AppState: ObservableObject {
                 )
             } ?? false
 
-            // Persisted-history window bookkeeping. The window describes the
-            // REST-fetched display history only — runtime state above is
-            // untouched. A pagination echo carrying the `order=latest` tail
-            // contract opens the bounded window; a legacy one-shot hydration
-            // (or a hydration that failed the session-identity gate) leaves
-            // no window, because no older page exists to fetch.
-            //
-            // The refresh resets coverage to the fetched page even when the
-            // graft below kept older rows. The next backfills then retrace
-            // the backfilled prefix in page-sized increments, each deduped
-            // against held rows, until coverage catches up — harmless
-            // duplicate requests that self-correct, never gaps. Under-
-            // counting is the safe direction: trusting the prior coverage
-            // after a server-side rewrite could silently skip rows. A
-            // conversation that was already fully backfilled re-lights the
-            // affordance once and re-retires on its first terminal page.
-            //
             // Capture the pre-reconcile transcript and window for the graft
-            // decision below before either is replaced.
+            // decision below before either is replaced. The window write
+            // itself happens after the graft: whether the refreshed tail
+            // grafted onto the backfilled prefix determines whether the
+            // prefix-preservation fact survives into the refreshed window.
             let previousTranscriptMessages = messages
             let priorWindow = persistedTranscriptWindow
-            if let transcript, transcriptMatches, let page = transcript.page,
-               page.honorsTailContract {
-                persistedTranscriptWindow = PersistedTranscriptWindowState(
-                    requestedSessionID: sessionId,
-                    profile: profile,
-                    pageSize: PersistedTranscriptPagination.pageSize,
-                    resolvedSessionID: transcript.resolvedSessionId ?? result.sessionId,
-                    nextOffset: page.rawReturned,
-                    canLoadEarlier: page.mayHaveOlderRows(fetchedRowCount: page.rawReturned)
-                )
-            } else {
-                persistedTranscriptWindow = nil
-            }
             if let transcript, transcriptMatches, result.snapshot.hasLiveProjection, !transcript.messages.isEmpty {
                 // Desktop keeps its live projection during an active turn. Seed
                 // the same durable presentation details first so the completed
@@ -2854,27 +2827,69 @@ final class AppState: ObservableObject {
             let shouldUsePersistedTranscript = transcriptMatches
                 && (transcript.map { !$0.messages.isEmpty || !resumeCarriedTranscript } ?? false)
                 && (!result.snapshot.hasLiveProjection || !resumeCarriedTranscript)
+            let priorWindowForGraft = priorWindowOwnsThisConversation(
+                priorWindow,
+                requestedSessionId: sessionId,
+                profile: profile
+            ) ? priorWindow : nil
             let presentationResult: SessionResumeResult
+            var graftedBackfilledPrefix = false
             if let transcript, shouldUsePersistedTranscript {
                 // A re-reconciliation replaces only the newest page. Keep
                 // everything "Load earlier messages" already backfilled by
                 // re-anchoring the refreshed tail onto the older prefix;
                 // without this, any reconnect during a browsed long session
                 // would silently truncate the visible history back to one
-                // page.
-                let graftedTail = PersistedTranscriptWindow.grafting(
+                // page. The graft must survive REPEATED reconciles — the
+                // explicit hasBackfilledPrefix flag carries that fact, since
+                // the network coverage reset below erases the offset
+                // evidence after the first one.
+                let grafted = PersistedTranscriptWindow.grafting(
                     refreshedTail: transcript.messages,
                     ontoBackfilled: previousTranscriptMessages,
-                    window: priorWindowOwnsThisConversation(priorWindow, requestedSessionId: sessionId, profile: profile)
-                        ? priorWindow : nil
+                    window: priorWindowForGraft
                 )
                 presentationResult = SessionResumeResult(
                     sessionId: result.sessionId,
-                    messages: graftedTail,
+                    messages: grafted.messages,
                     snapshot: result.snapshot
                 )
+                graftedBackfilledPrefix = grafted.grafted
             } else {
                 presentationResult = result
+            }
+
+            // Persisted-history window bookkeeping. The window describes the
+            // REST-fetched display history only — runtime state above is
+            // untouched. A pagination echo carrying the `order=latest` tail
+            // contract opens the bounded window; a legacy one-shot hydration
+            // (or a hydration that failed the session-identity gate) leaves
+            // no window, because no older page exists to fetch. A graft that
+            // kept the backfilled prefix preserves that fact; a refreshed
+            // tail with no safe anchor is authoritative and resets it.
+            //
+            // The refresh resets coverage to the fetched page even when the
+            // graft kept older rows. The next backfills then retrace
+            // the backfilled prefix in page-sized increments, each deduped
+            // against held rows, until coverage catches up — harmless
+            // duplicate requests that self-correct, never gaps. Under-
+            // counting is the safe direction: trusting the prior coverage
+            // after a server-side rewrite could silently skip rows. A
+            // conversation that was already fully backfilled re-lights the
+            // affordance once and re-retires on its first terminal page.
+            if let transcript, transcriptMatches, let page = transcript.page,
+               page.honorsTailContract {
+                persistedTranscriptWindow = PersistedTranscriptWindowState(
+                    requestedSessionID: sessionId,
+                    profile: profile,
+                    pageSize: PersistedTranscriptPagination.pageSize,
+                    resolvedSessionID: transcript.resolvedSessionId ?? result.sessionId,
+                    nextOffset: page.rawReturned,
+                    canLoadEarlier: page.mayHaveOlderRows(fetchedRowCount: page.rawReturned),
+                    hasBackfilledPrefix: graftedBackfilledPrefix
+                )
+            } else {
+                persistedTranscriptWindow = nil
             }
 
             let resumeSessionIDs = [result.sessionId, reconciliation?.requestedSessionId]
@@ -3025,13 +3040,15 @@ final class AppState: ObservableObject {
                 return false
             }
             turnState = .reconnecting
-            if case DashboardTicketBridgeError.oversizedResponse = error {
-                // A known-oversized one-shot history response from an old
-                // backend: retrying the same giant transcript over the
-                // bounded WebSocket is not a recovery. Surface the
-                // controlled compatibility error instead.
+            switch error {
+            case is LegacyTranscriptOversizedError, DashboardTicketBridgeError.oversizedResponse:
+                // Oversized history responses carry their own user-facing
+                // copy: the legacy compatibility message for an old backend
+                // attempting the whole transcript, neutral copy for a
+                // bounded current-Hermes page with one enormous row (which
+                // must not claim the backend lacks pagination).
                 errorMessage = error.localizedDescription
-            } else {
+            default:
                 errorMessage = "Failed to restore this conversation: \(error.localizedDescription)"
             }
             settleReconciliation(token, automaticSyncOperationID: automaticSyncOperationID)
@@ -6214,13 +6231,12 @@ final class AppState: ObservableObject {
         case .unavailable:
             return .unavailable
         case .failed(let error):
-            // One classification for both the bridge fetch and the seam:
-            // structural endpoint gaps, a bridge that never became ready
-            // inside its bounded poll, and transient transport trouble
-            // (429, 5xx, status-0 WebKit/network failures, request timeouts)
-            // degrade to the single legacy resume; authentication, a known-
-            // oversized one-shot history response, and every other failure
-            // must surface instead of silently degrading.
+            // Only STRUCTURAL endpoint absence degrades to the single legacy
+            // resume. Transient trouble (429, 5xx, status-0 WebKit/network
+            // failures, request timeouts, a bridge that never became ready)
+            // surfaces instead: a slow or failing BOUNDED read must never
+            // silently become a full-transcript WebSocket transport (the
+            // giant-payload path compact resume exists to eliminate).
             if Self.historySourceIsUnavailable(error) {
                 sessionCatalogLog.debug("Persisted transcript unavailable for \(sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)")
                 return .unavailable
@@ -6236,11 +6252,16 @@ final class AppState: ObservableObject {
             // A pagination echo WITHOUT the `order=latest` tail contract
             // describes a backend that pages from the oldest end: honoring
             // its offsets would walk the transcript forward from row zero
-            // and never reach the newest rows. Re-read one-shot — the exact
-            // request pre-pagination Conduit made — and treat the response
-            // as the legacy full transcript. Shape-detected from the echo,
+            // and never reach the newest rows. A paginated-contract page
+            // whose rows lack durable identity is equally unpageable —
+            // overlap dedup and the graft key on the persisted row ID, and
+            // id-less rows would normalize to page-local positional IDs.
+            // Either way, re-read one-shot — the exact request
+            // pre-pagination Conduit made — and treat the response as the
+            // legacy full transcript. Shape-detected from the response,
             // never version-sniffed, and performed at most once.
-            if let page, !page.honorsTailContract {
+            if let page, !(page.honorsTailContract
+                && PersistedTranscriptWindow.rowsHaveDurableIdentity(rawMessages)) {
                 let oneShotOutcome = await fetchPersistedHistoryPayload(
                     sessionId: sessionId,
                     profile: profile,
@@ -6260,6 +6281,13 @@ final class AppState: ObservableObject {
                 case .unavailable:
                     return .unavailable
                 case .failed(let error):
+                    if case DashboardTicketBridgeError.oversizedResponse = error {
+                        // The legacy one-shot transcript outgrew the safe
+                        // bound: an old backend attempted the entire
+                        // transcript. Surface the transcript-specific
+                        // compatibility copy.
+                        return .failed(LegacyTranscriptOversizedError(limit: DataURLLimits.maxJSONResponseBytes))
+                    }
                     if Self.historySourceIsUnavailable(error) {
                         return .unavailable
                     }
@@ -6314,51 +6342,29 @@ final class AppState: ObservableObject {
         (response["session_id"] as? String) ?? (response["sessionId"] as? String)
     }
 
-    /// Classifies a history-fetch failure for the resume fallback. Everything
-    /// that leaves the resume without a usable transcript *right now*
-    /// degrades to the single legacy resume:
+    /// Classifies a history-fetch failure as STRUCTURAL ENDPOINT ABSENCE —
+    /// the only condition that degrades the initial hydration to the single
+    /// legacy full-transcript resume, and the only one that retires the
+    /// backfill affordance:
     ///
-    ///  - structural endpoint gaps — 404/410 (the gateway predates the
-    ///    messages route);
-    ///  - a bridge that did not become ready within its bounded readiness
-    ///    poll, or a request that outlived its deadline (both funnel into
-    ///    `.notReady` by the bridge's error contract);
-    ///  - transient transport trouble — HTTP 408/429, any 5xx (which
-    ///    subsumes 501), and status 0 (WebKit-level network/abort failures).
+    ///  - 404/410 — the gateway predates the messages route (or the session
+    ///    is gone from it);
+    ///  - 501 — the endpoint is explicitly unimplemented.
     ///
-    /// A known-oversized one-shot history response is deliberately NOT
-    /// classified here: retrying the same giant transcript over the bounded
-    /// WebSocket is not a recovery, so the typed oversized condition
-    /// surfaces its controlled compatibility error instead.
-    ///
-    /// Client-originated request/bridge timeouts always arrive through one of
-    /// the status-0/`.notReady` funnels above; other authentication (401/403 →
-    /// `.signInRequired`) and every unlisted error is a real failure that must
-    /// propagate instead of silently degrading the resume into a fallback.
+    /// Everything else must NOT silently escalate to the unbounded legacy
+    /// transport: transient trouble (408/429, any other 5xx, status-0
+    /// WebKit/network failures), a bridge that did not become ready or a
+    /// request that outlived its deadline (both `.notReady`), an oversized
+    /// response, authentication, and every unlisted error surfaces instead.
+    /// This is the giant-session safety property: current Hermes can serve
+    /// the bounded `include_compacted=true` page slowly for heavily
+    /// compacted sessions until upstream bounding lands (#97440), so a slow
+    /// bounded read must fail boundedly and retry through reconnect — never
+    /// silently become "load the entire transcript over the WebSocket".
     nonisolated static func historySourceIsUnavailable(_ error: Error) -> Bool {
-        if case DashboardTicketBridgeError.oversizedResponse = error { return false }
-        if case DashboardTicketBridgeError.notReady = error { return true }
         guard case let DashboardTicketBridgeError.http(status, _) = error else { return false }
         switch status {
-        case 0, 404, 408, 410, 429: return true
-        case 500...599: return true
-        default: return false
-        }
-    }
-
-    /// Classifies a backfill failure for affordance retirement: only a
-    /// history source that is structurally gone retires "Load earlier
-    /// messages" — the endpoint disappeared (404/410), the bridge never
-    /// became ready, or the server is failing (5xx). Transient transport
-    /// trouble (408/429, status-0 WebKit failures) and every other failure
-    /// stay retryable through another explicit tap — a failed backfill never
-    /// loops on its own.
-    nonisolated static func historySourceIsStructurallyGone(_ error: Error) -> Bool {
-        if case DashboardTicketBridgeError.notReady = error { return true }
-        guard case let DashboardTicketBridgeError.http(status, _) = error else { return false }
-        switch status {
-        case 404, 410: return true
-        case 500...599: return true
+        case 404, 410, 501: return true
         default: return false
         }
     }
@@ -6452,6 +6458,25 @@ final class AppState: ObservableObject {
                 current.canLoadEarlier = false
                 return false
             }
+            // Response ownership: the page must still describe THIS
+            // conversation. The endpoint may resolve a runtime ID to its
+            // stored ID, so accept the requested ID, the window's resolved
+            // stored ID, and any known alias of the same conversation —
+            // never a foreign session's rows. A foreign response neither
+            // normalizes into the transcript nor advances coverage.
+            if let returnedId = Self.resolvedSessionId(in: response),
+               !returnedId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                var acceptedIds = knownSessionIDs(for: requestSessionId)
+                acceptedIds.insert(requestSessionId)
+                if let resolvedId = current.resolvedSessionID {
+                    acceptedIds.insert(resolvedId)
+                }
+                guard acceptedIds.contains(returnedId) else {
+                    sessionCatalogLog.debug("Older-page backfill for \(requestSessionId, privacy: .public) returned foreign session \(returnedId, privacy: .public); discarding and retiring the affordance")
+                    current.canLoadEarlier = false
+                    return false
+                }
+            }
             let fetchedRowCount = rawRows.count
             let page = PersistedTranscriptPagination.parse(response, rawRowCount: fetchedRowCount)
             // Only pages still answering under the tail contract may splice
@@ -6464,13 +6489,59 @@ final class AppState: ObservableObject {
                 current.canLoadEarlier = false
                 return false
             }
+            // Overlap dedup keys on the durable persisted row ID. A page
+            // whose rows lack one would normalize to page-local positional
+            // IDs that cannot survive across pages — refuse it before it can
+            // silently corrupt dedup.
+            guard PersistedTranscriptWindow.rowsHaveDurableIdentity(rawRows) else {
+                sessionCatalogLog.debug("Older-page backfill for \(requestSessionId, privacy: .public) returned rows without durable IDs; retiring the affordance")
+                current.canLoadEarlier = false
+                return false
+            }
             var didPrepend = false
             if fetchedRowCount > 0 {
-                let olderPage = MessageNormalizer.normalizeMessages(rawRows.map(AnyCodable.from))
-                if let merged = PersistedTranscriptWindow.prepending(olderPage, onto: messages) {
+                let normalizedPage = MessageNormalizer.normalizeMessages(rawRows.map(AnyCodable.from))
+                // A page boundary can split a tool call from its result row.
+                // Fold any trailing call cards back together with the
+                // matching held result cards by durable tool-call identity
+                // before prepending, so one logical tool run never renders
+                // as an orphan call card plus a duplicate standalone result.
+                let (olderPage, foldedFromHeld) = PersistedTranscriptWindow.reconcilingToolCallsAcrossBoundary(
+                    olderPage: normalizedPage,
+                    held: messages
+                )
+                let merged: [ChatMessage]?
+                if foldedFromHeld > 0 {
+                    let remainingHeld = messages.dropFirst(foldedFromHeld)
+                    if remainingHeld.isEmpty {
+                        // Every held row folded into the adjusted page (the
+                        // stale-response guard already proved this window is
+                        // current): the folded page itself is the whole
+                        // transcript. Never fall back to the unfolded page
+                        // here — that would resurrect the duplicate the fold
+                        // just removed.
+                        merged = olderPage.isEmpty ? nil : olderPage
+                    } else {
+                        merged = PersistedTranscriptWindow.prepending(olderPage, onto: Array(remainingHeld))
+                    }
+                } else {
+                    merged = nil
+                }
+                if let merged {
                     messages = merged
                     didPrepend = true
+                } else if let plain = PersistedTranscriptWindow.prepending(normalizedPage, onto: messages) {
+                    messages = plain
+                    didPrepend = true
                 }
+            }
+            if didPrepend {
+                // The visible transcript now starts with backfilled rows.
+                // The reconcile graft relies on this explicit fact to keep
+                // preserving the prefix across repeated reconciles — the
+                // network coverage reset below erases the offset evidence
+                // after the first one.
+                current.hasBackfilledPrefix = true
             }
             // A full page means older history may still exist; a short or
             // empty page marks the transcript fully backfilled and retires
@@ -6489,11 +6560,12 @@ final class AppState: ObservableObject {
             return false
         case .failed(let error):
             // Only a structurally gone history source retires the
-            // affordance; transient transport trouble stays retryable
-            // through another explicit tap — a failed backfill never loops
-            // on its own.
+            // affordance; transient trouble — rate limits, slow bounded
+            // reads, a temporarily cold bridge — stays retryable through
+            // another explicit tap. A failed backfill never loops on its
+            // own.
             sessionCatalogLog.debug("Older-page backfill failed for \(requestSessionId, privacy: .public): \(error.localizedDescription, privacy: .public)")
-            current.canLoadEarlier = !Self.historySourceIsStructurallyGone(error)
+            current.canLoadEarlier = !Self.historySourceIsUnavailable(error)
             return false
         }
     }

--- a/Conduit/Services/ChatViewportController.swift
+++ b/Conduit/Services/ChatViewportController.swift
@@ -440,14 +440,18 @@ struct ChatViewportController: Equatable {
             // switched sessions since. The anchor must still belong to BOTH
             // the rendered and the active conversation (they can disagree
             // for one update turn during a switch, before the session-change
-            // observer runs). Following-latest holds position via the bottom
-            // pin; a live restoration owns the viewport outright. No anchor
-            // row means there is nothing stable to pin — the prepend simply
+            // observer runs) and must still exist among the rendered rows —
+            // a rewrite can delete the captured row, and scrolling to it
+            // would be a dead no-op that leaves the prepend unanchored
+            // anyway. Following-latest holds position via the bottom pin; a
+            // live restoration owns the viewport outright. No anchor row
+            // means there is nothing stable to pin — the prepend simply
             // lands.
             if let messageID = anchor.messageID,
                let anchorSession = anchor.sessionKey,
                identity.areEquivalent(anchorSession, renderedSessionKey),
                identity.areEquivalent(anchorSession, activeSessionKey ?? anchorSession),
+               targetCache.targets.contains(where: { $0.id == messageID }),
                mode != .followingLatest,
                restoration == nil,
                notificationHandoff == nil {

--- a/Conduit/Services/ChatViewportController.swift
+++ b/Conduit/Services/ChatViewportController.swift
@@ -17,6 +17,9 @@ struct ChatViewportCommand: Equatable {
         case bottom(anchorID: String)
         case top(anchorID: String, request: Int)
         case message(id: String)
+        /// Re-pin the viewport to the row the user was looking at before an
+        /// older-history page was prepended above it.
+        case prependAnchor(id: String)
     }
 
     enum Retry: Equatable {
@@ -42,6 +45,16 @@ enum ChatViewportEffect: Equatable {
     /// executes it on a later MainActor turn (see
     /// ChatViewportController.followCorrectionDue).
     case scheduleFollowCorrection(ChatFollowCorrectionToken)
+}
+
+/// A "Load earlier messages" backfill that is in flight: the transcript row
+/// the user is currently looking at, captured at request time. When the
+/// transcript change carrying the prepended older page lands, the controller
+/// pins this row back to the viewport top so the prepend never visually
+/// jumps the transcript.
+struct ChatPrependAnchorRequest: Equatable {
+    let messageID: String?
+    let sessionKey: ChatScrollSessionKey?
 }
 
 /// Identity of one outstanding coalesced follow correction: the ownership
@@ -166,6 +179,9 @@ struct ChatViewportController: Equatable {
     private var followCorrectionContentBottom: CGFloat?
     private(set) var notificationHandoff: ChatViewportHandoffState?
     private(set) var restoration: RestorationState?
+    /// Armed while an older-page backfill is in flight; consumed by the
+    /// transcript change that carries the prepend.
+    private(set) var pendingPrependAnchor: ChatPrependAnchorRequest?
 
     let nearBottomTolerance: CGFloat
     let followDriftTolerance: CGFloat
@@ -290,6 +306,7 @@ struct ChatViewportController: Equatable {
             effects.append(contentsOf: invalidateDrag(hasActiveGesture: dragGestureActive))
             generation &+= 1
             pendingFollowCorrection = nil
+            pendingPrependAnchor = nil
             followCorrectionContentBottom = nil
         followCorrectionLastExecutionAt = nil
         }
@@ -327,6 +344,53 @@ struct ChatViewportController: Equatable {
         return []
     }
 
+    // MARK: - Older-page backfill anchoring
+
+    /// Arms the viewport to hold position across an older-history prepend.
+    /// `anchorMessageID` is the transcript row the user is currently looking
+    /// at (the controller's stable-top observation). When the transcript
+    /// change carrying the prepended page lands, exactly one unanimated
+    /// scroll re-pins that row to the viewport top.
+    ///
+    /// Following-latest never arms: content inserted above cannot move the
+    /// bottom-pinned viewport, so the existing follow system already holds
+    /// position. Restoration and notification handoff likewise own the
+    /// viewport and are not fought.
+    mutating func olderPageBackfillRequested(
+        anchorMessageID: String?,
+        sessionKey: ChatScrollSessionKey?
+    ) {
+        guard mode != .followingLatest,
+              restoration == nil,
+              notificationHandoff == nil else { return }
+        pendingPrependAnchor = ChatPrependAnchorRequest(
+            messageID: anchorMessageID,
+            sessionKey: sessionKey
+        )
+    }
+
+    /// Discharges an armed prepend anchor without scrolling: the backfill
+    /// finished without publishing a prepend (short page, transient failure,
+    /// all-duplicate page), so nothing may re-pin on a later unrelated
+    /// transcript change. Scoped to the session the view armed — a stale
+    /// task's discharge must not clobber a newer conversation's anchor.
+    mutating func prependAnchorDischarged(matching sessionKey: ChatScrollSessionKey?) {
+        guard let armed = pendingPrependAnchor else { return }
+        if armed.sessionKey == nil || identity.areEquivalent(armed.sessionKey, sessionKey) {
+            pendingPrependAnchor = nil
+        }
+    }
+
+    private func prependAnchorCommand(id: String) -> ChatViewportCommand {
+        ChatViewportCommand(
+            generation: generation,
+            sessionKey: activeSessionKey ?? renderedSessionKey,
+            destination: .prependAnchor(id: id),
+            animated: false,
+            retry: .delayed(milliseconds: 150)
+        )
+    }
+
     // MARK: - Transcript changes
 
     /// Ports the old onChange(messages) reassert policy: cache + revision
@@ -349,15 +413,53 @@ struct ChatViewportController: Equatable {
         if let activeSessionKey {
             self.activeSessionKey = activeSessionKey
         }
+        // The anchor is consumed only by a change that REPLACED the front
+        // row — the shape of a prepend landing. Any other mid-flight change
+        // (streaming growth, a turn completing, a reconcile tail graft that
+        // kept the prefix) must leave the anchor armed for the actual
+        // prepend, or the prepend would land unanchored and shift the
+        // transcript under the user.
+        let frontRowIDBefore = targetCache.targets.first?.id
         let update = targetCache.update(for: messages)
         renderedTranscriptRevision = transcriptRevision
         mirroredViewportTransitionGeneration = viewportTransitionGeneration
+        var effects: [ChatViewportEffect] = []
+        if let anchor = pendingPrependAnchor,
+           update != .unchanged,
+           targetCache.targets.first?.id != frontRowIDBefore,
+           // A true prepend RETAINS the previously-front row (prepending
+           // never drops held rows). A same-conversation rewrite that
+           // deleted the front row must not consume the anchor — the
+           // in-flight backfill's own landing (or the view's discharge)
+           // still owns it.
+           frontRowIDBefore == nil
+               || targetCache.targets.contains(where: { $0.id == frontRowIDBefore }) {
+            pendingPrependAnchor = nil
+            // Re-validate ownership at landing time: the backfill resolves
+            // after the tap, and the user may have dragged, scrolled, or
+            // switched sessions since. The anchor must still belong to BOTH
+            // the rendered and the active conversation (they can disagree
+            // for one update turn during a switch, before the session-change
+            // observer runs). Following-latest holds position via the bottom
+            // pin; a live restoration owns the viewport outright. No anchor
+            // row means there is nothing stable to pin — the prepend simply
+            // lands.
+            if let messageID = anchor.messageID,
+               let anchorSession = anchor.sessionKey,
+               identity.areEquivalent(anchorSession, renderedSessionKey),
+               identity.areEquivalent(anchorSession, activeSessionKey ?? anchorSession),
+               mode != .followingLatest,
+               restoration == nil,
+               notificationHandoff == nil {
+                effects.append(.scroll(prependAnchorCommand(id: messageID)))
+            }
+        }
         guard !isInitialSync,
               update != .unchanged,
               mode == .followingLatest,
               restoration == nil,
               notificationHandoff == nil,
-              !isOpeningNotificationSession else { return [] }
+              !isOpeningNotificationSession else { return effects }
         // The animated reassert owns the follow for this change (it carries
         // its own delayed retry); a coalesced correction pending from an
         // earlier drift tick would only fight the in-flight animation.
@@ -607,6 +709,7 @@ struct ChatViewportController: Equatable {
         generation &+= 1
         pendingDragEvaluation = nil
         pendingFollowCorrection = nil
+        pendingPrependAnchor = nil
         followCorrectionContentBottom = nil
         followCorrectionLastExecutionAt = nil
         restoration = nil
@@ -898,6 +1001,7 @@ struct ChatViewportController: Equatable {
 
     mutating func viewDisappeared() -> [ChatViewportEffect] {
         pendingFollowCorrection = nil
+        pendingPrependAnchor = nil
         followCorrectionContentBottom = nil
         followCorrectionLastExecutionAt = nil
         return abandonDrag()
@@ -918,6 +1022,12 @@ struct ChatViewportController: Equatable {
             return sessionMatches && currentRequest == request
         case .message:
             return sessionMatches && mode == .restoring && restoration != nil
+        case .prependAnchor:
+            // The delayed re-pin re-validates against session, mode, and
+            // the ownership generation already checked at the top of this
+            // method: a drag, explicit command, or session switch in the
+            // interim bumps the generation and kills it.
+            return sessionMatches && mode != .restoring && restoration == nil
         }
     }
 
@@ -940,6 +1050,7 @@ struct ChatViewportController: Equatable {
         _ = invalidateDrag(hasActiveGesture: dragGestureActive)
         generation &+= 1
         pendingFollowCorrection = nil
+        pendingPrependAnchor = nil
         followCorrectionContentBottom = nil
         followCorrectionLastExecutionAt = nil
     }
@@ -948,6 +1059,7 @@ struct ChatViewportController: Equatable {
         _ = invalidateDrag(hasActiveGesture: dragGestureActive)
         generation &+= 1
         pendingFollowCorrection = nil
+        pendingPrependAnchor = nil
         followCorrectionContentBottom = nil
         followCorrectionLastExecutionAt = nil
         restoration = nil

--- a/Conduit/Services/DashboardTicketBridge.swift
+++ b/Conduit/Services/DashboardTicketBridge.swift
@@ -132,6 +132,12 @@ enum DashboardTicketBridgeError: LocalizedError {
     /// 0) and fall back deliberately instead of treating them like unrelated
     /// server errors.
     case http(status: Int, detail: String)
+    /// The response exceeded the client's safe response bound
+    /// (`DataURLLimits.maxJSONResponseBytes`) before it could be parsed.
+    /// Distinguished from generic status-0 failures so callers can react to
+    /// a known-oversized history response without retrying the same giant
+    /// transcript over another transport.
+    case oversizedResponse(limit: Int)
 
     var errorDescription: String? {
         switch self {
@@ -143,6 +149,8 @@ enum DashboardTicketBridgeError: LocalizedError {
             return message
         case .http(_, let detail):
             return detail
+        case .oversizedResponse:
+            return "This conversation is too large to load safely with this Hermes version. Update Hermes to enable paginated conversation history."
         }
     }
 }
@@ -806,6 +814,18 @@ extension DashboardTicketBridge: WKScriptMessageHandler {
             return
         }
         let detail = payload["error"] as? String ?? "Dashboard request failed (\(status))."
+        // The injected fetch throws exactly one sentinel for a response that
+        // outgrew the safe bound (content-length or streamed bytes). It
+        // arrives here as a status-0 failure like every other JS-level
+        // error, but it is a known-oversized response, not transport
+        // trouble — give callers the typed condition so an oversized
+        // history read is never mistaken for a retryable network failure.
+        if status == 0, detail.contains("response_too_large") {
+            continuation.resume(throwing: DashboardTicketBridgeError.oversizedResponse(
+                limit: DataURLLimits.maxJSONResponseBytes
+            ))
+            return
+        }
         continuation.resume(throwing: DashboardTicketBridgeError.http(status: status, detail: detail))
     }
 }

--- a/Conduit/Services/DashboardTicketBridge.swift
+++ b/Conduit/Services/DashboardTicketBridge.swift
@@ -150,7 +150,13 @@ enum DashboardTicketBridgeError: LocalizedError {
         case .http(_, let detail):
             return detail
         case .oversizedResponse:
-            return "This conversation is too large to load safely with this Hermes version. Update Hermes to enable paginated conversation history."
+            // Generic bridge-level copy: this error is raised for ANY
+            // dashboard response that exceeds the safe bound (workspace-file
+            // reads, catalogs, history), not exclusively transcripts.
+            // Transcript-specific messaging is mapped in the transcript
+            // layer, which knows whether the request was a legacy one-shot
+            // or a bounded current-Hermes page.
+            return "This response is too large to load safely."
         }
     }
 }

--- a/Conduit/Services/PersistedTranscriptWindow.swift
+++ b/Conduit/Services/PersistedTranscriptWindow.swift
@@ -1,0 +1,169 @@
+import Foundation
+
+/// Bounded persisted-history hydration for the active conversation, mirroring
+/// Hermes Desktop's transcript window: `session.resume` stays compact and the
+/// persisted transcript arrives as tail-anchored pages of
+/// `GET /api/sessions/{id}/messages` instead of one unbounded payload.
+enum PersistedTranscriptPagination {
+    /// Rows per persisted-history page. Matches Hermes Desktop's
+    /// `LATEST_SESSION_MESSAGES_LIMIT`: enough tail to fill the transcript
+    /// window a few times over, small enough that opening a hundred-thousand-
+    /// row session does not ship (and normalize) rows nobody scrolled to.
+    static let pageSize = 120
+
+    /// Query for one tail-anchored page. The backend measures `offset` back
+    /// from the NEWEST persisted row and still returns the selected page in
+    /// chronological order. `include_compacted=true` keeps compaction-
+    /// preserved display rows reachable; without them the transcript
+    /// silently ends at the compaction boundary.
+    static func tailQuery(offset: Int) -> String {
+        "?limit=\(pageSize)&offset=\(offset)&order=latest&include_compacted=true"
+    }
+
+    /// Legacy one-shot request: no paging parameters. Older Hermes builds
+    /// answer it with the complete transcript, exactly as pre-pagination
+    /// Conduit read them.
+    static let legacyQuery = ""
+
+    /// Pagination echo of one `/messages` response. Absent means the backend
+    /// served the legacy one-shot full transcript.
+    struct PageInfo: Equatable {
+        let limit: Int?
+        let offset: Int?
+        let order: String?
+        let returned: Int
+        /// Rows actually present in the response — the offset bookkeeping
+        /// source of truth. The echoed `returned` is retained for parity
+        /// with the server's view but never trusted over the row array.
+        let rawReturned: Int
+
+        /// True only when the backend honored the tail-anchored contract by
+        /// echoing the `order=latest` paging mode. Older dashboard builds
+        /// that page from the OLDEST end also return a pagination object —
+        /// without the order echo — so their echo must never be read as
+        /// tail-truncation evidence.
+        var honorsTailContract: Bool { order == "latest" }
+
+        /// A full page means older history may still exist; a short (or
+        /// empty) page means the beginning has been reached. Trusts the
+        /// echoed `limit` as the backend's real page size — a lying echo
+        /// only costs bounded extra no-op taps before a short or empty
+        /// page retires the affordance.
+        func mayHaveOlderRows(fetchedRowCount: Int) -> Bool {
+            honorsTailContract && fetchedRowCount >= (limit ?? PersistedTranscriptPagination.pageSize)
+        }
+    }
+
+    /// Parses the response's pagination echo. `rawRowCount` backs the
+    /// `returned` field when a backend omits it — the row array itself is
+    /// the direct evidence of how much was fetched.
+    static func parse(_ payload: [String: Any], rawRowCount: Int) -> PageInfo? {
+        guard let raw = payload["pagination"] as? [String: Any] else { return nil }
+        let returned = Self.integerValue(raw["returned"])
+        return PageInfo(
+            limit: Self.integerValue(raw["limit"]),
+            offset: Self.integerValue(raw["offset"]),
+            order: raw["order"] as? String,
+            returned: returned ?? rawRowCount,
+            rawReturned: rawRowCount
+        )
+    }
+
+    private static func integerValue(_ value: Any?) -> Int? {
+        switch value {
+        case let number as Int: return number
+        case let number as Int64: return Int(number)
+        case let number as Double: return Int(number)
+        case let string as String: return Int(string)
+        default: return nil
+        }
+    }
+}
+
+/// Identity-safe per-active-session state of the loaded persisted-transcript
+/// window. One value describes "how much of this conversation's persisted
+/// history is on screen and whether older pages remain" — the pagination
+/// counterpart of the compact resume's runtime state, never mixed into it.
+struct PersistedTranscriptWindowState: Equatable {
+    /// Session ID the window was hydrated for (as requested; the resolved
+    /// stored ID is tracked separately because the endpoint may re-home a
+    /// runtime alias).
+    let requestedSessionID: String
+    let profile: String
+    let pageSize: Int
+    var resolvedSessionID: String?
+    /// Number of newest persisted rows the local transcript covers. Advances
+    /// by the fetched row count of every page, which self-corrects the
+    /// offset drift that live rows create under `order=latest` paging.
+    var nextOffset: Int
+    var canLoadEarlier: Bool
+    var isLoadingEarlier = false
+}
+
+/// Pure row-algebra for older-page backfill.
+enum PersistedTranscriptWindow {
+    /// Prepends an older page onto the loaded transcript, dropping rows the
+    /// transcript already holds. Offset drift under `order=latest` paging
+    /// (rows persisted while the conversation is open shift the origin) makes
+    /// overlap normal, so pages are never assumed disjoint. Deduplication
+    /// keys on the durable message identity — `ChatMessage.id`, which for
+    /// persisted rows is the database row id carried by the payload — never
+    /// on visible text. (Rows without any payload id would fall back to a
+    /// positional identity and defeat dedup; unreachable with Hermes, whose
+    /// persisted rows always carry their SQLite row id.)
+    ///
+    /// Only the strictly-older region of the page is prepended: everything
+    /// from the first already-held row onward is either duplicate or
+    /// newer-side content that arrived outside the window, and prepending
+    /// the latter would land it ABOVE older held rows. Newer-side rows
+    /// reach the transcript through the live projection and the reconcile
+    /// tail graft instead.
+    ///
+    /// Returns nil when nothing would change: an empty transcript means the
+    /// session was swapped or wiped mid-fetch (prepending would paint the
+    /// older page as the whole conversation), and a page with no fresh rows
+    /// must not publish a redundant transcript replacement.
+    static func prepending(
+        _ olderPage: [ChatMessage],
+        onto existing: [ChatMessage]
+    ) -> [ChatMessage]? {
+        guard !existing.isEmpty, !olderPage.isEmpty else { return nil }
+        let knownIDs = Set(existing.map { $0.id })
+        let olderRegion: ArraySlice<ChatMessage>
+        if let firstKnown = olderPage.firstIndex(where: { knownIDs.contains($0.id) }) {
+            olderRegion = olderPage[..<firstKnown]
+        } else {
+            olderRegion = olderPage[...]
+        }
+        var freshIDs = knownIDs
+        var fresh: [ChatMessage] = []
+        fresh.reserveCapacity(olderRegion.count)
+        for message in olderRegion where freshIDs.insert(message.id).inserted {
+            fresh.append(message)
+        }
+        guard !fresh.isEmpty else { return nil }
+        return fresh + existing
+    }
+
+    /// Re-anchors a refreshed tail onto a transcript with backfilled older
+    /// pages. A re-reconciliation re-reads only the newest page; replacing
+    /// the transcript with it outright would silently drop everything
+    /// "Load earlier messages" already loaded. The refreshed tail's first
+    /// row locates where it begins inside the previous transcript and the
+    /// older prefix is kept. When no anchor is found (compaction rewrite,
+    /// session identity change) the refreshed tail is authoritative.
+    static func grafting(
+        refreshedTail: [ChatMessage],
+        ontoBackfilled previous: [ChatMessage],
+        window: PersistedTranscriptWindowState?
+    ) -> [ChatMessage] {
+        guard let window, window.nextOffset > window.pageSize,
+              !previous.isEmpty, !refreshedTail.isEmpty,
+              let first = refreshedTail.first,
+              let anchor = previous.firstIndex(where: { $0.id == first.id }),
+              anchor > 0 else {
+            return refreshedTail
+        }
+        return Array(previous[..<anchor]) + refreshedTail
+    }
+}

--- a/Conduit/Services/PersistedTranscriptWindow.swift
+++ b/Conduit/Services/PersistedTranscriptWindow.swift
@@ -92,12 +92,34 @@ struct PersistedTranscriptWindowState: Equatable {
     let profile: String
     let pageSize: Int
     var resolvedSessionID: String?
-    /// Number of newest persisted rows the local transcript covers. Advances
-    /// by the fetched row count of every page, which self-corrects the
-    /// offset drift that live rows create under `order=latest` paging.
+    /// Number of newest persisted rows the local transcript already covers.
+    /// Advances by the fetched row count of every page, which self-corrects
+    /// the offset drift that live rows create under `order=latest` paging.
+    /// Network coverage only — never used as evidence about what the visible
+    /// transcript contains.
     var nextOffset: Int
     var canLoadEarlier: Bool
     var isLoadingEarlier = false
+    /// The visible transcript starts with rows loaded through backfill.
+    /// Explicit state because the reconnect graft must keep preserving that
+    /// prefix across REPEATED reconciles, while the network coverage reset
+    /// below erases the offset evidence after the first one. Set when a
+    /// backfill prepends; kept by a reconcile that grafts onto the prefix;
+    /// cleared when a refreshed tail is authoritative (no safe anchor).
+    var hasBackfilledPrefix = false
+}
+
+/// A legacy one-shot transcript that exceeded the client's safe response
+/// bound. Distinguished from the bridge's generic oversized-response error
+/// so the transcript layer can surface the compatibility copy — an old
+/// backend attempting the entire transcript — without that copy leaking
+/// into unrelated oversized dashboard operations.
+struct LegacyTranscriptOversizedError: LocalizedError {
+    let limit: Int
+
+    var errorDescription: String? {
+        "This conversation is too large to load safely with this Hermes version. Update Hermes to enable paginated conversation history."
+    }
 }
 
 /// Pure row-algebra for older-page backfill.
@@ -152,18 +174,90 @@ enum PersistedTranscriptWindow {
     /// row locates where it begins inside the previous transcript and the
     /// older prefix is kept. When no anchor is found (compaction rewrite,
     /// session identity change) the refreshed tail is authoritative.
+    ///
+    /// Returns whether the graft applied, so the caller can carry the
+    /// backfilled-prefix fact into the refreshed window and keep preserving
+    /// the prefix across repeated reconciles.
     static func grafting(
         refreshedTail: [ChatMessage],
         ontoBackfilled previous: [ChatMessage],
         window: PersistedTranscriptWindowState?
-    ) -> [ChatMessage] {
-        guard let window, window.nextOffset > window.pageSize,
+    ) -> (messages: [ChatMessage], grafted: Bool) {
+        guard let window, window.hasBackfilledPrefix,
               !previous.isEmpty, !refreshedTail.isEmpty,
               let first = refreshedTail.first,
               let anchor = previous.firstIndex(where: { $0.id == first.id }),
               anchor > 0 else {
-            return refreshedTail
+            return (refreshedTail, false)
         }
-        return Array(previous[..<anchor]) + refreshedTail
+        return (Array(previous[..<anchor]) + refreshedTail, true)
+    }
+
+    /// Reconciles a tool call/result pair that a page boundary split apart.
+    /// The initial tail and each older page are normalized independently, so
+    /// when a call row is the last row of an older page and its result row
+    /// is the first row of the already-held newer page, the call normalizes
+    /// to an unanswered call card and the result to a standalone result card
+    /// — one logical tool run rendered as two. Both sides carry the durable
+    /// tool-call identity (`ToolActivity.id` = Hermes `tool_call_id`), so
+    /// the result is folded back into its call card by ID, never by visible
+    /// text, and the duplicate standalone card is dropped from the held
+    /// prefix.
+    ///
+    /// Returns the adjusted older page and how many leading held messages
+    /// were folded into it. The caller must only drop those held rows when
+    /// the prepend actually publishes (an empty held side means the session
+    /// was swapped mid-fetch and nothing may be dropped).
+    static func reconcilingToolCallsAcrossBoundary(
+        olderPage: [ChatMessage],
+        held: [ChatMessage]
+    ) -> (olderPage: [ChatMessage], foldedFromHeld: Int) {
+        var adjusted = olderPage
+        var folded = 0
+        let maximumBoundaryPairs = 8
+        while folded < maximumBoundaryPairs {
+            let heldIndex = folded
+            guard heldIndex < held.count,
+                  held[heldIndex].role == .tool,
+                  let resultTool = held[heldIndex].tool,
+                  resultTool.status == .complete,
+                  let callID = resultTool.id, !callID.isEmpty,
+                  let callIndex = adjusted.lastIndex(where: { message in
+                      guard message.role == .tool, let tool = message.tool else { return false }
+                      return tool.id == callID && (tool.output?.isEmpty ?? true)
+                  }),
+                  adjusted[callIndex].id != held[heldIndex].id else {
+                break
+            }
+            adjusted[callIndex].tool?.output = resultTool.output
+            adjusted[callIndex].tool?.status = .complete
+            folded += 1
+        }
+        return (adjusted, folded)
+    }
+
+    /// Paginated-contract pages are deduplicated and grafted by durable row
+    /// identity, so every row must carry one. Real Hermes persisted rows
+    /// always carry their SQLite `id`; a page without durable identity means
+    /// normalization would fall back to page-local positional IDs that
+    /// cannot survive across pages — reject it before it can silently
+    /// corrupt overlap dedup.
+    nonisolated static func rowsHaveDurableIdentity(_ rows: [Any]) -> Bool {
+        rows.allSatisfy { row in
+            guard let dict = row as? [String: Any] else { return false }
+            for key in ["id", "message_id"] {
+                switch dict[key] {
+                case let string as String where !string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty:
+                    return true
+                case let number as NSNumber where number.doubleValue != 0:
+                    // SQLite AUTOINCREMENT ids start at 1; zero is never a
+                    // real persisted row id.
+                    return true
+                default:
+                    continue
+                }
+            }
+            return false
+        }
     }
 }

--- a/Conduit/Services/PersistedTranscriptWindow.swift
+++ b/Conduit/Services/PersistedTranscriptWindow.swift
@@ -214,11 +214,16 @@ enum PersistedTranscriptWindow {
     ) -> (olderPage: [ChatMessage], foldedFromHeld: Int) {
         var adjusted = olderPage
         var folded = 0
-        let maximumBoundaryPairs = 8
-        while folded < maximumBoundaryPairs {
+        // Bounded by the loaded inputs, with no arbitrary pair ceiling — a
+        // single assistant turn can carry any number of tool calls. Each
+        // iteration consumes exactly one held row and stops at the first
+        // held row that is not a foldable result, so the scan covers only
+        // the contiguous boundary region (at most the held transcript's
+        // length; call cards and their results are matched by durable ID,
+        // never by position or name).
+        while folded < held.count {
             let heldIndex = folded
-            guard heldIndex < held.count,
-                  held[heldIndex].role == .tool,
+            guard held[heldIndex].role == .tool,
                   let resultTool = held[heldIndex].tool,
                   resultTool.status == .complete,
                   let callID = resultTool.id, !callID.isEmpty,

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -83,6 +83,82 @@ struct ChatView: View {
         appState.chatResumeRestorationRequest != nil
     }
 
+    /// The bounded persisted-history window reports older pages behind the
+    /// loaded tail. Only offered while the window belongs to the active
+    /// profile and there is a hydrated transcript to extend.
+    private var transcriptBackfillAvailable: Bool {
+        guard let window = appState.persistedTranscriptWindow,
+              window.canLoadEarlier,
+              window.profile == appState.activeProfile,
+              !appState.messages.isEmpty else {
+            return false
+        }
+        return true
+    }
+
+    private var transcriptBackfillIsLoading: Bool {
+        appState.persistedTranscriptWindow?.isLoadingEarlier == true
+    }
+
+    /// Transcript-top affordance for bounded history: fetches the next older
+    /// page and prepends it. The currently visible row is captured as the
+    /// viewport anchor before the fetch so the prepend lands without moving
+    /// the user's position. Label-exposed for accessibility — never
+    /// icon-only — and the loading state is announced by the combined
+    /// progress row.
+    private var transcriptTopBackfillControl: some View {
+        Group {
+            if transcriptBackfillIsLoading {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Loading earlier messages")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityElement(children: .combine)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 4)
+            } else {
+                Button {
+                    // A second tap while the first backfill is in flight
+                    // must not overwrite the armed anchor (the single-flight
+                    // guard in AppState would then discard nothing and the
+                    // discharge below would kill the first request's anchor).
+                    guard !transcriptBackfillIsLoading else { return }
+                    ChatViewportTrace.shared.log("event loadEarlier")
+                    let armedKey = renderedScrollSessionKey ?? activeScrollSessionKey
+                    viewport.olderPageBackfillRequested(
+                        anchorMessageID: viewport.stableTopMessageID,
+                        sessionKey: armedKey
+                    )
+                    Task { @MainActor in
+                        let didPrepend = await appState.loadEarlierMessages()
+                        if !didPrepend {
+                            // Nothing landed (short page, transient failure,
+                            // all-duplicate page): discharge the anchor so it
+                            // can never re-pin on a later unrelated change.
+                            // Scoped to the session this tap armed — a stale
+                            // task must not clobber a newer conversation's
+                            // anchor.
+                            viewport.prependAnchorDischarged(matching: armedKey)
+                        }
+                    }
+                } label: {
+                    Label("Load earlier messages", systemImage: "clock.arrow.circlepath")
+                        .font(.footnote.weight(.semibold))
+                        .labelStyle(.titleAndIcon)
+                }
+                .buttonStyle(.plain)
+                .conduitGlassControl(cornerRadius: 16, tint: .conduitAccent.opacity(0.12))
+                .accessibilityLabel("Load earlier messages")
+                .accessibilityHint("Fetches the next older page of this conversation")
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
     /// Latest global frames + transcript order of rendered stable rows for
     /// the current scope. Only message rows report frames (streaming/typing/
     /// markers never do), so ephemeral identifiers cannot enter stable-top
@@ -158,6 +234,10 @@ struct ChatView: View {
                 Color.clear
                     .frame(height: 1)
                     .id(topAnchor)
+
+                if transcriptBackfillAvailable {
+                    transcriptTopBackfillControl
+                }
 
                 if appState.messages.isEmpty {
                     EmptyChatState().padding(.top, 60)
@@ -749,6 +829,8 @@ struct ChatView: View {
             case .top(let anchorID, _):
                 proxy.scrollTo(anchorID, anchor: .top)
             case .message(let id):
+                proxy.scrollTo(id, anchor: .top)
+            case .prependAnchor(let id):
                 proxy.scrollTo(id, anchor: .top)
             }
         }

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -25,6 +25,11 @@ struct ChatView: View {
     /// re-materialization in the hosted transcript fixture). The retry
     /// itself guarantees the animated command lands.
     @State private var armedAnimatedBottomRetry: ChatViewportCommand?
+    /// Lifecycle-aware backfill task: cancelled when the view disappears so
+    /// a late response cannot mutate viewport state after teardown. (The
+    /// session/profile staleness of the response itself is AppState's
+    /// concern — this is view-lifetime only.)
+    @State private var backfillViewportTask: Task<Void, Never>?
     @GestureState private var isDraggingChat = false
 
     private var renderedScrollSessionKey: ChatScrollSessionKey? { viewport.renderedSessionKey }
@@ -132,8 +137,10 @@ struct ChatView: View {
                         anchorMessageID: viewport.stableTopMessageID,
                         sessionKey: armedKey
                     )
-                    Task { @MainActor in
+                    backfillViewportTask?.cancel()
+                    backfillViewportTask = Task { @MainActor in
                         let didPrepend = await appState.loadEarlierMessages()
+                        guard !Task.isCancelled else { return }
                         if !didPrepend {
                             // Nothing landed (short page, transient failure,
                             // all-duplicate page): discharge the anchor so it
@@ -388,6 +395,7 @@ struct ChatView: View {
             }
             .onDisappear {
                 performViewportEffects(viewport.viewDisappeared(), using: proxy)
+                backfillViewportTask?.cancel()
                 appState.removeChatViewportSnapshotProvider(id: viewportSnapshotProviderID)
             }
             .task(id: appState.chatResumeRestorationRequest?.generation) {

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -1662,16 +1662,20 @@ final class AppStateChatResumeTests: XCTestCase {
 
         XCTAssertEqual(catalogLoadCount, 2)
         // The dashboard bridge created by connect() is cold, so the resume
-        // begins compact (omit_messages) and — the bridge never becoming
-        // ready inside the bounded readiness poll — degrades to exactly one
-        // legacy resume for the same session (issue #106 follow-up).
-        XCTAssertEqual(openedSessionIDs, [active.id, active.id])
+        // begins compact (omit_messages). A bridge that never becomes ready
+        // inside its bounded readiness poll must NOT escalate to the legacy
+        // full-transcript resume: the bounded history failure surfaces
+        // (turnState .reconnecting) and the bounded request retries through
+        // reconnect recovery instead — never a giant WebSocket transcript.
+        // The viewport-cancellation handoff under test is unchanged by that
+        // outcome.
+        XCTAssertEqual(openedSessionIDs, [active.id])
         XCTAssertEqual(harness.appState.activeSessionId, active.id)
-        XCTAssertEqual(harness.appState.messages, restoredMessages)
+        XCTAssertTrue(harness.appState.messages.isEmpty)
         XCTAssertTrue(harness.appState.isConnected)
         XCTAssertFalse(harness.appState.isConnecting)
-        XCTAssertEqual(harness.appState.turnState, .idle)
-        XCTAssertTrue(harness.appState.composerIsEnabled)
+        XCTAssertEqual(harness.appState.turnState, .reconnecting)
+        XCTAssertFalse(harness.appState.composerIsEnabled)
         XCTAssertNil(harness.appState.chatResumeRestorationRequest)
         XCTAssertEqual(scheduler.scheduledCount, 0)
     }

--- a/ConduitTests/ChatViewportControllerTests.swift
+++ b/ConduitTests/ChatViewportControllerTests.swift
@@ -2910,7 +2910,7 @@ extension ChatViewportControllerTests {
         _ = controller.userDragGestureEnded()
         controller.olderPageBackfillRequested(anchorMessageID: "m5", sessionKey: keyA)
         let effects = controller.transcriptChanged(
-            messages: [message("m-older", "older row"), message("m0", "row")],
+            messages: [message("m-older", "older row"), message("m0", "row 0"), message("m5", "row 5")],
             transcriptRevision: 1,
             viewportTransitionGeneration: 1,
             activeSessionKey: keyA
@@ -2963,7 +2963,7 @@ extension ChatViewportControllerTests {
         // A discharge naming a different session must not clobber the arm.
         controller.prependAnchorDischarged(matching: keyB)
         var effects = controller.transcriptChanged(
-            messages: [message("m-older", "older row"), message("m0", "row")],
+            messages: [message("m-older", "older row"), message("m0", "row 0"), message("m5", "row 5")],
             transcriptRevision: 1,
             viewportTransitionGeneration: 1,
             activeSessionKey: keyA
@@ -2994,6 +2994,56 @@ extension ChatViewportControllerTests {
                 return true
             },
             "A discharged anchor must not re-pin on a later unrelated transcript change"
+        )
+    }
+
+    /// A same-conversation rewrite that DELETES the front row must neither
+    /// consume the anchor nor re-pin early (a true prepend retains the old
+    /// front row); the anchor stays armed for the in-flight backfill's own
+    /// landing, so a prefix-dropping rewrite can never strand it into
+    /// firing on an unrelated later update.
+    func testBackfillAnchorSurvivesFrontRowDeletionThenPrepends() {
+        var controller = makeController(following: keyA)
+        _ = dragBegan(&controller, sessionKey: keyA)
+        _ = controller.userDragGestureEnded()
+        _ = controller.transcriptChanged(
+            messages: [message("m0", "row 0"), message("m5", "row 5")],
+            transcriptRevision: 1,
+            viewportTransitionGeneration: 1,
+            activeSessionKey: keyA
+        )
+        controller.olderPageBackfillRequested(anchorMessageID: "m0", sessionKey: keyA)
+
+        // Mid-flight: a rewrite drops the front row entirely.
+        var effects = controller.transcriptChanged(
+            messages: [message("m5", "row 5")],
+            transcriptRevision: 2,
+            viewportTransitionGeneration: 1,
+            activeSessionKey: keyA
+        )
+        XCTAssertTrue(
+            scrollCommands(effects).allSatisfy { command in
+                if case .prependAnchor = command.destination { return false }
+                return true
+            },
+            "A prefix-dropping rewrite must not re-pin or consume the anchor"
+        )
+
+        // The backfill lands: the old front row is gone, so the anchor still
+        // must not fire for a row that no longer exists; the gate re-evaluates
+        // per landing and the view's discharge owns the cleanup.
+        effects = controller.transcriptChanged(
+            messages: [message("m-older", "older row"), message("m5", "row 5")],
+            transcriptRevision: 3,
+            viewportTransitionGeneration: 1,
+            activeSessionKey: keyA
+        )
+        XCTAssertTrue(
+            scrollCommands(effects).allSatisfy { command in
+                if case .prependAnchor = command.destination { return false }
+                return true
+            },
+            "The deleted anchor row must not be re-pinned"
         )
     }
 

--- a/ConduitTests/ChatViewportControllerTests.swift
+++ b/ConduitTests/ChatViewportControllerTests.swift
@@ -2793,4 +2793,261 @@ extension ChatViewportControllerTests {
         XCTAssertTrue(inert.isEmpty)
         XCTAssertEqual(controller.generation, before)
     }
+
+    // MARK: - Older-page backfill anchoring
+
+    /// A controller in browsing ownership that armed the backfill anchor
+    /// emits exactly one unanimated prepend re-pin when the transcript
+    /// change carrying the older page lands, and never re-pins again.
+    func testBackfillAnchorPinsRowOnceWhenPrependLands() {
+        var controller = makeController(following: keyA)
+        _ = dragBegan(&controller, sessionKey: keyA)
+        _ = controller.userDragGestureEnded()
+        controller.olderPageBackfillRequested(anchorMessageID: "m5", sessionKey: keyA)
+
+        var messages = (0..<10).map { message("m\($0)", "row \($0)") }
+        let landed = controller.transcriptChanged(
+            messages: [message("m-older", "older row")] + messages,
+            transcriptRevision: 1,
+            viewportTransitionGeneration: 1,
+            activeSessionKey: keyA
+        )
+        let commands = scrollCommands(landed)
+        XCTAssertEqual(commands.count, 1, "The prepend landing emits exactly one re-pin")
+        guard case .prependAnchor(let anchorID)? = commands.first?.destination else {
+            return XCTFail("expected a prepend anchor command, got \(String(describing: commands.first?.destination))")
+        }
+        XCTAssertEqual(anchorID, "m5")
+        XCTAssertFalse(commands[0].animated, "The re-pin must be unanimated")
+        XCTAssertTrue(controller.isCommandCurrent(commands[0]), "The delayed re-pin retry re-validates against the same ownership")
+
+        // One-shot: the next transcript change (e.g. streaming growth) must
+        // not re-pin.
+        messages.append(message("m-new", "new row"))
+        let later = controller.transcriptChanged(
+            messages: messages,
+            transcriptRevision: 2,
+            viewportTransitionGeneration: 1,
+            activeSessionKey: keyA
+        )
+        XCTAssertTrue(scrollCommands(later).isEmpty, "The anchor is consumed by the first landing")
+    }
+
+    /// Following-latest never arms an anchor and never re-pins: content
+    /// inserted above cannot move the bottom-pinned viewport.
+    func testBackfillAnchorNeverArmsWhileFollowingLatest() {
+        var controller = makeController(following: keyA)
+        controller.olderPageBackfillRequested(anchorMessageID: "m5", sessionKey: keyA)
+        let effects = controller.transcriptChanged(
+            messages: [message("m-older", "older row"), message("m0", "row")],
+            transcriptRevision: 1,
+            viewportTransitionGeneration: 1,
+            activeSessionKey: keyA
+        )
+        let commands = scrollCommands(effects)
+        XCTAssertTrue(
+            commands.allSatisfy { command in
+                if case .prependAnchor = command.destination { return false }
+                return true
+            },
+            "No prepend re-pin may fire while following latest (bottom follow holds position)"
+        )
+    }
+
+    /// An armed anchor dies on a session switch or a fresh drag: the prepend
+    /// landing afterwards must not scroll for a conversation/gesture that
+    /// moved on.
+    func testBackfillAnchorDroppedOnSessionChangeAndNewDrag() {
+        var controller = makeController(following: keyA)
+        _ = dragBegan(&controller, sessionKey: keyA)
+        _ = controller.userDragGestureEnded()
+        controller.olderPageBackfillRequested(anchorMessageID: "m5", sessionKey: keyA)
+        // Session switch to an unrelated key disarms the anchor.
+        _ = controller.renderedSessionChanged(
+            to: keyB,
+            identity: identity(for: keyB),
+            viaNotification: false,
+            viewportTransitionGeneration: 1
+        )
+        let afterSwitch = controller.transcriptChanged(
+            messages: [message("m0", "row")],
+            transcriptRevision: 1,
+            viewportTransitionGeneration: 1,
+            activeSessionKey: keyB
+        )
+        XCTAssertTrue(
+            scrollCommands(afterSwitch).allSatisfy { command in
+                if case .prependAnchor = command.destination { return false }
+                return true
+            }
+        )
+
+        var controller2 = makeController(following: keyA)
+        _ = dragBegan(&controller2, sessionKey: keyA)
+        _ = controller2.userDragGestureEnded()
+        controller2.olderPageBackfillRequested(anchorMessageID: "m5", sessionKey: keyA)
+        _ = dragBegan(&controller2, sessionKey: keyA)
+        let afterDrag = controller2.transcriptChanged(
+            messages: [message("m0", "row")],
+            transcriptRevision: 1,
+            viewportTransitionGeneration: 1,
+            activeSessionKey: keyA
+        )
+        XCTAssertTrue(
+            scrollCommands(afterDrag).allSatisfy { command in
+                if case .prependAnchor = command.destination { return false }
+                return true
+            },
+            "A drag begun while the backfill was in flight disarms the anchor"
+        )
+    }
+
+    /// The re-pin's delayed retry dies once ownership generation moved on
+    /// (drag, explicit command, session switch).
+    func testPrependAnchorCommandCurrencyDiesWithGeneration() {
+        var controller = makeController(following: keyA)
+        _ = dragBegan(&controller, sessionKey: keyA)
+        _ = controller.userDragGestureEnded()
+        controller.olderPageBackfillRequested(anchorMessageID: "m5", sessionKey: keyA)
+        let effects = controller.transcriptChanged(
+            messages: [message("m-older", "older row"), message("m0", "row")],
+            transcriptRevision: 1,
+            viewportTransitionGeneration: 1,
+            activeSessionKey: keyA
+        )
+        guard let command = scrollCommands(effects).first,
+              case .prependAnchor = command.destination else {
+            return XCTFail("expected a prepend anchor command")
+        }
+        XCTAssertTrue(controller.isCommandCurrent(command))
+        _ = dragBegan(&controller, sessionKey: keyA)
+        XCTAssertFalse(
+            controller.isCommandCurrent(command),
+            "A generation bump after the landing kills the delayed re-pin"
+        )
+    }
+
+    /// An anchor armed for session A must not re-pin after the active
+    /// conversation became session B, even when the session-change observer
+    /// has not run yet (the one-update-turn disagreement between rendered
+    /// and active keys).
+    func testBackfillAnchorSkippedWhenActiveSessionMovedBeforeLanding() {
+        var controller = makeController(following: keyA)
+        _ = dragBegan(&controller, sessionKey: keyA)
+        _ = controller.userDragGestureEnded()
+        controller.olderPageBackfillRequested(anchorMessageID: "m5", sessionKey: keyA)
+        let effects = controller.transcriptChanged(
+            messages: [message("m0", "row")],
+            transcriptRevision: 1,
+            viewportTransitionGeneration: 1,
+            activeSessionKey: keyB
+        )
+        XCTAssertTrue(
+            scrollCommands(effects).allSatisfy { command in
+                if case .prependAnchor = command.destination { return false }
+                return true
+            },
+            "The anchor belongs to session A; no re-pin may fire against session B"
+        )
+    }
+
+    /// An armed anchor that outlived its backfill (nothing prepended) must
+    /// be dischargeable without scrolling, so a later unrelated transcript
+    /// change can never re-pin it. The discharge is scoped to the armed
+    /// session: a stale task must not clobber a newer conversation's anchor.
+    func testPrependAnchorDischargedWithoutPrependDoesNotPinLater() {
+        var controller = makeController(following: keyA)
+        _ = dragBegan(&controller, sessionKey: keyA)
+        _ = controller.userDragGestureEnded()
+        controller.olderPageBackfillRequested(anchorMessageID: "m5", sessionKey: keyA)
+        // A discharge naming a different session must not clobber the arm.
+        controller.prependAnchorDischarged(matching: keyB)
+        var effects = controller.transcriptChanged(
+            messages: [message("m-older", "older row"), message("m0", "row")],
+            transcriptRevision: 1,
+            viewportTransitionGeneration: 1,
+            activeSessionKey: keyA
+        )
+        XCTAssertEqual(
+            scrollCommands(effects).compactMap { command -> String? in
+                if case .prependAnchor(let id) = command.destination { return id }
+                return nil
+            },
+            ["m5"],
+            "The anchor survives a foreign-session discharge and still re-pins on the prepend"
+        )
+
+        var controller2 = makeController(following: keyA)
+        _ = dragBegan(&controller2, sessionKey: keyA)
+        _ = controller2.userDragGestureEnded()
+        controller2.olderPageBackfillRequested(anchorMessageID: "m5", sessionKey: keyA)
+        controller2.prependAnchorDischarged(matching: keyA)
+        effects = controller2.transcriptChanged(
+            messages: [message("m0", "row")],
+            transcriptRevision: 1,
+            viewportTransitionGeneration: 1,
+            activeSessionKey: keyA
+        )
+        XCTAssertTrue(
+            scrollCommands(effects).allSatisfy { command in
+                if case .prependAnchor = command.destination { return false }
+                return true
+            },
+            "A discharged anchor must not re-pin on a later unrelated transcript change"
+        )
+    }
+
+    /// Streaming growth (or any transcript change that does not replace the
+    /// front row) landing between the tap and the prepend must neither
+    /// consume the anchor nor re-pin early; only the prepend's front-row
+    /// replacement fires the re-pin.
+    func testBackfillAnchorSurvivesMidFlightSuffixChanges() {
+        var controller = makeController(following: keyA)
+        _ = dragBegan(&controller, sessionKey: keyA)
+        _ = controller.userDragGestureEnded()
+        // Rendered transcript before the tap (the cache already holds it).
+        _ = controller.transcriptChanged(
+            messages: [message("m0", "row 0"), message("m5", "row 5")],
+            transcriptRevision: 1,
+            viewportTransitionGeneration: 1,
+            activeSessionKey: keyA
+        )
+        controller.olderPageBackfillRequested(anchorMessageID: "m5", sessionKey: keyA)
+
+        // Mid-flight: an unrelated change updated content and appended a row
+        // behind the front row.
+        var effects = controller.transcriptChanged(
+            messages: [
+                message("m0", "row 0"),
+                message("m5", "row 5 (edited while backfill in flight)"),
+                message("m-new", "streaming row")
+            ],
+            transcriptRevision: 2,
+            viewportTransitionGeneration: 1,
+            activeSessionKey: keyA
+        )
+        XCTAssertTrue(
+            scrollCommands(effects).allSatisfy { command in
+                if case .prependAnchor = command.destination { return false }
+                return true
+            },
+            "A suffix change must not re-pin early or consume the anchor"
+        )
+
+        // The prepend lands: exactly one re-pin, anchored to m5.
+        effects = controller.transcriptChanged(
+            messages: [message("m-older", "older row"), message("m0", "row 0"), message("m5", "row 5 (edited while backfill in flight)"), message("m-new", "streaming row")],
+            transcriptRevision: 3,
+            viewportTransitionGeneration: 1,
+            activeSessionKey: keyA
+        )
+        XCTAssertEqual(
+            scrollCommands(effects).compactMap { command -> String? in
+                if case .prependAnchor(let id) = command.destination { return id }
+                return nil
+            },
+            ["m5"],
+            "The prepend still re-pins the originally visible row"
+        )
+    }
 }

--- a/ConduitTests/CompactResumeTranscriptTests.swift
+++ b/ConduitTests/CompactResumeTranscriptTests.swift
@@ -1676,6 +1676,104 @@ final class CompactResumeTranscriptTests: XCTestCase {
         XCTAssertTrue(harness.appState.persistedTranscriptWindow?.hasBackfilledPrefix ?? false)
     }
 
+    /// A single assistant turn can carry any number of tool calls. A page
+    /// boundary splitting one 12-call run from its 12 result rows must
+    /// reconstruct every pair — no pair ceiling, no orphan standalone
+    /// results, one completed card per durable tool_call_id.
+    func testTwelveToolCallRunSplitAcrossPageBoundaryReconstructsFully() async throws {
+        let callCount = 12
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                // Newer page: 12 unmatched result rows (their call row is on
+                // the older page) followed by the untouched loaded tail.
+                let resultRows = (1...callCount).map { index -> [String: Any] in
+                    var row = self.transcriptRow(1879 + index, role: "tool", content: "body \(index)")
+                    row["tool_call_id"] = "call_\(index)"
+                    row["name"] = "read_file"
+                    return row
+                }
+                let rows = resultRows + self.syntheticRows((1880 + callCount)..<2000)
+                return self.tailPagePayload(sessionId: "stored-a", rows: rows, offset: 0)
+            },
+            loadEarlierTranscriptPage: { _, _, offset in
+                // Older page: 111 conversational rows, then ONE assistant
+                // row carrying all 12 tool calls as its final row.
+                var callRow = self.transcriptRow(1879, role: "assistant", content: "")
+                callRow["tool_calls"] = (1...callCount).map { index in
+                    [
+                        "id": "call_\(index)",
+                        "type": "function",
+                        "function": [
+                            "name": "read_file",
+                            "arguments": "{\"path\": \"/tmp/row\(index)\"}"
+                        ]
+                    ]
+                }
+                let rows = self.syntheticRows(1768..<1879) + [callRow]
+                return self.tailPagePayload(sessionId: "stored-a", rows: rows, offset: offset)
+            }
+        )
+        harness.appState.sessions = [active]
+        let opened = await harness.appState.openSession("stored-a")
+        XCTAssertTrue(opened)
+        // Every unmatched result hydrates as a standalone card on the newer
+        // page (their call row is not in that page).
+        XCTAssertEqual(harness.appState.messages.count, 120)
+        XCTAssertEqual(
+            harness.appState.messages.prefix(callCount).compactMap { $0.tool?.id },
+            (1...callCount).map { "call_\($0)" }
+        )
+
+        await harness.appState.loadEarlierMessages()
+
+        let messages = harness.appState.messages
+        XCTAssertEqual(
+            messages.count,
+            (111 + callCount) + (120 - callCount),
+            "123 adjusted older-page messages prepended onto the 108 held rows left after the 12 folds"
+        )
+        let callCards = messages.filter { $0.role == .tool && $0.tool?.id?.hasPrefix("call_") == true }
+        XCTAssertEqual(callCards.count, callCount, "Exactly one logical card per durable tool_call_id")
+        XCTAssertEqual(
+            Set(callCards.compactMap { $0.tool?.id }),
+            Set((1...callCount).map { "call_\($0)" }),
+            "No duplicate tool-call identities"
+        )
+        for index in 1...callCount {
+            let card = messages.first { $0.tool?.id == "call_\(index)" }
+            XCTAssertNotNil(card, "call_\(index) must have its card")
+            XCTAssertEqual(card?.id, "1879.0-tool-\(index - 1)")
+            XCTAssertEqual(card?.tool?.name, "read_file")
+            XCTAssertEqual(card?.tool?.input, "{\"path\": \"/tmp/row\(index)\"}")
+            XCTAssertEqual(card?.tool?.output, "body \(index)")
+            XCTAssertEqual(card?.tool?.status, .complete)
+        }
+        // The dropped standalone result cards occupied row ids 1880–1891.
+        let orphanIDs = Set((1880...(1879 + callCount)).map { "\($0).0" })
+        XCTAssertFalse(
+            messages.contains { orphanIDs.contains($0.id) },
+            "No orphan standalone result card may remain"
+        )
+        // Chronology stays intact across the fold, and the loaded newer
+        // tail after the tool results is untouched.
+        let rowIndexes = messages.compactMap { message -> Int? in
+            guard message.content.hasPrefix("Row ") else { return nil }
+            return Int(message.content.dropFirst(4))
+        }
+        XCTAssertEqual(rowIndexes, Array(1768...1878) + Array((1880 + callCount)...1999))
+        XCTAssertEqual(messages[110].content, "Row 1878", "Last conversational row before the call block")
+        XCTAssertEqual(messages[111 + callCount].content, "Row 1892", "The newer tail resumes immediately after the folded block")
+        XCTAssertTrue(harness.appState.persistedTranscriptWindow?.hasBackfilledPrefix ?? false)
+    }
+
     // MARK: - Harness
 
     private func makeHarness(

--- a/ConduitTests/CompactResumeTranscriptTests.swift
+++ b/ConduitTests/CompactResumeTranscriptTests.swift
@@ -633,6 +633,10 @@ final class CompactResumeTranscriptTests: XCTestCase {
         XCTAssertEqual(harness.appState.messages.count, count)
         XCTAssertEqual(harness.appState.messages.first?.content, "Row 0 \(filler)")
         XCTAssertEqual(harness.appState.messages.last?.content, "Row \(count - 1) \(filler)")
+        XCTAssertNil(
+            harness.appState.persistedTranscriptWindow,
+            "A legacy full-transcript resume leaves no window: there is no older page to fetch"
+        )
     }
 
     func testHistoryFailureSurfacesWithoutLegacyFallback() async throws {
@@ -727,6 +731,12 @@ final class CompactResumeTranscriptTests: XCTestCase {
             DashboardTicketBridgeError.http(status: 0, detail: "Failed to fetch")
         ))
         XCTAssertTrue(AppState.historySourceIsUnavailable(DashboardTicketBridgeError.notReady))
+        // A known-oversized one-shot history response is a typed condition,
+        // not transport trouble: it must surface its controlled compatibility
+        // error instead of retrying the giant transcript over the WebSocket.
+        XCTAssertFalse(AppState.historySourceIsUnavailable(
+            DashboardTicketBridgeError.oversizedResponse(limit: DataURLLimits.maxJSONResponseBytes)
+        ))
         // Authentication and unclassified failures must surface instead.
         XCTAssertFalse(AppState.historySourceIsUnavailable(DashboardTicketBridgeError.signInRequired))
         XCTAssertFalse(AppState.historySourceIsUnavailable(
@@ -737,11 +747,734 @@ final class CompactResumeTranscriptTests: XCTestCase {
         ))
     }
 
+    /// Backfill affordance retirement is structural-only: 404/410/5xx and a
+    /// bridge that never became ready retire "Load earlier messages"; every
+    /// transient transport trouble (408/429/status-0) and unclassified or
+    /// auth failures stay tap-retryable.
+    func testBackfillStructuralRetirementClassification() {
+        for status in [404, 410, 500, 502, 503] {
+            XCTAssertTrue(
+                AppState.historySourceIsStructurallyGone(
+                    DashboardTicketBridgeError.http(status: status, detail: "gone")
+                ),
+                "status \(status) must retire the affordance"
+            )
+        }
+        XCTAssertTrue(AppState.historySourceIsStructurallyGone(DashboardTicketBridgeError.notReady))
+        for status in [0, 408, 429] {
+            XCTAssertFalse(
+                AppState.historySourceIsStructurallyGone(
+                    DashboardTicketBridgeError.http(status: status, detail: "transient")
+                ),
+                "status \(status) must stay tap-retryable"
+            )
+        }
+        XCTAssertFalse(AppState.historySourceIsStructurallyGone(DashboardTicketBridgeError.signInRequired))
+        XCTAssertFalse(AppState.historySourceIsStructurallyGone(
+            DashboardTicketBridgeError.oversizedResponse(limit: DataURLLimits.maxJSONResponseBytes)
+        ))
+        XCTAssertFalse(AppState.historySourceIsStructurallyGone(
+            DashboardTicketBridgeError.requestFailed("Could not encode dashboard request.")
+        ))
+    }
+
+    // MARK: - Bounded persisted-history pagination
+
+    /// Large-session invariant: a session with thousands of persisted rows
+    /// opens by transferring and normalizing exactly one bounded page, and
+    /// the pagination echo reports older history behind it.
+    func testPaginatedHistoryHydratesOnlyNewestPage() async throws {
+        let recorder = ResumeCallRecorder()
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let harness = try makeHarness(
+            openSession: { _, sessionID, compact in
+                recorder.record(sessionID: sessionID, compact: compact)
+                return SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],  // compact projection: transcript omitted
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                // The session holds 2,000 persisted rows; the paginated
+                // endpoint answers with only the newest 120 plus its
+                // pagination echo.
+                self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1880..<2000), offset: 0)
+            }
+        )
+        harness.appState.sessions = [active]
+
+        let opened = await harness.appState.openSession("stored-a")
+
+        XCTAssertTrue(opened)
+        XCTAssertEqual(
+            recorder.calls.map { $0.compact },
+            [true],
+            "A paginated-history session must resume compactly — no full transcript over the WebSocket"
+        )
+        XCTAssertEqual(harness.appState.messages.count, 120, "Only the requested page may be normalized and published")
+        XCTAssertEqual(harness.appState.messages.first?.content, "Row 1880")
+        XCTAssertEqual(harness.appState.messages.last?.content, "Row 1999")
+        let window = harness.appState.persistedTranscriptWindow
+        XCTAssertEqual(window?.requestedSessionID, "stored-a")
+        XCTAssertEqual(window?.profile, "default")
+        XCTAssertEqual(window?.resolvedSessionID, "stored-a")
+        XCTAssertEqual(window?.nextOffset, 120)
+        XCTAssertEqual(window?.canLoadEarlier, true, "A full page means older history may still exist")
+        XCTAssertEqual(window?.isLoadingEarlier, false)
+    }
+
+    /// Backfill: "Load earlier messages" fetches the next older page under
+    /// the same tail-anchored contract and prepends it. Rows persisted while
+    /// the conversation was open shift the offset origin, so the page
+    /// overlaps rows already held — the prepend must deduplicate them without
+    /// disturbing the loaded tail.
+    func testLoadEarlierPrependsOlderPageWithOverlapDeduplicated() async throws {
+        let backfillCalls = Counter()
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let harness = try makeHarness(
+            openSession: { _, _, compact in
+                XCTAssertTrue(compact)
+                return SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1880..<2000), offset: 0)
+            },
+            loadEarlierTranscriptPage: { sessionId, profile, offset in
+                backfillCalls.value += 1
+                XCTAssertEqual(sessionId, "stored-a", "The backfill must stay scoped to the requested session")
+                XCTAssertEqual(profile, "default", "The backfill must stay scoped to the requesting profile")
+                XCTAssertEqual(offset, 120)
+                // Ten rows persisted since the tail hydration shifted the
+                // offset origin: the page overlaps 110 already-held rows and
+                // adds ten genuinely older ones.
+                return self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1870..<1990), offset: offset)
+            }
+        )
+        harness.appState.sessions = [active]
+        let opened = await harness.appState.openSession("stored-a")
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.count, 120)
+
+        await harness.appState.loadEarlierMessages()
+
+        XCTAssertEqual(backfillCalls.value, 1)
+        let messages = harness.appState.messages
+        XCTAssertEqual(messages.count, 120 + 120 - 110, "The overlapping prefix must be deduplicated, the loaded tail kept")
+        XCTAssertEqual(messages.first?.content, "Row 1870")
+        XCTAssertEqual(messages.last?.content, "Row 1999")
+        let ids = messages.map { $0.id }
+        XCTAssertEqual(Set(ids).count, ids.count, "No duplicate user messages, tool cards, or timeline events may result")
+        let numericIDs = ids.compactMap { Double($0) }
+        XCTAssertEqual(numericIDs, numericIDs.sorted(), "Prepended pages must keep the transcript chronological")
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.nextOffset, 240)
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.canLoadEarlier, true)
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.isLoadingEarlier, false)
+    }
+
+    /// A short page means the beginning of the persisted transcript has been
+    /// reached: the affordance retires and repeated taps issue no further
+    /// requests.
+    func testShortBackfillPageMarksTranscriptFullyBackfilled() async throws {
+        let backfillCalls = Counter()
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1880..<2000), offset: 0)
+            },
+            loadEarlierTranscriptPage: { _, _, offset in
+                backfillCalls.value += 1
+                XCTAssertEqual(offset, 120)
+                return self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1843..<1880), offset: offset)
+            }
+        )
+        harness.appState.sessions = [active]
+        let opened = await harness.appState.openSession("stored-a")
+        XCTAssertTrue(opened)
+
+        await harness.appState.loadEarlierMessages()
+        XCTAssertEqual(harness.appState.messages.count, 157)
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.canLoadEarlier, false, "A short page proves the beginning was reached")
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.nextOffset, 157)
+
+        // Repeated taps after the terminal page must not issue more requests.
+        await harness.appState.loadEarlierMessages()
+        await harness.appState.loadEarlierMessages()
+        XCTAssertEqual(backfillCalls.value, 1)
+    }
+
+    /// A backfill resolving after a session switch belongs to a conversation
+    /// nobody is viewing: it must be discarded whole, leaving the newly
+    /// active session untouched.
+    func testStaleBackfillDiscardedAfterSessionSwitch() async throws {
+        let backfillStarted = Flag()
+        let activeA = session("stored-a", alternateIDs: ["runtime-a"])
+        let activeB = session("stored-b", alternateIDs: ["runtime-b"])
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { sessionId, _ in
+                if sessionId == "stored-a" {
+                    return self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1880..<2000), offset: 0)
+                }
+                return self.tailPagePayload(
+                    sessionId: "stored-b",
+                    rows: self.syntheticRows(0..<2),
+                    offset: 0
+                )
+            },
+            loadEarlierTranscriptPage: { sessionId, _, offset in
+                backfillStarted.isOn = true
+                XCTAssertEqual(sessionId, "stored-a")
+                try? await Task.sleep(for: .milliseconds(250))
+                return self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1760..<1880), offset: offset)
+            }
+        )
+        harness.appState.sessions = [activeA, activeB]
+        let openedA = await harness.appState.openSession("stored-a")
+        XCTAssertTrue(openedA)
+
+        let backfill = Task { await harness.appState.loadEarlierMessages() }
+        for _ in 0..<1_000 where !backfillStarted.isOn {
+            await Task.yield()
+        }
+        XCTAssertTrue(backfillStarted.isOn, "The backfill fetch must have started")
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.isLoadingEarlier, true)
+
+        let openedB = await harness.appState.openSession("stored-b")
+        XCTAssertTrue(openedB)
+        await backfill
+
+        XCTAssertEqual(harness.appState.messages.count, 2, "Session B must be completely unchanged by the stale page")
+        XCTAssertEqual(harness.appState.messages.first?.content, "Row 0")
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.requestedSessionID, "stored-b")
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.isLoadingEarlier, false)
+        XCTAssertFalse(
+            harness.appState.messages.contains { $0.id == "1760" },
+            "No row from the stale session-A page may leak into session B"
+        )
+    }
+
+    /// Backfilled pages carry the same display-contract rows as the initial
+    /// hydration (hidden compaction carriers, display_content asks,
+    /// model-switch and auto-continue pivots); the projection must stay
+    /// correct after a prepend.
+    func testCompactedDisplayRowsProjectCorrectlyInBackfilledPage() async throws {
+        let modelSwitchMarker = "[System: The active model for this chat has changed to GLM-5.3-Flash via provider zai. From this point forward, use this runtime metadata when answering questions about what model/provider is active.]"
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1880..<2000), offset: 0)
+            },
+            loadEarlierTranscriptPage: { _, _, offset in
+                var hiddenRow = self.transcriptRow(900, role: "user", content: "INTERNAL MODEL SCAFFOLD — do not render")
+                hiddenRow["display_kind"] = "hidden"
+                var autoContinueRow = self.transcriptRow(901, role: "user", content: "[System note: Your previous turn was interrupted mid-run. Continuing from the checkpoint.]")
+                autoContinueRow["display_kind"] = "auto_continue"
+                var displayCarrierRow = self.transcriptRow(902, role: "user", content: "Older ask.\n\n[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]")
+                displayCarrierRow["display_content"] = "Older ask."
+                var modelSwitchRow = self.transcriptRow(903, role: "user", content: modelSwitchMarker)
+                modelSwitchRow["display_kind"] = "model_switch"
+                return .payload([
+                    "session_id": "stored-a",
+                    "messages": [
+                        hiddenRow,
+                        autoContinueRow,
+                        displayCarrierRow,
+                        modelSwitchRow,
+                        self.transcriptRow(904, role: "user", content: "Older human turn"),
+                        self.transcriptRow(905, role: "assistant", content: "Older assistant turn"),
+                    ],
+                    "pagination": ["limit": 120, "offset": offset, "order": "latest", "returned": 6]
+                ])
+            }
+        )
+        harness.appState.sessions = [active]
+        let opened = await harness.appState.openSession("stored-a")
+        XCTAssertTrue(opened)
+
+        await harness.appState.loadEarlierMessages()
+
+        let messages = harness.appState.messages
+        XCTAssertEqual(messages.count, 120 + 6 - 1, "The hidden carrier row disappears; every visible projection stays")
+        XCTAssertEqual(
+            messages.prefix(5).map { $0.role },
+            [.system, .user, .system, .user, .assistant]
+        )
+        XCTAssertEqual(
+            messages.prefix(5).map { $0.content },
+            [
+                "Resumed interrupted turn",
+                "Older ask.",
+                "[Model has been changed to zai/GLM-5.3-Flash]",
+                "Older human turn",
+                "Older assistant turn"
+            ]
+        )
+        XCTAssertFalse(
+            messages.contains { $0.content.contains("SCAFFOLD") || $0.content.contains("COMPACTION SUMMARY") },
+            "No model-facing scaffold text may surface through a backfilled page"
+        )
+        XCTAssertEqual(messages.last?.content, "Row 1999", "The loaded tail must remain intact after the prepend")
+    }
+
+    /// Legacy one-shot backend: no pagination metadata means the complete
+    /// transcript — accepted as the compatibility path, with no window and
+    /// therefore no load-earlier affordance. (The large-session legacy merge
+    /// is additionally covered by
+    /// testLargeSessionResumeShipsNoTranscriptOverWebSocket.)
+    func testLegacyOneShotResponseHydratesFullyWithoutWindow() async throws {
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                .payload([
+                    "session_id": "stored-a",
+                    "messages": self.syntheticRows(0..<300)
+                ])
+            }
+        )
+        harness.appState.sessions = [active]
+
+        let opened = await harness.appState.openSession("stored-a")
+
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.count, 300)
+        XCTAssertNil(
+            harness.appState.persistedTranscriptWindow,
+            "A one-shot transcript leaves no window: there is no older page to fetch"
+        )
+    }
+
+    /// A pagination echo WITHOUT the `order=latest` tail contract describes a
+    /// backend whose offsets page from the oldest end. Honoring those offsets
+    /// would walk forward from row zero and never reach the newest rows, so
+    /// the transcript is re-read one-shot — the exact request pre-pagination
+    /// Conduit made — and treated as the legacy contract.
+    func testPaginationEchoWithoutLatestOrderFallsBackToOneShot() async throws {
+        let fetchCalls = Counter()
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                fetchCalls.value += 1
+                if fetchCalls.value == 1 {
+                    // Oldest-anchored build: bounded request, no order echo.
+                    return self.tailPagePayload(
+                        sessionId: "stored-a",
+                        rows: self.syntheticRows(0..<3),
+                        offset: 0,
+                        limit: 120,
+                        order: nil
+                    )
+                }
+                // The unbounded re-read returns the complete transcript.
+                return .payload([
+                    "session_id": "stored-a",
+                    "messages": self.syntheticRows(0..<6)
+                ])
+            }
+        )
+        harness.appState.sessions = [active]
+
+        let opened = await harness.appState.openSession("stored-a")
+
+        XCTAssertTrue(opened)
+        XCTAssertEqual(fetchCalls.value, 2, "Exactly one bounded read and one one-shot re-read")
+        XCTAssertEqual(harness.appState.messages.count, 6)
+        XCTAssertEqual(harness.appState.messages.first?.content, "Row 0")
+        XCTAssertEqual(harness.appState.messages.last?.content, "Row 5")
+        XCTAssertNil(harness.appState.persistedTranscriptWindow)
+    }
+
+    /// An old backend answering a one-shot history that exceeds the client's
+    /// safe response bound must surface the controlled compatibility error —
+    /// never a retry of the same giant transcript over the bounded
+    /// WebSocket.
+    func testOversizedLegacyHistorySurfacesWithoutWebSocketRetry() async throws {
+        let recorder = ResumeCallRecorder()
+        let active = session("stored-a")
+        let harness = try makeHarness(
+            openSession: { _, sessionID, compact in
+                recorder.record(sessionID: sessionID, compact: compact)
+                return SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                .failed(DashboardTicketBridgeError.oversizedResponse(
+                    limit: DataURLLimits.maxJSONResponseBytes
+                ))
+            }
+        )
+        harness.appState.sessions = [active]
+
+        let opened = await harness.appState.openSession("stored-a")
+
+        XCTAssertFalse(opened, "The oversized-history compatibility error must surface")
+        XCTAssertEqual(
+            recorder.calls.map { $0.compact },
+            [true],
+            "No legacy full-transcript WebSocket retry may follow an oversized history response"
+        )
+        XCTAssertTrue(
+            harness.appState.errorMessage?.contains("too large to load safely") == true,
+            "The surfaced error should be the controlled compatibility copy, got: \(harness.appState.errorMessage ?? "nil")"
+        )
+    }
+
+    /// Live resume over a paginated tail: the persisted newest page stays the
+    /// durable base and the inflight assistant continuation still rides the
+    /// streaming bubble as exactly the unpersisted suffix.
+    func testLiveResumeWithPaginatedTailKeepsInflightProjection() async throws {
+        let persistedPrefix = "Streaming the report now."
+        let inflightText = persistedPrefix + " The numbers section is next."
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],  // compact projection: transcript omitted
+                    snapshot: SessionRuntimeSnapshot(
+                        object: ["running": .bool(true)],
+                        inflight: .object(["assistant": .string(inflightText)])
+                    )
+                )
+            },
+            persistedTranscript: { _, _ in
+                .payload([
+                    "session_id": "stored-a",
+                    "messages": [
+                        self.transcriptRow(1, role: "user", content: "Write the report."),
+                        self.transcriptRow(2, role: "assistant", content: persistedPrefix)
+                    ],
+                    "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                ])
+            }
+        )
+        harness.appState.sessions = [active]
+
+        let opened = await harness.appState.openSession("stored-a")
+
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map { $0.role }, [.user, .assistant])
+        XCTAssertEqual(harness.appState.messages[1].content, persistedPrefix)
+        XCTAssertEqual(
+            harness.appState.persistedTranscriptWindow?.nextOffset, 2,
+            "A short page under the paginated contract means the whole persisted history is loaded"
+        )
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.canLoadEarlier, false)
+        harness.appState.showSidebar = true
+        harness.appState.showSidebar = false
+        XCTAssertEqual(harness.appState.streamingText, "The numbers section is next.")
+        XCTAssertFalse(
+            harness.appState.messages.contains { $0.content.contains("The numbers section is next.") },
+            "The inflight continuation must ride the live bubble, not duplicate into rows"
+        )
+    }
+
+    /// A re-reconciliation re-reads only the newest page; the pages already
+    /// loaded through "Load earlier messages" must survive it via the tail
+    /// graft instead of being truncated away.
+    func testReconcileRefreshGraftsBackfilledPrefix() async throws {
+        let holdsRefreshedTail = Flag()
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                if holdsRefreshedTail.isOn {
+                    // Twenty new rows persisted since the backfill: the
+                    // refreshed tail covers the newest 120 rows.
+                    return self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1900..<2020), offset: 0)
+                }
+                return self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1880..<2000), offset: 0)
+            },
+            loadEarlierTranscriptPage: { _, _, offset in
+                self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1760..<1880), offset: offset)
+            },
+            additionalOperations: { ops in
+                ops.connectClient = { _ in }
+                ops.loadCatalog = { _, _ in [active] }
+                ops.loadProfiles = {}
+                ops.loadBusyInputMode = { _ in }
+                ops.loadProfileDisplayPreferences = {}
+                ops.loadSlashCommands = {}
+            }
+        )
+        harness.appState.sessions = [active]
+        let opened = await harness.appState.openSession("stored-a")
+        XCTAssertTrue(opened)
+
+        await harness.appState.loadEarlierMessages()
+        XCTAssertEqual(harness.appState.messages.count, 240)
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.nextOffset, 240)
+
+        // A reconnect re-reconciles the same session without clearing the
+        // transcript; the refreshed tail grafts onto the backfilled prefix.
+        holdsRefreshedTail.isOn = true
+        harness.coordinator.rememberSessionID("stored-a", for: "default")
+        await harness.appState.connect(
+            with: HermesConnection(baseUrl: "https://one.example", ticket: "graft-ticket")
+        )
+
+        XCTAssertEqual(harness.appState.messages.count, 140 + 120, "Older prefix (rows 1760–1899) plus the refreshed tail (rows 1900–2019)")
+        XCTAssertEqual(harness.appState.messages.first?.content, "Row 1760")
+        XCTAssertEqual(harness.appState.messages[139].content, "Row 1899")
+        XCTAssertEqual(harness.appState.messages[140].content, "Row 1900")
+        XCTAssertEqual(harness.appState.messages.last?.content, "Row 2019")
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.nextOffset, 120)
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.canLoadEarlier, true)
+    }
+
+    /// Pins the request contract: the production history request is an
+    /// explicit tail-anchored bounded page — never the implicit default and
+    /// never an unbounded one-shot — and older pages continue the same
+    /// contract at the next offset.
+    func testPersistedHistoryRequestContractIsBoundedTailPaging() {
+        XCTAssertEqual(PersistedTranscriptPagination.pageSize, 120)
+        XCTAssertEqual(
+            PersistedTranscriptPagination.tailQuery(offset: 0),
+            "?limit=120&offset=0&order=latest&include_compacted=true"
+        )
+        XCTAssertEqual(
+            PersistedTranscriptPagination.tailQuery(offset: 240),
+            "?limit=120&offset=240&order=latest&include_compacted=true"
+        )
+        XCTAssertEqual(PersistedTranscriptPagination.legacyQuery, "")
+        XCTAssertEqual(
+            AppState.sessionMessagesPath(
+                sessionId: "stored a",
+                profile: "default",
+                query: PersistedTranscriptPagination.tailQuery(offset: 0)
+            ),
+            "/api/sessions/stored%20a/messages?limit=120&offset=0&order=latest&include_compacted=true"
+        )
+        XCTAssertEqual(
+            AppState.sessionMessagesPath(
+                sessionId: "stored-a",
+                profile: "work",
+                query: PersistedTranscriptPagination.tailQuery(offset: 120)
+            ),
+            "/api/sessions/stored-a/messages?limit=120&offset=120&order=latest&include_compacted=true&profile=work"
+        )
+    }
+
+    /// A transient backfill failure (429, status-0, 408) stays retryable:
+    /// the affordance remains and a later tap succeeds. Only a structurally
+    /// gone history source (404/410/5xx, dead bridge) retires it — pinned by
+    /// testHistorySourceUnavailableClassification's structural counterpart.
+    func testTransientBackfillFailureStaysRetryable() async throws {
+        let backfillCalls = Counter()
+        let shouldFail = Flag()
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1880..<2000), offset: 0)
+            },
+            loadEarlierTranscriptPage: { _, _, offset in
+                backfillCalls.value += 1
+                if shouldFail.isOn {
+                    return .failed(DashboardTicketBridgeError.http(status: 429, detail: "Too Many Requests"))
+                }
+                return self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1760..<1880), offset: offset)
+            }
+        )
+        harness.appState.sessions = [active]
+        let opened = await harness.appState.openSession("stored-a")
+        XCTAssertTrue(opened)
+
+        shouldFail.isOn = true
+        let didPrependFailure = await harness.appState.loadEarlierMessages()
+        XCTAssertFalse(didPrependFailure)
+        XCTAssertEqual(backfillCalls.value, 1)
+        XCTAssertEqual(
+            harness.appState.persistedTranscriptWindow?.canLoadEarlier,
+            true,
+            "A transient failure must keep the affordance retryable"
+        )
+        XCTAssertEqual(harness.appState.messages.count, 120, "A failed backfill must not touch the transcript")
+
+        shouldFail.isOn = false
+        let didPrependRetry = await harness.appState.loadEarlierMessages()
+        XCTAssertTrue(didPrependRetry)
+        XCTAssertEqual(backfillCalls.value, 2)
+        XCTAssertEqual(harness.appState.messages.count, 240)
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.canLoadEarlier, true)
+    }
+
+    /// A full page that dedupes to nothing (heavy offset drift) publishes no
+    /// transcript replacement but still advances coverage so the next tap
+    /// fetches genuinely older rows — and reports that nothing landed so the
+    /// viewport anchor is discharged rather than re-pinning later.
+    func testDuplicateOnlyPageAdvancesCoverageWithoutPrepending() async throws {
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1880..<2000), offset: 0)
+            },
+            loadEarlierTranscriptPage: { _, _, offset in
+                self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1880..<2000), offset: offset)
+            }
+        )
+        harness.appState.sessions = [active]
+        let opened = await harness.appState.openSession("stored-a")
+        XCTAssertTrue(opened)
+
+        let didPrepend = await harness.appState.loadEarlierMessages()
+
+        XCTAssertFalse(didPrepend, "An all-duplicate page must not report a prepend")
+        XCTAssertEqual(harness.appState.messages.count, 120)
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.nextOffset, 240, "Coverage still advances past the held rows")
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.canLoadEarlier, true)
+    }
+
+    /// A malformed backfill payload retires the affordance without touching
+    /// the already-hydrated transcript.
+    func testMalformedBackfillPayloadRetiresAffordanceWithoutTouchingTranscript() async throws {
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1880..<2000), offset: 0)
+            },
+            loadEarlierTranscriptPage: { _, _, _ in
+                .payload(["session_id": "stored-a"])
+            }
+        )
+        harness.appState.sessions = [active]
+        let opened = await harness.appState.openSession("stored-a")
+        XCTAssertTrue(opened)
+
+        let didPrepend = await harness.appState.loadEarlierMessages()
+
+        XCTAssertFalse(didPrepend)
+        XCTAssertEqual(harness.appState.messages.count, 120, "The transcript stays untouched")
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.canLoadEarlier, false, "A malformed page is a backfill dead end")
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.isLoadingEarlier, false)
+    }
+
+    /// The graft gate is alias-aware: a window opened under a runtime ID
+    /// survives a reconnect that reconciles under the catalog's stored ID.
+    func testGraftSurvivesRuntimeAliasReconcile() async throws {
+        let holdsRefreshedTail = Flag()
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                if holdsRefreshedTail.isOn {
+                    return self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1900..<2020), offset: 0)
+                }
+                return self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1880..<2000), offset: 0)
+            },
+            loadEarlierTranscriptPage: { _, _, offset in
+                self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1760..<1880), offset: offset)
+            },
+            additionalOperations: { ops in
+                ops.connectClient = { _ in }
+                ops.loadCatalog = { _, _ in [active] }
+                ops.loadProfiles = {}
+                ops.loadBusyInputMode = { _ in }
+                ops.loadProfileDisplayPreferences = {}
+                ops.loadSlashCommands = {}
+            }
+        )
+        harness.appState.sessions = [active]
+        // Open under the runtime alias; the window is owned by "runtime-a".
+        let opened = await harness.appState.openSession("runtime-a")
+        XCTAssertTrue(opened)
+
+        await harness.appState.loadEarlierMessages()
+        XCTAssertEqual(harness.appState.messages.count, 240)
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.requestedSessionID, "runtime-a")
+
+        // The automatic reconnect reconciles under the catalog's stored ID;
+        // the alias-aware graft gate must still recognize the window.
+        holdsRefreshedTail.isOn = true
+        harness.coordinator.rememberSessionID("stored-a", for: "default")
+        await harness.appState.connect(
+            with: HermesConnection(baseUrl: "https://one.example", ticket: "alias-graft-ticket")
+        )
+
+        XCTAssertEqual(harness.appState.messages.count, 140 + 120, "Backfilled pages survive the alias reconcile")
+        XCTAssertEqual(harness.appState.messages.first?.content, "Row 1760")
+        XCTAssertEqual(harness.appState.messages.last?.content, "Row 2019")
+    }
+
     // MARK: - Harness
 
     private func makeHarness(
         openSession: @escaping @MainActor (HermesClient, String, Bool) async throws -> SessionResumeResult,
         persistedTranscript: (@MainActor (String, String) async -> PersistedTranscriptFetchOutcome)? = nil,
+        loadEarlierTranscriptPage: (@MainActor (String, String, Int) async -> PersistedTranscriptFetchOutcome)? = nil,
         additionalOperations: (inout ChatResumeLifecycleOperations) -> Void = { _ in }
     ) throws -> (appState: AppState, coordinator: ChatResumeCoordinator, defaults: UserDefaults) {
         let suite = "CompactResumeTranscriptTests.\(UUID().uuidString)"
@@ -757,7 +1490,8 @@ final class CompactResumeTranscriptTests: XCTestCase {
 
         var operations = ChatResumeLifecycleOperations(
             openSession: openSession,
-            persistedTranscript: persistedTranscript
+            persistedTranscript: persistedTranscript,
+            loadEarlierTranscriptPage: loadEarlierTranscriptPage
         )
         additionalOperations(&operations)
         let coordinator = ChatResumeCoordinator(store: ChatResumeStore(defaults: defaults))
@@ -792,5 +1526,61 @@ final class CompactResumeTranscriptTests: XCTestCase {
             isArchived: false,
             lineageRootId: nil
         )
+    }
+
+    // MARK: - Pagination fixtures
+
+    private final class Counter {
+        var value = 0
+    }
+
+    private final class Flag {
+        var isOn = false
+    }
+
+    /// One persisted transcript row exactly as the messages endpoint returns
+    /// it (numeric row id, chronological insertion order).
+    private func transcriptRow(
+        _ id: Int,
+        role: String,
+        content: String
+    ) -> [String: Any] {
+        [
+            "id": id,
+            "role": role,
+            "content": content,
+            "timestamp": String(format: "2026-09-01T%02d:%02d:00Z", 10 + (id / 60) % 10, id % 60)
+        ]
+    }
+
+    private func syntheticRows(_ range: Range<Int>) -> [[String: Any]] {
+        range.map { index in
+            transcriptRow(
+                index,
+                role: index.isMultiple(of: 2) ? "user" : "assistant",
+                content: "Row \(index)"
+            )
+        }
+    }
+
+    private func tailPagePayload(
+        sessionId: String,
+        rows: [[String: Any]],
+        offset: Int,
+        limit: Int? = 120,
+        order: String? = "latest"
+    ) -> PersistedTranscriptFetchOutcome {
+        var pagination: [String: Any] = ["offset": offset, "returned": rows.count]
+        if let limit {
+            pagination["limit"] = limit
+        }
+        if let order {
+            pagination["order"] = order
+        }
+        return .payload([
+            "session_id": sessionId,
+            "messages": rows,
+            "pagination": pagination
+        ])
     }
 }

--- a/ConduitTests/CompactResumeTranscriptTests.swift
+++ b/ConduitTests/CompactResumeTranscriptTests.swift
@@ -396,12 +396,12 @@ final class CompactResumeTranscriptTests: XCTestCase {
     }
 
     /// Drives one reconciliation against a history source that fails with
-    /// `failure` and asserts the transient-failure contract: the session
-    /// still opens via exactly one legacy resume, and the fallback can never
-    /// cascade (the legacy call itself never triggers a second one).
-    private func assertTransientHistoryFailureFallsBackExactlyOnce(
+    /// `failure` and asserts the bounded-failure contract: a failing or slow
+    /// BOUNDED history request must never escalate into the legacy
+    /// full-transcript WebSocket resume. The restore surfaces the error
+    /// instead; the compact resume stays the only transport used.
+    private func assertTransientHistoryFailureSurfacesWithoutLegacyResume(
         _ failure: Error,
-        expectedLegacyContent: String,
         file: StaticString = #filePath,
         line: UInt = #line
     ) async throws {
@@ -410,23 +410,9 @@ final class CompactResumeTranscriptTests: XCTestCase {
         let harness = try makeHarness(
             openSession: { _, sessionID, compact in
                 recorder.record(sessionID: sessionID, compact: compact)
-                if compact {
-                    return SessionResumeResult(
-                        sessionId: sessionID,
-                        messages: [],
-                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
-                    )
-                }
                 return SessionResumeResult(
                     sessionId: sessionID,
-                    messages: [
-                        ChatMessage(
-                            id: "legacy-1",
-                            role: .assistant,
-                            content: expectedLegacyContent,
-                            timestamp: "2026-09-01T08:00:00Z"
-                        )
-                    ],
+                    messages: [],
                     snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
                 )
             },
@@ -436,27 +422,32 @@ final class CompactResumeTranscriptTests: XCTestCase {
 
         let opened = await harness.appState.openSession("stored-transient")
 
-        XCTAssertTrue(opened, "\(failure) must fall back instead of failing the resume", file: file, line: line)
+        XCTAssertFalse(opened, "\(failure) must surface instead of silently degrading", file: file, line: line)
         XCTAssertEqual(
             recorder.calls.map { $0.compact },
-            [true, false],
-            "\(failure) must trigger exactly one legacy resume",
+            [true],
+            "\(failure) must not trigger any legacy full-transcript resume",
             file: file,
             line: line
         )
-        XCTAssertEqual(
-            harness.appState.messages.map { $0.content },
-            [expectedLegacyContent],
+        XCTAssertFalse(
+            harness.appState.errorMessage?.isEmpty ?? true,
+            "\(failure) must surface a visible restore error",
             file: file,
             line: line
         )
     }
 
-    func testTransientHistoryFailuresFallBackExactlyOnce() async throws {
-        // 429 / 5xx / status-0 WebKit failures / bridge readiness-timeout are
-        // temporary availability problems: preserve session access through
-        // exactly one legacy resume instead of failing the restore.
+    func testTransientHistoryFailuresSurfaceWithoutLegacyResume() async throws {
+        // A slow or failing BOUNDED history request must never become the
+        // giant-payload path: timeouts, rate limits, ordinary 5xx, status-0
+        // WebKit failures, and a bridge that outlived its readiness window
+        // all surface a retryable restore error instead of requesting the
+        // entire transcript over the WebSocket. (Current Hermes can serve
+        // the include_compacted page slowly for heavily compacted sessions
+        // until upstream #97440 bounds that work server-side.)
         let transientFailures: [Error] = [
+            DashboardTicketBridgeError.http(status: 408, detail: "Request Timeout"),
             DashboardTicketBridgeError.http(status: 429, detail: "Too Many Requests"),
             DashboardTicketBridgeError.http(status: 500, detail: "Internal error"),
             DashboardTicketBridgeError.http(status: 503, detail: "Service Unavailable"),
@@ -464,20 +455,56 @@ final class CompactResumeTranscriptTests: XCTestCase {
             DashboardTicketBridgeError.notReady,
         ]
         for failure in transientFailures {
-            try await assertTransientHistoryFailureFallsBackExactlyOnce(
-                failure,
-                expectedLegacyContent: "Legacy transcript"
-            )
+            try await assertTransientHistoryFailureSurfacesWithoutLegacyResume(failure)
         }
     }
 
     func testStructuralHistoryEndpointGapsFallBackExactlyOnce() async throws {
-        // Gateways predating the history endpoint fall back cleanly as well.
+        // Gateways predating the history endpoint are the one case where the
+        // legacy full-transcript resume remains the compatibility path: the
+        // endpoint cannot serve ANY page, bounded or not. Exactly one legacy
+        // resume, and the fallback never cascades.
         for status in [404, 410, 501] {
-            try await assertTransientHistoryFailureFallsBackExactlyOnce(
-                DashboardTicketBridgeError.http(status: status, detail: "missing endpoint"),
-                expectedLegacyContent: "Legacy transcript"
+            let recorder = ResumeCallRecorder()
+            let active = session("stored-structural")
+            let harness = try makeHarness(
+                openSession: { _, sessionID, compact in
+                    recorder.record(sessionID: sessionID, compact: compact)
+                    if compact {
+                        return SessionResumeResult(
+                            sessionId: sessionID,
+                            messages: [],
+                            snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                        )
+                    }
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [
+                            ChatMessage(
+                                id: "legacy-1",
+                                role: .assistant,
+                                content: "Legacy transcript",
+                                timestamp: "2026-09-01T08:00:00Z"
+                            )
+                        ],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    .failed(DashboardTicketBridgeError.http(status: status, detail: "missing endpoint"))
+                }
             )
+            harness.appState.sessions = [active]
+
+            let opened = await harness.appState.openSession("stored-structural")
+
+            XCTAssertTrue(opened, "status \(status) must fall back instead of failing the resume")
+            XCTAssertEqual(
+                recorder.calls.map { $0.compact },
+                [true, false],
+                "status \(status) must trigger exactly one legacy resume"
+            )
+            XCTAssertEqual(harness.appState.messages.map { $0.content }, ["Legacy transcript"])
         }
     }
 
@@ -522,14 +549,14 @@ final class CompactResumeTranscriptTests: XCTestCase {
         XCTAssertEqual(harness.appState.messages.first?.content, "Late hydration")
     }
 
-    func testColdDashboardBridgeStillBeginsWithCompactResume() async throws {
-        // Regression for the cold-launch hole: a dashboard bridge that exists
-        // but is not ready yet must NOT push the resume onto the legacy
-        // full-transcript path immediately. The resume begins compact, the
-        // transcript fetch waits inside requestJSON's bounded readiness poll,
-        // and a bridge that never becomes usable degrades to exactly one
-        // legacy resume. A modern gateway therefore never receives a legacy
-        // full-transcript request just because the bridge was cold.
+    func testColdDashboardBridgeBeginsCompactAndNeverEscalatesToLegacy() async throws {
+        // Regression for the cold-launch hole AND the giant-session safety
+        // property: a dashboard bridge that exists but is not ready yet must
+        // not push the resume onto the legacy full-transcript path — neither
+        // immediately nor after its bounded readiness window expires. The
+        // resume begins compact; a bridge that never becomes usable surfaces
+        // a retryable restore error instead of requesting the entire
+        // transcript over the WebSocket.
         let recorder = ResumeCallRecorder()
         let active = session("stored-cold")
         let harness = try makeHarness(
@@ -537,14 +564,7 @@ final class CompactResumeTranscriptTests: XCTestCase {
                 recorder.record(sessionID: sessionID, compact: compact)
                 return SessionResumeResult(
                     sessionId: sessionID,
-                    messages: [
-                        ChatMessage(
-                            id: "restored",
-                            role: .assistant,
-                            content: "Restored",
-                            timestamp: "1"
-                        )
-                    ],
+                    messages: [],
                     snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
                 )
             },
@@ -565,13 +585,18 @@ final class CompactResumeTranscriptTests: XCTestCase {
             with: HermesConnection(baseUrl: "https://one.example", ticket: "cold-ticket")
         )
 
-        XCTAssertTrue(harness.appState.isConnected)
-        XCTAssertEqual(
-            recorder.calls.map { $0.compact },
-            [true, false],
-            "A cold bridge must begin compact and fall back to at most one legacy resume"
+        XCTAssertFalse(
+            recorder.calls.isEmpty,
+            "The resume must have begun on the compact transport"
         )
-        XCTAssertEqual(harness.appState.messages.map { $0.content }, ["Restored"])
+        XCTAssertTrue(
+            recorder.calls.allSatisfy { $0.compact },
+            "A cold bridge must never trigger a legacy full-transcript resume, got: \(recorder.calls.map { $0.compact })"
+        )
+        XCTAssertFalse(
+            harness.appState.errorMessage?.isEmpty ?? true,
+            "The bounded history failure must surface to the user"
+        )
     }
 
     func testLegacyFallbackMergeHandlesLargeTranscriptAtAppStateLevel() async throws {
@@ -704,7 +729,9 @@ final class CompactResumeTranscriptTests: XCTestCase {
     // MARK: - Unavailable-source classification
 
     func testHistorySourceUnavailableClassification() {
-        // Structural endpoint gaps fall back to the legacy resume…
+        // ONLY structural endpoint absence degrades to the legacy resume /
+        // retires the backfill affordance: 404/410 gateways without the
+        // messages route, and 501 explicitly-unimplemented.
         for status in [404, 410, 501] {
             XCTAssertTrue(
                 AppState.historySourceIsUnavailable(
@@ -713,27 +740,20 @@ final class CompactResumeTranscriptTests: XCTestCase {
                 "status \(status) must be classified as unavailable"
             )
         }
-        // …as do transient availability problems: rate limiting, any 5xx,
-        // status-0 WebKit/network failures, and a bridge (or request) that
-        // outlived its bounded readiness strategy.
-        XCTAssertTrue(AppState.historySourceIsUnavailable(
-            DashboardTicketBridgeError.http(status: 429, detail: "Too Many Requests")
-        ))
-        for status in [500, 502, 503, 504] {
-            XCTAssertTrue(
+        // Transient transport trouble must SURFACE (initial hydration) or
+        // stay tap-retryable (backfill) instead of silently escalating into
+        // the unbounded legacy transcript transport: rate limits, timeouts,
+        // ordinary 5xx, status-0 WebKit failures, and a bridge that never
+        // became ready or a request that outlived its deadline.
+        for status in [0, 408, 429, 500, 502, 503, 504] {
+            XCTAssertFalse(
                 AppState.historySourceIsUnavailable(
-                    DashboardTicketBridgeError.http(status: status, detail: "server error")
+                    DashboardTicketBridgeError.http(status: status, detail: "transient")
                 ),
-                "status \(status) must be classified as unavailable"
+                "status \(status) must not be classified as unavailable"
             )
         }
-        XCTAssertTrue(AppState.historySourceIsUnavailable(
-            DashboardTicketBridgeError.http(status: 0, detail: "Failed to fetch")
-        ))
-        XCTAssertTrue(AppState.historySourceIsUnavailable(DashboardTicketBridgeError.notReady))
-        // A known-oversized one-shot history response is a typed condition,
-        // not transport trouble: it must surface its controlled compatibility
-        // error instead of retrying the giant transcript over the WebSocket.
+        XCTAssertFalse(AppState.historySourceIsUnavailable(DashboardTicketBridgeError.notReady))
         XCTAssertFalse(AppState.historySourceIsUnavailable(
             DashboardTicketBridgeError.oversizedResponse(limit: DataURLLimits.maxJSONResponseBytes)
         ))
@@ -747,35 +767,14 @@ final class CompactResumeTranscriptTests: XCTestCase {
         ))
     }
 
-    /// Backfill affordance retirement is structural-only: 404/410/5xx and a
-    /// bridge that never became ready retire "Load earlier messages"; every
-    /// transient transport trouble (408/429/status-0) and unclassified or
-    /// auth failures stay tap-retryable.
-    func testBackfillStructuralRetirementClassification() {
-        for status in [404, 410, 500, 502, 503] {
-            XCTAssertTrue(
-                AppState.historySourceIsStructurallyGone(
-                    DashboardTicketBridgeError.http(status: status, detail: "gone")
-                ),
-                "status \(status) must retire the affordance"
-            )
-        }
-        XCTAssertTrue(AppState.historySourceIsStructurallyGone(DashboardTicketBridgeError.notReady))
-        for status in [0, 408, 429] {
-            XCTAssertFalse(
-                AppState.historySourceIsStructurallyGone(
-                    DashboardTicketBridgeError.http(status: status, detail: "transient")
-                ),
-                "status \(status) must stay tap-retryable"
-            )
-        }
-        XCTAssertFalse(AppState.historySourceIsStructurallyGone(DashboardTicketBridgeError.signInRequired))
-        XCTAssertFalse(AppState.historySourceIsStructurallyGone(
-            DashboardTicketBridgeError.oversizedResponse(limit: DataURLLimits.maxJSONResponseBytes)
-        ))
-        XCTAssertFalse(AppState.historySourceIsStructurallyGone(
-            DashboardTicketBridgeError.requestFailed("Could not encode dashboard request.")
-        ))
+    /// The bridge-level oversized error is generic — it can arise from any
+    /// oversized dashboard response (workspace-file reads, catalogs), not
+    /// only transcript history — so its copy must be neutral.
+    /// Transcript-specific compatibility messaging is mapped in the
+    /// transcript layer (see the oversized-history tests below).
+    func testGenericOversizedBridgeErrorUsesNeutralCopy() {
+        let error = DashboardTicketBridgeError.oversizedResponse(limit: DataURLLimits.maxJSONResponseBytes)
+        XCTAssertEqual(error.errorDescription, "This response is too large to load safely.")
     }
 
     // MARK: - Bounded persisted-history pagination
@@ -874,6 +873,10 @@ final class CompactResumeTranscriptTests: XCTestCase {
         XCTAssertEqual(harness.appState.persistedTranscriptWindow?.nextOffset, 240)
         XCTAssertEqual(harness.appState.persistedTranscriptWindow?.canLoadEarlier, true)
         XCTAssertEqual(harness.appState.persistedTranscriptWindow?.isLoadingEarlier, false)
+        XCTAssertTrue(
+            harness.appState.persistedTranscriptWindow?.hasBackfilledPrefix ?? false,
+            "A published prepend must mark the backfilled prefix"
+        )
     }
 
     /// A short page means the beginning of the persisted transcript has been
@@ -933,9 +936,10 @@ final class CompactResumeTranscriptTests: XCTestCase {
                 if sessionId == "stored-a" {
                     return self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1880..<2000), offset: 0)
                 }
+                // Row ids start at 1: SQLite AUTOINCREMENT never produces 0.
                 return self.tailPagePayload(
                     sessionId: "stored-b",
-                    rows: self.syntheticRows(0..<2),
+                    rows: self.syntheticRows(1..<3),
                     offset: 0
                 )
             },
@@ -962,7 +966,7 @@ final class CompactResumeTranscriptTests: XCTestCase {
         await backfill
 
         XCTAssertEqual(harness.appState.messages.count, 2, "Session B must be completely unchanged by the stale page")
-        XCTAssertEqual(harness.appState.messages.first?.content, "Row 0")
+        XCTAssertEqual(harness.appState.messages.first?.content, "Row 1")
         XCTAssertEqual(harness.appState.persistedTranscriptWindow?.requestedSessionID, "stored-b")
         XCTAssertEqual(harness.appState.persistedTranscriptWindow?.isLoadingEarlier, false)
         XCTAssertFalse(
@@ -1126,7 +1130,10 @@ final class CompactResumeTranscriptTests: XCTestCase {
     /// safe response bound must surface the controlled compatibility error —
     /// never a retry of the same giant transcript over the bounded
     /// WebSocket.
-    func testOversizedLegacyHistorySurfacesWithoutWebSocketRetry() async throws {
+    /// A bounded current-Hermes page that exceeds the safe response bound
+    /// (one enormous physical row) surfaces NEUTRAL copy — the backend does
+    /// have pagination, and no giant WebSocket retry may follow.
+    func testOversizedBoundedHistorySurfacesNeutralError() async throws {
         let recorder = ResumeCallRecorder()
         let active = session("stored-a")
         let harness = try makeHarness(
@@ -1148,6 +1155,59 @@ final class CompactResumeTranscriptTests: XCTestCase {
 
         let opened = await harness.appState.openSession("stored-a")
 
+        XCTAssertFalse(opened, "The oversized-response error must surface")
+        XCTAssertEqual(
+            recorder.calls.map { $0.compact },
+            [true],
+            "No legacy full-transcript WebSocket retry may follow an oversized history response"
+        )
+        XCTAssertEqual(
+            harness.appState.errorMessage,
+            "This response is too large to load safely.",
+            "A bounded page oversize must not claim the backend lacks pagination"
+        )
+    }
+
+    /// A legacy one-shot transcript (an old backend attempting the entire
+    /// conversation after the oldest-anchored echo was detected) that
+    /// exceeds the safe bound surfaces the transcript-specific
+    /// compatibility copy — and never retries over the WebSocket.
+    func testOversizedLegacyOneShotSurfacesCompatibilityCopy() async throws {
+        let fetchCalls = Counter()
+        let recorder = ResumeCallRecorder()
+        let active = session("stored-a")
+        let harness = try makeHarness(
+            openSession: { _, sessionID, compact in
+                recorder.record(sessionID: sessionID, compact: compact)
+                return SessionResumeResult(
+                    sessionId: sessionID,
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                fetchCalls.value += 1
+                if fetchCalls.value == 1 {
+                    // Oldest-anchored build: bounded request, no order echo.
+                    return self.tailPagePayload(
+                        sessionId: "stored-a",
+                        rows: self.syntheticRows(0..<3),
+                        offset: 0,
+                        limit: 120,
+                        order: nil
+                    )
+                }
+                // The one-shot re-read of the full transcript outgrew the
+                // safe bound.
+                return .failed(DashboardTicketBridgeError.oversizedResponse(
+                    limit: DataURLLimits.maxJSONResponseBytes
+                ))
+            }
+        )
+        harness.appState.sessions = [active]
+
+        let opened = await harness.appState.openSession("stored-a")
+
         XCTAssertFalse(opened, "The oversized-history compatibility error must surface")
         XCTAssertEqual(
             recorder.calls.map { $0.compact },
@@ -1155,8 +1215,8 @@ final class CompactResumeTranscriptTests: XCTestCase {
             "No legacy full-transcript WebSocket retry may follow an oversized history response"
         )
         XCTAssertTrue(
-            harness.appState.errorMessage?.contains("too large to load safely") == true,
-            "The surfaced error should be the controlled compatibility copy, got: \(harness.appState.errorMessage ?? "nil")"
+            harness.appState.errorMessage?.contains("Update Hermes to enable paginated conversation history") == true,
+            "A legacy one-shot oversize should carry the compatibility copy, got: \(harness.appState.errorMessage ?? "nil")"
         )
     }
 
@@ -1467,6 +1527,153 @@ final class CompactResumeTranscriptTests: XCTestCase {
         XCTAssertEqual(harness.appState.messages.count, 140 + 120, "Backfilled pages survive the alias reconcile")
         XCTAssertEqual(harness.appState.messages.first?.content, "Row 1760")
         XCTAssertEqual(harness.appState.messages.last?.content, "Row 2019")
+    }
+
+    /// A backfill response whose session_id belongs to another conversation
+    /// is rejected whole: no normalization into the transcript, no coverage
+    /// advance, affordance retired.
+    func testForeignBackfillResponseRejected() async throws {
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1880..<2000), offset: 0)
+            },
+            loadEarlierTranscriptPage: { _, _, offset in
+                self.tailPagePayload(sessionId: "stored-b", rows: self.syntheticRows(0..<120), offset: offset)
+            }
+        )
+        harness.appState.sessions = [active]
+        let opened = await harness.appState.openSession("stored-a")
+        XCTAssertTrue(opened)
+
+        let didPrepend = await harness.appState.loadEarlierMessages()
+
+        XCTAssertFalse(didPrepend)
+        XCTAssertEqual(harness.appState.messages.count, 120, "Foreign rows must never reach the transcript")
+        XCTAssertFalse(harness.appState.messages.contains { $0.content == "Row 0" })
+        XCTAssertEqual(
+            harness.appState.persistedTranscriptWindow?.nextOffset, 120,
+            "Foreign responses must not advance pagination coverage"
+        )
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.canLoadEarlier, false)
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.isLoadingEarlier, false)
+    }
+
+    /// A backfill page whose rows lack durable persisted IDs would dedup on
+    /// page-local positional identities that cannot survive across pages —
+    /// refuse it instead of silently corrupting overlap dedup.
+    func testBackfillPageWithoutDurableIdsRetiresAffordance() async throws {
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1880..<2000), offset: 0)
+            },
+            loadEarlierTranscriptPage: { _, _, offset in
+                .payload([
+                    "session_id": "stored-a",
+                    "messages": [
+                        // Missing id entirely…
+                        ["role": "user", "content": "Id-less row", "timestamp": "2026-09-01T10:00:00Z"],
+                        // …and an empty-string id, which would likewise
+                        // collapse every such row onto one dedup key.
+                        ["id": "", "role": "user", "content": "Empty-id row", "timestamp": "2026-09-01T10:00:01Z"]
+                    ],
+                    "pagination": ["limit": 120, "offset": offset, "order": "latest", "returned": 2]
+                ])
+            }
+        )
+        harness.appState.sessions = [active]
+        let opened = await harness.appState.openSession("stored-a")
+        XCTAssertTrue(opened)
+
+        let didPrepend = await harness.appState.loadEarlierMessages()
+
+        XCTAssertFalse(didPrepend)
+        XCTAssertEqual(harness.appState.messages.count, 120, "The transcript stays untouched")
+        XCTAssertFalse(harness.appState.messages.contains { $0.content == "Id-less row" })
+        XCTAssertFalse(harness.appState.messages.contains { $0.content == "Empty-id row" })
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.canLoadEarlier, false)
+        XCTAssertEqual(
+            harness.appState.persistedTranscriptWindow?.nextOffset, 120,
+            "No coverage advance for an unusable page"
+        )
+    }
+
+    /// A page boundary can split a tool call from its result row: the call
+    /// row is the last row of the older page, its result the first row of
+    /// the loaded newer page. One logical tool run must reconstruct — never
+    /// an orphan call card plus a duplicate standalone result.
+    func testToolCallSplitAcrossPageBoundaryReconstructsOneRun() async throws {
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                var resultRow = self.transcriptRow(1880, role: "tool", content: "file body")
+                resultRow["tool_call_id"] = "call_123"
+                resultRow["name"] = "read_file"
+                let rows = [resultRow] + self.syntheticRows(1881..<2000)
+                return self.tailPagePayload(sessionId: "stored-a", rows: rows, offset: 0)
+            },
+            loadEarlierTranscriptPage: { _, _, offset in
+                var callRow = self.transcriptRow(1879, role: "assistant", content: "")
+                callRow["tool_calls"] = [[
+                    "id": "call_123",
+                    "type": "function",
+                    "function": [
+                        "name": "read_file",
+                        "arguments": "{\"path\": \"/tmp/row1879\"}"
+                    ]
+                ]]
+                let rows = self.syntheticRows(1760..<1879) + [callRow]
+                return self.tailPagePayload(sessionId: "stored-a", rows: rows, offset: offset)
+            }
+        )
+        harness.appState.sessions = [active]
+        let opened = await harness.appState.openSession("stored-a")
+        XCTAssertTrue(opened)
+        // The unmatched result hydrates as a standalone card on the newer
+        // page (its call row is not in that page).
+        XCTAssertEqual(harness.appState.messages.count, 120)
+        XCTAssertEqual(harness.appState.messages.first?.role, .tool)
+        XCTAssertEqual(harness.appState.messages.first?.tool?.id, "call_123")
+
+        await harness.appState.loadEarlierMessages()
+
+        let messages = harness.appState.messages
+        XCTAssertEqual(messages.count, 120 + 120 - 1, "The standalone result card folds away into its call card")
+        let callCards = messages.filter { $0.tool?.id == "call_123" }
+        XCTAssertEqual(callCards.count, 1, "Exactly one card for the durable tool-call identity")
+        XCTAssertEqual(callCards.first?.id, "1879.0-tool-0")
+        XCTAssertEqual(callCards.first?.tool?.name, "read_file")
+        XCTAssertEqual(callCards.first?.tool?.input, "{\"path\": \"/tmp/row1879\"}")
+        XCTAssertEqual(callCards.first?.tool?.output, "file body")
+        XCTAssertEqual(callCards.first?.tool?.status, .complete)
+        XCTAssertFalse(
+            messages.contains { $0.id == "1880.0" },
+            "No orphan standalone result may remain"
+        )
+        XCTAssertEqual(messages.last?.content, "Row 1999", "The loaded tail stays intact")
+        XCTAssertTrue(harness.appState.persistedTranscriptWindow?.hasBackfilledPrefix ?? false)
     }
 
     // MARK: - Harness


### PR DESCRIPTION
## Summary

Follow-up to PR #110 / issue #106: opening a conversation now has **bounded transport and normalization cost** regardless of session size (200 / 2,000 / 20,000 / 100,000 persisted rows). PR #110 removed giant transcripts from `session.resume` via `omit_messages`, but Conduit still assumed `GET /api/sessions/{id}/messages` returns the entire transcript in one response — no longer true for current Hermes, which serves it as a paged history API. Conduit now matches Hermes Desktop's division of responsibility: compact `session.resume(omit_messages: true)` for runtime/inflight state, bounded tail pages of `/messages` for persisted display history.

## The pagination model

- **Request contract (explicit, never the implicit default):** `?limit=120&offset=0&order=latest&include_compacted=true` — `PersistedTranscriptPagination.pageSize = 120`, matching Desktop's `LATEST_SESSION_MESSAGES_LIMIT`. Older pages continue the same contract at the next offset.
- **`PersistedTranscriptWindowState`** (per active session): requested/resolved session IDs, profile, pageSize, nextOffset (rows of the newest tail covered locally), canLoadEarlier, isLoadingEarlier, hasBackfilledPrefix. Identity-safe across session switch, profile switch, disconnect/reconnect, runtime↔stored ID remapping, and stale async backfills (multi-field discard guard + alias-aware ownership gate).
- **Backfill:** "Load earlier messages" prepends older pages. Offset advances by fetched row count (self-corrects `order=latest` drift); overlap is deduplicated by durable row identity (`ChatMessage.id` = SQLite row id, never visible text), and only the strictly-older region of a page is prepended. A short/empty page or a response that lost the tail contract retires the affordance; failures never loop — only a structurally gone source retires it, transient trouble stays tap-retryable. Every page validates its returned `session_id` against the requested ID, the window's resolved stored ID, and known aliases before normalizing — foreign responses never prepend nor advance coverage.
- **Repeated-reconnect prefix preservation:** a reconnect re-reads only the newest page; the refreshed tail grafts onto the backfilled prefix via the explicit `hasBackfilledPrefix` flag (alias-aware gate) — set when a backfill prepends, carried by every successful graft, cleared when a refreshed tail has no safe anchor. The prefix therefore survives reconnect #2, #3, … even though network coverage resets to the fresh tail; the next backfills retrace the prefix in deduped page-sized increments (harmless duplicates, never gaps).

## Current Hermes vs legacy Hermes (shape detection, no version sniffing)

- **pagination echo with `order:"latest"`** → current tail-anchored contract (offset measured back from the newest row; pages arrive chronological — verified against upstream Hermes and Desktop's client).
- **pagination echo without `order`** → an older dashboard generation whose offsets page from the *oldest* end (deployed installs of that era silently ignore `order`/`include_compacted`). Conduit re-reads the transcript one-shot at most once and treats it as legacy — never walks forward from row zero. The same one-shot re-read covers a paginated echo whose rows lack durable persisted IDs (positional fallback IDs can never enter dedup).
- **no pagination object** → legacy one-shot full transcript; hydrated exactly as before, no window, no affordance.

## Fallback policy (final contract)

**Structural endpoint absence — exactly one legacy full-transcript resume fallback:**

```text
404 / 410 / 501
→ the endpoint cannot serve any page; exactly one legacy resume, never a cascade
```

**Transient / bounded-history failures — DO NOT fall back to the full-transcript WebSocket resume:**

```text
status 0 · notReady / request timeout · 408 · 429 · ordinary 5xx · oversized bounded response
→ surface a retryable restore error; retry the BOUNDED request through reconnect recovery only
```

This is the giant-session safety property: current Hermes can serve the bounded `include_compacted=true` page slowly for heavily compacted sessions until upstream #97440 bounds that work server-side, so a slow bounded read fails boundedly and never silently becomes "load the entire transcript over the WebSocket". Authentication and unclassified failures also surface.

## Oversized responses: generic vs transcript-specific

The bridge-level `oversizedResponse` error carries **neutral copy** ("This response is too large to load safely.") — it can arise from any oversized dashboard operation, not only transcripts. The transcript layer maps a **legacy one-shot** oversize (an old backend attempting the entire conversation) to the compatibility message ("This conversation is too large to load safely with this Hermes version. Update Hermes to enable paginated conversation history."), while a **bounded current-Hermes page** oversize keeps the neutral copy — it never claims the backend lacks pagination. No global response-size guard was weakened or raised.

## Viewport stability

Prepends re-pin the currently visible row via the pure `ChatViewportController`: the anchor is captured at tap time, consumed only by the prepend's front-row replacement (streaming growth, turn completion, tail grafts, and prefix-dropping rewrites never consume it or re-pin early), one unanimated scroll + delayed generation-stamped retry, ownership re-validated against rendered *and* active session at landing, and silently discharged when the captured row no longer exists. Following-latest holds via the existing bottom-follow system; discharge is session-scoped. The backfill task is view-lifetime-aware (cancelled on disappear, cancellation-checked before viewport mutation). Saved viewport anchors older than the loaded tail fall back to latest through the existing `ChatResumeViewportResolver` — opening never becomes an N-page anchor chase.

## Tool calls across a page boundary

A single assistant turn can carry any number of tool calls. When a call row ends an older page and its result rows begin the newer page, `PersistedTranscriptWindow.reconcilingToolCallsAcrossBoundary` folds the trailing unmatched call cards together with the matching held standalone result cards **by durable `ToolActivity.id` (Hermes `tool_call_id`) — unbounded, with no pair ceiling; identity only, never name, text, or position**. One logical tool run renders as one completed card with the right input/output; no orphan call cards, no duplicate standalone results. Regression coverage pins a 12-call run split across the boundary reconstructing fully.

## Replaced PR #110 assumptions

The old `CompactResumeTranscriptTests` assumption that a giant REST response carries the whole transcript is now the explicitly-pinned *legacy/one-shot compatibility* path. Regression coverage (29 new tests): bounded explicit request contract, tail-only hydration of a 2,000-row session, drift-overlap backfill dedup, terminal short page (repeated taps issue no requests), stale backfill discard on session switch, foreign-response ownership rejection, compacted display-row projection after prepend (hidden carriers, display_content, model-switch, auto-continue), legacy one-shot acceptance, oldest-anchored-echo and durable-ID-less fallbacks, oversized-history no-WS-retry (neutral + compatibility copies), live paginated resume inflight behavior, reconnect graft across repeated reconciles (same-id and runtime-alias), transient-failure retryability, duplicate-only coverage advance, malformed page and id-less page retirement, structural/transient classification matrices, and the viewport-controller anchor state machine (arming, landing, discharge, ownership races, mid-flight suffix changes, deleted anchors).

## Not changed

Display projection/`MessageNormalizer` architecture, live/inflight reconciliation (running, inflight continuation, persisted prefix vs streaming suffix, pending decisions, YOLO), compact WS resume behavior, session catalogs, profile discovery, voice, WebSocket/REST size limits, chat chrome, Markdown pipeline, Hermes backend code, page size, and the manual "Load earlier messages" UX.

## Verification (at head `01b24af`)

- Focused: `CompactResumeTranscriptTests` + `ChatViewportControllerTests` — **125/125** on the Mac build host (iPhone 17 Pro), including the >8-call (12-call) page-boundary regression: all results reconstruct, zero orphan cards.
- Full unit suite: **1458/1458, 0 failures** (PR #116 baseline 1429 + 29 new) at the final commit.
- `git diff --check` clean; no lint tooling exists in the repo.
- Multi-model review gate: base implementation 3 reviewer rounds (final APPROVE); the hardening pass (repeated-reconcile prefix, structural-only fallback, ownership validation, tool-boundary reconstruction, oversized split) was delta-reviewed — its one BLOCKER (all-held-folded duplicate) fixed; the final cap-lift delta was reviewed 3× APPROVE.
- Known accepted trade-offs (documented in code): after a reconnect the window resets coverage, so backfills retrace the backfilled prefix in deduped page-sized increments before reaching fresh rows; a cold bridge or slow bounded read now fails the session open with a visible error instead of degrading to legacy content.

Out of scope: upstream Hermes tagging/writing fixes; Conduit never loads the complete transcript automatically at open and does not chase ancient scroll anchors through REST pages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paginated transcript history with a “Load earlier messages” control.
  * Older messages load in bounded batches while preserving scroll position.
  * Tool calls and results remain correctly connected across loaded pages.
* **Bug Fixes**
  * Prevented duplicate or unrelated messages during history loading.
  * Preserved previously loaded messages when transcripts refresh.
  * Improved handling of oversized, unavailable, or temporarily inaccessible history.
  * Prevented stale or cancelled loads from affecting the active conversation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->