### PR TITLE
fix(chat): make transcript backfill ownership self-contained, not catalog-dependent

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2830,6 +2830,8 @@ final class AppState: ObservableObject {
             let priorWindowForGraft = priorWindowOwnsThisConversation(
                 priorWindow,
                 requestedSessionId: sessionId,
+                resolvedSessionId: transcript?.resolvedSessionId,
+                runtimeSessionId: result.sessionId,
                 profile: profile
             ) ? priorWindow : nil
             let presentationResult: SessionResumeResult
@@ -2879,11 +2881,16 @@ final class AppState: ObservableObject {
             // affordance once and re-retires on its first terminal page.
             if let transcript, transcriptMatches, let page = transcript.page,
                page.honorsTailContract {
+                // The window records EVERY identity the accepted
+                // transaction produced — requested, resolved stored, and
+                // runtime — so ownership stays self-contained even before
+                // the session catalog learns the runtime↔stored alias.
                 persistedTranscriptWindow = PersistedTranscriptWindowState(
                     requestedSessionID: sessionId,
                     profile: profile,
                     pageSize: PersistedTranscriptPagination.pageSize,
-                    resolvedSessionID: transcript.resolvedSessionId ?? result.sessionId,
+                    resolvedSessionID: transcript.resolvedSessionId,
+                    runtimeSessionID: result.sessionId,
                     nextOffset: page.rawReturned,
                     canLoadEarlier: page.mayHaveOlderRows(fetchedRowCount: page.rawReturned),
                     hasBackfilledPrefix: graftedBackfilledPrefix
@@ -6381,18 +6388,30 @@ final class AppState: ObservableObject {
         )
     }
 
+    /// Whether a persisted-history window from the previous reconciliation
+    /// belongs to the conversation this reconcile just accepted. Identity is
+    /// compared through the ONE centralized rule with the new transaction's
+    /// full identity set (requested, resolved stored, runtime), so a
+    /// reconnect keeps the backfilled prefix even when the catalog is
+    /// temporarily stale about the stored↔runtime alias.
     private func priorWindowOwnsThisConversation(
         _ window: PersistedTranscriptWindowState?,
         requestedSessionId: String,
+        resolvedSessionId: String?,
+        runtimeSessionId: String?,
         profile: String
     ) -> Bool {
-        guard let window, window.profile == profile else { return false }
-        if window.requestedSessionID == requestedSessionId { return true }
-        // Alias-aware, exactly like the backfill ownership gate: the window
-        // may have been opened under a runtime ID while this reconcile runs
-        // under the catalog's stored ID (or vice versa).
-        return knownSessionIDs(for: requestedSessionId).contains(window.requestedSessionID)
-            || knownSessionIDs(for: window.requestedSessionID).contains(requestedSessionId)
+        guard let window else { return false }
+        let conversationIds = PersistedTranscriptWindow.normalizingSessionIDs([
+            requestedSessionId, resolvedSessionId, runtimeSessionId
+        ])
+        return PersistedTranscriptWindow.ownershipHolds(
+            window: window,
+            conversationSessionIds: conversationIds,
+            profile: profile,
+            windowAliasIds: catalogAliasIDs(for: window.trustedSessionIDs),
+            conversationAliasIds: catalogAliasIDs(for: conversationIds)
+        )
     }
 
     /// Fetches the next older persisted-history page for the active
@@ -6410,14 +6429,32 @@ final class AppState: ObservableObject {
     func loadEarlierMessages() async -> Bool {
         guard let window = persistedTranscriptWindow,
               window.canLoadEarlier,
-              !window.isLoadingEarlier,
-              persistedTranscriptWindowOwnershipIsCurrent(
-                requestedSessionId: window.requestedSessionID,
-                profile: window.profile
-              ) else {
+              !window.isLoadingEarlier else {
             return false
         }
-        let requestSessionId = window.requestedSessionID
+        guard persistedTranscriptWindowOwnershipIsCurrent(window) else {
+            // No user-facing error for an already-departed conversation —
+            // and normally unreachable from a tap, because the affordance
+            // exposes this exact ownership truth. The debug capture below
+            // is purely diagnostic (it also fires on the legitimate
+            // render-to-tap race during a session switch).
+            sessionCatalogLog.debug("""
+                Older-page backfill rejected ownership of an otherwise-actionable window: \
+                requested=\(window.requestedSessionID, privacy: .public) \
+                resolved=\(window.resolvedSessionID ?? "none", privacy: .public) \
+                runtime=\(window.runtimeSessionID ?? "none", privacy: .public) \
+                active=\(self.activeSessionId ?? "none", privacy: .public) \
+                windowProfile=\(window.profile, privacy: .public) \
+                activeProfile=\(self.activeProfile, privacy: .public)
+                """)
+            return false
+        }
+        // Older pages are persisted transcript history: continue against
+        // the durable stored identity the hydration resolved (Desktop's
+        // `BackfillRequest.storedSessionId` contract) — never the runtime
+        // WebSocket ID, and never re-derived from a later catalog refresh.
+        let wireSessionId = window.resolvedSessionID ?? window.requestedSessionID
+        let requestedSessionId = window.requestedSessionID
         let profile = window.profile
         let offset = window.nextOffset
         var arming = window
@@ -6425,7 +6462,7 @@ final class AppState: ObservableObject {
         persistedTranscriptWindow = arming
 
         let outcome = await fetchOlderTranscriptPage(
-            sessionId: requestSessionId,
+            sessionId: wireSessionId,
             profile: profile,
             offset: offset
         )
@@ -6434,15 +6471,23 @@ final class AppState: ObservableObject {
         // request's window (same session, same profile, still loading, and
         // no other fetch advanced it meanwhile). Anything else — session
         // switch, profile switch, disconnect re-home — discards the page.
+        // The first four conditions identify THIS armed window; only then
+        // may the bookkeeping below touch it.
         guard var current = persistedTranscriptWindow,
-              current.requestedSessionID == requestSessionId,
+              current.requestedSessionID == requestedSessionId,
               current.profile == profile,
-              current.isLoadingEarlier,
               current.nextOffset == offset,
-              persistedTranscriptWindowOwnershipIsCurrent(
-                requestedSessionId: requestSessionId,
-                profile: profile
-              ) else {
+              current.isLoadingEarlier else {
+            return false
+        }
+        guard persistedTranscriptWindowOwnershipIsCurrent(current) else {
+            // The armed window survived untouched but the conversation
+            // moved on underneath it (e.g. activeSessionId cleared by a
+            // disconnect). Discard the response whole AND release the
+            // single-flight flag so the affordance can re-arm later — a
+            // replaced window never reaches this branch.
+            current.isLoadingEarlier = false
+            persistedTranscriptWindow = current
             return false
         }
         current.isLoadingEarlier = false
@@ -6454,28 +6499,30 @@ final class AppState: ObservableObject {
                 // A malformed page is a backfill dead end, not a chat
                 // failure: stop offering older pages rather than erroring
                 // the already-hydrated conversation.
-                sessionCatalogLog.debug("Older-page backfill for \(requestSessionId, privacy: .public) returned a malformed payload; retiring the affordance")
+                sessionCatalogLog.debug("Older-page backfill for \(wireSessionId, privacy: .public) returned a malformed payload; retiring the affordance")
                 current.canLoadEarlier = false
                 return false
             }
             // Response ownership: the page must still describe THIS
-            // conversation. The endpoint may resolve a runtime ID to its
-            // stored ID, so accept the requested ID, the window's resolved
-            // stored ID, and any known alias of the same conversation —
-            // never a foreign session's rows. A foreign response neither
-            // normalizes into the transcript nor advances coverage.
+            // conversation. The SAME centralized identity rule decides —
+            // the echoed session_id plays the role of the checked
+            // conversation — so an echo is accepted exactly when it is a
+            // transaction-captured identity of this window or a
+            // catalog-proven alias of one. Never a foreign session's rows;
+            // a foreign response neither normalizes into the transcript
+            // nor advances coverage.
             if let returnedId = Self.resolvedSessionId(in: response),
-               !returnedId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                var acceptedIds = knownSessionIDs(for: requestSessionId)
-                acceptedIds.insert(requestSessionId)
-                if let resolvedId = current.resolvedSessionID {
-                    acceptedIds.insert(resolvedId)
-                }
-                guard acceptedIds.contains(returnedId) else {
-                    sessionCatalogLog.debug("Older-page backfill for \(requestSessionId, privacy: .public) returned foreign session \(returnedId, privacy: .public); discarding and retiring the affordance")
-                    current.canLoadEarlier = false
-                    return false
-                }
+               !returnedId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+               !PersistedTranscriptWindow.ownershipHolds(
+                 window: current,
+                 conversationSessionIds: [returnedId],
+                 profile: current.profile,
+                 windowAliasIds: catalogAliasIDs(for: current.trustedSessionIDs),
+                 conversationAliasIds: knownSessionIDs(for: returnedId)
+               ) {
+                sessionCatalogLog.debug("Older-page backfill for \(wireSessionId, privacy: .public) returned foreign session \(returnedId, privacy: .public); discarding and retiring the affordance")
+                current.canLoadEarlier = false
+                return false
             }
             let fetchedRowCount = rawRows.count
             let page = PersistedTranscriptPagination.parse(response, rawRowCount: fetchedRowCount)
@@ -6485,7 +6532,7 @@ final class AppState: ObservableObject {
             // and prepending them would break chronology. That response
             // retires the affordance instead.
             guard let page, page.honorsTailContract else {
-                sessionCatalogLog.debug("Older-page backfill for \(requestSessionId, privacy: .public) lost the tail contract; retiring the affordance")
+                sessionCatalogLog.debug("Older-page backfill for \(wireSessionId, privacy: .public) lost the tail contract; retiring the affordance")
                 current.canLoadEarlier = false
                 return false
             }
@@ -6494,7 +6541,7 @@ final class AppState: ObservableObject {
             // IDs that cannot survive across pages — refuse it before it can
             // silently corrupt dedup.
             guard PersistedTranscriptWindow.rowsHaveDurableIdentity(rawRows) else {
-                sessionCatalogLog.debug("Older-page backfill for \(requestSessionId, privacy: .public) returned rows without durable IDs; retiring the affordance")
+                sessionCatalogLog.debug("Older-page backfill for \(wireSessionId, privacy: .public) returned rows without durable IDs; retiring the affordance")
                 current.canLoadEarlier = false
                 return false
             }
@@ -6564,7 +6611,7 @@ final class AppState: ObservableObject {
             // reads, a temporarily cold bridge — stays retryable through
             // another explicit tap. A failed backfill never loops on its
             // own.
-            sessionCatalogLog.debug("Older-page backfill failed for \(requestSessionId, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            sessionCatalogLog.debug("Older-page backfill failed for \(wireSessionId, privacy: .public): \(error.localizedDescription, privacy: .public)")
             current.canLoadEarlier = !Self.historySourceIsUnavailable(error)
             return false
         }
@@ -6593,17 +6640,49 @@ final class AppState: ObservableObject {
         }
     }
 
-    /// Ownership gate for the backfill: the window's session and profile
-    /// must still be the active conversation (alias-aware, since the
-    /// endpoint may resolve a runtime ID to its stored ID).
+    /// Catalog alias knowledge for a set of session identities: every ID
+    /// the live catalog groups with any of them (an unknown ID expands to
+    /// just itself).
+    private func catalogAliasIDs(for sessionIds: Set<String>) -> Set<String> {
+        sessionIds.reduce(into: Set<String>()) { expanded, sessionId in
+            expanded.formUnion(knownSessionIDs(for: sessionId))
+        }
+    }
+
+    /// Ownership gate for the persisted-history window: the window must
+    /// belong to the conversation that is actually active. The window's
+    /// transaction-captured identities (requested, resolved stored, runtime)
+    /// are the primary truth — `applyChatResume` re-homes `activeSessionId`
+    /// to the runtime ID long before the catalog learns the alias — while
+    /// catalog alias knowledge remains a compatibility source only.
     private func persistedTranscriptWindowOwnershipIsCurrent(
-        requestedSessionId: String,
-        profile: String
+        _ window: PersistedTranscriptWindowState
     ) -> Bool {
-        guard profile == activeProfile, let activeId = activeSessionId else { return false }
-        if activeId == requestedSessionId { return true }
-        return knownSessionIDs(for: activeId).contains(requestedSessionId)
-            || knownSessionIDs(for: requestedSessionId).contains(activeId)
+        guard let activeId = activeSessionId else { return false }
+        return PersistedTranscriptWindow.ownershipHolds(
+            window: window,
+            conversationSessionIds: [activeId],
+            profile: activeProfile,
+            windowAliasIds: catalogAliasIDs(for: window.trustedSessionIDs),
+            conversationAliasIds: knownSessionIDs(for: activeId)
+        )
+    }
+
+    /// Whether "Load earlier messages" may be offered AND executed right
+    /// now: a hydrated, non-empty transcript whose persisted-history window
+    /// still has an older page and belongs to the conversation that is
+    /// actually active. The single ownership truth for the ChatView
+    /// affordance and the `loadEarlierMessages` action, so the control can
+    /// never render for a window the action would reject (the production
+    /// no-op regression).
+    var canLoadEarlierMessagesForActiveConversation: Bool {
+        guard let window = persistedTranscriptWindow,
+              window.canLoadEarlier,
+              !messages.isEmpty,
+              persistedTranscriptWindowOwnershipIsCurrent(window) else {
+            return false
+        }
+        return true
     }
 
     /// The endpoint may resolve a runtime ID to its stored session ID. Accept

--- a/Conduit/Services/PersistedTranscriptWindow.swift
+++ b/Conduit/Services/PersistedTranscriptWindow.swift
@@ -85,13 +85,21 @@ enum PersistedTranscriptPagination {
 /// history is on screen and whether older pages remain" — the pagination
 /// counterpart of the compact resume's runtime state, never mixed into it.
 struct PersistedTranscriptWindowState: Equatable {
-    /// Session ID the window was hydrated for (as requested; the resolved
-    /// stored ID is tracked separately because the endpoint may re-home a
-    /// runtime alias).
+    /// Session ID the window was hydrated for (as requested). The resolved
+    /// stored ID and the runtime ID are tracked separately because the
+    /// endpoint may re-home a runtime alias and `session.resume` may answer
+    /// with a fresh runtime ID.
     let requestedSessionID: String
     let profile: String
     let pageSize: Int
+    /// Stored session ID the accepted hydration's `/messages` response
+    /// echoed (`session_id`), when the backend supplied one — the durable
+    /// identity of the persisted rows and the ID older-page requests
+    /// continue against.
     var resolvedSessionID: String?
+    /// Runtime session ID the same accepted `session.resume` returned —
+    /// the identity `applyChatResume` made active.
+    var runtimeSessionID: String?
     /// Number of newest persisted rows the local transcript already covers.
     /// Advances by the fetched row count of every page, which self-corrects
     /// the offset drift that live rows create under `order=latest` paging.
@@ -107,6 +115,18 @@ struct PersistedTranscriptWindowState: Equatable {
     /// backfill prepends; kept by a reconcile that grafts onto the prefix;
     /// cleared when a refreshed tail is authoritative (no safe anchor).
     var hasBackfilledPrefix = false
+
+    /// Every session identity the accepted hydration/resume transaction
+    /// vouched for together: the requested ID, the persisted stored ID, and
+    /// the runtime ID. Trusted as one conversation because they arrived in
+    /// the SAME accepted transaction after the transcript ownership
+    /// validation — never reconstructed from a later catalog refresh, whose
+    /// freshness must not gate backfill (the production no-op regression).
+    var trustedSessionIDs: Set<String> {
+        PersistedTranscriptWindow.normalizingSessionIDs([
+            requestedSessionID, resolvedSessionID, runtimeSessionID
+        ])
+    }
 }
 
 /// A legacy one-shot transcript that exceeded the client's safe response
@@ -122,8 +142,52 @@ struct LegacyTranscriptOversizedError: LocalizedError {
     }
 }
 
-/// Pure row-algebra for older-page backfill.
+/// Pure algebra for older-page backfill: row merging, reconnect grafting,
+/// tool-boundary reconstruction, and conversation-identity ownership.
 enum PersistedTranscriptWindow {
+    /// Whether a persisted-history window belongs to a conversation — the
+    /// ONE identity rule shared by the backfill action, stale-response
+    /// validation, the ChatView affordance, and the reconnect graft gate.
+    ///
+    /// Primary truth is explicit overlap between the window's
+    /// transaction-captured IDs (`trustedSessionIDs`: requested + resolved
+    /// stored + runtime) and the checked conversation's IDs. Catalog alias
+    /// knowledge — pre-expanded by the caller into the alias sets — remains
+    /// a secondary compatibility source, but its freshness is never
+    /// required: a resume re-homes `activeSessionId` to the runtime ID long
+    /// before (sometimes never before) the catalog learns the alias, and
+    /// requiring it silently disabled "Load earlier messages".
+    static func ownershipHolds(
+        window: PersistedTranscriptWindowState,
+        conversationSessionIds: Set<String>,
+        profile: String,
+        windowAliasIds: Set<String>,
+        conversationAliasIds: Set<String>
+    ) -> Bool {
+        guard window.profile == profile else { return false }
+        let windowIDs = window.trustedSessionIDs
+        if !windowIDs.isDisjoint(with: conversationSessionIds) { return true }
+        if !windowIDs.isDisjoint(with: conversationAliasIds) { return true }
+        if !conversationSessionIds.isDisjoint(with: windowAliasIds) { return true }
+        return false
+    }
+
+    /// Session-ID candidates reduced to a trusted identity set: nil and
+    /// whitespace-only entries are dropped, everything else is kept as-is.
+    /// One normalization rule for every identity set compared by
+    /// `ownershipHolds`.
+    static func normalizingSessionIDs(_ candidates: [String?]) -> Set<String> {
+        var ids: Set<String> = []
+        for candidate in candidates {
+            guard let candidate,
+                  !candidate.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                continue
+            }
+            ids.insert(candidate)
+        }
+        return ids
+    }
+
     /// Prepends an older page onto the loaded transcript, dropping rows the
     /// transcript already holds. Offset drift under `order=latest` paging
     /// (rows persisted while the conversation is open shift the origin) makes

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -88,17 +88,13 @@ struct ChatView: View {
         appState.chatResumeRestorationRequest != nil
     }
 
-    /// The bounded persisted-history window reports older pages behind the
-    /// loaded tail. Only offered while the window belongs to the active
-    /// profile and there is a hydrated transcript to extend.
+    /// Whether "Load earlier messages" is offered right now. AppState owns
+    /// the complete truth — window state, transcript content, and
+    /// active-conversation ownership — the exact predicate
+    /// `loadEarlierMessages` enforces, so the control can never render for
+    /// a window the action would silently reject.
     private var transcriptBackfillAvailable: Bool {
-        guard let window = appState.persistedTranscriptWindow,
-              window.canLoadEarlier,
-              window.profile == appState.activeProfile,
-              !appState.messages.isEmpty else {
-            return false
-        }
-        return true
+        appState.canLoadEarlierMessagesForActiveConversation
     }
 
     private var transcriptBackfillIsLoading: Bool {

--- a/ConduitTests/CompactResumeTranscriptTests.swift
+++ b/ConduitTests/CompactResumeTranscriptTests.swift
@@ -1774,6 +1774,517 @@ final class CompactResumeTranscriptTests: XCTestCase {
         XCTAssertTrue(harness.appState.persistedTranscriptWindow?.hasBackfilledPrefix ?? false)
     }
 
+    // MARK: - Window conversation-identity ownership
+
+    /// THE production no-op regression: a long stored session opens, the
+    /// bounded tail hydrates, and `session.resume` re-homes
+    /// `activeSessionId` to a runtime ID the session catalog has NOT
+    /// learned as an alias. The window's transaction-captured identity must
+    /// keep the backfill owned and actionable — the old catalog-alias gate
+    /// silently early-returned before any request, spinner, or error, while
+    /// the button stayed visible.
+    func testBackfillWorksWithoutCatalogLearningRuntimeAlias() async throws {
+        let backfillCalls = BackfillCallRecorder()
+        // Catalog contains ONLY stored-a; runtime-a appears nowhere in it.
+        let active = session("stored-a")
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1880..<2000), offset: 0)
+            },
+            loadEarlierTranscriptPage: { sessionId, profile, offset in
+                backfillCalls.record(sessionId: sessionId, profile: profile, offset: offset)
+                return self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1760..<1880), offset: offset)
+            }
+        )
+        harness.appState.sessions = [active]
+
+        let opened = await harness.appState.openSession("stored-a")
+        XCTAssertTrue(opened)
+
+        // The resume re-homed the active identity to the runtime ID, and
+        // the window captured the whole accepted transaction.
+        XCTAssertEqual(harness.appState.activeSessionId, "runtime-a")
+        let window = harness.appState.persistedTranscriptWindow
+        XCTAssertEqual(window?.requestedSessionID, "stored-a")
+        XCTAssertEqual(window?.resolvedSessionID, "stored-a")
+        XCTAssertEqual(window?.runtimeSessionID, "runtime-a")
+        XCTAssertEqual(window?.canLoadEarlier, true)
+        XCTAssertTrue(
+            harness.appState.canLoadEarlierMessagesForActiveConversation,
+            "The affordance must stay actionable before the catalog learns the runtime↔stored alias"
+        )
+
+        let didPrepend = await harness.appState.loadEarlierMessages()
+
+        XCTAssertTrue(didPrepend, "Backfill must run — not silently early-return — without catalog aliases")
+        XCTAssertEqual(backfillCalls.calls.count, 1, "The older-page loader must be invoked exactly once")
+        XCTAssertEqual(backfillCalls.calls.first?.sessionId, "stored-a", "The persisted-history request must use the stored session ID")
+        XCTAssertEqual(backfillCalls.calls.first?.profile, "default")
+        XCTAssertEqual(backfillCalls.calls.first?.offset, 120)
+        XCTAssertEqual(harness.appState.messages.count, 240)
+        XCTAssertEqual(harness.appState.messages.first?.content, "Row 1760")
+        XCTAssertEqual(harness.appState.messages.last?.content, "Row 1999")
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.nextOffset, 240)
+        XCTAssertTrue(harness.appState.persistedTranscriptWindow?.hasBackfilledPrefix ?? false)
+    }
+
+    /// A requested runtime alias that resolves to a DIFFERENT stored ID:
+    /// backfill continues against the resolved stored ID (Desktop's
+    /// `BackfillRequest.storedSessionId` contract) while ownership stays
+    /// with the active runtime conversation.
+    func testBackfillUsesResolvedStoredIDWhenOpenedViaRuntimeAlias() async throws {
+        let backfillCalls = BackfillCallRecorder()
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1880..<2000), offset: 0)
+            },
+            loadEarlierTranscriptPage: { sessionId, profile, offset in
+                backfillCalls.record(sessionId: sessionId, profile: profile, offset: offset)
+                XCTAssertEqual(
+                    sessionId, "stored-a",
+                    "Persisted-history reads continue against the stored ID, never the requested runtime alias"
+                )
+                return self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1760..<1880), offset: offset)
+            }
+        )
+        harness.appState.sessions = [active]
+
+        let opened = await harness.appState.openSession("runtime-a")
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.activeSessionId, "runtime-a")
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.requestedSessionID, "runtime-a")
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.resolvedSessionID, "stored-a")
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.runtimeSessionID, "runtime-a")
+
+        let didPrepend = await harness.appState.loadEarlierMessages()
+
+        XCTAssertTrue(didPrepend)
+        XCTAssertEqual(backfillCalls.calls.first?.sessionId, "stored-a")
+        XCTAssertEqual(backfillCalls.calls.first?.offset, 120)
+        XCTAssertEqual(harness.appState.messages.count, 240)
+        XCTAssertTrue(harness.appState.canLoadEarlierMessagesForActiveConversation)
+    }
+
+    /// A backfill resolving after a session switch is discarded even with a
+    /// catalog that never learned any runtime aliases: session B's
+    /// transcript is untouched and session A's coverage is not published
+    /// into it.
+    func testStaleBackfillDiscardedAfterSwitchWithoutCatalogAliases() async throws {
+        let backfillStarted = Flag()
+        let sessionA = session("stored-a")
+        let sessionB = session("stored-b")
+        let harness = try makeHarness(
+            openSession: { _, sessionID, _ in
+                SessionResumeResult(
+                    sessionId: sessionID == "stored-a" ? "runtime-a" : "runtime-b",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { sessionId, _ in
+                if sessionId == "stored-a" {
+                    return self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1880..<2000), offset: 0)
+                }
+                return self.tailPagePayload(sessionId: "stored-b", rows: self.syntheticRows(1..<3), offset: 0)
+            },
+            loadEarlierTranscriptPage: { sessionId, _, offset in
+                backfillStarted.isOn = true
+                XCTAssertEqual(sessionId, "stored-a")
+                try? await Task.sleep(for: .milliseconds(250))
+                return self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1760..<1880), offset: offset)
+            }
+        )
+        harness.appState.sessions = [sessionA, sessionB]
+        let openedA = await harness.appState.openSession("stored-a")
+        XCTAssertTrue(openedA)
+        XCTAssertEqual(harness.appState.activeSessionId, "runtime-a")
+
+        let backfill = Task { await harness.appState.loadEarlierMessages() }
+        for _ in 0..<1_000 where !backfillStarted.isOn {
+            await Task.yield()
+        }
+        XCTAssertTrue(backfillStarted.isOn, "The backfill fetch must have started")
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.isLoadingEarlier, true)
+
+        let openedB = await harness.appState.openSession("stored-b")
+        XCTAssertTrue(openedB)
+        let didPrependStale = await backfill.value
+        XCTAssertFalse(didPrependStale, "The stale session-A page must not publish")
+
+        XCTAssertEqual(harness.appState.messages.count, 2, "Session B must be completely unchanged by the stale page")
+        XCTAssertEqual(harness.appState.messages.first?.content, "Row 1")
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.requestedSessionID, "stored-b")
+        XCTAssertFalse(
+            harness.appState.persistedTranscriptWindow?.hasBackfilledPrefix ?? true,
+            "Session A's backfill coverage must not be published into session B"
+        )
+        XCTAssertFalse(harness.appState.messages.contains { $0.id == "1760" }, "No session-A row may leak into session B")
+    }
+
+    /// A window from a genuinely different conversation must neither show
+    /// an actionable control nor issue a request.
+    func testForeignActiveSessionHidesAffordanceAndRejectsBackfill() async throws {
+        let backfillCalls = BackfillCallRecorder()
+        let active = session("stored-a")
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1880..<2000), offset: 0)
+            },
+            loadEarlierTranscriptPage: { sessionId, profile, offset in
+                backfillCalls.record(sessionId: sessionId, profile: profile, offset: offset)
+                return self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1760..<1880), offset: offset)
+            }
+        )
+        harness.appState.sessions = [active]
+        let opened = await harness.appState.openSession("stored-a")
+        XCTAssertTrue(opened)
+        XCTAssertTrue(harness.appState.canLoadEarlierMessagesForActiveConversation)
+
+        // A different conversation becomes active — no alias relationship
+        // with the window's stored/runtime identities.
+        harness.appState.activeSessionId = "runtime-b"
+
+        XCTAssertFalse(
+            harness.appState.canLoadEarlierMessagesForActiveConversation,
+            "A foreign active session must not show an actionable control"
+        )
+        let didPrepend = await harness.appState.loadEarlierMessages()
+        XCTAssertFalse(didPrepend)
+        XCTAssertEqual(backfillCalls.calls.count, 0, "No network request may be issued for a foreign conversation")
+    }
+
+    /// The catalog learning the stored↔runtime alias LATER must not reset
+    /// or re-own the history window: the transaction-derived identity stays
+    /// sufficient before and after the refresh.
+    func testCatalogLearningAliasLaterPreservesWindowAndOwnership() async throws {
+        let backfillCalls = BackfillCallRecorder()
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1880..<2000), offset: 0)
+            },
+            loadEarlierTranscriptPage: { sessionId, profile, offset in
+                backfillCalls.record(sessionId: sessionId, profile: profile, offset: offset)
+                return self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1760..<1880), offset: offset)
+            }
+        )
+        harness.appState.sessions = [session("stored-a")]
+        let opened = await harness.appState.openSession("stored-a")
+        XCTAssertTrue(opened)
+        let windowBefore = harness.appState.persistedTranscriptWindow
+        XCTAssertEqual(windowBefore?.runtimeSessionID, "runtime-a")
+
+        // The catalog later learns the alias.
+        harness.appState.sessions = [session("stored-a", alternateIDs: ["runtime-a"])]
+
+        XCTAssertEqual(
+            harness.appState.persistedTranscriptWindow, windowBefore,
+            "A catalog refresh must not reset or rewrite the history window"
+        )
+        XCTAssertTrue(harness.appState.canLoadEarlierMessagesForActiveConversation)
+
+        let didPrepend = await harness.appState.loadEarlierMessages()
+        XCTAssertTrue(didPrepend)
+        XCTAssertEqual(backfillCalls.calls.count, 1)
+        XCTAssertEqual(backfillCalls.calls.first?.sessionId, "stored-a")
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.nextOffset, 240)
+    }
+
+    /// The exact production sequence end to end: backfill under a catalog
+    /// that never learned the runtime↔stored alias, then a
+    /// reconnect/reconcile — the backfilled prefix survives, ownership
+    /// holds, and continued backfilling still routes by the stored ID.
+    /// (The harness reuses one runtime ID per stored session; a backend
+    /// minting a FRESH runtime ID per resume is still safe because the
+    /// reconcile rebuilds the window inside the same accepted transaction
+    /// — the graft gate then compares that new transaction's full identity
+    /// against the previous window's.)
+    func testReconnectGraftSurvivesStaleCatalogAliases() async throws {
+        let holdsRefreshedTail = Flag()
+        let backfillCalls = BackfillCallRecorder()
+        let active = session("stored-a")
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                if holdsRefreshedTail.isOn {
+                    return self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1900..<2020), offset: 0)
+                }
+                return self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1880..<2000), offset: 0)
+            },
+            loadEarlierTranscriptPage: { sessionId, profile, offset in
+                backfillCalls.record(sessionId: sessionId, profile: profile, offset: offset)
+                if backfillCalls.calls.count == 1 {
+                    return self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1760..<1880), offset: offset)
+                }
+                return self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1640..<1760), offset: offset)
+            },
+            additionalOperations: { ops in
+                ops.connectClient = { _ in }
+                // The refreshed catalog STILL lacks the runtime alias.
+                ops.loadCatalog = { _, _ in [active] }
+                ops.loadProfiles = {}
+                ops.loadBusyInputMode = { _ in }
+                ops.loadProfileDisplayPreferences = {}
+                ops.loadSlashCommands = {}
+            }
+        )
+        harness.appState.sessions = [active]
+        let opened = await harness.appState.openSession("stored-a")
+        XCTAssertTrue(opened)
+
+        let didPrepend = await harness.appState.loadEarlierMessages()
+        XCTAssertTrue(didPrepend)
+        XCTAssertEqual(harness.appState.messages.count, 240)
+        XCTAssertEqual(backfillCalls.calls.first?.sessionId, "stored-a")
+
+        // The reconnect re-reconciles under the stored ID while the catalog
+        // is still alias-stale; resume re-homes active to runtime-a again.
+        holdsRefreshedTail.isOn = true
+        harness.coordinator.rememberSessionID("stored-a", for: "default")
+        await harness.appState.connect(
+            with: HermesConnection(baseUrl: "https://one.example", ticket: "stale-alias-graft")
+        )
+
+        // Backfilled prefix (rows 1760–1899) plus the refreshed tail
+        // (rows 1900–2019) — not truncated to the refreshed tail alone.
+        XCTAssertEqual(harness.appState.messages.count, 140 + 120)
+        XCTAssertEqual(harness.appState.messages.first?.content, "Row 1760")
+        XCTAssertEqual(harness.appState.messages[139].content, "Row 1899")
+        XCTAssertEqual(harness.appState.messages[140].content, "Row 1900")
+        XCTAssertEqual(harness.appState.messages.last?.content, "Row 2019")
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.requestedSessionID, "stored-a")
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.runtimeSessionID, "runtime-a")
+        XCTAssertTrue(harness.appState.persistedTranscriptWindow?.hasBackfilledPrefix ?? false)
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.nextOffset, 120)
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.canLoadEarlier, true)
+        XCTAssertTrue(
+            harness.appState.canLoadEarlierMessagesForActiveConversation,
+            "Ownership must survive the reconnect without catalog aliases"
+        )
+
+        // Continued backfilling after the reconnect still uses the stored ID.
+        let didPrependAfter = await harness.appState.loadEarlierMessages()
+        XCTAssertTrue(didPrependAfter)
+        XCTAssertEqual(backfillCalls.calls.count, 2)
+        XCTAssertEqual(backfillCalls.calls.last?.sessionId, "stored-a")
+        XCTAssertEqual(backfillCalls.calls.last?.offset, 120)
+        XCTAssertEqual(harness.appState.messages.count, 380, "Rows 1640–1759 prepend onto the grafted transcript")
+        XCTAssertEqual(harness.appState.messages.first?.content, "Row 1640")
+    }
+
+    /// The centralized identity rule behind every window-ownership check:
+    /// explicit transaction-captured overlap is primary truth, catalog
+    /// aliases only assist, and a profile mismatch always rejects.
+    func testWindowOwnershipIdentityRule() {
+        func expanded(_ ids: Set<String>, catalog: [String: Set<String>]) -> Set<String> {
+            ids.reduce(into: Set<String>()) { out, id in out.formUnion(catalog[id] ?? [id]) }
+        }
+        let window = PersistedTranscriptWindowState(
+            requestedSessionID: "stored-a",
+            profile: "default",
+            pageSize: 120,
+            resolvedSessionID: "stored-a",
+            runtimeSessionID: "runtime-a",
+            nextOffset: 120,
+            canLoadEarlier: true
+        )
+        func holds(
+            active: String,
+            profile: String = "default",
+            catalog: [String: Set<String>] = [:]
+        ) -> Bool {
+            let conversationIds = Set([active])
+            return PersistedTranscriptWindow.ownershipHolds(
+                window: window,
+                conversationSessionIds: conversationIds,
+                profile: profile,
+                windowAliasIds: expanded(window.trustedSessionIDs, catalog: catalog),
+                conversationAliasIds: expanded(conversationIds, catalog: catalog)
+            )
+        }
+
+        // Active runtime conversation, catalog ignorant of the alias:
+        // owned through the transaction-captured runtime ID alone.
+        XCTAssertTrue(holds(active: "runtime-a"))
+        XCTAssertTrue(holds(active: "stored-a"))
+        // Catalog alias knowledge still proves equivalence either direction.
+        XCTAssertTrue(holds(
+            active: "runtime-x",
+            catalog: ["runtime-x": ["runtime-x", "stored-a"]]
+        ))
+        XCTAssertTrue(holds(
+            active: "runtime-x",
+            catalog: ["stored-a": ["stored-a", "runtime-x"]]
+        ))
+        // A genuinely foreign conversation with no proven alias rejects.
+        XCTAssertFalse(holds(active: "runtime-b"))
+        XCTAssertFalse(holds(active: "stored-b", catalog: ["stored-b": ["stored-b", "runtime-b"]]))
+        // Profile mismatch rejects even with explicit ID overlap.
+        XCTAssertFalse(holds(active: "runtime-a", profile: "work"))
+    }
+
+    /// If ownership is lost MID-FLIGHT while the armed window itself
+    /// survived (e.g. a disconnect clears `activeSessionId` without a
+    /// reconcile replacing the window), the response is discarded whole AND
+    /// the single-flight flag is released — the affordance can re-arm later
+    /// instead of spinning forever.
+    func testOwnershipLossMidFlightReleasesLoadingFlag() async throws {
+        let backfillCalls = BackfillCallRecorder()
+        let active = session("stored-a")
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1880..<2000), offset: 0)
+            },
+            loadEarlierTranscriptPage: { sessionId, profile, offset in
+                backfillCalls.record(sessionId: sessionId, profile: profile, offset: offset)
+                try? await Task.sleep(for: .milliseconds(150))
+                return self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1760..<1880), offset: offset)
+            }
+        )
+        harness.appState.sessions = [active]
+        let opened = await harness.appState.openSession("stored-a")
+        XCTAssertTrue(opened)
+
+        let backfill = Task { await harness.appState.loadEarlierMessages() }
+        // Detach the conversation identity WITHOUT replacing the window —
+        // the ownership-lost-but-window-survived shape.
+        for _ in 0..<1_000 where backfillCalls.calls.isEmpty {
+            await Task.yield()
+        }
+        harness.appState.activeSessionId = "runtime-b"
+        let didPrepend = await backfill.value
+
+        XCTAssertFalse(didPrepend, "The response must be discarded once the conversation moved on")
+        XCTAssertEqual(harness.appState.messages.count, 120, "The transcript stays untouched")
+        XCTAssertFalse(
+            harness.appState.persistedTranscriptWindow?.isLoadingEarlier ?? true,
+            "The single-flight flag must be released, not stranded"
+        )
+
+        // Re-owning the conversation re-arms the affordance and backfill works.
+        harness.appState.activeSessionId = "runtime-a"
+        XCTAssertTrue(harness.appState.canLoadEarlierMessagesForActiveConversation)
+        let didPrependRetry = await harness.appState.loadEarlierMessages()
+        XCTAssertTrue(didPrependRetry)
+        XCTAssertEqual(backfillCalls.calls.count, 2)
+        XCTAssertEqual(harness.appState.messages.count, 240)
+    }
+
+    /// A `/messages` response without a `session_id` echo (legacy backend
+    /// shape) leaves the window without a resolved stored ID: older-page
+    /// requests fall back to the requested session ID.
+    func testBackfillFallsBackToRequestedIDWhenHydrationEchoesNoSessionID() async throws {
+        let backfillCalls = BackfillCallRecorder()
+        let active = session("stored-a")
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                // Tail page under the current contract, but with NO
+                // `session_id` echo.
+                .payload([
+                    "messages": self.syntheticRows(1880..<2000),
+                    "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 120]
+                ])
+            },
+            loadEarlierTranscriptPage: { sessionId, profile, offset in
+                backfillCalls.record(sessionId: sessionId, profile: profile, offset: offset)
+                XCTAssertEqual(sessionId, "stored-a", "No resolved stored ID: fall back to the requested ID")
+                return self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1760..<1880), offset: offset)
+            }
+        )
+        harness.appState.sessions = [active]
+        let opened = await harness.appState.openSession("stored-a")
+        XCTAssertTrue(opened)
+        XCTAssertNil(harness.appState.persistedTranscriptWindow?.resolvedSessionID)
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.runtimeSessionID, "runtime-a")
+
+        let didPrepend = await harness.appState.loadEarlierMessages()
+
+        XCTAssertTrue(didPrepend)
+        XCTAssertEqual(backfillCalls.calls.first?.sessionId, "stored-a")
+        XCTAssertEqual(backfillCalls.calls.first?.offset, 120)
+        XCTAssertEqual(harness.appState.messages.count, 240)
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.nextOffset, 240)
+    }
+
+    /// An older-page response that echoes the TRANSACTION-CAPTURED runtime
+    /// ID is still this conversation's rows: the accepted resume proved
+    /// that identity, so the page must not be rejected as foreign.
+    func testBackfillAcceptsResponseEchoingTransactionRuntimeID() async throws {
+        let active = session("stored-a")
+        let harness = try makeHarness(
+            openSession: { _, _, _ in
+                SessionResumeResult(
+                    sessionId: "runtime-a",
+                    messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                )
+            },
+            persistedTranscript: { _, _ in
+                self.tailPagePayload(sessionId: "stored-a", rows: self.syntheticRows(1880..<2000), offset: 0)
+            },
+            loadEarlierTranscriptPage: { _, _, offset in
+                self.tailPagePayload(sessionId: "runtime-a", rows: self.syntheticRows(1760..<1880), offset: offset)
+            }
+        )
+        harness.appState.sessions = [active]
+        let opened = await harness.appState.openSession("stored-a")
+        XCTAssertTrue(opened)
+
+        let didPrepend = await harness.appState.loadEarlierMessages()
+
+        XCTAssertTrue(didPrepend, "An echo of the window's own resume-proven runtime ID is not foreign")
+        XCTAssertEqual(harness.appState.messages.count, 240)
+        XCTAssertEqual(harness.appState.persistedTranscriptWindow?.canLoadEarlier, true, "The affordance must not be retired")
+    }
+
     // MARK: - Harness
 
     private func makeHarness(
@@ -1841,6 +2352,16 @@ final class CompactResumeTranscriptTests: XCTestCase {
 
     private final class Flag {
         var isOn = false
+    }
+
+    /// Records every older-page backfill request: the wire session ID, the
+    /// routing profile, and the offset — the identity contract of "Load
+    /// earlier messages".
+    private final class BackfillCallRecorder {
+        private(set) var calls: [(sessionId: String, profile: String, offset: Int)] = []
+        func record(sessionId: String, profile: String, offset: Int) {
+            calls.append((sessionId, profile, offset))
+        }
     }
 
     /// One persisted transcript row exactly as the messages endpoint returns


### PR DESCRIPTION
Fixes the production regression where the **"Load earlier messages"** button renders but tapping it does absolutely nothing — no spinner, no error, no older rows, no network request. The initial bounded tail hydration itself was correct.

## Root cause (the actual early-return)

A session carries three identities: the catalog/requested ID, the persisted stored ID, and the runtime ID that `session.resume` returns. After resume, `applyChatResume(_:)` re-homes `activeSessionId` to the **runtime** ID, but the session catalog does not learn the `stored ↔ runtime` alias (for catalog-opened sessions it often never does — only the *new-session* path records `alternateIds`).

`loadEarlierMessages()` began with an ownership gate that recognized only the window's **requested** ID:

```swift
persistedTranscriptWindowOwnershipIsCurrent(
    requestedSessionId: window.requestedSessionID,
    profile: window.profile
)
```

That helper depended entirely on live catalog aliases (`knownSessionIDs(for:)`) to equate `stored-a ↔ runtime-a`. With an alias-stale catalog it returned `false` **before** `isLoadingEarlier = true`, before any REST request, before any user-visible failure — the exact observed no-op. Every PR #118 backfill test preloaded `session("stored-a", alternateIDs: ["runtime-a"])` into the catalog, which recreated the synthetic condition that hid the bug.

## What changed

**1. Window models the conversation identity explicitly** — `PersistedTranscriptWindowState` now captures all three identities **from the same accepted hydration/resume transaction**:

- `requestedSessionID` — ID used to open/resume
- `resolvedSessionID` — `session_id` echoed by `/messages` (now strictly that; the old `?? result.sessionId` coalescing that conflated it with the runtime ID is gone)
- `runtimeSessionID` — `session.resume` `result.sessionId` (new)

Exposed as `trustedSessionIDs`. These are trusted together because they arrived in one accepted transaction after the existing transcript identity validation — never reconstructed from a later catalog refresh.

**2. One centralized, self-contained ownership rule** — `PersistedTranscriptWindow.ownershipHolds(window:conversationSessionIds:profile:windowAliasIds:conversationAliasIds:)`:

- profile mismatch always rejects;
- primary truth: explicit ID overlap between the window's transaction-captured set and the checked conversation's IDs;
- catalog aliases remain a compatibility source (either direction), but catalog freshness is **never required**.

The same rule now serves `loadEarlierMessages()`'s entry guard, the stale-response re-validation, the reconnect graft gate (`priorWindowOwnsThisConversation`, now comparing against the new transaction's requested + resolved + runtime identities), and the response-echo acceptance check — one identity semantics, no divergent copies.

**3. Older pages fetch by the durable stored ID** — requests go to `window.resolvedSessionID ?? window.requestedSessionID`, mirroring Hermes Desktop's `BackfillRequest.storedSessionId → getOlderSessionMessages(storedSessionId, ...)`. The runtime WebSocket ID is never used for persisted-history reads; `profile` routing is unchanged.

**4. UI availability = action ownership** — new AppState-owned `canLoadEarlierMessagesForActiveConversation` (window state + non-empty transcript + the exact ownership predicate the action enforces). `ChatView.transcriptBackfillAvailable` now just reads it, so the control can no longer render for a window the action would silently reject. A genuinely stale window from another conversation no longer shows an actionable button.

**5. Observability** — an unexpected ownership rejection of an otherwise-actionable window logs a diagnostic `debug` line with requested/resolved/runtime/active IDs and both profiles (non-sensitive; `privacy: .public`). Stale session-switch races stay silent — no user-facing error.

**6. Review-hardening extras** — the single-flight `isLoadingEarlier` flag is released when ownership is lost mid-flight while the armed window itself survived (previously it could strand the affordance forever — pre-existing, fixed here); ID normalization and alias expansion are shared helpers; response-echo acceptance routes through the same centralized rule.

## Reconnect/graft behavior

The graft gate now compares the previous window's transaction-derived identity set against the new reconciliation's full identity set, so a reconnect **keeps already-loaded older history even when the catalog is temporarily stale** about the alias. The existing safety rule is preserved: with no safe identity/row-ID anchor proving continuity, the refreshed tail stays authoritative, and grafting still requires the refreshed tail's first row to actually exist inside the previous transcript — never grafted across unrelated sessions.

## Regression coverage (10 new tests, `CompactResumeTranscriptTests`)

- **The production no-op repro**: catalog contains `stored-a` only, resume returns `runtime-a`, **no alias preloaded** → active is `runtime-a`, window owned, `canLoadEarlierMessagesForActiveConversation == true`, `loadEarlierMessages()` does **not** early-return, loader invoked exactly once with `("stored-a", "default", 120)`, rows prepend, `nextOffset` advances. Fails on the pre-fix implementation (zero calls, silent `false`).
- Requested runtime alias resolving to a different stored ID → backfill fetches the **stored** ID and stays owned (fails on old code: it requested the runtime alias).
- Session-switch discard with an alias-less catalog (B untouched, no coverage leak).
- Truly foreign active session → affordance hidden, action rejects, zero network requests.
- Catalog learning the alias later → window unchanged, ownership intact.
- Reconnect/graft with a stale catalog end to end: backfill → reconnect (catalog still alias-less) → prefix survives → ownership holds → continued backfill still routes by the stored ID. Fails on old code (backfill no-op; prefix would truncate).
- Mid-flight ownership loss releases the loading flag and re-arms.
- No-echo hydration falls back to the requested ID for older pages.
- Response echoing the transaction-vouched runtime ID is accepted (not foreign).
- The pure identity rule (explicit overlap primary, catalog aliases assist, profile mismatch always rejects).

## Architecture unchanged

All PR #118 invariants preserved: initial page `limit=120&offset=0&order=latest&include_compacted=true`; manual, bounded, tail-anchored, raw-row-offset older pages; `hasBackfilledPrefix`; overlap dedupe by durable persisted row ID; cross-page tool-call reconstruction; compact `session.resume(omit_messages=true)`; structural-only legacy fallback; no transient-failure → giant WebSocket fallback; viewport prepend anchoring; current response-size/WebSocket limits. No automatic scrolling, no full-session auto-load, no Markdown/rendering changes, no Hermes backend changes.

## Verification

- Focused: `CompactResumeTranscriptTests` 44/44 (34 existing + 10 new) + `ChatViewportControllerTests` 91/91 = 135/135 on iPhone 17 Pro (per-class executed counts audited from the xcresult).
- Full unit suite on the build Mac: 1485 passed, 0 assertion failures; the runner then aborted with the **known end-of-day host audio degradation** (`SIGABRT` in `AURemoteIO::_ReportRPCTimeout`, untouched suites — same signature hit on 2026-08-31 during #117 work). A focused re-run of the interrupted classes passed another 145 with 0 failures before the same host abort. CI's fresh runners gate the complete matrix.
- `git diff --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript history loading when conversations use different runtime and stored session IDs.
  * Prevented older-message requests for unrelated or outdated conversations.
  * Ensured the history-loading state resets correctly after ownership changes.
  * Improved handling of missing or alternate session identifiers in backfill responses.

* **Improvements**
  * More accurately determines when earlier transcript messages are available.
  * Added comprehensive coverage for conversation ownership and transcript backfill behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->