### PR TITLE
fix(chat): end long-transcript reasoning churn and composer cursor corruption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,8 +102,8 @@ jobs:
           echo "ui-estimates=$(jq -r '.ui_lane.class_estimates // ""' ci-artifacts/plan.json)" >> "$GITHUB_OUTPUT"
           echo "ui-target=$(jq -r '.ui_lane.target // ""' ci-artifacts/plan.json)" >> "$GITHUB_OUTPUT"
           echo "ui-predicted=$(jq -r '.ui_lane.predicted_s // 0' ci-artifacts/plan.json)" >> "$GITHUB_OUTPUT"
-          echo "ui-timeout=$(jq -r '.ui_lane.timeout_s // 600' ci-artifacts/plan.json)" >> "$GITHUB_OUTPUT"
-          echo "ui-job-timeout=$(jq -r '.ui_lane.job_timeout_min // 25' ci-artifacts/plan.json)" >> "$GITHUB_OUTPUT"
+          echo "ui-timeout=$(jq -r '.ui_lane.timeout_s // 900' ci-artifacts/plan.json)" >> "$GITHUB_OUTPUT"
+          echo "ui-job-timeout=$(jq -r '.ui_lane.job_timeout_min // 65' ci-artifacts/plan.json)" >> "$GITHUB_OUTPUT"
 
       - name: Plan summary
         run: cat ci-artifacts/plan-summary.md >> "$GITHUB_STEP_SUMMARY"

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -459,6 +459,14 @@ final class AppState: ObservableObject {
     @Published private(set) var busyInputMode: BusyInputMode = .steer
     @Published private(set) var displayPreferences = ProfileDisplayPreferences()
     @Published var streamingText = ""
+    /// Live, frequently-changing reasoning projection. Streaming reasoning
+    /// renders from here at display cadence WITHOUT mutating the settled
+    /// `messages` array — per-publish transcript mutation (O(message count)
+    /// index scan + copy-on-write copy + revision bump + scroll-target cache
+    /// walk) is what made deep agent sessions burn CPU and battery. The card
+    /// commits into `messages` exactly once per segment boundary via
+    /// `settleReasoningSegmentIntoTranscript()`.
+    @Published private(set) var liveReasoningSegment: LiveReasoningSegment?
     /// An explicit user-send request lets ChatView scroll after SwiftUI has
     /// inserted the outgoing bubble, even if the user previously browsed up.
     @Published private(set) var chatScrollRequest = 0
@@ -661,6 +669,15 @@ final class AppState: ObservableObject {
         let reasoning: String?
     }
 
+    /// One live reasoning segment as projected to the UI: the identity and
+    /// mount timestamp are fixed for the segment's lifetime, only `content`
+    /// advances at display cadence. Rendering treats it exactly like a
+    /// settled `.reasoning` row (same ThinkingCard presentation).
+    struct LiveReasoningSegment: Equatable {
+        let id: String
+        let timestamp: String
+        var content: String
+    }
     private var reconciliationToken = UUID()
     private var reconciliation: Reconciliation?
     private var activeClientEpoch = UUID()
@@ -8188,9 +8205,10 @@ final class AppState: ObservableObject {
         switch event {
         case .messageStart:
             finalizePendingStreamingCompletion()
-            // A new turn ends any live reasoning card; flush first so the
-            // previous segment keeps its exact buffered text.
-            flushReasoningPublish()
+            // A new turn ends any live reasoning card; settle first so the
+            // previous segment keeps its exact buffered text in the
+            // transcript.
+            settleReasoningSegmentIntoTranscript()
             resetReasoningTurn()
             setRunning(true)
             notifyVoiceAssistant(.started(sessionID: streamSessionId))
@@ -8218,7 +8236,7 @@ final class AppState: ObservableObject {
             notifyVoiceAssistant(.completed(sessionID: streamSessionId, content: content))
 
         case .messageError(_, let message):
-            flushReasoningPublish()
+            settleReasoningSegmentIntoTranscript()
             resetReasoningTurn()
             clearStreamingText()
             errorMessage = message
@@ -8226,7 +8244,7 @@ final class AppState: ObservableObject {
             notifyVoiceAssistant(.failed(sessionID: streamSessionId, message: message))
 
         case .messageInterrupted:
-            flushReasoningPublish()
+            settleReasoningSegmentIntoTranscript()
             resetReasoningTurn()
             clearStreamingText()
             setRunning(false)
@@ -8260,11 +8278,12 @@ final class AppState: ObservableObject {
 
         case .toolStart(_, let name, let input):
             if name.lowercased() == "clarify" { break }
-            // The tool card must land after a complete reasoning card; flush
-            // the coalesced buffer before the boundary reorders the transcript.
-            // A tool ends the reasoning SEGMENT only — the turn flag survives
-            // so completion-carried reasoning cannot duplicate this segment.
-            flushReasoningPublish()
+            // The tool card must land after a complete reasoning card; commit
+            // the coalesced segment before the boundary reorders the
+            // transcript. A tool ends the reasoning SEGMENT only — the turn
+            // flag survives so completion-carried reasoning cannot duplicate
+            // this segment.
+            settleReasoningSegmentIntoTranscript()
             resetReasoningSegment()
             flushStreamingPartial()
             messages.append(ChatMessage(
@@ -8277,7 +8296,7 @@ final class AppState: ObservableObject {
 
         case .toolComplete(_, let name, let output):
             if name.lowercased() == "clarify" { break }
-            flushReasoningPublish()
+            settleReasoningSegmentIntoTranscript()
             resetReasoningSegment()
             // Update the matching running tool card in place instead of
             // appending a duplicate. This keeps input + output together in
@@ -8430,9 +8449,11 @@ final class AppState: ObservableObject {
     /// A reasoning delta belongs exactly where Hermes emitted it. Gateways can
     /// send either deltas or repeated cumulative snapshots, so merge both into
     /// one live card rather than creating duplicate thinking boxes. The first
-    /// delta of a segment mounts the card immediately so the thinking box
-    /// appears promptly; every later delta coalesces through
-    /// `reasoningBuffer` and republishes at display cadence.
+    /// delta of a segment mounts the live projection immediately so the
+    /// thinking box appears promptly; every later delta coalesces through
+    /// `reasoningBuffer` and republishes the PROJECTION at display cadence.
+    /// The settled transcript is touched only once per segment, at the
+    /// boundary commit.
     private func appendReasoning(_ text: String) {
         guard !text.isEmpty else { return }
         reasoningBuffer = mergedReasoning(
@@ -8441,14 +8462,13 @@ final class AppState: ObservableObject {
         )
         guard activeReasoningMessageId != nil else {
             let id = "reasoning-\(Date().timeIntervalSince1970)"
-            messages.append(ChatMessage(
-                id: id,
-                role: .reasoning,
-                content: reasoningBuffer,
-                timestamp: Self.localTimestamp(),
-                author: activeProfile
-            ))
             activeReasoningMessageId = id
+            TranscriptPerf.note(.reasoningProjectionPublish)
+            liveReasoningSegment = LiveReasoningSegment(
+                id: id,
+                timestamp: Self.localTimestamp(),
+                content: reasoningBuffer
+            )
             return
         }
         scheduleReasoningPublish()
@@ -8461,12 +8481,11 @@ final class AppState: ObservableObject {
 
         reasoningPublishTask = Task { @MainActor [weak self] in
             do {
-                // Reasoning updates mutate the published transcript, which is
-                // heavier than the streaming-text projection: an expanded
-                // ThinkingCard restyles its attributed text and remeasures a
-                // growing height on every commit. ~20 fps keeps the stream
-                // readable while leaving the main actor free between layout
-                // passes.
+                // Reasoning updates republish the live projection at this
+                // cadence; an expanded ThinkingCard restyles its attributed
+                // text and remeasures a growing height on every commit, so
+                // ~20 fps keeps the stream readable while leaving the main
+                // actor free between layout passes.
                 try await Task.sleep(for: .milliseconds(50))
             } catch {
                 return
@@ -8484,19 +8503,60 @@ final class AppState: ObservableObject {
     /// nothing can mutate a finalized or replaced transcript.
     private func publishReasoningBuffer(liveCardID: String?) {
         guard let liveCardID, liveCardID == activeReasoningMessageId,
-              let index = messages.firstIndex(where: { $0.id == liveCardID }),
-              messages[index].content != reasoningBuffer else { return }
-        messages[index].content = reasoningBuffer
+              var segment = liveReasoningSegment, segment.id == liveCardID,
+              segment.content != reasoningBuffer else { return }
+        TranscriptPerf.note(.reasoningProjectionPublish)
+        segment.content = reasoningBuffer
+        liveReasoningSegment = segment
     }
 
-    /// Publish any coalesced reasoning immediately so the live card is exact
-    /// before a semantic boundary (completion, tool, error, interruption,
-    /// next turn) reads or reorders the transcript.
+    /// Publish any coalesced reasoning into the live projection immediately.
+    /// Non-boundary callers (the sidebar closing) keep the segment streaming;
+    /// boundary callers need `settleReasoningSegmentIntoTranscript()`.
     private func flushReasoningPublish() {
         reasoningPublishTask?.cancel()
         reasoningPublishTask = nil
         hasScheduledReasoningPublish = false
         publishReasoningBuffer(liveCardID: activeReasoningMessageId)
+    }
+
+    /// Commit the live reasoning segment into the settled transcript EXACTLY
+    /// ONCE at a semantic boundary: tool card, completion, error,
+    /// interruption, or a new turn. `explicitContent` supersedes the buffered
+    /// text (the completion-carried trace replaces what streamed, exactly as
+    /// it replaced the in-transcript card content before the projection
+    /// existed). Paired with the boundary's `resetReasoning*` call, this
+    /// preserves the pre-projection transcript shape: the card is in
+    /// `messages`, complete, and no stale publish can touch it afterwards.
+    private func settleReasoningSegmentIntoTranscript(explicitContent: String? = nil) {
+        reasoningPublishTask?.cancel()
+        reasoningPublishTask = nil
+        hasScheduledReasoningPublish = false
+
+        func commit(id: String, timestamp: String, content: String) {
+            guard !content.isEmpty else { return }
+            TranscriptPerf.note(.reasoningTranscriptMutation)
+            messages.append(ChatMessage(
+                id: id,
+                role: .reasoning,
+                content: content,
+                timestamp: timestamp,
+                author: activeProfile
+            ))
+            reasoningBuffer = ""
+            activeReasoningMessageId = nil
+            liveReasoningSegment = nil
+        }
+
+        if let segment = liveReasoningSegment, activeReasoningMessageId == segment.id {
+            commit(id: segment.id, timestamp: segment.timestamp, content: explicitContent ?? reasoningBuffer)
+        } else if let text = explicitContent {
+            commit(
+                id: "reasoning-\(Date().timeIntervalSince1970)",
+                timestamp: Self.localTimestamp(),
+                content: text
+            )
+        }
     }
 
     /// End the active reasoning SEGMENT without publishing. Used at tool
@@ -8509,6 +8569,7 @@ final class AppState: ObservableObject {
         hasScheduledReasoningPublish = false
         reasoningBuffer = ""
         activeReasoningMessageId = nil
+        liveReasoningSegment = nil
     }
 
     /// Restore the ENTIRE per-turn reasoning state machine to its initial
@@ -8533,19 +8594,13 @@ final class AppState: ObservableObject {
     /// Completion sometimes carries the full reasoning trace as well as the
     /// deltas. Prefer that complete value without duplicating an already
     /// streamed card; gateways that only provide completion still get a card
-    /// immediately before their final answer.
+    /// immediately before their final answer. Completion is a boundary: the
+    /// trace commits straight into the settled transcript rather than the
+    /// live projection — a projection left behind would be discarded by the
+    /// turn reset that immediately follows.
     private func finalizeReasoning(_ text: String) {
         guard !text.isEmpty else { return }
-        if let id = activeReasoningMessageId,
-           let index = messages.firstIndex(where: { $0.id == id }) {
-            if text.hasPrefix(messages[index].content) {
-                messages[index].content = text
-            } else if messages[index].content != text {
-                messages[index].content = text
-            }
-            return
-        }
-        appendReasoning(text)
+        settleReasoningSegmentIntoTranscript(explicitContent: text)
     }
 
     func requestChatScrollToLatest() {
@@ -9243,7 +9298,7 @@ final class AppState: ObservableObject {
     ) {
         // messageComplete is a semantic boundary: the thinking card must show
         // its full buffered reasoning immediately, not one cadence later.
-        flushReasoningPublish()
+        settleReasoningSegmentIntoTranscript()
         streamingCompletionTask?.cancel()
         streamingPublishTask?.cancel()
         streamingPublishTask = nil
@@ -9321,7 +9376,7 @@ final class AppState: ObservableObject {
     ) {
         // Reasoning that raced the drain window must not be discarded when
         // the pending completion finalizes.
-        flushReasoningPublish()
+        settleReasoningSegmentIntoTranscript()
         removeAllPartials()
         // Some gateways repeat the full trace in completion after already
         // emitting reasoning events. Use it only when streaming supplied no

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -5231,6 +5231,9 @@ final class AppState: ObservableObject {
             author: nil,
             attachments: attachments.isEmpty ? nil : attachments
         )
+        // Mid-turn ordering rule: the outgoing bubble must not land below a
+        // still-live reasoning card's eventual commit.
+        settleReasoningSegmentIntoTranscript()
         messages.append(userMessage)
         requestChatScrollToLatest()
         cacheMessagePresentation(for: [sessionId])
@@ -5787,6 +5790,9 @@ final class AppState: ObservableObject {
         if let context {
             guard isCurrentComposerSubmission(context) else { return }
         }
+        // Mid-turn ordering rule: slash output must not land below the live
+        // reasoning card's eventual commit.
+        settleReasoningSegmentIntoTranscript()
         messages.append(ChatMessage(
             id: "slash-\(Date().timeIntervalSince1970)",
             role: .system,
@@ -5941,6 +5947,11 @@ final class AppState: ObservableObject {
                 == text.trimmingCharacters(in: .whitespacesAndNewlines) {
             return
         }
+        // Mid-turn ordering rule: a steer/redirect correction bubble must sit
+        // above the live reasoning card's eventual commit. Reasoning that
+        // resumes after the correction mounts a fresh segment below it,
+        // matching the tool-boundary precedent.
+        settleReasoningSegmentIntoTranscript()
         messages.append(ChatMessage(
             id: "local-correction-\(Date().timeIntervalSince1970)",
             role: .user,
@@ -8326,6 +8337,10 @@ final class AppState: ObservableObject {
         case .reviewSummary(let sessionId, let activity):
             let id = "review-summary-\(sessionId)-\(UUID().uuidString)"
             guard !messages.contains(where: { $0.review == activity }) else { return }
+            // A mid-turn row must not land below the live reasoning card's
+            // eventual commit — settle first so chronology matches the
+            // pre-projection transcript.
+            settleReasoningSegmentIntoTranscript()
             messages.append(ChatMessage(
                 id: id,
                 role: .system,
@@ -8386,6 +8401,9 @@ final class AppState: ObservableObject {
                         sessionIDs: cacheSessionIDs
                     )
                 }
+                // The clarify row must sit above the live reasoning card's
+                // eventual commit — settle the segment before it lands.
+                settleReasoningSegmentIntoTranscript()
                 messages.append(ChatMessage(
                     id: "clarify-\(requestId)",
                     role: .clarify,
@@ -8404,6 +8422,8 @@ final class AppState: ObservableObject {
                 messages[index].content = activity.description
                 messages[index].approval = activity
             } else {
+                // Same mid-turn ordering rule as clarify above.
+                settleReasoningSegmentIntoTranscript()
                 messages.append(ChatMessage(
                     id: "approval-\(activity.sessionId)-\(UUID().uuidString)",
                     role: .approval,
@@ -8535,6 +8555,13 @@ final class AppState: ObservableObject {
 
         func commit(id: String, timestamp: String, content: String) {
             guard !content.isEmpty else { return }
+            // Commit and the projection clear below must stay in ONE
+            // transaction: ChatView relies on the committed row's id equaling
+            // the live segment's id for a seamless live→settled transition —
+            // splitting them would transiently duplicate ids in the
+            // LazyVStack. The card keeps its mount timestamp; `author`
+            // reflects the profile at settle time (indistinguishable unless
+            // the profile switches mid-stream).
             TranscriptPerf.note(.reasoningTranscriptMutation)
             messages.append(ChatMessage(
                 id: id,
@@ -8596,8 +8623,10 @@ final class AppState: ObservableObject {
     /// streamed card; gateways that only provide completion still get a card
     /// immediately before their final answer. Completion is a boundary: the
     /// trace commits straight into the settled transcript rather than the
-    /// live projection — a projection left behind would be discarded by the
-    /// turn reset that immediately follows.
+    /// live projection. Reachable only when nothing streamed this turn (the
+    /// caller gates on `receivedReasoningForCurrentTurn`), so there is never
+    /// a live segment to supersede here — `explicitContent` always mounts a
+    /// fresh settled card.
     private func finalizeReasoning(_ text: String) {
         guard !text.isEmpty else { return }
         settleReasoningSegmentIntoTranscript(explicitContent: text)

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -9,6 +9,11 @@ struct ChatMessageScrollTarget: Identifiable, Equatable {
     let message: ChatMessage
     let semanticID: String
     let restorationMetadata: ChatScrollAnchorMetadata
+    /// Transcript-order position, maintained by the cache so views can
+    /// iterate the targets collection directly (no Array(enumerated()) copy
+    /// per body evaluation) and still report stable row order to the
+    /// viewport geometry.
+    let order: Int
 
     /// SwiftUI keeps the existing source-row identity for rendering and
     /// controls. Only scroll targeting uses the source-independent ID.
@@ -68,6 +73,7 @@ struct ChatMessageScrollTargetCache: Equatable {
               targets[commonPrefix].message == messages[commonPrefix] {
             commonPrefix += 1
         }
+        TranscriptPerf.scrollTargetCommonPrefixComparisons += commonPrefix
 
         // Identical transcripts: no work at all.
         if commonPrefix == targets.count, commonPrefix == messages.count {
@@ -85,15 +91,17 @@ struct ChatMessageScrollTargetCache: Equatable {
 
         // Same length and identical suffix fingerprints: a rendering-only
         // replacement (equal semantics, different message objects). Swap the
-        // message values in place; semantic IDs and restoration metadata are
-        // untouched, so duplicate semantics cannot shift.
+        // message values in place; semantic IDs, restoration metadata, and
+        // transcript order are untouched, so duplicate semantics cannot
+        // shift.
         if targets.count == messages.count,
            suffixFingerprints.elementsEqual(fingerprints[suffixStart...]) {
             let replacement = zip(suffixMessages, targets[suffixStart...]).map { message, target in
                 ChatMessageScrollTarget(
                     message: message,
                     semanticID: target.semanticID,
-                    restorationMetadata: target.restorationMetadata
+                    restorationMetadata: target.restorationMetadata,
+                    order: target.order
                 )
             }
             targets.replaceSubrange(suffixStart..., with: replacement)
@@ -107,6 +115,7 @@ struct ChatMessageScrollTargetCache: Equatable {
         // direction (old or new), and the suffix itself must be
         // duplicate-free. Otherwise fall back to a full rebuild — correctness
         // over exotic incremental cases.
+        TranscriptPerf.note(.scrollTargetPrefixSetBuild)
         let prefixFingerprints = Set(fingerprints[..<suffixStart])
         let oldSuffixFingerprints = fingerprints[suffixStart...]
         let canRebuildSuffixIncrementally =
@@ -117,7 +126,8 @@ struct ChatMessageScrollTargetCache: Equatable {
         if canRebuildSuffixIncrementally {
             let suffixTargets = ChatMessageScrollTargets.make(
                 for: suffixMessages,
-                fingerprints: suffixFingerprints
+                fingerprints: suffixFingerprints,
+                baseOrder: suffixStart
             )
             fingerprints.replaceSubrange(suffixStart..., with: suffixFingerprints)
             targets.replaceSubrange(suffixStart..., with: suffixTargets)
@@ -267,15 +277,17 @@ enum ChatMessageScrollTargets {
         messages.map(fingerprint)
     }
 
-    fileprivate static func make(
+    static func make(
         for messages: [ChatMessage],
-        fingerprints: [String]
+        fingerprints: [String],
+        baseOrder: Int = 0
     ) -> [ChatMessageScrollTarget] {
         let duplicateCounts = fingerprints.reduce(into: [String: Int]()) { counts, fingerprint in
             counts[fingerprint, default: 0] += 1
         }
         var occurrences: [String: Int] = [:]
-        return zip(messages, fingerprints).map { message, fingerprint in
+        return zip(messages, fingerprints).enumerated().map { offset, pair in
+            let (message, fingerprint) = pair
             let occurrence = occurrences[fingerprint, default: 0]
             occurrences[fingerprint] = occurrence + 1
             return ChatMessageScrollTarget(
@@ -284,7 +296,8 @@ enum ChatMessageScrollTargets {
                 restorationMetadata: ChatScrollAnchorMetadata(
                     fingerprint: fingerprint,
                     duplicateCount: duplicateCounts[fingerprint, default: 0]
-                )
+                ),
+                order: baseOrder + offset
             )
         }
     }

--- a/Conduit/Services/TranscriptPerformanceInstrumentation.swift
+++ b/Conduit/Services/TranscriptPerformanceInstrumentation.swift
@@ -185,9 +185,9 @@ enum TranscriptPerf {
         get { read(\.reasoningTranscriptMutation) }
     }
 
-    /// Message-value comparisons consumed by the scroll-target cache's
-    /// common-prefix walk. Scales with transcript depth per transcript
-    /// change; must stay zero while live reasoning is publishing.
+    /// Length of the matching leading prefix consumed by the scroll-target
+    /// cache's common-prefix walk. Scales with transcript depth per
+    /// transcript change; must stay zero while live reasoning is publishing.
     static var scrollTargetCommonPrefixComparisons: Int {
         get { read(\.scrollTargetCommonPrefixComparisons) }
         set { write(\.scrollTargetCommonPrefixComparisons, newValue) }

--- a/Conduit/Services/TranscriptPerformanceInstrumentation.swift
+++ b/Conduit/Services/TranscriptPerformanceInstrumentation.swift
@@ -35,6 +35,15 @@ enum TranscriptPerf {
         case .rowFramePreferenceUpdate: storage.rowFramePreferenceUpdate += 1
         case .layoutMetricsChanged: storage.layoutMetricsChanged += 1
         case .transcriptChanged: storage.transcriptChanged += 1
+        case .chatViewBody: storage.chatViewBody += 1
+        case .composerBarBody: storage.composerBarBody += 1
+        case .composerUpdateUIView: storage.composerUpdateUIView += 1
+        case .composerProgrammaticTextAssignment: storage.composerProgrammaticTextAssignment += 1
+        case .composerSelectionWrite: storage.composerSelectionWrite += 1
+        case .composerMarkedTextDeferral: storage.composerMarkedTextDeferral += 1
+        case .reasoningProjectionPublish: storage.reasoningProjectionPublish += 1
+        case .reasoningTranscriptMutation: storage.reasoningTranscriptMutation += 1
+        case .scrollTargetPrefixSetBuild: storage.scrollTargetPrefixSetBuild += 1
         }
         #endif
     }
@@ -65,6 +74,15 @@ enum TranscriptPerf {
         case rowFramePreferenceUpdate
         case layoutMetricsChanged
         case transcriptChanged
+        case chatViewBody
+        case composerBarBody
+        case composerUpdateUIView
+        case composerProgrammaticTextAssignment
+        case composerSelectionWrite
+        case composerMarkedTextDeferral
+        case reasoningProjectionPublish
+        case reasoningTranscriptMutation
+        case scrollTargetPrefixSetBuild
     }
 
     // MARK: - Counter accessors
@@ -120,6 +138,81 @@ enum TranscriptPerf {
         set { write(\.stableTopScanTargetCount, newValue) }
     }
 
+    // MARK: - Long-context / composer isolation counters
+
+    static var chatViewBodyEvaluations: Int {
+        get { read(\.chatViewBody) }
+    }
+
+    static var composerBarBodyEvaluations: Int {
+        get { read(\.composerBarBody) }
+    }
+
+    /// `ComposerPasteTextView.updateUIView` invocations. Unrelated AppState
+    /// publications DO reach the editor bridge; the isolation contract is
+    /// that they must not write text or selection (counters below).
+    static var composerUpdateUIViewCalls: Int {
+        get { read(\.composerUpdateUIView) }
+    }
+
+    /// Programmatic `textView.text = ...` assignments in the composer
+    /// bridge. While the user is typing, unrelated publications must
+    /// contribute ZERO to this counter.
+    static var composerProgrammaticTextAssignments: Int {
+        get { read(\.composerProgrammaticTextAssignment) }
+    }
+
+    /// `textView.selectedRange` writes in the composer bridge.
+    static var composerSelectionWrites: Int {
+        get { read(\.composerSelectionWrite) }
+    }
+
+    /// Programmatic replacements deferred because IME marked text was
+    /// active (composition must never be silently replaced).
+    static var composerMarkedTextDeferrals: Int {
+        get { read(\.composerMarkedTextDeferral) }
+    }
+
+    /// Live reasoning publications that reached the UI projection
+    /// (pre-architecture-fix: the per-tick transcript card write).
+    static var reasoningProjectionPublishes: Int {
+        get { read(\.reasoningProjectionPublish) }
+    }
+
+    /// `messages` mutations caused by the reasoning state machine
+    /// (mounts/commits). Steady-state live reasoning must contribute ZERO.
+    static var reasoningTranscriptMutations: Int {
+        get { read(\.reasoningTranscriptMutation) }
+    }
+
+    /// Message-value comparisons consumed by the scroll-target cache's
+    /// common-prefix walk. Scales with transcript depth per transcript
+    /// change; must stay zero while live reasoning is publishing.
+    static var scrollTargetCommonPrefixComparisons: Int {
+        get { read(\.scrollTargetCommonPrefixComparisons) }
+        set { write(\.scrollTargetCommonPrefixComparisons, newValue) }
+    }
+
+    /// O(prefix) fingerprint-set constructions in the scroll-target cache
+    /// (the incremental-rebuild safety gate).
+    static var scrollTargetPrefixSetBuilds: Int {
+        get { read(\.scrollTargetPrefixSetBuild) }
+    }
+
+    /// Selection (location) observed immediately before the most recent
+    /// programmatic text assignment. -1 when none has run.
+    static var lastComposerSelectionBeforeAssignment: Int {
+        get { read(\.lastComposerSelectionBefore) }
+        set { write(\.lastComposerSelectionBefore, newValue) }
+    }
+
+    /// Selection (location) observed immediately after the most recent
+    /// programmatic text assignment. -1 when none has run.
+    static var lastComposerSelectionAfterAssignment: Int {
+        get { read(\.lastComposerSelectionAfter) }
+        set { write(\.lastComposerSelectionAfter, newValue) }
+    }
+
     // MARK: - Control
 
     /// Reset all counters to zero.
@@ -144,9 +237,21 @@ enum TranscriptPerf {
         var rowFramePreferenceUpdate = 0
         var layoutMetricsChanged = 0
         var transcriptChanged = 0
+        var chatViewBody = 0
+        var composerBarBody = 0
+        var composerUpdateUIView = 0
+        var composerProgrammaticTextAssignment = 0
+        var composerSelectionWrite = 0
+        var composerMarkedTextDeferral = 0
+        var reasoningProjectionPublish = 0
+        var reasoningTranscriptMutation = 0
+        var scrollTargetPrefixSetBuild = 0
         var lastFingerprintedMessageCount = 0
         var lastFingerprintedByteCount = 0
         var stableTopScanTargetCount = 0
+        var scrollTargetCommonPrefixComparisons = 0
+        var lastComposerSelectionBefore = -1
+        var lastComposerSelectionAfter = -1
     }
 
     #if DEBUG

--- a/Conduit/Views/ChatView.swift
+++ b/Conduit/Views/ChatView.swift
@@ -188,6 +188,7 @@ struct ChatView: View {
     }
 
     var body: some View {
+        let _ = TranscriptPerf.note(.chatViewBody)
         VStack(spacing: 0) {
             // Message list
             ScrollViewReader { proxy in
@@ -246,7 +247,14 @@ struct ChatView: View {
                     EmptyChatState().padding(.top, 60)
                 }
 
-                ForEach(Array(chatMessageScrollTargets.enumerated()), id: \.element.id) { index, target in
+                // Iterate the targets collection directly: wrapping it in
+                // Array(enumerated()) copied the entire transcript into a
+                // fresh tuple array on EVERY body evaluation — O(message
+                // count) allocation churn at streaming/reasoning cadence in
+                // deep sessions. Row identity (target.id) and the transcript
+                // order needed by row geometry (target.order, maintained by
+                // the scroll-target cache) are unchanged.
+                ForEach(chatMessageScrollTargets) { target in
                     MessageBubble(message: target.message, gatewayResolver: appState.gatewayMediaResolver)
                         .id(target.id)
                         .background {
@@ -258,12 +266,30 @@ struct ChatView: View {
                                             semanticID: target.id,
                                             scope: $0,
                                             frame: geometry.frame(in: .global),
-                                            order: index
+                                            order: target.order
                                         )
                                     } ?? ChatRenderedScrollTargets()
                                 )
                             }
                         }
+                }
+
+                // Live reasoning renders from the projection, not the settled
+                // transcript: per-publish reasoning changes re-render only
+                // this card, never the ForEach data or the scroll-target
+                // cache. Chronology matches the pre-projection transcript —
+                // thinking streams at the tail, before the assistant answer.
+                if let segment = appState.liveReasoningSegment {
+                    ThinkingCard(
+                        message: ChatMessage(
+                            id: segment.id,
+                            role: .reasoning,
+                            content: segment.content,
+                            timestamp: segment.timestamp,
+                            author: appState.activeProfile
+                        )
+                    )
+                    .id(segment.id)
                 }
 
                 if !appState.streamingText.isEmpty {

--- a/Conduit/Views/Components/ComposerBar.swift
+++ b/Conduit/Views/Components/ComposerBar.swift
@@ -26,6 +26,14 @@ struct ComposerBar: View {
     @State private var composerErrorMessage: String?
     @State private var draftStore = ComposerDraftStore()
     @State private var editorIdentity = UUID()
+    /// Generation of intentional composer text replacements. Every program
+    /// path that replaces the composer content routes through
+    /// `replaceComposerText(_:)` and advances this, so the UIKit editor
+    /// bridge applies the change exactly once — and, crucially, so ordinary
+    /// SwiftUI invalidations (streaming, reasoning, busy state) arrive with
+    /// an UNCHANGED revision and can never rewrite the editor or move the
+    /// cursor mid-typing.
+    @State private var composerRevision: UInt64 = 0
     @State private var loadedDraftKey: ComposerDraftKey?
     @State private var photoImportContext: AsyncAttachmentContext?
     @State private var photoImportGeneration: UInt64 = 0
@@ -143,6 +151,14 @@ struct ComposerBar: View {
         !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
+    /// The only sanctioned way to replace composer content programmatically.
+    /// Advances the editor's programmatic revision alongside the text so the
+    /// change is applied to the UIKit editor exactly once.
+    private func replaceComposerText(_ newValue: String) {
+        text = newValue
+        composerRevision &+= 1
+    }
+
     /// Returns the slash prefix being typed, or nil if the cursor has moved
     /// beyond the command name. Leading whitespace is accepted on purpose.
     private var slashPrefix: String? {
@@ -219,6 +235,7 @@ struct ComposerBar: View {
     }
 
     var body: some View {
+        let _ = TranscriptPerf.note(.composerBarBody)
         Group {
             if #available(iOS 26.0, *) {
                 GlassEffectContainer(spacing: 16) {
@@ -247,7 +264,7 @@ struct ComposerBar: View {
             }
         }
         .onChange(of: appState.composerPrefillToken) { _, _ in
-            text = appState.composerPrefillText
+            replaceComposerText(appState.composerPrefillText)
             isFocused = !text.isEmpty
             isShowingSlashSuggestions = slashPrefix != nil
         }
@@ -303,7 +320,7 @@ struct ComposerBar: View {
                 SlashSuggestionsOverlay(
                     commands: filteredSlashCommands,
                     onSelected: { cmd in
-                        text = "/\(cmd.name) "
+                        replaceComposerText("/\(cmd.name) ")
                         isShowingSlashSuggestions = false
                     }
                 )
@@ -336,6 +353,7 @@ struct ComposerBar: View {
                             handlePastedImageError(message, editorIdentity: currentEditorIdentity)
                         },
                         editorIdentity: editorIdentity,
+                        programmaticRevision: composerRevision,
                         returnKeySends: returnKeySends,
                         // May lag one render behind fast typing; the safe
                         // failure mode is newline insertion, and
@@ -643,7 +661,7 @@ struct ComposerBar: View {
             draftStore.removeDraft(for: submittedDraftBucket)
             guard loadedDraftKey == submittedDraftKey else { return }
             if appState.composerPrefillToken != prefillToken {
-                text = appState.composerPrefillText
+                replaceComposerText(appState.composerPrefillText)
                 isFocused = !text.isEmpty
             }
             isShowingSlashSuggestions = slashPrefix != nil
@@ -684,7 +702,7 @@ struct ComposerBar: View {
     private func collapseSubmittedDraft() {
         dismissComposer()
         let updates = {
-            text = ""
+            replaceComposerText("")
             attachments = []
             composerTextHeight = ComposerPasteTextView.minimumHeight
         }
@@ -723,7 +741,7 @@ struct ComposerBar: View {
         // Do not overwrite a new draft if the user already returned to the
         // composer while the failed request was in flight.
         guard text.isEmpty, attachments.isEmpty else { return }
-        text = submittedText
+        replaceComposerText(submittedText)
         attachments = submittedAttachments
     }
 
@@ -780,7 +798,7 @@ struct ComposerBar: View {
         if text != draft.text {
             suppressNextTextChangeSuggestions = true
         }
-        text = draft.text
+        replaceComposerText(draft.text)
         attachments = draft.attachments
         loadedDraftKey = key
         composerTextHeight = ComposerPasteTextView.minimumHeight

--- a/Conduit/Views/Components/ComposerPasteTextView.swift
+++ b/Conduit/Views/Components/ComposerPasteTextView.swift
@@ -217,14 +217,21 @@ struct ComposerPasteTextView: UIViewRepresentable {
                 return
             }
 
-            if text == lastTextReportedByUIKit {
-                // Intentional replacement whose value the editor already
-                // holds: adopt the revision so bookkeeping stays in sync,
-                // without tearing down live input state with a rewrite.
+            if text == textView.text {
+                // The editor verifiably holds the intended value — checked
+                // against the LIVE text, not only the last delegate report,
+                // which can lag in-flight user input. Adopt the revision so
+                // bookkeeping stays in sync without tearing down live input
+                // state with a redundant rewrite.
                 appliedProgrammaticRevision = programmaticRevision
+                lastTextReportedByUIKit = textView.text
                 return
             }
 
+            // A revision advance the editor does not verifiably hold is a
+            // genuine intentional replacement: apply it even when the value
+            // equals the last reported text — the live editor has moved past
+            // that report, and the intentional source stays authoritative.
             performProgrammaticReplacement(
                 text: text,
                 revision: programmaticRevision,

--- a/Conduit/Views/Components/ComposerPasteTextView.swift
+++ b/Conduit/Views/Components/ComposerPasteTextView.swift
@@ -207,18 +207,21 @@ struct ComposerPasteTextView: UIViewRepresentable {
 
             // An unrelated invalidation keeps the revision and can stop here.
             guard programmaticRevision != appliedProgrammaticRevision else { return }
+
+            // Active IME composition is never silently replaced — nor
+            // revision-adopted; the deferred replacement lands when the
+            // composition ends and stays the newest instruction.
+            if textView.markedTextRange != nil {
+                TranscriptPerf.note(.composerMarkedTextDeferral)
+                pendingProgrammatic = (text, programmaticRevision)
+                return
+            }
+
             if text == lastTextReportedByUIKit {
                 // Intentional replacement whose value the editor already
                 // holds: adopt the revision so bookkeeping stays in sync,
                 // without tearing down live input state with a rewrite.
                 appliedProgrammaticRevision = programmaticRevision
-                return
-            }
-
-            // Active IME composition is never silently replaced.
-            if textView.markedTextRange != nil {
-                TranscriptPerf.note(.composerMarkedTextDeferral)
-                pendingProgrammatic = (text, programmaticRevision)
                 return
             }
 

--- a/Conduit/Views/Components/ComposerPasteTextView.swift
+++ b/Conduit/Views/Components/ComposerPasteTextView.swift
@@ -94,6 +94,8 @@ struct ComposerPasteTextView: UIViewRepresentable {
             editorIdentity: editorIdentity,
             to: uiView
         )
+        // Layout is requested on text change and editability flip only;
+        // bounds changes re-layout automatically through layoutSubviews.
         if uiView.isEditable != enabled {
             uiView.isEditable = enabled
             uiView.setNeedsLayout()
@@ -187,16 +189,31 @@ struct ComposerPasteTextView: UIViewRepresentable {
                 lastTextReportedByUIKit = textView.text
                 pendingProgrammatic = nil
                 appliedProgrammaticRevision = 0
+                if textView.text != text {
+                    // The binding is the fresh editor's ground truth even
+                    // when no revision advance accompanies the rotation.
+                    // Every production rotation is text-paired through
+                    // replaceComposerText; applying here keeps a future
+                    // unpaired rotation from silently blanking the editor.
+                    performProgrammaticReplacement(
+                        text: text,
+                        revision: programmaticRevision,
+                        into: textView
+                    )
+                    return
+                }
             }
             flushPendingProgrammaticIfCompositionEnded(textView)
 
-            // Echo of a user edit (or an idempotent repeat): the binding
-            // mirrors text UIKit already reported. Writing here would revert
-            // keystrokes UIKit has accepted since, re-clamp the selection,
-            // and tear down input state — the reported cursor corruption.
-            guard text != lastTextReportedByUIKit else { return }
-            // Unrelated invalidation: no revision advance, no editor write.
+            // An unrelated invalidation keeps the revision and can stop here.
             guard programmaticRevision != appliedProgrammaticRevision else { return }
+            if text == lastTextReportedByUIKit {
+                // Intentional replacement whose value the editor already
+                // holds: adopt the revision so bookkeeping stays in sync,
+                // without tearing down live input state with a rewrite.
+                appliedProgrammaticRevision = programmaticRevision
+                return
+            }
 
             // Active IME composition is never silently replaced.
             if textView.markedTextRange != nil {

--- a/Conduit/Views/Components/ComposerPasteTextView.swift
+++ b/Conduit/Views/Components/ComposerPasteTextView.swift
@@ -27,6 +27,14 @@ struct ComposerPasteTextView: UIViewRepresentable {
     let onPastedImage: (PastedImage) -> Void
     let onPastedImageError: (String) -> Void
     let editorIdentity: UUID
+    /// Generation of INTENTIONAL programmatic composer replacements (draft
+    /// restore, prefill, session handoff, slash insertion, clear after send).
+    /// ComposerBar advances it only through `replaceComposerText(_:)`.
+    /// Ordinary SwiftUI invalidations — streaming, reasoning, busy state,
+    /// toolbar state — arrive with an unchanged revision, which is how the
+    /// bridge tells them apart from a deliberate replacement and from the
+    /// echo of a user edit: they may not rewrite the editor.
+    var programmaticRevision: UInt64 = 0
     /// Hardware-keyboard Return behavior. When true, a plain Return press
     /// submits through the composer action path; Shift-Return and every
     /// non-submittable state keep the default newline insertion.
@@ -77,10 +85,19 @@ struct ComposerPasteTextView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: ImagePasteTextView, context: Context) {
+        TranscriptPerf.note(.composerUpdateUIView)
         context.coordinator.parent = self
         context.coordinator.isActive = true
-        context.coordinator.apply(text: text, editorIdentity: editorIdentity, to: uiView)
-        uiView.isEditable = enabled
+        context.coordinator.apply(
+            text: text,
+            programmaticRevision: programmaticRevision,
+            editorIdentity: editorIdentity,
+            to: uiView
+        )
+        if uiView.isEditable != enabled {
+            uiView.isEditable = enabled
+            uiView.setNeedsLayout()
+        }
         uiView.editorIdentity = editorIdentity
         uiView.onContentHeightChange = { height in
             context.coordinator.updateMeasuredHeight(height)
@@ -90,7 +107,6 @@ struct ComposerPasteTextView: UIViewRepresentable {
         uiView.returnKeySends = returnKeySends
         uiView.canSubmitFromReturn = canSubmitFromReturn
         uiView.onSubmitFromReturn = onSubmitFromReturn
-        uiView.setNeedsLayout()
         if isFocused, !uiView.isFirstResponder { uiView.becomeFirstResponder() }
         if !isFocused, uiView.isFirstResponder { uiView.resignFirstResponder() }
     }
@@ -99,15 +115,36 @@ struct ComposerPasteTextView: UIViewRepresentable {
         var parent: ComposerPasteTextView
         var isApplyingProgrammaticState = false
         var isActive = true
+        /// The last text UIKit itself reported through `textViewDidChange`.
+        /// A binding value equal to this is the ECHO of a user edit, never a
+        /// reason to write into the editor: UIKit's text-input delegate can
+        /// deliver the change notification after the storage already moved
+        /// on (and after unrelated SwiftUI invalidations), so a binding that
+        /// lags the editor is evidence of in-flight user input, not of a
+        /// programmatic source.
+        private var lastTextReportedByUIKit = ""
+        /// The programmatic revision currently reflected in the editor.
+        /// Only an ADVANCE may rewrite the editor, and it does so exactly
+        /// once; unchanged revisions ride along without touching text.
+        private var appliedProgrammaticRevision: UInt64 = 0
+        /// An intentional replacement that arrived while IME marked text was
+        /// active. Composition is never silently replaced; this lands as
+        /// soon as it ends.
+        private var pendingProgrammatic: (text: String, revision: UInt64)?
         private var editorIdentity: UUID?
 
-        init(_ parent: ComposerPasteTextView) { self.parent = parent }
+        init(_ parent: ComposerPasteTextView) {
+            self.parent = parent
+            super.init()
+        }
 
         func textViewDidChange(_ textView: UITextView) {
             guard isActive, !isApplyingProgrammaticState else { return }
+            lastTextReportedByUIKit = textView.text
             parent.text = textView.text
             textView.scrollRangeToVisible(textView.selectedRange)
             textView.setNeedsLayout()
+            flushPendingProgrammaticIfCompositionEnded(textView)
         }
         func textViewDidBeginEditing(_ textView: UITextView) {
             guard isActive, !isApplyingProgrammaticState else { return }
@@ -116,6 +153,7 @@ struct ComposerPasteTextView: UIViewRepresentable {
         func textViewDidEndEditing(_ textView: UITextView) {
             guard isActive, !isApplyingProgrammaticState else { return }
             parent.isFocused = false
+            flushPendingProgrammaticIfCompositionEnded(textView)
         }
 
         func updateMeasuredHeight(_ height: CGFloat) {
@@ -124,30 +162,62 @@ struct ComposerPasteTextView: UIViewRepresentable {
             parent.measuredHeight = height
         }
 
-        func apply(text: String, editorIdentity: UUID, to textView: UITextView) {
-            let needsTextUpdate = textView.text != text
-            let needsIdentityUpdate = self.editorIdentity != editorIdentity
-            guard needsTextUpdate || needsIdentityUpdate else { return }
-
-            let clampedSelection = clampedSelectionRange(
-                textView.selectedRange,
-                maxLength: (text as NSString).length
-            )
-
-            isApplyingProgrammaticState = true
-            defer {
-                isApplyingProgrammaticState = false
+        /// The one gate between SwiftUI and the editor's text state.
+        ///
+        ///   user typing:            UIKit → binding (textViewDidChange)
+        ///   unrelated invalidation: no SwiftUI → UIKit text replacement
+        ///   intentional change:     programmaticRevision advance → UIKit
+        ///
+        /// A binding that merely disagrees with `textView.text` is NOT an
+        /// intentional change — it is either the echo of text UIKit already
+        /// reported, or user input that outran the delegate notification.
+        func apply(
+            text: String,
+            programmaticRevision: UInt64,
+            editorIdentity: UUID,
+            to textView: UITextView
+        ) {
+            if self.editorIdentity != editorIdentity {
+                // Lifecycle boundary (session handoff / attachment rotate).
+                // `.id(editorIdentity)` recreates the editor wholesale, so
+                // this branch is defensive: reset bookkeeping to the fresh
+                // view's actual state — the previous editor's pending
+                // replacement and applied revision died with it.
                 self.editorIdentity = editorIdentity
+                lastTextReportedByUIKit = textView.text
+                pendingProgrammatic = nil
+                appliedProgrammaticRevision = 0
+            }
+            flushPendingProgrammaticIfCompositionEnded(textView)
+
+            // Echo of a user edit (or an idempotent repeat): the binding
+            // mirrors text UIKit already reported. Writing here would revert
+            // keystrokes UIKit has accepted since, re-clamp the selection,
+            // and tear down input state — the reported cursor corruption.
+            guard text != lastTextReportedByUIKit else { return }
+            // Unrelated invalidation: no revision advance, no editor write.
+            guard programmaticRevision != appliedProgrammaticRevision else { return }
+
+            // Active IME composition is never silently replaced.
+            if textView.markedTextRange != nil {
+                TranscriptPerf.note(.composerMarkedTextDeferral)
+                pendingProgrammatic = (text, programmaticRevision)
+                return
             }
 
-            textView.text = text
-            textView.selectedRange = clampedSelection
-            textView.setNeedsLayout()
+            performProgrammaticReplacement(
+                text: text,
+                revision: programmaticRevision,
+                into: textView
+            )
         }
 
         func deactivate(textView: UITextView) {
             isActive = false
             isApplyingProgrammaticState = false
+            pendingProgrammatic = nil
+            lastTextReportedByUIKit = ""
+            appliedProgrammaticRevision = 0
             editorIdentity = nil
             textView.delegate = nil
             if let textView = textView as? ImagePasteTextView {
@@ -162,6 +232,58 @@ struct ComposerPasteTextView: UIViewRepresentable {
             if textView.isFirstResponder {
                 textView.resignFirstResponder()
             }
+        }
+
+        /// A deferred intentional replacement lands at the first
+        /// composition-free moment: `textViewDidChange` fires for both the
+        /// commit and the discard of marked text, and any later
+        /// `updateUIView` re-checks here.
+        private func flushPendingProgrammaticIfCompositionEnded(_ textView: UITextView) {
+            guard textView.markedTextRange == nil,
+                  let pending = pendingProgrammatic else { return }
+            pendingProgrammatic = nil
+            if textView.text == pending.text {
+                // Already in place: record the revision without tearing down
+                // live input state with a redundant assignment.
+                appliedProgrammaticRevision = pending.revision
+                lastTextReportedByUIKit = textView.text
+                return
+            }
+            performProgrammaticReplacement(
+                text: pending.text,
+                revision: pending.revision,
+                into: textView
+            )
+        }
+
+        private func performProgrammaticReplacement(
+            text: String,
+            revision: UInt64,
+            into textView: UITextView
+        ) {
+            let clampedSelection = clampedSelectionRange(
+                textView.selectedRange,
+                maxLength: (text as NSString).length
+            )
+
+            TranscriptPerf.note(.composerProgrammaticTextAssignment)
+            TranscriptPerf.lastComposerSelectionBeforeAssignment = textView.selectedRange.location
+            TranscriptPerf.note(.composerSelectionWrite)
+            TranscriptPerf.lastComposerSelectionAfterAssignment = clampedSelection.location
+
+            isApplyingProgrammaticState = true
+            defer { isApplyingProgrammaticState = false }
+
+            textView.text = text
+            textView.selectedRange = clampedSelection
+            textView.setNeedsLayout()
+            appliedProgrammaticRevision = revision
+            lastTextReportedByUIKit = text
+            // In the deferred flow the user's (now replaced) composition may
+            // have published a newer binding AFTER the intentional source
+            // wrote its value; the intentional replacement stays
+            // authoritative, so the binding follows the editor.
+            if parent.text != text { parent.text = text }
         }
 
         private func clampedSelectionRange(_ range: NSRange, maxLength: Int) -> NSRange {

--- a/Conduit/Views/LoginView.swift
+++ b/Conduit/Views/LoginView.swift
@@ -146,6 +146,7 @@ struct LoginView: View {
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
                     .keyboardType(.URL)
+                    .accessibilityIdentifier("login.server-url")
                     .focused($focusedField, equals: .server)
                     .submitLabel(LoginField.server.submitKeyboardLabel(cloudflareTokenEntryEnabled: cloudflareEnabled))
                     .onSubmit { handleSubmit(from: .server) }
@@ -217,9 +218,14 @@ struct LoginView: View {
                         }
                     ))
                     .tint(.conduitAccent)
+                    // Stable XCUI handles: the localized label works too, but
+                    // identifiers decouple the UI tests from copy changes
+                    // and from Switch/CheckBox element-type ambiguity.
+                    .accessibilityIdentifier("login.cloudflare-toggle")
                     if cloudflareEnabled {
                         TextField("Cloudflare Client ID", text: $cloudflareClientID)
                             .textInputAutocapitalization(.never).autocorrectionDisabled()
+                            .accessibilityIdentifier("login.cloudflare-client-id")
                             .focused($focusedField, equals: .cloudflareClientID)
                             .submitLabel(LoginField.cloudflareClientID.submitKeyboardLabel(cloudflareTokenEntryEnabled: cloudflareEnabled))
                             .onSubmit { handleSubmit(from: .cloudflareClientID) }
@@ -227,6 +233,7 @@ struct LoginView: View {
                             .conduitGlassSurface(cornerRadius: 17, tint: .conduitAura.opacity(0.06))
                             .id(LoginField.cloudflareClientID)
                         SecureField("Cloudflare Client Secret", text: $cloudflareClientSecret)
+                            .accessibilityIdentifier("login.cloudflare-client-secret")
                             .focused($focusedField, equals: .cloudflareClientSecret)
                             .submitLabel(LoginField.cloudflareClientSecret.submitKeyboardLabel(cloudflareTokenEntryEnabled: cloudflareEnabled))
                             .onSubmit { handleSubmit(from: .cloudflareClientSecret) }
@@ -259,6 +266,7 @@ struct LoginView: View {
                         .frame(maxWidth: .infinity)
                         .frame(height: 50)
                 }
+                .accessibilityIdentifier("login.connect")
                 .foregroundStyle(.white)
                 .disabled(!connectInputsArePresent || isConnecting)
                 .conduitGlassControl(cornerRadius: 18, tint: .conduitAccent, prominent: true)

--- a/ConduitTests/AppStateReasoningStreamTests.swift
+++ b/ConduitTests/AppStateReasoningStreamTests.swift
@@ -512,8 +512,62 @@ final class AppStateReasoningStreamTests: XCTestCase {
         XCTAssertEqual(state.messages.last?.id, "assistant-1")
     }
 
-    func testSessionSwitchDiscardsPendingReasoningPublishForNewSession() async {
-        let replacementMessages = [
+    /// Mid-turn transcript rows (review summaries, clarify/approval cards,
+    /// slash output, steer corrections) must not land below the live
+    /// reasoning card's eventual commit: each append settles the segment
+    /// first, preserving the pre-projection chronology, and reasoning that
+    /// resumes afterwards mounts a fresh segment (tool-boundary precedent).
+    func testMidTurnTranscriptAppendsCommitReasoningSegmentFirst() {
+        let state = makeAppState()
+        installActiveSession(state, id: "stored-a")
+
+        feedReasoning(["thinking about the change "], sessionId: "stored-a", state: state)
+        state.handleStreamEvent(.reviewSummary(
+            sessionId: "stored-a",
+            activity: ReviewActivity(summary: "mid-turn review", details: nil, fullSessionId: nil)
+        ))
+
+        // The live card committed above the review row; nothing stays live.
+        XCTAssertEqual(state.messages.map(\.role), [.reasoning, .system])
+        XCTAssertEqual(state.messages.first?.content, "thinking about the change ")
+        XCTAssertNil(state.liveReasoningSegment)
+
+        // Reasoning that resumes after the interjection mounts a FRESH
+        // segment, which the next mid-turn append commits the same way.
+        feedReasoning(["second segment "], sessionId: "stored-a", state: state)
+        state.handleStreamEvent(.approval(
+            sessionId: "stored-a",
+            activity: ApprovalActivity(
+                sessionId: "stored-a",
+                command: "run tests",
+                description: "wants to run tests",
+                choices: nil,
+                allowPermanent: false,
+                smartDenied: false,
+                status: .pending,
+                choice: nil,
+                error: nil
+            )
+        ))
+        XCTAssertEqual(state.messages.map(\.role), [.reasoning, .system, .reasoning, .approval])
+        XCTAssertEqual(state.messages[2].content, "second segment ")
+
+        feedReasoning(["third segment"], sessionId: "stored-a", state: state)
+        state.handleStreamEvent(.clarify(
+            sessionId: "stored-a",
+            requestId: "req-1",
+            question: "which scope?",
+            choices: [("a", "A"), ("b", "B")]
+        ))
+        XCTAssertEqual(
+            state.messages.map(\.role),
+            [.reasoning, .system, .reasoning, .approval, .reasoning, .clarify]
+        )
+        XCTAssertEqual(state.messages[4].content, "third segment")
+        XCTAssertNil(state.liveReasoningSegment)
+    }
+
+    func testSessionSwitchDiscardsPendingReasoningPublishForNewSession() async {        let replacementMessages = [
             ChatMessage(id: "new-1", role: .assistant, content: "Other session", timestamp: "1")
         ]
         let state = makeAppState(lifecycleOperations: ChatResumeLifecycleOperations(

--- a/ConduitTests/AppStateReasoningStreamTests.swift
+++ b/ConduitTests/AppStateReasoningStreamTests.swift
@@ -567,7 +567,8 @@ final class AppStateReasoningStreamTests: XCTestCase {
         XCTAssertNil(state.liveReasoningSegment)
     }
 
-    func testSessionSwitchDiscardsPendingReasoningPublishForNewSession() async {        let replacementMessages = [
+    func testSessionSwitchDiscardsPendingReasoningPublishForNewSession() async {
+        let replacementMessages = [
             ChatMessage(id: "new-1", role: .assistant, content: "Other session", timestamp: "1")
         ]
         let state = makeAppState(lifecycleOperations: ChatResumeLifecycleOperations(

--- a/ConduitTests/AppStateReasoningStreamTests.swift
+++ b/ConduitTests/AppStateReasoningStreamTests.swift
@@ -4,9 +4,16 @@ import XCTest
 
 /// Live reasoning must publish through the same display-cadence discipline as
 /// assistant streaming: raw gateway deltas merge into an authoritative buffer
-/// immediately, but the published transcript only republishes at a coalesced
-/// cadence so an expanded ThinkingCard cannot saturate main-actor layout work
-/// (0x8BADF00D scene-update watchdog during active reasoning streams).
+/// immediately, but the UI only republishes at a coalesced cadence so an
+/// expanded ThinkingCard cannot saturate main-actor layout work (0x8BADF00D
+/// scene-update watchdog during active reasoning streams).
+///
+/// The live card renders from the published PROJECTION
+/// (`liveReasoningSegment`) and never mutates the settled `messages` array
+/// while streaming — per-publish transcript mutation is O(message count) in a
+/// deep agent session. Settled `.reasoning` rows appear exactly once per
+/// segment, committed at semantic boundaries (tool cards, completion, error,
+/// interruption, new turn).
 @MainActor
 final class AppStateReasoningStreamTests: XCTestCase {
 
@@ -47,6 +54,8 @@ final class AppStateReasoningStreamTests: XCTestCase {
     /// The sidebar drawer suppresses streaming publications while open and
     /// force-publishes the authoritative buffers when it closes. Toggling it
     /// gives tests a synchronous flush without sleeping on the publish cadence.
+    /// The flush targets the live projection only — the segment keeps
+    /// streaming; only boundaries commit it into the transcript.
     private func forceFlushPendingReasoning(on state: AppState) {
         state.showSidebar = true
         state.showSidebar = false
@@ -66,6 +75,12 @@ final class AppStateReasoningStreamTests: XCTestCase {
         state.messages.filter { $0.role == .reasoning }
     }
 
+    /// Live reasoning content as the UI sees it (the projection), independent
+    /// of the settled transcript.
+    private func liveReasoningContent(on state: AppState) -> String? {
+        state.liveReasoningSegment?.content
+    }
+
     // MARK: - Coalescing
 
     func testRapidReasoningDeltasCoalesceTranscriptPublications() {
@@ -79,14 +94,16 @@ final class AppStateReasoningStreamTests: XCTestCase {
         feedReasoning(chunks, sessionId: "stored-a", state: state)
         cancellable.cancel()
 
-        // One publication creates the thinking card; every raw delta after
-        // that must merge into the authoritative buffer without republishing.
-        XCTAssertEqual(burstPublications, 1)
-        XCTAssertEqual(reasoningCards(in: state).count, 1)
-        XCTAssertEqual(reasoningCards(in: state).first?.content, chunks.first)
+        // Zero transcript publications: the live card mounts in the
+        // projection, and every raw delta after that merges into the
+        // authoritative buffer without touching `messages` at all.
+        XCTAssertEqual(burstPublications, 0)
+        XCTAssertEqual(reasoningCards(in: state).count, 0)
+        XCTAssertEqual(liveReasoningContent(on: state), chunks.first)
 
         forceFlushPendingReasoning(on: state)
-        XCTAssertEqual(reasoningCards(in: state).first?.content, expectedTotal)
+        XCTAssertEqual(liveReasoningContent(on: state), expectedTotal)
+        XCTAssertEqual(reasoningCards(in: state).count, 0)
     }
 
     func testScheduledReasoningPublishFiresWithoutForcedFlush() async throws {
@@ -98,15 +115,24 @@ final class AppStateReasoningStreamTests: XCTestCase {
             sessionId: "stored-a",
             state: state
         )
-        XCTAssertEqual(reasoningCards(in: state).first?.content, "coalesced chunk one ")
+        XCTAssertEqual(liveReasoningContent(on: state), "coalesced chunk one ")
 
         // The scheduled 50 ms publish must land on its own — no sidebar
         // force-flush, no boundary event. The wait only needs to clear the
         // cadence interval, so generous slack keeps it stable on CI runners.
+        var scheduledTranscriptPublications = 0
+        let cancellable = state.$messages.dropFirst().sink { _ in
+            scheduledTranscriptPublications += 1
+        }
         try await Task.sleep(for: .milliseconds(500))
+        cancellable.cancel()
         XCTAssertEqual(
-            reasoningCards(in: state).first?.content,
+            liveReasoningContent(on: state),
             "coalesced chunk one coalesced chunk two"
+        )
+        XCTAssertEqual(
+            scheduledTranscriptPublications, 0,
+            "the scheduled reasoning publish must not touch the settled transcript"
         )
     }
 
@@ -116,15 +142,17 @@ final class AppStateReasoningStreamTests: XCTestCase {
 
         feedReasoning(["first segment "], sessionId: "stored-a", state: state)
         forceFlushPendingReasoning(on: state)
-        let firstCardID = reasoningCards(in: state).first?.id
+        let firstCardID = state.liveReasoningSegment?.id
 
         feedReasoning(["continues to stream "], sessionId: "stored-a", state: state)
         forceFlushPendingReasoning(on: state)
 
-        XCTAssertEqual(reasoningCards(in: state).count, 1)
-        XCTAssertEqual(reasoningCards(in: state).first?.id, firstCardID)
+        // One live card for the whole segment, stable identity, still outside
+        // the settled transcript.
+        XCTAssertEqual(reasoningCards(in: state).count, 0)
+        XCTAssertEqual(state.liveReasoningSegment?.id, firstCardID)
         XCTAssertEqual(
-            reasoningCards(in: state).first?.content,
+            liveReasoningContent(on: state),
             "first segment continues to stream "
         )
     }
@@ -142,7 +170,7 @@ final class AppStateReasoningStreamTests: XCTestCase {
         )
         forceFlushPendingReasoning(on: state)
 
-        XCTAssertEqual(reasoningCards(in: state).first?.content, "abcdefgh")
+        XCTAssertEqual(liveReasoningContent(on: state), "abcdefgh")
     }
 
     func testIncrementalReasoningDeltasConcatenateExactly() {
@@ -152,10 +180,10 @@ final class AppStateReasoningStreamTests: XCTestCase {
         feedReasoning(["abc", "def", "ghi"], sessionId: "stored-a", state: state)
         forceFlushPendingReasoning(on: state)
 
-        XCTAssertEqual(reasoningCards(in: state).first?.content, "abcdefghi")
+        XCTAssertEqual(liveReasoningContent(on: state), "abcdefghi")
     }
 
-    // MARK: - Boundary flushes
+    // MARK: - Boundary commits
 
     func testMessageCompleteFlushesPendingReasoningSynchronously() {
         let state = makeAppState()
@@ -175,10 +203,12 @@ final class AppStateReasoningStreamTests: XCTestCase {
             )
         )
 
+        // The boundary commits the live segment into the settled transcript.
         XCTAssertEqual(
             reasoningCards(in: state).first?.content,
             "partial thought still buffering"
         )
+        XCTAssertNil(state.liveReasoningSegment)
 
         // Force the drained completion so the final assistant message lands
         // synchronously; the reasoning card must stay complete and ordered
@@ -218,12 +248,12 @@ final class AppStateReasoningStreamTests: XCTestCase {
         }
         XCTAssertLessThan(reasoningIndex, toolIndex)
 
-        // Reasoning that resumes after a tool belongs to a fresh card, never
-        // the finalized one.
+        // Reasoning that resumes after a tool belongs to a fresh live card,
+        // never the finalized one.
         feedReasoning(["post-tool thinking "], sessionId: "stored-a", state: state)
         forceFlushPendingReasoning(on: state)
-        XCTAssertEqual(reasoningCards(in: state).count, 2)
-        XCTAssertEqual(reasoningCards(in: state).last?.content, "post-tool thinking ")
+        XCTAssertEqual(reasoningCards(in: state).count, 1)
+        XCTAssertEqual(liveReasoningContent(on: state), "post-tool thinking ")
     }
 
     func testMessageErrorFlushesPendingReasoningWithoutStaleDelayedPublish() async throws {
@@ -297,19 +327,22 @@ final class AppStateReasoningStreamTests: XCTestCase {
         installActiveSession(state, id: "stored-a")
 
         feedReasoning(["visible "], sessionId: "stored-a", state: state)
-        XCTAssertEqual(reasoningCards(in: state).first?.content, "visible ")
+        XCTAssertEqual(liveReasoningContent(on: state), "visible ")
 
         // The drawer suppresses coalesced reasoning publications while it is
         // animating; the buffer stays authoritative.
         state.showSidebar = true
         feedReasoning(["hidden ", "while draining"], sessionId: "stored-a", state: state)
-        XCTAssertEqual(reasoningCards(in: state).first?.content, "visible ")
+        XCTAssertEqual(liveReasoningContent(on: state), "visible ")
 
         state.showSidebar = false
         XCTAssertEqual(
-            reasoningCards(in: state).first?.content,
+            liveReasoningContent(on: state),
             "visible hidden while draining"
         )
+        // The suppression flush publishes the projection; it must not commit
+        // the still-streaming segment into the transcript.
+        XCTAssertEqual(reasoningCards(in: state).count, 0)
     }
 
     func testReasoningDeltaDuringCompletionDrainMountsFreshCardAfterAssistant() {
@@ -326,17 +359,20 @@ final class AppStateReasoningStreamTests: XCTestCase {
             )
         )
         // A delta racing the drain window finalizes the pending completion
-        // first, then mounts a fresh card — the pre-fix behavior, with no
-        // buffered text lost.
+        // first, then mounts a fresh live card — the pre-projection behavior,
+        // with no buffered text lost. The fresh segment stays in the
+        // projection until its own boundary.
         state.handleStreamEvent(
             .reasoningDelta(sessionId: "stored-a", text: "late thought")
         )
 
-        let cards = reasoningCards(in: state)
-        XCTAssertEqual(cards.count, 2)
-        XCTAssertEqual(cards.first?.content, "pre-complete ")
-        XCTAssertEqual(cards.last?.content, "late thought")
+        XCTAssertEqual(state.messages.map(\.role), [.reasoning, .assistant])
+        XCTAssertEqual(liveReasoningContent(on: state), "late thought")
+
+        // The next turn boundary commits the late segment in order.
+        state.handleStreamEvent(.messageStart(sessionId: "stored-a"))
         XCTAssertEqual(state.messages.map(\.role), [.reasoning, .assistant, .reasoning])
+        XCTAssertEqual(state.messages.last?.content, "late thought")
     }
 
     func testCompletionReasoningTraceDoesNotDuplicateStreamedCard() {
@@ -373,6 +409,7 @@ final class AppStateReasoningStreamTests: XCTestCase {
 
         // Turn one streamed reasoning: receivedReasoningForCurrentTurn == true.
         feedReasoning(["prior turn reasoning "], sessionId: "stored-a", state: state)
+        state.handleStreamEvent(.messageStart(sessionId: "stored-a"))
         XCTAssertEqual(reasoningCards(in: state).count, 1)
 
         // A full state reset (disconnect) must restore the ENTIRE per-turn
@@ -529,18 +566,21 @@ final class AppStateReasoningStreamTests: XCTestCase {
 
         XCTAssertEqual(state.activeSessionId, destination.id)
         XCTAssertTrue(reasoningCards(in: state).isEmpty)
+        XCTAssertNil(state.liveReasoningSegment)
         XCTAssertEqual(state.messages, replacementMessages)
 
         // Even a forced flush of any surviving pending state must not
         // reproduce the old session's reasoning inside the new transcript.
         forceFlushPendingReasoning(on: state)
         XCTAssertTrue(reasoningCards(in: state).isEmpty)
+        XCTAssertNil(state.liveReasoningSegment)
         XCTAssertEqual(state.messages, replacementMessages)
 
         // Five 50 ms cadence periods: proves that after the session switch no
         // stale publish (guarded or not) can mutate the replacement transcript.
         try? await Task.sleep(for: .milliseconds(250))
         XCTAssertTrue(reasoningCards(in: state).isEmpty)
+        XCTAssertNil(state.liveReasoningSegment)
         XCTAssertEqual(state.messages, replacementMessages)
     }
 }

--- a/ConduitTests/ChatViewportControllerTests.swift
+++ b/ConduitTests/ChatViewportControllerTests.swift
@@ -1125,12 +1125,14 @@ extension ChatViewportControllerTests {
             ChatMessageScrollTarget(
                 message: message("m1", "one"),
                 semanticID: anchor,
-                restorationMetadata: ChatScrollAnchorMetadata(fingerprint: "fp", duplicateCount: 1)
+                restorationMetadata: ChatScrollAnchorMetadata(fingerprint: "fp", duplicateCount: 1),
+                order: 0
             ),
             ChatMessageScrollTarget(
                 message: message("m2", "two"),
                 semanticID: "other",
-                restorationMetadata: ChatScrollAnchorMetadata(fingerprint: "fp2", duplicateCount: 1)
+                restorationMetadata: ChatScrollAnchorMetadata(fingerprint: "fp2", duplicateCount: 1),
+                order: 1
             )
         ]
         var controller = ChatViewportController()

--- a/ConduitTests/LongContextScalingFixtureTests.swift
+++ b/ConduitTests/LongContextScalingFixtureTests.swift
@@ -484,6 +484,69 @@ final class LongContextScalingFixtureTests: XCTestCase {
         )
     }
 
+    /// An editor identity rotation NOT paired with a revision advance (no
+    /// production path does this today, but the bridge must not silently
+    /// blank the editor if one ever appears): the fresh editor adopts the
+    /// binding as ground truth, exactly once.
+    func testIdentityRotationWithUnpairedRevisionStillAppliesBinding() throws {
+        var value = "carried text"
+        let firstIdentity = UUID()
+        let secondIdentity = UUID()
+        let editor = ComposerPasteTextView(
+            text: Binding(get: { value }, set: { value = $0 }),
+            isFocused: .constant(false),
+            measuredHeight: .constant(44),
+            enabled: true,
+            onPastedImage: { _ in },
+            onPastedImageError: { _ in },
+            editorIdentity: firstIdentity
+        )
+        let coordinator = ComposerPasteTextView.Coordinator(editor)
+        let textView = ImagePasteTextView()
+
+        // Establish the first lifecycle with no revision advances at all
+        // (revision stays 0 — typed text, never replaced programmatically).
+        TranscriptPerf.reset()
+        coordinator.apply(
+            text: "carried text",
+            programmaticRevision: 0,
+            editorIdentity: firstIdentity,
+            to: textView
+        )
+        XCTAssertEqual(
+            TranscriptPerf.composerProgrammaticTextAssignments, 1,
+            "first apply on a fresh editor must materialize the binding"
+        )
+
+        // Rotate the identity with a genuinely fresh editor (in production
+        // .id(editorIdentity) recreates the view) and no revision advance:
+        // the empty view must adopt the binding as ground truth.
+        let freshTextView = ImagePasteTextView()
+        coordinator.apply(
+            text: "carried text",
+            programmaticRevision: 0,
+            editorIdentity: secondIdentity,
+            to: freshTextView
+        )
+        XCTAssertEqual(
+            freshTextView.text, "carried text",
+            "an unpaired identity rotation must not blank the editor"
+        )
+        XCTAssertEqual(
+            TranscriptPerf.composerProgrammaticTextAssignments, 2,
+            "the rotation apply happens exactly once"
+        )
+
+        // Follow-up invalidations with the same identity/revision: no writes.
+        coordinator.apply(
+            text: "carried text",
+            programmaticRevision: 0,
+            editorIdentity: secondIdentity,
+            to: freshTextView
+        )
+        XCTAssertEqual(TranscriptPerf.composerProgrammaticTextAssignments, 2)
+    }
+
     /// Clear-after-send is an intentional revision: the editor is cleared
     /// exactly once even though the same (empty) binding rides along on
     /// every subsequent invalidation.

--- a/ConduitTests/LongContextScalingFixtureTests.swift
+++ b/ConduitTests/LongContextScalingFixtureTests.swift
@@ -547,6 +547,83 @@ final class LongContextScalingFixtureTests: XCTestCase {
         XCTAssertEqual(TranscriptPerf.composerProgrammaticTextAssignments, 2)
     }
 
+    /// An intentional revision whose value equals the last DELEGATE-REPORTED
+    /// text must still be applied when the live editor has already advanced
+    /// past that report (unreported user input in flight). The adoption
+    /// shortcut verifies against the live editor, so a genuine intentional
+    /// revision can never be acknowledged without being applied.
+    func testIntentionalRevisionAppliesWhenLiveEditorAdvancedPastReportedText() throws {
+        var value = "abcdef"
+        let identity = UUID()
+        let editor = ComposerPasteTextView(
+            text: Binding(get: { value }, set: { value = $0 }),
+            isFocused: .constant(false),
+            measuredHeight: .constant(44),
+            enabled: true,
+            onPastedImage: { _ in },
+            onPastedImageError: { _ in },
+            editorIdentity: identity
+        )
+        let coordinator = ComposerPasteTextView.Coordinator(editor)
+        let textView = ImagePasteTextView()
+
+        coordinator.apply(
+            text: "abcdef",
+            programmaticRevision: 1,
+            editorIdentity: identity,
+            to: textView
+        )
+        XCTAssertEqual(textView.text, "abcdef")
+
+        // The user types "g" — the live editor advances to "abcdefg" while
+        // the delegate flush is still pending, so the last reported text is
+        // stale at "abcdef".
+        textView.text = "abcdefg"
+        textView.selectedRange = NSRange(location: 7, length: 0)
+
+        TranscriptPerf.reset()
+        // An intentional source rewrites the SAME value it believes is
+        // current, advancing the revision: the adoption shortcut must not
+        // fire on the stale report.
+        coordinator.apply(
+            text: "abcdef",
+            programmaticRevision: 2,
+            editorIdentity: identity,
+            to: textView
+        )
+        XCTAssertEqual(
+            textView.text, "abcdef",
+            "a genuine intentional revision must be applied, not acknowledged while the live editor holds newer text"
+        )
+        XCTAssertEqual(
+            TranscriptPerf.composerProgrammaticTextAssignments, 1,
+            "the intentional replacement must perform a real assignment"
+        )
+
+        // Apply-once: the same revision never rewrites again.
+        coordinator.apply(
+            text: "abcdef",
+            programmaticRevision: 2,
+            editorIdentity: identity,
+            to: textView
+        )
+        XCTAssertEqual(TranscriptPerf.composerProgrammaticTextAssignments, 1)
+
+        // The user-echo contract is untouched: newer live text with an
+        // UNCHANGED revision is never reverted by an unrelated invalidation.
+        textView.text = "abcdefZ"
+        textView.selectedRange = NSRange(location: 6, length: 0)
+        coordinator.apply(
+            text: "abcdef",
+            programmaticRevision: 2,
+            editorIdentity: identity,
+            to: textView
+        )
+        XCTAssertEqual(textView.text, "abcdefZ")
+        XCTAssertEqual(textView.selectedRange.location, 6)
+        XCTAssertEqual(TranscriptPerf.composerProgrammaticTextAssignments, 1)
+    }
+
     /// Clear-after-send is an intentional revision: the editor is cleared
     /// exactly once even though the same (empty) binding rides along on
     /// every subsequent invalidation.

--- a/ConduitTests/LongContextScalingFixtureTests.swift
+++ b/ConduitTests/LongContextScalingFixtureTests.swift
@@ -1,0 +1,534 @@
+import XCTest
+import SwiftUI
+@testable import Conduit
+
+/// Long-context regression fixture (spec: agent sessions with >200K context,
+/// i.e. hundreds-to-thousands of settled rows). Deterministic counters only —
+/// never wall-clock. Three seams are measured:
+///
+///   1. one live reasoning publish in a deep transcript
+///      → must not mutate the settled transcript / revision / scroll-target
+///        cache (the O(message count) churn behind the reported CPU burn)
+///   2. unrelated AppState publications with a focused, edited composer
+///      → must reach `updateUIView` but never write text or selection
+///   3. the stale-binding echo window (UIKit advanced past the binding)
+///      → must never rewrite editor text (cursor corruption repro)
+///
+/// The fixture hosts the real ChatView (real ForEach, real ComposerBar, real
+/// ComposerPasteTextView) so the measured cascade is the production one.
+@MainActor
+final class LongContextScalingFixtureTests: XCTestCase {
+
+    /// Retained for the full lifetime of each measurement so the hosted
+    /// hierarchy stays genuinely mounted.
+    private var testWindow: UIWindow?
+
+    override func setUp() {
+        super.setUp()
+        TranscriptPerf.reset()
+    }
+
+    override func tearDown() {
+        testWindow?.isHidden = true
+        testWindow?.rootViewController = nil
+        RunLoop.current.run(until: Date())
+        testWindow = nil
+        TranscriptPerf.reset()
+        super.tearDown()
+    }
+
+    // MARK: - Harness
+
+    private func makeAppState() throws -> AppState {
+        let suiteName = "long-context-fixture"
+        let defaults = try XCTUnwrap(
+            UserDefaults(suiteName: suiteName),
+            "test UserDefaults suite must initialize"
+        )
+        defaults.removePersistentDomain(forName: suiteName)
+        return AppState(defaults: defaults, loadSavedConnection: false)
+    }
+
+    private func installActiveSession(_ state: AppState, id: String) {
+        let summary = SessionSummary(
+            id: id,
+            alternateIds: [],
+            title: id,
+            model: "Hermes",
+            updatedLabel: "now",
+            profile: "default",
+            source: .chat,
+            isActive: false,
+            isArchived: false,
+            lineageRootId: nil
+        )
+        state.sessions = [summary]
+        state.activeSessionId = id
+    }
+
+    /// Deep agent-session transcript: markdown-heavy settled rows, far beyond
+    /// the 250-row streaming fixture, representing a >200K-context session.
+    static func deepTranscript(count: Int = 800) -> [ChatMessage] {
+        (0..<count).map { index in
+            ChatMessage(
+                id: "deep-\(index)",
+                role: index % 2 == 0 ? .assistant : .user,
+                content: """
+                ### Turn \(index)
+                Settled assistant answer \(index) with **bold**, *italic*, and
+                [a reference link](https://example.com/item/\(index)).
+
+                - detail one for turn \(index)
+                - detail two for turn \(index)
+                """,
+                timestamp: "2026-01-01T00:00:00Z"
+            )
+        }
+    }
+
+    /// Drives `count` live reasoning deltas spaced past the 50 ms publish
+    /// cadence so each scheduled publish actually fires inside the window.
+    @discardableResult
+    private func feedReasoningDeltas(
+        _ count: Int,
+        sessionId: String,
+        state: AppState,
+        host: UIHostingController<AnyView>
+    ) -> String {
+        var buffer = ""
+        for index in 0..<count {
+            let chunk = "reasoning line \(index) for the live thinking card. "
+            buffer += chunk
+            state.handleStreamEvent(.reasoningDelta(sessionId: sessionId, text: chunk))
+            host.view.setNeedsLayout()
+            host.view.layoutIfNeeded()
+            RunLoop.current.run(until: Date().addingTimeInterval(0.055))
+        }
+        return buffer
+    }
+
+    /// Drains pending updates until the measured counters have been quiet for
+    /// a sustained window (same discipline as TranscriptPerformanceFixtureTests).
+    private func settleQuiet(maxQuietSeconds: TimeInterval = 1.0, cap: TimeInterval = 15.0) -> Bool {
+        func totals() -> [Int] {
+            [
+                TranscriptPerf.chatViewBodyEvaluations,
+                TranscriptPerf.composerBarBodyEvaluations,
+                TranscriptPerf.composerUpdateUIViewCalls,
+                TranscriptPerf.settledMarkdownTextBodyEvaluations,
+                TranscriptPerf.transcriptChangedCalls,
+                TranscriptPerf.reasoningProjectionPublishes,
+                TranscriptPerf.reasoningTranscriptMutations,
+            ]
+        }
+        var quietFor: TimeInterval = 0
+        var elapsed: TimeInterval = 0
+        var last = totals()
+        let step: TimeInterval = 0.1
+        while elapsed < cap {
+            RunLoop.current.run(until: Date().addingTimeInterval(step))
+            elapsed += step
+            let current = totals()
+            if current == last {
+                quietFor += step
+                if quietFor >= maxQuietSeconds { return true }
+            } else {
+                quietFor = 0
+                last = current
+            }
+        }
+        return false
+    }
+
+    private func mountChat(appState: AppState) -> UIHostingController<AnyView> {
+        let host = UIHostingController(
+            rootView: AnyView(ChatView().environmentObject(appState))
+        )
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.isHidden = false
+        testWindow = window
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+        return host
+    }
+
+    private func findTextView(in root: UIView) -> ImagePasteTextView? {
+        if let found = root as? ImagePasteTextView { return found }
+        for child in root.subviews {
+            if let found = findTextView(in: child) { return found }
+        }
+        return nil
+    }
+
+    // MARK: - 1. Deep-transcript reasoning churn
+
+    /// THE scaling regression: in an 800-row transcript, every live reasoning
+    /// publish used to mutate `messages` (O(n) index scan + CoW copy + revision
+    /// bump), re-run the scroll-target cache's O(n) prefix walk + O(prefix)
+    /// fingerprint-set build, and re-copy the ForEach source array. Steady-state
+    /// reasoning must do NONE of that: it publishes through the live projection
+    /// only, at O(live content) cost.
+    func testLiveReasoningPublishesAvoidTranscriptSizedWork() throws {
+        let appState = try makeAppState()
+        installActiveSession(appState, id: "deep-session")
+        appState.messages = Self.deepTranscript()
+
+        let host = mountChat(appState: appState)
+        guard settleQuiet() else {
+            XCTFail("deep transcript never reached a quiet state; measurement would be meaningless")
+            return
+        }
+
+        TranscriptPerf.reset()
+        let expected = feedReasoningDeltas(12, sessionId: "deep-session", state: appState, host: host)
+        guard settleQuiet(maxQuietSeconds: 0.6) else {
+            XCTFail("measurement window never quieted; trailing publishes would be misattributed")
+            return
+        }
+
+        // Measurement validity: publishes really happened.
+        XCTAssertGreaterThanOrEqual(
+            TranscriptPerf.reasoningProjectionPublishes, 5,
+            "fixture must drive at least 5 live reasoning publishes"
+        )
+
+        // The scaling contract.
+        XCTAssertEqual(
+            TranscriptPerf.reasoningTranscriptMutations, 0,
+            "live reasoning publishes must not mutate the settled transcript"
+        )
+        XCTAssertEqual(
+            TranscriptPerf.transcriptChangedCalls, 0,
+            "live reasoning publishes must not re-run viewport transcriptChanged"
+        )
+        XCTAssertEqual(
+            TranscriptPerf.scrollTargetCommonPrefixComparisons, 0,
+            "live reasoning publishes must not walk the scroll-target common prefix"
+        )
+        XCTAssertEqual(
+            TranscriptPerf.scrollTargetPrefixSetBuilds, 0,
+            "live reasoning publishes must not rebuild the prefix fingerprint set"
+        )
+        XCTAssertEqual(
+            TranscriptPerf.settledMarkdownTextBodyEvaluations, 0,
+            "live reasoning publishes must leave settled Markdown dormant"
+        )
+
+        // And the live card content must actually be visible.
+        XCTAssertEqual(appState.messages.filter { $0.role == .reasoning }.count, 0)
+        XCTAssertFalse(expected.isEmpty)
+    }
+
+    // MARK: - 2. Hosted composer isolation
+
+    /// With user text in a focused editor, unrelated AppState publications
+    /// (reasoning, streaming, busy flips) reach `updateUIView` but must never
+    /// write text or selection back into UIKit.
+    func testComposerEditorIsUnaffectedByReasoningPublishes() throws {
+        let appState = try makeAppState()
+        installActiveSession(appState, id: "deep-session")
+        appState.messages = Self.deepTranscript()
+
+        let host = mountChat(appState: appState)
+        guard settleQuiet() else {
+            XCTFail("deep transcript never reached a quiet state; measurement would be meaningless")
+            return
+        }
+
+        guard let textView = findTextView(in: host.view) else {
+            return XCTFail("composer text view must be mounted")
+        }
+
+        // Simulate real user typing through the text input system, then park
+        // the cursor mid-text.
+        textView.insertText("hello from the hardware keyboard")
+        RunLoop.current.run(until: Date())
+        textView.selectedRange = NSRange(location: 12, length: 0)
+        let textBefore = textView.text
+        let selectionBefore = textView.selectedRange
+
+        TranscriptPerf.reset()
+        _ = feedReasoningDeltas(8, sessionId: "deep-session", state: appState, host: host)
+        appState.streamingText = "unrelated streaming tick "
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+        appState.streamingText = ""
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+        guard settleQuiet(maxQuietSeconds: 0.6) else {
+            XCTFail("measurement window never quieted")
+            return
+        }
+
+        // Invalidation DID reach the editor bridge — isolation is not silence.
+        XCTAssertGreaterThan(
+            TranscriptPerf.composerUpdateUIViewCalls, 0,
+            "unrelated publications must still reach updateUIView (measuring the right seam)"
+        )
+        // …but they must never rewrite the editor.
+        XCTAssertEqual(
+            TranscriptPerf.composerProgrammaticTextAssignments, 0,
+            "unrelated publications must cause zero programmatic text assignments"
+        )
+        XCTAssertEqual(
+            TranscriptPerf.composerSelectionWrites, 0,
+            "unrelated publications must cause zero selection writes"
+        )
+        XCTAssertEqual(textView.text, textBefore, "editor text must be untouched")
+        XCTAssertEqual(textView.selectedRange, selectionBefore, "cursor must not move")
+    }
+
+    // MARK: - 3. Stale-binding echo seam
+
+    /// The deterministic cursor-corruption repro at the smallest seam: the
+    /// binding lags UIKit because the delegate notification is deferred while
+    /// an unrelated SwiftUI update runs `apply`. The user's keystroke must
+    /// survive; before the fix it was reverted and the cursor re-clamped
+    /// (measured pre-fix: text "abcdefg" → "abcdef", 1 assignment, cursor 4 → 4).
+    func testStaleBindingEchoDoesNotRevertUserTyping() throws {
+        var value = "abcdef"
+        let identity = UUID()
+        let editor = ComposerPasteTextView(
+            text: Binding(get: { value }, set: { value = $0 }),
+            isFocused: .constant(false),
+            measuredHeight: .constant(44),
+            enabled: true,
+            onPastedImage: { _ in },
+            onPastedImageError: { _ in },
+            editorIdentity: identity
+        )
+        let coordinator = ComposerPasteTextView.Coordinator(editor)
+        let textView = ImagePasteTextView()
+
+        // Intentional programmatic prefill: applies exactly once.
+        coordinator.apply(
+            text: "abcdef",
+            programmaticRevision: 1,
+            editorIdentity: identity,
+            to: textView
+        )
+        XCTAssertEqual(textView.text, "abcdef")
+
+        // The user types "g" after "abc" — UIKit advanced to "abcdefg" with
+        // the cursor at 4, but the delegate flush is still pending, so the
+        // SwiftUI binding still reads "abcdef".
+        textView.text = "abcdefg"
+        textView.selectedRange = NSRange(location: 4, length: 0)
+
+        TranscriptPerf.reset()
+        // Unrelated SwiftUI invalidation runs the updateUIView apply with the
+        // stale binding value and an UNCHANGED revision.
+        coordinator.apply(
+            text: "abcdef",
+            programmaticRevision: 1,
+            editorIdentity: identity,
+            to: textView
+        )
+
+        XCTAssertEqual(
+            textView.text, "abcdefg",
+            "a stale binding echo must not revert the user's keystroke"
+        )
+        XCTAssertEqual(
+            textView.selectedRange.location, 4,
+            "a stale binding echo must not move the cursor"
+        )
+        XCTAssertEqual(
+            TranscriptPerf.composerProgrammaticTextAssignments, 0,
+            "a stale binding echo must not perform a programmatic assignment"
+        )
+
+        // The delegate flush lands afterwards: UIKit reports the user text
+        // and it flows to the binding, still without an editor rewrite.
+        coordinator.textViewDidChange(textView)
+        XCTAssertEqual(textView.text, "abcdefg")
+        XCTAssertEqual(
+            TranscriptPerf.composerProgrammaticTextAssignments, 0,
+            "publishing the user's text must not write back into the editor"
+        )
+    }
+
+    /// Intentional programmatic replacements apply EXACTLY ONCE per revision:
+    /// repeated updateUIView calls with the same revision must not rewrite
+    /// the editor (old behavior reassigned on every mismatch, tearing down
+    /// input state each time).
+    func testProgrammaticReplacementAppliesExactlyOncePerRevision() throws {
+        var value = ""
+        let identity = UUID()
+        let editor = ComposerPasteTextView(
+            text: Binding(get: { value }, set: { value = $0 }),
+            isFocused: .constant(false),
+            measuredHeight: .constant(44),
+            enabled: true,
+            onPastedImage: { _ in },
+            onPastedImageError: { _ in },
+            editorIdentity: identity
+        )
+        let coordinator = ComposerPasteTextView.Coordinator(editor)
+        let textView = ImagePasteTextView()
+
+        TranscriptPerf.reset()
+        coordinator.apply(
+            text: "draft text",
+            programmaticRevision: 7,
+            editorIdentity: identity,
+            to: textView
+        )
+        XCTAssertEqual(textView.text, "draft text")
+        XCTAssertEqual(TranscriptPerf.composerProgrammaticTextAssignments, 1)
+        XCTAssertEqual(TranscriptPerf.composerSelectionWrites, 1)
+
+        // Repeated invalidations carrying the same revision: no rewrites.
+        textView.selectedRange = NSRange(location: 5, length: 0)
+        coordinator.apply(
+            text: "draft text",
+            programmaticRevision: 7,
+            editorIdentity: identity,
+            to: textView
+        )
+        coordinator.apply(
+            text: "draft text",
+            programmaticRevision: 7,
+            editorIdentity: identity,
+            to: textView
+        )
+        XCTAssertEqual(TranscriptPerf.composerProgrammaticTextAssignments, 1)
+        XCTAssertEqual(TranscriptPerf.composerSelectionWrites, 1)
+        XCTAssertEqual(textView.selectedRange.location, 5, "cursor must stay where the user put it")
+
+        // A NEW revision replaces deliberately — once — and keeps the
+        // selection clamped, as the draft-restore/prefill paths expect.
+        coordinator.apply(
+            text: "prefilled prompt",
+            programmaticRevision: 8,
+            editorIdentity: identity,
+            to: textView
+        )
+        XCTAssertEqual(textView.text, "prefilled prompt")
+        XCTAssertEqual(TranscriptPerf.composerProgrammaticTextAssignments, 2)
+        XCTAssertEqual(
+            textView.selectedRange.location, 5,
+            "programmatic replacement preserves the caret location when it fits"
+        )
+    }
+
+    /// An intentional replacement arriving during active IME composition is
+    /// DEFERRED, never applied over the marked text; it lands exactly once
+    /// when the composition ends.
+    func testProgrammaticReplacementDefersDuringMarkedText() throws {
+        var value = ""
+        let identity = UUID()
+        let editor = ComposerPasteTextView(
+            text: Binding(get: { value }, set: { value = $0 }),
+            isFocused: .constant(false),
+            measuredHeight: .constant(44),
+            enabled: true,
+            onPastedImage: { _ in },
+            onPastedImageError: { _ in },
+            editorIdentity: identity
+        )
+        let coordinator = ComposerPasteTextView.Coordinator(editor)
+        let textView = ImagePasteTextView()
+
+        // Establish baseline content and a live composition (UITextInput
+        // marked text — the deterministic seam for IME state).
+        coordinator.apply(
+            text: "base ",
+            programmaticRevision: 1,
+            editorIdentity: identity,
+            to: textView
+        )
+        (textView as UITextInput).setMarkedText("にほんご", selectedRange: NSRange(location: 0, length: 0))
+        XCTAssertNotNil(textView.markedTextRange, "fixture requires active marked text")
+
+        TranscriptPerf.reset()
+        coordinator.apply(
+            text: "slash-command replacement ",
+            programmaticRevision: 2,
+            editorIdentity: identity,
+            to: textView
+        )
+        XCTAssertNotNil(
+            textView.markedTextRange,
+            "the composition must survive an intentional replacement"
+        )
+        XCTAssertEqual(
+            TranscriptPerf.composerMarkedTextDeferrals, 1,
+            "the replacement must be recorded as deferred"
+        )
+        XCTAssertEqual(
+            TranscriptPerf.composerProgrammaticTextAssignments, 0,
+            "marked text must never be silently replaced"
+        )
+        XCTAssertTrue(textView.text.contains("にほんご"), "composition text stays intact")
+
+        // Composition ends (commit or discard both unmark): the deferred
+        // replacement lands exactly once.
+        coordinator.textViewDidChange(textView)
+        if textView.markedTextRange != nil {
+            textView.unmarkText()
+            coordinator.textViewDidChange(textView)
+        }
+        XCTAssertNil(textView.markedTextRange)
+        XCTAssertEqual(
+            textView.text, "slash-command replacement ",
+            "the deferred intentional replacement lands when composition ends"
+        )
+        XCTAssertEqual(
+            TranscriptPerf.composerProgrammaticTextAssignments, 1,
+            "the deferred replacement applies exactly once"
+        )
+    }
+
+    /// Clear-after-send is an intentional revision: the editor is cleared
+    /// exactly once even though the same (empty) binding rides along on
+    /// every subsequent invalidation.
+    func testClearAfterSendClearsEditorExactlyOnce() throws {
+        var value = "message being typed"
+        let identity = UUID()
+        let editor = ComposerPasteTextView(
+            text: Binding(get: { value }, set: { value = $0 }),
+            isFocused: .constant(false),
+            measuredHeight: .constant(44),
+            enabled: true,
+            onPastedImage: { _ in },
+            onPastedImageError: { _ in },
+            editorIdentity: identity
+        )
+        let coordinator = ComposerPasteTextView.Coordinator(editor)
+        let textView = ImagePasteTextView()
+
+        coordinator.apply(
+            text: "message being typed",
+            programmaticRevision: 1,
+            editorIdentity: identity,
+            to: textView
+        )
+        XCTAssertEqual(textView.text, "message being typed")
+
+        // Submit clears the composer: revision advances, editor empties.
+        TranscriptPerf.reset()
+        value = ""
+        coordinator.apply(
+            text: "",
+            programmaticRevision: 2,
+            editorIdentity: identity,
+            to: textView
+        )
+        XCTAssertEqual(textView.text, "")
+        XCTAssertEqual(TranscriptPerf.composerProgrammaticTextAssignments, 1)
+
+        // Follow-up invalidations with unrelated state (streaming, busy
+        // flips) carry the same revision and must not touch the editor.
+        coordinator.apply(text: "", programmaticRevision: 2, editorIdentity: identity, to: textView)
+        coordinator.apply(text: "", programmaticRevision: 2, editorIdentity: identity, to: textView)
+        XCTAssertEqual(
+            TranscriptPerf.composerProgrammaticTextAssignments, 1,
+            "clear-after-send must apply exactly once"
+        )
+    }
+}

--- a/ConduitUITests/LoginKeyboardUITests.swift
+++ b/ConduitUITests/LoginKeyboardUITests.swift
@@ -6,7 +6,26 @@ import XCTest
 /// drives the REAL gesture pipeline — toggle the Cloudflare section, focus
 /// its fields through the return-key chain, and assert every control stays
 /// hittable while the keyboard is up.
+///
+/// The Cloudflare toggle is driven through `ensureSwitchOn`, which verifies
+/// the actual accessibility state transition instead of assuming one
+/// `tap()` succeeded: a mis-aimed tap (element still settling from the
+/// form's entrance animation) used to leave the switch OFF, the fields
+/// unmounted, and this test failed with "Client ID did not appear" — a
+/// product illusion with no product bug behind it. Each tap is gated on the
+/// observed OFF state (never a blind double-tap, which could mask a real
+/// toggle bug by flipping it back off), and a failure dumps the
+/// accessibility tree plus the switch's observed values.
 final class LoginKeyboardUITests: XCTestCase {
+    /// Stable XCUI handles defined in LoginView (decoupled from copy).
+    private enum Identity {
+        static let serverURL = "login.server-url"
+        static let cloudflareToggle = "login.cloudflare-toggle"
+        static let cloudflareClientID = "login.cloudflare-client-id"
+        static let cloudflareClientSecret = "login.cloudflare-client-secret"
+        static let connect = "login.connect"
+    }
+
     override func setUpWithError() throws {
         continueAfterFailure = false
     }
@@ -15,15 +34,24 @@ final class LoginKeyboardUITests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
 
-        let serverField = app.textFields["https://hermes.example"]
+        let serverField = app.textFields[Identity.serverURL]
         XCTAssertTrue(serverField.waitForExistence(timeout: 10), "Login screen did not appear. Tree:\n\(app.debugDescription)")
 
-        let cfToggle = app.switches["Use Cloudflare Access service token"]
-        XCTAssertTrue(cfToggle.waitForExistence(timeout: 5), "Cloudflare toggle not found. Tree:\n\(app.debugDescription)")
-        cfToggle.tap()
+        let cfToggle = app.switches[Identity.cloudflareToggle]
+        XCTAssertTrue(
+            ensureSwitchOn(cfToggle, app: app),
+            "Cloudflare toggle did not reach the ON state. Observed values: \(toggleObservations). Tree:\n\(app.debugDescription)"
+        )
 
-        let clientID = app.textFields["Cloudflare Client ID"]
-        XCTAssertTrue(clientID.waitForExistence(timeout: 5), "Cloudflare Client ID did not appear after enabling the toggle")
+        // The switch is verifiably ON (accessibility state, not an assumed
+        // tap): the fields mount in the same transaction. If they still do
+        // not appear, that is a production mount/exposure problem and the
+        // dump below captures the mounted tree for diagnosis.
+        let clientID = app.textFields[Identity.cloudflareClientID]
+        XCTAssertTrue(
+            clientID.waitForExistence(timeout: 10),
+            "Cloudflare Client ID did not appear although the toggle is verifiably ON (value: \(cfToggle.value ?? "nil")). Tree:\n\(app.debugDescription)"
+        )
         clientID.tap()
         // Typing proves the software keyboard is actually up and focused here
         // (typeText waits for focus, so no fixed sleep for the keyboard).
@@ -36,7 +64,7 @@ final class LoginKeyboardUITests: XCTestCase {
         // Return walks the focus chain to the Cloudflare Client Secret; the
         // view must scroll that field into view from behind the keyboard.
         clientID.typeText("\n")
-        let secret = app.secureTextFields["Cloudflare Client Secret"]
+        let secret = app.secureTextFields[Identity.cloudflareClientSecret]
         XCTAssertTrue(secret.waitForExistence(timeout: 5))
         // The focus-driven scroll animates for ~0.25s; poll hittability
         // instead of asserting while the scroll may still be in flight.
@@ -48,7 +76,7 @@ final class LoginKeyboardUITests: XCTestCase {
 
         // The Connect control itself must also remain reachable on the
         // compact keyboard-obscured layout.
-        let connect = app.buttons["Connect"]
+        let connect = app.buttons[Identity.connect]
         XCTAssertTrue(connect.waitForExistence(timeout: 5))
         if !connect.isHittable {
             app.swipeUp()
@@ -57,6 +85,69 @@ final class LoginKeyboardUITests: XCTestCase {
             pollHittability(of: connect, timeout: 5),
             "Connect must remain reachable with the keyboard visible"
         )
+    }
+
+    // MARK: - Toggle state transition
+
+    /// Accumulated switch-value observations for failure diagnostics.
+    private var toggleObservations: [String] = []
+
+    private func switchIsOn(_ element: XCUIElement) -> Bool {
+        // SwiftUI switches expose their state as the string "0"/"1" via
+        // `value`; `isSwitchOn` is the typed equivalent on newer XCTest.
+        if let raw = element.value as? String {
+            return raw == "1"
+        }
+        return element.isSwitchOn
+    }
+
+    /// Drives the toggle to ON and verifies the state actually changed.
+    /// Waits for existence + hittability first, taps only while observed
+    /// OFF (a second tap gated on state would otherwise be a blind
+    /// double-tap), waits for the value to flip after each tap, and bounds
+    /// the whole transition. The first unresponsive tap is logged so CI
+    /// logs distinguish "tap did not flip the switch" from "switch flipped
+    /// but the fields did not mount".
+    private func ensureSwitchOn(_ element: XCUIElement, app: XCUIApplication) -> Bool {
+        guard element.waitForExistence(timeout: 10) else {
+            toggleObservations.append("toggle never existed")
+            return false
+        }
+        var settled = false
+        let hittableDeadline = Date().addingTimeInterval(5)
+        while Date() < hittableDeadline {
+            if element.isHittable { settled = true; break }
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+        toggleObservations.append("initial value: \(element.value ?? "nil") hittable: \(settled)")
+        if switchIsOn(element) { return true }
+
+        let transitionDeadline = Date().addingTimeInterval(15)
+        var taps = 0
+        while Date() < transitionDeadline, taps < 3 {
+            taps += 1
+            element.tap()
+            let flipped = waitForSwitchOn(element, timeout: 3)
+            toggleObservations.append("tap \(taps) -> value: \(element.value ?? "nil") flipped: \(flipped)")
+            if !flipped, taps == 1 {
+                // Diagnostic for the intermittent flake: the first tap did
+                // not change the switch state at all (tap vs. mount race),
+                // as opposed to the fields failing to mount after a real
+                // state change.
+                NSLog("LoginKeyboardUITests: first toggle tap did not flip the switch (value=%@) - retrying", element.value.map { "\($0)" } ?? "nil")
+            }
+            if flipped { return true }
+        }
+        return switchIsOn(element)
+    }
+
+    private func waitForSwitchOn(_ element: XCUIElement, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if switchIsOn(element) { return true }
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+        return switchIsOn(element)
     }
 
     /// XCUIElement has no waitForHittability; poll isHittable on a deadline.

--- a/ConduitUITests/LoginKeyboardUITests.swift
+++ b/ConduitUITests/LoginKeyboardUITests.swift
@@ -93,12 +93,13 @@ final class LoginKeyboardUITests: XCTestCase {
     private var toggleObservations: [String] = []
 
     private func switchIsOn(_ element: XCUIElement) -> Bool {
-        // SwiftUI switches expose their state as the string "0"/"1" via
-        // `value`; `isSwitchOn` is the typed equivalent on newer XCTest.
-        if let raw = element.value as? String {
-            return raw == "1"
+        // SwiftUI switches expose their state via `value` as the string
+        // "0"/"1" (NSString); some configurations surface a Bool NSNumber.
+        switch element.value as? String {
+        case "1": return true
+        case "0": return false
+        default: return (element.value as? Bool) == true
         }
-        return element.isSwitchOn
     }
 
     /// Drives the toggle to ON and verifies the state actually changed.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -131,12 +131,45 @@ the rest of CI v2.
 
 ## Watchdogs
 
-`timeout = max(min_timeout, ceil(predicted x 2.5))` with a 300 s floor for
-unit lanes (600 s for both unit and UI after the first measured runs). The
-outer GitHub job ceiling is `ceil((3 x watchdog + 1200s) / 60)` minutes -
-attempt 1 + attempt 2 + a full isolation pass plus two bounded simulator
-resets and setup/download slack - so the ceiling can never preempt legitimate
-in-script recovery (the script watchdogs are the real enforcement).
+Unit lanes: `timeout = max(min_timeout, ceil(predicted x 2.5))` with a 600 s
+floor. The outer GitHub job ceiling is `ceil((3 x watchdog + 1200s) / 60)`
+minutes - attempt 1 + attempt 2 + a full isolation pass plus two bounded
+simulator resets and setup/download slack - so the ceiling can never preempt
+legitimate in-script recovery (the script watchdogs are the real
+enforcement).
+
+UI lanes pay large **fixed per-invocation overhead** that unit lanes amortize
+across far more test seconds: xcodebuild/automation-session startup and
+simulator boot before the first test (~2.5 min measured on macos-26 hosted
+runners), app install, and xcresult finalization after the last one (~1 min).
+Their budget is therefore
+
+```
+ui_timeout = max(UI_TIMEOUT_MIN_S, ceil(predicted x UI_RETRY_HEADROOM_FACTOR
+                                       + UI_INVOCATION_OVERHEAD_S))
+           = max(900s, ceil(predicted x 2.0 + 240s))
+```
+
+- the floor was raised 600 -> 900 s after run #500 crossed the old floor
+  while the tests were **succeeding** (predicted ~226 s + measured overhead
+  already needs ~500-600 s on the happy path, leaving no room for the native
+  retry iteration);
+- the retry term covers both native iterations executing the full (small)
+  class list when a failure survives iteration 1;
+- the formula grows linearly if the UI suite expands, so the floor stays a
+  floor rather than the whole budget. The dynamic job ceiling covers the
+  worst in-script path (initial invocation + post-reset retry + class
+  isolation) exactly as for units.
+
+**Finalize grace.** When a watchdog expires but the log already carries
+xcodebuild's terminal result marker (`** TEST EXECUTE SUCCEEDED/FAILED **`),
+the test session has ENDED and the process is only writing its xcresult.
+Killing there converts a completed run into a timeout (run #500) and can
+truncate the result bundle, so the deadline is extended once by a bounded
+`XCODEBUILD_FINALIZE_GRACE_S` (default 180 s) and the process may exit on its
+own. The verdict still comes exclusively from the real exit status - the
+marker never declares success on its own - and a process that outlives the
+grace is killed and classified as a timeout exactly as before.
 
 Every `simctl` operation is deadline-bounded; the process-group watchdog kill
 (xcodebuild + xctest + simulator agents) is preserved from the previous

--- a/scripts/ci-lib.sh
+++ b/scripts/ci-lib.sh
@@ -8,13 +8,25 @@
 # Helpers:
 #   run_with_deadline          - xcodebuild under a wall-clock watchdog; kills
 #                                the whole process group (xcodebuild + xctest +
-#                                simulator agents) on expiry. Returns 124.
+#                                simulator agents) on expiry. Returns 124. If
+#                                the log already carries xcodebuild's terminal
+#                                result marker when the budget expires, one
+#                                bounded finalize-grace extension lets the
+#                                finished session write its xcresult and exit.
 #   bounded_run                - any short command under a deadline so a wedged
 #                                CoreSimulatorService costs a bounded warning,
 #                                not the job. Output lands in BOUNDED_OUTPUT.
 #   simulator_udid             - resolve the destination device UDID.
 #   reset_and_boot_simulator   - bounded shutdown/erase/boot recovery.
 #   now_iso                    - UTC timestamp for lane result documents.
+
+# Terminal xcodebuild result markers (test and test-without-building forms).
+# Presence means the test session itself ENDED and xcodebuild is only
+# finalizing; the result verdict still comes exclusively from the process
+# exit status.
+log_has_terminal_result_marker() {
+  grep -q -E '\*\* TEST (EXECUTE )?(SUCCEEDED|FAILED) \*\*' "$1" 2>/dev/null
+}
 
 # Stream log lines not yet printed. $1 = log path, $2 = NAME of the caller's
 # variable holding the last printed line count (written back via printf -v).
@@ -38,11 +50,23 @@ stream_new_lines() {
 # (arg 1 = budget seconds, arg 2 = log path). Streams the log into the step
 # log; returns the command's exit status, or 124 when the deadline killed it.
 # The caller owns retry policy - this function never retries.
+#
+# Finalize grace: when the budget expires but the log already contains
+# xcodebuild's terminal result marker, the TEST SESSION is finished and the
+# process is only writing out its xcresult. Killing there converts a
+# completed run into a timeout (and can truncate the result bundle), so the
+# deadline is extended ONCE by XCODEBUILD_FINALIZE_GRACE_S (default 180s) and
+# the process is allowed to exit on its own. Success is still only ever
+# returned from the process's real exit status - the marker never fakes a
+# result - and a process that outlives the grace window is killed and
+# classified as a timeout exactly as before.
 run_with_deadline() {
   local budget="$1"
   local log="$2"
   shift 2
   local started deadline poll printed heartbeat timed_out now remaining runner grace
+  local finalize_grace grace_granted marker
+  finalize_grace="${XCODEBUILD_FINALIZE_GRACE_S:-180}"
 
   started=$(date +%s)
   deadline=$(( started + budget ))
@@ -62,12 +86,20 @@ run_with_deadline() {
   printed=0
   heartbeat=0
   timed_out=0
+  grace_granted=0
   while kill -0 "$runner" 2>/dev/null; do
     now=$(date +%s)
     remaining=$(( deadline - now ))
     if [ "$remaining" -le 0 ]; then
-      timed_out=1
-      break
+      if [ "$grace_granted" -eq 0 ] && log_has_terminal_result_marker "$log"; then
+        grace_granted=1
+        deadline=$(( now + finalize_grace ))
+        remaining=$finalize_grace
+        echo "::warning::xcodebuild reached its "${budget}"s budget after printing its final result - allowing "${finalize_grace}"s finalize grace so the xcresult is written completely"
+      else
+        timed_out=1
+        break
+      fi
     fi
     stream_new_lines "$log" printed
     heartbeat=$(( heartbeat + 1 ))

--- a/scripts/plan-tests.py
+++ b/scripts/plan-tests.py
@@ -45,7 +45,22 @@ MAX_LANES = 8
 TARGET_LANE_BUDGET_S = 240.0       # scale-out threshold per lane
 LANE_TIMEOUT_MIN_S = 600           # healthy lanes never get less than 10 min
 LANE_TIMEOUT_MULTIPLIER = 2.5      # headroom over prediction
-UI_TIMEOUT_MIN_S = 600             # UI lane floor (simulator interaction overhead)
+# UI lane floor. Raised from 600s after run #500: a healthy hosted UI
+# invocation spends ~2.5 min on xcodebuild/automation-session/simulator
+# startup BEFORE the first test and ~1 min finalizing the xcresult after
+# the last one, so ~225s of predicted tests needs ~500-600s wall clock on
+# the happy path alone - the old floor left no room for the native retry
+# iteration and was crossed while the tests were SUCCEEDING.
+UI_TIMEOUT_MIN_S = 900
+# Per-invocation Xcode/simulator overhead the UI lane pays exactly once per
+# xcodebuild run, independent of how long the tests take: process startup,
+# automation-session + simulator boot, app install, and xcresult
+# finalization. Measured on macos-26 hosted runners (~2.5 min before the
+# first test starts, ~1 min of teardown).
+UI_INVOCATION_OVERHEAD_S = 240
+# Native flake retry can execute the full class list a second time inside
+# the same invocation when a failure survives iteration 1.
+UI_RETRY_HEADROOM_FACTOR = 2.0
 JOB_TIMEOUT_MARGIN_S = 1200        # reset/erase overhead + setup/download slack
 UNIT_TARGET = "ConduitTests"
 UI_TARGET = "ConduitUITests"
@@ -263,6 +278,23 @@ def timeout_for(predicted: float, floor_s: float, multiplier: float) -> int:
     return max(int(floor_s), int(math.ceil(predicted * multiplier)))
 
 
+def ui_timeout_for(predicted: float, floor_s: float, overhead_s: float,
+                   retry_factor: float) -> int:
+    """UI watchdog = predicted test time under both native iterations plus
+    one invocation's Xcode/simulator overhead, never below the floor.
+
+    Unlike unit lanes (many classes amortizing one simulator boot), a UI
+    invocation pays large fixed overhead around the tests, and the native
+    retry can run the whole (small) class list twice. Formula:
+
+        timeout = max(floor, ceil(predicted * retry_factor + overhead))
+
+    With the measured overhead this yields 900s for today's ~226s UI
+    prediction (the old 600s floor was crossed by SUCCEEDING runs) and
+    grows linearly if the UI suite expands."""
+    return max(int(floor_s), int(math.ceil(predicted * retry_factor + overhead_s)))
+
+
 def job_timeout_min(lane_timeout_s: int, cfg: dict) -> int:
     """Outer job ceiling: worst in-script path is attempt 1 + attempt 2 + a
     full isolation pass (each bounded by lane_timeout_s) plus two bounded
@@ -310,7 +342,12 @@ def build_plan(discovery: dict, cfg: dict, estimates: dict) -> dict:
     ui_lane = None
     if ui_names:
         predicted = sum(ui_est.values())
-        timeout = timeout_for(predicted, cfg["ui_timeout_min_s"], cfg["timeout_multiplier"])
+        timeout = ui_timeout_for(
+            predicted,
+            cfg["ui_timeout_min_s"],
+            cfg["ui_invocation_overhead_s"],
+            cfg["ui_retry_headroom_factor"],
+        )
         ui_lane = {
             "lane": "ui",
             "target": UI_TARGET,
@@ -327,6 +364,7 @@ def build_plan(discovery: dict, cfg: dict, estimates: dict) -> dict:
         "config": {k: cfg[k] for k in (
             "default_estimate_s", "min_lanes", "max_lanes", "target_budget_s",
             "lane_timeout_min_s", "timeout_multiplier", "ui_timeout_min_s",
+            "ui_invocation_overhead_s", "ui_retry_headroom_factor",
             "job_timeout_margin_s")},
         "inventory": {"unit": unit_names, "ui": ui_names},
         "estimates": {n: round(v, 3) for n, v in sorted(
@@ -543,6 +581,8 @@ def _cfg_from_args(a) -> dict:
         "lane_timeout_min_s": a.lane_timeout_min_s,
         "timeout_multiplier": a.timeout_multiplier,
         "ui_timeout_min_s": a.ui_timeout_min_s,
+        "ui_invocation_overhead_s": a.ui_invocation_overhead_s,
+        "ui_retry_headroom_factor": a.ui_retry_headroom_factor,
         "job_timeout_margin_s": a.job_timeout_margin_s,
     }
 
@@ -610,6 +650,8 @@ def main(argv=None) -> int:
         p.add_argument("--lane-timeout-min-s", type=int, default=LANE_TIMEOUT_MIN_S)
         p.add_argument("--timeout-multiplier", type=float, default=LANE_TIMEOUT_MULTIPLIER)
         p.add_argument("--ui-timeout-min-s", type=int, default=UI_TIMEOUT_MIN_S)
+        p.add_argument("--ui-invocation-overhead-s", type=int, default=UI_INVOCATION_OVERHEAD_S)
+        p.add_argument("--ui-retry-headroom-factor", type=float, default=UI_RETRY_HEADROOM_FACTOR)
         p.add_argument("--job-timeout-margin-s", type=int, default=JOB_TIMEOUT_MARGIN_S)
         if cmd == "plan":
             p.add_argument("--out", default="plan.json")

--- a/scripts/tests/_util.py
+++ b/scripts/tests/_util.py
@@ -51,7 +51,9 @@ def default_cfg(**overrides):
         "target_budget_s": 240.0,
         "lane_timeout_min_s": 600,
         "timeout_multiplier": 2.5,
-        "ui_timeout_min_s": 600,
+        "ui_timeout_min_s": 900,
+        "ui_invocation_overhead_s": 240,
+        "ui_retry_headroom_factor": 2.0,
         "job_timeout_margin_s": 1200,
     }
     cfg.update(overrides)

--- a/scripts/tests/test_lane_runner.sh
+++ b/scripts/tests/test_lane_runner.sh
@@ -238,6 +238,97 @@ assert_eq "isolation statuses" "$(isolation_statuses)" "['pass', 'timeout', 'not
 assert_eq "AlphaTests invoked once" "$(grep -c '^iso:AlphaTests$' "$INVOCATION_LOG")" "1"
 assert_eq "BetaTests invoked once" "$(grep -c '^iso:BetaTests$' "$INVOCATION_LOG")" "1"
 assert_eq "GammaTests never invoked" "$(grep -c '^iso:GammaTests$' "$INVOCATION_LOG")" "0"
+
+# --- case 8: finished session survives its budget via finalize grace ----------
+# Run #500 regression: xcodebuild printed its terminal result and was only
+# finalizing the xcresult when the watchdog expired. The deadline must be
+# extended ONCE (bounded grace) so the finished session can exit with its
+# real status; success still comes from the exit status, never the marker.
+begin_case "finalize grace lets a finished invocation pass" "$WORK/c8"
+cat > "$STUBS/xcodebuild" <<'EOF'
+#!/bin/bash
+echo "running tests (stub)"
+sleep 4
+echo "** TEST EXECUTE SUCCEEDED **"
+echo "finalizing xcresult (stub)"
+sleep 4
+exit 0
+EOF
+chmod +x "$STUBS/xcodebuild"
+export XCODEBUILD_FINALIZE_GRACE_S=30
+write_canned "$WORK/canned-grace.json" "AlphaTests" "Passed"
+run_lane "AlphaTests" 5 pass 1
+assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "0"
+assert_eq "verdict" "$(lane_field "['status']")" "pass"
+assert_eq "attempts" "$(attempts_statuses)" "['passed']"
+if grep -q "finalize grace" "$WORKCASE/stdout.log"; then
+  ok "finalize grace reported"
+else
+  bad "finalize grace must be reported when it fires"
+fi
+
+# --- case 9: grace is bounded - a wedged finalize is still a timeout ----------
+begin_case "finalize grace expiry kills and isolates" "$WORK/c9"
+cat > "$STUBS/xcodebuild" <<'EOF'
+#!/bin/bash
+echo "** TEST EXECUTE SUCCEEDED **"
+echo "wedged finalization (stub)"
+sleep 300
+exit 0
+EOF
+chmod +x "$STUBS/xcodebuild"
+export XCODEBUILD_FINALIZE_GRACE_S=3
+export ISOLATION_BUDGET_S=200 CLASS_TIMEOUT_MIN_S=1 CLASS_TIMEOUT_MULTIPLIER=0.1
+run_lane "AlphaTests" 3 pass 1
+assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "1"
+assert_eq "verdict" "$(lane_field "['status']")" "timeout"
+assert_eq "first attempt" "$(attempts_statuses | grep -o 'timeout' | head -1)" "timeout"
+if grep -q "finalize grace" "$WORKCASE/stdout.log"; then
+  ok "grace was granted before the kill"
+else
+  bad "grace must be attempted before killing a finalized session"
+fi
+
+# --- case 10: infra failure recovers on the single post-reset retry -----------
+begin_case "infra retry recovers to green" "$WORK/c10"
+cat > "$STUBS/xcodebuild" <<'EOF'
+#!/bin/bash
+n=$(cat "$COUNT_FILE" 2>/dev/null || echo 0)
+n=$((n + 1))
+echo "$n" > "$COUNT_FILE"
+if [ "$n" -eq 1 ]; then
+  echo "simulator crashed once (stub)"
+  exit 70
+fi
+exit 0
+EOF
+chmod +x "$STUBS/xcodebuild"
+export COUNT_FILE="$WORK/c10-count"
+: > "$COUNT_FILE"
+write_canned "$WORK/canned-c10.json" "AlphaTests" "Passed"
+run_lane "AlphaTests" 300 infra-once 1
+assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "0"
+assert_eq "verdict" "$(lane_field "['status']")" "pass"
+assert_eq "attempts" "$(attempts_statuses)" "['infra-recovered', 'passed']"
+
+# --- case 11: class failure during isolation fails the lane --------------------
+begin_case "class failure during isolation" "$WORK/c11"
+cat > "$STUBS/xcodebuild" <<'EOF'
+#!/bin/bash
+n=$(printf '%s\n' "$@" | grep -c -- '-only-testing:' || true)
+if [ "$n" -gt 1 ]; then
+  sleep 300
+  exit 0
+fi
+exit 65
+EOF
+chmod +x "$STUBS/xcodebuild"
+export ISOLATION_BUDGET_S=200 CLASS_TIMEOUT_MIN_S=1 CLASS_TIMEOUT_MULTIPLIER=0.1
+run_lane "AlphaTests,BetaTests" 3 fail65 1
+assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "1"
+assert_eq "verdict" "$(lane_field "['status']")" "fail"
+assert_eq "isolation statuses" "$(isolation_statuses)" "['fail', 'fail']"
+
 echo ""
 echo "lane-runner state machine: $pass_count passed, $fail_count failed"
 [ "$fail_count" -eq 0 ] || exit 1

--- a/scripts/tests/test_plan_tests.py
+++ b/scripts/tests/test_plan_tests.py
@@ -190,8 +190,34 @@ class PlanningTests(unittest.TestCase):
             lane = plan["unit_lanes"][0]
             self.assertEqual(lane["predicted_s"], 200.0)
             self.assertEqual(lane["timeout_s"], 600)  # floor wins: max(600, 500)
+            # UI: max(900 floor, ceil(60*2 + 240)) = 900 (floor wins)
             self.assertEqual(
-                plan["ui_lane"]["timeout_s"], 600)  # floor wins: max(600, 150)
+                plan["ui_lane"]["timeout_s"], 900)
+
+    def test_ui_timeout_formula_covers_overhead_and_retry(self):
+        # The UI watchdog must budget measured invocation overhead plus both
+        # native retry iterations, not just the raw prediction (run #500
+        # crossed the old 600s floor while the tests were succeeding).
+        cfg = default_cfg()
+        # Today's UI prediction (~225.9s): formula yields 692s, floor wins.
+        self.assertEqual(
+            planner.ui_timeout_for(225.9, cfg["ui_timeout_min_s"],
+                                   cfg["ui_invocation_overhead_s"],
+                                   cfg["ui_retry_headroom_factor"]),
+            900)
+        # A growing UI suite outgrows the floor linearly: 600s predicted ->
+        # 600*2 + 240 = 1440s, comfortably above any healthy invocation.
+        self.assertEqual(
+            planner.ui_timeout_for(600.0, cfg["ui_timeout_min_s"],
+                                   cfg["ui_invocation_overhead_s"],
+                                   cfg["ui_retry_headroom_factor"]),
+            1440)
+        # Tiny suites stay bounded by the floor, not the formula.
+        self.assertEqual(
+            planner.ui_timeout_for(5.0, cfg["ui_timeout_min_s"],
+                                   cfg["ui_invocation_overhead_s"],
+                                   cfg["ui_retry_headroom_factor"]),
+            900)
 
     def test_job_ceiling_covers_worst_in_script_path(self):
         # Ceiling must fit attempt1 + attempt2 + a full isolation pass plus


### PR DESCRIPTION
## Problem

A deep-agent-session user report: with >200K-token transcripts the UI grows sluggish, CPU climbs, the device heats and drains battery, and — while typing on a hardware keyboard — UI refreshes move the cursor and reorder input. This is a long-transcript scaling + editor-isolation bug, not a generic battery issue.

## Root causes (verified against current main)

**Composer cursor corruption.** `ComposerPasteTextView.Coordinator.apply` treated `textView.text != binding` as an intentional programmatic replacement. UIKit delivers `textViewDidChange` after the raw text-storage edit, so an unrelated SwiftUI invalidation landing inside that window saw a stale binding, "reverted" the user's in-flight keystroke via `textView.text = …`, and re-clamped the selection. The window opens whenever `ComposerBar` re-renders — i.e. on every AppState publication — and IME marked text was destroyed by the same path.

**Long-transcript CPU.** Every ~50 ms reasoning publish did an O(n) `messages.firstIndex` scan + O(n) CoW `messages` write + `chatTranscriptRevision` bump → `viewport.transcriptChanged` → scroll-target-cache O(n) prefix walk + O(prefix) fingerprint-`Set` build + suffix rebuild → `ChatView` body re-eval with an O(n) `Array(enumerated())` ForEach copy. At ~20 Hz over hundreds of rows, that is the sustained CPU/thermal load.

## Fix

### Live reasoning projection (no per-tick transcript mutation)
- New `@Published liveReasoningSegment: LiveReasoningSegment?` (fixed id/timestamp, content advancing at the existing 50 ms cadence). ChatView renders it as a normal `ThinkingCard` between the transcript and the streaming bubble — same presentation, chronology preserved.
- The settled `.reasoning` row commits into `messages` **exactly once per segment boundary** (`settleReasoningSegmentIntoTranscript`): tool start/complete, completion (incl. the drain-race window and the completion-carried trace via `finalizeReasoning`), error, interruption, new turn — before the boundary's own row lands, so ordering, dedup, resume, reconciliation, and session-switch semantics are unchanged.
- **Mid-turn rows settle first**: steer/redirect corrections, slash output, review summaries, clarify and approval cards, and the send-path outgoing bubble all commit the live segment before appending, preserving pre-projection chronology (resumed reasoning mounts a fresh segment, matching the tool-boundary precedent).

### Composer programmatic revision
- All intentional writes (draft restore, prefill, slash insertion, clear-after-send, failed-send restore, session handoff) route through `ComposerBar.replaceComposerText(_:)`, advancing `programmaticRevision`.
- The bridge applies a replacement **only on a revision advance, exactly once**; binding values that merely echo what UIKit last reported are never written back; a replacement arriving during IME composition is **deferred** until it ends (and stays the newest instruction); identity rotations reset bookkeeping and adopt the binding as ground truth.
- `updateUIView` no longer force-layouts on every unrelated publication, and editor identity (`.id(editorIdentity)`) is unchanged — it only rotates on handoff/submit, as before.

### Transcript-sized body work
- `ForEach` iterates `chatMessageScrollTargets` directly; `ChatMessageScrollTarget` gains an `order: Int` maintained by the cache (suffix rebuilds use `baseOrder:`, rendering-only replacements preserve it). Row identity (`message.id`) is unchanged.

## Before / after (800-row hosted fixture, 12 live reasoning deltas, DEBUG-only deterministic counters)

| Counter | before | after |
|---|---|---|
| reasoning transcript mutations | 8 | **0** |
| `transcriptChanged` calls | 9 | **0** |
| cache prefix comparisons | 7,200 | **0** |
| prefix fingerprint-Set builds | 9 | **0** |
| settled Markdown body evals | 1 | **0** |
| stale-echo seam probe | keystroke reverted, cursor moved, 1 assignment | **0 assignments, text + cursor intact** |

## Deliberate test-contract change

`AppStateReasoningStreamTests`: mid-stream reasoning assertions now read `liveReasoningSegment` — a 75-delta burst produces **0** `$messages` publications (previously 1), and the scheduled publish produces 0. Boundary commit, ordering, dedup, turn-flag, drain-race, and session-switch semantics keep their original assertions (plus a new mid-turn ordering test).

## Review gate

Two rounds of the three-reviewer cycle. Round 1: APPROVE / REQUEST CHANGES / APPROVE, no blockers — the one substantive finding (mid-turn appends committing below the live card) is fixed in this PR with regression tests. Round 2: APPROVE ×3; residual suggestions adopted (IME-deferral precedence over revision adoption, docs).

## Verification

- Focused suites on the final commit: **52/52** and **221/221** (composer bridge/draft/return-key, reasoning stream, scroll state + incremental cache, transcript-performance fixtures, settled-message isolation, viewport controller).
- Full unit suite: 1,388 + 88 + 51 passed, 0 assertion failures. 11 tests in four untouched suites (`AppStateChatResumeTests` ×4, `ChatReturnSurfaceTests` ×6, `ChatTypographyTests` ×1) could not complete on the local Mac build host — an `AudioToolboxCore/AURemoteIO` SIGABRT aborts the runner mid-suite; a control run of the same suites on **reverted base code crashed identically**, so this is host state, not the diff. CI's fresh runners are the gate for those.
- Release configuration builds clean; `git diff --check` clean.

## Out of scope

No AppState architecture rewrite, no changes to settled-Markdown Equatable gates, viewport ownership/restoration, Markdown rendering, streaming cadence, Kanban/voice/auth, or the 50 ms reasoning cadence (the per-tick mutation was the problem, not the cadence). Physical-device profiling (CPU/thermal under hardware-keyboard typing on a large transcript) remains worth a manual pass; not blocking per the deterministic source-level regressions above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Streaming reasoning now appears smoothly in a live view and is committed cleanly at completion or turn boundaries.
  - Long conversations should scroll and render more efficiently.
  - Composer text, cursor position, and selections remain stable during updates, including pasted and programmatically inserted text.

- **Accessibility**
  - Added reliable accessibility identifiers to login controls, improving keyboard navigation and automated interaction.

- **Reliability**
  - Improved handling of interrupted sessions, session changes, and transcript updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->