### PR TITLE
fix(auth): restore Cloudflare Access sign-in and keyboard-safe login form

### DIFF
--- a/Conduit/Services/CloudflareAccess.swift
+++ b/Conduit/Services/CloudflareAccess.swift
@@ -1,30 +1,4 @@
 import Foundation
-import WebKit
-
-/// Cloudflare's Access login page runs a Turnstile-backed verification that
-/// scores the bare WKWebView user agent as automation, so the interactive
-/// sign-in fails inside the app while the same login succeeds in Safari on
-/// the same device (issue #117). Appending the tokens Safari carries but a
-/// default WKWebView omits ("Version/… Safari/…") before the first load
-/// lets the legitimate Cloudflare/IdP flow verify. "Safari/604.1" is Apple's
-/// frozen WebKit build marker (an identity token, not an OS version — it has
-/// been constant across every iOS Safari release), and "Version/…" tracks
-/// the current OS; the device part of the UA keeps coming from WebKit
-/// itself. No credentials or navigation policy are affected.
-enum WebViewUserAgent {
-    static func safariCompatibilitySuffix() -> String {
-        let version = ProcessInfo.processInfo.operatingSystemVersion
-        // Safari's Version token is major.minor only — the OS patch level
-        // never appears in a real iOS UA, so omit it to stay byte-faithful.
-        return "Version/\(version.majorVersion).\(version.minorVersion) Safari/604.1"
-    }
-
-    /// Must run before the web view loads anything: WebKit ignores user-agent
-    /// changes once a page has started loading.
-    static func apply(to configuration: WKWebViewConfiguration) {
-        configuration.applicationNameForUserAgent = safariCompatibilitySuffix()
-    }
-}
 
 struct CloudflareAccessKeychainRecord: Codable, Equatable {
     let clientID: String

--- a/Conduit/Services/CloudflareAccess.swift
+++ b/Conduit/Services/CloudflareAccess.swift
@@ -14,11 +14,9 @@ import WebKit
 enum WebViewUserAgent {
     static func safariCompatibilitySuffix() -> String {
         let version = ProcessInfo.processInfo.operatingSystemVersion
-        var versionText = "\(version.majorVersion).\(version.minorVersion)"
-        if version.patchVersion > 0 {
-            versionText += ".\(version.patchVersion)"
-        }
-        return "Version/\(versionText) Safari/604.1"
+        // Safari's Version token is major.minor only — the OS patch level
+        // never appears in a real iOS UA, so omit it to stay byte-faithful.
+        return "Version/\(version.majorVersion).\(version.minorVersion) Safari/604.1"
     }
 
     /// Must run before the web view loads anything: WebKit ignores user-agent

--- a/Conduit/Services/CloudflareAccess.swift
+++ b/Conduit/Services/CloudflareAccess.swift
@@ -1,4 +1,32 @@
 import Foundation
+import WebKit
+
+/// Cloudflare's Access login page runs a Turnstile-backed verification that
+/// scores the bare WKWebView user agent as automation, so the interactive
+/// sign-in fails inside the app while the same login succeeds in Safari on
+/// the same device (issue #117). Appending the tokens Safari carries but a
+/// default WKWebView omits ("Version/… Safari/…") before the first load
+/// lets the legitimate Cloudflare/IdP flow verify. "Safari/604.1" is Apple's
+/// frozen WebKit build marker (an identity token, not an OS version — it has
+/// been constant across every iOS Safari release), and "Version/…" tracks
+/// the current OS; the device part of the UA keeps coming from WebKit
+/// itself. No credentials or navigation policy are affected.
+enum WebViewUserAgent {
+    static func safariCompatibilitySuffix() -> String {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        var versionText = "\(version.majorVersion).\(version.minorVersion)"
+        if version.patchVersion > 0 {
+            versionText += ".\(version.patchVersion)"
+        }
+        return "Version/\(versionText) Safari/604.1"
+    }
+
+    /// Must run before the web view loads anything: WebKit ignores user-agent
+    /// changes once a page has started loading.
+    static func apply(to configuration: WKWebViewConfiguration) {
+        configuration.applicationNameForUserAgent = safariCompatibilitySuffix()
+    }
+}
 
 struct CloudflareAccessKeychainRecord: Codable, Equatable {
     let clientID: String

--- a/Conduit/Services/CloudflareAccess.swift
+++ b/Conduit/Services/CloudflareAccess.swift
@@ -40,6 +40,14 @@ struct CloudflareAccessCredentials: Equatable, CustomStringConvertible {
 
     func applying(to request: URLRequest) -> URLRequest {
         guard isConfigured else { return request }
+        // Service tokens are HTTPS/WSS-only. Cleartext transports — plain
+        // HTTP dashboards and ws:// upgrades on trusted LANs — must never
+        // carry the long-lived Cloudflare credentials, even when a token is
+        // configured for the session; local Hermes connectivity works
+        // without them, so they are silently omitted rather than blocking
+        // the login.
+        let scheme = request.url?.scheme?.lowercased()
+        guard scheme == "https" || scheme == "wss" else { return request }
         var request = request
         request.setValue(clientID, forHTTPHeaderField: "CF-Access-Client-Id")
         request.setValue(clientSecret, forHTTPHeaderField: "CF-Access-Client-Secret")
@@ -58,10 +66,14 @@ struct CloudflareAccessCredentials: Equatable, CustomStringConvertible {
     /// `fetch()` and `XMLHttpRequest` calls inside the WKWebView include the
     /// Cloudflare Access service-token headers. The script is intentionally
     /// scoped to the configured dashboard origin; native requests still apply
-    /// the headers directly to the initial dashboard request.
+    /// the headers directly to the initial dashboard request. Shares the
+    /// HTTPS-only invariant of `applying(to:)`: plain-HTTP dashboard origins
+    /// get no script at all, so the credentials are never embedded in page
+    /// JavaScript either.
     func fetchInjectionUserScript(expectedBaseURL: String) -> String {
         guard isConfigured,
               let normalizedBaseURL = try? ConnectionURLPolicy.normalizedBaseURL(expectedBaseURL),
+              normalizedBaseURL.lowercased().hasPrefix("https://"),
               let baseURLLiteral = javaScriptStringLiteral(normalizedBaseURL),
               let idLiteral = javaScriptStringLiteral(clientID),
               let secretLiteral = javaScriptStringLiteral(clientSecret) else { return "" }

--- a/Conduit/Services/ConnectionURLPolicy.swift
+++ b/Conduit/Services/ConnectionURLPolicy.swift
@@ -26,6 +26,34 @@ enum ConnectionURLPolicy {
         return scheme == "https" || (scheme == "http" && isInsecureTransportAllowed(host))
     }
 
+    /// The `about:` documents Cloudflare's Turnstile WebView requirements
+    /// call out ("Allow connections to `about:blank` and `about:srcdoc`").
+    /// Allowed only in SUBframes. Those documents inherit the parent page's
+    /// origin, so script inside them could attempt a top-level navigation —
+    /// but any such navigation is evaluated as a MAIN frame against the
+    /// strict transport/dashboard-origin rules, so this allowance never
+    /// widens the top-level boundary.
+    static func isTurnstileRequiredSubframeDocument(_ url: URL?) -> Bool {
+        // Classify from the absolute string: WebKit's own URL objects for
+        // these subframe navigations do not necessarily expose the document
+        // tail through `path`/`host` the way a string-constructed URL does
+        // (observed directly in the boundary tests).
+        guard var raw = url?.absoluteString.lowercased() else { return false }
+        guard raw.hasPrefix("about:") else { return false }
+        raw.removeFirst("about:".count)
+        // Strip any trailing slashes WebKit may append to about: URLs.
+        while raw.hasSuffix("/") { raw.removeLast() }
+        return raw == "blank" || raw == "srcdoc"
+    }
+
+    /// Transport policy for WebView SUBFRAME navigations: ordinary HTTP(S)
+    /// (identity providers, challenges.cloudflare.com) plus the about:
+    /// documents Turnstile requires. Everything else (custom schemes,
+    /// other about: variants, data:) is denied.
+    static func isAllowedWebViewSubframeTransport(_ url: URL?) -> Bool {
+        isAllowedTransport(url) || isTurnstileRequiredSubframeDocument(url)
+    }
+
     static func normalizedBaseURL(_ value: String) throws -> String {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty,

--- a/Conduit/Services/DashboardTicketBridge.swift
+++ b/Conduit/Services/DashboardTicketBridge.swift
@@ -274,7 +274,6 @@ final class DashboardTicketBridge: NSObject {
         self.readinessPollInterval = readinessPollInterval
         self.requestDeadlineGraceMilliseconds = max(0, requestDeadlineGraceMilliseconds)
         let configuration = WKWebViewConfiguration()
-        WebViewUserAgent.apply(to: configuration)
         configuration.websiteDataStore = .default()
         if let script = cloudflareAccess?.fetchInjectionUserScript(expectedBaseURL: normalizedBaseURL), !script.isEmpty {
             configuration.userContentController.addUserScript(
@@ -682,12 +681,22 @@ extension DashboardTicketBridge: WKNavigationDelegate {
         decidePolicyFor navigationAction: WKNavigationAction,
         decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
     ) {
-        guard ConnectionURLPolicy.isAllowedTransport(navigationAction.request.url) else {
-            decisionHandler(.cancel)
+        // Subframe check must come BEFORE the main-frame transport guard:
+        // Turnstile's WebView requirements call for about:blank and
+        // about:srcdoc subframe documents, which plain HTTP(S) transport
+        // rules would reject. The allowance is confined to subframes —
+        // a top-level navigation attempt from such a document re-enters
+        // this delegate as a MAIN frame and still must match the dashboard
+        // origin below.
+        if let targetFrame = navigationAction.targetFrame, !targetFrame.isMainFrame {
+            decisionHandler(
+                ConnectionURLPolicy.isAllowedWebViewSubframeTransport(navigationAction.request.url)
+                    ? .allow : .cancel
+            )
             return
         }
-        if let targetFrame = navigationAction.targetFrame, !targetFrame.isMainFrame {
-            decisionHandler(.allow)
+        guard ConnectionURLPolicy.isAllowedTransport(navigationAction.request.url) else {
+            decisionHandler(.cancel)
             return
         }
         guard let expectedURL = URL(string: baseURL),

--- a/Conduit/Services/DashboardTicketBridge.swift
+++ b/Conduit/Services/DashboardTicketBridge.swift
@@ -274,6 +274,7 @@ final class DashboardTicketBridge: NSObject {
         self.readinessPollInterval = readinessPollInterval
         self.requestDeadlineGraceMilliseconds = max(0, requestDeadlineGraceMilliseconds)
         let configuration = WKWebViewConfiguration()
+        WebViewUserAgent.apply(to: configuration)
         configuration.websiteDataStore = .default()
         if let script = cloudflareAccess?.fetchInjectionUserScript(expectedBaseURL: normalizedBaseURL), !script.isEmpty {
             configuration.userContentController.addUserScript(

--- a/Conduit/Services/NativeAuthClient.swift
+++ b/Conduit/Services/NativeAuthClient.swift
@@ -107,12 +107,14 @@ struct NativeAuthClient {
         case 301, 302, 303, 307, 308:
             // The SecureRedirectDelegate cancels cross-origin redirects, so a
             // 3xx final response here is the edge bouncing us to its sign-in
-            // page. Without a token that is the expected interactive-auth
-            // signal (empty list → WebView fallback). With a configured
-            // service token it means Cloudflare rejected that token — say so
-            // instead of presenting the same login page that should have
-            // been bypassed.
-            if cloudflareAccess != nil,
+            // page. Without a configured token that is the expected
+            // interactive-auth signal (empty list → WebView fallback). With
+            // an actually configured service token it means Cloudflare
+            // rejected that token — say so instead of presenting the same
+            // login page that should have been bypassed. Match
+            // `applying(to:)`'s configuration state: a non-nil but empty
+            // credentials value sends no headers and must fall back too.
+            if cloudflareAccess?.isConfigured == true,
                Self.redirectsToCloudflareAccessLogin(http) {
                 throw AuthClientError.cloudflareServiceTokenRejected
             }

--- a/Conduit/Services/NativeAuthClient.swift
+++ b/Conduit/Services/NativeAuthClient.swift
@@ -21,6 +21,12 @@ enum AuthClientError: LocalizedError {
     case loginFailed(String)
     case ticketFailed(String)
     case providerDiscoveryFailed(String)
+    /// A configured Cloudflare Access service token did not satisfy the
+    /// edge: provider discovery was still answered with a redirect to the
+    /// Cloudflare Access login page. Distinct from `.loginFailed`/`.ticketFailed`
+    /// so the UI can point at the token configuration instead of silently
+    /// dropping the user into interactive Cloudflare sign-in.
+    case cloudflareServiceTokenRejected
 
     var errorDescription: String? {
         switch self {
@@ -32,6 +38,11 @@ enum AuthClientError: LocalizedError {
             return "Could not get session ticket: \(detail)"
         case .providerDiscoveryFailed(let detail):
             return "Could not check dashboard sign-in options: \(detail)"
+        case .cloudflareServiceTokenRejected:
+            return "Cloudflare Access did not accept the configured service token. "
+                + "Verify the Client ID / Secret and that the token is allowed by a "
+                + "Service Auth policy for this Access application, or turn off "
+                + "\"Use Cloudflare Access service token\" to sign in interactively."
         }
     }
 }
@@ -94,6 +105,17 @@ struct NativeAuthClient {
         }
         switch http.statusCode {
         case 301, 302, 303, 307, 308:
+            // The SecureRedirectDelegate cancels cross-origin redirects, so a
+            // 3xx final response here is the edge bouncing us to its sign-in
+            // page. Without a token that is the expected interactive-auth
+            // signal (empty list → WebView fallback). With a configured
+            // service token it means Cloudflare rejected that token — say so
+            // instead of presenting the same login page that should have
+            // been bypassed.
+            if cloudflareAccess != nil,
+               Self.redirectsToCloudflareAccessLogin(http) {
+                throw AuthClientError.cloudflareServiceTokenRejected
+            }
             return []
         default:
             break
@@ -245,6 +267,20 @@ struct NativeAuthClient {
         }, onCancel: {
             holder.cancel()
         })
+    }
+
+    /// True when the redirect's `Location` lands on a Cloudflare Access
+    /// login origin (`*.cloudflareaccess.com`). Only such redirects may
+    /// classify a configured token as rejected; redirects from other edges
+    /// or from the dashboard itself keep the existing WebView fallback.
+    /// A relative `Location` always resolves against the dashboard's own
+    /// origin (and same-origin redirects are followed by the delegate, never
+    /// reaching this classifier), so absolute-URL parsing alone is exact.
+    static func redirectsToCloudflareAccessLogin(_ response: HTTPURLResponse) -> Bool {
+        guard let location = response.value(forHTTPHeaderField: "Location"),
+              let url = URL(string: location),
+              let host = url.host?.lowercased() else { return false }
+        return host == "cloudflareaccess.com" || host.hasSuffix(".cloudflareaccess.com")
     }
 
     private func parseError(_ data: Data) -> String? {

--- a/Conduit/Views/LoginView.swift
+++ b/Conduit/Views/LoginView.swift
@@ -32,16 +32,10 @@ struct LoginView: View {
 
     var body: some View {
         ZStack {
+            // Purely decorative: the scroll content fills the screen, so
+            // keyboard dismissal is owned by scroll-dismiss, the keyboard
+            // Done button, and moving focus between fields.
             ConduitBackdrop()
-                .contentShape(Rectangle())
-                .onTapGesture {
-                    // Tapping the backdrop (outside any field or control) clears
-                    // focus so the keyboard dismisses and the Connect button is
-                    // reachable. The gesture lives on the background layer — not
-                    // the root — so it never competes with a text field's
-                    // first-responder touch (no two-tap-to-focus regression).
-                    focusedField = nil
-                }
 
             // The login form is a responsive scroll view inside a fixed
             // decorative layer: at compact iPhone heights with the keyboard
@@ -266,7 +260,7 @@ struct LoginView: View {
                         .frame(height: 50)
                 }
                 .foregroundStyle(.white)
-                .disabled(serverUrl.isEmpty || username.isEmpty || password.isEmpty || isConnecting)
+                .disabled(!connectInputsArePresent || isConnecting)
                 .conduitGlassControl(cornerRadius: 18, tint: .conduitAccent, prominent: true)
             }
             .padding(20)
@@ -278,6 +272,14 @@ struct LoginView: View {
                 .padding(.bottom, 16)
         }
         .padding(.horizontal, 24)
+    }
+
+    /// Trimmed-presence check so whitespace-only input is treated the same
+    /// by the Connect button and by connect()'s guard.
+    private var connectInputsArePresent: Bool {
+        !serverUrl.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !password.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     /// Return-key behavior shared by every field: walk the focus chain
@@ -401,6 +403,51 @@ enum LoginField: Hashable, CaseIterable {
     }
 }
 
+// MARK: - Auth WebView navigation policy
+
+/// The authentication WebView's navigation boundary, extracted so the rules
+/// are unit-testable without hosting a WKWebView.
+///
+/// Main frames follow the strict dashboard policy: allowed transport only,
+/// unpinned sign-in may traverse the legitimate Cloudflare/IdP redirect
+/// chain, and once the dashboard origin pins, top-level navigation cannot
+/// escape it. Subframes additionally accept the `about:blank` /
+/// `about:srcdoc` documents Cloudflare's Turnstile WebView requirements
+/// name. Those documents inherit the parent page's origin, so script inside
+/// them could attempt a top-level navigation — but any such attempt
+/// re-enters this policy as a MAIN frame navigation, so the allowance never
+/// moves the main-frame dashboard-origin boundary.
+enum AuthWebViewNavigationPolicy {
+    enum Decision: Equatable {
+        case allow
+        case cancel
+    }
+
+    static func decide(
+        url: URL?,
+        isMainFrame: Bool,
+        hasPinnedDashboardOrigin: Bool,
+        expectedDashboardURL: URL?
+    ) -> Decision {
+        if !isMainFrame {
+            return ConnectionURLPolicy.isAllowedWebViewSubframeTransport(url) ? .allow : .cancel
+        }
+        guard ConnectionURLPolicy.isAllowedTransport(url) else { return .cancel }
+        if !hasPinnedDashboardOrigin {
+            // Passwordless/OAuth providers legitimately use a short
+            // cross-origin redirect chain during sign-in. The ticket
+            // message remains origin-pinned below, and navigation locks
+            // to the dashboard as soon as the authenticated route loads.
+            return .allow
+        }
+        guard let expectedDashboardURL,
+              ConnectionURLPolicy.originMatches(url, expected: expectedDashboardURL) else {
+            return .cancel
+        }
+        return .allow
+    }
+}
+
 // MARK: - Auth WebView
 
 struct AuthWebView: UIViewRepresentable {
@@ -412,7 +459,6 @@ struct AuthWebView: UIViewRepresentable {
     func makeUIView(context: Context) -> WKWebView {
         let normalized = try? ConnectionURLPolicy.normalizedBaseURL(url)
         let config = WKWebViewConfiguration()
-        WebViewUserAgent.apply(to: config)
         config.websiteDataStore = .default()
         config.userContentController.add(context.coordinator, name: "ticket")
         if let normalized,
@@ -562,30 +608,20 @@ struct AuthWebView: UIViewRepresentable {
             decidePolicyFor navigationAction: WKNavigationAction,
             decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
         ) {
-            guard ConnectionURLPolicy.isAllowedTransport(navigationAction.request.url) else {
-                decisionHandler(.cancel)
-                return
-            }
-            // Subframes may host an identity provider, but every top-level
-            // navigation must stay on the configured dashboard origin.
-            if let targetFrame = navigationAction.targetFrame, !targetFrame.isMainFrame {
+            // A nil targetFrame is treated as main-frame, matching the
+            // historical policy for the initial navigation.
+            let isMainFrame = navigationAction.targetFrame?.isMainFrame ?? true
+            switch AuthWebViewNavigationPolicy.decide(
+                url: navigationAction.request.url,
+                isMainFrame: isMainFrame,
+                hasPinnedDashboardOrigin: hasPinnedDashboardOrigin,
+                expectedDashboardURL: expectedURL
+            ) {
+            case .allow:
                 decisionHandler(.allow)
-                return
-            }
-            if !hasPinnedDashboardOrigin {
-                // Passwordless/OAuth providers legitimately use a short
-                // cross-origin redirect chain during sign-in. The ticket
-                // message remains origin-pinned below, and navigation locks
-                // to the dashboard as soon as the authenticated route loads.
-                decisionHandler(.allow)
-                return
-            }
-            guard let expectedURL,
-                  ConnectionURLPolicy.originMatches(navigationAction.request.url, expected: expectedURL) else {
+            case .cancel:
                 decisionHandler(.cancel)
-                return
             }
-            decisionHandler(.allow)
         }
     }
 }

--- a/Conduit/Views/LoginView.swift
+++ b/Conduit/Views/LoginView.swift
@@ -65,8 +65,13 @@ struct LoginView: View {
                     .onChange(of: revealCloudflareSection) { _, requested in
                         guard requested else { return }
                         revealCloudflareSection = false
-                        withAnimation(.easeOut(duration: 0.25)) {
-                            proxy.scrollTo(LoginField.cloudflareClientID, anchor: .center)
+                        // Defer one runloop turn: the CF fields this scroll
+                        // targets are inserted in the same transaction, and
+                        // scrolling to not-yet-installed ids would no-op.
+                        DispatchQueue.main.async {
+                            withAnimation(.easeOut(duration: 0.25)) {
+                                proxy.scrollTo(LoginField.cloudflareClientID, anchor: .center)
+                            }
                         }
                     }
                 }
@@ -208,6 +213,13 @@ struct LoginView: View {
                         set: { enabled in
                             cloudflareEnabled = enabled
                             revealCloudflareSection = enabled
+                            // Turning the section off while typing in one of
+                            // its fields unmounts them mid-focus; drop focus
+                            // explicitly so the keyboard never dangles.
+                            if !enabled,
+                               focusedField == .cloudflareClientID || focusedField == .cloudflareClientSecret {
+                                focusedField = nil
+                            }
                         }
                     ))
                     .tint(.conduitAccent)
@@ -287,9 +299,10 @@ struct LoginView: View {
         guard !cleaned.isEmpty else { return }
         // The return-key chain can reach submit while an earlier field was
         // skipped (e.g. tapping straight into the Cloudflare Secret); land
-        // focus on the missing field instead of a raw remote 401.
+        // focus on the missing field instead of a raw remote 401. The
+        // password value itself is sent untrimmed.
         guard !username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-              !password.isEmpty else {
+              !password.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             error = "Enter your dashboard username and password."
             focusedField = username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? .username : .password
             return

--- a/Conduit/Views/LoginView.swift
+++ b/Conduit/Views/LoginView.swift
@@ -24,12 +24,11 @@ struct LoginView: View {
     @State private var isConnecting = false
     @State private var showWebView = false
     @State private var error: String?
+    /// Set only by the user's Cloudflare toggle (never by the onAppear
+    /// Keychain restore), so a returning saved-token user is not scrolled
+    /// away from the top of the form every time the login screen appears.
+    @State private var revealCloudflareSection = false
     @FocusState private var focusedField: LoginField?
-
-    private enum LoginField {
-        case server, username, password
-        case cloudflareClientID, cloudflareClientSecret
-    }
 
     var body: some View {
         ZStack {
@@ -44,143 +43,40 @@ struct LoginView: View {
                     focusedField = nil
                 }
 
-            VStack(spacing: 28) {
-                Spacer(minLength: 36)
-
-                VStack(spacing: 14) {
-                    Image(loginIconAssetName)
-                        .resizable()
-                        .scaledToFill()
-                        .frame(width: 96, height: 96)
-                        .clipShape(RoundedRectangle(cornerRadius: 25, style: .continuous))
-                        .overlay {
-                            RoundedRectangle(cornerRadius: 25, style: .continuous)
-                                .strokeBorder(Color.white.opacity(colorScheme == .dark ? 0.17 : 0.45), lineWidth: 1)
+            // The login form is a responsive scroll view inside a fixed
+            // decorative layer: at compact iPhone heights with the keyboard
+            // up, the focused field (including the optional Cloudflare fields
+            // near the bottom) scrolls into view instead of hiding behind the
+            // keyboard. minHeight keeps the centered layout when the content
+            // fits and only introduces scrolling when it cannot.
+            GeometryReader { geometry in
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        loginContent
+                            .frame(minHeight: geometry.size.height)
+                    }
+                    .scrollDismissesKeyboard(.interactively)
+                    .onChange(of: focusedField) { _, field in
+                        guard let field else { return }
+                        withAnimation(.easeOut(duration: 0.25)) {
+                            proxy.scrollTo(field, anchor: .center)
                         }
-
-                    VStack(spacing: 6) {
-                        Text("Conduit")
-                            .font(.system(size: 38, weight: .bold, design: .rounded))
-                        Text("A focused home for your Hermes work")
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
+                    }
+                    .onChange(of: revealCloudflareSection) { _, requested in
+                        guard requested else { return }
+                        revealCloudflareSection = false
+                        withAnimation(.easeOut(duration: 0.25)) {
+                            proxy.scrollTo(LoginField.cloudflareClientID, anchor: .center)
+                        }
                     }
                 }
-
-                Spacer()
-
-                VStack(alignment: .leading, spacing: 16) {
-                    Label("Connect a Hermes dashboard", systemImage: "link")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(.conduitAccent)
-
-                    TextField("https://hermes.example", text: $serverUrl)
-                        .textContentType(.URL)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
-                        .keyboardType(.URL)
-                        .focused($focusedField, equals: .server)
-                        .padding(.horizontal, 14)
-                        .frame(height: 50)
-                        .conduitGlassSurface(cornerRadius: 17, tint: .conduitAura.opacity(0.06))
-
-                    TextField("Username", text: $username)
-                        .textContentType(.username)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
-                        .submitLabel(.next)
-                        .focused($focusedField, equals: .username)
-                        .onSubmit { focusedField = .password }
-                        .padding(.horizontal, 14)
-                        .frame(height: 50)
-                        .conduitGlassSurface(cornerRadius: 17, tint: .conduitAura.opacity(0.06))
-
-                    SecureField("Password", text: $password)
-                        .textContentType(.password)
-                        .submitLabel(.go)
-                        .focused($focusedField, equals: .password)
-                        .onSubmit { Task { await connect() } }
-                        .padding(.horizontal, 14)
-                        .frame(height: 50)
-                        .conduitGlassSurface(cornerRadius: 17, tint: .conduitAura.opacity(0.06))
-
-                    VStack(alignment: .leading, spacing: 10) {
-                        Toggle("Save credentials", isOn: $saveCredentials)
-                            .tint(.conduitAccent)
-                            .onChange(of: saveCredentials) { _, savesCredentials in
-                                if !savesCredentials { useFaceID = false }
-                            }
-
-                        Toggle("Use Face ID", isOn: $useFaceID)
-                            .tint(.conduitAccent)
-                            .disabled(!saveCredentials || !BiometricAuth.isFaceIDAvailable)
-
-                        if !BiometricAuth.isFaceIDAvailable {
-                            Text("Face ID is not available on this device. You can still save credentials.")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        } else if saveCredentials {
-                            Text(useFaceID
-                                ? "Face ID, with device passcode recovery, is required on launch."
-                                : "Saved credentials reconnect without a Face ID prompt.")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                    .padding(.horizontal, 2)
-
-                    VStack(alignment: .leading, spacing: 10) {
-                        Toggle("Use Cloudflare Access service token", isOn: $cloudflareEnabled)
-                            .tint(.conduitAccent)
-                        if cloudflareEnabled {
-                            TextField("Cloudflare Client ID", text: $cloudflareClientID)
-                                .textInputAutocapitalization(.never).autocorrectionDisabled()
-                                .focused($focusedField, equals: .cloudflareClientID)
-                                .padding(.horizontal, 14).frame(height: 50)
-                                .conduitGlassSurface(cornerRadius: 17, tint: .conduitAura.opacity(0.06))
-                            SecureField("Cloudflare Client Secret", text: $cloudflareClientSecret)
-                                .focused($focusedField, equals: .cloudflareClientSecret)
-                                .padding(.horizontal, 14).frame(height: 50)
-                                .conduitGlassSurface(cornerRadius: 17, tint: .conduitAura.opacity(0.06))
-                            Text("Used only to reach this Cloudflare-protected dashboard; the secret stays in Keychain.")
-                                .font(.caption).foregroundStyle(.secondary)
-                        }
-                    }
-                    .padding(.horizontal, 2)
-                    if let error {
-                        HStack(alignment: .top, spacing: 8) {
-                            Image(systemName: "exclamationmark.triangle.fill")
-                                .font(.footnote)
-                            Text(error)
-                                .font(.footnote)
-                                .multilineTextAlignment(.leading)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
-                        .foregroundStyle(.red)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-
-                    Button {
-                        Task { await connect() }
-                    } label: {
-                        Label(isConnecting ? "Connecting..." : "Connect", systemImage: "arrow.right")
-                            .font(.headline)
-                            .frame(maxWidth: .infinity)
-                            .frame(height: 50)
-                    }
-                    .foregroundStyle(.white)
-                    .disabled(serverUrl.isEmpty || username.isEmpty || password.isEmpty || isConnecting)
-                    .conduitGlassControl(cornerRadius: 18, tint: .conduitAccent, prominent: true)
-                }
-                .padding(20)
-                .conduitGlassSurface(cornerRadius: 28, tint: .conduitAccent.opacity(0.07))
-
-                Text("Your credentials stay on this device when you choose to save them.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .padding(.bottom, 16)
             }
-            .padding(.horizontal, 24)
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
+                Button("Done") { focusedField = nil }
+            }
         }
         .onAppear {
             guard serverUrl.isEmpty else { return }
@@ -215,9 +111,189 @@ struct LoginView: View {
         }
     }
 
+    private var loginContent: some View {
+        VStack(spacing: 28) {
+            Spacer(minLength: 36)
+
+            VStack(spacing: 14) {
+                Image(loginIconAssetName)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 96, height: 96)
+                    .clipShape(RoundedRectangle(cornerRadius: 25, style: .continuous))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 25, style: .continuous)
+                            .strokeBorder(Color.white.opacity(colorScheme == .dark ? 0.17 : 0.45), lineWidth: 1)
+                    }
+
+                VStack(spacing: 6) {
+                    Text("Conduit")
+                        .font(.system(size: 38, weight: .bold, design: .rounded))
+                    Text("A focused home for your Hermes work")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+
+            VStack(alignment: .leading, spacing: 16) {
+                Label("Connect a Hermes dashboard", systemImage: "link")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.conduitAccent)
+
+                TextField("https://hermes.example", text: $serverUrl)
+                    .textContentType(.URL)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .keyboardType(.URL)
+                    .focused($focusedField, equals: .server)
+                    .submitLabel(LoginField.server.submitKeyboardLabel(cloudflareTokenEntryEnabled: cloudflareEnabled))
+                    .onSubmit { handleSubmit(from: .server) }
+                    .padding(.horizontal, 14)
+                    .frame(height: 50)
+                    .conduitGlassSurface(cornerRadius: 17, tint: .conduitAura.opacity(0.06))
+                    .id(LoginField.server)
+
+                TextField("Username", text: $username)
+                    .textContentType(.username)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .submitLabel(LoginField.username.submitKeyboardLabel(cloudflareTokenEntryEnabled: cloudflareEnabled))
+                    .focused($focusedField, equals: .username)
+                    .onSubmit { handleSubmit(from: .username) }
+                    .padding(.horizontal, 14)
+                    .frame(height: 50)
+                    .conduitGlassSurface(cornerRadius: 17, tint: .conduitAura.opacity(0.06))
+                    .id(LoginField.username)
+
+                SecureField("Password", text: $password)
+                    .textContentType(.password)
+                    .submitLabel(LoginField.password.submitKeyboardLabel(cloudflareTokenEntryEnabled: cloudflareEnabled))
+                    .focused($focusedField, equals: .password)
+                    .onSubmit { handleSubmit(from: .password) }
+                    .padding(.horizontal, 14)
+                    .frame(height: 50)
+                    .conduitGlassSurface(cornerRadius: 17, tint: .conduitAura.opacity(0.06))
+                    .id(LoginField.password)
+
+                VStack(alignment: .leading, spacing: 10) {
+                    Toggle("Save credentials", isOn: $saveCredentials)
+                        .tint(.conduitAccent)
+                        .onChange(of: saveCredentials) { _, savesCredentials in
+                            if !savesCredentials { useFaceID = false }
+                        }
+
+                    Toggle("Use Face ID", isOn: $useFaceID)
+                        .tint(.conduitAccent)
+                        .disabled(!saveCredentials || !BiometricAuth.isFaceIDAvailable)
+
+                    if !BiometricAuth.isFaceIDAvailable {
+                        Text("Face ID is not available on this device. You can still save credentials.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else if saveCredentials {
+                        Text(useFaceID
+                            ? "Face ID, with device passcode recovery, is required on launch."
+                            : "Saved credentials reconnect without a Face ID prompt.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.horizontal, 2)
+
+                VStack(alignment: .leading, spacing: 10) {
+                    Toggle("Use Cloudflare Access service token", isOn: Binding(
+                        get: { cloudflareEnabled },
+                        set: { enabled in
+                            cloudflareEnabled = enabled
+                            revealCloudflareSection = enabled
+                        }
+                    ))
+                    .tint(.conduitAccent)
+                    if cloudflareEnabled {
+                        TextField("Cloudflare Client ID", text: $cloudflareClientID)
+                            .textInputAutocapitalization(.never).autocorrectionDisabled()
+                            .focused($focusedField, equals: .cloudflareClientID)
+                            .submitLabel(LoginField.cloudflareClientID.submitKeyboardLabel(cloudflareTokenEntryEnabled: cloudflareEnabled))
+                            .onSubmit { handleSubmit(from: .cloudflareClientID) }
+                            .padding(.horizontal, 14).frame(height: 50)
+                            .conduitGlassSurface(cornerRadius: 17, tint: .conduitAura.opacity(0.06))
+                            .id(LoginField.cloudflareClientID)
+                        SecureField("Cloudflare Client Secret", text: $cloudflareClientSecret)
+                            .focused($focusedField, equals: .cloudflareClientSecret)
+                            .submitLabel(LoginField.cloudflareClientSecret.submitKeyboardLabel(cloudflareTokenEntryEnabled: cloudflareEnabled))
+                            .onSubmit { handleSubmit(from: .cloudflareClientSecret) }
+                            .padding(.horizontal, 14).frame(height: 50)
+                            .conduitGlassSurface(cornerRadius: 17, tint: .conduitAura.opacity(0.06))
+                            .id(LoginField.cloudflareClientSecret)
+                        Text("Used only to reach this Cloudflare-protected dashboard; the secret stays in Keychain.")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.horizontal, 2)
+                if let error {
+                    HStack(alignment: .top, spacing: 8) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.footnote)
+                        Text(error)
+                            .font(.footnote)
+                            .multilineTextAlignment(.leading)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .foregroundStyle(.red)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                Button {
+                    Task { await connect() }
+                } label: {
+                    Label(isConnecting ? "Connecting..." : "Connect", systemImage: "arrow.right")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 50)
+                }
+                .foregroundStyle(.white)
+                .disabled(serverUrl.isEmpty || username.isEmpty || password.isEmpty || isConnecting)
+                .conduitGlassControl(cornerRadius: 18, tint: .conduitAccent, prominent: true)
+            }
+            .padding(20)
+            .conduitGlassSurface(cornerRadius: 28, tint: .conduitAccent.opacity(0.07))
+
+            Text("Your credentials stay on this device when you choose to save them.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.bottom, 16)
+        }
+        .padding(.horizontal, 24)
+    }
+
+    /// Return-key behavior shared by every field: walk the focus chain
+    /// (server → username → password → Cloudflare Client ID → Client Secret)
+    /// and only submit when the focused field ends the chain. While the
+    /// Cloudflare token entry is on, the password field hands focus to the
+    /// Cloudflare Client ID instead of triggering Connect.
+    private func handleSubmit(from field: LoginField) {
+        if let destination = field.submitDestination(cloudflareTokenEntryEnabled: cloudflareEnabled) {
+            focusedField = destination
+        } else {
+            Task { await connect() }
+        }
+    }
+
+    @MainActor
     private func connect() async {
         let cleaned = serverUrl.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !cleaned.isEmpty else { return }
+        // The return-key chain can reach submit while an earlier field was
+        // skipped (e.g. tapping straight into the Cloudflare Secret); land
+        // focus on the missing field instead of a raw remote 401.
+        guard !username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !password.isEmpty else {
+            error = "Enter your dashboard username and password."
+            focusedField = username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? .username : .password
+            return
+        }
         guard let normalized = try? ConnectionURLPolicy.normalizedBaseURL(cleaned) else {
             error = ConnectionURLPolicyError.insecureTransport.localizedDescription
             return
@@ -276,6 +352,42 @@ struct LoginView: View {
     }
 }
 
+// MARK: - Login field focus chain
+
+/// The login form's focusable fields, in tab order. Internal (not nested in
+/// `LoginView`) so the return-key/focus-chain rules are unit-testable without
+/// hosting the view.
+enum LoginField: Hashable, CaseIterable {
+    case server, username, password
+    case cloudflareClientID, cloudflareClientSecret
+
+    /// The field the return key should move focus to, or `nil` when return on
+    /// this field submits (Connect) instead. While Cloudflare token entry is
+    /// enabled, the password field hands focus to the Cloudflare Client ID
+    /// rather than triggering Connect, so finishing the dashboard password
+    /// can never accidentally submit half-entered Cloudflare credentials.
+    func submitDestination(cloudflareTokenEntryEnabled: Bool) -> LoginField? {
+        switch self {
+        case .server: return .username
+        case .username: return .password
+        case .password: return cloudflareTokenEntryEnabled ? .cloudflareClientID : nil
+        case .cloudflareClientID: return .cloudflareClientSecret
+        case .cloudflareClientSecret: return nil
+        }
+    }
+
+    /// Whether return on this field submits (Connect) instead of advancing
+    /// focus. Exposed separately from the keyboard label so the decision
+    /// stays unit-testable (SubmitLabel is not Equatable).
+    func submits(cloudflareTokenEntryEnabled: Bool) -> Bool {
+        submitDestination(cloudflareTokenEntryEnabled: cloudflareTokenEntryEnabled) == nil
+    }
+
+    func submitKeyboardLabel(cloudflareTokenEntryEnabled: Bool) -> SubmitLabel {
+        submits(cloudflareTokenEntryEnabled: cloudflareTokenEntryEnabled) ? .go : .next
+    }
+}
+
 // MARK: - Auth WebView
 
 struct AuthWebView: UIViewRepresentable {
@@ -287,6 +399,7 @@ struct AuthWebView: UIViewRepresentable {
     func makeUIView(context: Context) -> WKWebView {
         let normalized = try? ConnectionURLPolicy.normalizedBaseURL(url)
         let config = WKWebViewConfiguration()
+        WebViewUserAgent.apply(to: config)
         config.websiteDataStore = .default()
         config.userContentController.add(context.coordinator, name: "ticket")
         if let normalized,
@@ -298,15 +411,32 @@ struct AuthWebView: UIViewRepresentable {
         }
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
-        guard let normalized, let dashboardURL = URL(string: normalized) else {
+        guard let normalized else {
             onError(ConnectionURLPolicyError.invalidURL.localizedDescription)
             return webView
+        }
+        if let request = try? Self.dashboardRequest(normalizedBaseURL: normalized, cloudflareAccess: cloudflareAccess) {
+            webView.load(request)
+        } else {
+            onError(ConnectionURLPolicyError.invalidURL.localizedDescription)
+        }
+        return webView
+    }
+
+    /// The dashboard sign-in request the WebView boots with. Extracted so the
+    /// service-token header placement on the initial request stays covered by
+    /// unit tests without hosting a WKWebView.
+    static func dashboardRequest(
+        normalizedBaseURL: String,
+        cloudflareAccess: CloudflareAccessCredentials?
+    ) throws -> URLRequest {
+        guard let dashboardURL = URL(string: normalizedBaseURL) else {
+            throw ConnectionURLPolicyError.invalidURL
         }
         let loginURL = dashboardURL.appending(path: "login")
         var request = URLRequest(url: loginURL)
         request = cloudflareAccess?.applying(to: request) ?? request
-        webView.load(request)
-        return webView
+        return request
     }
 
     func updateUIView(_ uiView: WKWebView, context: Context) {}

--- a/Conduit/Views/LoginView.swift
+++ b/Conduit/Views/LoginView.swift
@@ -277,7 +277,13 @@ struct LoginView: View {
     /// Trimmed-presence check so whitespace-only input is treated the same
     /// by the Connect button and by connect()'s guard.
     private var connectInputsArePresent: Bool {
-        !serverUrl.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        Self.hasConnectableInput(serverURL: serverUrl, username: username, password: password)
+    }
+
+    /// Static seam for the trimmed-presence rule so the validation contract
+    /// is unit-testable without hosting the view.
+    static func hasConnectableInput(serverURL: String, username: String, password: String) -> Bool {
+        !serverURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             && !username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             && !password.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
@@ -298,7 +304,15 @@ struct LoginView: View {
     @MainActor
     private func connect() async {
         let cleaned = serverUrl.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !cleaned.isEmpty else { return }
+        guard !cleaned.isEmpty else {
+            // The return-key chain can reach submit without the Connect
+            // button ever being enabled (e.g. a whitespace-only URL).
+            // Surface the standard invalid-URL feedback instead of a silent
+            // no-op.
+            error = ConnectionURLPolicyError.invalidURL.localizedDescription
+            focusedField = .server
+            return
+        }
         // The return-key chain can reach submit while an earlier field was
         // skipped (e.g. tapping straight into the Cloudflare Secret); land
         // focus on the missing field instead of a raw remote 401. The

--- a/ConduitTests/AuthWebViewNavigationPolicyTests.swift
+++ b/ConduitTests/AuthWebViewNavigationPolicyTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import XCTest
+@testable import Conduit
+
+/// Boundary coverage for the authentication WebView's navigation policy
+/// (issue #117). Main-frame rules preserve the dashboard-origin boundary —
+/// unpinned sign-in may traverse the legitimate Cloudflare/IdP redirect
+/// chain, pinned navigation cannot escape the dashboard origin. Subframes
+/// additionally accept the `about:blank` / `about:srcdoc` documents
+/// Cloudflare's Turnstile WebView requirements name; the tests below pin
+/// that this allowance cannot be escalated to a main-frame escape or to
+/// arbitrary schemes.
+final class AuthWebViewNavigationPolicyTests: XCTestCase {
+    private let dashboard = URL(string: "https://hermes.example")!
+
+    private func decide(
+        _ url: URL?,
+        mainFrame: Bool,
+        pinned: Bool = false,
+        expected: URL? = nil
+    ) -> AuthWebViewNavigationPolicy.Decision {
+        AuthWebViewNavigationPolicy.decide(
+            url: url,
+            isMainFrame: mainFrame,
+            hasPinnedDashboardOrigin: pinned,
+            expectedDashboardURL: expected ?? dashboard
+        )
+    }
+
+    // MARK: - Subframes (Turnstile / identity-provider operation)
+
+    func testSubframeAboutBlankAndSrcdocAreAllowedForTurnstile() throws {
+        XCTAssertEqual(
+            decide(URL(string: "about:blank"), mainFrame: false),
+            .allow,
+            "Turnstile's WebView requirements call for about:blank subframe documents"
+        )
+        XCTAssertEqual(
+            decide(URL(string: "about:srcdoc"), mainFrame: false),
+            .allow,
+            "Turnstile's WebView requirements call for about:srcdoc subframe documents"
+        )
+    }
+
+    func testSubframeHTTPSRemainsAllowedForIdentityProvidersAndChallenges() {
+        XCTAssertEqual(decide(URL(string: "https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/b/orchestrate/encrypted/v1"), mainFrame: false), .allow)
+        XCTAssertEqual(decide(URL(string: "https://accounts.google.com/o/oauth2/auth"), mainFrame: false), .allow)
+    }
+
+    func testSubframeArbitrarySchemesAndAboutVariantsRemainDenied() {
+        XCTAssertEqual(decide(URL(string: "about:config"), mainFrame: false), .cancel)
+        XCTAssertEqual(decide(URL(string: "ftp://challenges.cloudflare.com/x"), mainFrame: false), .cancel)
+        XCTAssertEqual(decide(URL(string: "conduit-probe://attacker"), mainFrame: false), .cancel)
+        XCTAssertEqual(decide(URL(string: "data:text/html,<script>alert(1)</script>"), mainFrame: false), .cancel)
+        XCTAssertEqual(decide(nil, mainFrame: false), .cancel)
+    }
+
+    func testSubframeAllowanceIsIndependentOfDashboardPin() {
+        // Turnstile documents must keep loading inside authenticated
+        // dashboard pages too; the pin only governs MAIN frames.
+        XCTAssertEqual(decide(URL(string: "about:blank"), mainFrame: false, pinned: true), .allow)
+        XCTAssertEqual(decide(URL(string: "about:srcdoc"), mainFrame: false, pinned: true), .allow)
+    }
+
+    // MARK: - Main frames before origin pinning
+
+    func testUnpinnedMainFrameHTTPSAuthChainRemainsAllowed() {
+        XCTAssertEqual(decide(URL(string: "https://hermes.example/login"), mainFrame: true), .allow)
+        XCTAssertEqual(decide(URL(string: "https://tenant.cloudflareaccess.com/cdn-cgi/access/login/hermes.example"), mainFrame: true), .allow)
+        XCTAssertEqual(decide(URL(string: "https://accounts.google.com/o/oauth2/auth"), mainFrame: true), .allow)
+    }
+
+    func testUnpinnedMainFrameInsecureAndMalformedTransportsRemainBlocked() {
+        XCTAssertEqual(decide(URL(string: "http://untrusted.example/login"), mainFrame: true), .cancel)
+        XCTAssertEqual(decide(URL(string: "https://user:pass@hermes.example/login"), mainFrame: true), .cancel)
+        XCTAssertEqual(decide(URL(string: "about:blank"), mainFrame: true), .cancel, "about: allowance is subframe-only")
+        XCTAssertEqual(decide(URL(string: "about:srcdoc"), mainFrame: true), .cancel, "about: allowance is subframe-only")
+        XCTAssertEqual(decide(nil, mainFrame: true), .cancel)
+    }
+
+    func testUnpinnedMainFrameLocalHTTPRemainsAllowed() {
+        // Existing rule: HTTP only for loopback/private LAN/Tailscale hosts.
+        XCTAssertEqual(decide(URL(string: "http://192.168.1.200:9119/login"), mainFrame: true), .allow)
+    }
+
+    // MARK: - Main frames after origin pinning
+
+    func testPinnedMainFrameStaysBoundToDashboardOrigin() {
+        XCTAssertEqual(decide(URL(string: "https://hermes.example/api/status"), mainFrame: true, pinned: true), .allow)
+        XCTAssertEqual(decide(URL(string: "https://hermes.example/login"), mainFrame: true, pinned: true), .allow)
+        XCTAssertEqual(decide(URL(string: "https://tenant.cloudflareaccess.com/cdn-cgi/access/login"), mainFrame: true, pinned: true), .cancel)
+        XCTAssertEqual(decide(URL(string: "https://accounts.google.com/signin"), mainFrame: true, pinned: true), .cancel)
+        XCTAssertEqual(decide(URL(string: "https://hermes.example.evil.example/login"), mainFrame: true, pinned: true), .cancel)
+    }
+
+    func testPinnedMainFrameCannotEscapeViaAboutDocuments() {
+        XCTAssertEqual(
+            decide(URL(string: "about:blank"), mainFrame: true, pinned: true),
+            .cancel,
+            "The Turnstile subframe allowance must not open a main-frame escape hatch"
+        )
+        XCTAssertEqual(decide(URL(string: "about:srcdoc"), mainFrame: true, pinned: true), .cancel)
+    }
+
+    func testPinnedMainFrameWithUnknownExpectedOriginFailsClosed() {
+        // Call the policy directly: the test helper's default substitutes
+        // the dashboard origin, and this case must exercise a genuinely
+        // absent expectation.
+        XCTAssertEqual(
+            AuthWebViewNavigationPolicy.decide(
+                url: URL(string: "https://hermes.example/login"),
+                isMainFrame: true,
+                hasPinnedDashboardOrigin: true,
+                expectedDashboardURL: nil
+            ),
+            .cancel
+        )
+    }
+
+    // MARK: - Subframe transport helper (shared with DashboardTicketBridge)
+
+    func testSubframeTransportHelperClassification() {
+        XCTAssertTrue(ConnectionURLPolicy.isAllowedWebViewSubframeTransport(URL(string: "about:blank")))
+        XCTAssertTrue(ConnectionURLPolicy.isAllowedWebViewSubframeTransport(URL(string: "about:srcdoc")))
+        XCTAssertTrue(ConnectionURLPolicy.isAllowedWebViewSubframeTransport(URL(string: "https://challenges.cloudflare.com/x")))
+        XCTAssertFalse(ConnectionURLPolicy.isAllowedWebViewSubframeTransport(URL(string: "about:other")))
+        XCTAssertFalse(ConnectionURLPolicy.isAllowedWebViewSubframeTransport(URL(string: "conduit-probe://attacker")))
+        XCTAssertFalse(ConnectionURLPolicy.isAllowedWebViewSubframeTransport(nil))
+        // Case-insensitivity of the about: document tail.
+        XCTAssertTrue(ConnectionURLPolicy.isTurnstileRequiredSubframeDocument(URL(string: "ABOUT:BLANK")))
+        XCTAssertFalse(ConnectionURLPolicy.isTurnstileRequiredSubframeDocument(URL(string: "https://blank.example")))
+        // The classifier is an exact-tail match and fails closed on every
+        // near-miss; these pins keep a future parser refactor from silently
+        // loosening the contract.
+        XCTAssertFalse(ConnectionURLPolicy.isTurnstileRequiredSubframeDocument(URL(string: "about://blank")))
+        XCTAssertFalse(ConnectionURLPolicy.isTurnstileRequiredSubframeDocument(URL(string: "about:blank?x=1")))
+        XCTAssertFalse(ConnectionURLPolicy.isTurnstileRequiredSubframeDocument(URL(string: "about:blank#frag")))
+        XCTAssertFalse(ConnectionURLPolicy.isTurnstileRequiredSubframeDocument(URL(string: "about:blank/extra")))
+        XCTAssertFalse(ConnectionURLPolicy.isTurnstileRequiredSubframeDocument(URL(string: "about:blank.evil.example")))
+        XCTAssertFalse(ConnectionURLPolicy.isTurnstileRequiredSubframeDocument(URL(string: "about:srcdoc.evil.example")))
+        XCTAssertFalse(ConnectionURLPolicy.isTurnstileRequiredSubframeDocument(URL(string: "about:%62lank")))
+        XCTAssertFalse(ConnectionURLPolicy.isTurnstileRequiredSubframeDocument(URL(string: "https://hermes.example/?about:blank")))
+        XCTAssertFalse(ConnectionURLPolicy.isTurnstileRequiredSubframeDocument(URL(string: "xabout:blank")))
+    }
+}

--- a/ConduitTests/CloudflareAccessTests.swift
+++ b/ConduitTests/CloudflareAccessTests.swift
@@ -1,6 +1,5 @@
 import Foundation
 import JavaScriptCore
-import WebKit
 import XCTest
 @testable import Conduit
 
@@ -55,33 +54,6 @@ final class CloudflareAccessTests: XCTestCase {
     func testIncompleteConfigurationIsAbsent() {
         XCTAssertNil(CloudflareAccessCredentials.from(clientID: "client-id", clientSecret: ""))
         XCTAssertNil(CloudflareAccessCredentials.from(clientID: "", clientSecret: "secret"))
-    }
-
-    // MARK: - WebView User Agent (issue #117 interactive verification)
-
-    func testUserAgentSuffixCarriesSafariVerificationTokens() {
-        let suffix = WebViewUserAgent.safariCompatibilitySuffix()
-        XCTAssertTrue(suffix.contains("Safari/604.1"), "Cloudflare's challenge scores a UA without the Safari token as automation: \(suffix)")
-        XCTAssertTrue(suffix.hasPrefix("Version/"), "Safari's Version token must be present: \(suffix)")
-        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
-        XCTAssertTrue(
-            suffix.contains("Version/\(osVersion.majorVersion).\(osVersion.minorVersion)"),
-            "Version token should track the current OS: \(suffix)"
-        )
-        // Real Safari UAs never carry the OS patch level in the Version
-        // token; emitting one would fingerprint the UA as synthetic.
-        if osVersion.patchVersion > 0 {
-            XCTAssertFalse(
-                suffix.contains("Version/\(osVersion.majorVersion).\(osVersion.minorVersion)."),
-                "Version token must be major.minor only: \(suffix)"
-            )
-        }
-    }
-
-    func testUserAgentApplyTargetsConfigurationBeforeFirstLoad() {
-        let configuration = WKWebViewConfiguration()
-        WebViewUserAgent.apply(to: configuration)
-        XCTAssertEqual(configuration.applicationNameForUserAgent, WebViewUserAgent.safariCompatibilitySuffix())
     }
 
     // MARK: - Auth WebView initial request construction

--- a/ConduitTests/CloudflareAccessTests.swift
+++ b/ConduitTests/CloudflareAccessTests.swift
@@ -68,6 +68,14 @@ final class CloudflareAccessTests: XCTestCase {
             suffix.contains("Version/\(osVersion.majorVersion).\(osVersion.minorVersion)"),
             "Version token should track the current OS: \(suffix)"
         )
+        // Real Safari UAs never carry the OS patch level in the Version
+        // token; emitting one would fingerprint the UA as synthetic.
+        if osVersion.patchVersion > 0 {
+            XCTAssertFalse(
+                suffix.contains("Version/\(osVersion.majorVersion).\(osVersion.minorVersion)."),
+                "Version token must be major.minor only: \(suffix)"
+            )
+        }
     }
 
     func testUserAgentApplyTargetsConfigurationBeforeFirstLoad() {

--- a/ConduitTests/CloudflareAccessTests.swift
+++ b/ConduitTests/CloudflareAccessTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import JavaScriptCore
+import WebKit
 import XCTest
 @testable import Conduit
 
@@ -54,6 +55,47 @@ final class CloudflareAccessTests: XCTestCase {
     func testIncompleteConfigurationIsAbsent() {
         XCTAssertNil(CloudflareAccessCredentials.from(clientID: "client-id", clientSecret: ""))
         XCTAssertNil(CloudflareAccessCredentials.from(clientID: "", clientSecret: "secret"))
+    }
+
+    // MARK: - WebView User Agent (issue #117 interactive verification)
+
+    func testUserAgentSuffixCarriesSafariVerificationTokens() {
+        let suffix = WebViewUserAgent.safariCompatibilitySuffix()
+        XCTAssertTrue(suffix.contains("Safari/604.1"), "Cloudflare's challenge scores a UA without the Safari token as automation: \(suffix)")
+        XCTAssertTrue(suffix.hasPrefix("Version/"), "Safari's Version token must be present: \(suffix)")
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+        XCTAssertTrue(
+            suffix.contains("Version/\(osVersion.majorVersion).\(osVersion.minorVersion)"),
+            "Version token should track the current OS: \(suffix)"
+        )
+    }
+
+    func testUserAgentApplyTargetsConfigurationBeforeFirstLoad() {
+        let configuration = WKWebViewConfiguration()
+        WebViewUserAgent.apply(to: configuration)
+        XCTAssertEqual(configuration.applicationNameForUserAgent, WebViewUserAgent.safariCompatibilitySuffix())
+    }
+
+    // MARK: - Auth WebView initial request construction
+
+    func testAuthWebViewInitialDashboardRequestCarriesServiceTokenHeaders() throws {
+        let request = try AuthWebView.dashboardRequest(
+            normalizedBaseURL: "https://hermes.example",
+            cloudflareAccess: CloudflareAccessCredentials(clientID: "web-id", clientSecret: "web-secret")
+        )
+        XCTAssertEqual(request.url?.absoluteString, "https://hermes.example/login")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "CF-Access-Client-Id"), "web-id")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "CF-Access-Client-Secret"), "web-secret")
+    }
+
+    func testAuthWebViewInitialDashboardRequestWithoutTokenStaysUnauthenticated() throws {
+        let request = try AuthWebView.dashboardRequest(
+            normalizedBaseURL: "https://hermes.example",
+            cloudflareAccess: nil
+        )
+        XCTAssertEqual(request.url?.absoluteString, "https://hermes.example/login")
+        XCTAssertNil(request.value(forHTTPHeaderField: "CF-Access-Client-Id"))
+        XCTAssertNil(request.value(forHTTPHeaderField: "CF-Access-Client-Secret"))
     }
 
     // MARK: - Fetch Injection Script

--- a/ConduitTests/CloudflareAccessTests.swift
+++ b/ConduitTests/CloudflareAccessTests.swift
@@ -17,6 +17,30 @@ final class CloudflareAccessTests: XCTestCase {
         XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
     }
 
+    func testCleartextHTTPRequestNeverReceivesAccessHeaders() throws {
+        // Trusted-LAN plain HTTP stays supported for ordinary Hermes
+        // connectivity, but the long-lived Cloudflare credentials must never
+        // ride it.
+        let credentials = CloudflareAccessCredentials(clientID: "client-id", clientSecret: "client-secret")
+        for urlString in ["http://192.168.1.20:9119/api/status", "http://localhost:9119/api/auth/providers"] {
+            let request = credentials.applying(to: URLRequest(url: try XCTUnwrap(URL(string: urlString))))
+            XCTAssertNil(request.value(forHTTPHeaderField: "CF-Access-Client-Id"), urlString)
+            XCTAssertNil(request.value(forHTTPHeaderField: "CF-Access-Client-Secret"), urlString)
+        }
+    }
+
+    func testWebSocketUpgradesCarryTokenOnlyOverWSS() throws {
+        let credentials = CloudflareAccessCredentials(clientID: "ws-id", clientSecret: "ws-secret")
+        // HermesClient derives wss/ws from the dashboard scheme before
+        // applying credentials, so the secure transform is what matters.
+        let secure = credentials.applying(to: URLRequest(url: try XCTUnwrap(URL(string: "wss://hermes.example/api/ws?ticket=t"))))
+        XCTAssertEqual(secure.value(forHTTPHeaderField: "CF-Access-Client-Id"), "ws-id")
+        XCTAssertEqual(secure.value(forHTTPHeaderField: "CF-Access-Client-Secret"), "ws-secret")
+        let cleartext = credentials.applying(to: URLRequest(url: try XCTUnwrap(URL(string: "ws://192.168.1.20:9119/api/ws?ticket=t"))))
+        XCTAssertNil(cleartext.value(forHTTPHeaderField: "CF-Access-Client-Id"))
+        XCTAssertNil(cleartext.value(forHTTPHeaderField: "CF-Access-Client-Secret"))
+    }
+
     func testDisabledRetainedFieldsDoNotAdmitCredentialsOrHeaders() throws {
         // LoginView uses @State which SwiftUI manages outside of view
         // lifecycle. Test the factory directly instead.
@@ -76,6 +100,25 @@ final class CloudflareAccessTests: XCTestCase {
         XCTAssertEqual(request.url?.absoluteString, "https://hermes.example/login")
         XCTAssertNil(request.value(forHTTPHeaderField: "CF-Access-Client-Id"))
         XCTAssertNil(request.value(forHTTPHeaderField: "CF-Access-Client-Secret"))
+    }
+
+    func testAuthWebViewInitialRequestOverPlainHTTPOmitsServiceToken() throws {
+        let request = try AuthWebView.dashboardRequest(
+            normalizedBaseURL: "http://192.168.1.20",
+            cloudflareAccess: CloudflareAccessCredentials(clientID: "web-id", clientSecret: "web-secret")
+        )
+        XCTAssertEqual(request.url?.absoluteString, "http://192.168.1.20/login")
+        XCTAssertNil(request.value(forHTTPHeaderField: "CF-Access-Client-Id"), "Initial WebView requests over cleartext HTTP must not carry the service token")
+        XCTAssertNil(request.value(forHTTPHeaderField: "CF-Access-Client-Secret"))
+    }
+
+    // MARK: - Fetch injection HTTPS-only invariant
+
+    func testFetchInjectionIsEmptyForPlainHTTPOrigin() {
+        let credentials = CloudflareAccessCredentials(clientID: "http-id", clientSecret: "http-secret")
+        let script = credentials.fetchInjectionUserScript(expectedBaseURL: "http://192.168.1.20:9119")
+        XCTAssertEqual(script, "", "Plain-HTTP dashboard origins must not receive an injection script at all")
+        XCTAssertFalse(script.contains("http-secret"), "The secret must never be embedded in page JavaScript over cleartext origins")
     }
 
     // MARK: - Fetch Injection Script

--- a/ConduitTests/HermesClientTests.swift
+++ b/ConduitTests/HermesClientTests.swift
@@ -149,6 +149,47 @@ final class HermesClientTests: XCTestCase {
         client.disconnect()
     }
 
+    /// The Cloudflare service token rides only secure upgrades: an HTTPS
+    /// dashboard yields wss:// with both headers; a plain-HTTP LAN dashboard
+    /// yields ws:// with the credentials silently omitted.
+    func testCloudflareServiceTokenRidesOnlySecureWebSocketUpgrades() async throws {
+        let credentials = CloudflareAccessCredentials(clientID: "ws-id", clientSecret: "ws-secret")
+
+        let secureTransport = FakeTransport()
+        let secureSocket = FakeSocket()
+        secureTransport.nextSocket = { secureSocket }
+        let secureClient = HermesClient(
+            connection: HermesConnection(baseUrl: "https://hermes.example", ticket: "ticket"),
+            cloudflareAccess: credentials,
+            transportFactory: { secureTransport }
+        )
+        let secureConnect = Task { try? await secureClient.connect() }
+        secureTransport.open(secureSocket)
+        try await awaitCompletion(of: secureConnect, "the secure connect to complete")
+        let secureRequest = try XCTUnwrap(secureTransport.requestsMade.first)
+        XCTAssertEqual(secureRequest.url?.scheme, "wss")
+        XCTAssertEqual(secureRequest.value(forHTTPHeaderField: "CF-Access-Client-Id"), "ws-id")
+        XCTAssertEqual(secureRequest.value(forHTTPHeaderField: "CF-Access-Client-Secret"), "ws-secret")
+        secureClient.disconnect()
+
+        let plainTransport = FakeTransport()
+        let plainSocket = FakeSocket()
+        plainTransport.nextSocket = { plainSocket }
+        let plainClient = HermesClient(
+            connection: HermesConnection(baseUrl: "http://192.168.1.50:9119", ticket: "ticket"),
+            cloudflareAccess: credentials,
+            transportFactory: { plainTransport }
+        )
+        let plainConnect = Task { try? await plainClient.connect() }
+        plainTransport.open(plainSocket)
+        try await awaitCompletion(of: plainConnect, "the plain-HTTP connect to complete")
+        let plainRequest = try XCTUnwrap(plainTransport.requestsMade.first)
+        XCTAssertEqual(plainRequest.url?.scheme, "ws", "Local ws:// connectivity must remain supported")
+        XCTAssertNil(plainRequest.value(forHTTPHeaderField: "CF-Access-Client-Id"))
+        XCTAssertNil(plainRequest.value(forHTTPHeaderField: "CF-Access-Client-Secret"))
+        plainClient.disconnect()
+    }
+
     func testConcurrentConnectSupersedesPriorWithoutHanging() async throws {
         // A second connect() while the first is still mid-handshake must resume
         // the first's open continuation (via the teardown, mirroring disconnect),
@@ -591,6 +632,9 @@ private final class FakeSocket: HermesWebSocket {
 private final class FakeTransport: HermesWebSocketTransport {
     private(set) var invalidated = false
     private(set) var socketsMade: [FakeSocket] = []
+    /// Every upgrade request handed to `makeSocket`, in order — used by the
+    /// Cloudflare HTTPS/WSS-only header tests.
+    private(set) var requestsMade: [URLRequest] = []
     var nextSocket: (() -> FakeSocket)?
     private var openCallbacks: [ObjectIdentifier: () -> Void] = [:]
     private var earlyOpenRequests = Set<ObjectIdentifier>()
@@ -600,6 +644,7 @@ private final class FakeTransport: HermesWebSocketTransport {
         onOpen: @escaping (any HermesWebSocket) -> Void,
         onCloseBeforeOpen: @escaping (any HermesWebSocket) -> Void
     ) -> any HermesWebSocket {
+        requestsMade.append(request)
         let socket = nextSocket?() ?? FakeSocket()
         socketsMade.append(socket)
         let key = ObjectIdentifier(socket)

--- a/ConduitTests/LoginFieldNavigationTests.swift
+++ b/ConduitTests/LoginFieldNavigationTests.swift
@@ -58,4 +58,15 @@ final class LoginFieldNavigationTests: XCTestCase {
         XCTAssertTrue(LoginField.password.submits(cloudflareTokenEntryEnabled: false))
         XCTAssertTrue(LoginField.cloudflareClientSecret.submits(cloudflareTokenEntryEnabled: true))
     }
+
+    func testWhitespaceOnlyInputsBlockConnectPresence() {
+        // The Connect button and connect()'s return-key guard share this
+        // trimmed-presence rule: a whitespace-only dashboard URL reached
+        // through the return-key path surfaces invalid-URL feedback rather
+        // than silently no-oping.
+        XCTAssertFalse(LoginView.hasConnectableInput(serverURL: "   ", username: "chris", password: "pw"))
+        XCTAssertFalse(LoginView.hasConnectableInput(serverURL: "https://hermes.example", username: "  ", password: "pw"))
+        XCTAssertFalse(LoginView.hasConnectableInput(serverURL: "https://hermes.example", username: "chris", password: " "))
+        XCTAssertTrue(LoginView.hasConnectableInput(serverURL: " https://hermes.example ", username: " chris ", password: "pw"))
+    }
 }

--- a/ConduitTests/LoginFieldNavigationTests.swift
+++ b/ConduitTests/LoginFieldNavigationTests.swift
@@ -19,8 +19,6 @@ final class LoginFieldNavigationTests: XCTestCase {
             [.server, .username, .password, .cloudflareClientID, .cloudflareClientSecret],
             "Every field, including both Cloudflare fields, must sit on the return-key focus chain"
         )
-        // Submit (connect) happens only after the last field of the chain.
-        XCTAssertNil(current)
     }
 
     func testPasswordSubmitsDirectlyWhenTokenEntryDisabled() {

--- a/ConduitTests/LoginFieldNavigationTests.swift
+++ b/ConduitTests/LoginFieldNavigationTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import Conduit
+
+/// Unit coverage for the login form's return-key focus chain (issue #117,
+/// keyboard covering the Cloudflare fields). The chain itself is what keeps
+/// every field reachable one-handed on compact iPhones: each field either
+/// hands focus to the next or — only at the end of the chain — submits.
+final class LoginFieldNavigationTests: XCTestCase {
+    func testFocusChainCoversCloudflareFieldsWhenTokenEntryEnabled() {
+        var visited: [LoginField] = []
+        var current: LoginField? = .server
+        while let field = current {
+            visited.append(field)
+            current = field.submitDestination(cloudflareTokenEntryEnabled: true)
+        }
+
+        XCTAssertEqual(
+            visited,
+            [.server, .username, .password, .cloudflareClientID, .cloudflareClientSecret],
+            "Every field, including both Cloudflare fields, must sit on the return-key focus chain"
+        )
+        // Submit (connect) happens only after the last field of the chain.
+        XCTAssertNil(current)
+    }
+
+    func testPasswordSubmitsDirectlyWhenTokenEntryDisabled() {
+        XCTAssertNil(LoginField.password.submitDestination(cloudflareTokenEntryEnabled: false))
+        XCTAssertEqual(LoginField.server.submitDestination(cloudflareTokenEntryEnabled: false), .username)
+        XCTAssertEqual(LoginField.username.submitDestination(cloudflareTokenEntryEnabled: false), .password)
+        XCTAssertEqual(LoginField.cloudflareClientID.submitDestination(cloudflareTokenEntryEnabled: false), .cloudflareClientSecret)
+        XCTAssertNil(LoginField.cloudflareClientSecret.submitDestination(cloudflareTokenEntryEnabled: false))
+    }
+
+    func testPasswordReturnDoesNotConnectWhileEnteringCloudflareCredentials() {
+        XCTAssertEqual(
+            LoginField.password.submitDestination(cloudflareTokenEntryEnabled: true),
+            .cloudflareClientID,
+            "Return on the password field must advance to the Cloudflare Client ID, never trigger Connect"
+        )
+    }
+
+    func testKeyboardReturnSubmitsOnlyAtChainEnd() {
+        // SubmitLabel itself is not Equatable, so tests assert on the pure
+        // decision the label derives from: submit only at the chain's end.
+        for field in LoginField.allCases {
+            XCTAssertEqual(
+                field.submits(cloudflareTokenEntryEnabled: true),
+                field.submitDestination(cloudflareTokenEntryEnabled: true) == nil,
+                "\(field) submit decision must match its chain position"
+            )
+            XCTAssertEqual(
+                field.submits(cloudflareTokenEntryEnabled: false),
+                field.submitDestination(cloudflareTokenEntryEnabled: false) == nil,
+                "\(field) submit decision must match its chain position"
+            )
+        }
+        // The password field flips between submit and continue depending on
+        // whether the Cloudflare token entry follows it.
+        XCTAssertFalse(LoginField.password.submits(cloudflareTokenEntryEnabled: true))
+        XCTAssertTrue(LoginField.password.submits(cloudflareTokenEntryEnabled: false))
+        XCTAssertTrue(LoginField.cloudflareClientSecret.submits(cloudflareTokenEntryEnabled: true))
+    }
+}

--- a/ConduitTests/NativeAuthClientTests.swift
+++ b/ConduitTests/NativeAuthClientTests.swift
@@ -152,6 +152,31 @@ final class NativeAuthClientTests: XCTestCase {
         XCTAssertEqual(providers[0]["name"] as? String, "basic")
     }
 
+    func testProviderDiscoveryUnconfiguredTokenObjectFallsBackToWebView() async throws {
+        // A non-nil but empty credentials value is unconfigured: it must
+        // send no Cloudflare headers and, on a Cloudflare redirect, follow
+        // the normal interactive WebView fallback instead of reporting the
+        // token rejected.
+        let client = NativeAuthClient(
+            baseURL: "https://cfreject.example",
+            cloudflareAccess: CloudflareAccessCredentials(clientID: "", clientSecret: "   "),
+            sessionConfiguration: makeSessionConfiguration()
+        )
+
+        let providers = try await client.authProviders()
+
+        XCTAssertTrue(providers.isEmpty, "Unconfigured credentials must keep the WebView fallback signal")
+        XCTAssertNil(
+            NativeAuthURLProtocol.requestHeader(forPath: "/api/auth/providers", name: "CF-Access-Client-Id"),
+            "Unconfigured credentials must send no service-token id"
+        )
+        XCTAssertNil(
+            NativeAuthURLProtocol.requestHeader(forPath: "/api/auth/providers", name: "CF-Access-Client-Secret"),
+            "Unconfigured credentials must send no service-token secret"
+        )
+        XCTAssertEqual(NativeAuthURLProtocol.requestCount(for: "tenant.cloudflareaccess.com"), 0)
+    }
+
     func testProviderDiscoveryThrowsTokenRejectedWhenCloudflareRedirectsDespiteServiceToken() async throws {
         let client = NativeAuthClient(
             baseURL: "https://cfreject.example",

--- a/ConduitTests/NativeAuthClientTests.swift
+++ b/ConduitTests/NativeAuthClientTests.swift
@@ -266,6 +266,36 @@ final class NativeAuthClientTests: XCTestCase {
         ))
     }
 
+    func testHTTPLANDashboardNeverReceivesCloudflareHeadersDespiteConfiguredToken() async throws {
+        // A plain-HTTP trusted-LAN dashboard with a (stale or misconfigured)
+        // Cloudflare token still configured: ordinary local authentication
+        // must work, and none of the native requests may carry the
+        // credentials.
+        let client = NativeAuthClient(
+            baseURL: "http://192.168.1.202:9119",
+            cloudflareAccess: CloudflareAccessCredentials(
+                clientID: "lan-client-id",
+                clientSecret: "lan-client-secret"
+            ),
+            sessionConfiguration: makeSessionConfiguration()
+        )
+
+        _ = try await client.authProviders()
+        let connection = try await client.connect(username: "chris", password: "correct-password")
+
+        XCTAssertEqual(connection.ticket, "lan-ticket")
+        for path in ["/api/auth/providers", "/auth/password-login", "/api/auth/ws-ticket"] {
+            XCTAssertNil(
+                NativeAuthURLProtocol.requestHeader(forPath: path, name: "CF-Access-Client-Id"),
+                "\(path) over cleartext HTTP must not carry the service-token id"
+            )
+            XCTAssertNil(
+                NativeAuthURLProtocol.requestHeader(forPath: path, name: "CF-Access-Client-Secret"),
+                "\(path) over cleartext HTTP must not carry the service-token secret"
+            )
+        }
+    }
+
     func testCancelledConnectSurfacesAsCancellationError() async throws {
         let client = NativeAuthClient(
             baseURL: "https://cancel.example",
@@ -418,6 +448,7 @@ private final class NativeAuthURLProtocol: URLProtocol {
         return [
             "192.168.1.200",
             "192.168.1.201",
+            "192.168.1.202",
             "redirect.example",
             "providers.example",
             "server-error.example",
@@ -590,6 +621,30 @@ private final class NativeAuthURLProtocol: URLProtocol {
                     statusCode: 200,
                     headers: ["Content-Type": "application/json"],
                     body: Data(#"{"ticket":"fresh-ticket"}"#.utf8)
+                )
+            default:
+                return nil
+            }
+        case "192.168.1.202":
+            // Plain-HTTP LAN dashboard: succeeds for ordinary Hermes auth
+            // regardless of any configured Cloudflare token.
+            switch request.url?.path {
+            case "/api/auth/providers":
+                return Fixture(statusCode: 200, headers: [:], body: providerBody())
+            case "/auth/password-login":
+                return Fixture(
+                    statusCode: 200,
+                    headers: [
+                        "Content-Type": "application/json",
+                        "Set-Cookie": "hermes_session_at=lan-flow-token; Path=/; HttpOnly"
+                    ],
+                    body: Data(#"{"ok":true,"next":"/"}"#.utf8)
+                )
+            case "/api/auth/ws-ticket":
+                return Fixture(
+                    statusCode: 200,
+                    headers: ["Content-Type": "application/json"],
+                    body: Data(#"{"ticket":"lan-ticket"}"#.utf8)
                 )
             default:
                 return nil

--- a/ConduitTests/NativeAuthClientTests.swift
+++ b/ConduitTests/NativeAuthClientTests.swift
@@ -152,6 +152,120 @@ final class NativeAuthClientTests: XCTestCase {
         XCTAssertEqual(providers[0]["name"] as? String, "basic")
     }
 
+    func testProviderDiscoveryThrowsTokenRejectedWhenCloudflareRedirectsDespiteServiceToken() async throws {
+        let client = NativeAuthClient(
+            baseURL: "https://cfreject.example",
+            cloudflareAccess: CloudflareAccessCredentials(
+                clientID: "test-client-id",
+                clientSecret: "super-secret-value"
+            ),
+            sessionConfiguration: makeSessionConfiguration()
+        )
+
+        do {
+            _ = try await client.authProviders()
+            XCTFail("Expected the Cloudflare redirect despite a configured token to be a typed rejection")
+        } catch let error as AuthClientError {
+            guard case .cloudflareServiceTokenRejected = error else {
+                return XCTFail("Expected cloudflareServiceTokenRejected, got \(error)")
+            }
+            let message = error.errorDescription ?? ""
+            XCTAssertTrue(message.contains("Service Auth policy"), "Diagnostic must guide the operator: \(message)")
+            XCTAssertFalse(message.contains("super-secret-value"), "Diagnostic must never contain the secret")
+        }
+        // The rejected token must not be replayed against the Cloudflare
+        // login origin: the redirect delegate cancels it before any request.
+        XCTAssertEqual(NativeAuthURLProtocol.requestCount(for: "tenant.cloudflareaccess.com"), 0)
+        // And the configured token still goes to the dashboard origin only.
+        XCTAssertEqual(
+            NativeAuthURLProtocol.requestHeader(forPath: "/api/auth/providers", name: "CF-Access-Client-Id"),
+            "test-client-id"
+        )
+        XCTAssertEqual(
+            NativeAuthURLProtocol.requestHeader(forPath: "/api/auth/providers", name: "CF-Access-Client-Secret"),
+            "super-secret-value"
+        )
+    }
+
+    func testProviderDiscoveryNonCloudflareRedirectWithTokenStillFallsBackToWebView() async throws {
+        let client = NativeAuthClient(
+            baseURL: "https://ssoedge.example",
+            cloudflareAccess: CloudflareAccessCredentials(
+                clientID: "test-client-id",
+                clientSecret: "test-client-secret"
+            ),
+            sessionConfiguration: makeSessionConfiguration()
+        )
+
+        let providers = try await client.authProviders()
+
+        // A redirect from a non-Cloudflare edge is not evidence the service
+        // token was rejected; the WebView fallback must stay available.
+        XCTAssertTrue(providers.isEmpty)
+    }
+
+    func testServiceTokenAppliesToLoginAndTicketRequests() async throws {
+        let client = NativeAuthClient(
+            baseURL: "https://cftoken.example",
+            cloudflareAccess: CloudflareAccessCredentials(
+                clientID: "flow-client-id",
+                clientSecret: "flow-client-secret"
+            ),
+            sessionConfiguration: makeSessionConfiguration()
+        )
+
+        // The full shipped connect sequence: LoginView probes providers
+        // first, then connects natively, then mints the ticket.
+        _ = try await client.authProviders()
+        let connection = try await client.connect(username: "chris", password: "correct-password")
+
+        XCTAssertEqual(connection.ticket, "fresh-ticket")
+        for path in ["/api/auth/providers", "/auth/password-login", "/api/auth/ws-ticket"] {
+            XCTAssertEqual(
+                NativeAuthURLProtocol.requestHeader(forPath: path, name: "CF-Access-Client-Id"),
+                "flow-client-id",
+                "\(path) must carry the service-token id"
+            )
+            XCTAssertEqual(
+                NativeAuthURLProtocol.requestHeader(forPath: path, name: "CF-Access-Client-Secret"),
+                "flow-client-secret",
+                "\(path) must carry the service-token secret"
+            )
+        }
+    }
+
+    func testRedirectClassifierOnlyMatchesCloudflareAccessLoginOrigins() throws {
+        func responseWithLocation(_ location: String?) throws -> HTTPURLResponse {
+            var fields: [String: String] = [:]
+            if let location { fields["Location"] = location }
+            return HTTPURLResponse(
+                url: URL(string: "https://dash.example/api/auth/providers")!,
+                statusCode: 302,
+                httpVersion: "HTTP/1.1",
+                headerFields: fields
+            )!
+        }
+
+        XCTAssertTrue(try NativeAuthClient.redirectsToCloudflareAccessLogin(
+            responseWithLocation("https://tenant.cloudflareaccess.com/cdn-cgi/access/login")
+        ))
+        XCTAssertTrue(try NativeAuthClient.redirectsToCloudflareAccessLogin(
+            responseWithLocation("https://cloudflareaccess.com/cdn-cgi/access/login")
+        ))
+        XCTAssertFalse(try NativeAuthClient.redirectsToCloudflareAccessLogin(
+            responseWithLocation("https://evil.example/u/cloudflareaccess.com")
+        ))
+        XCTAssertFalse(try NativeAuthClient.redirectsToCloudflareAccessLogin(
+            responseWithLocation("https://dash.example/login")
+        ))
+        XCTAssertFalse(try NativeAuthClient.redirectsToCloudflareAccessLogin(
+            responseWithLocation(nil)
+        ))
+        XCTAssertFalse(try NativeAuthClient.redirectsToCloudflareAccessLogin(
+            responseWithLocation("not a url")
+        ))
+    }
+
     func testCancelledConnectSurfacesAsCancellationError() async throws {
         let client = NativeAuthClient(
             baseURL: "https://cancel.example",
@@ -311,7 +425,10 @@ private final class NativeAuthURLProtocol: URLProtocol {
             "multiple.example",
             "tenant.cloudflareaccess.com",
             "cancel.example",
-            "cookieless.example"
+            "cookieless.example",
+            "cfreject.example",
+            "ssoedge.example",
+            "cftoken.example"
         ].contains(host)
     }
 
@@ -513,6 +630,64 @@ private final class NativeAuthURLProtocol: URLProtocol {
             return hasExpectedHeaders
                 ? Fixture(statusCode: 200, headers: [:], body: providerBody())
                 : Fixture(statusCode: 403, headers: [:], body: Data(#"{"error":"missing Cloudflare service token"}"#.utf8))
+        case "cfreject.example":
+            // Cloudflare bounces the request to its Access login page even
+            // though a service token was configured: the token was rejected.
+            return Fixture(
+                statusCode: 302,
+                headers: ["Location": "https://tenant.cloudflareaccess.com/cdn-cgi/access/login"],
+                body: Data()
+            )
+        case "ssoedge.example":
+            // A non-Cloudflare edge redirect (cross-origin, so the redirect
+            // delegate cancels it): not evidence of token rejection.
+            return Fixture(
+                statusCode: 302,
+                headers: ["Location": "https://sso.example/signin"],
+                body: Data()
+            )
+        case "cftoken.example":
+            // Full native flow behind an accepting Cloudflare edge: every
+            // request must carry both service-token headers or it is bounced.
+            let hasToken = request.value(forHTTPHeaderField: "CF-Access-Client-Id") == "flow-client-id"
+                && request.value(forHTTPHeaderField: "CF-Access-Client-Secret") == "flow-client-secret"
+            guard hasToken else {
+                return Fixture(
+                    statusCode: 302,
+                    headers: ["Location": "https://tenant.cloudflareaccess.com/cdn-cgi/access/login"],
+                    body: Data()
+                )
+            }
+            switch request.url?.path {
+            case "/api/auth/providers":
+                return Fixture(statusCode: 200, headers: [:], body: providerBody())
+            case "/auth/password-login":
+                return Fixture(
+                    statusCode: 200,
+                    headers: [
+                        "Content-Type": "application/json",
+                        "Set-Cookie": "hermes_session_at=cf-flow-token; Path=/; HttpOnly"
+                    ],
+                    body: Data(#"{"ok":true,"next":"/"}"#.utf8)
+                )
+            case "/api/auth/ws-ticket":
+                // Mirror the hardened flow: the ticket is only minted when
+                // the login's host-scoped session cookie reached the request.
+                guard request.value(forHTTPHeaderField: "Cookie") == "hermes_session_at=cf-flow-token" else {
+                    return Fixture(
+                        statusCode: 401,
+                        headers: ["Content-Type": "application/json"],
+                        body: Data(#"{"detail":"Unauthorized"}"#.utf8)
+                    )
+                }
+                return Fixture(
+                    statusCode: 200,
+                    headers: ["Content-Type": "application/json"],
+                    body: Data(#"{"ticket":"fresh-ticket"}"#.utf8)
+                )
+            default:
+                return nil
+            }
         default:
             return nil
         }

--- a/ConduitTests/TurnstileSubframeBoundaryTests.swift
+++ b/ConduitTests/TurnstileSubframeBoundaryTests.swift
@@ -1,0 +1,103 @@
+import WebKit
+import XCTest
+@testable import Conduit
+
+/// Live-WKWebView regression coverage for the subframe navigation boundary
+/// (issue #117). WebKit consults the navigation delegate for the
+/// `about:blank` / `about:srcdoc` subframe documents Cloudflare's Turnstile
+/// WebView requirements call for, and cancelling those navigations
+/// suppresses the documents (verified empirically: a cancelled srcdoc
+/// subframe never instantiates its document). These tests pin that the
+/// shipped subframe policy — `ConnectionURLPolicy.isAllowedWebViewSubframe
+/// Transport`, shared by the auth WebView and the ticket bridge — allows
+/// them through a real engine, while custom-scheme subframes stay denied.
+///
+/// The probe page's MAIN frame is always allowed: loadHTMLString presents
+/// an about:blank main navigation, and the real delegates' main-frame rules
+/// (HTTPS/dashboard-origin pinning) are covered exhaustively by
+/// `AuthWebViewNavigationPolicyTests` against the pure policy.
+@MainActor
+final class TurnstileSubframeBoundaryTests: XCTestCase {
+    private final class BoundaryDelegate: NSObject, WKNavigationDelegate {
+        /// (url, isMainFrame, allowed) for every consulted navigation.
+        private(set) var decisions: [(url: String, isMainFrame: Bool, allowed: Bool)] = []
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        ) {
+            let isMainFrame = navigationAction.targetFrame?.isMainFrame ?? true
+            let allowed: Bool
+            if isMainFrame {
+                // The probe page itself; the shipped main-frame policy is
+                // pure and covered by AuthWebViewNavigationPolicyTests.
+                allowed = true
+            } else {
+                allowed = ConnectionURLPolicy.isAllowedWebViewSubframeTransport(
+                    navigationAction.request.url
+                )
+            }
+            decisions.append((navigationAction.request.url?.absoluteString ?? "nil", isMainFrame, allowed))
+            decisionHandler(allowed ? .allow : .cancel)
+        }
+
+        func subframeDecision(for urlSubstring: String) -> (url: String, isMainFrame: Bool, allowed: Bool)? {
+            decisions.first { !$0.isMainFrame && $0.url.contains(urlSubstring) }
+        }
+    }
+
+    func testTurnstileSubframeDocumentsLoadAndCustomSchemesStayDenied() async throws {
+        let delegate = BoundaryDelegate()
+        let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+        webView.navigationDelegate = delegate
+        webView.loadHTMLString(
+            """
+            <!DOCTYPE html><html><body>
+            <iframe id="blank" src="about:blank"></iframe>
+            <iframe id="doc" srcdoc="<p>turnstile</p>"></iframe>
+            <iframe id="custom" src="conduit-boundary-probe://attacker"></iframe>
+            </body></html>
+            """,
+            baseURL: nil
+        )
+
+        // Settle until the srcdoc document instantiates or the budget is
+        // exhausted (local subframe loads settle in well under a second).
+        var srcdocBody = ""
+        for _ in 0..<50 {
+            try await Task.sleep(nanoseconds: 100_000_000)
+            srcdocBody = (try? await webView.evaluateJavaScript(
+                "var f=document.getElementById('doc'); f && f.contentDocument ? f.contentDocument.body.innerHTML : 'NO-DOC'"
+            )) as? String ?? "EVAL-FAIL"
+            if srcdocBody.contains("turnstile") { break }
+        }
+
+        // The Turnstile-required documents must actually load: the shipped
+        // subframe policy allowed them and WebKit instantiated the document.
+        if srcdocBody != "<p>turnstile</p>" {
+            XCTFail("srcdoc body='\(srcdocBody)'; decisions=\(delegate.decisions)")
+        }
+
+        let blankDecision = try XCTUnwrap(
+            delegate.subframeDecision(for: "about:blank"),
+            "WebKit never consulted the delegate for the about:blank subframe; decisions=\(delegate.decisions)"
+        )
+        XCTAssertTrue(blankDecision.allowed, "about:blank subframes must be allowed for Turnstile; decisions=\(delegate.decisions)")
+        let srcdocDecision = try XCTUnwrap(
+            delegate.subframeDecision(for: "about:srcdoc"),
+            "WebKit never consulted the delegate for the about:srcdoc subframe; decisions=\(delegate.decisions)"
+        )
+        XCTAssertTrue(srcdocDecision.allowed, "about:srcdoc subframes must be allowed for Turnstile; decisions=\(delegate.decisions)")
+
+        // Arbitrary non-HTTP(S) subframe schemes must remain denied. WebKit
+        // consulted the delegate for this frame in every observed run; if a
+        // future WebKit skips it entirely, this fails loudly rather than
+        // silently dropping the denial claim.
+        let customDecision = try XCTUnwrap(
+            delegate.subframeDecision(for: "conduit-boundary-probe://"),
+            "WebKit never consulted the delegate for the custom-scheme subframe; decisions=\(delegate.decisions)"
+        )
+        XCTAssertFalse(customDecision.allowed, "Custom-scheme subframes must stay denied")
+    }
+}

--- a/ConduitUITests/LoginKeyboardUITests.swift
+++ b/ConduitUITests/LoginKeyboardUITests.swift
@@ -15,7 +15,7 @@ final class LoginKeyboardUITests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
 
-        let serverField = app.textFields.firstMatch
+        let serverField = app.textFields["https://hermes.example"]
         XCTAssertTrue(serverField.waitForExistence(timeout: 10), "Login screen did not appear. Tree:\n\(app.debugDescription)")
 
         let cfToggle = app.switches["Use Cloudflare Access service token"]
@@ -53,7 +53,10 @@ final class LoginKeyboardUITests: XCTestCase {
         if !connect.isHittable {
             app.swipeUp()
         }
-        XCTAssertTrue(connect.isHittable, "Connect must remain reachable with the keyboard visible")
+        XCTAssertTrue(
+            pollHittability(of: connect, timeout: 5),
+            "Connect must remain reachable with the keyboard visible"
+        )
     }
 
     /// XCUIElement has no waitForHittability; poll isHittable on a deadline.

--- a/ConduitUITests/LoginKeyboardUITests.swift
+++ b/ConduitUITests/LoginKeyboardUITests.swift
@@ -1,0 +1,68 @@
+import XCTest
+
+/// Issue #117, part 2: on an iPhone-sized screen the software keyboard used
+/// to cover the optional Cloudflare service-token fields with no way to
+/// reach them. The login form is now a keyboard-aware scroll view, so this
+/// drives the REAL gesture pipeline — toggle the Cloudflare section, focus
+/// its fields through the return-key chain, and assert every control stays
+/// hittable while the keyboard is up.
+final class LoginKeyboardUITests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testCloudflareFieldsAndConnectStayReachableWithKeyboardVisible() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        let serverField = app.textFields.firstMatch
+        XCTAssertTrue(serverField.waitForExistence(timeout: 10), "Login screen did not appear. Tree:\n\(app.debugDescription)")
+
+        let cfToggle = app.switches["Use Cloudflare Access service token"]
+        XCTAssertTrue(cfToggle.waitForExistence(timeout: 5), "Cloudflare toggle not found. Tree:\n\(app.debugDescription)")
+        cfToggle.tap()
+
+        let clientID = app.textFields["Cloudflare Client ID"]
+        XCTAssertTrue(clientID.waitForExistence(timeout: 5), "Cloudflare Client ID did not appear after enabling the toggle")
+        clientID.tap()
+        // Typing proves the software keyboard is actually up and focused here
+        // (typeText waits for focus, so no fixed sleep for the keyboard).
+        clientID.typeText("access-client-id.example")
+
+        // The keyboard toolbar Done affordance must render with the form.
+        let done = app.buttons["Done"]
+        XCTAssertTrue(done.waitForExistence(timeout: 5), "Keyboard Done button did not appear")
+
+        // Return walks the focus chain to the Cloudflare Client Secret; the
+        // view must scroll that field into view from behind the keyboard.
+        clientID.typeText("\n")
+        let secret = app.secureTextFields["Cloudflare Client Secret"]
+        XCTAssertTrue(secret.waitForExistence(timeout: 5))
+        // The focus-driven scroll animates for ~0.25s; poll hittability
+        // instead of asserting while the scroll may still be in flight.
+        XCTAssertTrue(
+            pollHittability(of: secret, timeout: 5),
+            "Cloudflare Client Secret must scroll into view when it receives focus"
+        )
+        secret.typeText("access-client-secret")
+
+        // The Connect control itself must also remain reachable on the
+        // compact keyboard-obscured layout.
+        let connect = app.buttons["Connect"]
+        XCTAssertTrue(connect.waitForExistence(timeout: 5))
+        if !connect.isHittable {
+            app.swipeUp()
+        }
+        XCTAssertTrue(connect.isHittable, "Connect must remain reachable with the keyboard visible")
+    }
+
+    /// XCUIElement has no waitForHittability; poll isHittable on a deadline.
+    private func pollHittability(of element: XCUIElement, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if element.isHittable { return true }
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+        return element.isHittable
+    }
+}


### PR DESCRIPTION
Closes #117.

## Root cause — Conduit's navigation policy blocked documents Cloudflare's Turnstile requires

Regression archaeology (diffing every commit that touched `LoginView.swift`/`AuthWebView`, plus #25, #38, and the native-auth rework) shows the WebView shell is essentially unchanged since the initial public release — this is not a code regression but a latent incompatibility with how Cloudflare's interactive verification operates inside WebViews.

`AuthWebView.Coordinator.decidePolicyFor` (and `DashboardTicketBridge`'s, identically) applied the HTTPS-only transport guard **before** the subframe allowance:

```
guard ConnectionURLPolicy.isAllowedTransport(url) else { cancel }   // https/http + host only
if !targetFrame.isMainFrame { allow }                                // never reached for about:
```

Cloudflare's [Turnstile mobile implementation requirements](https://developers.cloudflare.com/turnstile/get-started/mobile-implementation/) state that an embedding WebView must **"Allow connections to `about:blank` and `about:srcdoc`"** (alongside JavaScript, storage, a consistent User Agent, and reachability of `challenges.cloudflare.com`). Conduit cancelled every `about:` subframe navigation — including the two Turnstile names — so verification could not complete inside the app while the same login succeeded in Safari. This produces exactly the reported failure: the Cloudflare login page renders, then "there was a problem with verification".

### Runtime evidence (WKWebView, iPhone 17 Pro simulator, iOS 26.5)

A probe page embedding `<iframe src="about:blank">` and `<iframe srcdoc="…">` was loaded under two navigation delegates:

- **PR's previous policy (subframe `about:` cancelled):** WebKit consulted the delegate for **both** `about:blank` and `about:srcdoc` subframe navigations, both were cancelled, and the `srcdoc` iframe's document was never instantiated (`contentDocument.body.innerHTML === ""`).
- **Fixed policy (subframe allowance):** both navigations allowed; the `srcdoc` document instantiates (`<p>…</p>`).

So the delegate is demonstrably in the path for exactly the documents Cloudflare requires, and cancellation demonstrably suppresses them. (The originally suspected mechanism — Cloudflare rejecting the default WKWebView User Agent — was **withdrawn**: the same Cloudflare page requires only a *consistent* User Agent and explicitly recommends maintaining the default WebView UA. The `WebViewUserAgent` spoof from the previous iteration of this PR has been removed, and with it the tests that asserted the unsupported causal claim.)

## Fix

### 1. Narrow subframe allowance (`about:blank` / `about:srcdoc`)

- `ConnectionURLPolicy.isTurnstileRequiredSubframeDocument` recognizes exactly `about:blank` and `about:srcdoc`; `isAllowedWebViewSubframeTransport` = ordinary HTTP(S) transport **or** those documents.
- Both `decidePolicyFor` implementations now classify **subframes first**: HTTP(S) subframes (identity providers, `challenges.cloudflare.com`) and the two Turnstile documents are allowed; every other scheme (`about:` variants, custom schemes, `data:`) is denied.
- The allowance is **subframe-only**. `about:` documents are opaque and cannot navigate the top level, so the main-frame rules are untouched: unpinned sign-in may still traverse the legitimate Cloudflare/IdP redirect chain; once the dashboard origin pins, top-level navigation still cannot escape it (`about:` main-frame navigations remain cancelled — pinned or not). The User Agent is left exactly as WebKit ships it.
- The auth WebView's policy is extracted into `AuthWebViewNavigationPolicy.decide(url:isMainFrame:hasPinnedDashboardOrigin:expectedDashboardURL:)` so the entire boundary is unit-testable without hosting a WKWebView.

### 2. Service-token mode (unchanged, re-verified)

- `CF-Access-Client-Id/Secret` remain attached to every dashboard-origin native request (providers → password-login → ws-ticket → WebSocket upgrade) and to the initial WebView `/login` request; the injected fetch/XHR script stays scoped to same-origin dashboard requests only.
- Rejected tokens remain a **typed diagnostic**: provider discovery still redirected to a `*.cloudflareaccess.com` login origin with a token configured throws `AuthClientError.cloudflareServiceTokenRejected` ("…verify the Client ID / Secret and that the token is allowed by a Service Auth policy for this Access application, or turn off \"Use Cloudflare Access service token\" to sign in interactively."). Token values are never logged, never in errors, never replayed cross-origin (regression-tested: 0 requests reach the tenant host).
- No new auth mode; normal non-Cloudflare password login is untouched.

### 3. Keyboard-safe login form (unchanged from review)

Responsive `ScrollView`/`ScrollViewReader` layout, focus-driven scrolling of the Cloudflare fields, keyboard **Done** control, return-key focus chain (password return hands focus to the Cloudflare Client ID instead of triggering Connect), typed token-rejection diagnostic, Keychain storage with origin binding. Two review findings addressed: the stale backdrop tap-to-dismiss gesture (dead behind the full-screen scroll view) is removed with an accurate comment — dismissal is owned by interactive scroll-dismiss, the Done control, and field-to-field focus movement — and Connect-button enablement now uses trimmed emptiness, consistent with `connect()`'s guard.

## Tests

- `AuthWebViewNavigationPolicyTests` (new) — the full boundary matrix: Turnstile subframe documents allowed; HTTPS subframes (identity providers, `challenges.cloudflare.com`) allowed; `about:` variants / custom schemes / `data:` / nil denied; unpinned main-frame auth chain allowed while insecure/malformed/about: transports stay blocked; pinned main-frame stays dashboard-origin-bound (including suffix-spoof hosts and `about:` escapes) and fails closed on an unknown expected origin.
- `TurnstileSubframeBoundaryTests` (new) — live-WKWebView regression: the shipped subframe policy lets the `about:blank` / `about:srcdoc` documents instantiate in a real engine (the srcdoc document is asserted present), and custom-scheme subframes stay denied.
- `NativeAuthClientTests` — token headers present on every dashboard-origin request and absent cross-origin (redirect cancelled, 0 requests to the tenant host); provider-discovery matrix (no token → WebView fallback, rejected token → typed error, non-CF redirect → fallback, normal/3xx/5xx preserved); full-sequence token propagation with a cookie-gated ws-ticket; redirect-classifier adversarial cases.
- `LoginFieldNavigationTests` — the focus-chain contract under both token-entry states.
- `LoginKeyboardUITests` — real-gesture keyboard coverage on an iPhone simulator.
- UA-composition tests from the previous iteration were **removed** with the withdrawn mechanism.

## Verification

- Focused suites (AuthWebViewNavigationPolicy, TurnstileSubframeBoundary, CloudflareAccess, NativeAuthClient, NativeAuthClientIntegration, LoginFieldNavigation): all green.
- Full `ConduitTests`: green on the Mac build host (iPhone 17 Pro simulator) at the pushed commit.
- `git diff --check` clean.
- Multi-model review cycle run on the earlier iteration; this rework supersedes its UA-related items with the documented evidence above.
- Known local limitation: the UI-test runner on the Mac build host wedges at bootstrap ("Timed out waiting for AX loaded notification") — a recurring local-environment failure; CI's UI lane is the execution gate for `LoginKeyboardUITests`.
- A real-tenant interactive Cloudflare Access login was not available for manual verification; the mechanism is established by Cloudflare's documented requirements plus the WKWebView probe above.

## Security hardening: service tokens are HTTPS/WSS-only

`CloudflareAccessCredentials.applying(to:)` now fails closed for any non-HTTPS/WSS URL, and that single guard covers every application path (native provider discovery, password login, ticket minting, the WebSocket upgrade, the auth WebView's initial `/login` request, and the ticket bridge's `/api/status` load). The document-start fetch/XHR injection shares the invariant: a plain-HTTP configured origin gets no script at all, so the secret is never embedded in page JavaScript either. Plain-HTTP/wss-less transports silently omit the credentials — trusted-LAN Hermes connectivity is unaffected, and a configured-but-unusable token over HTTP never blocks a local login. Regression tests: cleartext HTTP and `ws://` requests carry no CF headers while `https`/`wss` carry both (both header names asserted); the WebView initial request over HTTP omits them; an HTTP LAN dashboard completes the full native sequence with a configured token and zero CF headers on any request; the injection script fails closed for HTTP origins; existing cross-origin/IdP/Cloudflare-login-origin leak tests remain green.

## Out of scope

No new auth mode, no changes to Hermes server auth, no weakening of origin scoping or of the main-frame dashboard-origin boundary, no unrelated login-screen redesign.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Cloudflare Access credentials are now sent only over secure HTTPS and WSS connections.
  - Credentials are no longer embedded in cleartext WebView requests or scripts.

- **Bug Fixes**
  - Added a clear error when a Cloudflare Access service token is rejected.
  - Improved WebView sign-in compatibility with Turnstile and identity-provider pages.
  - Login validation now ignores whitespace-only entries.

- **Usability**
  - Login fields and the Connect button remain accessible while the keyboard is open.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->