### PR TITLE
fix(chat): keep foreground observational and prompt delivery authoritative

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -4450,7 +4450,18 @@ final class AppState: ObservableObject {
         }
         switch probe {
         case let .live(row):
-            if row.isRunning, !messages.isEmpty {
+            if row.status == "starting" {
+                // Runtime present, liveness inconclusive: "starting" also
+                // covers promptless agent pre-warm (session.create / cold
+                // resume) and transiently masks a running turn during the
+                // build window, so it proves neither busy nor idle. Leave the
+                // local turn state exactly as the stream left it and let live
+                // events own the next edge; never manufacture a resume here.
+                lifecycleLog.notice(
+                    "Foreground refresh: probe=starting session=\(requestedSessionID ?? "-", privacy: .public) → observation-only, state untouched"
+                )
+                settleForegroundBoundary(token, automaticWorkToken: automaticWorkToken)
+            } else if row.isRunning, !messages.isEmpty {
                 // The same turn is still live over a hydrated transcript: keep
                 // the session, the transcript, the streaming buffer, and the
                 // PR #121 live reasoning projection exactly as they are. Only
@@ -4570,25 +4581,38 @@ final class AppState: ObservableObject {
 
     /// Adopts an authoritative running state WITHOUT replacing any
     /// presentation state: no transcript swap, no streaming-buffer reset, no
-    /// reasoning-segment reset. Buffered events captured while the foreground
-    /// reconciliation boundary was open are replayed FIRST (applyStreamEvent's
-    /// active-session gate still applies), then the probe's later-authoritative
-    /// running state is adopted — a buffered turn-end edge is intentionally
-    /// overridden by the registry snapshot the decision was made from. The
+    /// reasoning-segment reset. Ordering: the probe snapshot is the OLDER
+    /// observation, so it establishes the running baseline FIRST; the buffered
+    /// events captured while the foreground reconciliation boundary was open
+    /// are replayed SECOND — they arrived after the snapshot was taken and the
+    /// newest authoritative edge must win (a buffered sessionBusy(false) or
+    /// completion therefore settles the turn instead of being overwritten back
+    /// to running). applyStreamEvent's active-session gate still applies. The
     /// boundary settles last.
     private func adoptForegroundRunningState(
         reconciliationToken token: UUID,
         automaticWorkToken: ChatResumeAutomaticWorkToken?
     ) {
         guard token == reconciliationToken else { return }
-        let bufferedEvents = reconciliation?.bufferedEvents ?? []
-        bufferedEvents.forEach { applyStreamEvent($0) }
-        // The registry is authoritative: a locally idle state that disagreed
-        // with it (missed turn start) is corrected, and a running state is
-        // confirmed. setRunning also clears the pending-decision restoration
-        // guard exactly like a live sessionBusy(true) event would.
+        // Probe baseline (older observation).
         setRunning(true)
         turnStateIsStale = false
+        // Newer live edges win over the snapshot.
+        let bufferedEvents = reconciliation?.bufferedEvents ?? []
+        bufferedEvents.forEach { applyStreamEvent($0) }
+        _ = settleReconciliationAndPublish(token, automaticWorkToken: automaticWorkToken)
+    }
+
+    /// Settles the foreground reconciliation boundary without adopting any
+    /// turn state — used when the registry answer is inconclusive ("starting")
+    /// so buffered events still land but the local state stays stream-owned.
+    private func settleForegroundBoundary(
+        _ token: UUID,
+        automaticWorkToken: ChatResumeAutomaticWorkToken?
+    ) {
+        guard token == reconciliationToken else { return }
+        let bufferedEvents = reconciliation?.bufferedEvents ?? []
+        bufferedEvents.forEach { applyStreamEvent($0) }
         _ = settleReconciliationAndPublish(token, automaticWorkToken: automaticWorkToken)
     }
 
@@ -5480,7 +5504,7 @@ final class AppState: ObservableObject {
         // One authoritative read-only probe corrects the state before the
         // routing decision. Trusted state never pays for the probe.
         if turnState == .idle, turnStateIsStale,
-           await correctStaleIdleTurnState() {
+           await correctStaleIdleTurnState(using: submissionContext) {
             guard attachments.isEmpty else {
                 errorMessage = "Attachments can only be sent in a new message, after the current response finishes."
                 return false
@@ -5503,21 +5527,60 @@ final class AppState: ObservableObject {
     }
 
     /// Read-only authoritative correction of a possibly stale local idle
-    /// state. Returns true when the gateway proves the session is RUNNING (the
-    /// caller must use the configured busy action); false when the session is
-    /// idle (safe to send a new turn) or the state could not be verified (do
-    /// not add RPC chatter — fall through to the ordinary send).
-    private func correctStaleIdleTurnState() async -> Bool {
+    /// state, OWNED BY THIS SUBMISSION. Returns true when the gateway proves
+    /// the session is RUNNING (the caller must use the configured busy
+    /// action); false when the session is idle (safe to send a new turn) or
+    /// the state could not be verified (do not add RPC chatter — fall through
+    /// to the ordinary send, whose typed outcome reconciles). If ownership of
+    /// the submission was lost across the probe's await (session/profile
+    /// handoff), NOTHING is mutated: the session the user switched to keeps
+    /// its own stale marker and will run its own correction.
+    private func correctStaleIdleTurnState(
+        using submissionContext: ComposerSubmissionContext
+    ) async -> Bool {
         guard let client, let sessionId = activeSessionId else {
-            turnStateIsStale = false
+            // Nothing to probe; leave the stale marker for the real owner.
             return false
         }
-        let probe = await probeForegroundRuntime(
-            requestedSessionID: sessionId,
-            using: client
-        )
-        switch probe {
-        case let .live(row) where row.isRunning:
+        // Capture the probe identity BEFORE the await — never re-derive it
+        // from the mutable active session afterwards.
+        let acceptedIDs = acceptedIdentitySessionIDs(forRequested: sessionId)
+        let rows: [LiveSessionStatus]
+        do {
+            if let probeActiveSessions = chatResumeLifecycleOperations.probeActiveSessions {
+                rows = try await probeActiveSessions(client)
+            } else {
+                rows = try await client.activeSessions()
+            }
+        } catch {
+            // The registry could not be read (older gateway, transient
+            // failure). Proceed with the ordinary send rather than blocking
+            // the user; the submission's own typed outcome will reconcile.
+            // The one-time stale clear is submission-owned so an unsupported
+            // gateway does not turn every later submit into probe chatter.
+            lifecycleLog.notice(
+                "submitComposer: stale-idle probe unavailable; proceeding with send session=\(sessionId, privacy: .public)"
+            )
+            if isCurrentComposerSubmission(submissionContext) {
+                turnStateIsStale = false
+            }
+            return false
+        }
+        // Ownership re-check AFTER the await: if the user switched sessions or
+        // profiles while the probe was suspended, this result belongs to the
+        // OLD conversation and must not mutate the new one's turn state — nor
+        // clear its stale marker.
+        guard isCurrentComposerSubmission(submissionContext),
+              turnState == .idle, turnStateIsStale else {
+            lifecycleLog.notice(
+                "submitComposer: stale-idle probe superseded by session handoff; no state mutation session=\(sessionId, privacy: .public)"
+            )
+            return false
+        }
+        let row = rows.first(where: {
+            acceptedIDs.contains($0.runtimeSessionId) || acceptedIDs.contains($0.storedSessionId)
+        })
+        if let row, row.isRunning {
             lifecycleLog.notice(
                 "submitComposer: authoritative probe=live status=\(row.status, privacy: .public) corrects stale idle session=\(sessionId, privacy: .public)"
             )
@@ -5526,21 +5589,13 @@ final class AppState: ObservableObject {
             setRunning(true)
             turnStateIsStale = false
             return true
-        case .live, .absent:
-            // Authoritative idle (or the runtime is gone): the local idle
-            // state is confirmed for this submission.
-            turnStateIsStale = false
-            return false
-        case let .unavailable(reason):
-            // The registry could not be read (older gateway, transient
-            // failure). Proceed with the ordinary send rather than blocking
-            // the user; the submission's own typed outcome will reconcile.
-            lifecycleLog.notice(
-                "submitComposer: stale-idle probe unavailable (\(reason, privacy: .public)); proceeding with send"
-            )
-            turnStateIsStale = false
-            return false
         }
+        // Authoritative idle/absent/starting for THIS submission: the local
+        // idle state is confirmed and a starting runtime is not committed
+        // busy (pre-warm builds report it too), so send as an ordinary new
+        // turn — the typed prompt.submit outcome catches a genuine busy race.
+        turnStateIsStale = false
+        return false
     }
 
     func sendMessage(
@@ -5553,6 +5608,14 @@ final class AppState: ObservableObject {
         guard let client, let sessionId = activeSessionId else { return false }
         cancelChatResumeRestoration()
         resetResponseHapticTurn()
+        // Durable before/after identity for ambiguous-delivery recovery:
+        // everything this conversation held BEFORE the optimistic append, so
+        // a later bounded tail read can prove whether the submitted turn
+        // landed even when the registry has already gone idle/absent.
+        let submissionBaseline = PromptTranscriptBaseline(messages: messages)
+        // The identity under probe must be captured BEFORE any await — never
+        // re-derived from the mutable active session afterwards.
+        let submissionSessionIDs = acceptedIdentitySessionIDs(forRequested: sessionId)
 
         let userMessage = ChatMessage(
             id: "local-\(Date().timeIntervalSince1970)",
@@ -5608,22 +5671,24 @@ final class AppState: ObservableObject {
             }
             // The gateway accepted the prompt. A session handoff may have
             // happened while the RPC was suspended, but that does not turn a
-            // remotely successful send into a local draft failure. There are
-            // no current-session mutations after this point.
+            // remotely successful send into a local draft failure. All local
+            // state writes below are submission-owned: an operation started
+            // for session A must never mutate turn state that now belongs to
+            // session B.
             lifecycleLog.notice(
                 "prompt.submit outcome=\(Self.promptOutcomeLogValue(outcome), privacy: .public) session=\(sessionId, privacy: .public)"
             )
-            if outcome.isBusySubmission, isCurrentComposerSubmission(submissionContext) {
-                // Hermes applied its busy policy, which proves THIS session
-                // was RUNNING when the prompt landed — the local state was
-                // stale. Adopt the authoritative busy state so the composer
-                // keeps offering the configured busy action and the next
-                // submission is routed correctly. A session handoff while the
-                // RPC was suspended must not misattribute the busy state to
-                // the newly active session.
-                turnState = .running
+            if isCurrentComposerSubmission(submissionContext) {
+                if outcome.isBusySubmission {
+                    // Hermes applied its busy policy, which proves THIS
+                    // session was RUNNING when the prompt landed — the local
+                    // state was stale. Adopt the authoritative busy state so
+                    // the composer keeps offering the configured busy action
+                    // and the next submission is routed correctly.
+                    turnState = .running
+                }
+                turnStateIsStale = false
             }
-            turnStateIsStale = false
             return true
         } catch {
             guard isCurrentComposerSubmission(submissionContext) else { return false }
@@ -5633,17 +5698,38 @@ final class AppState: ObservableObject {
                 )
                 let (resolution, reconnected) = await reconcileAmbiguousPromptSubmission(
                     requestedSessionID: sessionId,
+                    acceptedSessionIDs: submissionSessionIDs,
+                    baseline: submissionBaseline,
+                    submittedText: text,
                     submissionContext: submissionContext
                 )
+                // Every write below is submission-owned: the guard is
+                // re-checked inside each branch so a handoff during the
+                // recovery awaits cannot leak state into the new session.
                 switch resolution {
-                case .acceptedRunning, .acceptedSettled:
-                    // Hermes accepted the submission and the turn is live:
-                    // keep the optimistic user row and the running turn, and
-                    // never re-send the prompt. In the settled flavor the
-                    // recovery reconnect's sync already replaced the
-                    // transcript; either way the turn is authoritative.
-                    turnState = .running
-                    turnStateIsStale = false
+                case .acceptedRunning:
+                    // Hermes accepted the submission and the turn is still
+                    // live: keep the optimistic user row and the running turn,
+                    // and never re-send the prompt.
+                    if isCurrentComposerSubmission(submissionContext) {
+                        turnState = .running
+                        turnStateIsStale = false
+                    }
+                    return true
+                case .acceptedSettled:
+                    // The durable transcript proves the submitted turn landed
+                    // and settled (the registry had already gone idle/absent
+                    // by the time recovery looked). The submission stays
+                    // accepted: the composer remains cleared, nothing is
+                    // restored, and the transcript converges on the next
+                    // bounded refresh.
+                    lifecycleLog.notice(
+                        "prompt.submit accepted (durable transcript); turn settled session=\(sessionId, privacy: .public)"
+                    )
+                    if isCurrentComposerSubmission(submissionContext) {
+                        turnState = .idle
+                        turnStateIsStale = false
+                    }
                     return true
                 case .notAccepted:
                     // Authoritative evidence shows Hermes did not accept the
@@ -5651,9 +5737,11 @@ final class AppState: ObservableObject {
                     lifecycleLog.notice(
                         "prompt.submit not accepted (authoritative); restoring unsent state session=\(sessionId, privacy: .public)"
                     )
-                    turnStateIsStale = false
+                    if isCurrentComposerSubmission(submissionContext) {
+                        turnStateIsStale = false
+                    }
                 case .unresolved:
-                    // The authoritative state could not be read. Be
+                    // Acceptance could be neither proven nor disproven. Be
                     // conservative about duplicate delivery: restore rather
                     // than re-send blindly.
                     lifecycleLog.notice(
@@ -5661,7 +5749,7 @@ final class AppState: ObservableObject {
                     )
                 }
                 errorMessage = "Failed to send: \(error.localizedDescription)"
-                if !reconnected {
+                if !reconnected, isCurrentComposerSubmission(submissionContext) {
                     await recoverComposerSubmission(using: submissionContext)
                 }
                 // A reconnect inside the recovery already synced the
@@ -5713,19 +5801,25 @@ final class AppState: ObservableObject {
     /// `reconnected` reports whether a transport recovery (with its own full
     /// transcript sync) ran, so the caller can skip a duplicate restoration.
     private enum AmbiguousPromptResolution {
-        /// Accepted; the turn is running on the current transport.
+        /// Accepted and still running on the current transport.
         case acceptedRunning
-        /// Accepted; the recovery reconnect's sync already settled the
-        /// transcript authoritatively.
+        /// Accepted and proven settled by the durable transcript: the turn ran
+        /// to completion before recovery looked (the registry had already gone
+        /// idle/absent, which alone cannot prove non-acceptance).
         case acceptedSettled
-        /// The registry proves the prompt was not accepted.
+        /// Authoritative evidence (registry idle/absent AND the durable
+        /// transcript advanced without the submitted turn) that the prompt was
+        /// not accepted.
         case notAccepted
-        /// The registry could not be read.
+        /// Neither acceptance nor non-acceptance could be established.
         case unresolved
     }
 
     private func reconcileAmbiguousPromptSubmission(
         requestedSessionID: String,
+        acceptedSessionIDs: Set<String>,
+        baseline: PromptTranscriptBaseline,
+        submittedText: String,
         submissionContext: ComposerSubmissionContext
     ) async -> (resolution: AmbiguousPromptResolution, reconnected: Bool) {
         var reconnected = false
@@ -5736,11 +5830,15 @@ final class AppState: ObservableObject {
             // turn's persisted rows.
             await reconnectForRetry(purpose: .preserveCurrent)
             probeClient = self.client
-            reconnected = true
+            // Only a SUCCESSFUL reconnect (whose sync already restored the
+            // authoritative transcript) may skip the caller's restoration; a
+            // failed reconnect must fall back to it.
+            reconnected = probeClient?.isConnected == true
         }
         guard isCurrentOrAliasedComposerSubmission(submissionContext),
               let probeClient else { return (.unresolved, reconnected) }
-        let acceptedIDs = acceptedIdentitySessionIDs(forRequested: requestedSessionID)
+        // The alias set was captured from the ORIGINAL submission before any
+        // await; it is never re-derived from the mutable active session here.
         let rows: [LiveSessionStatus]
         do {
             if let probeActiveSessions = chatResumeLifecycleOperations.probeActiveSessions {
@@ -5752,21 +5850,150 @@ final class AppState: ObservableObject {
             return (.unresolved, reconnected)
         }
         guard let row = rows.first(where: {
-            acceptedIDs.contains($0.runtimeSessionId) || acceptedIDs.contains($0.storedSessionId)
+            acceptedSessionIDs.contains($0.runtimeSessionId) || acceptedSessionIDs.contains($0.storedSessionId)
         }) else {
-            // Authoritative absence: the runtime is gone. A turn accepted
-            // seconds ago would still be listed (the registry reaps a runtime
-            // only after its transport is gone AND it settled), so treat this
-            // as not accepted.
-            return (.notAccepted, reconnected)
+            // No runtime for this conversation anymore: current liveness is
+            // gone, but that alone cannot prove non-acceptance — the accepted
+            // turn may have completed and been reaped. Verify durably below.
+            let transcript = await verifySubmittedTurnInTranscript(
+                requestedSessionID: requestedSessionID,
+                profile: submissionContext.profile,
+                baseline: baseline,
+                submittedText: submittedText
+            )
+            switch transcript {
+            case .present: return (.acceptedSettled, reconnected)
+            case .absent: return (.notAccepted, reconnected)
+            case .indeterminate: return (.unresolved, reconnected)
+            }
         }
         if row.isRunning {
+            // A committed-busy runtime can only describe an accepted,
+            // still-running submission.
             let resolution: AmbiguousPromptResolution = self.client === probeClient
                 ? .acceptedRunning
                 : .acceptedSettled
             return (resolution, reconnected)
         }
-        return (.notAccepted, reconnected)
+        // The registry is authoritative about CURRENT liveness only: an
+        // idle/absent-or-starting runtime cannot by itself prove
+        // non-acceptance, because the accepted turn may have completed (and
+        // the runtime gone idle or been reaped) before recovery looked. Fall
+        // through to the durable transcript.
+        let transcript = await verifySubmittedTurnInTranscript(
+            requestedSessionID: requestedSessionID,
+            profile: submissionContext.profile,
+            baseline: baseline,
+            submittedText: submittedText
+        )
+        switch transcript {
+        case .present:
+            return (.acceptedSettled, reconnected)
+        case .absent:
+            return (.notAccepted, reconnected)
+        case .indeterminate:
+            return (.unresolved, reconnected)
+        }
+    }
+
+    /// Durable before/after identity captured BEFORE the optimistic append.
+    /// The submitted turn is proven by ORDERING (rows the conversation did not
+    /// hold at submit time) corroborated by user-role content — never by
+    /// content alone, since identical texts are legitimate.
+    struct PromptTranscriptBaseline {
+        let knownMessageIDs: Set<String>
+        let knownMessageCount: Int
+
+        init(messages: [ChatMessage]) {
+            self.knownMessageIDs = Set(messages.map(\.id))
+            self.knownMessageCount = messages.count
+        }
+    }
+
+    private enum SubmittedTurnEvidence {
+        case present
+        case absent
+        case indeterminate
+    }
+
+    /// Bounded tail read (the PR #118 `order=latest` page via the existing
+    /// persisted-transcript source) to decide whether an ambiguously
+    /// acknowledged prompt actually landed. `profile` comes from the owning
+    /// submission context, captured before any await.
+    private func verifySubmittedTurnInTranscript(
+        requestedSessionID: String,
+        profile: String,
+        baseline: PromptTranscriptBaseline,
+        submittedText: String
+    ) async -> SubmittedTurnEvidence {
+        let outcome = await persistedTranscriptOutcome(
+            sessionId: requestedSessionID,
+            profile: profile,
+            using: dashboardTicketBridge
+        )
+        let tail: [ChatMessage]
+        let idsAreDurable: Bool
+        switch outcome {
+        case .hydrated(let persisted):
+            tail = persisted.messages
+            // A paginated page only comes back when the echo honored the
+            // tail contract AND the rows carried durable identity; the
+            // legacy one-shot re-read makes no such guarantee.
+            idsAreDurable = persisted.page != nil
+        case .unavailable, .failed:
+            // No usable durable source: acceptance stays unproven.
+            return .indeterminate
+        }
+
+        let wanted = submittedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let isNewRow: (ChatMessage) -> Bool = { message in
+            !baseline.knownMessageIDs.contains(message.id)
+        }
+        let contentMatches: (ChatMessage) -> Bool = { message in
+            message.role == .user
+                && message.content.trimmingCharacters(in: .whitespacesAndNewlines) == wanted
+        }
+
+        if idsAreDurable {
+            if tail.contains(where: { isNewRow($0) && contentMatches($0) }) {
+                // A user row this conversation did not hold before the
+                // submission carries the submitted text: the turn landed.
+                // Response rows after it only strengthen the proof; their
+                // absence means the accepted turn was interrupted, which is
+                // still acceptance.
+                return .present
+            }
+            if tail.contains(where: isNewRow) {
+                // The durable transcript advanced past the submit-time
+                // baseline without any new user row carrying the submitted
+                // text: whatever landed, this prompt did not.
+                return .absent
+            }
+            // The tail is exactly what this conversation already held: no
+            // new row at all — the submitted turn never landed.
+            return .absent
+        }
+
+        // Positional-id fallback (legacy one-shot transcript): row identity
+        // cannot distinguish new from old rows, so decide by transcript
+        // growth plus the newest user row.
+        if tail.count <= baseline.knownMessageCount {
+            // Nothing landed beyond what this conversation already held.
+            return .absent
+        }
+        let newestUserRow = tail.last(where: { $0.role == .user })
+        if let newestUserRow, contentMatches(newestUserRow) {
+            // The transcript grew and its newest user turn carries the
+            // submitted text: acceptance, settled.
+            return .present
+        }
+        if tail.contains(where: contentMatches) {
+            // Grew with our text present but not newest — an identical older
+            // send makes this ambiguous.
+            return .indeterminate
+        }
+        // Grew without the submitted text: this prompt did not land.
+        return .absent
     }
 
     func toggleYolo(context: ComposerSubmissionContext? = nil) async {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -494,6 +494,20 @@ final class AppState: ObservableObject {
     /// `prompt.submit` — Hermes would apply its busy policy to it and the
     /// message would silently join a turn the user never saw start.
     private(set) var turnStateIsStale = false
+    /// Monotonic revision of AUTHORITATIVE live turn-lifecycle evidence:
+    /// every `setRunning` edge (sessionBusy, message start/delta, completion,
+    /// interruption, error, registry-probe corrections, buffered-event
+    /// replay), the authoritative resume-snapshot adoption, and the typed
+    /// busy-submission outcome advance it. Optimistic local writes (the
+    /// pre-send `.running`, the ambiguous-recovery stamps themselves) never
+    /// do. The ambiguous-submission recovery captures this revision at its
+    /// registry observation; a changed revision at stamp time proves newer
+    /// live evidence arrived while the recovery awaited, so the older
+    /// recovery result must not overwrite `turnState`/`turnStateIsStale`.
+    /// Plain value equality cannot prove that — the pre-send stamp already
+    /// leaves `turnState == .running`, so a newer `sessionBusy(true)` is
+    /// value-indistinguishable from the stale baseline.
+    private var turnLifecycleRevision: UInt64 = 0
     /// Session identities with a locally-observed running turn at the last
     /// scene transition (empty = no continuity evidence). A foreground probe
     /// whose working/waiting row matches one of these ids continues a turn
@@ -3572,6 +3586,7 @@ final class AppState: ObservableObject {
             turnState = TurnState.fromGatewayRunning(result.snapshot.running)
         }
         // The resume snapshot is authoritative about the turn state.
+        turnLifecycleRevision &+= 1
         turnStateIsStale = false
         return true
     }
@@ -7025,6 +7040,7 @@ final class AppState: ObservableObject {
                     // state was stale. Adopt the authoritative busy state so
                     // the composer keeps offering the configured busy action
                     // and the next submission is routed correctly.
+                    turnLifecycleRevision &+= 1
                     turnState = .running
                 }
                 turnStateIsStale = false
@@ -7081,13 +7097,24 @@ final class AppState: ObservableObject {
                 lifecycleLog.notice(
                     "prompt.submit ambiguous (\(error.localizedDescription, privacy: .private)); querying authoritative state session=\(sessionId, privacy: .public)"
                 )
-                let (resolution, reconnected) = await reconcileAmbiguousPromptSubmission(
+                let (resolution, reconnected, recoveryLifecycleRevision) = await reconcileAmbiguousPromptSubmission(
                     requestedSessionID: sessionId,
                     acceptedSessionIDs: submissionSessionIDs,
                     baseline: submissionBaseline,
                     submittedText: text,
                     submissionContext: submissionContext
                 )
+                // Ordering guard for the recovery stamps: the recovery
+                // captured the lifecycle revision at its registry
+                // observation. A changed revision proves an authoritative
+                // live edge (sessionBusy, settlement, interruption, error,
+                // resume snapshot) arrived while the recovery awaited — that
+                // evidence is NEWER and owns the UI. Plain turnState equality
+                // cannot prove this: sendMessage stamped .running before
+                // prompt.submit, so a newer sessionBusy(true) leaves the
+                // value equal. Only the lifecycle stamps below are guarded —
+                // the acceptance decisions stay authoritative either way.
+                let recoveryOwnsLifecycleState = turnLifecycleRevision == recoveryLifecycleRevision
                 // Every write below is submission-owned: the guard is
                 // re-checked inside each branch so a handoff during the
                 // recovery awaits cannot leak state into the new session.
@@ -7097,19 +7124,50 @@ final class AppState: ObservableObject {
                     // live: keep the optimistic user row and the running turn,
                     // and never re-send the prompt.
                     if isCurrentComposerSubmission(submissionContext) {
-                        turnState = .running
-                        turnStateIsStale = false
-                        // Same proof as the ordinary success path: the turn
-                        // in flight is provably Conduit's own submission.
-                        // The anchor is intentionally the PRE-SEND capture
-                        // even though ambiguity recovery may have re-hydrated
-                        // the transcript in between: validation at use plus
-                        // the anchor lookup at use neutralize any staleness.
-                        locallyOwnedInFlightTurn = LocallyOwnedInFlightTurn(
-                            sessionIDs: submissionSessionIDs,
-                            optimisticUserRowID: userMessage.id,
-                            preSubmitOrderingBaseline: preSubmitOrderingBaseline
-                        )
+                        if recoveryOwnsLifecycleState {
+                            turnState = .running
+                            turnStateIsStale = false
+                            // Same proof as the ordinary success path: the
+                            // turn in flight is provably Conduit's own
+                            // submission. The anchor is intentionally the
+                            // PRE-SEND capture even though ambiguity recovery
+                            // may have re-hydrated the transcript in between:
+                            // validation at use plus the anchor lookup at use
+                            // neutralize any staleness. Guarded with the
+                            // stamps: if newer evidence settled the turn while
+                            // the probe awaited, the older recovery must not
+                            // re-assert in-flight ownership.
+                            locallyOwnedInFlightTurn = LocallyOwnedInFlightTurn(
+                                sessionIDs: submissionSessionIDs,
+                                optimisticUserRowID: userMessage.id,
+                                preSubmitOrderingBaseline: preSubmitOrderingBaseline
+                            )
+                        }
+                    }
+                    return true
+                case .acceptedUnsettled:
+                    // The durable transcript proves Hermes accepted the
+                    // submission, but the registry reported `starting` —
+                    // runtime present, liveness inconclusive (the agent build
+                    // may still be arming around a committed turn). The
+                    // submission stays accepted: never re-send, the optimistic
+                    // row remains. But settlement is NOT proven: keep the turn
+                    // running-like for composer routing, leave
+                    // `turnStateIsStale` exactly as it stands (uncertainty is
+                    // not cleared as though settlement were proven), and let
+                    // the next authoritative registry/stream edge settle it.
+                    lifecycleLog.notice(
+                        "prompt.submit accepted (durable transcript); registry starting — liveness unresolved session=\(sessionId, privacy: .public)"
+                    )
+                    if isCurrentComposerSubmission(submissionContext) {
+                        if recoveryOwnsLifecycleState {
+                            turnState = .running
+                            locallyOwnedInFlightTurn = LocallyOwnedInFlightTurn(
+                                sessionIDs: submissionSessionIDs,
+                                optimisticUserRowID: userMessage.id,
+                                preSubmitOrderingBaseline: preSubmitOrderingBaseline
+                            )
+                        }
                     }
                     return true
                 case .acceptedSettled:
@@ -7125,8 +7183,10 @@ final class AppState: ObservableObject {
                         "prompt.submit accepted (durable transcript); turn settled session=\(sessionId, privacy: .public)"
                     )
                     if isCurrentComposerSubmission(submissionContext) {
-                        turnState = .idle
-                        turnStateIsStale = false
+                        if recoveryOwnsLifecycleState {
+                            turnState = .idle
+                            turnStateIsStale = false
+                        }
                         // The marker is nil here (prompt.submit threw), but
                         // the durable transcript PROVED this submission's
                         // turn persisted: record its ordering debt from the
@@ -7145,7 +7205,8 @@ final class AppState: ObservableObject {
                     lifecycleLog.notice(
                         "prompt.submit not accepted (authoritative); restoring unsent state session=\(sessionId, privacy: .public)"
                     )
-                    if isCurrentComposerSubmission(submissionContext) {
+                    if isCurrentComposerSubmission(submissionContext),
+                       recoveryOwnsLifecycleState {
                         turnStateIsStale = false
                     }
                 case .unresolved:
@@ -7215,9 +7276,18 @@ final class AppState: ObservableObject {
     /// must never be re-sent; an idle/absent session means it was not.
     /// `reconnected` reports whether a transport recovery (with its own full
     /// transcript sync) ran, so the caller can skip a duplicate restoration.
-    private enum AmbiguousPromptResolution {
+    /// `lifecycleRevision` is the `turnLifecycleRevision` captured at the
+    /// registry observation — the baseline the caller's stamp guard compares.
+    /// Internal (not private) so the classification contract is directly
+    /// testable.
+    enum AmbiguousPromptResolution {
         /// Accepted and still running on the current transport.
         case acceptedRunning
+        /// Accepted — the durable transcript holds the submitted row — but
+        /// the registry reported `starting`: runtime present, liveness
+        /// inconclusive. Settlement is UNPROVEN; the next authoritative
+        /// registry/stream edge settles the turn.
+        case acceptedUnsettled
         /// Accepted and proven settled by the durable transcript: the turn ran
         /// to completion before recovery looked (the registry had already gone
         /// idle/absent, which alone cannot prove non-acceptance).
@@ -7230,13 +7300,72 @@ final class AppState: ObservableObject {
         case unresolved
     }
 
+    /// The ambiguous-recovery registry status, split beyond
+    /// `LiveSessionStatus.isRunning`. `isRunning` deliberately excludes
+    /// `starting` because Hermes arms `starting` for plain session.create /
+    /// cold-resume pre-warm with no prompt involved — but in an ambiguous
+    /// submission recovery, that same mask can cover a COMMITTED turn during
+    /// the submit → agent-ready window. `starting` is therefore its own
+    /// classification: runtime present, liveness inconclusive — never settled,
+    /// never committed-busy. Internal for the classification-contract tests.
+    enum AmbiguousRegistryLiveness {
+        /// `working` | `waiting` — authoritative committed-busy state.
+        case committedBusy
+        /// `starting` — runtime present, liveness inconclusive.
+        case starting
+        /// An explicit `idle` row (or any unrecognized non-running status).
+        case idle
+        /// No matching runtime row for the submitted session.
+        case absent
+    }
+
+    /// The classification contract for an ambiguous submission's
+    /// authoritative evidence pair. Pure and total so the status × evidence
+    /// matrix is pinned directly by tests:
+    ///
+    /// - `committedBusy` ALWAYS classifies `.acceptedRunning`, before the
+    ///   transcript is consulted and regardless of which client performed the
+    ///   probe — a running registry row is never settled (client
+    ///   replacement/submission ownership is a separate concern).
+    /// - `starting` NEVER classifies `.acceptedSettled`: a `.present` durable
+    ///   row proves acceptance, not settlement (`.acceptedUnsettled`), and
+    ///   `.absent`/`.indeterminate` prove nothing — the committed turn may not
+    ///   have reached the durable verification point yet, so the outcome is
+    ///   conservative `.unresolved` (restore; never a blind resend), never
+    ///   `.notAccepted` merely because `starting` was present.
+    /// - `idle`/`absent` fall through to the durable transcript: present →
+    ///   `.acceptedSettled`, absent → `.notAccepted`, indeterminate →
+    ///   `.unresolved`.
+    static func classifyAmbiguousSubmission(
+        registryLiveness: AmbiguousRegistryLiveness,
+        transcript: SubmittedTurnEvidence
+    ) -> AmbiguousPromptResolution {
+        switch registryLiveness {
+        case .committedBusy:
+            // Ignoring `transcript` here is the contract: a working/waiting
+            // row settles the acceptance question on the registry alone.
+            return .acceptedRunning
+        case .starting:
+            switch transcript {
+            case .present: return .acceptedUnsettled
+            case .absent, .indeterminate: return .unresolved
+            }
+        case .idle, .absent:
+            switch transcript {
+            case .present: return .acceptedSettled
+            case .absent: return .notAccepted
+            case .indeterminate: return .unresolved
+            }
+        }
+    }
+
     private func reconcileAmbiguousPromptSubmission(
         requestedSessionID: String,
         acceptedSessionIDs: Set<String>,
         baseline: PromptTranscriptBaseline,
         submittedText: String,
         submissionContext: ComposerSubmissionContext
-    ) async -> (resolution: AmbiguousPromptResolution, reconnected: Bool) {
+    ) async -> (resolution: AmbiguousPromptResolution, reconnected: Bool, lifecycleRevision: UInt64) {
         var reconnected = false
         var probeClient = client
         if probeClient?.isConnected != true {
@@ -7251,7 +7380,14 @@ final class AppState: ObservableObject {
             reconnected = probeClient?.isConnected == true
         }
         guard isCurrentOrAliasedComposerSubmission(submissionContext),
-              let probeClient else { return (.unresolved, reconnected) }
+              let probeClient else {
+            return (.unresolved, reconnected, turnLifecycleRevision)
+        }
+        // The revision baseline for the caller's stamp guard, captured at the
+        // registry observation: the probe result already includes every edge
+        // processed up to this point, so anything that increments
+        // `turnLifecycleRevision` afterwards is strictly newer evidence.
+        let lifecycleRevision = turnLifecycleRevision
         // The alias set was captured from the ORIGINAL submission before any
         // await; it is never re-derived from the mutable active session here.
         let rows: [LiveSessionStatus]
@@ -7262,53 +7398,49 @@ final class AppState: ObservableObject {
                 rows = try await probeClient.activeSessions()
             }
         } catch {
-            return (.unresolved, reconnected)
+            return (.unresolved, reconnected, lifecycleRevision)
         }
-        guard let row = rows.first(where: {
+        let matchedRow = rows.first(where: {
             acceptedSessionIDs.contains($0.runtimeSessionId) || acceptedSessionIDs.contains($0.storedSessionId)
-        }) else {
+        })
+        // Registry liveness split: `working`/`waiting` are committed-busy,
+        // `starting` is runtime-present but liveness-inconclusive, and only a
+        // genuine `idle`/absent runtime lets the durable transcript decide
+        // between settled and not-accepted.
+        let registryLiveness: AmbiguousRegistryLiveness
+        if let matchedRow {
+            if matchedRow.isRunning {
+                registryLiveness = .committedBusy
+            } else if matchedRow.status == "starting" {
+                registryLiveness = .starting
+            } else {
+                registryLiveness = .idle
+            }
+        } else {
             // No runtime for this conversation anymore: current liveness is
             // gone, but that alone cannot prove non-acceptance — the accepted
             // turn may have completed and been reaped. Verify durably below.
-            let transcript = await verifySubmittedTurnInTranscript(
+            registryLiveness = .absent
+        }
+        // A committed-busy row classifies on the registry alone; the bounded
+        // durable verifier is only consulted when liveness alone cannot
+        // classify.
+        let transcript: SubmittedTurnEvidence = registryLiveness == .committedBusy
+            ? .indeterminate
+            : await verifySubmittedTurnInTranscript(
                 requestedSessionID: requestedSessionID,
                 profile: submissionContext.profile,
                 baseline: baseline,
                 submittedText: submittedText
             )
-            switch transcript {
-            case .present: return (.acceptedSettled, reconnected)
-            case .absent: return (.notAccepted, reconnected)
-            case .indeterminate: return (.unresolved, reconnected)
-            }
-        }
-        if row.isRunning {
-            // A committed-busy runtime can only describe an accepted,
-            // still-running submission.
-            let resolution: AmbiguousPromptResolution = self.client === probeClient
-                ? .acceptedRunning
-                : .acceptedSettled
-            return (resolution, reconnected)
-        }
-        // The registry is authoritative about CURRENT liveness only: an
-        // idle/absent-or-starting runtime cannot by itself prove
-        // non-acceptance, because the accepted turn may have completed (and
-        // the runtime gone idle or been reaped) before recovery looked. Fall
-        // through to the durable transcript.
-        let transcript = await verifySubmittedTurnInTranscript(
-            requestedSessionID: requestedSessionID,
-            profile: submissionContext.profile,
-            baseline: baseline,
-            submittedText: submittedText
+        return (
+            Self.classifyAmbiguousSubmission(
+                registryLiveness: registryLiveness,
+                transcript: transcript
+            ),
+            reconnected,
+            lifecycleRevision
         )
-        switch transcript {
-        case .present:
-            return (.acceptedSettled, reconnected)
-        case .absent:
-            return (.notAccepted, reconnected)
-        case .indeterminate:
-            return (.unresolved, reconnected)
-        }
     }
 
     /// Durable before/after identity captured BEFORE the optimistic append.
@@ -7340,7 +7472,9 @@ final class AppState: ObservableObject {
         }
     }
 
-    private enum SubmittedTurnEvidence {
+    /// Internal (not private) so `classifyAmbiguousSubmission`'s contract is
+    /// directly testable.
+    enum SubmittedTurnEvidence {
         case present
         case absent
         case indeterminate
@@ -7966,6 +8100,11 @@ final class AppState: ObservableObject {
             } else {
                 try await client.steer(sessionId, text: text)
             }
+            // A successful steer proves Hermes applied the session's busy
+            // policy — the session was RUNNING when the steer landed. That is
+            // authoritative live liveness evidence for the recovery stamp
+            // guard, even though steer writes no local turn state.
+            turnLifecycleRevision &+= 1
             // A successful steer is accepted by Hermes even if the user
             // switched sessions while the RPC was suspended. It has no local
             // post-await mutation, so preserve success for draft handling.
@@ -11067,6 +11206,9 @@ final class AppState: ObservableObject {
 
     private func setRunning(_ running: Bool) {
         guard turnState != .unsupportedGateway else { return }
+        // Every call is authoritative live evidence, even a re-affirmation:
+        // the ambiguity-recovery guard compares revisions, not values.
+        turnLifecycleRevision &+= 1
         if running {
             clearPendingDecisionRestorationGuard()
         } else {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -16,6 +16,10 @@ import WebKit
 private let sessionCatalogLog = Logger(subsystem: "com.milim.conduit", category: "SessionCatalog")
 private let titleGenerationLog = Logger(subsystem: "com.milim.conduit", category: "TitleGeneration")
 private let sessionYoloLog = Logger(subsystem: "com.milim.conduit", category: "SessionYolo")
+/// Foreground/turn-lifecycle decisions: why a refresh chose observation vs
+/// resume, and how prompt submissions were classified. Ids only — never
+/// prompt text, credentials, or message content.
+private let lifecycleLog = Logger(subsystem: "com.milim.conduit", category: "TurnLifecycle")
 
 typealias ChatResumeReconnectCancellation = @MainActor () -> Void
 typealias ChatResumeReconnectExecutor = @MainActor (ChatResumeSyncPurpose) async -> Void
@@ -51,7 +55,14 @@ struct ChatResumeLifecycleOperations {
     ) async throws -> BranchResult)?
     var setSessionTitle: (@MainActor (HermesClient, String, String) async throws -> Void)?
     var refreshContext: (@MainActor (HermesClient, String) async -> Void)?
-    var sendPrompt: (@MainActor (HermesClient, String, String) async throws -> Void)?
+    var sendPrompt: (@MainActor (HermesClient, String, String) async throws -> PromptSubmissionOutcome)?
+    /// Foreground transport verification. Production calls the client's
+    /// `session.list` health check; tests substitute a controllable outcome.
+    var verifyTransportHealth: (@MainActor (HermesClient) async throws -> Void)?
+    /// Foreground liveness probe against the gateway's runtime registry.
+    /// Production calls `session.active_list`; unsupported gateways throw and
+    /// the caller degrades to the resume-based refresh.
+    var probeActiveSessions: (@MainActor (HermesClient) async throws -> [LiveSessionStatus])?
     var steer: (@MainActor (HermesClient, String, String) async throws -> Void)?
     var redirect: (@MainActor (
         HermesClient,
@@ -89,7 +100,9 @@ struct ChatResumeLifecycleOperations {
         ) async throws -> BranchResult)? = nil,
         setSessionTitle: (@MainActor (HermesClient, String, String) async throws -> Void)? = nil,
         refreshContext: (@MainActor (HermesClient, String) async -> Void)? = nil,
-        sendPrompt: (@MainActor (HermesClient, String, String) async throws -> Void)? = nil,
+        sendPrompt: (@MainActor (HermesClient, String, String) async throws -> PromptSubmissionOutcome)? = nil,
+        verifyTransportHealth: (@MainActor (HermesClient) async throws -> Void)? = nil,
+        probeActiveSessions: (@MainActor (HermesClient) async throws -> [LiveSessionStatus])? = nil,
         steer: (@MainActor (HermesClient, String, String) async throws -> Void)? = nil,
         redirect: (@MainActor (
             HermesClient,
@@ -121,6 +134,8 @@ struct ChatResumeLifecycleOperations {
         self.setSessionTitle = setSessionTitle
         self.refreshContext = refreshContext
         self.sendPrompt = sendPrompt
+        self.verifyTransportHealth = verifyTransportHealth
+        self.probeActiveSessions = probeActiveSessions
         self.steer = steer
         self.redirect = redirect
         self.interrupt = interrupt
@@ -456,6 +471,15 @@ final class AppState: ObservableObject {
     @Published private(set) var isOpeningNotificationSession = false
     @Published private(set) var isBranchingChat = false
     @Published private(set) var turnState: TurnState = .idle
+    /// Whether `turnState` may have missed server-side turn edges. Set at
+    /// lifecycle boundaries where the socket can die or the gateway can change
+    /// state unobserved (scene dips, reconnects, ambiguous submissions);
+    /// cleared only when an authoritative source (the `session.active_list`
+    /// probe, a resume snapshot, or a typed prompt outcome) re-confirms the
+    /// state. A stale idle state must not route the next input as a new-turn
+    /// `prompt.submit` — Hermes would apply its busy policy to it and the
+    /// message would silently join a turn the user never saw start.
+    private(set) var turnStateIsStale = false
     @Published private(set) var busyInputMode: BusyInputMode = .steer
     @Published private(set) var displayPreferences = ProfileDisplayPreferences()
     @Published var streamingText = ""
@@ -3383,6 +3407,8 @@ final class AppState: ObservableObject {
         } else {
             turnState = TurnState.fromGatewayRunning(result.snapshot.running)
         }
+        // The resume snapshot is authoritative about the turn state.
+        turnStateIsStale = false
         return true
     }
 
@@ -4051,6 +4077,10 @@ final class AppState: ObservableObject {
         if purpose == .automaticReturn, reconnectTask != nil {
             cancelScheduledReconnect()
         }
+        // The old socket died: turn edges may have been missed while the
+        // transport was down. The sync this cycle runs will re-confirm the
+        // state from the authoritative resume snapshot and clear the flag.
+        turnStateIsStale = true
         isConnecting = true
         turnState = .reconnecting
 
@@ -4249,16 +4279,19 @@ final class AppState: ObservableObject {
                     // these flags for unhealthy sockets.
                     self.isConnected = true
                     self.isConnecting = false
+                    lifecycleLog.notice(
+                        "Foreground refresh start: transport=retained localTurn=\(self.turnStateLogValue, privacy: .public)"
+                    )
                     do {
-                        try await client.healthCheck()
+                        try await self.verifyChatResumeTransportHealth(client)
                         guard self.scenePhaseAttemptIsCurrent(sceneAttemptID),
                               self.automaticChatResumeWorkIsCurrent(automaticWorkToken) else {
                             self.settleReconciliation(token)
                             return
                         }
-                        await self.syncSession(
-                            purpose: .automaticReturn,
-                            using: token,
+                        await self.refreshForegroundOnHealthyTransport(
+                            using: client,
+                            reconciliationToken: token,
                             automaticWorkToken: automaticWorkToken
                         )
                     } catch {
@@ -4267,6 +4300,9 @@ final class AppState: ObservableObject {
                             self.settleReconciliation(token)
                             return
                         }
+                        lifecycleLog.notice(
+                            "Foreground refresh: health check failed (\(error.localizedDescription, privacy: .public)); reconnecting"
+                        )
                         await self.reconnectForRetry(purpose: .automaticReturn)
                         self.settleReconciliation(token)
                     }
@@ -4276,6 +4312,9 @@ final class AppState: ObservableObject {
                         self.settleReconciliation(token)
                         return
                     }
+                    lifecycleLog.notice(
+                        "Foreground refresh start: transport=missing-or-unhealthy; reconnecting"
+                    )
                     await self.reconnectForRetry(purpose: .automaticReturn)
                     self.settleReconciliation(token)
                 }
@@ -4286,6 +4325,11 @@ final class AppState: ObservableObject {
         case .background:
             isSceneActive = false
             hasEnteredBackgroundScenePhase = true
+            // The socket can die while suspended and turn edges can be missed,
+            // so the local turn state must be re-confirmed against the
+            // authoritative runtime registry before the next composer submit
+            // decides between a new turn and a busy submission.
+            turnStateIsStale = true
             voiceConversationController.setForegroundActive(false)
             messageReadAloudController.setForegroundActive(false)
             showVoiceSheet = false
@@ -4304,6 +4348,10 @@ final class AppState: ObservableObject {
 
         case .inactive:
             isSceneActive = false
+            // Same reasoning as .background: a dip through Control Center or a
+            // system overlay can miss turn edges. This never causes a resume —
+            // the foreground path treats staleness as a read-only probe.
+            turnStateIsStale = true
             // Reconnects are suppressed during .inactive too, so an armed
             // timer would only fire to be discarded. Drop it here; a socket
             // that dies under a system overlay (incoming call, control
@@ -4340,6 +4388,226 @@ final class AppState: ObservableObject {
         scenePhaseAttemptID = nil
         scenePhaseTask = nil
     }
+
+    private var turnStateLogValue: String {
+        switch turnState {
+        case .synchronizing: return "synchronizing"
+        case .idle: return "idle"
+        case .running: return "running"
+        case .reconnecting: return "reconnecting"
+        case .unsupportedGateway: return "unsupportedGateway"
+        }
+    }
+
+    // MARK: - Foreground observational refresh
+
+    /// Outcome of the read-only liveness probe for the active conversation.
+    private enum ForegroundRuntimeProbe {
+        /// A live runtime row matched the active session's identity.
+        case live(LiveSessionStatus)
+        /// The registry answered but listed no runtime for this session: the
+        /// turn ended and its transport went away, or the gateway restarted.
+        case absent
+        /// The registry could not be read (older gateway, transient RPC
+        /// failure). The caller falls back to the resume-based refresh.
+        case unavailable(String)
+    }
+
+    /// A healthy foreground transition must be observational, not a session
+    /// replacement. `session.resume` is a session SWITCH upstream (switch_
+    /// session), and the full sync path re-derives the target session,
+    /// replaces the transcript, and resets the live reasoning projection — a
+    /// harmless background→foreground cycle must not manufacture a semantic
+    /// turn boundary. So the healthy-socket path first probes the gateway's
+    /// in-memory runtime registry (`session.active_list`), which upstream
+    /// guarantees does not resume, focus, or mutate a session, and only falls
+    /// back to `session.resume` when the registry proves the live runtime is
+    /// gone (or cannot answer).
+    private func refreshForegroundOnHealthyTransport(
+        using client: HermesClient,
+        reconciliationToken token: UUID,
+        automaticWorkToken: ChatResumeAutomaticWorkToken?
+    ) async {
+        guard foregroundRefreshOwnsReconciliation(token),
+              automaticChatResumeWorkIsCurrent(automaticWorkToken) else {
+            settleReconciliation(token)
+            return
+        }
+        let requestedSessionID = activeSessionId
+        let probe: ForegroundRuntimeProbe
+        if let requestedSessionID {
+            probe = await probeForegroundRuntime(
+                requestedSessionID: requestedSessionID,
+                using: client
+            )
+        } else {
+            probe = .absent
+        }
+        guard foregroundRefreshOwnsReconciliation(token),
+              automaticChatResumeWorkIsCurrent(automaticWorkToken) else {
+            settleReconciliation(token)
+            return
+        }
+        switch probe {
+        case let .live(row):
+            if row.isRunning, !messages.isEmpty {
+                // The same turn is still live over a hydrated transcript: keep
+                // the session, the transcript, the streaming buffer, and the
+                // PR #121 live reasoning projection exactly as they are. Only
+                // the buffered events captured while the reconciliation
+                // boundary was open need replaying — nothing was replaced, so
+                // no dedup is needed.
+                lifecycleLog.notice(
+                    "Foreground refresh: probe=live status=\(row.status, privacy: .public) session=\(requestedSessionID ?? "-", privacy: .public) → observation-only adopt"
+                )
+                adoptForegroundRunningState(
+                    reconciliationToken: token,
+                    automaticWorkToken: automaticWorkToken
+                )
+            } else if row.isRunning {
+                // A running runtime over an empty local transcript means this
+                // surface never hydrated (failed resume, or the turn was
+                // started from another surface): attach through the full
+                // refresh, whose resume returns the live projection.
+                lifecycleLog.notice(
+                    "Foreground refresh: probe=live localTranscript=empty → resume refresh (attach live projection)"
+                )
+                await syncSession(
+                    purpose: .automaticReturn,
+                    using: token,
+                    automaticWorkToken: automaticWorkToken
+                )
+            } else if turnState.isRunning {
+                // The turn ended while the app was suspended and the idle edge
+                // was missed. Presentation recovery needs the authoritative
+                // bounded transcript refresh, which is allowed to resume
+                // because nothing is running anymore.
+                lifecycleLog.notice(
+                    "Foreground refresh: probe=idle localTurn=running → resume refresh (turn ended while away)"
+                )
+                await syncSession(
+                    purpose: .automaticReturn,
+                    using: token,
+                    automaticWorkToken: automaticWorkToken
+                )
+            } else {
+                // Idle before, idle now: the session is stable and attached.
+                lifecycleLog.notice(
+                    "Foreground refresh: probe=idle localTurn=idle → no-op"
+                )
+                turnStateIsStale = false
+                _ = settleReconciliationAndPublish(token, automaticWorkToken: automaticWorkToken)
+            }
+        case .absent:
+            // No live runtime for this session: either the turn completed and
+            // the registry reaped it while the transport was away, or the
+            // gateway restarted and the runtime id is gone. Both need the
+            // resume-based refresh to reattach (or recover completed work).
+            // `session.resume` reuses a live runtime when one exists, so this
+            // cannot create a duplicate runtime for a session that is alive.
+            lifecycleLog.notice(
+                "Foreground refresh: probe=absent → resume refresh (runtime not live)"
+            )
+            await syncSession(
+                purpose: .automaticReturn,
+                using: token,
+                automaticWorkToken: automaticWorkToken
+            )
+        case let .unavailable(reason):
+            // Older gateway or transient registry failure: keep the proven
+            // resume-based refresh rather than guessing.
+            lifecycleLog.notice(
+                "Foreground refresh: probe unavailable (\(reason, privacy: .public)) → resume refresh"
+            )
+            await syncSession(
+                purpose: .automaticReturn,
+                using: token,
+                automaticWorkToken: automaticWorkToken
+            )
+        }
+    }
+
+    /// Read-only registry probe for the active conversation. Matches a row by
+    /// ANY identity the conversation is known under (requested, stored, and
+    /// runtime aliases), so a runtime-id rotation cannot be mistaken for a
+    /// dead runtime while the catalog already knows the alias.
+    private func probeForegroundRuntime(
+        requestedSessionID: String,
+        using client: HermesClient
+    ) async -> ForegroundRuntimeProbe {
+        do {
+            let rows: [LiveSessionStatus]
+            if let probeActiveSessions = chatResumeLifecycleOperations.probeActiveSessions {
+                rows = try await probeActiveSessions(client)
+            } else {
+                rows = try await client.activeSessions()
+            }
+            let acceptedIDs = acceptedIdentitySessionIDs(forRequested: requestedSessionID)
+            if let row = rows.first(where: {
+                acceptedIDs.contains($0.runtimeSessionId) || acceptedIDs.contains($0.storedSessionId)
+            }) {
+                return .live(row)
+            }
+            return .absent
+        } catch {
+            return .unavailable(error.localizedDescription)
+        }
+    }
+
+    /// Every identity the active conversation answers to: the requested id,
+    /// its canonical stored id, and the catalog's confirmed aliases.
+    private func acceptedIdentitySessionIDs(forRequested requestedSessionID: String) -> Set<String> {
+        var ids = knownSessionIDs(for: requestedSessionID)
+        ids.insert(requestedSessionID)
+        if let canonical = canonicalSessionID(for: requestedSessionID) {
+            ids.insert(canonical)
+        }
+        if let activeSessionId {
+            ids.insert(activeSessionId)
+        }
+        return ids
+    }
+
+    /// Adopts an authoritative running state WITHOUT replacing any
+    /// presentation state: no transcript swap, no streaming-buffer reset, no
+    /// reasoning-segment reset. Buffered events captured while the foreground
+    /// reconciliation boundary was open are replayed FIRST (applyStreamEvent's
+    /// active-session gate still applies), then the probe's later-authoritative
+    /// running state is adopted — a buffered turn-end edge is intentionally
+    /// overridden by the registry snapshot the decision was made from. The
+    /// boundary settles last.
+    private func adoptForegroundRunningState(
+        reconciliationToken token: UUID,
+        automaticWorkToken: ChatResumeAutomaticWorkToken?
+    ) {
+        guard token == reconciliationToken else { return }
+        let bufferedEvents = reconciliation?.bufferedEvents ?? []
+        bufferedEvents.forEach { applyStreamEvent($0) }
+        // The registry is authoritative: a locally idle state that disagreed
+        // with it (missed turn start) is corrected, and a running state is
+        // confirmed. setRunning also clears the pending-decision restoration
+        // guard exactly like a live sessionBusy(true) event would.
+        setRunning(true)
+        turnStateIsStale = false
+        _ = settleReconciliationAndPublish(token, automaticWorkToken: automaticWorkToken)
+    }
+
+    private func verifyChatResumeTransportHealth(_ client: HermesClient) async throws {
+        if let verifyTransportHealth = chatResumeLifecycleOperations.verifyTransportHealth {
+            try await verifyTransportHealth(client)
+        } else {
+            try await client.healthCheck()
+        }
+    }
+
+    /// Continuation guard for the foreground refresh: the refresh decision may
+    /// only mutate state while its reconciliation token still owns the
+    /// boundary (a newer transition rotates the token and cancels the task).
+    private func foregroundRefreshOwnsReconciliation(_ token: UUID) -> Bool {
+        token == reconciliationToken && !Task.isCancelled
+    }
+
+    // MARK: - Authoritative turn-state correction
 
     // MARK: - Session management
 
@@ -5204,11 +5472,75 @@ final class AppState: ObservableObject {
             }
         }
 
+        // A lifecycle/recovery boundary (scene dip, reconnect, ambiguous
+        // submission) may have left the local idle state stale while Hermes
+        // still considers the session running. Submitting blind would enter
+        // Hermes' server-side busy policy with a message the user meant as a
+        // new turn — the queued/steered follow-up the user never asked for.
+        // One authoritative read-only probe corrects the state before the
+        // routing decision. Trusted state never pays for the probe.
+        if turnState == .idle, turnStateIsStale,
+           await correctStaleIdleTurnState() {
+            guard attachments.isEmpty else {
+                errorMessage = "Attachments can only be sent in a new message, after the current response finishes."
+                return false
+            }
+            switch busyInputMode {
+            case .steer:
+                lifecycleLog.notice("submitComposer: stale-idle corrected to running → busy steer")
+                return await steer(text, context: submissionContext)
+            case .interrupt:
+                lifecycleLog.notice("submitComposer: stale-idle corrected to running → busy redirect/interrupt")
+                return await redirectOrInterruptAndSend(text, context: submissionContext)
+            }
+        }
+
         return await sendMessage(
             text,
             attachments: attachments,
             context: submissionContext
         )
+    }
+
+    /// Read-only authoritative correction of a possibly stale local idle
+    /// state. Returns true when the gateway proves the session is RUNNING (the
+    /// caller must use the configured busy action); false when the session is
+    /// idle (safe to send a new turn) or the state could not be verified (do
+    /// not add RPC chatter — fall through to the ordinary send).
+    private func correctStaleIdleTurnState() async -> Bool {
+        guard let client, let sessionId = activeSessionId else {
+            turnStateIsStale = false
+            return false
+        }
+        let probe = await probeForegroundRuntime(
+            requestedSessionID: sessionId,
+            using: client
+        )
+        switch probe {
+        case let .live(row) where row.isRunning:
+            lifecycleLog.notice(
+                "submitComposer: authoritative probe=live status=\(row.status, privacy: .public) corrects stale idle session=\(sessionId, privacy: .public)"
+            )
+            // setRunning also clears the pending-decision restoration guard,
+            // exactly like a live sessionBusy(true) edge would.
+            setRunning(true)
+            turnStateIsStale = false
+            return true
+        case .live, .absent:
+            // Authoritative idle (or the runtime is gone): the local idle
+            // state is confirmed for this submission.
+            turnStateIsStale = false
+            return false
+        case let .unavailable(reason):
+            // The registry could not be read (older gateway, transient
+            // failure). Proceed with the ordinary send rather than blocking
+            // the user; the submission's own typed outcome will reconcile.
+            lifecycleLog.notice(
+                "submitComposer: stale-idle probe unavailable (\(reason, privacy: .public)); proceeding with send"
+            )
+            turnStateIsStale = false
+            return false
+        }
     }
 
     func sendMessage(
@@ -5268,22 +5600,173 @@ final class AppState: ObservableObject {
         }
 
         do {
+            let outcome: PromptSubmissionOutcome
             if let sendPrompt = chatResumeLifecycleOperations.sendPrompt {
-                try await sendPrompt(client, sessionId, text)
+                outcome = try await sendPrompt(client, sessionId, text)
             } else {
-                try await client.sendPrompt(sessionId, text: text)
+                outcome = try await client.sendPrompt(sessionId, text: text)
             }
             // The gateway accepted the prompt. A session handoff may have
             // happened while the RPC was suspended, but that does not turn a
             // remotely successful send into a local draft failure. There are
             // no current-session mutations after this point.
+            lifecycleLog.notice(
+                "prompt.submit outcome=\(Self.promptOutcomeLogValue(outcome), privacy: .public) session=\(sessionId, privacy: .public)"
+            )
+            if outcome.isBusySubmission, isCurrentComposerSubmission(submissionContext) {
+                // Hermes applied its busy policy, which proves THIS session
+                // was RUNNING when the prompt landed — the local state was
+                // stale. Adopt the authoritative busy state so the composer
+                // keeps offering the configured busy action and the next
+                // submission is routed correctly. A session handoff while the
+                // RPC was suspended must not misattribute the busy state to
+                // the newly active session.
+                turnState = .running
+            }
+            turnStateIsStale = false
             return true
         } catch {
             guard isCurrentComposerSubmission(submissionContext) else { return false }
+            if Self.isAmbiguousPromptDelivery(error) {
+                lifecycleLog.notice(
+                    "prompt.submit ambiguous (\(error.localizedDescription, privacy: .public)); querying authoritative state session=\(sessionId, privacy: .public)"
+                )
+                let (resolution, reconnected) = await reconcileAmbiguousPromptSubmission(
+                    requestedSessionID: sessionId,
+                    submissionContext: submissionContext
+                )
+                switch resolution {
+                case .acceptedRunning, .acceptedSettled:
+                    // Hermes accepted the submission and the turn is live:
+                    // keep the optimistic user row and the running turn, and
+                    // never re-send the prompt. In the settled flavor the
+                    // recovery reconnect's sync already replaced the
+                    // transcript; either way the turn is authoritative.
+                    turnState = .running
+                    turnStateIsStale = false
+                    return true
+                case .notAccepted:
+                    // Authoritative evidence shows Hermes did not accept the
+                    // prompt: restore the unsent state exactly once below.
+                    lifecycleLog.notice(
+                        "prompt.submit not accepted (authoritative); restoring unsent state session=\(sessionId, privacy: .public)"
+                    )
+                    turnStateIsStale = false
+                case .unresolved:
+                    // The authoritative state could not be read. Be
+                    // conservative about duplicate delivery: restore rather
+                    // than re-send blindly.
+                    lifecycleLog.notice(
+                        "prompt.submit state unresolved; restoring unsent state session=\(sessionId, privacy: .public)"
+                    )
+                }
+                errorMessage = "Failed to send: \(error.localizedDescription)"
+                if !reconnected {
+                    await recoverComposerSubmission(using: submissionContext)
+                }
+                // A reconnect inside the recovery already synced the
+                // authoritative transcript, so the restoration happened there.
+                return false
+            }
             errorMessage = "Failed to send: \(error.localizedDescription)"
             await recoverComposerSubmission(using: submissionContext)
             return false
         }
+    }
+
+    private static func promptOutcomeLogValue(_ outcome: PromptSubmissionOutcome) -> String {
+        switch outcome {
+        case .accepted: return "accepted"
+        case .steered: return "steered"
+        case .redirected: return "redirected"
+        case .queued: return "queued"
+        }
+    }
+
+    /// Which failures leave it genuinely unknown whether Hermes received the
+    /// prompt. Two classes are DEFINITIVE rejections: a structured `RpcError`
+    /// (the gateway answered, so the prompt was not accepted) and
+    /// `notConnected` (`rpc` throws before any bytes leave the device). The
+    /// remaining transport failures are ambiguous — the bytes may have
+    /// reached Hermes and the turn may already be running — so the
+    /// authoritative registry probe decides, and unknown future `HermesError`
+    /// cases fail toward the probe rather than toward a blind retry.
+    private static func isAmbiguousPromptDelivery(_ error: Error) -> Bool {
+        switch error {
+        case HermesError.notConnected:
+            return false
+        case is RpcError:
+            return false
+        case is HermesError:
+            return true
+        case is URLError, is CancellationError:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Recovery for a `prompt.submit` whose acknowledgement was lost. Reconnects
+    /// the transport if needed, then consults the authoritative runtime
+    /// registry: a live turn for this session means the prompt was accepted and
+    /// must never be re-sent; an idle/absent session means it was not.
+    /// `reconnected` reports whether a transport recovery (with its own full
+    /// transcript sync) ran, so the caller can skip a duplicate restoration.
+    private enum AmbiguousPromptResolution {
+        /// Accepted; the turn is running on the current transport.
+        case acceptedRunning
+        /// Accepted; the recovery reconnect's sync already settled the
+        /// transcript authoritatively.
+        case acceptedSettled
+        /// The registry proves the prompt was not accepted.
+        case notAccepted
+        /// The registry could not be read.
+        case unresolved
+    }
+
+    private func reconcileAmbiguousPromptSubmission(
+        requestedSessionID: String,
+        submissionContext: ComposerSubmissionContext
+    ) async -> (resolution: AmbiguousPromptResolution, reconnected: Bool) {
+        var reconnected = false
+        var probeClient = client
+        if probeClient?.isConnected != true {
+            // The transport died around the submission. A reconnect here is a
+            // real recovery, and its sync may already surface the accepted
+            // turn's persisted rows.
+            await reconnectForRetry(purpose: .preserveCurrent)
+            probeClient = self.client
+            reconnected = true
+        }
+        guard isCurrentOrAliasedComposerSubmission(submissionContext),
+              let probeClient else { return (.unresolved, reconnected) }
+        let acceptedIDs = acceptedIdentitySessionIDs(forRequested: requestedSessionID)
+        let rows: [LiveSessionStatus]
+        do {
+            if let probeActiveSessions = chatResumeLifecycleOperations.probeActiveSessions {
+                rows = try await probeActiveSessions(probeClient)
+            } else {
+                rows = try await probeClient.activeSessions()
+            }
+        } catch {
+            return (.unresolved, reconnected)
+        }
+        guard let row = rows.first(where: {
+            acceptedIDs.contains($0.runtimeSessionId) || acceptedIDs.contains($0.storedSessionId)
+        }) else {
+            // Authoritative absence: the runtime is gone. A turn accepted
+            // seconds ago would still be listed (the registry reaps a runtime
+            // only after its transport is gone AND it settled), so treat this
+            // as not accepted.
+            return (.notAccepted, reconnected)
+        }
+        if row.isRunning {
+            let resolution: AmbiguousPromptResolution = self.client === probeClient
+                ? .acceptedRunning
+                : .acceptedSettled
+            return (resolution, reconnected)
+        }
+        return (.notAccepted, reconnected)
     }
 
     func toggleYolo(context: ComposerSubmissionContext? = nil) async {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -8177,14 +8177,27 @@ final class AppState: ObservableObject {
             // A successful steer proves Hermes applied the session's busy
             // policy — the session was RUNNING when the steer landed. That is
             // authoritative live liveness evidence for the recovery stamp
-            // guard, even though steer writes no local turn state.
-            turnLifecycleEvidence = TurnLifecycleEvidence(
-                revision: turnLifecycleEvidence.revision &+ 1,
-                running: true
-            )
+            // guard, even though steer writes no local turn state. It is
+            // evidence about the ORIGINATING conversation only: the RPC may
+            // complete after the user switched conversations, and a late
+            // Session-A steer must never contaminate Session B's global
+            // evidence — a stale running claim here would let B's older
+            // ambiguous recovery resurrect ownership over B's newer settled
+            // edge. Alias rotation within the same conversation still counts;
+            // a genuine handoff does not.
+            // Bool test only — the re-homed context it computes internally is
+            // not needed, because steer performs no further session-scoped
+            // writes after this point.
+            if isCurrentOrAliasedComposerSubmission(submissionContext) {
+                turnLifecycleEvidence = TurnLifecycleEvidence(
+                    revision: turnLifecycleEvidence.revision &+ 1,
+                    running: true
+                )
+            }
             // A successful steer is accepted by Hermes even if the user
-            // switched sessions while the RPC was suspended. It has no local
-            // post-await mutation, so preserve success for draft handling.
+            // switched sessions while the RPC was suspended. Apart from the
+            // ownership-gated evidence write above it has no local post-await
+            // mutation, so preserve success for draft handling.
             return true
         } catch {
             guard isCurrentOrAliasedComposerSubmission(submissionContext) else { return false }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -511,6 +511,30 @@ final class AppState: ObservableObject {
     /// events keep flowing — so they observe but do not arm the freshness
     /// check.
     private(set) var foregroundFreshnessCheckArmed = false
+    /// Whether the visible persisted transcript may be MISSING rows —
+    /// conceptually disjoint from `turnStateIsStale`, which answers "do I
+    /// know whether Hermes is currently busy?". Set only when a bounded
+    /// foreground freshness read failed transiently on a real background
+    /// return; a liveness answer (the registry probe) can never clear it.
+    /// Cleared only when an authoritative transcript source proves
+    /// convergence: an unchanged bounded verdict, an advancement merge, or a
+    /// resume/reconcile hydration (`applyChatResume`).
+    private(set) var transcriptFreshnessIsStale = false
+    /// Evidence that the in-flight turn was submitted from THIS surface:
+    /// recorded when a locally-initiated, non-busy `prompt.submit` is
+    /// accepted (or ambiguity recovery proves `.acceptedRunning`), and
+    /// validated at use against the transcript (the optimistic user row must
+    /// still be present, unpersisted, and head a fully-unpersisted suffix)
+    /// plus the local turn state. Hermes runs one turn per session, so a
+    /// remote turn B normally requires our turn A to have settled — and
+    /// settling clears the marker; the residual unobserved-settle window is
+    /// documented on `locallyOwnedFreshnessTailRowIDs`. Distinct from durable
+    /// provenance: optimistic row ids never enter `durablePersistedRowIDs`.
+    private struct LocallyOwnedInFlightTurn {
+        var sessionIDs: Set<String>
+        var optimisticUserRowID: String
+    }
+    private var locallyOwnedInFlightTurn: LocallyOwnedInFlightTurn?
     @Published private(set) var busyInputMode: BusyInputMode = .steer
     @Published private(set) var displayPreferences = ProfileDisplayPreferences()
     @Published var streamingText = ""
@@ -1774,6 +1798,7 @@ final class AppState: ObservableObject {
         activeSessionTitle = "New conversation"
         messages = []
         persistedTranscriptWindow = nil
+        resetTranscriptLifecycleEvidence()
         clearStreamingText()
         resetReasoningTurn()
         activeSessionTitlesByProfile = [:]
@@ -2358,13 +2383,15 @@ final class AppState: ObservableObject {
         purpose: ChatResumeSyncPurpose,
         using existingReconciliationToken: UUID?,
         automaticWorkToken existingAutomaticWorkToken: ChatResumeAutomaticWorkToken?,
-        requiredViewportTransitionGeneration: UInt64? = nil
+        requiredViewportTransitionGeneration: UInt64? = nil,
+        historySourceUnavailable: Bool = false
     ) async {
         _ = await performSyncSession(
             purpose: purpose,
             using: existingReconciliationToken,
             automaticWorkToken: existingAutomaticWorkToken,
-            requiredViewportTransitionGeneration: requiredViewportTransitionGeneration
+            requiredViewportTransitionGeneration: requiredViewportTransitionGeneration,
+            historySourceUnavailable: historySourceUnavailable
         )
     }
 
@@ -2372,7 +2399,8 @@ final class AppState: ObservableObject {
         purpose: ChatResumeSyncPurpose,
         using existingReconciliationToken: UUID?,
         automaticWorkToken existingAutomaticWorkToken: ChatResumeAutomaticWorkToken?,
-        requiredViewportTransitionGeneration: UInt64? = nil
+        requiredViewportTransitionGeneration: UInt64? = nil,
+        historySourceUnavailable: Bool = false
     ) async -> ChatResumeSyncExecutionOutcome {
         guard chatViewportTransitionIsCurrent(
             requiredViewportTransitionGeneration
@@ -2503,7 +2531,8 @@ final class AppState: ObservableObject {
                     acceptedSessionIDs: Set([target.id] + target.alternateIds),
                     automaticWorkToken: automaticWorkToken,
                     automaticSyncOperationID: automaticOperationID,
-                    requiredViewportTransitionGeneration: requiredViewportTransitionGeneration
+                    requiredViewportTransitionGeneration: requiredViewportTransitionGeneration,
+                    historySourceUnavailable: historySourceUnavailable
                 )
                 if !succeeded,
                    purpose == .automaticReturn,
@@ -2746,7 +2775,8 @@ final class AppState: ObservableObject {
         acceptedSessionIDs: Set<String> = [],
         automaticWorkToken: ChatResumeAutomaticWorkToken? = nil,
         automaticSyncOperationID: UUID? = nil,
-        requiredViewportTransitionGeneration: UInt64? = nil
+        requiredViewportTransitionGeneration: UInt64? = nil,
+        historySourceUnavailable: Bool = false
     ) async -> Bool {
         guard automaticChatResumeWorkIsCurrent(
             automaticWorkToken,
@@ -2794,21 +2824,28 @@ final class AppState: ObservableObject {
             // legacy resume — cold bridge, gateway without the history route —
             // carries the transcript in the RPC response, whose size is
             // bounded by the socket limit (the pre-compact behavior).
-            let compactResume = chatResumeLifecycleOperations.persistedTranscript != nil || bridge != nil
-            async let resumedSession = openChatResumeSession(
-                sessionId,
-                using: client,
-                compact: compactResume
-            )
-            async let transcriptOutcome = persistedTranscriptOutcome(
-                sessionId: sessionId,
-                profile: profile,
-                using: bridge
-            )
-
-            var result = try await resumedSession
+            //
+            // A caller that POSITIVELY established structural history
+            // absence moments ago (the foreground freshness path) skips the
+            // compact attempt entirely: a compact resume here would be
+            // followed by a doomed history request and a second legacy
+            // resume — one non-compact resume does the whole job.
+            let compactResume = !historySourceUnavailable
+                && (chatResumeLifecycleOperations.persistedTranscript != nil || bridge != nil)
+            var result: SessionResumeResult
             var transcript: PersistedSessionTranscript?
             if compactResume {
+                async let resumedSession = openChatResumeSession(
+                    sessionId,
+                    using: client,
+                    compact: true
+                )
+                async let transcriptOutcome = persistedTranscriptOutcome(
+                    sessionId: sessionId,
+                    profile: profile,
+                    using: bridge
+                )
+                result = try await resumedSession
                 switch await transcriptOutcome {
                 case .hydrated(let persisted):
                     // The endpoint may resolve a runtime ID to its stored
@@ -2843,6 +2880,12 @@ final class AppState: ObservableObject {
                     // a legacy resume that would hide it: surface it instead.
                     throw error
                 }
+            } else {
+                result = try await openChatResumeSession(
+                    sessionId,
+                    using: client,
+                    compact: false
+                )
             }
             guard automaticChatResumeWorkIsCurrent(
                     automaticWorkToken,
@@ -3228,6 +3271,7 @@ final class AppState: ObservableObject {
             setActiveSessionState(id: runtimeSessionID, title: "New conversation")
             messages = []
             persistedTranscriptWindow = nil
+            resetTranscriptLifecycleEvidence()
             noteChatViewportTranscriptReplacement()
             clearStreamingText()
             activeAssistantMessageId = nil
@@ -3358,6 +3402,12 @@ final class AppState: ObservableObject {
         )
         messages = mergeCachedReviews(into: restored, sessionId: result.sessionId)
         noteChatViewportTranscriptReplacement()
+        // An authoritative resume/reconcile just replaced the transcript:
+        // whatever rows a failed freshness read could not see are now either
+        // present or authoritatively absent, and any optimistic-turn
+        // provenance died with the rows it pointed at.
+        transcriptFreshnessIsStale = false
+        locallyOwnedInFlightTurn = nil
         let gatewayPendingDecisionKeys = SessionPresentationCache.pendingDecisionKeys(in: result.messages)
         let restoredPendingDecisionKeys = SessionPresentationCache
             .pendingDecisionKeys(in: messages)
@@ -4384,6 +4434,19 @@ final class AppState: ObservableObject {
             preSuspensionTurnRunningSessionIDs = turnState.isRunning
                 ? acceptedIdentitySessionIDs(forRequested: activeSessionId ?? "")
                 : []
+            // A locally-owned in-flight turn is only continuity evidence
+            // while this conversation's turn is unsettled. A SETTLED turn
+            // (idle, or the unsupported-gateway dead end) expires the marker;
+            // .synchronizing/.reconnecting are mid-recovery, not settle —
+            // the turn may still be live, so the marker survives them. A
+            // marker left over from another session never survives.
+            if turnState == .idle || turnState == .unsupportedGateway {
+                locallyOwnedInFlightTurn = nil
+            } else if let marker = locallyOwnedInFlightTurn,
+                      let active = activeSessionId,
+                      !marker.sessionIDs.contains(active) {
+                locallyOwnedInFlightTurn = nil
+            }
             foregroundFreshnessCheckArmed = true
             voiceConversationController.setForegroundActive(false)
             messageReadAloudController.setForegroundActive(false)
@@ -4767,6 +4830,16 @@ final class AppState: ObservableObject {
 
     // MARK: - Cross-surface transcript freshness
 
+    /// Transcript-scoped lifecycle evidence (freshness uncertainty and
+    /// locally-owned turn provenance) belongs to the conversation it was
+    /// captured for. Call wherever the transcript is wholesale reset for a
+    /// new/different conversation identity: sign-out, profile switch,
+    /// conversation replacement, session open.
+    private func resetTranscriptLifecycleEvidence() {
+        transcriptFreshnessIsStale = false
+        locallyOwnedInFlightTurn = nil
+    }
+
     /// Outcome of the bounded persisted-tail freshness comparison against the
     /// locally adopted durable frontier.
     private enum ForegroundFreshnessVerdict {
@@ -4779,14 +4852,19 @@ final class AppState: ObservableObject {
         /// No durable ordering proof: the frontier rotated out of the newest
         /// page, the backend has no tail contract, the response belongs to
         /// another conversation identity, the local tail is not durably
-        /// anchored, there is no local frontier, or the history source is
-        /// structurally absent. Same invariant as the ambiguous-delivery
-        /// verifier — no anchor means "unchanged" can never be declared.
-        /// The bounded resume refresh is the authoritative fallback.
+        /// anchored, or there is no local frontier. Same invariant as the
+        /// ambiguous-delivery verifier — no anchor means "unchanged" can
+        /// never be declared. The bounded resume refresh is the
+        /// authoritative fallback.
         case inconclusive
+        /// The history source is positively, structurally absent for this
+        /// conversation (no bridge, or the endpoint answered 404/410/501):
+        /// bounded evidence cannot exist, so the authoritative refresh can
+        /// skip its doomed history request and resume non-compact directly.
+        case sourceUnavailable
         /// The bounded read failed transiently (timeout, 429/5xx, bridge not
         /// ready). Liveness stays authoritative, but freshness is UNRESOLVED:
-        /// the stale marker is retained so the next authoritative source
+        /// the freshness marker is retained so the next authoritative source
         /// re-confirms, and no "unchanged" verdict may be claimed.
         case unresolvedTransient
     }
@@ -4796,22 +4874,37 @@ final class AppState: ObservableObject {
     /// durable row present in the page is the anchor and only strictly-later
     /// page rows are candidates; candidate rows already held (streamed in
     /// live under any identity) are dropped by id.
+    ///
+    /// The local transcript may end on the locally-owned turn's optimistic
+    /// rows (`locallyOwnedTailRowIDs` non-nil): those rows have no persisted
+    /// twins YET, so the frontier anchor plus an empty candidate set still
+    /// proves the durable conversation unchanged — same-turn continuation
+    /// without demanding durable ids for Conduit's own optimistic rows. Any
+    /// candidate BEYOND the anchor while the tail is optimistic is persisted
+    /// advancement that cannot be safely attributed (the optimistic user row's
+    /// persisted twin, or a foreign turn) — never merged, always the
+    /// authoritative fallback. Persisted advancement always wins over an
+    /// optimistic tail.
     private func foregroundFreshnessVerdict(
         _ outcome: ForegroundPersistedTailOutcome,
         localFrontier: Set<String>,
         localMessageIDs: Set<String>,
         lastLocalMessageID: String?,
         requestedSessionID: String,
-        runtimeSessionID: String
+        runtimeSessionID: String,
+        livenessIsRunning: Bool,
+        locallyOwnedTailRowIDs: Set<String>?
     ) -> ForegroundFreshnessVerdict {
         switch outcome {
         case .failed:
             return .unresolvedTransient
-        case .unavailable, .unsupportedTailContract:
-            // Structural source absence or a backend without the tail
-            // contract: there is no bounded evidence and the freshness check
-            // deliberately does not escalate to a full-transcript read — the
-            // bounded resume refresh is the authoritative fallback.
+        case .unavailable:
+            return .sourceUnavailable
+        case .unsupportedTailContract:
+            // A backend without the tail contract: there is no bounded
+            // evidence and the freshness check deliberately does not escalate
+            // to a full-transcript read — the bounded resume refresh is the
+            // authoritative fallback.
             return .inconclusive
         case let .hydrated(transcript):
             // Defense-in-depth only: foregroundPersistedTailOutcome already
@@ -4840,21 +4933,25 @@ final class AppState: ObservableObject {
                 // identity: never merge rows from a foreign transcript.
                 return .inconclusive
             }
-            // The local transcript must END on a row the frontier vouches
-            // for. Trailing optimistic/streaming rows have persisted twins
-            // (same turn, database id) that would merge as duplicates, so
-            // the append-only merge is ineligible: the bounded resume
-            // refresh — which replaces the tail wholesale and already
-            // converges this exact shape — takes over.
+            // The transcript must end either on a row the frontier vouches
+            // for, or on the locally-owned turn's optimistic rows. In the
+            // latter case the page must also prove nothing persisted beyond
+            // the frontier — our own optimistic rows have no persisted twins
+            // yet, and anything else cannot be safely attributed. A tail that
+            // is neither (an abandoned optimistic row, minted rows from a
+            // foreign turn) keeps the strict anchor requirement.
             guard let lastLocalMessageID,
-                  localFrontier.contains(lastLocalMessageID),
                   let anchorIndex = transcript.messages.lastIndex(where: {
                       localFrontier.contains($0.id)
                   }) else {
-                // Unanchored tail, no local frontier, or the frontier
-                // rotated out of the newest page (an accepted turn can push
-                // hundreds of rows past the window): no ordering proof —
-                // same invariant as the ambiguous-delivery verifier.
+                // No local frontier, or the frontier rotated out of the
+                // newest page (an accepted turn can push hundreds of rows
+                // past the window): no ordering proof — same invariant as the
+                // ambiguous-delivery verifier.
+                return .inconclusive
+            }
+            let tailIsDurablyAnchored = localFrontier.contains(lastLocalMessageID)
+            guard tailIsDurablyAnchored || locallyOwnedTailRowIDs != nil else {
                 return .inconclusive
             }
             var knownIDs = localMessageIDs
@@ -4864,7 +4961,35 @@ final class AppState: ObservableObject {
                 newRows.append(row)
             }
             if newRows.isEmpty {
+                // Same-turn continuation also requires the runtime to still
+                // be working/waiting on OUR turn: an idle registry behind an
+                // optimistic tail cannot prove the turn landed at all, and
+                // the authoritative refresh converges it.
+                //
+                // Defense-in-depth only: the refresh routing above already
+                // sends "locally running turn + idle registry" to the
+                // authoritative resume before any freshness read, and
+                // `locallyOwnedFreshnessTailRowIDs` requires a running local
+                // turn — so this arm cannot fire through the current call
+                // graph. It pins the invariant should that routing change.
+                //
+                // Note the companion assumption: the in-flight turn has
+                // persisted NOTHING yet, so an empty candidate set is the
+                // normal in-flight shape. A backend that persists rows at
+                // accept-time yields candidates → authoritative attach once,
+                // after which the tail is durably anchored again.
+                if !tailIsDurablyAnchored, !livenessIsRunning {
+                    return .inconclusive
+                }
                 return .unchanged
+            }
+            if !tailIsDurablyAnchored {
+                // Persisted advancement beyond the pre-turn frontier behind an
+                // optimistic tail: the append-only merge would duplicate the
+                // optimistic row's persisted twin (and cannot attribute the
+                // rest), so the advancement wins and forces the authoritative
+                // attach.
+                return .inconclusive
             }
             return .advanced(transcript: transcript, newRows: newRows)
         }
@@ -4876,20 +5001,27 @@ final class AppState: ObservableObject {
     /// never a full-transcript fallback — decides:
     ///
     /// - anchor overlap, nothing newer → observational liveness adoption,
-    ///   transcript untouched, zero `session.resume`;
+    ///   transcript untouched, zero `session.resume`. With a locally-owned
+    ///   optimistic tail, the anchor overlap plus an empty candidate set
+    ///   additionally proves same-turn continuation of the turn Conduit
+    ///   itself submitted (the normal locally-started running turn), still
+    ///   zero `session.resume`;
     /// - anchor overlap, newer durable rows → the advancement is appended to
     ///   the local transcript (loaded-earlier prefix untouched, persisted
     ///   window re-anchored) and the liveness adopted — still zero
     ///   `session.resume`, because the persisted-history source supplied
     ///   everything a completed turn needs;
     /// - inconclusive (rotated anchor, no tail contract, foreign resolved id,
-    ///   unanchored optimistic tail, structurally absent source) → the
-    ///   existing bounded resume refresh, the authoritative fallback that
-    ///   re-anchors the whole conversation (and, for a live runtime, returns
-    ///   the in-flight projection);
+    ///   unanchored foreign tail, persisted advancement behind an optimistic
+    ///   tail) → the existing bounded resume refresh, the authoritative
+    ///   fallback that re-anchors the whole conversation (and, for a live
+    ///   runtime, returns the in-flight projection);
+    /// - structurally absent source → the same authoritative refresh, hinted
+    ///   so it skips the doomed history request and resumes non-compact
+    ///   exactly once;
     /// - transient read failure → the authoritative liveness adoption with
-    ///   the stale marker RETAINED: freshness is unresolved, never claimed
-    ///   current, and the next authoritative source re-confirms.
+    ///   the transcript-freshness marker SET: freshness is unresolved, never
+    ///   claimed current, and the next authoritative source re-confirms.
     private func reconcileForegroundCrossSurfaceActivity(
         livenessIsRunning: Bool,
         requestedSessionID: String,
@@ -4902,6 +5034,9 @@ final class AppState: ObservableObject {
         let localFrontier = durablePersistedRowIDs
         let localMessageIDs = Set(messages.map { $0.id })
         let lastLocalMessageID = messages.last?.id
+        let locallyOwnedTailRowIDs = locallyOwnedFreshnessTailRowIDs(
+            forRequested: requestedSessionID
+        )
         let outcome = await foregroundPersistedTailOutcome(
             sessionId: requestedSessionID,
             profile: profile,
@@ -4934,7 +5069,9 @@ final class AppState: ObservableObject {
             localMessageIDs: localMessageIDs,
             lastLocalMessageID: lastLocalMessageID,
             requestedSessionID: requestedSessionID,
-            runtimeSessionID: probeRow.runtimeSessionId
+            runtimeSessionID: probeRow.runtimeSessionId,
+            livenessIsRunning: livenessIsRunning,
+            locallyOwnedTailRowIDs: locallyOwnedTailRowIDs
         ) {
         case let .advanced(transcript, newRows):
             if livenessIsRunning {
@@ -4971,6 +5108,10 @@ final class AppState: ObservableObject {
             lifecycleLog.notice(
                 "Foreground freshness: probe=\(livenessIsRunning ? "running" : "idle", privacy: .public) session=\(requestedSessionID, privacy: .public) verdict=unchanged → observational adopt"
             )
+            // The bounded read proved the durable conversation current (an
+            // optimistic locally-owned tail is live-turn content, not
+            // divergence).
+            transcriptFreshnessIsStale = false
             adoptForegroundLiveness(
                 livenessIsRunning,
                 token: token,
@@ -4985,13 +5126,25 @@ final class AppState: ObservableObject {
                 token: token,
                 automaticWorkToken: automaticWorkToken
             )
-            // The bounded read failed transiently: freshness is UNRESOLVED.
-            // Retain the stale marker so the next authoritative source (the
-            // pre-send probe, the next background's freshness check, a
-            // reconnect) re-confirms — never claim a currency the read could
-            // not prove, and never escalate the failed bounded read into a
-            // full-transcript transfer.
-            turnStateIsStale = true
+            // The bounded read failed transiently: transcript freshness is
+            // UNRESOLVED — tracked separately from turn-state staleness
+            // (liveness was just adopted authoritatively above). The
+            // pre-send freshness retry and the next background's freshness
+            // check re-confirm; a registry probe alone can never clear this.
+            transcriptFreshnessIsStale = true
+        case .sourceUnavailable:
+            // Positively structural: the authoritative refresh re-anchors
+            // the conversation, hinted to skip the history request that just
+            // proved absent and resume non-compact exactly once.
+            lifecycleLog.notice(
+                "Foreground freshness: probe=\(livenessIsRunning ? "running" : "idle", privacy: .public) session=\(requestedSessionID, privacy: .public) verdict=source-unavailable → single authoritative resume"
+            )
+            await syncSession(
+                purpose: .automaticReturn,
+                using: token,
+                automaticWorkToken: automaticWorkToken,
+                historySourceUnavailable: true
+            )
         case .inconclusive:
             lifecycleLog.notice(
                 "Foreground freshness: probe=\(livenessIsRunning ? "running" : "idle", privacy: .public) session=\(requestedSessionID, privacy: .public) verdict=inconclusive → bounded resume refresh"
@@ -5002,6 +5155,34 @@ final class AppState: ObservableObject {
                 automaticWorkToken: automaticWorkToken
             )
         }
+    }
+
+    /// Non-nil when the transcript's trailing unpersisted rows belong to a
+    /// turn THIS surface submitted and the local turn state still agrees the
+    /// turn is in flight: the recorded optimistic user row is still present
+    /// and unpersisted, and every row after it is unpersisted too. The
+    /// residual window this cannot close — our turn settling unobserved
+    /// (dead socket) while a remote turn starts before anything of either
+    /// persisted — degrades to the same observational adopt the pre-marker
+    /// code took (a bounded resume in that exact window was the PR #121
+    /// regression); persisted advancement, idle liveness, and buffered
+    /// settle edges all still force the authoritative path.
+    private func locallyOwnedFreshnessTailRowIDs(
+        forRequested sessionID: String
+    ) -> Set<String>? {
+        guard turnState.isRunning,
+              let marker = locallyOwnedInFlightTurn,
+              marker.sessionIDs.contains(sessionID),
+              !durablePersistedRowIDs.contains(marker.optimisticUserRowID),
+              let userIndex = messages.lastIndex(where: {
+                  $0.id == marker.optimisticUserRowID
+              }),
+              messages[userIndex...].allSatisfy({
+                  !durablePersistedRowIDs.contains($0.id)
+              }) else {
+            return nil
+        }
+        return Set(messages[userIndex...].map { $0.id })
     }
 
     /// Adopts the freshly-decided foreground liveness after a freshness
@@ -5048,6 +5229,9 @@ final class AppState: ObservableObject {
             merged.append(row)
         }
         messages = merged
+        // The bounded read just proved exactly which persisted rows were
+        // missing and merged them: transcript freshness is restored.
+        transcriptFreshnessIsStale = false
         // The merge just made the newest persisted page local: adopt its
         // durable ids as the frontier (same per-hydration replacement
         // semantics as reconcile) so the next freshness check anchors
@@ -5396,6 +5580,7 @@ final class AppState: ObservableObject {
         setActiveSessionState(id: nil, title: "New conversation")
         messages = []
         persistedTranscriptWindow = nil
+        resetTranscriptLifecycleEvidence()
         clearStreamingText()
         activeAssistantMessageId = nil
         resetReasoningTurn()
@@ -5475,6 +5660,9 @@ final class AppState: ObservableObject {
         setActiveSessionState(id: sessionId)
         messages = []
         persistedTranscriptWindow = nil
+        // Freshness evidence belongs to the conversation it was captured
+        // for; the reconcile below re-establishes it authoritatively.
+        resetTranscriptLifecycleEvidence()
         clearStreamingText()
         activeAssistantMessageId = nil
         resetReasoningTurn()
@@ -5977,6 +6165,45 @@ final class AppState: ObservableObject {
             }
         }
 
+        // Transcript freshness is a separate concern from turn-state
+        // staleness: the registry probe above proves whether Hermes is busy,
+        // never whether the visible transcript is missing persisted rows. A
+        // foreground freshness read that failed transiently left that
+        // uncertainty open — resolve it with exactly one bounded tail-only
+        // retry before appending a new-turn prompt into a possibly-reordered
+        // transcript.
+        if turnState == .idle, transcriptFreshnessIsStale {
+            switch await confirmTranscriptFreshnessBeforeSend(
+                using: submissionContext
+            ) {
+            case .proceed:
+                break
+            case .routeToBusySubmission:
+                // The authoritative recovery revealed a live turn: the text
+                // routes through the configured busy submission, exactly like
+                // a stale-idle correction to running.
+                guard attachments.isEmpty else {
+                    errorMessage = "Attachments can only be sent in a new message, after the current response finishes."
+                    return false
+                }
+                switch busyInputMode {
+                case .steer:
+                    lifecycleLog.notice(
+                        "submitComposer: freshness recovery found live turn → busy steer"
+                    )
+                    return await steer(text, context: submissionContext)
+                case .interrupt:
+                    lifecycleLog.notice(
+                        "submitComposer: freshness recovery found live turn → busy redirect/interrupt"
+                    )
+                    return await redirectOrInterruptAndSend(text, context: submissionContext)
+                }
+            case .blocked(let message):
+                errorMessage = message
+                return false
+            }
+        }
+
         return await sendMessage(
             text,
             attachments: attachments,
@@ -6054,6 +6281,175 @@ final class AppState: ObservableObject {
         // turn — the typed prompt.submit outcome catches a genuine busy race.
         turnStateIsStale = false
         return false
+    }
+
+    /// Outcome of the pre-send transcript-freshness gate.
+    private enum TranscriptFreshnessGateOutcome {
+        /// Ordering is proven current (or the concern no longer applies):
+        /// proceed with the ordinary new-turn submission.
+        case proceed
+        /// The recovery revealed a live turn: route the text through the
+        /// configured busy submission instead of a new-turn prompt.
+        case routeToBusySubmission
+        /// Freshness could not be restored; do not append into an unresolved
+        /// ordering. Associated value is the user-facing message.
+        case blocked(String)
+    }
+
+    /// Exactly one bounded tail-only freshness retry before an ordinary
+    /// NEW-TURN submit while `transcriptFreshnessIsStale` (a foreground
+    /// freshness read failed transiently on a real background return). Never
+    /// polls: a second transient failure blocks the send rather than
+    /// silently appending into an unresolved ordering, and structural
+    /// absence takes the existing authoritative recovery (a non-compact
+    /// resume needs no history endpoint) before the send proceeds.
+    private func confirmTranscriptFreshnessBeforeSend(
+        using submissionContext: ComposerSubmissionContext
+    ) async -> TranscriptFreshnessGateOutcome {
+        guard client != nil, let sessionId = activeSessionId else {
+            // Nothing to verify against; the ordinary send path owns the
+            // no-client outcome.
+            return .proceed
+        }
+        let profile = activeProfile
+        let bridge = dashboardTicketBridge
+        let localFrontier = durablePersistedRowIDs
+        let localMessageIDs = Set(messages.map { $0.id })
+        let lastLocalMessageID = messages.last?.id
+        lifecycleLog.notice(
+            "submitComposer: transcript freshness unresolved; one bounded pre-send retry session=\(sessionId, privacy: .public)"
+        )
+        let outcome = await foregroundPersistedTailOutcome(
+            sessionId: sessionId,
+            profile: profile,
+            using: bridge
+        )
+        // Ownership re-check after the await: a session/profile handoff or a
+        // scene transition during the read invalidates this gate's evidence,
+        // and the ordinary flow's own guards own the outcome then.
+        guard isCurrentComposerSubmission(submissionContext),
+              activeSessionId == sessionId,
+              turnState == .idle else {
+            return .proceed
+        }
+        switch outcome {
+        case .failed:
+            // Second transient failure: no loop, no escalation, no silently
+            // claimed freshness — block the new-turn prompt instead.
+            return .blocked("Unable to refresh this conversation. Try again.")
+        case .unavailable:
+            // Positively structural: the authoritative reconcile is the
+            // recovery path that still converges the transcript (a
+            // non-compact resume needs no history endpoint), hinted to skip
+            // the doomed history request.
+            await syncSession(
+                purpose: .preserveCurrent,
+                using: nil,
+                automaticWorkToken: nil,
+                historySourceUnavailable: true
+            )
+            return postRecoveryFreshnessGateOutcome(
+                submissionContext: submissionContext,
+                sessionID: sessionId
+            )
+        case .unsupportedTailContract:
+            // A shapeless page: no comparable evidence either way — the
+            // authoritative reconcile re-classifies the source itself.
+            await syncSession(
+                purpose: .preserveCurrent,
+                using: nil,
+                automaticWorkToken: nil
+            )
+            return postRecoveryFreshnessGateOutcome(
+                submissionContext: submissionContext,
+                sessionID: sessionId
+            )
+        case .hydrated:
+            // The transcript moved under the gate (a stream edge landed):
+            // the comparison evidence is stale — converge authoritatively.
+            guard messages.last?.id == lastLocalMessageID,
+                  durablePersistedRowIDs == localFrontier else {
+                await syncSession(
+                    purpose: .preserveCurrent,
+                    using: nil,
+                    automaticWorkToken: nil
+                )
+                return postRecoveryFreshnessGateOutcome(
+                    submissionContext: submissionContext,
+                    sessionID: sessionId
+                )
+            }
+            let verdict = foregroundFreshnessVerdict(
+                outcome,
+                localFrontier: localFrontier,
+                localMessageIDs: localMessageIDs,
+                lastLocalMessageID: lastLocalMessageID,
+                requestedSessionID: sessionId,
+                runtimeSessionID: canonicalSessionID(for: sessionId)
+                    ?? persistedTranscriptWindow?.runtimeSessionID
+                    ?? sessionId,
+                livenessIsRunning: false,
+                locallyOwnedTailRowIDs: nil
+            )
+            switch verdict {
+            case .unchanged:
+                transcriptFreshnessIsStale = false
+                return .proceed
+            case let .advanced(transcript, newRows):
+                applyPersistedForegroundAdvancement(
+                    requestedSessionID: sessionId,
+                    transcript: transcript,
+                    newRows: newRows,
+                    runtimeSessionID: persistedTranscriptWindow?.runtimeSessionID
+                        ?? transcript.resolvedSessionId
+                        ?? sessionId,
+                    profile: profile
+                )
+                return .proceed
+            case .inconclusive:
+                await syncSession(
+                    purpose: .preserveCurrent,
+                    using: nil,
+                    automaticWorkToken: nil
+                )
+                return postRecoveryFreshnessGateOutcome(
+                    submissionContext: submissionContext,
+                    sessionID: sessionId
+                )
+            case .sourceUnavailable, .unresolvedTransient:
+                // Unreachable for a `.hydrated` outcome (both are produced
+                // only from the fetch-level cases above); kept as defensive
+                // exhaustiveness. Blocking is the safe direction regardless.
+                return .blocked("Unable to refresh this conversation. Try again.")
+            }
+        }
+    }
+
+    /// Shared post-recovery checks for the freshness gate: a converged
+    /// authoritative reconcile cleared `transcriptFreshnessIsStale` (via
+    /// `applyChatResume`); anything else means recovery did not converge and
+    /// the send must not proceed into an unresolved ordering.
+    private func postRecoveryFreshnessGateOutcome(
+        submissionContext: ComposerSubmissionContext,
+        sessionID: String
+    ) -> TranscriptFreshnessGateOutcome {
+        guard isCurrentComposerSubmission(submissionContext),
+              activeSessionId == sessionID else {
+            return .proceed
+        }
+        if turnState.isRunning {
+            return .routeToBusySubmission
+        }
+        if transcriptFreshnessIsStale {
+            // Either recovery was superseded (a newer boundary owns the
+            // conversation) or it genuinely failed to converge; both must
+            // not send into an unresolved ordering.
+            lifecycleLog.notice(
+                "submitComposer: pre-send freshness recovery did not converge; blocking send session=\(sessionID, privacy: .public)"
+            )
+            return .blocked("Unable to refresh this conversation. Try again.")
+        }
+        return .proceed
     }
 
     func sendMessage(
@@ -6151,6 +6547,22 @@ final class AppState: ObservableObject {
                     turnState = .running
                 }
                 turnStateIsStale = false
+                if outcome.isBusySubmission {
+                    // A steered/queued/redirected outcome joined a turn that
+                    // was ALREADY running — possibly started by another
+                    // surface — so it is not proof of a locally-owned turn;
+                    // the optimistic row gets no continuity marker.
+                    locallyOwnedInFlightTurn = nil
+                } else {
+                    // The turn in flight is now provably Conduit's own: record
+                    // the optimistic user row so a later foreground freshness
+                    // check can prove same-turn continuity WITHOUT demanding a
+                    // durable id for a row the gateway has not persisted yet.
+                    locallyOwnedInFlightTurn = LocallyOwnedInFlightTurn(
+                        sessionIDs: submissionSessionIDs,
+                        optimisticUserRowID: userMessage.id
+                    )
+                }
             }
             return true
         } catch {
@@ -6177,6 +6589,13 @@ final class AppState: ObservableObject {
                     if isCurrentComposerSubmission(submissionContext) {
                         turnState = .running
                         turnStateIsStale = false
+                        // Same proof as the ordinary success path: the turn
+                        // in flight is provably Conduit's own submission.
+                        // Validation at use still gates every later adopt.
+                        locallyOwnedInFlightTurn = LocallyOwnedInFlightTurn(
+                            sessionIDs: submissionSessionIDs,
+                            optimisticUserRowID: userMessage.id
+                        )
                     }
                     return true
                 case .acceptedSettled:
@@ -8452,6 +8871,7 @@ final class AppState: ObservableObject {
         slashCommands = Self.builtInSlashCommands
         messages = []
         persistedTranscriptWindow = nil
+        resetTranscriptLifecycleEvidence()
         clearStreamingText()
         resetReasoningTurn()
         // The next profile's approval mode is unknown until its first session
@@ -10123,6 +10543,10 @@ final class AppState: ObservableObject {
         guard turnState != .unsupportedGateway else { return }
         if running {
             clearPendingDecisionRestorationGuard()
+        } else {
+            // The turn settled: any locally-owned in-flight turn evidence
+            // expired with it.
+            locallyOwnedInFlightTurn = nil
         }
         turnState = running ? .running : .idle
     }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -494,6 +494,23 @@ final class AppState: ObservableObject {
     /// `prompt.submit` — Hermes would apply its busy policy to it and the
     /// message would silently join a turn the user never saw start.
     private(set) var turnStateIsStale = false
+    /// Session identities with a locally-observed running turn at the last
+    /// scene transition (empty = no continuity evidence). A foreground probe
+    /// whose working/waiting row matches one of these ids continues a turn
+    /// Conduit already knows — the fast observational path. A working/waiting
+    /// row WITHOUT this evidence may be a turn another surface started while
+    /// Conduit was suspended, so liveness alone must not stand in for
+    /// transcript freshness. Captured at the transition (before
+    /// reconciliation resets any state), consumed by exactly one foreground
+    /// refresh.
+    private(set) var preSuspensionTurnRunningSessionIDs: Set<String> = []
+    /// Armed by a real `.background` transition and consumed synchronously by
+    /// the next `.active` transition: the socket can die while suspended, so
+    /// bounded persisted-history activity from another surface could have
+    /// been missed. Overlay (`.inactive`) dips keep the socket alive — live
+    /// events keep flowing — so they observe but do not arm the freshness
+    /// check.
+    private(set) var foregroundFreshnessCheckArmed = false
     @Published private(set) var busyInputMode: BusyInputMode = .steer
     @Published private(set) var displayPreferences = ProfileDisplayPreferences()
     @Published var streamingText = ""
@@ -4284,6 +4301,13 @@ final class AppState: ObservableObject {
             // Publish the foreground reconciliation boundary synchronously.
             // ChatView may receive the same scene transition before the health
             // check task runs, so geometry alone must not restore stale rows.
+            // Consume the freshness arming here, synchronously with the
+            // transition: exactly one foreground return pays the bounded
+            // freshness check, overlay dips stay observational, and a refresh
+            // superseded mid-read is token-dead before it can act on stale
+            // evidence (every deactivation rotates the token).
+            let freshnessCheckArmed = foregroundFreshnessCheckArmed
+            foregroundFreshnessCheckArmed = false
             let token = beginReconciliation()
             let automaticWorkToken = beginAutomaticChatResumeWork()
             let sceneAttemptID = UUID()
@@ -4313,6 +4337,7 @@ final class AppState: ObservableObject {
                         }
                         await self.refreshForegroundOnHealthyTransport(
                             using: client,
+                            freshnessCheckArmed: freshnessCheckArmed,
                             reconciliationToken: token,
                             automaticWorkToken: automaticWorkToken
                         )
@@ -4352,6 +4377,14 @@ final class AppState: ObservableObject {
             // authoritative runtime registry before the next composer submit
             // decides between a new turn and a busy submission.
             turnStateIsStale = true
+            // Snapshot the pre-suspension liveness evidence and arm the
+            // cross-surface freshness check: while suspended, another Hermes
+            // surface can start or finish turns whose stream events Conduit
+            // will never see (the socket may not survive the suspension).
+            preSuspensionTurnRunningSessionIDs = turnState.isRunning
+                ? acceptedIdentitySessionIDs(forRequested: activeSessionId ?? "")
+                : []
+            foregroundFreshnessCheckArmed = true
             voiceConversationController.setForegroundActive(false)
             messageReadAloudController.setForegroundActive(false)
             showVoiceSheet = false
@@ -4374,6 +4407,12 @@ final class AppState: ObservableObject {
             // system overlay can miss turn edges. This never causes a resume —
             // the foreground path treats staleness as a read-only probe.
             turnStateIsStale = true
+            // Capture the continuity evidence (an in-flight Conduit turn stays
+            // the same turn across a dip) but do NOT arm the freshness check:
+            // the socket survives overlay dips, so live events kept flowing.
+            preSuspensionTurnRunningSessionIDs = turnState.isRunning
+                ? acceptedIdentitySessionIDs(forRequested: activeSessionId ?? "")
+                : []
             // Reconnects are suppressed during .inactive too, so an armed
             // timer would only fire to be discarded. Drop it here; a socket
             // that dies under a system overlay (incoming call, control
@@ -4447,6 +4486,7 @@ final class AppState: ObservableObject {
     /// gone (or cannot answer).
     private func refreshForegroundOnHealthyTransport(
         using client: HermesClient,
+        freshnessCheckArmed: Bool,
         reconciliationToken token: UUID,
         automaticWorkToken: ChatResumeAutomaticWorkToken?
     ) async {
@@ -4470,6 +4510,17 @@ final class AppState: ObservableObject {
             settleReconciliation(token)
             return
         }
+        // Scene-transition evidence. The arming flag was consumed at the
+        // `.active` transition itself (one foreground return pays the check;
+        // dips stay observational). The pre-suspension running set is read
+        // but never cleared here: the next real transition overwrites it, so
+        // a token-rotated refresh cannot consume evidence a newer refresh
+        // still needs. A working/waiting row matching the pre-suspension
+        // running set continues a turn Conduit already owns; without that
+        // match, liveness alone says nothing about whether the local
+        // transcript saw the activity, and a real background interval may
+        // have hidden persisted turns from another surface entirely.
+        let preSuspensionRunningIDs = preSuspensionTurnRunningSessionIDs
         switch probe {
         case let .live(row):
             if row.status == "starting" {
@@ -4483,33 +4534,64 @@ final class AppState: ObservableObject {
                     "Foreground refresh: probe=starting session=\(requestedSessionID ?? "-", privacy: .public) → observation-only, state untouched"
                 )
                 settleForegroundBoundary(token, automaticWorkToken: automaticWorkToken)
-            } else if row.isRunning, !messages.isEmpty {
-                // The same turn is still live over a hydrated transcript: keep
-                // the session, the transcript, the streaming buffer, and the
-                // PR #121 live reasoning projection exactly as they are. Only
-                // the buffered events captured while the reconciliation
-                // boundary was open need replaying — nothing was replaced, so
-                // no dedup is needed.
-                lifecycleLog.notice(
-                    "Foreground refresh: probe=live status=\(row.status, privacy: .public) session=\(requestedSessionID ?? "-", privacy: .public) → observation-only adopt"
-                )
-                adoptForegroundRunningState(
-                    reconciliationToken: token,
-                    automaticWorkToken: automaticWorkToken
-                )
             } else if row.isRunning {
-                // A running runtime over an empty local transcript means this
-                // surface never hydrated (failed resume, or the turn was
-                // started from another surface): attach through the full
-                // refresh, whose resume returns the live projection.
-                lifecycleLog.notice(
-                    "Foreground refresh: probe=live localTranscript=empty → resume refresh (attach live projection)"
+                let acceptedIDs = acceptedIdentitySessionIDs(
+                    forRequested: requestedSessionID ?? ""
                 )
-                await syncSession(
-                    purpose: .automaticReturn,
-                    using: token,
-                    automaticWorkToken: automaticWorkToken
-                )
+                let continuesLocalTurn = !preSuspensionRunningIDs.isDisjoint(with: acceptedIDs)
+                if continuesLocalTurn, !messages.isEmpty {
+                    // The same turn is still live over a hydrated transcript:
+                    // keep the session, the transcript, the streaming buffer,
+                    // and the PR #121 live reasoning projection exactly as
+                    // they are. Only the buffered events captured while the
+                    // reconciliation boundary was open need replaying —
+                    // nothing was replaced, so no dedup is needed.
+                    lifecycleLog.notice(
+                        "Foreground refresh: probe=live status=\(row.status, privacy: .public) session=\(requestedSessionID ?? "-", privacy: .public) → observation-only adopt"
+                    )
+                    adoptForegroundRunningState(
+                        reconciliationToken: token,
+                        automaticWorkToken: automaticWorkToken
+                    )
+                } else if !freshnessCheckArmed, !messages.isEmpty {
+                    // Overlay-dip semantics: the socket survived the dip and
+                    // live events kept the transcript current, so the
+                    // observational adopt stands without a transcript read.
+                    lifecycleLog.notice(
+                        "Foreground refresh: probe=live status=\(row.status, privacy: .public) session=\(requestedSessionID ?? "-", privacy: .public) → observation-only adopt (unarmed)"
+                    )
+                    adoptForegroundRunningState(
+                        reconciliationToken: token,
+                        automaticWorkToken: automaticWorkToken
+                    )
+                } else if freshnessCheckArmed {
+                    // Working/waiting without turn-continuity evidence (or an
+                    // unanchored transcript) after a real background: a turn
+                    // another surface started may be missing locally. One
+                    // bounded persisted-tail read decides between an
+                    // observational adopt, a merged advancement, and the
+                    // bounded resume refresh.
+                    await reconcileForegroundCrossSurfaceActivity(
+                        livenessIsRunning: true,
+                        requestedSessionID: requestedSessionID ?? "",
+                        probeRow: row,
+                        reconciliationToken: token,
+                        automaticWorkToken: automaticWorkToken
+                    )
+                } else {
+                    // A running runtime over an empty local transcript means
+                    // this surface never hydrated (failed resume, or the turn
+                    // was started from another surface): attach through the
+                    // full refresh, whose resume returns the live projection.
+                    lifecycleLog.notice(
+                        "Foreground refresh: probe=live localTranscript=empty → resume refresh (attach live projection)"
+                    )
+                    await syncSession(
+                        purpose: .automaticReturn,
+                        using: token,
+                        automaticWorkToken: automaticWorkToken
+                    )
+                }
             } else if turnState.isRunning {
                 // The turn ended while the app was suspended and the idle edge
                 // was missed. Presentation recovery needs the authoritative
@@ -4523,24 +4605,24 @@ final class AppState: ObservableObject {
                     using: token,
                     automaticWorkToken: automaticWorkToken
                 )
-            } else {
-                // The registry is authoritative that this runtime is idle.
-                // Adopt idle through the shared helper so a transitional
-                // state (.synchronizing / .reconnecting) left behind by an
-                // aborted recovery attempt cannot survive a healthy-socket
-                // foreground cycle — the observational refresh must still end
-                // with a usable composer. setRunning(false) is idempotent for
-                // .idle and preserves an unsupportedGateway marker.
-                lifecycleLog.notice(
-                    "Foreground refresh: probe=idle → adopt idle"
+            } else if freshnessCheckArmed {
+                // Authoritative idle after a real background: the runtime
+                // being idle does not prove the local transcript saw
+                // everything persisted while Conduit was away. One bounded
+                // persisted-tail read decides between the observational idle
+                // adoption and merging the missed rows.
+                await reconcileForegroundCrossSurfaceActivity(
+                    livenessIsRunning: false,
+                    requestedSessionID: requestedSessionID ?? "",
+                    probeRow: row,
+                    reconciliationToken: token,
+                    automaticWorkToken: automaticWorkToken
                 )
-                // The adopted idle is the OLDER observation: events buffered
-                // while the boundary was open are newer live edges and must
-                // win (a busy edge that raced the probe re-owns the state)
-                // before the boundary settles and discards them.
-                setRunning(false)
-                turnStateIsStale = false
-                settleForegroundBoundary(token, automaticWorkToken: automaticWorkToken)
+            } else {
+                adoptForegroundAuthoritativeIdle(
+                    token: token,
+                    automaticWorkToken: automaticWorkToken
+                )
             }
         case .absent:
             // No live runtime for this session: either the turn completed and
@@ -4650,6 +4732,312 @@ final class AppState: ObservableObject {
         let bufferedEvents = reconciliation?.bufferedEvents ?? []
         bufferedEvents.forEach { applyStreamEvent($0) }
         _ = settleReconciliationAndPublish(token, automaticWorkToken: automaticWorkToken)
+    }
+
+    /// Adopts an authoritative idle observation: the registry says this
+    /// runtime is idle, so a transitional state (.synchronizing /
+    /// .reconnecting) left behind by an aborted recovery attempt cannot
+    /// survive a healthy-socket foreground cycle — the observational refresh
+    /// must still end with a usable composer. setRunning(false) is idempotent
+    /// for .idle and preserves an unsupportedGateway marker. The adopted idle
+    /// is the OLDER observation: events buffered while the boundary was open
+    /// are newer live edges and must win (a busy edge that raced the probe
+    /// re-owns the state) before the boundary settles and discards them.
+    private func adoptForegroundAuthoritativeIdle(
+        token: UUID,
+        automaticWorkToken: ChatResumeAutomaticWorkToken?
+    ) {
+        lifecycleLog.notice("Foreground refresh: probe=idle → adopt idle")
+        setRunning(false)
+        turnStateIsStale = false
+        settleForegroundBoundary(token, automaticWorkToken: automaticWorkToken)
+    }
+
+    // MARK: - Cross-surface transcript freshness
+
+    /// Outcome of the bounded persisted-tail freshness comparison against the
+    /// locally adopted durable frontier.
+    private enum ForegroundFreshnessVerdict {
+        /// The newest page overlaps the local durable frontier and contains
+        /// nothing beyond it: the local transcript is current.
+        case unchanged
+        /// The page overlaps the frontier and holds validated durable rows
+        /// after it: persisted activity the local transcript never saw.
+        case advanced(transcript: PersistedSessionTranscript, newRows: [ChatMessage])
+        /// No durable ordering proof: the frontier rotated out of the newest
+        /// page, the read was a legacy one-shot without durable identity, the
+        /// response belongs to another conversation identity, the local tail
+        /// is not durably anchored, or there is no local frontier. Same
+        /// invariant as the ambiguous-delivery verifier — no anchor means
+        /// "unchanged" can never be declared.
+        case inconclusive
+        /// The check could not run at all: no usable history source, or the
+        /// bounded read failed transiently. The authoritative liveness
+        /// observation stands on the previously accepted observational
+        /// terms — a failed check must not escalate into a resume cascade.
+        case unverifiable
+    }
+
+    /// Compares one bounded persisted-tail read against the local durable
+    /// frontier. Ordering key: the page is chronological, so the NEWEST local
+    /// durable row present in the page is the anchor and only strictly-later
+    /// page rows are candidates; candidate rows already held (streamed in
+    /// live under any identity) are dropped by id.
+    private func foregroundFreshnessVerdict(
+        _ outcome: PersistedTranscriptOutcome,
+        localFrontier: Set<String>,
+        localMessageIDs: Set<String>,
+        lastLocalMessageID: String?,
+        requestedSessionID: String,
+        runtimeSessionID: String
+    ) -> ForegroundFreshnessVerdict {
+        switch outcome {
+        case .unavailable, .failed:
+            return .unverifiable
+        case let .hydrated(transcript):
+            guard let page = transcript.page, page.honorsTailContract,
+                  transcript.messages.isEmpty || !transcript.durableRowIDs.isEmpty else {
+                // Legacy one-shot: positively the entire transcript, but its
+                // rows carry no durable identity, so nothing can be compared
+                // (text and count comparisons are forbidden). The bounded
+                // resume refresh owns legacy conversations end-to-end.
+                return .inconclusive
+            }
+            // A positively empty page with no older rows proves the
+            // conversation has no persisted rows at all: an idle runtime
+            // cannot hide anything behind it, and an empty local transcript
+            // has nothing to diverge from.
+            if transcript.messages.isEmpty {
+                guard !page.mayHaveOlderRows(fetchedRowCount: 0),
+                      lastLocalMessageID == nil else {
+                    return .inconclusive
+                }
+                return .unchanged
+            }
+            guard transcriptMatchesSession(
+                transcript,
+                requestedSessionId: requestedSessionID,
+                resumedSessionId: runtimeSessionID
+            ) else {
+                // The endpoint answered for a different conversation
+                // identity: never merge rows from a foreign transcript.
+                return .inconclusive
+            }
+            // The local transcript must END on a row the frontier vouches
+            // for. Trailing optimistic/streaming rows have persisted twins
+            // (same turn, database id) that would merge as duplicates, so
+            // the append-only merge is ineligible: the bounded resume
+            // refresh — which replaces the tail wholesale and already
+            // converges this exact shape — takes over.
+            guard let lastLocalMessageID,
+                  localFrontier.contains(lastLocalMessageID),
+                  let anchorIndex = transcript.messages.lastIndex(where: {
+                      localFrontier.contains($0.id)
+                  }) else {
+                // Unanchored tail, no local frontier, or the frontier
+                // rotated out of the newest page (an accepted turn can push
+                // hundreds of rows past the window): no ordering proof —
+                // same invariant as the ambiguous-delivery verifier.
+                return .inconclusive
+            }
+            var knownIDs = localMessageIDs
+            var newRows: [ChatMessage] = []
+            for row in transcript.messages[transcript.messages.index(after: anchorIndex)...]
+            where knownIDs.insert(row.id).inserted {
+                newRows.append(row)
+            }
+            if newRows.isEmpty {
+                return .unchanged
+            }
+            return .advanced(transcript: transcript, newRows: newRows)
+        }
+    }
+
+    /// Runs the bounded cross-surface freshness reconciliation for a
+    /// foreground whose probe liveness could hide missed persisted activity
+    /// (real background interval, no turn-continuity evidence):
+    ///
+    /// - anchor overlap, nothing newer → observational liveness adoption,
+    ///   transcript untouched, zero `session.resume`;
+    /// - anchor overlap, newer durable rows → the advancement is appended to
+    ///   the local transcript (loaded-earlier prefix untouched, persisted
+    ///   window re-anchored) and the liveness adopted — still zero
+    ///   `session.resume`, because the persisted-history source supplied
+    ///   everything a completed turn needs;
+    /// - inconclusive → the existing bounded resume refresh (the one
+    ///   `session.resume` that re-anchors the whole conversation and, for a
+    ///   live runtime, returns the in-flight projection);
+    /// - unverifiable → the previously accepted observational behavior.
+    private func reconcileForegroundCrossSurfaceActivity(
+        livenessIsRunning: Bool,
+        requestedSessionID: String,
+        probeRow: LiveSessionStatus,
+        reconciliationToken token: UUID,
+        automaticWorkToken: ChatResumeAutomaticWorkToken?
+    ) async {
+        let profile = activeProfile
+        let bridge = dashboardTicketBridge
+        let localFrontier = durablePersistedRowIDs
+        let localMessageIDs = Set(messages.map { $0.id })
+        let lastLocalMessageID = messages.last?.id
+        let outcome = await persistedTranscriptOutcome(
+            sessionId: requestedSessionID,
+            profile: profile,
+            using: bridge
+        )
+        guard foregroundRefreshOwnsReconciliation(token),
+              automaticChatResumeWorkIsCurrent(automaticWorkToken) else {
+            settleReconciliation(token)
+            return
+        }
+        // The composer stays enabled during the bounded read: a submit that
+        // landed mid-read appends an optimistic row and would invert the
+        // merge order. The transcript moved, so the append-only merge can no
+        // longer be proven safe — the bounded resume refresh converges it.
+        guard messages.last?.id == lastLocalMessageID,
+              durablePersistedRowIDs == localFrontier else {
+            lifecycleLog.notice(
+                "Foreground freshness: session=\(requestedSessionID, privacy: .public) transcript moved during read → bounded resume refresh"
+            )
+            await syncSession(
+                purpose: .automaticReturn,
+                using: token,
+                automaticWorkToken: automaticWorkToken
+            )
+            return
+        }
+        switch foregroundFreshnessVerdict(
+            outcome,
+            localFrontier: localFrontier,
+            localMessageIDs: localMessageIDs,
+            lastLocalMessageID: lastLocalMessageID,
+            requestedSessionID: requestedSessionID,
+            runtimeSessionID: probeRow.runtimeSessionId
+        ) {
+        case let .advanced(transcript, newRows):
+            lifecycleLog.notice(
+                "Foreground freshness: probe=\(livenessIsRunning ? "running" : "idle", privacy: .public) session=\(requestedSessionID, privacy: .public) verdict=advanced rows=\(newRows.count, privacy: .public) → merge persisted advancement"
+            )
+            applyPersistedForegroundAdvancement(
+                requestedSessionID: requestedSessionID,
+                transcript: transcript,
+                newRows: newRows,
+                runtimeSessionID: probeRow.runtimeSessionId,
+                profile: profile
+            )
+            adoptForegroundLiveness(
+                livenessIsRunning,
+                token: token,
+                automaticWorkToken: automaticWorkToken
+            )
+        case .unchanged:
+            lifecycleLog.notice(
+                "Foreground freshness: probe=\(livenessIsRunning ? "running" : "idle", privacy: .public) session=\(requestedSessionID, privacy: .public) verdict=unchanged → observational adopt"
+            )
+            adoptForegroundLiveness(
+                livenessIsRunning,
+                token: token,
+                automaticWorkToken: automaticWorkToken
+            )
+        case .unverifiable:
+            lifecycleLog.notice(
+                "Foreground freshness: probe=\(livenessIsRunning ? "running" : "idle", privacy: .public) session=\(requestedSessionID, privacy: .public) verdict=unverifiable → observational fallback"
+            )
+            if livenessIsRunning, messages.isEmpty {
+                // Pre-freshness semantics for a running runtime over an empty
+                // transcript: attach the live projection.
+                await syncSession(
+                    purpose: .automaticReturn,
+                    using: token,
+                    automaticWorkToken: automaticWorkToken
+                )
+            } else {
+                adoptForegroundLiveness(
+                    livenessIsRunning,
+                    token: token,
+                    automaticWorkToken: automaticWorkToken
+                )
+            }
+        case .inconclusive:
+            lifecycleLog.notice(
+                "Foreground freshness: probe=\(livenessIsRunning ? "running" : "idle", privacy: .public) session=\(requestedSessionID, privacy: .public) verdict=inconclusive → bounded resume refresh"
+            )
+            await syncSession(
+                purpose: .automaticReturn,
+                using: token,
+                automaticWorkToken: automaticWorkToken
+            )
+        }
+    }
+
+    /// Adopts the freshly-decided foreground liveness after a freshness
+    /// verdict: the merged transcript / unchanged snapshot is the OLDER
+    /// observation, so buffered events replay after it (newer edges win) and
+    /// the boundary settles last.
+    private func adoptForegroundLiveness(
+        _ running: Bool,
+        token: UUID,
+        automaticWorkToken: ChatResumeAutomaticWorkToken?
+    ) {
+        if running {
+            adoptForegroundRunningState(
+                reconciliationToken: token,
+                automaticWorkToken: automaticWorkToken
+            )
+        } else {
+            adoptForegroundAuthoritativeIdle(
+                token: token,
+                automaticWorkToken: automaticWorkToken
+            )
+        }
+    }
+
+    /// Appends cross-surface persisted advancement to the live transcript.
+    /// Append-only by construction: the verdict selected rows strictly after
+    /// the newest local durable anchor, deduplicated against every held row
+    /// id, so the loaded-earlier prefix and any durably-anchored tail remain
+    /// exactly as they were. The persisted window is re-anchored to the
+    /// fetched page (same coverage-reset semantics as a reconcile refresh:
+    /// subsequent backfills retrace deduped page-sized increments), keeping
+    /// "Load earlier messages" coherent without a resume.
+    private func applyPersistedForegroundAdvancement(
+        requestedSessionID: String,
+        transcript: PersistedSessionTranscript,
+        newRows: [ChatMessage],
+        runtimeSessionID: String,
+        profile: String
+    ) {
+        var knownIDs = Set(messages.map { $0.id })
+        var merged = messages
+        merged.reserveCapacity(merged.count + newRows.count)
+        for row in newRows where knownIDs.insert(row.id).inserted {
+            merged.append(row)
+        }
+        messages = merged
+        // The merge just made the newest persisted page local: adopt its
+        // durable ids as the frontier (same per-hydration replacement
+        // semantics as reconcile) so the next freshness check anchors
+        // against the rows this merge added.
+        durablePersistedRowIDs = transcript.durableRowIDs
+        let priorOwned: PersistedTranscriptWindowState? = priorWindowOwnsThisConversation(
+            persistedTranscriptWindow,
+            requestedSessionId: requestedSessionID,
+            resolvedSessionId: transcript.resolvedSessionId,
+            runtimeSessionId: runtimeSessionID,
+            profile: profile
+        ) ? persistedTranscriptWindow : nil
+        if let page = transcript.page, page.honorsTailContract {
+            persistedTranscriptWindow = PersistedTranscriptWindowState(
+                requestedSessionID: requestedSessionID,
+                profile: profile,
+                pageSize: PersistedTranscriptPagination.pageSize,
+                resolvedSessionID: transcript.resolvedSessionId,
+                runtimeSessionID: runtimeSessionID,
+                nextOffset: page.rawReturned,
+                canLoadEarlier: page.mayHaveOlderRows(fetchedRowCount: page.rawReturned),
+                hasBackfilledPrefix: priorOwned?.hasBackfilledPrefix ?? false
+            )
+        }
     }
 
     private func verifyChatResumeTransportHealth(_ client: HermesClient) async throws {
@@ -10230,15 +10618,29 @@ final class AppState: ObservableObject {
 
         let firstTurnUserMessage = messages.first(where: { $0.role == .user })?.content
         let isFirstUserTurn = messages.filter { $0.role == .user }.count == 1
-        let resolvedMessageID = messageId
+        let trimmedMessageID = messageId
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .flatMap { $0.isEmpty ? nil : $0 }
+        let resolvedMessageID = trimmedMessageID
             ?? "assistant-\(Date().timeIntervalSince1970)"
         let systemNotice = MessageNormalizer.systemNoticeText(fromText: finalContent)
         let displayContent = systemNotice ?? finalContent
         let displayRole: MessageRole = systemNotice == nil ? .assistant : .system
-        if !displayContent.isEmpty,
-           (messages.last?.role != displayRole || messages.last?.content != displayContent) {
+        // In-place finalization only for GATEWAY-SUPPLIED ids: a cross-surface
+        // persisted advancement can merge the persisted row before the live
+        // completion arrives, and the completion must finalize that row in
+        // place instead of appending a twin. The timestamp fallback id is
+        // minted locally per completion — matching on it could overwrite an
+        // unrelated same-second completion — so it keeps the historical
+        // append semantics.
+        if let trimmedMessageID,
+           let existingIndex = messages.lastIndex(where: { $0.id == trimmedMessageID }) {
+            if !displayContent.isEmpty {
+                messages[existingIndex].content = displayContent
+                messages[existingIndex].rawContent = systemNotice == nil ? nil : finalContent
+            }
+        } else if !displayContent.isEmpty,
+                  (messages.last?.role != displayRole || messages.last?.content != displayContent) {
             messages.append(ChatMessage(
                 id: resolvedMessageID,
                 role: displayRole,

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -541,7 +541,32 @@ final class AppState: ObservableObject {
         var sessionIDs: Set<String>
         var optimisticUserRowID: String
         var preSubmitOrderingBaseline: PersistedOrderingBaseline
+        /// Set when a validated bounded read positively observed this turn's
+        /// persisted user boundary (the frontier advanced through it). A
+        /// turn that settles WITHOUT this proof leaves ordering debt: its
+        /// twin is expected in persisted history beyond the frontier, and
+        /// the next locally-owned turn must not anchor before it.
+        var persistedBoundaryObserved = false
     }
+    /// Ordering debt for locally-owned turns that settled locally BEFORE any
+    /// validated persisted read observed their durable user boundary
+    /// (foreground-only lifecycles). One bounded pre-send tail read
+    /// reconciles it: exactly `expectedUserTurnCount` new canonical user
+    /// boundaries after the frontier satisfies the debt (and advances the
+    /// frontier); more proves foreign activity (authoritative reconcile);
+    /// fewer means persisted state has not caught up (conservative
+    /// recovery). Conversation-scoped: reset with the transcript lifecycle
+    /// evidence, cleared by authoritative adoption. Residual windows, both
+    /// routed to the safe direction: a settled turn whose assistant output
+    /// persists AFTER a satisfied re-anchor leaves the next debt read facing
+    /// a leading non-user row (one conservative reconcile); a turn accepted
+    /// but lost server-side leaves unsatisfiable debt until one reconcile
+    /// converges it.
+    private struct PendingLocalOrderingDebt {
+        var sessionIDs: Set<String>
+        var expectedUserTurnCount: Int
+    }
+    private var pendingLocalOrderingDebt: PendingLocalOrderingDebt?
     private var locallyOwnedInFlightTurn: LocallyOwnedInFlightTurn?
     /// Persisted ORDERING evidence — deliberately distinct from
     /// `durablePersistedRowIDs` (provenance for rows currently represented
@@ -3451,10 +3476,13 @@ final class AppState: ObservableObject {
         noteChatViewportTranscriptReplacement()
         // An authoritative resume/reconcile just replaced the transcript:
         // whatever rows a failed freshness read could not see are now either
-        // present or authoritatively absent, and any optimistic-turn
-        // provenance died with the rows it pointed at.
+        // present or authoritatively absent, any optimistic-turn provenance
+        // died with the rows it pointed at, and the adopted ordering
+        // frontier covers everything persisted — no local debt can outlive
+        // it.
         transcriptFreshnessIsStale = false
         locallyOwnedInFlightTurn = nil
+        pendingLocalOrderingDebt = nil
         let gatewayPendingDecisionKeys = SessionPresentationCache.pendingDecisionKeys(in: result.messages)
         let restoredPendingDecisionKeys = SessionPresentationCache
             .pendingDecisionKeys(in: messages)
@@ -4894,6 +4922,11 @@ final class AppState: ObservableObject {
             if case .positivelyEmpty = self { return true }
             return false
         }
+
+        var isUnknown: Bool {
+            if case .unknown = self { return true }
+            return false
+        }
     }
 
     /// Derives ordering evidence from a transcript a reconcile or freshness
@@ -4921,10 +4954,11 @@ final class AppState: ObservableObject {
                 newestObservedDurableRowID: transcript.messages[anchorIndex].id
             )
         }
-        // Emptiness is proven on the RAW row view: a page whose rows all
-        // normalize away (hidden display_kind scaffolding) still carries
-        // durable ids and is NOT a positively empty transcript.
-        if transcript.messages.isEmpty,
+        // Emptiness is proven on the RAW row view: the server must have
+        // returned ZERO rows (not merely rows that all normalize away as
+        // hidden display_kind scaffolding — those still carry durable ids).
+        if page.rawReturned == 0,
+           transcript.messages.isEmpty,
            transcript.durableRowIDs.isEmpty,
            !page.mayHaveOlderRows(fetchedRowCount: 0) {
             return PersistedOrderingFrontier(isPositivelyEmpty: true)
@@ -4942,6 +4976,7 @@ final class AppState: ObservableObject {
         transcriptFreshnessIsStale = false
         locallyOwnedInFlightTurn = nil
         persistedOrderingFrontier = PersistedOrderingFrontier()
+        pendingLocalOrderingDebt = nil
     }
 
     /// Outcome of the bounded persisted-tail freshness comparison against the
@@ -4954,7 +4989,10 @@ final class AppState: ObservableObject {
         /// validated read positively observed — the caller may advance the
         /// ordering frontier with it while the visible transcript stays
         /// untouched.
-        case unchanged(observedOrderingFrontier: PersistedOrderingFrontier)
+        case unchanged(
+            observedOrderingFrontier: PersistedOrderingFrontier,
+            observedNewUserBoundaries: Int?
+        )
         /// The page overlaps the frontier and holds validated durable rows
         /// after it: persisted activity the local transcript never saw.
         case advanced(transcript: PersistedSessionTranscript, newRows: [ChatMessage])
@@ -5043,22 +5081,25 @@ final class AppState: ObservableObject {
             // other tail has no ordering proof.
             if transcript.messages.isEmpty {
                 // A page whose raw rows all normalize away (hidden
-                // scaffolding) is not positively empty — its durable ids
-                // prove rows exist.
-                guard transcript.durableRowIDs.isEmpty,
+                // scaffolding) is not positively empty — positive emptiness
+                // requires the server to have returned zero raw rows.
+                guard page.rawReturned == 0,
+                      transcript.durableRowIDs.isEmpty,
                       !page.mayHaveOlderRows(fetchedRowCount: 0) else {
                     return .inconclusive
                 }
                 if lastLocalMessageID == nil {
                     return .unchanged(
-                        observedOrderingFrontier: Self.orderingFrontier(from: transcript)
+                        observedOrderingFrontier: Self.orderingFrontier(from: transcript),
+                        observedNewUserBoundaries: nil
                     )
                 }
                 if let locallyOwnedTurn,
                    locallyOwnedTurn.baseline.isPositivelyEmpty,
                    livenessIsRunning {
                     return .unchanged(
-                        observedOrderingFrontier: Self.orderingFrontier(from: transcript)
+                        observedOrderingFrontier: Self.orderingFrontier(from: transcript),
+                        observedNewUserBoundaries: 0
                     )
                 }
                 return .inconclusive
@@ -5097,7 +5138,8 @@ final class AppState: ObservableObject {
             )
             if newRows.isEmpty {
                 return .unchanged(
-                    observedOrderingFrontier: Self.orderingFrontier(from: transcript)
+                    observedOrderingFrontier: Self.orderingFrontier(from: transcript),
+                    observedNewUserBoundaries: nil
                 )
             }
             return .advanced(transcript: transcript, newRows: newRows)
@@ -5171,7 +5213,8 @@ final class AppState: ObservableObject {
         if newRows.isEmpty {
             // Nothing of ours persisted yet — the earliest in-flight shape.
             return .unchanged(
-                observedOrderingFrontier: Self.orderingFrontier(from: transcript)
+                observedOrderingFrontier: Self.orderingFrontier(from: transcript),
+                observedNewUserBoundaries: 0
             )
         }
         let newUserTurnBoundaries = newRows.filter { $0.role == .user }
@@ -5183,9 +5226,12 @@ final class AppState: ObservableObject {
         // any Turn A output/tool rows): our turn is still the only one. The
         // visible transcript stays untouched, but the ordering frontier may
         // advance through the newest observed durable row of this proven
-        // Turn A region so the NEXT locally-owned turn anchors past it.
+        // Turn A region so the NEXT locally-owned turn anchors past it — and
+        // this read positively observed the turn's persisted boundary, so a
+        // later settle owes no ordering debt.
         return .unchanged(
-            observedOrderingFrontier: Self.orderingFrontier(from: transcript)
+            observedOrderingFrontier: Self.orderingFrontier(from: transcript),
+            observedNewUserBoundaries: newUserTurnBoundaries.count
         )
     }
 
@@ -5299,7 +5345,7 @@ final class AppState: ObservableObject {
                 token: token,
                 automaticWorkToken: automaticWorkToken
             )
-        case let .unchanged(observedOrderingFrontier):
+        case let .unchanged(observedOrderingFrontier, observedNewUserBoundaries):
             lifecycleLog.notice(
                 "Foreground freshness: probe=\(livenessIsRunning ? "running" : "idle", privacy: .public) session=\(requestedSessionID, privacy: .public) verdict=unchanged → observational adopt"
             )
@@ -5314,6 +5360,11 @@ final class AppState: ObservableObject {
             // observation (see PersistedOrderingFrontier for the
             // non-monotonicity rationale).
             persistedOrderingFrontier = observedOrderingFrontier
+            if let observedNewUserBoundaries, observedNewUserBoundaries > 0 {
+                // The read positively observed the locally-owned turn's
+                // persisted boundary: a later settle owes no ordering debt.
+                locallyOwnedInFlightTurn?.persistedBoundaryObserved = true
+            }
             adoptForegroundLiveness(
                 livenessIsRunning,
                 token: token,
@@ -5464,10 +5515,12 @@ final class AppState: ObservableObject {
         }
         messages = merged
         // The bounded read just proved exactly which persisted rows were
-        // missing and merged them: transcript freshness is restored, and the
-        // accepted page re-establishes the persisted ordering frontier.
+        // missing and merged them: transcript freshness is restored, the
+        // accepted page re-establishes the persisted ordering frontier, and
+        // that page covers any outstanding local ordering debt.
         transcriptFreshnessIsStale = false
         persistedOrderingFrontier = Self.orderingFrontier(from: transcript)
+        pendingLocalOrderingDebt = nil
         // The merge just made the newest persisted page local: adopt its
         // durable ids as the frontier (same per-hydration replacement
         // semantics as reconcile) so the next freshness check anchors
@@ -6428,7 +6481,8 @@ final class AppState: ObservableObject {
         // uncertainty open — resolve it with exactly one bounded tail-only
         // retry before appending a new-turn prompt into a possibly-reordered
         // transcript.
-        if turnState == .idle, transcriptFreshnessIsStale {
+        if turnState == .idle,
+           transcriptFreshnessIsStale || pendingLocalOrderingDebt != nil {
             switch await confirmTranscriptFreshnessBeforeSend(
                 using: submissionContext
             ) {
@@ -6552,13 +6606,18 @@ final class AppState: ObservableObject {
         case blocked(String)
     }
 
-    /// Exactly one bounded tail-only freshness retry before an ordinary
+    /// Exactly one bounded tail-only persisted read before an ordinary
     /// NEW-TURN submit while `transcriptFreshnessIsStale` (a foreground
-    /// freshness read failed transiently on a real background return). Never
-    /// polls: a second transient failure blocks the send rather than
-    /// silently appending into an unresolved ordering, and structural
-    /// absence takes the existing authoritative recovery (a non-compact
-    /// resume needs no history endpoint) before the send proceeds.
+    /// freshness read failed transiently on a real background return) OR
+    /// local ordering debt is outstanding (foreground-only settled turns
+    /// whose persisted boundaries no read has observed). Debt reconciliation
+    /// runs first; both concerns consume this one read. Never polls: a
+    /// transient failure blocks the send rather than silently appending
+    /// into an unresolved ordering (for debt, on the FIRST failure — debt is
+    /// a positive claim about persisted content, not a suspicion worth a
+    /// second chance), and structural absence takes the existing
+    /// authoritative recovery (a non-compact resume needs no history
+    /// endpoint) before the send proceeds.
     private func confirmTranscriptFreshnessBeforeSend(
         using submissionContext: ComposerSubmissionContext
     ) async -> TranscriptFreshnessGateOutcome {
@@ -6573,7 +6632,7 @@ final class AppState: ObservableObject {
         let localMessageIDs = Set(messages.map { $0.id })
         let lastLocalMessageID = messages.last?.id
         lifecycleLog.notice(
-            "submitComposer: transcript freshness unresolved; one bounded pre-send retry session=\(sessionId, privacy: .public)"
+            "submitComposer: pre-send persisted evidence unresolved (freshness or local ordering debt); one bounded retry session=\(sessionId, privacy: .public)"
         )
         let outcome = await foregroundPersistedTailOutcome(
             sessionId: sessionId,
@@ -6639,7 +6698,7 @@ final class AppState: ObservableObject {
                 submissionContext: submissionContext,
                 sessionID: sessionId
             )
-        case .hydrated:
+        case .hydrated(let transcript):
             // The transcript moved under the gate (a stream edge landed):
             // the comparison evidence is stale — converge authoritatively.
             guard messages.last?.id == lastLocalMessageID,
@@ -6654,37 +6713,20 @@ final class AppState: ObservableObject {
                     sessionID: sessionId
                 )
             }
-            let verdict = foregroundFreshnessVerdict(
-                outcome,
-                localFrontier: localFrontier,
-                localMessageIDs: localMessageIDs,
-                lastLocalMessageID: lastLocalMessageID,
-                requestedSessionID: sessionId,
-                runtimeSessionID: canonicalSessionID(for: sessionId)
+            // Identity first: a page echoing a foreign conversation id is
+            // never evidence — for the freshness verdict or debt
+            // reconciliation alike. (Pages echoing no session id at all
+            // match by construction.)
+            guard transcriptMatchesSession(
+                transcript,
+                requestedSessionId: sessionId,
+                resumedSessionId: canonicalSessionID(for: sessionId)
                     ?? persistedTranscriptWindow?.runtimeSessionID
-                    ?? sessionId,
-                livenessIsRunning: false,
-                locallyOwnedTurn: nil
-            )
-            switch verdict {
-            case let .unchanged(observedOrderingFrontier):
-                transcriptFreshnessIsStale = false
-                // Re-anchor the ordering frontier on the read's validated
-                // observation (non-monotonic by design).
-                persistedOrderingFrontier = observedOrderingFrontier
-                return .proceed
-            case let .advanced(transcript, newRows):
-                applyPersistedForegroundAdvancement(
-                    requestedSessionID: sessionId,
-                    transcript: transcript,
-                    newRows: newRows,
-                    runtimeSessionID: persistedTranscriptWindow?.runtimeSessionID
-                        ?? transcript.resolvedSessionId
-                        ?? sessionId,
-                    profile: profile
+                    ?? sessionId
+            ) else {
+                lifecycleLog.notice(
+                    "submitComposer: pre-send read answered for a different conversation → authoritative reconcile session=\(sessionId, privacy: .public)"
                 )
-                return .proceed
-            case .inconclusive:
                 await syncSession(
                     purpose: .preserveCurrent,
                     using: nil,
@@ -6694,13 +6736,152 @@ final class AppState: ObservableObject {
                     submissionContext: submissionContext,
                     sessionID: sessionId
                 )
-            case .sourceUnavailable, .unresolvedTransient:
-                // Unreachable for a `.hydrated` outcome (both are produced
-                // only from the fetch-level cases above); kept as defensive
-                // exhaustiveness. Blocking is the safe direction regardless.
-                return .blocked("Unable to refresh this conversation. Try again.")
             }
+            // Debt reconciliation FIRST: ordering metadata is counted
+            // against the frontier the settled turns were recorded against,
+            // and both concerns consume this one read.
+            if let debt = pendingLocalOrderingDebt {
+                switch localOrderingDebtOutcome(transcript, debt: debt) {
+                case .satisfied:
+                    pendingLocalOrderingDebt = nil
+                    persistedOrderingFrontier = Self.orderingFrontier(from: transcript)
+                case .exceeded, .notCaughtUp, .unprovable:
+                    lifecycleLog.notice(
+                        "submitComposer: pre-send ordering debt not reconcilable → authoritative reconcile session=\(sessionId, privacy: .public)"
+                    )
+                    await syncSession(
+                        purpose: .preserveCurrent,
+                        using: nil,
+                        automaticWorkToken: nil
+                    )
+                    return postRecoveryFreshnessGateOutcome(
+                        submissionContext: submissionContext,
+                        sessionID: sessionId
+                    )
+                }
+            }
+            if transcriptFreshnessIsStale {
+                let verdict = foregroundFreshnessVerdict(
+                    outcome,
+                    localFrontier: localFrontier,
+                    localMessageIDs: localMessageIDs,
+                    lastLocalMessageID: lastLocalMessageID,
+                    requestedSessionID: sessionId,
+                    runtimeSessionID: canonicalSessionID(for: sessionId)
+                        ?? persistedTranscriptWindow?.runtimeSessionID
+                        ?? sessionId,
+                    livenessIsRunning: false,
+                    locallyOwnedTurn: nil
+                )
+                switch verdict {
+                case let .unchanged(observedOrderingFrontier, _):
+                    transcriptFreshnessIsStale = false
+                    // Re-anchor the ordering frontier on the read's validated
+                    // observation (non-monotonic by design).
+                    persistedOrderingFrontier = observedOrderingFrontier
+                    return .proceed
+                case let .advanced(transcript, newRows):
+                    applyPersistedForegroundAdvancement(
+                        requestedSessionID: sessionId,
+                        transcript: transcript,
+                        newRows: newRows,
+                        runtimeSessionID: persistedTranscriptWindow?.runtimeSessionID
+                            ?? transcript.resolvedSessionId
+                            ?? sessionId,
+                        profile: profile
+                    )
+                    return .proceed
+                case .inconclusive:
+                    await syncSession(
+                        purpose: .preserveCurrent,
+                        using: nil,
+                        automaticWorkToken: nil
+                    )
+                    return postRecoveryFreshnessGateOutcome(
+                        submissionContext: submissionContext,
+                        sessionID: sessionId
+                    )
+                case .sourceUnavailable, .unresolvedTransient:
+                    // Unreachable for a `.hydrated` outcome (both are produced
+                    // only from the fetch-level cases above); kept as defensive
+                    // exhaustiveness. Blocking is the safe direction regardless.
+                    return .blocked("Unable to refresh this conversation. Try again.")
+                }
+            }
+            return .proceed
         }
+    }
+
+    /// Outcome of reconciling outstanding local ordering debt against one
+    /// validated bounded page.
+    private enum LocalOrderingDebtOutcome {
+        /// Exactly the expected number of canonical user-turn boundaries
+        /// follow the frontier: the debt is satisfied and the frontier may
+        /// re-anchor on this page.
+        case satisfied
+        /// More user boundaries than outstanding locally-owned turns:
+        /// foreign activity exists — authoritative reconcile before any
+        /// local send.
+        case exceeded
+        /// Fewer boundaries than expected (or an anomalous leading row):
+        /// persisted state has not caught up — conservative recovery.
+        case notCaughtUp
+        /// No ordering anchor to count against (unknown frontier, or it
+        /// rotated out of the page).
+        case unprovable
+        // notCaughtUp and unprovable deliberately share the conservative
+        // recovery routing at the caller; the split exists for field triage
+        // in the logs only.
+    }
+
+    /// Counts canonical user-turn boundaries after the ordering frontier and
+    /// compares them with the outstanding locally-owned settled-turn count.
+    /// Never advances anything: the caller owns frontier/debt mutation.
+    private func localOrderingDebtOutcome(
+        _ transcript: PersistedSessionTranscript,
+        debt: PendingLocalOrderingDebt
+    ) -> LocalOrderingDebtOutcome {
+        let heldIDs = Set(messages.map { $0.id })
+        switch persistedOrderingFrontier.baseline {
+        case .unknown:
+            return .unprovable
+        case .positivelyEmpty:
+            // The whole transcript follows the empty baseline; the page must
+            // be complete or the boundary count understates.
+            guard let page = transcript.page,
+                  !page.mayHaveOlderRows(fetchedRowCount: page.rawReturned) else {
+                return .unprovable
+            }
+            return Self.classifyDebtCandidates(
+                persistedRowsAfter(nil, in: transcript, heldIDs: heldIDs),
+                expected: debt.expectedUserTurnCount
+            )
+        case .anchored(let anchorID):
+            guard let anchorIndex = transcript.messages.lastIndex(where: {
+                $0.id == anchorID
+            }) else {
+                return .unprovable
+            }
+            return Self.classifyDebtCandidates(
+                persistedRowsAfter(anchorIndex, in: transcript, heldIDs: heldIDs),
+                expected: debt.expectedUserTurnCount
+            )
+        }
+    }
+
+    private static func classifyDebtCandidates(
+        _ candidates: [ChatMessage],
+        expected: Int
+    ) -> LocalOrderingDebtOutcome {
+        let boundaries = candidates.filter { $0.role == .user }
+        guard let firstRow = candidates.first, firstRow.role == .user else {
+            // Nothing after the frontier yet, or an assistant/tool row
+            // precedes the first boundary: the persisted state has not
+            // caught up (or ordering is anomalous) — conservative.
+            return boundaries.isEmpty ? .notCaughtUp : .unprovable
+        }
+        if boundaries.count == expected { return .satisfied }
+        return boundaries.count > expected ? .exceeded : .notCaughtUp
     }
 
     /// Shared post-recovery checks for the freshness gate: a converged
@@ -6718,10 +6899,11 @@ final class AppState: ObservableObject {
         if turnState.isRunning {
             return .routeToBusySubmission
         }
-        if transcriptFreshnessIsStale {
+        if transcriptFreshnessIsStale || pendingLocalOrderingDebt != nil {
             // Either recovery was superseded (a newer boundary owns the
             // conversation) or it genuinely failed to converge; both must
-            // not send into an unresolved ordering.
+            // not send into an unresolved ordering — freshness and local
+            // ordering debt alike.
             lifecycleLog.notice(
                 "submitComposer: pre-send freshness recovery did not converge; blocking send session=\(sessionID, privacy: .public)"
             )
@@ -6835,8 +7017,15 @@ final class AppState: ObservableObject {
                     // A steered/queued/redirected outcome joined a turn that
                     // was ALREADY running — possibly started by another
                     // surface — so it is not proof of a locally-owned turn;
-                    // the optimistic row gets no continuity marker.
+                    // the optimistic row gets no continuity marker. It DOES
+                    // persist as a canonical user row beyond the frontier,
+                    // though: carry ordering debt forward so the next local
+                    // turn anchors past it.
                     locallyOwnedInFlightTurn = nil
+                    recordLocalOrderingDebt(
+                        sessionIDs: submissionSessionIDs,
+                        baseline: preSubmitOrderingBaseline
+                    )
                 } else {
                     // The turn in flight is now provably Conduit's own: record
                     // the optimistic user row so a later foreground freshness
@@ -6893,13 +7082,25 @@ final class AppState: ObservableObject {
                     // by the time recovery looked). The submission stays
                     // accepted: the composer remains cleared, nothing is
                     // restored, and the transcript converges on the next
-                    // bounded refresh.
+                    // bounded refresh. That verification proved the turn
+                    // persisted but did not re-anchor the ordering frontier,
+                    // so an unobserved boundary leaves debt.
                     lifecycleLog.notice(
                         "prompt.submit accepted (durable transcript); turn settled session=\(sessionId, privacy: .public)"
                     )
                     if isCurrentComposerSubmission(submissionContext) {
                         turnState = .idle
                         turnStateIsStale = false
+                        // The marker is nil here (prompt.submit threw), but
+                        // the durable transcript PROVED this submission's
+                        // turn persisted: record its ordering debt from the
+                        // frame-captured baseline so the next local turn
+                        // anchors past it.
+                        recordLocalOrderingDebt(
+                            sessionIDs: submissionSessionIDs,
+                            baseline: preSubmitOrderingBaseline
+                        )
+                        locallyOwnedInFlightTurn = nil
                     }
                     return true
                 case .notAccepted:
@@ -10833,11 +11034,51 @@ final class AppState: ObservableObject {
         if running {
             clearPendingDecisionRestorationGuard()
         } else {
-            // The turn settled: any locally-owned in-flight turn evidence
-            // expired with it.
+            // The turn settled. A locally-owned turn whose persisted
+            // boundary was never positively observed leaves ordering debt:
+            // Hermes persisted its user row at turn start, so the next
+            // locally-owned turn must anchor AFTER it.
+            recordLocalOrderingDebtIfTurnUnobserved()
             locallyOwnedInFlightTurn = nil
         }
         turnState = running ? .running : .idle
+    }
+
+    /// Records one unit of local ordering debt when a locally-owned turn
+    /// settles before any validated read observed its persisted boundary.
+    /// Debt counts accumulate when several locally-owned turns settle
+    /// without an intervening read; authoritative adoption (a reconcile
+    /// replacing the transcript) clears the debt outright. Identity
+    /// rotation between turns replaces the slot — an undercount, which
+    /// degrades to a spurious-but-safe authoritative reconcile, never to a
+    /// silent overshoot.
+    private func recordLocalOrderingDebtIfTurnUnobserved() {
+        guard let marker = locallyOwnedInFlightTurn,
+              !marker.persistedBoundaryObserved else { return }
+        recordLocalOrderingDebt(
+            sessionIDs: marker.sessionIDs,
+            baseline: marker.preSubmitOrderingBaseline
+        )
+    }
+
+    /// Debt-accounting core. Debt is only meaningful when the ordering
+    /// baseline was PROVABLE: an unknown baseline (never hydrated, legacy
+    /// gateway) has no ordering metadata to owe — the next turn's
+    /// foreground classifies inconclusive and takes the conservative
+    /// attach, exactly as before ordering evidence existed.
+    private func recordLocalOrderingDebt(
+        sessionIDs: Set<String>,
+        baseline: PersistedOrderingBaseline
+    ) {
+        guard !baseline.isUnknown else { return }
+        if pendingLocalOrderingDebt?.sessionIDs == sessionIDs {
+            pendingLocalOrderingDebt?.expectedUserTurnCount += 1
+        } else {
+            pendingLocalOrderingDebt = PendingLocalOrderingDebt(
+                sessionIDs: sessionIDs,
+                expectedUserTurnCount: 1
+            )
+        }
     }
 
     private func applyResponseHapticSignal(_ signal: ResponseHapticPolicy.Signal) {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -525,21 +525,57 @@ final class AppState: ObservableObject {
     /// accepted (or ambiguity recovery proves `.acceptedRunning`), and
     /// validated at use against the transcript (the optimistic user row must
     /// still be present, unpersisted, and head a fully-unpersisted suffix)
-    /// plus the local turn state. `preSubmitDurableAnchorID` is the newest
-    /// durably-proven row captured BEFORE the send changed the transcript:
+    /// plus the local turn state. `preSubmitOrderingBaseline` freezes the
+    /// persisted ordering frontier BEFORE the send changes the transcript:
     /// the ordering anchor that lets a later bounded tail read classify
     /// persisted advancement as belonging to our turn (Hermes persists the
     /// user row at turn start, so the twin of the optimistic bubble is
-    /// normally there) versus belonging to a later foreign turn. Optimistic
+    /// normally there) versus belonging to a later foreign turn. Freezing at
+    /// submit time is load-bearing: a later frontier advance never moves a
+    /// live marker's baseline, so our turn's own persisted rows still count
+    /// as boundaries against a foreign turn that starts after it. Optimistic
     /// row ids never enter `durablePersistedRowIDs`; the two identities stay
     /// distinct — the marker only asserts that ONE new persisted user turn
     /// is expected while our turn is in flight.
     private struct LocallyOwnedInFlightTurn {
         var sessionIDs: Set<String>
         var optimisticUserRowID: String
-        var preSubmitDurableAnchorID: String?
+        var preSubmitOrderingBaseline: PersistedOrderingBaseline
     }
     private var locallyOwnedInFlightTurn: LocallyOwnedInFlightTurn?
+    /// Persisted ORDERING evidence — deliberately distinct from
+    /// `durablePersistedRowIDs` (provenance for rows currently represented
+    /// in the visible transcript). This is the newest durable row Conduit
+    /// has POSITIVELY observed through a validated bounded persisted-history
+    /// read or hydration, or a positive proof that the persisted transcript
+    /// is EMPTY. The visible transcript may keep an optimistic row whose
+    /// durable twin the frontier already knows about; the optimistic row is
+    /// never rewritten, the twin is never merged behind it, and the twin's
+    /// id never enters visible provenance — advancing the frontier is purely
+    /// ordering metadata for the NEXT locally-owned turn's baseline.
+    /// Conversation-scoped: reset on session/profile switch, conversation
+    /// replacement, sign-out; re-anchored by every authoritative reconcile
+    /// adoption and advancement merge, and advanced by every validated
+    /// `.unchanged` bounded read. Assignment is a RE-ANCHORING on the read's
+    /// own positive observation, not a monotonic advance: a validated read
+    /// whose page no longer contains the previous frontier row (server-side
+    /// deletion) re-anchors lower or to unknown — every use site verifies
+    /// anchors by id-presence in the page, so a stale anchor degrades to
+    /// inconclusive, never to a false verdict.
+    private struct PersistedOrderingFrontier {
+        var newestObservedDurableRowID: String?
+        var isPositivelyEmpty = false
+
+        /// Positively empty deliberately wins over an anchored id: the two
+        /// states are mutually exclusive by construction (see
+        /// `orderingFrontier(from:)`), and emptiness is the stronger claim.
+        var baseline: PersistedOrderingBaseline {
+            if isPositivelyEmpty { return .positivelyEmpty }
+            if let newestObservedDurableRowID { return .anchored(newestObservedDurableRowID) }
+            return .unknown
+        }
+    }
+    private var persistedOrderingFrontier = PersistedOrderingFrontier()
     @Published private(set) var busyInputMode: BusyInputMode = .steer
     @Published private(set) var displayPreferences = ProfileDisplayPreferences()
     @Published var streamingText = ""
@@ -2925,8 +2961,14 @@ final class AppState: ObservableObject {
             } ?? false
             // Adopt the durable row ids ONLY from a transcript this reconcile
             // validated and accepted; they anchor the ambiguous-delivery
-            // verifier's ordering evidence for this conversation.
+            // verifier's ordering evidence for this conversation. The
+            // persisted ORDERING frontier is re-established from the same
+            // acceptance — never carried over from a previous conversation
+            // state.
             durablePersistedRowIDs = (transcriptMatches ? transcript?.durableRowIDs : nil) ?? []
+            persistedOrderingFrontier = Self.orderingFrontier(
+                from: transcriptMatches ? transcript : nil
+            )
 
             // Capture the pre-reconcile transcript and window for the graft
             // decision below before either is replaced. The window write
@@ -4835,22 +4877,84 @@ final class AppState: ObservableObject {
 
     // MARK: - Cross-surface transcript freshness
 
-    /// Transcript-scoped lifecycle evidence (freshness uncertainty and
-    /// locally-owned turn provenance) belongs to the conversation it was
-    /// captured for. Call wherever the transcript is wholesale reset for a
-    /// new/different conversation identity: sign-out, profile switch,
-    /// conversation replacement, session open.
+    /// Ordering baseline a locally-owned turn captured at submit time.
+    private enum PersistedOrderingBaseline {
+        /// The newest durable row positively observed at submit time.
+        case anchored(String)
+        /// A validated read positively proved the persisted transcript EMPTY.
+        /// Valid ordering evidence — distinct from `unknown`, because a
+        /// single new user-turn boundary after a known-empty baseline is
+        /// provably the first turn.
+        case positivelyEmpty
+        /// No usable persisted ordering evidence (never hydrated, legacy
+        /// hydration, invalidated): every comparison stays inconclusive.
+        case unknown
+
+        var isPositivelyEmpty: Bool {
+            if case .positivelyEmpty = self { return true }
+            return false
+        }
+    }
+
+    /// Derives ordering evidence from a transcript a reconcile or freshness
+    /// read validated: a contract page anchors on its newest durable row
+    /// (contract pages carry durable ids on every row); a positively empty
+    /// page proves emptiness; anything else (legacy one-shot hydration, no
+    /// transcript) leaves the ordering evidence UNKNOWN — never carried over
+    /// from a previous conversation state.
+    private static func orderingFrontier(
+        from transcript: PersistedSessionTranscript?
+    ) -> PersistedOrderingFrontier {
+        guard let transcript,
+              let page = transcript.page,
+              page.honorsTailContract else {
+            return PersistedOrderingFrontier()
+        }
+        // Anchor on the NEWEST row the page positively proves durable: the
+        // page's newest row may normalize without a durable id while older
+        // rows carry theirs, and that older durable row is still the best
+        // positively-observed ordering anchor.
+        if let anchorIndex = transcript.messages.lastIndex(where: {
+            transcript.durableRowIDs.contains($0.id)
+        }) {
+            return PersistedOrderingFrontier(
+                newestObservedDurableRowID: transcript.messages[anchorIndex].id
+            )
+        }
+        // Emptiness is proven on the RAW row view: a page whose rows all
+        // normalize away (hidden display_kind scaffolding) still carries
+        // durable ids and is NOT a positively empty transcript.
+        if transcript.messages.isEmpty,
+           transcript.durableRowIDs.isEmpty,
+           !page.mayHaveOlderRows(fetchedRowCount: 0) {
+            return PersistedOrderingFrontier(isPositivelyEmpty: true)
+        }
+        return PersistedOrderingFrontier()
+    }
+
+    /// Transcript-scoped lifecycle evidence (freshness uncertainty,
+    /// locally-owned turn provenance, persisted ordering evidence) belongs
+    /// to the conversation it was captured for. Call wherever the
+    /// transcript is wholesale reset for a new/different conversation
+    /// identity: sign-out, profile switch, conversation replacement, session
+    /// open.
     private func resetTranscriptLifecycleEvidence() {
         transcriptFreshnessIsStale = false
         locallyOwnedInFlightTurn = nil
+        persistedOrderingFrontier = PersistedOrderingFrontier()
     }
 
     /// Outcome of the bounded persisted-tail freshness comparison against the
     /// locally adopted durable frontier.
     private enum ForegroundFreshnessVerdict {
         /// The newest page overlaps the local durable frontier and contains
-        /// nothing beyond it: the local transcript is current.
-        case unchanged
+        /// nothing beyond it (or, behind a locally-owned optimistic tail,
+        /// exactly the expected user-turn boundary): the local transcript is
+        /// current. The payload is the persisted ordering evidence this
+        /// validated read positively observed — the caller may advance the
+        /// ordering frontier with it while the visible transcript stays
+        /// untouched.
+        case unchanged(observedOrderingFrontier: PersistedOrderingFrontier)
         /// The page overlaps the frontier and holds validated durable rows
         /// after it: persisted activity the local transcript never saw.
         case advanced(transcript: PersistedSessionTranscript, newRows: [ChatMessage])
@@ -4917,17 +5021,10 @@ final class AppState: ObservableObject {
                   transcript.messages.isEmpty || !transcript.durableRowIDs.isEmpty else {
                 return .inconclusive
             }
-            // A positively empty page with no older rows proves the
-            // conversation has no persisted rows at all: an idle runtime
-            // cannot hide anything behind it, and an empty local transcript
-            // has nothing to diverge from.
-            if transcript.messages.isEmpty {
-                guard !page.mayHaveOlderRows(fetchedRowCount: 0),
-                      lastLocalMessageID == nil else {
-                    return .inconclusive
-                }
-                return .unchanged
-            }
+            // Identity first — even an empty page must belong to THIS
+            // conversation before it can prove anything (a page echoing a
+            // foreign session id is never evidence; pages echoing no id at
+            // all match by construction).
             guard transcriptMatchesSession(
                 transcript,
                 requestedSessionId: requestedSessionID,
@@ -4935,6 +5032,35 @@ final class AppState: ObservableObject {
             ) else {
                 // The endpoint answered for a different conversation
                 // identity: never merge rows from a foreign transcript.
+                return .inconclusive
+            }
+            // A positively empty page with no older rows proves the
+            // conversation has no persisted rows at all: an idle runtime
+            // cannot hide anything behind it, and an empty local transcript
+            // has nothing to diverge from. A visible optimistic tail over a
+            // positively empty page can only be a locally-owned turn whose
+            // rows simply have not persisted yet — still observational; any
+            // other tail has no ordering proof.
+            if transcript.messages.isEmpty {
+                // A page whose raw rows all normalize away (hidden
+                // scaffolding) is not positively empty — its durable ids
+                // prove rows exist.
+                guard transcript.durableRowIDs.isEmpty,
+                      !page.mayHaveOlderRows(fetchedRowCount: 0) else {
+                    return .inconclusive
+                }
+                if lastLocalMessageID == nil {
+                    return .unchanged(
+                        observedOrderingFrontier: Self.orderingFrontier(from: transcript)
+                    )
+                }
+                if let locallyOwnedTurn,
+                   locallyOwnedTurn.baseline.isPositivelyEmpty,
+                   livenessIsRunning {
+                    return .unchanged(
+                        observedOrderingFrontier: Self.orderingFrontier(from: transcript)
+                    )
+                }
                 return .inconclusive
             }
             let tailIsDurablyAnchored = lastLocalMessageID.map {
@@ -4970,7 +5096,9 @@ final class AppState: ObservableObject {
                 heldIDs: localMessageIDs
             )
             if newRows.isEmpty {
-                return .unchanged
+                return .unchanged(
+                    observedOrderingFrontier: Self.orderingFrontier(from: transcript)
+                )
             }
             return .advanced(transcript: transcript, newRows: newRows)
         }
@@ -5006,23 +5134,45 @@ final class AppState: ObservableObject {
             // turn landed at all: the authoritative refresh converges it.
             return .inconclusive
         }
-        guard let anchorID = owned.preSubmitDurableAnchorID,
-              let anchorIndex = transcript.messages.lastIndex(where: {
-                  $0.id == anchorID
-              }) else {
-            // No pre-submit ordering anchor, or it rotated out of the newest
-            // page (a long turn can push hundreds of rows past the window):
-            // no boundary proof — same invariant as the anchored path.
+        let newRows: [ChatMessage]
+        switch owned.baseline {
+        case .unknown:
+            // No usable ordering evidence was captured at submit time.
             return .inconclusive
+        case .anchored(let anchorID):
+            guard let anchorIndex = transcript.messages.lastIndex(where: {
+                $0.id == anchorID
+            }) else {
+                // The anchor rotated out of the newest page (a long turn can
+                // push hundreds of rows past the window): no boundary proof —
+                // same invariant as the anchored path.
+                return .inconclusive
+            }
+            newRows = persistedRowsAfter(
+                anchorIndex,
+                in: transcript,
+                heldIDs: localMessageIDs
+            )
+        case .positivelyEmpty:
+            // The whole persisted transcript follows the empty baseline, so
+            // every page row is a candidate — but only when the page is
+            // complete: older rotated-out rows could hide additional user
+            // boundaries and would make the count understate.
+            guard let page = transcript.page,
+                  !page.mayHaveOlderRows(fetchedRowCount: page.rawReturned) else {
+                return .inconclusive
+            }
+            newRows = persistedRowsAfter(
+                nil,
+                in: transcript,
+                heldIDs: localMessageIDs
+            )
         }
-        let newRows = persistedRowsAfter(
-            anchorIndex,
-            in: transcript,
-            heldIDs: localMessageIDs
-        )
         if newRows.isEmpty {
             // Nothing of ours persisted yet — the earliest in-flight shape.
-            return .unchanged
+            return .unchanged(
+                observedOrderingFrontier: Self.orderingFrontier(from: transcript)
+            )
         }
         let newUserTurnBoundaries = newRows.filter { $0.role == .user }
         guard let firstRow = newRows.first, firstRow.role == .user,
@@ -5030,8 +5180,13 @@ final class AppState: ObservableObject {
             return .inconclusive
         }
         // Exactly the expected twin of our optimistic Turn A user row (plus
-        // any Turn A output/tool rows): our turn is still the only one.
-        return .unchanged
+        // any Turn A output/tool rows): our turn is still the only one. The
+        // visible transcript stays untouched, but the ordering frontier may
+        // advance through the newest observed durable row of this proven
+        // Turn A region so the NEXT locally-owned turn anchors past it.
+        return .unchanged(
+            observedOrderingFrontier: Self.orderingFrontier(from: transcript)
+        )
     }
 
     /// Runs the bounded cross-surface freshness reconciliation for a
@@ -5144,14 +5299,21 @@ final class AppState: ObservableObject {
                 token: token,
                 automaticWorkToken: automaticWorkToken
             )
-        case .unchanged:
+        case let .unchanged(observedOrderingFrontier):
             lifecycleLog.notice(
                 "Foreground freshness: probe=\(livenessIsRunning ? "running" : "idle", privacy: .public) session=\(requestedSessionID, privacy: .public) verdict=unchanged → observational adopt"
             )
             // The bounded read proved the durable conversation current (an
             // optimistic locally-owned tail is live-turn content, not
-            // divergence).
+            // divergence). The visible transcript stays untouched, but the
+            // read's validated ordering evidence advances the persisted
+            // ordering frontier — pure metadata the NEXT locally-owned turn
+            // anchors against.
             transcriptFreshnessIsStale = false
+            // Re-anchor the ordering frontier on this read's own validated
+            // observation (see PersistedOrderingFrontier for the
+            // non-monotonicity rationale).
+            persistedOrderingFrontier = observedOrderingFrontier
             adoptForegroundLiveness(
                 livenessIsRunning,
                 token: token,
@@ -5200,10 +5362,10 @@ final class AppState: ObservableObject {
     /// Ordering evidence for the locally-owned optimistic tail, captured by
     /// `locallyOwnedFreshnessTurnEvidence` at freshness time. Non-nil means
     /// the trailing unpersisted rows belong to this surface's in-flight
-    /// turn; `preSubmitDurableAnchorID` is the ordering anchor the bounded
-    /// tail is classified against.
+    /// turn; `baseline` is the submit-time ordering anchor the bounded tail
+    /// is classified against.
     private struct LocallyOwnedTurnTailEvidence {
-        let preSubmitDurableAnchorID: String?
+        let baseline: PersistedOrderingBaseline
     }
 
     /// Non-nil when the transcript's trailing unpersisted rows belong to a
@@ -5234,7 +5396,7 @@ final class AppState: ObservableObject {
             return nil
         }
         return LocallyOwnedTurnTailEvidence(
-            preSubmitDurableAnchorID: marker.preSubmitDurableAnchorID
+            baseline: marker.preSubmitOrderingBaseline
         )
     }
 
@@ -5242,13 +5404,15 @@ final class AppState: ObservableObject {
     /// local transcript does not already hold — rows streamed in live under
     /// any identity dedupe by id, in both verdict paths.
     private func persistedRowsAfter(
-        _ anchorIndex: Int,
+        _ anchorIndex: Int?,
         in transcript: PersistedSessionTranscript,
         heldIDs: Set<String>
     ) -> [ChatMessage] {
         var knownIDs = heldIDs
         var newRows: [ChatMessage] = []
-        for row in transcript.messages[transcript.messages.index(after: anchorIndex)...]
+        let firstCandidateIndex = anchorIndex.map { $0 + 1 }
+            ?? transcript.messages.startIndex
+        for row in transcript.messages[firstCandidateIndex...]
         where knownIDs.insert(row.id).inserted {
             newRows.append(row)
         }
@@ -5300,8 +5464,10 @@ final class AppState: ObservableObject {
         }
         messages = merged
         // The bounded read just proved exactly which persisted rows were
-        // missing and merged them: transcript freshness is restored.
+        // missing and merged them: transcript freshness is restored, and the
+        // accepted page re-establishes the persisted ordering frontier.
         transcriptFreshnessIsStale = false
+        persistedOrderingFrontier = Self.orderingFrontier(from: transcript)
         // The merge just made the newest persisted page local: adopt its
         // durable ids as the frontier (same per-hydration replacement
         // semantics as reconcile) so the next freshness check anchors
@@ -6501,8 +6667,11 @@ final class AppState: ObservableObject {
                 locallyOwnedTurn: nil
             )
             switch verdict {
-            case .unchanged:
+            case let .unchanged(observedOrderingFrontier):
                 transcriptFreshnessIsStale = false
+                // Re-anchor the ordering frontier on the read's validated
+                // observation (non-monotonic by design).
+                persistedOrderingFrontier = observedOrderingFrontier
                 return .proceed
             case let .advanced(transcript, newRows):
                 applyPersistedForegroundAdvancement(
@@ -6581,12 +6750,12 @@ final class AppState: ObservableObject {
             durableIDs: durablePersistedRowIDs,
             holdsUnprovenRows: messages.contains { !durablePersistedRowIDs.contains($0.id) }
         )
-        // The locally-owned turn marker's ordering anchor: the newest
-        // durably-proven row, captured BEFORE the optimistic append changes
-        // the transcript below.
-        let preSubmitDurableAnchorID = messages.last(where: {
-            durablePersistedRowIDs.contains($0.id)
-        })?.id
+        // The locally-owned turn marker's ordering baseline, frozen BEFORE
+        // the optimistic append changes the transcript below: the persisted
+        // ordering FRONTIER, which may already run past the visible durable
+        // tail (a prior freshness read can have positively observed the
+        // previous turn's durable twins without adopting them visibly).
+        let preSubmitOrderingBaseline = persistedOrderingFrontier.baseline
         // The identity under probe must be captured BEFORE any await — never
         // re-derived from the mutable active session afterwards.
         let submissionSessionIDs = acceptedIdentitySessionIDs(forRequested: sessionId)
@@ -6676,7 +6845,7 @@ final class AppState: ObservableObject {
                     locallyOwnedInFlightTurn = LocallyOwnedInFlightTurn(
                         sessionIDs: submissionSessionIDs,
                         optimisticUserRowID: userMessage.id,
-                        preSubmitDurableAnchorID: preSubmitDurableAnchorID
+                        preSubmitOrderingBaseline: preSubmitOrderingBaseline
                     )
                 }
             }
@@ -6714,7 +6883,7 @@ final class AppState: ObservableObject {
                         locallyOwnedInFlightTurn = LocallyOwnedInFlightTurn(
                             sessionIDs: submissionSessionIDs,
                             optimisticUserRowID: userMessage.id,
-                            preSubmitDurableAnchorID: preSubmitDurableAnchorID
+                            preSubmitOrderingBaseline: preSubmitOrderingBaseline
                         )
                     }
                     return true

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -5748,7 +5748,12 @@ final class AppState: ObservableObject {
                         "prompt.submit state unresolved; restoring unsent state session=\(sessionId, privacy: .public)"
                     )
                 }
-                errorMessage = "Failed to send: \(error.localizedDescription)"
+                // Presentation writes below are submission-owned too: A's
+                // failed send must not paint an error onto the session the
+                // user switched to while recovery was suspended.
+                if isCurrentComposerSubmission(submissionContext) {
+                    errorMessage = "Failed to send: \(error.localizedDescription)"
+                }
                 if !reconnected, isCurrentComposerSubmission(submissionContext) {
                     await recoverComposerSubmission(using: submissionContext)
                 }
@@ -5756,7 +5761,9 @@ final class AppState: ObservableObject {
                 // authoritative transcript, so the restoration happened there.
                 return false
             }
-            errorMessage = "Failed to send: \(error.localizedDescription)"
+            if isCurrentComposerSubmission(submissionContext) {
+                errorMessage = "Failed to send: \(error.localizedDescription)"
+            }
             await recoverComposerSubmission(using: submissionContext)
             return false
         }
@@ -5897,16 +5904,46 @@ final class AppState: ObservableObject {
     }
 
     /// Durable before/after identity captured BEFORE the optimistic append.
-    /// The submitted turn is proven by ORDERING (rows the conversation did not
-    /// hold at submit time) corroborated by user-role content — never by
-    /// content alone, since identical texts are legitimate.
+    ///
+    /// Only rows backed by trusted durable persisted identity may serve as
+    /// baseline evidence. Visible `ChatMessage.id` values for optimistic or
+    /// locally synthesized rows (`local-…`, tool/reasoning/review cards) are
+    /// presentation identities: when Hermes persists those rows it mints NEW
+    /// database ids, so "persisted id not in the visible set" cannot prove a
+    /// row is new. The baseline therefore records the durable ids separately
+    /// and flags whether the conversation holds any local-only row whose
+    /// persisted twin is unknown.
     struct PromptTranscriptBaseline {
-        let knownMessageIDs: Set<String>
-        let knownMessageCount: Int
+        /// Visible ids backed by durable persisted identity (hydrated REST
+        /// rows), usable as overlap anchors against a persisted tail.
+        let durableIDs: Set<String>
+        /// Whether some pre-submit conversation content exists only as a
+        /// local row (e.g. an earlier optimistic send that was never
+        /// re-hydrated). If so, a matching persisted row after the anchor
+        /// could belong to THAT content, and acceptance is unprovable.
+        let includesLocalOnlyRows: Bool
 
         init(messages: [ChatMessage]) {
-            self.knownMessageIDs = Set(messages.map(\.id))
-            self.knownMessageCount = messages.count
+            var durable = Set<String>()
+            var sawLocalOnly = false
+            for message in messages {
+                if Self.isLocalSyntheticID(message.id) {
+                    sawLocalOnly = true
+                } else {
+                    durable.insert(message.id)
+                }
+            }
+            self.durableIDs = durable
+            self.includesLocalOnlyRows = sawLocalOnly
+        }
+
+        /// Locally synthesized presentation ids that never correspond 1:1 to
+        /// a persisted row id. Mirrors the id schemes AppState mints for
+        /// optimistic sends, live tool/reasoning/review projections, and
+        /// locally restored decision cards.
+        static func isLocalSyntheticID(_ id: String) -> Bool {
+            ["local-", "tool-start-", "tool-complete-", "review-summary-", "reasoning-", "approval-", "clarify-"]
+                .contains { id.hasPrefix($0) }
         }
     }
 
@@ -5946,53 +5983,55 @@ final class AppState: ObservableObject {
         }
 
         let wanted = submittedText.trimmingCharacters(in: .whitespacesAndNewlines)
-        let isNewRow: (ChatMessage) -> Bool = { message in
-            !baseline.knownMessageIDs.contains(message.id)
-        }
         let contentMatches: (ChatMessage) -> Bool = { message in
             message.role == .user
                 && message.content.trimmingCharacters(in: .whitespacesAndNewlines) == wanted
         }
 
         if idsAreDurable {
-            if tail.contains(where: { isNewRow($0) && contentMatches($0) }) {
-                // A user row this conversation did not hold before the
-                // submission carries the submitted text: the turn landed.
-                // Response rows after it only strengthen the proof; their
-                // absence means the accepted turn was interrupted, which is
-                // still acceptance.
-                return .present
+            // Overlap anchor: the NEWEST tail row the pre-submit durable
+            // evidence already held. Only rows strictly after that anchor are
+            // candidates for the submitted turn — a matching row at or before
+            // the anchor belongs to an OLDER identical send.
+            let anchorIndex = tail.lastIndex { baseline.durableIDs.contains($0.id) }
+            let candidates: ArraySlice<ChatMessage> = anchorIndex.map { anchor in
+                tail[tail.index(after: anchor)...]
+            } ?? tail[tail.startIndex..<tail.startIndex]
+            let candidateMatches = candidates.contains(where: contentMatches)
+
+            if candidateMatches {
+                if anchorIndex != nil, !baseline.includesLocalOnlyRows {
+                    // Every pre-submit row was durably identified, so the
+                    // anchor proves everything up to it; a matching user row
+                    // after the anchor can only be the new submission.
+                    return .present
+                }
+                // Either no durable anchor exists to order against, or the
+                // conversation held local-only rows whose persisted twins are
+                // unknown: an identical older row is indistinguishable from
+                // the new submission. Never fabricate certainty.
+                return .indeterminate
             }
-            if tail.contains(where: isNewRow) {
-                // The durable transcript advanced past the submit-time
-                // baseline without any new user row carrying the submitted
-                // text: whatever landed, this prompt did not.
+            if anchorIndex != nil {
+                // The tail advanced past the durable anchor without any
+                // matching user row: whatever landed, this prompt did not.
                 return .absent
             }
-            // The tail is exactly what this conversation already held: no
-            // new row at all — the submitted turn never landed.
+            // No anchor row appears in the tail (rotated out / empty
+            // baseline). Content absence still proves non-acceptance; content
+            // presence without ordering does not prove acceptance.
+            if tail.contains(where: contentMatches) {
+                return .indeterminate
+            }
             return .absent
         }
 
         // Positional-id fallback (legacy one-shot transcript): row identity
-        // cannot distinguish new from old rows, so decide by transcript
-        // growth plus the newest user row.
-        if tail.count <= baseline.knownMessageCount {
-            // Nothing landed beyond what this conversation already held.
-            return .absent
-        }
-        let newestUserRow = tail.last(where: { $0.role == .user })
-        if let newestUserRow, contentMatches(newestUserRow) {
-            // The transcript grew and its newest user turn carries the
-            // submitted text: acceptance, settled.
-            return .present
-        }
+        // cannot distinguish new from old rows at all, so a matching row is
+        // never proof of acceptance. Content absence proves non-acceptance.
         if tail.contains(where: contentMatches) {
-            // Grew with our text present but not newest — an identical older
-            // send makes this ambiguous.
             return .indeterminate
         }
-        // Grew without the submitted text: this prompt did not land.
         return .absent
     }
 

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -181,6 +181,11 @@ struct PersistedSessionTranscript {
     /// Nil (or an echo without the `order=latest` tail contract) means the
     /// backend served a one-shot full transcript.
     var page: PersistedTranscriptPagination.PageInfo?
+    /// Row ids positively extracted from raw rows carrying a durable
+    /// `id` / `message_id` key, populated only when this transcript came from
+    /// a validated `order=latest` page. Empty for legacy one-shot reads,
+    /// whose row identity is positional and untrustworthy.
+    var durableRowIDs: Set<String> = []
 }
 
 struct ComposerSubmissionContext: Equatable {
@@ -455,6 +460,15 @@ final class AppState: ObservableObject {
     /// transcript is either a legacy one-shot hydration or not persisted-
     /// history-backed at all, and no older pages exist to fetch.
     @Published private(set) var persistedTranscriptWindow: PersistedTranscriptWindowState?
+    /// Row ids POSITIVELY known to originate from validated persisted-
+    /// transcript hydration (raw rows carrying a durable `id`/`message_id`)
+    /// for the active conversation, adopted from the latest accepted
+    /// hydration and cleared whenever a reconcile begins or fails to adopt a
+    /// transcript. Consumed only by the ambiguous-delivery verifier as
+    /// ordering anchors — never populated from visible id shape, so local
+    /// optimistic / streaming / positional ids can never masquerade as
+    /// persisted anchors.
+    private var durablePersistedRowIDs: Set<String> = []
     @Published private(set) var isChatRefreshing = false
     @Published private(set) var chatResumeBehavior: ChatResumeBehavior = .continueWhereLeftOff
     @Published private(set) var chatReturnSurface: ChatReturnSurface = .conversation
@@ -2734,6 +2748,10 @@ final class AppState: ObservableObject {
             streamSessionIDAtBoundary: priorReconciliation?.streamSessionIDAtBoundary,
             bufferedEvents: bufferedEvents
         )
+        // Any previously held durable anchors belong to a different reconcile
+        // transaction; they are re-adopted below only from a transcript this
+        // reconcile actually validated and accepted.
+        durablePersistedRowIDs = []
         refreshActiveChatScrollSessionIdentity(isReconciling: true)
         turnState = .synchronizing
         let profile = activeProfile
@@ -2840,6 +2858,10 @@ final class AppState: ObservableObject {
                     resumedSessionId: result.sessionId
                 )
             } ?? false
+            // Adopt the durable row ids ONLY from a transcript this reconcile
+            // validated and accepted; they anchor the ambiguous-delivery
+            // verifier's ordering evidence for this conversation.
+            durablePersistedRowIDs = (transcriptMatches ? transcript?.durableRowIDs : nil) ?? []
 
             // Capture the pre-reconcile transcript and window for the graft
             // decision below before either is replaced. The window write
@@ -5609,10 +5631,15 @@ final class AppState: ObservableObject {
         cancelChatResumeRestoration()
         resetResponseHapticTurn()
         // Durable before/after identity for ambiguous-delivery recovery:
-        // everything this conversation held BEFORE the optimistic append, so
-        // a later bounded tail read can prove whether the submitted turn
-        // landed even when the registry has already gone idle/absent.
-        let submissionBaseline = PromptTranscriptBaseline(messages: messages)
+        // positively-proven persisted row ids (from the latest accepted
+        // hydration) plus whether the conversation holds rows whose persisted
+        // identity is unproven, so a later bounded tail read can decide
+        // whether the submitted turn landed even when the registry has gone
+        // idle/absent.
+        let submissionBaseline = PromptTranscriptBaseline(
+            durableIDs: durablePersistedRowIDs,
+            holdsUnprovenRows: messages.contains { !durablePersistedRowIDs.contains($0.id) }
+        )
         // The identity under probe must be captured BEFORE any await — never
         // re-derived from the mutable active session afterwards.
         let submissionSessionIDs = acceptedIdentitySessionIDs(forRequested: sessionId)
@@ -5905,45 +5932,30 @@ final class AppState: ObservableObject {
 
     /// Durable before/after identity captured BEFORE the optimistic append.
     ///
-    /// Only rows backed by trusted durable persisted identity may serve as
-    /// baseline evidence. Visible `ChatMessage.id` values for optimistic or
-    /// locally synthesized rows (`local-…`, tool/reasoning/review cards) are
-    /// presentation identities: when Hermes persists those rows it mints NEW
-    /// database ids, so "persisted id not in the visible set" cannot prove a
-    /// row is new. The baseline therefore records the durable ids separately
-    /// and flags whether the conversation holds any local-only row whose
-    /// persisted twin is unknown.
+    /// Only rows with POSITIVE durable provenance may serve as baseline
+    /// evidence: ids adopted from validated persisted-transcript hydration.
+    /// Visible `ChatMessage.id` values for optimistic or locally synthesized
+    /// rows (`local-…`, live tool/reasoning/review projections, positional
+    /// fallbacks, streaming completions) are presentation identities — Hermes
+    /// persists those rows under fresh database ids — so id shape can never
+    /// establish that a persisted row is new, and no prefix list can be
+    /// complete. The baseline therefore consumes only the positively adopted
+    /// durable id set and flags whether the conversation holds any visible
+    /// row whose persisted identity is unproven.
     struct PromptTranscriptBaseline {
-        /// Visible ids backed by durable persisted identity (hydrated REST
-        /// rows), usable as overlap anchors against a persisted tail.
+        /// Positively known durable persisted row ids for this conversation,
+        /// usable as overlap anchors against a persisted tail.
         let durableIDs: Set<String>
         /// Whether some pre-submit conversation content exists only as a
-        /// local row (e.g. an earlier optimistic send that was never
-        /// re-hydrated). If so, a matching persisted row after the anchor
-        /// could belong to THAT content, and acceptance is unprovable.
-        let includesLocalOnlyRows: Bool
+        /// row without durable provenance (e.g. an earlier optimistic send
+        /// that was never re-hydrated). If so, a matching persisted row after
+        /// the anchor could belong to THAT content, and acceptance is
+        /// unprovable.
+        let holdsUnprovenRows: Bool
 
-        init(messages: [ChatMessage]) {
-            var durable = Set<String>()
-            var sawLocalOnly = false
-            for message in messages {
-                if Self.isLocalSyntheticID(message.id) {
-                    sawLocalOnly = true
-                } else {
-                    durable.insert(message.id)
-                }
-            }
-            self.durableIDs = durable
-            self.includesLocalOnlyRows = sawLocalOnly
-        }
-
-        /// Locally synthesized presentation ids that never correspond 1:1 to
-        /// a persisted row id. Mirrors the id schemes AppState mints for
-        /// optimistic sends, live tool/reasoning/review projections, and
-        /// locally restored decision cards.
-        static func isLocalSyntheticID(_ id: String) -> Bool {
-            ["local-", "tool-start-", "tool-complete-", "review-summary-", "reasoning-", "approval-", "clarify-"]
-                .contains { id.hasPrefix($0) }
+        init(durableIDs: Set<String>, holdsUnprovenRows: Bool) {
+            self.durableIDs = durableIDs
+            self.holdsUnprovenRows = holdsUnprovenRows
         }
     }
 
@@ -5993,42 +6005,44 @@ final class AppState: ObservableObject {
             // evidence already held. Only rows strictly after that anchor are
             // candidates for the submitted turn — a matching row at or before
             // the anchor belongs to an OLDER identical send.
-            let anchorIndex = tail.lastIndex { baseline.durableIDs.contains($0.id) }
-            let candidates: ArraySlice<ChatMessage> = anchorIndex.map { anchor in
-                tail[tail.index(after: anchor)...]
-            } ?? tail[tail.startIndex..<tail.startIndex]
-            let candidateMatches = candidates.contains(where: contentMatches)
+            //
+            // A bounded `order=latest` page carries only the newest rows: an
+            // accepted turn can persist hundreds of rows after the
+            // submission, pushing BOTH the anchor and the submitted row out
+            // of this window. Without the anchor in the tail, ordering
+            // evidence is unavailable and content absence from the window
+            // proves nothing — the outcome is indeterminate, never
+            // notAccepted and never acceptedSettled.
+            guard let anchorIndex = tail.lastIndex(where: {
+                baseline.durableIDs.contains($0.id)
+            }) else {
+                return .indeterminate
+            }
+            let candidates = tail[tail.index(after: anchorIndex)...]
 
-            if candidateMatches {
-                if anchorIndex != nil, !baseline.includesLocalOnlyRows {
-                    // Every pre-submit row was durably identified, so the
-                    // anchor proves everything up to it; a matching user row
-                    // after the anchor can only be the new submission.
-                    return .present
+            if candidates.contains(where: contentMatches) {
+                if baseline.holdsUnprovenRows {
+                    // The conversation held visible rows whose persisted
+                    // twins are unknown: the matching candidate could be an
+                    // older identical send re-homed under a new id.
+                    return .indeterminate
                 }
-                // Either no durable anchor exists to order against, or the
-                // conversation held local-only rows whose persisted twins are
-                // unknown: an identical older row is indistinguishable from
-                // the new submission. Never fabricate certainty.
-                return .indeterminate
+                // Every pre-submit row was durably identified, so the anchor
+                // proves everything up to it; a matching user row after the
+                // anchor can only be the new submission.
+                return .present
             }
-            if anchorIndex != nil {
-                // The tail advanced past the durable anchor without any
-                // matching user row: whatever landed, this prompt did not.
-                return .absent
-            }
-            // No anchor row appears in the tail (rotated out / empty
-            // baseline). Content absence still proves non-acceptance; content
-            // presence without ordering does not prove acceptance.
-            if tail.contains(where: contentMatches) {
-                return .indeterminate
-            }
+            // The tail advanced past the durable anchor without any matching
+            // user row. The anchor's presence in this window bounds the
+            // search: the submitted row, if it had landed, would be newer
+            // than the anchor and therefore inside the window too.
             return .absent
         }
 
-        // Positional-id fallback (legacy one-shot transcript): row identity
-        // cannot distinguish new from old rows at all, so a matching row is
-        // never proof of acceptance. Content absence proves non-acceptance.
+        // Positional-id fallback (legacy one-shot transcript): this response
+        // IS the entire persisted transcript, so content absence proves
+        // non-acceptance — but row identity cannot distinguish new from old
+        // rows, so a matching row is never proof of acceptance.
         if tail.contains(where: contentMatches) {
             return .indeterminate
         }
@@ -7084,7 +7098,8 @@ final class AppState: ObservableObject {
             return .hydrated(PersistedSessionTranscript(
                 resolvedSessionId: Self.resolvedSessionId(in: response),
                 messages: MessageNormalizer.normalizeMessages(rawMessages.map(AnyCodable.from)),
-                page: page
+                page: page,
+                durableRowIDs: Set(rawMessages.compactMap(Self.durablePersistedRowID(from:)))
             ))
         }
     }
@@ -7120,6 +7135,42 @@ final class AppState: ObservableObject {
         ["messages", "data", "_array"]
             .compactMap { response[$0] as? [Any] }
             .first
+    }
+
+    /// Positively extracts the durable persisted row id from a raw `/messages`
+    /// row — the id the row actually persisted under — or nil when the row
+    /// carries no durable identity (the normalizer would fall back to a
+    /// positional index, which is presentation identity, not provenance).
+    ///
+    /// Keep the envelope merge and id-key order in sync with
+    /// `MessageNormalizer.normalizeMessages`, which consumes the same rows.
+    nonisolated static func durablePersistedRowID(from rawRow: Any) -> String? {
+        guard let envelope = rawRow as? [String: Any] else { return nil }
+        // Same envelope merge as normalizeMessages: `message` / `payload` /
+        // message-shaped `data` override the envelope, nested values win.
+        let dataMessage = envelope["data"] as? [String: Any]
+        let dataMessageIsCarrier = dataMessage.map { $0["role"] != nil || $0["type"] != nil } ?? false
+        let nested = (envelope["message"] as? [String: Any])
+            ?? (envelope["payload"] as? [String: Any])
+            ?? (dataMessageIsCarrier ? dataMessage : nil)
+            ?? [:]
+        var obj = envelope
+        for (key, value) in nested {
+            obj[key] = value
+        }
+        for key in ["id", "message_id"] {
+            switch obj[key] {
+            case let string as String where !string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty:
+                return string
+            case let number as NSNumber where number.doubleValue != 0:
+                // Match AnyCodable's number rendering so the extracted id is
+                // byte-identical to the normalized ChatMessage.id.
+                return String(number.doubleValue)
+            default:
+                continue
+            }
+        }
+        return nil
     }
 
     nonisolated static func resolvedSessionId(in response: [String: Any]) -> String? {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -494,20 +494,38 @@ final class AppState: ObservableObject {
     /// `prompt.submit` — Hermes would apply its busy policy to it and the
     /// message would silently join a turn the user never saw start.
     private(set) var turnStateIsStale = false
-    /// Monotonic revision of AUTHORITATIVE live turn-lifecycle evidence:
-    /// every `setRunning` edge (sessionBusy, message start/delta, completion,
-    /// interruption, error, registry-probe corrections, buffered-event
-    /// replay), the authoritative resume-snapshot adoption, and the typed
-    /// busy-submission outcome advance it. Optimistic local writes (the
-    /// pre-send `.running`, the ambiguous-recovery stamps themselves) never
-    /// do. The ambiguous-submission recovery captures this revision at its
-    /// registry observation; a changed revision at stamp time proves newer
-    /// live evidence arrived while the recovery awaited, so the older
-    /// recovery result must not overwrite `turnState`/`turnStateIsStale`.
-    /// Plain value equality cannot prove that — the pre-send stamp already
-    /// leaves `turnState == .running`, so a newer `sessionBusy(true)` is
-    /// value-indistinguishable from the stale baseline.
-    private var turnLifecycleRevision: UInt64 = 0
+    /// Newest AUTHORITATIVE live turn-lifecycle evidence. Every `setRunning`
+    /// edge (sessionBusy, message start/delta, completion, interruption,
+    /// error, registry-probe corrections, buffered-event replay), the
+    /// authoritative resume-snapshot adoption, the typed busy-submission
+    /// outcome, and a successful steer advance the revision; optimistic local
+    /// writes (the pre-send `.running`, the ambiguous-recovery stamps
+    /// themselves) never do. The ambiguous-submission recovery captures this
+    /// evidence at its registry observation. At stamp time:
+    ///
+    /// - A changed REVISION proves newer live evidence arrived while the
+    ///   recovery awaited, so the older recovery result must not overwrite
+    ///   `turnState`/`turnStateIsStale`. Plain value equality cannot prove
+    ///   that — the pre-send stamp already leaves `turnState == .running`,
+    ///   so a newer `sessionBusy(true)` is value-indistinguishable from the
+    ///   stale baseline.
+    /// - The RUNNING half answers a separate question: whether accepted-turn
+    ///   OWNERSHIP is still live. Newer busy/running evidence does not
+    ///   invalidate a positively-proven accepted submission; newer
+    ///   settled/idle/error/interruption evidence does. Stamp authority and
+    ///   accepted provenance are therefore decided independently. The
+    ///   running half is a single NEWEST-EDGE bit, not per-turn tracking: a
+    ///   settle immediately followed by a successor turn's busy edge inside
+    ///   one recovery window reads as "running". That is accepted — marker
+    ///   use stays validated at the foreground (durable-twin check) and a
+    ///   later settle flows into the bounded-debt lifecycle, so the worst
+    ///   case is a spurious-but-safe reconcile.
+    private struct TurnLifecycleEvidence {
+        var revision: UInt64
+        var running: Bool
+    }
+
+    private var turnLifecycleEvidence = TurnLifecycleEvidence(revision: 0, running: false)
     /// Session identities with a locally-observed running turn at the last
     /// scene transition (empty = no continuity evidence). A foreground probe
     /// whose working/waiting row matches one of these ids continues a turn
@@ -3586,7 +3604,10 @@ final class AppState: ObservableObject {
             turnState = TurnState.fromGatewayRunning(result.snapshot.running)
         }
         // The resume snapshot is authoritative about the turn state.
-        turnLifecycleRevision &+= 1
+        turnLifecycleEvidence = TurnLifecycleEvidence(
+            revision: turnLifecycleEvidence.revision &+ 1,
+            running: turnState.isRunning
+        )
         turnStateIsStale = false
         return true
     }
@@ -7040,7 +7061,10 @@ final class AppState: ObservableObject {
                     // state was stale. Adopt the authoritative busy state so
                     // the composer keeps offering the configured busy action
                     // and the next submission is routed correctly.
-                    turnLifecycleRevision &+= 1
+                    turnLifecycleEvidence = TurnLifecycleEvidence(
+                        revision: turnLifecycleEvidence.revision &+ 1,
+                        running: true
+                    )
                     turnState = .running
                 }
                 turnStateIsStale = false
@@ -7071,8 +7095,23 @@ final class AppState: ObservableObject {
                     )
                 case .redirected:
                     // Hermes replaces/corrects the current live model request;
-                    // it does not create an independent canonical user turn.
+                    // it does not create an independent canonical user turn —
+                    // so ZERO new user boundaries are expected. But the
+                    // mutated turn can keep persisting assistant/tool rows
+                    // AFTER the current ordering frontier, so a redirect still
+                    // owes one final-tail observation (the settled-tail shape):
+                    // the next operation freezing a new-turn baseline performs
+                    // one bounded read — a non-user-only suffix advances the
+                    // frontier and clears the obligation, while any canonical
+                    // user boundary proves a later/new turn exists and forces
+                    // an authoritative reconcile before the send.
                     locallyOwnedInFlightTurn = nil
+                    recordLocalOrderingDebt(
+                        sessionIDs: submissionSessionIDs,
+                        baseline: preSubmitOrderingBaseline,
+                        expectedUserTurnIncrement: 0,
+                        allowTrailingRowsWithoutNewUserBoundary: true
+                    )
                 case .steered:
                     // Hermes normally injects this into the current run without
                     // a canonical user row. A steer arriving after the final
@@ -7097,14 +7136,14 @@ final class AppState: ObservableObject {
                 lifecycleLog.notice(
                     "prompt.submit ambiguous (\(error.localizedDescription, privacy: .private)); querying authoritative state session=\(sessionId, privacy: .public)"
                 )
-                let (resolution, reconnected, recoveryLifecycleRevision) = await reconcileAmbiguousPromptSubmission(
+                let (resolution, reconnected, recoveryEvidence) = await reconcileAmbiguousPromptSubmission(
                     requestedSessionID: sessionId,
                     acceptedSessionIDs: submissionSessionIDs,
                     baseline: submissionBaseline,
                     submittedText: text,
                     submissionContext: submissionContext
                 )
-                // Ordering guard for the recovery stamps: the recovery
+                // Ordering guard for the recovery STATE stamps: the recovery
                 // captured the lifecycle revision at its registry
                 // observation. A changed revision proves an authoritative
                 // live edge (sessionBusy, settlement, interruption, error,
@@ -7112,9 +7151,25 @@ final class AppState: ObservableObject {
                 // evidence is NEWER and owns the UI. Plain turnState equality
                 // cannot prove this: sendMessage stamped .running before
                 // prompt.submit, so a newer sessionBusy(true) leaves the
-                // value equal. Only the lifecycle stamps below are guarded —
-                // the acceptance decisions stay authoritative either way.
-                let recoveryOwnsLifecycleState = turnLifecycleRevision == recoveryLifecycleRevision
+                // value equal.
+                //
+                // Stamp authority and accepted-turn provenance are SEPARATE
+                // facts. A changed revision suppresses the lifecycle stamps
+                // but does NOT by itself erase this recovery's positive
+                // proof that the submitted turn was accepted and is ours:
+                // newer busy/running evidence leaves that ownership live,
+                // while newer settled/idle evidence ends it (the evidence's
+                // running half). Only the lifecycle stamps below are
+                // revision-guarded; the acceptance decisions stay
+                // authoritative either way.
+                let recoveryMayStampLifecycle = turnLifecycleEvidence.revision == recoveryEvidence.revision
+                // Whether the NEWEST authoritative lifecycle edge still
+                // reports the turn as running (a newest-edge bit, not
+                // per-turn tracking — see TurnLifecycleEvidence). Only
+                // decisive when the revision changed (newer evidence owns
+                // the lifecycle state): a newer busy edge keeps the accepted
+                // turn's local ownership live, a newer settled edge ends it.
+                let newestEdgeReportsRunning = turnLifecycleEvidence.running
                 // Every write below is submission-owned: the guard is
                 // re-checked inside each branch so a handoff during the
                 // recovery awaits cannot leak state into the new session.
@@ -7124,19 +7179,26 @@ final class AppState: ObservableObject {
                     // live: keep the optimistic user row and the running turn,
                     // and never re-send the prompt.
                     if isCurrentComposerSubmission(submissionContext) {
-                        if recoveryOwnsLifecycleState {
+                        if recoveryMayStampLifecycle {
                             turnState = .running
                             turnStateIsStale = false
+                        }
+                        // Provenance is independent of stamp authority:
+                        // acceptedRunning POSITIVELY proves this submission
+                        // was accepted and is the active turn. A newer busy
+                        // edge that raced the probe owns the lifecycle state
+                        // but does not erase that ownership — the marker must
+                        // still be installed so a later foreground can prove
+                        // same-turn continuity without a resume. Only newer
+                        // settled/idle evidence ends live ownership.
+                        if recoveryMayStampLifecycle || newestEdgeReportsRunning {
                             // Same proof as the ordinary success path: the
                             // turn in flight is provably Conduit's own
                             // submission. The anchor is intentionally the
                             // PRE-SEND capture even though ambiguity recovery
                             // may have re-hydrated the transcript in between:
                             // validation at use plus the anchor lookup at use
-                            // neutralize any staleness. Guarded with the
-                            // stamps: if newer evidence settled the turn while
-                            // the probe awaited, the older recovery must not
-                            // re-assert in-flight ownership.
+                            // neutralize any staleness.
                             locallyOwnedInFlightTurn = LocallyOwnedInFlightTurn(
                                 sessionIDs: submissionSessionIDs,
                                 optimisticUserRowID: userMessage.id,
@@ -7160,8 +7222,14 @@ final class AppState: ObservableObject {
                         "prompt.submit accepted (durable transcript); registry starting — liveness unresolved session=\(sessionId, privacy: .public)"
                     )
                     if isCurrentComposerSubmission(submissionContext) {
-                        if recoveryOwnsLifecycleState {
+                        if recoveryMayStampLifecycle {
                             turnState = .running
+                        }
+                        // Same provenance split as acceptedRunning: the
+                        // durable row proves the submission was accepted. A
+                        // newer busy edge keeps that ownership live; a newer
+                        // settled edge ends it.
+                        if recoveryMayStampLifecycle || newestEdgeReportsRunning {
                             locallyOwnedInFlightTurn = LocallyOwnedInFlightTurn(
                                 sessionIDs: submissionSessionIDs,
                                 optimisticUserRowID: userMessage.id,
@@ -7183,7 +7251,7 @@ final class AppState: ObservableObject {
                         "prompt.submit accepted (durable transcript); turn settled session=\(sessionId, privacy: .public)"
                     )
                     if isCurrentComposerSubmission(submissionContext) {
-                        if recoveryOwnsLifecycleState {
+                        if recoveryMayStampLifecycle {
                             turnState = .idle
                             turnStateIsStale = false
                         }
@@ -7191,7 +7259,10 @@ final class AppState: ObservableObject {
                         // the durable transcript PROVED this submission's
                         // turn persisted: record its ordering debt from the
                         // frame-captured baseline so the next local turn
-                        // anchors past it.
+                        // anchors past it. Retained even when a newer edge
+                        // owns the lifecycle state — the boundary was never
+                        // positively observed, which stays true regardless of
+                        // which edge is newest.
                         recordLocalOrderingDebt(
                             sessionIDs: submissionSessionIDs,
                             baseline: preSubmitOrderingBaseline
@@ -7206,7 +7277,7 @@ final class AppState: ObservableObject {
                         "prompt.submit not accepted (authoritative); restoring unsent state session=\(sessionId, privacy: .public)"
                     )
                     if isCurrentComposerSubmission(submissionContext),
-                       recoveryOwnsLifecycleState {
+                       recoveryMayStampLifecycle {
                         turnStateIsStale = false
                     }
                 case .unresolved:
@@ -7276,8 +7347,9 @@ final class AppState: ObservableObject {
     /// must never be re-sent; an idle/absent session means it was not.
     /// `reconnected` reports whether a transport recovery (with its own full
     /// transcript sync) ran, so the caller can skip a duplicate restoration.
-    /// `lifecycleRevision` is the `turnLifecycleRevision` captured at the
-    /// registry observation — the baseline the caller's stamp guard compares.
+    /// `lifecycleEvidence` is the `TurnLifecycleEvidence` captured at the
+    /// registry observation — the baseline the caller's stamp/provenance
+    /// guards compare.
     /// Internal (not private) so the classification contract is directly
     /// testable.
     enum AmbiguousPromptResolution {
@@ -7365,7 +7437,7 @@ final class AppState: ObservableObject {
         baseline: PromptTranscriptBaseline,
         submittedText: String,
         submissionContext: ComposerSubmissionContext
-    ) async -> (resolution: AmbiguousPromptResolution, reconnected: Bool, lifecycleRevision: UInt64) {
+    ) async -> (resolution: AmbiguousPromptResolution, reconnected: Bool, lifecycleEvidence: TurnLifecycleEvidence) {
         var reconnected = false
         var probeClient = client
         if probeClient?.isConnected != true {
@@ -7381,13 +7453,15 @@ final class AppState: ObservableObject {
         }
         guard isCurrentOrAliasedComposerSubmission(submissionContext),
               let probeClient else {
-            return (.unresolved, reconnected, turnLifecycleRevision)
+            return (.unresolved, reconnected, turnLifecycleEvidence)
         }
-        // The revision baseline for the caller's stamp guard, captured at the
+        // The evidence baseline for the caller's guards, captured at the
         // registry observation: the probe result already includes every edge
-        // processed up to this point, so anything that increments
-        // `turnLifecycleRevision` afterwards is strictly newer evidence.
-        let lifecycleRevision = turnLifecycleRevision
+        // processed up to this point, so any later revision increment is
+        // strictly newer evidence. Capturing BEFORE the probe (not after) is
+        // deliberate: an edge processed DURING the probe await may postdate
+        // the registry snapshot server-side, so it must keep winning.
+        let lifecycleEvidence = turnLifecycleEvidence
         // The alias set was captured from the ORIGINAL submission before any
         // await; it is never re-derived from the mutable active session here.
         let rows: [LiveSessionStatus]
@@ -7398,7 +7472,7 @@ final class AppState: ObservableObject {
                 rows = try await probeClient.activeSessions()
             }
         } catch {
-            return (.unresolved, reconnected, lifecycleRevision)
+            return (.unresolved, reconnected, lifecycleEvidence)
         }
         let matchedRow = rows.first(where: {
             acceptedSessionIDs.contains($0.runtimeSessionId) || acceptedSessionIDs.contains($0.storedSessionId)
@@ -7439,7 +7513,7 @@ final class AppState: ObservableObject {
                 transcript: transcript
             ),
             reconnected,
-            lifecycleRevision
+            lifecycleEvidence
         )
     }
 
@@ -8104,7 +8178,10 @@ final class AppState: ObservableObject {
             // policy — the session was RUNNING when the steer landed. That is
             // authoritative live liveness evidence for the recovery stamp
             // guard, even though steer writes no local turn state.
-            turnLifecycleRevision &+= 1
+            turnLifecycleEvidence = TurnLifecycleEvidence(
+                revision: turnLifecycleEvidence.revision &+ 1,
+                running: true
+            )
             // A successful steer is accepted by Hermes even if the user
             // switched sessions while the RPC was suspended. It has no local
             // post-await mutation, so preserve success for draft handling.
@@ -11208,7 +11285,10 @@ final class AppState: ObservableObject {
         guard turnState != .unsupportedGateway else { return }
         // Every call is authoritative live evidence, even a re-affirmation:
         // the ambiguity-recovery guard compares revisions, not values.
-        turnLifecycleRevision &+= 1
+        turnLifecycleEvidence = TurnLifecycleEvidence(
+            revision: turnLifecycleEvidence.revision &+ 1,
+            running: running
+        )
         if running {
             clearPendingDecisionRestorationGuard()
         } else {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -4348,7 +4348,7 @@ final class AppState: ObservableObject {
                             return
                         }
                         lifecycleLog.notice(
-                            "Foreground refresh: health check failed (\(error.localizedDescription, privacy: .public)); reconnecting"
+                            "Foreground refresh: health check failed (\(error.localizedDescription, privacy: .private)); reconnecting"
                         )
                         await self.reconnectForRetry(purpose: .automaticReturn)
                         self.settleReconciliation(token)
@@ -4527,50 +4527,60 @@ final class AppState: ObservableObject {
                 // Runtime present, liveness inconclusive: "starting" also
                 // covers promptless agent pre-warm (session.create / cold
                 // resume) and transiently masks a running turn during the
-                // build window, so it proves neither busy nor idle. Leave the
-                // local turn state exactly as the stream left it and let live
+                // build window, so it proves neither busy nor idle. Live
                 // events own the next edge; never manufacture a resume here.
+                // A transitional state (.synchronizing / .reconnecting) left
+                // by an aborted recovery attempt is NOT valid stream-owned
+                // state, though: normalize it to a usable neutral baseline
+                // (starting is never classified as running) so the composer
+                // cannot stay disabled indefinitely — and a newer buffered
+                // busy edge still wins during the boundary replay.
                 lifecycleLog.notice(
-                    "Foreground refresh: probe=starting session=\(requestedSessionID ?? "-", privacy: .public) → observation-only, state untouched"
+                    "Foreground refresh: probe=starting session=\(requestedSessionID ?? "-", privacy: .public) → observation-only, transitional state normalized"
                 )
+                if turnState == .synchronizing || turnState == .reconnecting {
+                    setRunning(false)
+                }
                 settleForegroundBoundary(token, automaticWorkToken: automaticWorkToken)
             } else if row.isRunning {
                 let acceptedIDs = acceptedIdentitySessionIDs(
                     forRequested: requestedSessionID ?? ""
                 )
                 let continuesLocalTurn = !preSuspensionRunningIDs.isDisjoint(with: acceptedIDs)
-                if continuesLocalTurn, !messages.isEmpty {
-                    // The same turn is still live over a hydrated transcript:
-                    // keep the session, the transcript, the streaming buffer,
-                    // and the PR #121 live reasoning projection exactly as
-                    // they are. Only the buffered events captured while the
-                    // reconciliation boundary was open need replaying —
-                    // nothing was replaced, so no dedup is needed.
-                    lifecycleLog.notice(
-                        "Foreground refresh: probe=live status=\(row.status, privacy: .public) session=\(requestedSessionID ?? "-", privacy: .public) → observation-only adopt"
-                    )
-                    adoptForegroundRunningState(
-                        reconciliationToken: token,
-                        automaticWorkToken: automaticWorkToken
-                    )
-                } else if !freshnessCheckArmed, !messages.isEmpty {
+                if !freshnessCheckArmed {
                     // Overlay-dip semantics: the socket survived the dip and
                     // live events kept the transcript current, so the
                     // observational adopt stands without a transcript read.
-                    lifecycleLog.notice(
-                        "Foreground refresh: probe=live status=\(row.status, privacy: .public) session=\(requestedSessionID ?? "-", privacy: .public) → observation-only adopt (unarmed)"
-                    )
-                    adoptForegroundRunningState(
-                        reconciliationToken: token,
-                        automaticWorkToken: automaticWorkToken
-                    )
-                } else if freshnessCheckArmed {
-                    // Working/waiting without turn-continuity evidence (or an
-                    // unanchored transcript) after a real background: a turn
-                    // another surface started may be missing locally. One
-                    // bounded persisted-tail read decides between an
-                    // observational adopt, a merged advancement, and the
-                    // bounded resume refresh.
+                    if !messages.isEmpty {
+                        lifecycleLog.notice(
+                            "Foreground refresh: probe=live status=\(row.status, privacy: .public) session=\(requestedSessionID ?? "-", privacy: .public) → observation-only adopt (unarmed)"
+                        )
+                        adoptForegroundRunningState(
+                            reconciliationToken: token,
+                            automaticWorkToken: automaticWorkToken
+                        )
+                    } else {
+                        // A running runtime over an empty local transcript
+                        // means this surface never hydrated (failed resume,
+                        // or the turn was started from another surface):
+                        // attach through the full refresh, whose resume
+                        // returns the live projection.
+                        lifecycleLog.notice(
+                            "Foreground refresh: probe=live localTranscript=empty → resume refresh (attach live projection)"
+                        )
+                        await syncSession(
+                            purpose: .automaticReturn,
+                            using: token,
+                            automaticWorkToken: automaticWorkToken
+                        )
+                    }
+                } else if continuesLocalTurn, !messages.isEmpty {
+                    // Same-session working is NOT same-turn proof: Turn A can
+                    // complete and Turn B start in the SAME session while
+                    // Conduit was suspended. One bounded tail read proves
+                    // continuity — an unchanged verdict keeps the zero-resume
+                    // fast path; anything else takes the authoritative
+                    // attach below (which owns the in-flight projection).
                     await reconcileForegroundCrossSurfaceActivity(
                         livenessIsRunning: true,
                         requestedSessionID: requestedSessionID ?? "",
@@ -4579,12 +4589,14 @@ final class AppState: ObservableObject {
                         automaticWorkToken: automaticWorkToken
                     )
                 } else {
-                    // A running runtime over an empty local transcript means
-                    // this surface never hydrated (failed resume, or the turn
-                    // was started from another surface): attach through the
-                    // full refresh, whose resume returns the live projection.
+                    // Working without turn-continuity evidence after a real
+                    // background: a turn this device never owned. Persisted
+                    // history alone cannot supply the in-flight assistant/
+                    // reasoning projection, so attach authoritatively — the
+                    // compact resume fast-path returns the live projection
+                    // and the reconcile merges the persisted prefix.
                     lifecycleLog.notice(
-                        "Foreground refresh: probe=live localTranscript=empty → resume refresh (attach live projection)"
+                        "Foreground refresh: probe=live status=\(row.status, privacy: .public) session=\(requestedSessionID ?? "-", privacy: .public) → authoritative attach (remote running turn)"
                     )
                     await syncSession(
                         purpose: .automaticReturn,
@@ -4643,7 +4655,7 @@ final class AppState: ObservableObject {
             // Older gateway or transient registry failure: keep the proven
             // resume-based refresh rather than guessing.
             lifecycleLog.notice(
-                "Foreground refresh: probe unavailable (\(reason, privacy: .public)) → resume refresh"
+                "Foreground refresh: probe unavailable (\(reason, privacy: .private)) → resume refresh"
             )
             await syncSession(
                 purpose: .automaticReturn,
@@ -4765,17 +4777,18 @@ final class AppState: ObservableObject {
         /// after it: persisted activity the local transcript never saw.
         case advanced(transcript: PersistedSessionTranscript, newRows: [ChatMessage])
         /// No durable ordering proof: the frontier rotated out of the newest
-        /// page, the read was a legacy one-shot without durable identity, the
-        /// response belongs to another conversation identity, the local tail
-        /// is not durably anchored, or there is no local frontier. Same
-        /// invariant as the ambiguous-delivery verifier — no anchor means
-        /// "unchanged" can never be declared.
+        /// page, the backend has no tail contract, the response belongs to
+        /// another conversation identity, the local tail is not durably
+        /// anchored, there is no local frontier, or the history source is
+        /// structurally absent. Same invariant as the ambiguous-delivery
+        /// verifier — no anchor means "unchanged" can never be declared.
+        /// The bounded resume refresh is the authoritative fallback.
         case inconclusive
-        /// The check could not run at all: no usable history source, or the
-        /// bounded read failed transiently. The authoritative liveness
-        /// observation stands on the previously accepted observational
-        /// terms — a failed check must not escalate into a resume cascade.
-        case unverifiable
+        /// The bounded read failed transiently (timeout, 429/5xx, bridge not
+        /// ready). Liveness stays authoritative, but freshness is UNRESOLVED:
+        /// the stale marker is retained so the next authoritative source
+        /// re-confirms, and no "unchanged" verdict may be claimed.
+        case unresolvedTransient
     }
 
     /// Compares one bounded persisted-tail read against the local durable
@@ -4784,7 +4797,7 @@ final class AppState: ObservableObject {
     /// page rows are candidates; candidate rows already held (streamed in
     /// live under any identity) are dropped by id.
     private func foregroundFreshnessVerdict(
-        _ outcome: PersistedTranscriptOutcome,
+        _ outcome: ForegroundPersistedTailOutcome,
         localFrontier: Set<String>,
         localMessageIDs: Set<String>,
         lastLocalMessageID: String?,
@@ -4792,15 +4805,19 @@ final class AppState: ObservableObject {
         runtimeSessionID: String
     ) -> ForegroundFreshnessVerdict {
         switch outcome {
-        case .unavailable, .failed:
-            return .unverifiable
+        case .failed:
+            return .unresolvedTransient
+        case .unavailable, .unsupportedTailContract:
+            // Structural source absence or a backend without the tail
+            // contract: there is no bounded evidence and the freshness check
+            // deliberately does not escalate to a full-transcript read — the
+            // bounded resume refresh is the authoritative fallback.
+            return .inconclusive
         case let .hydrated(transcript):
+            // Defense-in-depth only: foregroundPersistedTailOutcome already
+            // refuses to construct .hydrated for a non-contract page.
             guard let page = transcript.page, page.honorsTailContract,
                   transcript.messages.isEmpty || !transcript.durableRowIDs.isEmpty else {
-                // Legacy one-shot: positively the entire transcript, but its
-                // rows carry no durable identity, so nothing can be compared
-                // (text and count comparisons are forbidden). The bounded
-                // resume refresh owns legacy conversations end-to-end.
                 return .inconclusive
             }
             // A positively empty page with no older rows proves the
@@ -4855,7 +4872,8 @@ final class AppState: ObservableObject {
 
     /// Runs the bounded cross-surface freshness reconciliation for a
     /// foreground whose probe liveness could hide missed persisted activity
-    /// (real background interval, no turn-continuity evidence):
+    /// (real background interval): exactly one TAIL-ONLY persisted read —
+    /// never a full-transcript fallback — decides:
     ///
     /// - anchor overlap, nothing newer → observational liveness adoption,
     ///   transcript untouched, zero `session.resume`;
@@ -4864,10 +4882,14 @@ final class AppState: ObservableObject {
     ///   window re-anchored) and the liveness adopted — still zero
     ///   `session.resume`, because the persisted-history source supplied
     ///   everything a completed turn needs;
-    /// - inconclusive → the existing bounded resume refresh (the one
-    ///   `session.resume` that re-anchors the whole conversation and, for a
-    ///   live runtime, returns the in-flight projection);
-    /// - unverifiable → the previously accepted observational behavior.
+    /// - inconclusive (rotated anchor, no tail contract, foreign resolved id,
+    ///   unanchored optimistic tail, structurally absent source) → the
+    ///   existing bounded resume refresh, the authoritative fallback that
+    ///   re-anchors the whole conversation (and, for a live runtime, returns
+    ///   the in-flight projection);
+    /// - transient read failure → the authoritative liveness adoption with
+    ///   the stale marker RETAINED: freshness is unresolved, never claimed
+    ///   current, and the next authoritative source re-confirms.
     private func reconcileForegroundCrossSurfaceActivity(
         livenessIsRunning: Bool,
         requestedSessionID: String,
@@ -4880,7 +4902,7 @@ final class AppState: ObservableObject {
         let localFrontier = durablePersistedRowIDs
         let localMessageIDs = Set(messages.map { $0.id })
         let lastLocalMessageID = messages.last?.id
-        let outcome = await persistedTranscriptOutcome(
+        let outcome = await foregroundPersistedTailOutcome(
             sessionId: requestedSessionID,
             profile: profile,
             using: bridge
@@ -4915,8 +4937,24 @@ final class AppState: ObservableObject {
             runtimeSessionID: probeRow.runtimeSessionId
         ) {
         case let .advanced(transcript, newRows):
+            if livenessIsRunning {
+                // A running turn whose persisted history advanced beyond the
+                // frontier cannot be proven same-turn, and the page cannot
+                // supply its in-flight projection: the authoritative attach
+                // (compact resume + reconcile) owns both the advancement and
+                // the live projection.
+                lifecycleLog.notice(
+                    "Foreground freshness: probe=running session=\(requestedSessionID, privacy: .public) verdict=advanced rows=\(newRows.count, privacy: .public) → authoritative attach"
+                )
+                await syncSession(
+                    purpose: .automaticReturn,
+                    using: token,
+                    automaticWorkToken: automaticWorkToken
+                )
+                return
+            }
             lifecycleLog.notice(
-                "Foreground freshness: probe=\(livenessIsRunning ? "running" : "idle", privacy: .public) session=\(requestedSessionID, privacy: .public) verdict=advanced rows=\(newRows.count, privacy: .public) → merge persisted advancement"
+                "Foreground freshness: probe=idle session=\(requestedSessionID, privacy: .public) verdict=advanced rows=\(newRows.count, privacy: .public) → merge persisted advancement"
             )
             applyPersistedForegroundAdvancement(
                 requestedSessionID: requestedSessionID,
@@ -4925,8 +4963,7 @@ final class AppState: ObservableObject {
                 runtimeSessionID: probeRow.runtimeSessionId,
                 profile: profile
             )
-            adoptForegroundLiveness(
-                livenessIsRunning,
+            adoptForegroundAuthoritativeIdle(
                 token: token,
                 automaticWorkToken: automaticWorkToken
             )
@@ -4939,25 +4976,22 @@ final class AppState: ObservableObject {
                 token: token,
                 automaticWorkToken: automaticWorkToken
             )
-        case .unverifiable:
+        case .unresolvedTransient:
             lifecycleLog.notice(
-                "Foreground freshness: probe=\(livenessIsRunning ? "running" : "idle", privacy: .public) session=\(requestedSessionID, privacy: .public) verdict=unverifiable → observational fallback"
+                "Foreground freshness: probe=\(livenessIsRunning ? "running" : "idle", privacy: .public) session=\(requestedSessionID, privacy: .public) verdict=transient-failure → liveness adopt, freshness unresolved"
             )
-            if livenessIsRunning, messages.isEmpty {
-                // Pre-freshness semantics for a running runtime over an empty
-                // transcript: attach the live projection.
-                await syncSession(
-                    purpose: .automaticReturn,
-                    using: token,
-                    automaticWorkToken: automaticWorkToken
-                )
-            } else {
-                adoptForegroundLiveness(
-                    livenessIsRunning,
-                    token: token,
-                    automaticWorkToken: automaticWorkToken
-                )
-            }
+            adoptForegroundLiveness(
+                livenessIsRunning,
+                token: token,
+                automaticWorkToken: automaticWorkToken
+            )
+            // The bounded read failed transiently: freshness is UNRESOLVED.
+            // Retain the stale marker so the next authoritative source (the
+            // pre-send probe, the next background's freshness check, a
+            // reconnect) re-confirms — never claim a currency the read could
+            // not prove, and never escalate the failed bounded read into a
+            // full-transcript transfer.
+            turnStateIsStale = true
         case .inconclusive:
             lifecycleLog.notice(
                 "Foreground freshness: probe=\(livenessIsRunning ? "running" : "idle", privacy: .public) session=\(requestedSessionID, privacy: .public) verdict=inconclusive → bounded resume refresh"
@@ -6123,7 +6157,7 @@ final class AppState: ObservableObject {
             guard isCurrentComposerSubmission(submissionContext) else { return false }
             if Self.isAmbiguousPromptDelivery(error) {
                 lifecycleLog.notice(
-                    "prompt.submit ambiguous (\(error.localizedDescription, privacy: .public)); querying authoritative state session=\(sessionId, privacy: .public)"
+                    "prompt.submit ambiguous (\(error.localizedDescription, privacy: .private)); querying authoritative state session=\(sessionId, privacy: .public)"
                 )
                 let (resolution, reconnected) = await reconcileAmbiguousPromptSubmission(
                     requestedSessionID: sessionId,
@@ -7415,6 +7449,72 @@ final class AppState: ObservableObject {
     /// pagination echo answers under the paginated tail contract; one
     /// without it is a legacy one-shot full transcript and hydrates as
     /// before.
+    /// Result of the foreground freshness tail read. Only the newest bounded
+    /// `order=latest` page is ever requested. Unlike `persistedTranscriptOutcome`
+    /// this deliberately has NO legacy one-shot fallback: a freshness check
+    /// must never escalate into a full-transcript transfer just to prove
+    /// currency — a backend that cannot serve the tail contract yields
+    /// inconclusive evidence instead, and the authoritative resume/reconcile
+    /// path owns any full hydration. (Gateway-only deployments without any
+    /// history source therefore re-attach authoritatively on each armed
+    /// return — the designed fallback, not a regression to optimize away.)
+    private enum ForegroundPersistedTailOutcome {
+        /// Validated tail page with positively durable row ids.
+        case hydrated(PersistedSessionTranscript)
+        /// The response did not honor the `order=latest` + durable-identity
+        /// contract — including a body with no message-rows array at all,
+        /// which the authoritative resume path re-classifies and SURFACES as
+        /// `HermesError.invalidResponse` (never silently absorbed here).
+        case unsupportedTailContract
+        /// The history source is structurally absent (no bridge/endpoint, or
+        /// the endpoint answered 404/410/501): no bounded capability exists.
+        case unavailable
+        /// Transient trouble (timeout, 429/5xx, bridge not ready, network).
+        case failed(Error)
+    }
+
+    /// Bounded tail-only read for the foreground freshness check: exactly one
+    /// `order=latest offset=0` page request, parsed with the shared
+    /// extraction/pagination/identity helpers, and stopping deliberately
+    /// before `persistedTranscriptOutcome`'s legacy one-shot re-read.
+    private func foregroundPersistedTailOutcome(
+        sessionId: String,
+        profile: String,
+        using bridge: DashboardTicketBridge?
+    ) async -> ForegroundPersistedTailOutcome {
+        let fetchOutcome = await fetchPersistedHistoryPayload(
+            sessionId: sessionId,
+            profile: profile,
+            query: PersistedTranscriptPagination.tailQuery(offset: 0),
+            using: bridge
+        )
+        switch fetchOutcome {
+        case .unavailable:
+            return .unavailable
+        case .failed(let error):
+            if Self.historySourceIsUnavailable(error) {
+                // Structural endpoint absence: no bounded capability exists.
+                return .unavailable
+            }
+            return .failed(error)
+        case .payload(let response):
+            guard let rawMessages = Self.persistedMessageRows(in: response) else {
+                return .unsupportedTailContract
+            }
+            guard let page = PersistedTranscriptPagination.parse(response, rawRowCount: rawMessages.count),
+                  page.honorsTailContract,
+                  PersistedTranscriptWindow.rowsHaveDurableIdentity(rawMessages) else {
+                return .unsupportedTailContract
+            }
+            return .hydrated(PersistedSessionTranscript(
+                resolvedSessionId: Self.resolvedSessionId(in: response),
+                messages: MessageNormalizer.normalizeMessages(rawMessages.map(AnyCodable.from)),
+                page: page,
+                durableRowIDs: Set(rawMessages.compactMap(Self.durablePersistedRowID(from:)))
+            ))
+        }
+    }
+
     private func persistedTranscriptOutcome(
         sessionId: String,
         profile: String,
@@ -7438,10 +7538,10 @@ final class AppState: ObservableObject {
             // silently become a full-transcript WebSocket transport (the
             // giant-payload path compact resume exists to eliminate).
             if Self.historySourceIsUnavailable(error) {
-                sessionCatalogLog.debug("Persisted transcript unavailable for \(sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                sessionCatalogLog.debug("Persisted transcript unavailable for \(sessionId, privacy: .public): \(error.localizedDescription, privacy: .private)")
                 return .unavailable
             }
-            sessionCatalogLog.debug("Persisted transcript failed for \(sessionId, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            sessionCatalogLog.debug("Persisted transcript failed for \(sessionId, privacy: .public): \(error.localizedDescription, privacy: .private)")
             return .failed(error)
         case .payload(let response):
             guard let rawMessages = Self.persistedMessageRows(in: response) else {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -525,14 +525,19 @@ final class AppState: ObservableObject {
     /// accepted (or ambiguity recovery proves `.acceptedRunning`), and
     /// validated at use against the transcript (the optimistic user row must
     /// still be present, unpersisted, and head a fully-unpersisted suffix)
-    /// plus the local turn state. Hermes runs one turn per session, so a
-    /// remote turn B normally requires our turn A to have settled — and
-    /// settling clears the marker; the residual unobserved-settle window is
-    /// documented on `locallyOwnedFreshnessTailRowIDs`. Distinct from durable
-    /// provenance: optimistic row ids never enter `durablePersistedRowIDs`.
+    /// plus the local turn state. `preSubmitDurableAnchorID` is the newest
+    /// durably-proven row captured BEFORE the send changed the transcript:
+    /// the ordering anchor that lets a later bounded tail read classify
+    /// persisted advancement as belonging to our turn (Hermes persists the
+    /// user row at turn start, so the twin of the optimistic bubble is
+    /// normally there) versus belonging to a later foreign turn. Optimistic
+    /// row ids never enter `durablePersistedRowIDs`; the two identities stay
+    /// distinct — the marker only asserts that ONE new persisted user turn
+    /// is expected while our turn is in flight.
     private struct LocallyOwnedInFlightTurn {
         var sessionIDs: Set<String>
         var optimisticUserRowID: String
+        var preSubmitDurableAnchorID: String?
     }
     private var locallyOwnedInFlightTurn: LocallyOwnedInFlightTurn?
     @Published private(set) var busyInputMode: BusyInputMode = .steer
@@ -4876,15 +4881,14 @@ final class AppState: ObservableObject {
     /// live under any identity) are dropped by id.
     ///
     /// The local transcript may end on the locally-owned turn's optimistic
-    /// rows (`locallyOwnedTailRowIDs` non-nil): those rows have no persisted
-    /// twins YET, so the frontier anchor plus an empty candidate set still
-    /// proves the durable conversation unchanged — same-turn continuation
-    /// without demanding durable ids for Conduit's own optimistic rows. Any
-    /// candidate BEYOND the anchor while the tail is optimistic is persisted
-    /// advancement that cannot be safely attributed (the optimistic user row's
-    /// persisted twin, or a foreign turn) — never merged, always the
-    /// authoritative fallback. Persisted advancement always wins over an
-    /// optimistic tail.
+    /// rows (`locallyOwnedTurn` non-nil). Hermes persists the user row at
+    /// TURN START, so the normal in-flight tail is the pre-submit frontier,
+    /// the durable twin of our optimistic user row, and any Turn A
+    /// output/tool rows; classification there is by canonical USER-turn
+    /// boundaries (see `locallyOwnedTurnFreshnessVerdict`), never raw row
+    /// count. A durably-anchored tail keeps the plain frontier comparison:
+    /// anchor overlap with nothing newer → unchanged; newer durable rows →
+    /// an append-only merge of the advancement.
     private func foregroundFreshnessVerdict(
         _ outcome: ForegroundPersistedTailOutcome,
         localFrontier: Set<String>,
@@ -4893,7 +4897,7 @@ final class AppState: ObservableObject {
         requestedSessionID: String,
         runtimeSessionID: String,
         livenessIsRunning: Bool,
-        locallyOwnedTailRowIDs: Set<String>?
+        locallyOwnedTurn: LocallyOwnedTurnTailEvidence?
     ) -> ForegroundFreshnessVerdict {
         switch outcome {
         case .failed:
@@ -4933,66 +4937,101 @@ final class AppState: ObservableObject {
                 // identity: never merge rows from a foreign transcript.
                 return .inconclusive
             }
-            // The transcript must end either on a row the frontier vouches
-            // for, or on the locally-owned turn's optimistic rows. In the
-            // latter case the page must also prove nothing persisted beyond
-            // the frontier — our own optimistic rows have no persisted twins
-            // yet, and anything else cannot be safely attributed. A tail that
-            // is neither (an abandoned optimistic row, minted rows from a
-            // foreign turn) keeps the strict anchor requirement.
-            guard let lastLocalMessageID,
+            let tailIsDurablyAnchored = lastLocalMessageID.map {
+                localFrontier.contains($0)
+            } ?? false
+            if !tailIsDurablyAnchored, let locallyOwnedTurn {
+                // The tail is Conduit's own optimistic turn: classify by
+                // user-turn boundaries against the pre-submit anchor.
+                return locallyOwnedTurnFreshnessVerdict(
+                    transcript,
+                    owned: locallyOwnedTurn,
+                    localMessageIDs: localMessageIDs,
+                    livenessIsRunning: livenessIsRunning
+                )
+            }
+            // Anchored path: the transcript must END on a row the frontier
+            // vouches for. Trailing optimistic/streaming rows WITHOUT
+            // locally-owned turn evidence keep the strict anchor requirement
+            // — the bounded resume refresh converges this exact shape.
+            guard tailIsDurablyAnchored,
                   let anchorIndex = transcript.messages.lastIndex(where: {
                       localFrontier.contains($0.id)
                   }) else {
-                // No local frontier, or the frontier rotated out of the
-                // newest page (an accepted turn can push hundreds of rows
-                // past the window): no ordering proof — same invariant as the
-                // ambiguous-delivery verifier.
+                // No local frontier, unanchored foreign tail, or the frontier
+                // rotated out of the newest page (an accepted turn can push
+                // hundreds of rows past the window): no ordering proof — same
+                // invariant as the ambiguous-delivery verifier.
                 return .inconclusive
             }
-            let tailIsDurablyAnchored = localFrontier.contains(lastLocalMessageID)
-            guard tailIsDurablyAnchored || locallyOwnedTailRowIDs != nil else {
-                return .inconclusive
-            }
-            var knownIDs = localMessageIDs
-            var newRows: [ChatMessage] = []
-            for row in transcript.messages[transcript.messages.index(after: anchorIndex)...]
-            where knownIDs.insert(row.id).inserted {
-                newRows.append(row)
-            }
+            let newRows = persistedRowsAfter(
+                anchorIndex,
+                in: transcript,
+                heldIDs: localMessageIDs
+            )
             if newRows.isEmpty {
-                // Same-turn continuation also requires the runtime to still
-                // be working/waiting on OUR turn: an idle registry behind an
-                // optimistic tail cannot prove the turn landed at all, and
-                // the authoritative refresh converges it.
-                //
-                // Defense-in-depth only: the refresh routing above already
-                // sends "locally running turn + idle registry" to the
-                // authoritative resume before any freshness read, and
-                // `locallyOwnedFreshnessTailRowIDs` requires a running local
-                // turn — so this arm cannot fire through the current call
-                // graph. It pins the invariant should that routing change.
-                //
-                // Note the companion assumption: the in-flight turn has
-                // persisted NOTHING yet, so an empty candidate set is the
-                // normal in-flight shape. A backend that persists rows at
-                // accept-time yields candidates → authoritative attach once,
-                // after which the tail is durably anchored again.
-                if !tailIsDurablyAnchored, !livenessIsRunning {
-                    return .inconclusive
-                }
                 return .unchanged
-            }
-            if !tailIsDurablyAnchored {
-                // Persisted advancement beyond the pre-turn frontier behind an
-                // optimistic tail: the append-only merge would duplicate the
-                // optimistic row's persisted twin (and cannot attribute the
-                // rest), so the advancement wins and forces the authoritative
-                // attach.
-                return .inconclusive
             }
             return .advanced(transcript: transcript, newRows: newRows)
         }
+    }
+
+    /// Classifies the bounded persisted tail behind a locally-owned
+    /// optimistic turn by USER-turn boundaries. Hermes persists the user row
+    /// at turn start (crash resilience), so the normal in-flight shape is:
+    /// the pre-submit durable anchor, the durable twin of our optimistic
+    /// user row, then any Turn A output/tool rows. The normalizer maps raw
+    /// tool results to `.tool` and drops hidden scaffolding before this
+    /// point, so `.user` rows in the page are real canonical prompts.
+    ///
+    /// Exactly ONE new user-turn boundary after the pre-submit anchor, and
+    /// it must be the FIRST row after that anchor (a linear transcript's
+    /// next row after the old frontier is the next turn's user prompt),
+    /// while the runtime is still working/waiting → same locally-owned
+    /// Turn A → observational continuation. A second user boundary — a
+    /// later turn, or a persisted steer/follow-up inside the running turn —
+    /// means the page cannot prove same-turn continuity → authoritative
+    /// attach (the safe direction). The merge stays INELIGIBLE
+    /// in every optimistic case — the twin would duplicate the optimistic
+    /// bubble — so "unchanged" here means transcript untouched and the live
+    /// projection stays authoritative.
+    private func locallyOwnedTurnFreshnessVerdict(
+        _ transcript: PersistedSessionTranscript,
+        owned: LocallyOwnedTurnTailEvidence,
+        localMessageIDs: Set<String>,
+        livenessIsRunning: Bool
+    ) -> ForegroundFreshnessVerdict {
+        guard livenessIsRunning else {
+            // An idle registry behind our optimistic tail cannot prove the
+            // turn landed at all: the authoritative refresh converges it.
+            return .inconclusive
+        }
+        guard let anchorID = owned.preSubmitDurableAnchorID,
+              let anchorIndex = transcript.messages.lastIndex(where: {
+                  $0.id == anchorID
+              }) else {
+            // No pre-submit ordering anchor, or it rotated out of the newest
+            // page (a long turn can push hundreds of rows past the window):
+            // no boundary proof — same invariant as the anchored path.
+            return .inconclusive
+        }
+        let newRows = persistedRowsAfter(
+            anchorIndex,
+            in: transcript,
+            heldIDs: localMessageIDs
+        )
+        if newRows.isEmpty {
+            // Nothing of ours persisted yet — the earliest in-flight shape.
+            return .unchanged
+        }
+        let newUserTurnBoundaries = newRows.filter { $0.role == .user }
+        guard let firstRow = newRows.first, firstRow.role == .user,
+              newUserTurnBoundaries.count == 1 else {
+            return .inconclusive
+        }
+        // Exactly the expected twin of our optimistic Turn A user row (plus
+        // any Turn A output/tool rows): our turn is still the only one.
+        return .unchanged
     }
 
     /// Runs the bounded cross-surface freshness reconciliation for a
@@ -5002,20 +5041,21 @@ final class AppState: ObservableObject {
     ///
     /// - anchor overlap, nothing newer → observational liveness adoption,
     ///   transcript untouched, zero `session.resume`. With a locally-owned
-    ///   optimistic tail, the anchor overlap plus an empty candidate set
-    ///   additionally proves same-turn continuation of the turn Conduit
-    ///   itself submitted (the normal locally-started running turn), still
-    ///   zero `session.resume`;
+    ///   optimistic tail, EXACTLY ONE new canonical user-turn boundary after
+    ///   the pre-submit anchor (the durable twin Hermes persists at turn
+    ///   start, plus any of our turn's output/tool rows) additionally proves
+    ///   same-turn continuation — still zero `session.resume`;
     /// - anchor overlap, newer durable rows → the advancement is appended to
     ///   the local transcript (loaded-earlier prefix untouched, persisted
     ///   window re-anchored) and the liveness adopted — still zero
     ///   `session.resume`, because the persisted-history source supplied
     ///   everything a completed turn needs;
     /// - inconclusive (rotated anchor, no tail contract, foreign resolved id,
-    ///   unanchored foreign tail, persisted advancement behind an optimistic
-    ///   tail) → the existing bounded resume refresh, the authoritative
-    ///   fallback that re-anchors the whole conversation (and, for a live
-    ///   runtime, returns the in-flight projection);
+    ///   unanchored foreign tail, a SECOND user-turn boundary behind an
+    ///   optimistic tail — a later turn exists) → the existing bounded resume
+    ///   refresh, the authoritative fallback that re-anchors the whole
+    ///   conversation (and, for a live runtime, returns the in-flight
+    ///   projection);
     /// - structurally absent source → the same authoritative refresh, hinted
     ///   so it skips the doomed history request and resumes non-compact
     ///   exactly once;
@@ -5034,7 +5074,7 @@ final class AppState: ObservableObject {
         let localFrontier = durablePersistedRowIDs
         let localMessageIDs = Set(messages.map { $0.id })
         let lastLocalMessageID = messages.last?.id
-        let locallyOwnedTailRowIDs = locallyOwnedFreshnessTailRowIDs(
+        let locallyOwnedTurn = locallyOwnedFreshnessTurnEvidence(
             forRequested: requestedSessionID
         )
         let outcome = await foregroundPersistedTailOutcome(
@@ -5071,7 +5111,7 @@ final class AppState: ObservableObject {
             requestedSessionID: requestedSessionID,
             runtimeSessionID: probeRow.runtimeSessionId,
             livenessIsRunning: livenessIsRunning,
-            locallyOwnedTailRowIDs: locallyOwnedTailRowIDs
+            locallyOwnedTurn: locallyOwnedTurn
         ) {
         case let .advanced(transcript, newRows):
             if livenessIsRunning {
@@ -5157,19 +5197,30 @@ final class AppState: ObservableObject {
         }
     }
 
+    /// Ordering evidence for the locally-owned optimistic tail, captured by
+    /// `locallyOwnedFreshnessTurnEvidence` at freshness time. Non-nil means
+    /// the trailing unpersisted rows belong to this surface's in-flight
+    /// turn; `preSubmitDurableAnchorID` is the ordering anchor the bounded
+    /// tail is classified against.
+    private struct LocallyOwnedTurnTailEvidence {
+        let preSubmitDurableAnchorID: String?
+    }
+
     /// Non-nil when the transcript's trailing unpersisted rows belong to a
     /// turn THIS surface submitted and the local turn state still agrees the
     /// turn is in flight: the recorded optimistic user row is still present
-    /// and unpersisted, and every row after it is unpersisted too. The
-    /// residual window this cannot close — our turn settling unobserved
-    /// (dead socket) while a remote turn starts before anything of either
-    /// persisted — degrades to the same observational adopt the pre-marker
-    /// code took (a bounded resume in that exact window was the PR #121
-    /// regression); persisted advancement, idle liveness, and buffered
-    /// settle edges all still force the authoritative path.
-    private func locallyOwnedFreshnessTailRowIDs(
+    /// and unpersisted, and every row after it is unpersisted too.
+    ///
+    /// The residual window this cannot close: a turn this surface submitted
+    /// that never persisted anything server-side (accepted, then lost) is
+    /// indistinguishable from our own twin when exactly ONE `.user` row
+    /// follows the anchor — the app stays observational until the next
+    /// authoritative sync converges and drops the phantom row. Turn A's
+    /// completion, a second user turn, idle liveness, and buffered settle
+    /// edges all still force the authoritative path.
+    private func locallyOwnedFreshnessTurnEvidence(
         forRequested sessionID: String
-    ) -> Set<String>? {
+    ) -> LocallyOwnedTurnTailEvidence? {
         guard turnState.isRunning,
               let marker = locallyOwnedInFlightTurn,
               marker.sessionIDs.contains(sessionID),
@@ -5182,7 +5233,26 @@ final class AppState: ObservableObject {
               }) else {
             return nil
         }
-        return Set(messages[userIndex...].map { $0.id })
+        return LocallyOwnedTurnTailEvidence(
+            preSubmitDurableAnchorID: marker.preSubmitDurableAnchorID
+        )
+    }
+
+    /// Chronological page rows strictly after `anchorIndex` whose ids the
+    /// local transcript does not already hold — rows streamed in live under
+    /// any identity dedupe by id, in both verdict paths.
+    private func persistedRowsAfter(
+        _ anchorIndex: Int,
+        in transcript: PersistedSessionTranscript,
+        heldIDs: Set<String>
+    ) -> [ChatMessage] {
+        var knownIDs = heldIDs
+        var newRows: [ChatMessage] = []
+        for row in transcript.messages[transcript.messages.index(after: anchorIndex)...]
+        where knownIDs.insert(row.id).inserted {
+            newRows.append(row)
+        }
+        return newRows
     }
 
     /// Adopts the freshly-decided foreground liveness after a freshness
@@ -6165,6 +6235,26 @@ final class AppState: ObservableObject {
             }
         }
 
+        // The stale-idle probe above can lose a race with a live busy edge:
+        // its post-await ownership check refuses to mutate a non-idle state
+        // and returns false, so without this re-route the submission would
+        // fall through to an ordinary prompt.submit into the now-running
+        // turn — the same busy-edge rule the freshness gate enforces.
+        if turnState.isRunning {
+            guard attachments.isEmpty else {
+                errorMessage = "Attachments can only be sent in a new message, after the current response finishes."
+                return false
+            }
+            switch busyInputMode {
+            case .steer:
+                lifecycleLog.notice("submitComposer: busy edge raced the stale-idle probe → busy steer")
+                return await steer(text, context: submissionContext)
+            case .interrupt:
+                lifecycleLog.notice("submitComposer: busy edge raced the stale-idle probe → busy redirect/interrupt")
+                return await redirectOrInterruptAndSend(text, context: submissionContext)
+            }
+        }
+
         // Transcript freshness is a separate concern from turn-state
         // staleness: the registry probe above proves whether Hermes is busy,
         // never whether the visible transcript is missing persisted rows. A
@@ -6324,13 +6414,32 @@ final class AppState: ObservableObject {
             profile: profile,
             using: bridge
         )
-        // Ownership re-check after the await: a session/profile handoff or a
-        // scene transition during the read invalidates this gate's evidence,
-        // and the ordinary flow's own guards own the outcome then.
+        // Ownership re-check after the await, SPLIT from the turn state. A
+        // session/profile/viewport handoff SUPERSEDES this gate: the old
+        // operation must mutate nothing in the newly selected conversation,
+        // and the ordinary flow's own ownership guards own that outcome. But
+        // a turn-state change on the SAME conversation is this submission's
+        // business: a busy edge that raced the read must route through the
+        // configured busy submission — never fall through to an ordinary
+        // new-turn prompt.submit into an already-running turn.
         guard isCurrentComposerSubmission(submissionContext),
-              activeSessionId == sessionId,
-              turnState == .idle else {
+              activeSessionId == sessionId else {
             return .proceed
+        }
+        if turnState.isRunning {
+            lifecycleLog.notice(
+                "submitComposer: conversation turned busy during pre-send freshness read → busy submission session=\(sessionId, privacy: .public)"
+            )
+            return .routeToBusySubmission
+        }
+        guard turnState == .idle else {
+            // A recovery boundary (.synchronizing/.reconnecting) or an
+            // unsupported gateway is in flight: neither proves the
+            // transcript ordering, and neither may blind-send.
+            lifecycleLog.notice(
+                "submitComposer: pre-send freshness read superseded by \(self.turnStateLogValue, privacy: .public); blocking send session=\(sessionId, privacy: .public)"
+            )
+            return .blocked("Unable to refresh this conversation. Try again.")
         }
         switch outcome {
         case .failed:
@@ -6389,7 +6498,7 @@ final class AppState: ObservableObject {
                     ?? persistedTranscriptWindow?.runtimeSessionID
                     ?? sessionId,
                 livenessIsRunning: false,
-                locallyOwnedTailRowIDs: nil
+                locallyOwnedTurn: nil
             )
             switch verdict {
             case .unchanged:
@@ -6472,6 +6581,12 @@ final class AppState: ObservableObject {
             durableIDs: durablePersistedRowIDs,
             holdsUnprovenRows: messages.contains { !durablePersistedRowIDs.contains($0.id) }
         )
+        // The locally-owned turn marker's ordering anchor: the newest
+        // durably-proven row, captured BEFORE the optimistic append changes
+        // the transcript below.
+        let preSubmitDurableAnchorID = messages.last(where: {
+            durablePersistedRowIDs.contains($0.id)
+        })?.id
         // The identity under probe must be captured BEFORE any await — never
         // re-derived from the mutable active session afterwards.
         let submissionSessionIDs = acceptedIdentitySessionIDs(forRequested: sessionId)
@@ -6560,7 +6675,8 @@ final class AppState: ObservableObject {
                     // durable id for a row the gateway has not persisted yet.
                     locallyOwnedInFlightTurn = LocallyOwnedInFlightTurn(
                         sessionIDs: submissionSessionIDs,
-                        optimisticUserRowID: userMessage.id
+                        optimisticUserRowID: userMessage.id,
+                        preSubmitDurableAnchorID: preSubmitDurableAnchorID
                     )
                 }
             }
@@ -6591,10 +6707,14 @@ final class AppState: ObservableObject {
                         turnStateIsStale = false
                         // Same proof as the ordinary success path: the turn
                         // in flight is provably Conduit's own submission.
-                        // Validation at use still gates every later adopt.
+                        // The anchor is intentionally the PRE-SEND capture
+                        // even though ambiguity recovery may have re-hydrated
+                        // the transcript in between: validation at use plus
+                        // the anchor lookup at use neutralize any staleness.
                         locallyOwnedInFlightTurn = LocallyOwnedInFlightTurn(
                             sessionIDs: submissionSessionIDs,
-                            optimisticUserRowID: userMessage.id
+                            optimisticUserRowID: userMessage.id,
+                            preSubmitDurableAnchorID: preSubmitDurableAnchorID
                         )
                     }
                     return true

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -542,29 +542,29 @@ final class AppState: ObservableObject {
         var optimisticUserRowID: String
         var preSubmitOrderingBaseline: PersistedOrderingBaseline
         /// Set when a validated bounded read positively observed this turn's
-        /// persisted user boundary (the frontier advanced through it). A
-        /// turn that settles WITHOUT this proof leaves ordering debt: its
-        /// twin is expected in persisted history beyond the frontier, and
-        /// the next locally-owned turn must not anchor before it.
+        /// persisted user boundary (the frontier advanced through it).
         var persistedBoundaryObserved = false
     }
-    /// Ordering debt for locally-owned turns that settled locally BEFORE any
-    /// validated persisted read observed their durable user boundary
-    /// (foreground-only lifecycles). One bounded pre-send tail read
-    /// reconciles it: exactly `expectedUserTurnCount` new canonical user
-    /// boundaries after the frontier satisfies the debt (and advances the
-    /// frontier); more proves foreign activity (authoritative reconcile);
-    /// fewer means persisted state has not caught up (conservative
-    /// recovery). Conversation-scoped: reset with the transcript lifecycle
-    /// evidence, cleared by authoritative adoption. Residual windows, both
-    /// routed to the safe direction: a settled turn whose assistant output
-    /// persists AFTER a satisfied re-anchor leaves the next debt read facing
-    /// a leading non-user row (one conservative reconcile); a turn accepted
-    /// but lost server-side leaves unsatisfiable debt until one reconcile
-    /// converges it.
+    /// Ordering debt for turns whose durable ordering is not yet proven. A
+    /// missing-boundary debt expects one or more canonical user rows after the
+    /// frontier. A zero-boundary observation obligation permits only trailing
+    /// assistant/tool rows: it covers a locally-owned turn whose boundary was
+    /// seen while live, plus busy `.queued`/`.steered` outcomes whose typed
+    /// response cannot prove whether Hermes later promoted input to a full
+    /// turn. One bounded pre-send read clears the matching shape and advances
+    /// the frontier; extra user boundaries prove new activity (authoritative
+    /// reconcile), while missing rows or an unprovable anchor recover
+    /// conservatively. Conversation-scoped: reset with transcript lifecycle
+    /// evidence and cleared by authoritative adoption.
     private struct PendingLocalOrderingDebt {
         var sessionIDs: Set<String>
         var expectedUserTurnCount: Int
+        /// No exact new boundary is owed. Rows before the next expected
+        /// boundary may be a settled local tail or the current busy turn's
+        /// tail. With zero expected boundaries, an empty or non-user-only
+        /// suffix satisfies the obligation; any user boundary proves new
+        /// activity that must be adopted authoritatively.
+        var allowTrailingRowsWithoutNewUserBoundary: Bool
     }
     private var pendingLocalOrderingDebt: PendingLocalOrderingDebt?
     private var locallyOwnedInFlightTurn: LocallyOwnedInFlightTurn?
@@ -5362,7 +5362,8 @@ final class AppState: ObservableObject {
             persistedOrderingFrontier = observedOrderingFrontier
             if let observedNewUserBoundaries, observedNewUserBoundaries > 0 {
                 // The read positively observed the locally-owned turn's
-                // persisted boundary: a later settle owes no ordering debt.
+                // persisted boundary. If the turn is still running this does
+                // NOT prove its final durable tail.
                 locallyOwnedInFlightTurn?.persistedBoundaryObserved = true
             }
             adoptForegroundLiveness(
@@ -6854,7 +6855,8 @@ final class AppState: ObservableObject {
             }
             return Self.classifyDebtCandidates(
                 persistedRowsAfter(nil, in: transcript, heldIDs: heldIDs),
-                expected: debt.expectedUserTurnCount
+                expected: debt.expectedUserTurnCount,
+                allowTrailingRowsWithoutNewUserBoundary: debt.allowTrailingRowsWithoutNewUserBoundary
             )
         case .anchored(let anchorID):
             guard let anchorIndex = transcript.messages.lastIndex(where: {
@@ -6864,16 +6866,29 @@ final class AppState: ObservableObject {
             }
             return Self.classifyDebtCandidates(
                 persistedRowsAfter(anchorIndex, in: transcript, heldIDs: heldIDs),
-                expected: debt.expectedUserTurnCount
+                expected: debt.expectedUserTurnCount,
+                allowTrailingRowsWithoutNewUserBoundary: debt.allowTrailingRowsWithoutNewUserBoundary
             )
         }
     }
 
     private static func classifyDebtCandidates(
         _ candidates: [ChatMessage],
-        expected: Int
+        expected: Int,
+        allowTrailingRowsWithoutNewUserBoundary: Bool = false
     ) -> LocalOrderingDebtOutcome {
         let boundaries = candidates.filter { $0.role == .user }
+        if expected == 0, allowTrailingRowsWithoutNewUserBoundary {
+            // Settled-tail debt: trailing assistant/tool rows (or no rows at
+            // all) are exactly what the bounded read is meant to absorb. A
+            // canonical user boundary cannot belong to that already-settled
+            // turn and therefore proves foreign/new activity.
+            return boundaries.isEmpty ? .satisfied : .exceeded
+        }
+        if allowTrailingRowsWithoutNewUserBoundary {
+            if boundaries.count == expected { return .satisfied }
+            return boundaries.count > expected ? .exceeded : .notCaughtUp
+        }
         guard let firstRow = candidates.first, firstRow.role == .user else {
             // Nothing after the frontier yet, or an assistant/tool row
             // precedes the first boundary: the persisted state has not
@@ -7013,20 +7028,8 @@ final class AppState: ObservableObject {
                     turnState = .running
                 }
                 turnStateIsStale = false
-                if outcome.isBusySubmission {
-                    // A steered/queued/redirected outcome joined a turn that
-                    // was ALREADY running — possibly started by another
-                    // surface — so it is not proof of a locally-owned turn;
-                    // the optimistic row gets no continuity marker. It DOES
-                    // persist as a canonical user row beyond the frontier,
-                    // though: carry ordering debt forward so the next local
-                    // turn anchors past it.
-                    locallyOwnedInFlightTurn = nil
-                    recordLocalOrderingDebt(
-                        sessionIDs: submissionSessionIDs,
-                        baseline: preSubmitOrderingBaseline
-                    )
-                } else {
+                switch outcome {
+                case .accepted:
                     // The turn in flight is now provably Conduit's own: record
                     // the optimistic user row so a later foreground freshness
                     // check can prove same-turn continuity WITHOUT demanding a
@@ -7035,6 +7038,39 @@ final class AppState: ObservableObject {
                         sessionIDs: submissionSessionIDs,
                         optimisticUserRowID: userMessage.id,
                         preSubmitOrderingBaseline: preSubmitOrderingBaseline
+                    )
+                case .queued:
+                    // Hermes normally drains queued input as a later full turn,
+                    // but `_enqueue_prompt` may drop an in-flight self-duplicate
+                    // or coalesce several text submissions into one envelope.
+                    // Therefore the typed outcome proves no exact boundary
+                    // count. Require one later bounded observation: no new user
+                    // row clears it; any user row is adopted authoritatively.
+                    locallyOwnedInFlightTurn = nil
+                    recordLocalOrderingDebt(
+                        sessionIDs: submissionSessionIDs,
+                        baseline: preSubmitOrderingBaseline,
+                        expectedUserTurnIncrement: 0,
+                        allowTrailingRowsWithoutNewUserBoundary: true
+                    )
+                case .redirected:
+                    // Hermes replaces/corrects the current live model request;
+                    // it does not create an independent canonical user turn.
+                    locallyOwnedInFlightTurn = nil
+                case .steered:
+                    // Hermes normally injects this into the current run without
+                    // a canonical user row. A steer arriving after the final
+                    // tool batch is returned as `pending_steer`, however, and
+                    // requeued as a full next turn. As with `.queued`, the typed
+                    // outcome proves no exact boundary count, so observe once
+                    // before the next ordinary local turn and reconcile if a
+                    // promoted steer produced a user boundary.
+                    locallyOwnedInFlightTurn = nil
+                    recordLocalOrderingDebt(
+                        sessionIDs: submissionSessionIDs,
+                        baseline: preSubmitOrderingBaseline,
+                        expectedUserTurnIncrement: 0,
+                        allowTrailingRowsWithoutNewUserBoundary: true
                     )
                 }
             }
@@ -11038,27 +11074,37 @@ final class AppState: ObservableObject {
             // boundary was never positively observed leaves ordering debt:
             // Hermes persisted its user row at turn start, so the next
             // locally-owned turn must anchor AFTER it.
-            recordLocalOrderingDebtIfTurnUnobserved()
+            recordLocalOrderingDebtForSettledTurn()
             locallyOwnedInFlightTurn = nil
         }
         turnState = running ? .running : .idle
     }
 
-    /// Records one unit of local ordering debt when a locally-owned turn
-    /// settles before any validated read observed its persisted boundary.
+    /// Records the minimum unresolved persisted-ordering obligation when a
+    /// locally-owned turn settles. An unseen boundary owes one canonical user
+    /// turn. A boundary observed only while live owes a zero-boundary settled
+    /// tail read, because later assistant/tool rows may still have persisted.
     /// Debt counts accumulate when several locally-owned turns settle
     /// without an intervening read; authoritative adoption (a reconcile
     /// replacing the transcript) clears the debt outright. Identity
     /// rotation between turns replaces the slot — an undercount, which
     /// degrades to a spurious-but-safe authoritative reconcile, never to a
     /// silent overshoot.
-    private func recordLocalOrderingDebtIfTurnUnobserved() {
-        guard let marker = locallyOwnedInFlightTurn,
-              !marker.persistedBoundaryObserved else { return }
-        recordLocalOrderingDebt(
-            sessionIDs: marker.sessionIDs,
-            baseline: marker.preSubmitOrderingBaseline
-        )
+    private func recordLocalOrderingDebtForSettledTurn() {
+        guard let marker = locallyOwnedInFlightTurn else { return }
+        if !marker.persistedBoundaryObserved {
+            recordLocalOrderingDebt(
+                sessionIDs: marker.sessionIDs,
+                baseline: marker.preSubmitOrderingBaseline
+            )
+        } else {
+            recordLocalOrderingDebt(
+                sessionIDs: marker.sessionIDs,
+                baseline: marker.preSubmitOrderingBaseline,
+                expectedUserTurnIncrement: 0,
+                allowTrailingRowsWithoutNewUserBoundary: true
+            )
+        }
     }
 
     /// Debt-accounting core. Debt is only meaningful when the ordering
@@ -11068,15 +11114,21 @@ final class AppState: ObservableObject {
     /// attach, exactly as before ordering evidence existed.
     private func recordLocalOrderingDebt(
         sessionIDs: Set<String>,
-        baseline: PersistedOrderingBaseline
+        baseline: PersistedOrderingBaseline,
+        expectedUserTurnIncrement: Int = 1,
+        allowTrailingRowsWithoutNewUserBoundary: Bool = false
     ) {
         guard !baseline.isUnknown else { return }
         if pendingLocalOrderingDebt?.sessionIDs == sessionIDs {
-            pendingLocalOrderingDebt?.expectedUserTurnCount += 1
+            pendingLocalOrderingDebt?.expectedUserTurnCount += expectedUserTurnIncrement
+            if allowTrailingRowsWithoutNewUserBoundary {
+                pendingLocalOrderingDebt?.allowTrailingRowsWithoutNewUserBoundary = true
+            }
         } else {
             pendingLocalOrderingDebt = PendingLocalOrderingDebt(
                 sessionIDs: sessionIDs,
-                expectedUserTurnCount: 1
+                expectedUserTurnCount: expectedUserTurnIncrement,
+                allowTrailingRowsWithoutNewUserBoundary: allowTrailingRowsWithoutNewUserBoundary
             )
         }
     }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -4524,12 +4524,23 @@ final class AppState: ObservableObject {
                     automaticWorkToken: automaticWorkToken
                 )
             } else {
-                // Idle before, idle now: the session is stable and attached.
+                // The registry is authoritative that this runtime is idle.
+                // Adopt idle through the shared helper so a transitional
+                // state (.synchronizing / .reconnecting) left behind by an
+                // aborted recovery attempt cannot survive a healthy-socket
+                // foreground cycle — the observational refresh must still end
+                // with a usable composer. setRunning(false) is idempotent for
+                // .idle and preserves an unsupportedGateway marker.
                 lifecycleLog.notice(
-                    "Foreground refresh: probe=idle localTurn=idle → no-op"
+                    "Foreground refresh: probe=idle → adopt idle"
                 )
+                // The adopted idle is the OLDER observation: events buffered
+                // while the boundary was open are newer live edges and must
+                // win (a busy edge that raced the probe re-owns the state)
+                // before the boundary settles and discards them.
+                setRunning(false)
                 turnStateIsStale = false
-                _ = settleReconciliationAndPublish(token, automaticWorkToken: automaticWorkToken)
+                settleForegroundBoundary(token, automaticWorkToken: automaticWorkToken)
             }
         case .absent:
             // No live runtime for this session: either the turn completed and
@@ -4625,9 +4636,12 @@ final class AppState: ObservableObject {
         _ = settleReconciliationAndPublish(token, automaticWorkToken: automaticWorkToken)
     }
 
-    /// Settles the foreground reconciliation boundary without adopting any
-    /// turn state — used when the registry answer is inconclusive ("starting")
-    /// so buffered events still land but the local state stays stream-owned.
+    /// Replays the events buffered while the foreground reconciliation
+    /// boundary was open — newer live edges win over any baseline the caller
+    /// just adopted — then settles the boundary. Used when the registry answer
+    /// is inconclusive ("starting", so the local state stays stream-owned) and
+    /// after the authoritative-idle adoption, where the caller establishes the
+    /// idle baseline first.
     private func settleForegroundBoundary(
         _ token: UUID,
         automaticWorkToken: ChatResumeAutomaticWorkToken?

--- a/Conduit/Services/HermesClient.swift
+++ b/Conduit/Services/HermesClient.swift
@@ -324,9 +324,18 @@ struct LiveSessionStatus: Equatable {
     let status: String
     let lastActive: TimeInterval?
 
-    /// "waiting" (a pending decision) and "starting" (turn accepted, agent
-    /// build in flight) still mean the session is committed busy.
-    var isRunning: Bool { status == "working" || status == "waiting" || status == "starting" }
+    /// Authoritative committed-busy state. Upstream `_session_live_status`
+    /// reports "working" while the turn thread runs and "waiting" while a
+    /// decision is pending. "starting" is deliberately excluded: it means
+    /// `agent_build_started` with the ready event unset, which
+    /// `_schedule_agent_build` also arms for PLAIN session.create /
+    /// cold-resume pre-warm with no prompt involved — and because the
+    /// starting check precedes the running check it can transiently mask a
+    /// committed running turn during the submit→agent-ready window. Hermes
+    /// Desktop likewise treats only working/waiting as busy. A "starting"
+    /// row is runtime-present, liveness-inconclusive; the typed
+    /// `prompt.submit` outcome is the authority for busy-input semantics.
+    var isRunning: Bool { status == "working" || status == "waiting" }
 
     init(runtimeSessionId: String, storedSessionId: String, status: String, lastActive: TimeInterval? = nil) {
         self.runtimeSessionId = runtimeSessionId

--- a/Conduit/Services/HermesClient.swift
+++ b/Conduit/Services/HermesClient.swift
@@ -279,6 +279,75 @@ struct SessionBranchMessage {
     let content: String
 }
 
+/// Typed result of `prompt.submit`, derived from the gateway's actual
+/// response `status` field (verified against upstream `tui_gateway`):
+/// `streaming` for a new turn, `steered`/`redirected`/`queued` when the
+/// gateway applied its busy-input policy to a mid-turn submission. The busy
+/// outcomes are NOT failures — Hermes accepted the text — but they prove the
+/// session was RUNNING when the prompt landed, so a caller that believed the
+/// session idle must adopt the authoritative busy state.
+enum PromptSubmissionOutcome: Equatable {
+    /// `{"status": "streaming"}` — the gateway started a new turn.
+    case accepted
+    /// `{"status": "steered"}` — injected into the live turn.
+    case steered
+    /// `{"status": "redirected"}` — live-turn correction accepted.
+    case redirected
+    /// `{"status": "queued"}` — held for the next turn.
+    case queued
+
+    var isBusySubmission: Bool { self != .accepted }
+
+    init(gatewayStatus: String?) {
+        switch gatewayStatus?.lowercased() {
+        case "steered": self = .steered
+        case "redirected": self = .redirected
+        case "queued": self = .queued
+        // "streaming" and any unrecognized success shape: the RPC envelope
+        // succeeded, so the submission was accepted. Older gateways may omit
+        // the status field; never invent a failure from a missing field.
+        default: self = .accepted
+        }
+    }
+}
+
+/// One row of `session.active_list` — the gateway's authoritative in-memory
+/// runtime registry. Reading it does not resume, focus, or otherwise mutate a
+/// session (upstream contract), which makes it the only safe liveness probe
+/// for a healthy foreground transition.
+struct LiveSessionStatus: Equatable {
+    /// The registry's runtime id for this live session.
+    let runtimeSessionId: String
+    /// The durable stored session key the runtime was resumed/created from.
+    let storedSessionId: String
+    /// Upstream `_session_live_status`: "working" | "waiting" | "starting" | "idle".
+    let status: String
+    let lastActive: TimeInterval?
+
+    /// "waiting" (a pending decision) and "starting" (turn accepted, agent
+    /// build in flight) still mean the session is committed busy.
+    var isRunning: Bool { status == "working" || status == "waiting" || status == "starting" }
+
+    init(runtimeSessionId: String, storedSessionId: String, status: String, lastActive: TimeInterval? = nil) {
+        self.runtimeSessionId = runtimeSessionId
+        self.storedSessionId = storedSessionId
+        self.status = status
+        self.lastActive = lastActive
+    }
+
+    init?(from object: [String: AnyCodable]) {
+        guard let runtimeId = object["id"]?.stringValue, !runtimeId.isEmpty else {
+            return nil
+        }
+        self.init(
+            runtimeSessionId: runtimeId,
+            storedSessionId: object["session_key"]?.stringValue ?? "",
+            status: object["status"]?.stringValue ?? "idle",
+            lastActive: object["last_active"]?.doubleValue
+        )
+    }
+}
+
 /// Result of the newer active-turn correction RPC. `queued` is still a
 /// successful delivery: Hermes accepted the correction while the agent was
 /// in its short turn-build window and will run it next.
@@ -946,11 +1015,33 @@ final class HermesClient: ObservableObject {
         return result.objectValue?["text"]?.stringValue
     }
 
-    func sendPrompt(_ sessionId: String, text: String) async throws {
-        _ = try await rpc("prompt.submit", params: [
+    /// The gateway's answer is meaningful and must not be discarded: an idle
+    /// session returns `{"status": "streaming"}`, while a busy session never
+    /// rejects — it applies the configured busy policy and reports
+    /// `steered`/`redirected`/`queued`. A lost RPC acknowledgement (timeout,
+    /// socket death after the bytes reached Hermes) leaves the turn running
+    /// server-side; upstream's own clients recover that case by querying the
+    /// authoritative session state instead of blindly re-submitting.
+    func sendPrompt(_ sessionId: String, text: String) async throws -> PromptSubmissionOutcome {
+        let result = try await rpc("prompt.submit", params: [
             "session_id": sessionId,
             "text": text
         ], timeout: Self.promptSubmitTimeout)
+        return PromptSubmissionOutcome(
+            gatewayStatus: result.objectValue?["status"]?.stringValue
+        )
+    }
+
+    /// Read-only liveness probe against the gateway's in-memory runtime
+    /// registry (`session.active_list`). Unlike `session.resume` this does not
+    /// switch, rebind, or mutate the session, and it is authoritative about
+    /// absence: a runtime that has ended (turn complete + transport gone, or
+    /// a gateway restart) is no longer listed. Older gateways without the
+    /// method throw `RpcError`; callers degrade to resume-based recovery.
+    func activeSessions() async throws -> [LiveSessionStatus] {
+        let result = try await rpc("session.active_list", params: [:])
+        let rows = result.objectValue?["sessions"]?.arrayValue ?? []
+        return rows.compactMap { LiveSessionStatus(from: $0.objectValue ?? [:]) }
     }
 
     func steer(_ sessionId: String, text: String) async throws {

--- a/Conduit/Services/HermesClient.swift
+++ b/Conduit/Services/HermesClient.swift
@@ -509,6 +509,14 @@ final class HermesClient: ObservableObject {
     /// so it gets a bounded-but-generous budget instead of the ordinary
     /// request timeout.
     static let legacyResumeTimeout: TimeInterval = 60
+    /// Shared budget for liveness probes (`healthCheck`,
+    /// `session.active_list`). These sit on latency-sensitive paths — the
+    /// foreground refresh and the pre-send stale-idle correction — so a
+    /// stalled gateway must fail them fast instead of holding the composer
+    /// for the generic request timeout. 8s matches the pre-existing
+    /// health-check budget; a timed-out probe takes the same fallback paths
+    /// as any other probe failure.
+    static let livenessProbeTimeout: TimeInterval = 8
 
     init(
         connection: HermesConnection,
@@ -846,7 +854,7 @@ final class HermesClient: ObservableObject {
     }
 
     func healthCheck() async throws {
-        _ = try await rpc("session.list", params: nil, timeout: 8)
+        _ = try await rpc("session.list", params: nil, timeout: Self.livenessProbeTimeout)
     }
 
     /// Resumes a session with the compact projection: `omit_messages` asks
@@ -1045,10 +1053,17 @@ final class HermesClient: ObservableObject {
     /// registry (`session.active_list`). Unlike `session.resume` this does not
     /// switch, rebind, or mutate the session, and it is authoritative about
     /// absence: a runtime that has ended (turn complete + transport gone, or
-    /// a gateway restart) is no longer listed. Older gateways without the
-    /// method throw `RpcError`; callers degrade to resume-based recovery.
+    /// a gateway restart) is no longer listed. The empty parameter map is
+    /// load-bearing: `scopeParams` collapses it to an argument-free request
+    /// under the default profile (non-default profiles add only the gateway
+    /// `profile` context). Older gateways without the method throw `RpcError`;
+    /// callers degrade to resume-based recovery.
     func activeSessions() async throws -> [LiveSessionStatus] {
-        let result = try await rpc("session.active_list", params: [:])
+        let result = try await rpc(
+            "session.active_list",
+            params: [:],
+            timeout: Self.livenessProbeTimeout
+        )
         let rows = result.objectValue?["sessions"]?.arrayValue ?? []
         return rows.compactMap { LiveSessionStatus(from: $0.objectValue ?? [:]) }
     }

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -2759,7 +2759,10 @@ final class AppStateChatResumeTests: XCTestCase {
         let rpcGate = ControlledSuspension()
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
-                sendPrompt: { _, _, _ in await rpcGate.suspend() }
+                sendPrompt: { _, _, _ in
+                    await rpcGate.suspend()
+                    return .accepted
+                }
             )
         )
         let request = publishRestoration(in: harness)
@@ -2917,6 +2920,7 @@ final class AppStateChatResumeTests: XCTestCase {
             lifecycleOperations: ChatResumeLifecycleOperations(
                 sendPrompt: { _, _, _ in
                     await rpcGate.suspend()
+                    return .accepted
                 }
             )
         )
@@ -3135,7 +3139,10 @@ final class AppStateChatResumeTests: XCTestCase {
         let sendGate = ControlledSuspension()
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
-                sendPrompt: { _, _, _ in await sendGate.suspend() },
+                sendPrompt: { _, _, _ in
+                    await sendGate.suspend()
+                    return .accepted
+                },
                 redirect: { _, _, _ in
                     throw RpcError(
                         code: 4010,
@@ -3193,6 +3200,7 @@ final class AppStateChatResumeTests: XCTestCase {
                 },
                 sendPrompt: { _, sessionID, _ in
                     sendSessionIDs.append(sessionID)
+                    return .accepted
                 },
                 redirect: { _, _, _ in
                     throw RpcError(

--- a/ConduitTests/AppStateForegroundLifecycleTests.swift
+++ b/ConduitTests/AppStateForegroundLifecycleTests.swift
@@ -5633,14 +5633,44 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
     }
 
     /// Hermes `prompt.submit` busy outcomes have distinct persistence
-    /// contracts. Redirect mutates the current live turn, so it cannot owe a
-    /// new canonical user boundary after that turn settles.
-    func testRedirectedBusySubmissionCreatesNoNewTurnOrderingDebt() async {
+    /// contracts. A redirect mutates the current live turn, so it owes ZERO
+    /// new canonical user boundaries — but the mutated turn can keep
+    /// persisting assistant/tool rows after the current ordering frontier.
+    /// The zero-user-boundary final-tail obligation is satisfied by exactly
+    /// that non-user-only suffix: one bounded read advances the frontier and
+    /// the next ordinary local send proceeds without an authoritative resume.
+    func testRedirectedBusySubmissionPersistsTrailingRowsBeforeNextSend() async {
         await assertBusyPromptOutcomeOrdering(
             outcome: .redirected,
-            persistedRowsOnDebtRead: nil,
-            expectedTranscriptReads: 1,
+            persistedRowsOnDebtRead: [
+                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                ["id": "102", "role": "assistant", "content": "Redirected output", "timestamp": "3"],
+                ["id": "103", "role": "tool", "name": "search", "content": "", "timestamp": "4"],
+                ["id": "104", "role": "assistant", "content": "Redirected conclusion", "timestamp": "5"]
+            ],
+            expectedTranscriptReads: 2,
             expectedResumeCount: 1
+        )
+    }
+
+    /// If a canonical user boundary appears after a redirect, a later or new
+    /// turn exists. The zero-user-boundary obligation is then EXCEEDED, and
+    /// the next ordinary local send must reconcile authoritatively — the
+    /// remote turn becomes visible before the local prompt is sent, exactly
+    /// once, with no duplicate delivery.
+    func testRedirectedBusySubmissionRemoteTurnReconcilesBeforeNextSend() async {
+        await assertBusyPromptOutcomeOrdering(
+            outcome: .redirected,
+            persistedRowsOnDebtRead: [
+                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                ["id": "102", "role": "assistant", "content": "Redirected output", "timestamp": "3"],
+                ["id": "103", "role": "user", "content": "Remote B", "timestamp": "4"],
+                ["id": "104", "role": "assistant", "content": "Remote B answer", "timestamp": "5"]
+            ],
+            expectedTranscriptReads: 3,
+            expectedResumeCount: 2
         )
     }
 
@@ -6840,11 +6870,13 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         var submitCount = 0
         var probeCount = 0
         var transcriptReads = 0
+        var resumeCount = 0
         let parkedProbe = LifecycleSuspension()
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 openSession: { _, sessionID, _ in
-                    SessionResumeResult(
+                    resumeCount += 1
+                    return SessionResumeResult(
                         sessionId: sessionID,
                         messages: [
                             ChatMessage(id: "100", role: .user, content: "Earlier question", timestamp: "1")
@@ -6864,18 +6896,27 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
                 refreshContext: { _, _ in },
                 sendPrompt: { _, _, _ in
                     submitCount += 1
-                    throw HermesError.timeout("prompt.submit")
+                    if submitCount == 1 {
+                        throw HermesError.timeout("prompt.submit")
+                    }
+                    return .accepted
                 },
                 probeActiveSessions: { _ in
                     probeCount += 1
-                    // The probe itself is parked: the registry says the turn
-                    // was working when ASKED, but newer edges land first.
-                    await parkedProbe.suspend()
-                    return [LiveSessionStatus(
-                        runtimeSessionId: "runtime-a",
-                        storedSessionId: "stored-a",
-                        status: "working"
-                    )]
+                    if probeCount == 1 {
+                        // The probe itself is parked: the registry says the
+                        // turn was working when ASKED, but newer edges land
+                        // first.
+                        await parkedProbe.suspend()
+                        return [LiveSessionStatus(
+                            runtimeSessionId: "runtime-a",
+                            storedSessionId: "stored-a",
+                            status: "working"
+                        )]
+                    }
+                    // Later probes (the stale-idle correction) see the
+                    // settled, absent runtime.
+                    return []
                 }
             )
         )
@@ -6885,6 +6926,7 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         let opened = await harness.appState.openSession(active.id)
         XCTAssertTrue(opened)
         XCTAssertEqual(harness.appState.messages.map(\.id), ["100"])
+        let resumesBeforeSubmit = resumeCount
 
         let submission = Task { @MainActor in
             await harness.appState.submitComposer(text: "Ambiguous send")
@@ -6919,6 +6961,398 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
             harness.appState.turnStateIsStale,
             "The staleness written by the newer boundary must not be cleared by the older recovery result"
         )
+        XCTAssertEqual(resumeCount, resumesBeforeSubmit)
+
+        // Regression B, ownership half: the settle edge ENDED live ownership,
+        // so the acceptedRunning recovery must not resurrect the locally-owned
+        // marker. A later turn cycle settles with no marker, records no
+        // ordering debt, and the next ordinary send therefore performs NO
+        // bounded read and no resume.
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: false))
+        let submittedNext = await harness.appState.submitComposer(text: "Ordinary next turn")
+        XCTAssertTrue(submittedNext)
+        XCTAssertEqual(submitCount, 2)
+        XCTAssertEqual(probeCount, 2, "The stale-idle correction probes once before the ordinary send")
+        XCTAssertEqual(
+            transcriptReads, 1,
+            "No resurrected ownership: the later settle recorded no debt, so the next send needs no bounded read"
+        )
+        XCTAssertEqual(resumeCount, resumesBeforeSubmit, "Stale settled ownership never forces an authoritative resume")
+        XCTAssertEqual(harness.appState.turnState, .running)
+        box.client.disconnect()
+    }
+
+    /// PRIMARY regression: an ambiguous submission whose recovery races a
+    /// newer busy edge must retain locally-owned turn continuity. The newer
+    /// edge owns the lifecycle STATE (no stale running stamp), but
+    /// acceptedRunning positively proves the submission was accepted and is
+    /// the active turn — so the locally-owned marker must still be installed.
+    /// Without it, the next foreground cannot prove same-turn continuity,
+    /// degrades to inconclusive, and a session.resume destroys the PR #121
+    /// live reasoning projection.
+    func testAmbiguousAcceptedRunningAfterNewerBusyEdgeRetainsLocalTurnContinuity() async {
+        let active = session("stored-a")
+        var submitCount = 0
+        var probeCount = 0
+        var transcriptReads = 0
+        var resumeCount = 0
+        var catalogCount = 0
+        let parkedProbe = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    catalogCount += 1
+                    return [active]
+                },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    // The foreground freshness read: the submitted turn's
+                    // durable twin persisted while Conduit was suspended.
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "A", "timestamp": "3"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 3]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    throw HermesError.timeout("prompt.submit")
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    if probeCount == 1 {
+                        // The recovery's registry probe is parked: a newer
+                        // busy edge lands while it is suspended.
+                        await parkedProbe.suspend()
+                    }
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101"])
+        let resumesBeforeSubmit = resumeCount
+
+        let submission = Task { @MainActor in
+            await harness.appState.submitComposer(text: "A")
+        }
+        await parkedProbe.waitUntilSuspended()
+        // Newer live evidence arrives while the recovery awaits. The
+        // lifecycle revision advances; the turn stays running.
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        XCTAssertEqual(harness.appState.turnState, .running)
+        parkedProbe.resume()
+
+        let submitted = await submission.value
+
+        // Accepted once, lifecycle state untouched by the older recovery.
+        XCTAssertTrue(submitted, "The accepted turn must not surface as a failed send")
+        XCTAssertEqual(submitCount, 1, "An accepted prompt must never be re-submitted")
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(
+            transcriptReads, 1,
+            "A running registry row never consults the durable verifier"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertEqual(
+            harness.appState.messages.count, 3,
+            "The optimistic user row remains accepted"
+        )
+        XCTAssertEqual(harness.appState.messages.last?.content, "A")
+
+        // The live reasoning projection starts on the running turn.
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "Thinking."))
+        let segmentBefore = harness.appState.liveReasoningSegment
+        XCTAssertNotNil(segmentBefore)
+
+        // A background/foreground cycle must stay observational: the
+        // retained locally-owned marker proves same-turn continuity against
+        // the persisted twin, so NO session.resume may run and the live
+        // reasoning segment must survive untouched.
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(resumeCount, resumesBeforeSubmit, "Zero session.resume: retained ownership proves same-turn continuity")
+        XCTAssertEqual(catalogCount, 0, "A healthy foreground must not reload the catalog")
+        XCTAssertEqual(probeCount, 2, "The foreground probes the registry once")
+        XCTAssertEqual(transcriptReads, 2, "The foreground freshness check reads the bounded tail once")
+        XCTAssertEqual(
+            harness.appState.liveReasoningSegment?.id, segmentBefore?.id,
+            "The live reasoning segment must survive the foreground"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertEqual(harness.appState.messages.count, 3, "Foregrounding must not replace the transcript")
+        XCTAssertEqual(harness.appState.messages.last?.content, "A")
+
+        // Later reasoning deltas extend the SAME segment (no reset, no
+        // duplicate settled thinking row).
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: " Step two."))
+        await flushMainActor()
+        XCTAssertEqual(
+            harness.appState.liveReasoningSegment?.id, segmentBefore?.id,
+            "The same live segment must extend across the foreground"
+        )
+        XCTAssertEqual(harness.appState.messages.count, 3)
+        box.client.disconnect()
+    }
+
+    /// Regression C: an acceptedRunning recovery that raced a newer busy edge
+    /// retains the locally-owned marker, so when the turn later settles it
+    /// flows into the SAME ordering-debt lifecycle as an ordinary accepted
+    /// turn: the settle records a missing-boundary debt (one canonical user
+    /// turn), and the next local send clears it with exactly one bounded
+    /// read — no authoritative resume.
+    func testAmbiguousAcceptedRunningRetainedOwnershipLaterSettlesIntoOrderingDebt() async {
+        let active = session("stored-a")
+        var submitCount = 0
+        var probeCount = 0
+        var transcriptReads = 0
+        var resumeCount = 0
+        let parkedProbe = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    // The pre-send debt read: turn A's persisted user twin
+                    // (plus its output tail) satisfies the missing-boundary
+                    // debt.
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "A", "timestamp": "3"],
+                            ["id": "103", "role": "assistant", "content": "Answer A", "timestamp": "4"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    if submitCount == 1 {
+                        throw HermesError.timeout("prompt.submit")
+                    }
+                    return .accepted
+                },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    if probeCount == 1 {
+                        await parkedProbe.suspend()
+                    }
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101"])
+        let resumesBeforeSubmit = resumeCount
+
+        let submission = Task { @MainActor in
+            await harness.appState.submitComposer(text: "A")
+        }
+        await parkedProbe.waitUntilSuspended()
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        parkedProbe.resume()
+
+        let submittedA = await submission.value
+        XCTAssertTrue(submittedA)
+        XCTAssertEqual(submitCount, 1)
+        XCTAssertEqual(transcriptReads, 1)
+
+        // The turn settles. The retained locally-owned marker turns this
+        // settle into the standard missing-boundary debt.
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: false))
+        XCTAssertEqual(harness.appState.turnState, .idle)
+
+        // The next ordinary send clears the debt with ONE bounded read
+        // (exactly one new canonical user boundary observed) and proceeds —
+        // no authoritative resume.
+        let submittedB = await harness.appState.submitComposer(text: "B")
+        XCTAssertTrue(submittedB)
+        XCTAssertEqual(submitCount, 2, "Exactly one new local prompt after the debt read")
+        XCTAssertEqual(
+            transcriptReads, 2,
+            "One bounded read satisfies the settle debt before the baseline freezes"
+        )
+        XCTAssertEqual(resumeCount, resumesBeforeSubmit, "A satisfied debt needs no authoritative resume")
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertEqual(harness.appState.messages.count, 4, "Both optimistic rows remain: A and B")
+        XCTAssertEqual(harness.appState.messages.last?.content, "B")
+        box.client.disconnect()
+    }
+
+    /// Symmetric provenance coverage for `.acceptedUnsettled`: a `starting`
+    /// registry row with the durable row present proves acceptance but not
+    /// settlement. When a newer busy edge races the durable verification, the
+    /// same split applies — the edge owns the lifecycle state, the accepted
+    /// marker stays live — and a later background/foreground cycle stays
+    /// observational with the live reasoning projection intact.
+    func testAmbiguousAcceptedUnsettledAfterNewerBusyEdgeRetainsLocalTurnContinuity() async {
+        let active = session("stored-a")
+        var submitCount = 0
+        var probeCount = 0
+        var transcriptReads = 0
+        var resumeCount = 0
+        let parkedRead = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    if transcriptReads == 2 {
+                        // Recovery's bounded verification: parked until the
+                        // newer busy edge has raced it; then the submitted
+                        // user row. Later reads (the foreground freshness
+                        // check) must pass through ungated.
+                        await parkedRead.suspend()
+                    }
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "A", "timestamp": "3"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 3]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    throw HermesError.timeout("prompt.submit")
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    // The recovery probe observes `starting` (the submit →
+                    // agent-ready window); by the foreground the build has
+                    // completed and the registry reports committed-busy.
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: probeCount == 1 ? "starting" : "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101"])
+        let resumesBeforeSubmit = resumeCount
+
+        let submission = Task { @MainActor in
+            await harness.appState.submitComposer(text: "A")
+        }
+        await parkedRead.waitUntilSuspended()
+        // A newer busy edge lands while the durable verification awaits.
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        XCTAssertEqual(harness.appState.turnState, .running)
+        parkedRead.resume()
+
+        let submitted = await submission.value
+
+        // Accepted-unsettled: never a failed send, no verifier re-read, and
+        // the newer edge's running state survives untouched.
+        XCTAssertTrue(submitted, "Durable acceptance must not surface as a failed send")
+        XCTAssertEqual(submitCount, 1, "An accepted prompt must never be re-submitted")
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 2, "One bounded tail read decides the outcome")
+        XCTAssertEqual(harness.appState.turnState, .running, "The newer busy edge owns the lifecycle state")
+        XCTAssertEqual(harness.appState.messages.count, 3, "The optimistic user row remains accepted")
+
+        // The retained ownership marker must carry the turn through a
+        // background/foreground cycle observationally.
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "Thinking."))
+        let segmentBefore = harness.appState.liveReasoningSegment
+        XCTAssertNotNil(segmentBefore)
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(resumeCount, resumesBeforeSubmit, "Zero session.resume: retained ownership proves same-turn continuity")
+        XCTAssertEqual(probeCount, 2, "The foreground probes the registry once")
+        XCTAssertEqual(transcriptReads, 3, "The foreground freshness check reads the bounded tail once")
+        XCTAssertEqual(
+            harness.appState.liveReasoningSegment?.id, segmentBefore?.id,
+            "The live reasoning segment must survive the foreground"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertEqual(harness.appState.messages.count, 3)
         box.client.disconnect()
     }
 

--- a/ConduitTests/AppStateForegroundLifecycleTests.swift
+++ b/ConduitTests/AppStateForegroundLifecycleTests.swift
@@ -3942,8 +3942,11 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
     /// A locally-submitted Turn A whose persisted evidence advanced past the
     /// pre-turn frontier while suspended (A completed, another surface
     /// started Turn B) must NOT keep the optimistic tail as same-turn
-    /// continuation: persisted advancement wins and forces the authoritative
-    /// attach, resetting Turn A's live projection in favor of Turn B's.
+    /// continuation. The tail shows TWO new canonical user-turn boundaries
+    /// after the pre-submit anchor (Turn A's twin and Turn B's prompt): the
+    /// second boundary proves a later turn exists and forces the
+    /// authoritative attach, resetting Turn A's live projection in favor of
+    /// Turn B's.
     func testForegroundLocallyOwnedOptimisticTailYieldsToPersistedTurnB() async {
         let active = session("stored-a")
         var probeCount = 0
@@ -4241,6 +4244,681 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         XCTAssertTrue(harness.appState.composerIsEnabled)
         XCTAssertFalse(harness.appState.activeChatScrollSessionIdentity.isReconciling)
         box.client.disconnect()
+    }
+
+    // MARK: - Round 9: realistic persisted shape, busy-edge race
+
+    /// The REALISTIC locally-submitted turn: Hermes persists the user row at
+    /// turn start, so the foreground bounded tail already contains the
+    /// durable twin (102) of Conduit's optimistic local row. Exactly ONE new
+    /// canonical user-turn boundary after the pre-submit anchor is the
+    /// expected Turn A twin — it must NOT force a resume: zero
+    /// `session.resume`, transcript untouched (the twin is never merged
+    /// behind the optimistic bubble), live reasoning projection intact.
+    func testForegroundLocalTurnAWithPersistedUserTwinStaysObservational() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        var submitCount = 0
+        let seedPayload: [String: Any] = [
+            "messages": [
+                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+            ],
+            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+        ]
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload(seedPayload)
+                    }
+                    // The freshness read: Hermes' crash-resilience path has
+                    // already persisted the durable twin of our optimistic
+                    // user row.
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "Follow-up question", "timestamp": "3"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 3]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101"])
+
+        let submitted = await harness.appState.submitComposer(text: "Follow-up question")
+        XCTAssertTrue(submitted)
+        XCTAssertEqual(submitCount, 1)
+        XCTAssertEqual(harness.appState.messages.count, 3)
+        XCTAssertTrue(
+            harness.appState.messages.last?.id.hasPrefix("local-") == true,
+            "The visible user row must still be the optimistic local row"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "Thinking."))
+        let segmentBefore = harness.appState.liveReasoningSegment
+        XCTAssertNotNil(segmentBefore)
+        let messagesBefore = harness.appState.messages
+        let resumesBeforeForeground = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 2, "One bounded freshness read")
+        XCTAssertEqual(
+            resumeCount, resumesBeforeForeground,
+            "The durable user twin of our own turn must NOT force a session.resume"
+        )
+        XCTAssertEqual(
+            harness.appState.messages, messagesBefore,
+            "The persisted twin is never merged behind the optimistic row"
+        )
+        XCTAssertEqual(harness.appState.liveReasoningSegment, segmentBefore)
+        XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertFalse(harness.appState.transcriptFreshnessIsStale)
+
+        // Future deltas extend the SAME turn.
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: " More."))
+        XCTAssertEqual(harness.appState.liveReasoningSegment?.id, segmentBefore?.id)
+        harness.appState.showSidebar = true
+        harness.appState.showSidebar = false
+        XCTAssertEqual(harness.appState.liveReasoningSegment?.content, "Thinking. More.")
+        box.client.disconnect()
+    }
+
+    /// Turn A's crash-resilience persistence can outrun the live stream:
+    /// besides the durable user twin, assistant and tool rows of the SAME
+    /// turn may already be persisted while the runtime is still working.
+    /// Non-user rows do not prove another turn: exactly one new canonical
+    /// user boundary stays same-turn continuation — zero resume, same live
+    /// projection, same optimistic local row.
+    func testForegroundLocalTurnAWithPersistedTurnARowsStaysObservational() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        var submitCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    // Turn A's user twin PLUS two Turn A rows (assistant
+                    // output and a tool row): still only ONE new user-turn
+                    // boundary after the pre-submit anchor.
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "Follow-up question", "timestamp": "3"],
+                            ["id": "103", "role": "assistant", "content": "Working answer", "timestamp": "4"],
+                            ["id": "104", "role": "tool", "content": "tool output", "timestamp": "5"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 5]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+
+        let submitted = await harness.appState.submitComposer(text: "Follow-up question")
+        XCTAssertTrue(submitted)
+        XCTAssertEqual(submitCount, 1)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "Thinking."))
+        let segmentBefore = harness.appState.liveReasoningSegment
+        let messagesBefore = harness.appState.messages
+        let resumesBeforeForeground = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 2)
+        XCTAssertEqual(
+            resumeCount, resumesBeforeForeground,
+            "Turn A's own persisted output/tool rows must NOT force a session.resume"
+        )
+        XCTAssertEqual(harness.appState.messages, messagesBefore)
+        XCTAssertEqual(harness.appState.liveReasoningSegment, segmentBefore)
+        XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertFalse(harness.appState.transcriptFreshnessIsStale)
+        box.client.disconnect()
+    }
+
+    /// A busy edge that races the pre-send freshness read must win: when the
+    /// gate's bounded read returns and the SAME conversation has turned
+    /// running, the text routes through the configured busy submission —
+    /// never an ordinary new-turn `prompt.submit`, and no optimistic
+    /// new-turn row is appended into the running turn.
+    func testPreSendFreshnessRetryYieldsToBusyEdge() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        var submitCount = 0
+        var steerCount = 0
+        let parkedRead = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    if transcriptReads == 2 {
+                        // The foreground freshness read fails transiently,
+                        // arming the pre-send gate.
+                        return .failed(DashboardTicketBridgeError.http(
+                            status: 503,
+                            detail: "temporarily unavailable"
+                        ))
+                    }
+                    // Hold ONLY the pre-send retry; the busy edge lands
+                    // while it is suspended.
+                    if transcriptReads == 3 {
+                        await parkedRead.suspend()
+                    }
+                    return .failed(DashboardTicketBridgeError.http(
+                        status: 503,
+                        detail: "temporarily unavailable"
+                    ))
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                },
+                steer: { _, _, _ in
+                    steerCount += 1
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+        XCTAssertTrue(harness.appState.transcriptFreshnessIsStale)
+        XCTAssertEqual(harness.appState.turnState, .idle)
+
+        let submission = Task { @MainActor in
+            await harness.appState.submitComposer(text: "Follow-up")
+        }
+        await parkedRead.waitUntilSuspended()
+        // The race: a live busy edge arrives while the pre-send freshness
+        // read is suspended.
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        XCTAssertEqual(harness.appState.turnState, .running)
+        parkedRead.resume()
+
+        let submitted = await submission.value
+        XCTAssertTrue(submitted, "The steered busy submission reports success")
+
+        XCTAssertEqual(submitCount, 0, "No ordinary prompt.submit into a running turn")
+        XCTAssertEqual(steerCount, 1, "The text routed through the configured busy action")
+        XCTAssertEqual(transcriptReads, 3, "No retry loop behind the routed submission")
+        XCTAssertEqual(
+            harness.appState.messages.map(\.id), ["100", "101"],
+            "No optimistic new-turn row is appended into the running turn"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertTrue(
+            harness.appState.transcriptFreshnessIsStale,
+            "The busy path does not claim transcript freshness it never checked"
+        )
+        box.client.disconnect()
+    }
+
+    // MARK: - Round 9 review hardening
+
+    /// The twin is what makes the one-boundary shape provable. When the
+    /// first persisted row after the pre-submit anchor is NOT a user prompt
+    /// (the twin is missing while Turn A output rows persisted), the page
+    /// cannot prove same-turn continuity — the classifier must take the
+    /// authoritative attach, not observational adoption.
+    func testForegroundLocalTurnAWithMissingUserTwinTakesAttach() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        var submitCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(
+                            object: ["running": .bool(resumeCount > 1)],
+                            inflight: resumeCount > 1
+                                ? .object(["text": .string("Recovered partial answer")])
+                                : nil
+                        )
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    // Turn A output rows persisted WITHOUT the user twin:
+                    // the first row after the anchor is not a user prompt.
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "103", "role": "assistant", "content": "Orphaned output", "timestamp": "3"],
+                            ["id": "104", "role": "assistant", "content": "More orphaned output", "timestamp": "4"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+
+        let submitted = await harness.appState.submitComposer(text: "Follow-up question")
+        XCTAssertTrue(submitted)
+        XCTAssertEqual(submitCount, 1)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "Turn A thinking."))
+        XCTAssertNotNil(harness.appState.liveReasoningSegment)
+        let resumesBeforeForeground = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 3, "Freshness read + the attach reconcile's bounded read")
+        XCTAssertEqual(
+            resumeCount, resumesBeforeForeground + 1,
+            "A non-user first row after the anchor cannot prove same-turn continuity"
+        )
+        XCTAssertEqual(
+            harness.appState.messages.map(\.id), ["100", "101", "103", "104"],
+            "The authoritative attach owns the unprovable tail"
+        )
+        XCTAssertNil(
+            harness.appState.liveReasoningSegment,
+            "The optimistic live projection must not survive the attach"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
+        box.client.disconnect()
+    }
+
+    /// A brand-new conversation's first locally-submitted turn has NO
+    /// durable pre-submit anchor, so no boundary proof can exist even for
+    /// the expected twin — the conservative attach owns it.
+    func testForegroundFirstTurnWithoutDurableAnchorTakesAttach() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        var submitCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(
+                            object: ["running": .bool(resumeCount > 1)],
+                            inflight: resumeCount > 1
+                                ? .object(["text": .string("First turn partial")])
+                                : nil
+                        )
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        // A positively empty conversation: no durable rows.
+                        return .payload([
+                            "messages": [],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 0]
+                        ])
+                    }
+                    // The twin of our optimistic first-turn user row.
+                    return .payload([
+                        "messages": [
+                            ["id": "102", "role": "user", "content": "First question", "timestamp": "1"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 1]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertTrue(harness.appState.messages.isEmpty)
+
+        let submitted = await harness.appState.submitComposer(text: "First question")
+        XCTAssertTrue(submitted)
+        XCTAssertEqual(submitCount, 1)
+        XCTAssertEqual(harness.appState.messages.count, 1)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "Thinking."))
+        XCTAssertNotNil(harness.appState.liveReasoningSegment)
+        let resumesBeforeForeground = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 3)
+        XCTAssertEqual(
+            resumeCount, resumesBeforeForeground + 1,
+            "No durable anchor → no ordering proof → the attach owns the tail"
+        )
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["102"])
+        XCTAssertNil(harness.appState.liveReasoningSegment)
+        XCTAssertEqual(harness.appState.turnState, .running)
+        box.client.disconnect()
+    }
+
+    /// The gate's second non-proceed arm: a recovery boundary
+    /// (.reconnecting here) racing the pre-send freshness read proves
+    /// neither liveness nor ordering — the send is blocked, not blind-sent
+    /// and not routed as a busy action.
+    func testPreSendFreshnessRetryBlockedByRecoveryBoundary() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        var submitCount = 0
+        let parkedRead = LifecycleSuspension()
+        let parkedMint = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                mintTicket: { _ in
+                    await parkedMint.suspend()
+                    return "ticket"
+                },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    if transcriptReads == 2 {
+                        return .failed(DashboardTicketBridgeError.http(
+                            status: 503,
+                            detail: "temporarily unavailable"
+                        ))
+                    }
+                    if transcriptReads == 3 {
+                        await parkedRead.suspend()
+                    }
+                    return .failed(DashboardTicketBridgeError.http(
+                        status: 503,
+                        detail: "temporarily unavailable"
+                    ))
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+        XCTAssertTrue(harness.appState.transcriptFreshnessIsStale)
+
+        let submission = Task { @MainActor in
+            await harness.appState.submitComposer(text: "Follow-up")
+        }
+        await parkedRead.waitUntilSuspended()
+        // The race: a reconnect boundary starts while the pre-send freshness
+        // read is suspended and parks mid-mint in .reconnecting.
+        let reconnect = Task { @MainActor in
+            await harness.appState.reconnectForRetry(purpose: .automaticReturn)
+        }
+        await parkedMint.waitUntilSuspended()
+        XCTAssertEqual(harness.appState.turnState, .reconnecting)
+        parkedRead.resume()
+
+        let submitted = await submission.value
+        XCTAssertFalse(submitted, "The blocked send must not report success")
+
+        XCTAssertEqual(submitCount, 0, "No ordinary prompt.submit past a recovery boundary")
+        XCTAssertEqual(transcriptReads, 3, "No retry loop behind the blocked send")
+        XCTAssertEqual(
+            harness.appState.messages.map(\.id), ["100", "101"],
+            "No optimistic new-turn row is appended past a recovery boundary"
+        )
+        XCTAssertEqual(
+            harness.appState.errorMessage, "Unable to refresh this conversation. Try again."
+        )
+        XCTAssertEqual(harness.appState.turnState, .reconnecting)
+        box.client.disconnect()
+    }
+
+    /// The busy-edge rule also covers the sibling stale-idle probe: a busy
+    /// edge landing while THAT probe is suspended must route through the
+    /// configured busy action instead of falling through to an ordinary
+    /// new-turn prompt.submit into the now-running turn.
+    func testStaleIdleProbeBusyEdgeRaceRoutesThroughBusyAction() async {
+        let active = session("stored-a")
+        var submitCount = 0
+        var steerCount = 0
+        var probeCount = 0
+        let parkedProbe = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    await parkedProbe.suspend()
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                },
+                steer: { _, _, _ in
+                    steerCount += 1
+                }
+            )
+        )
+        installDisconnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        // The lifecycle boundary marks the local idle state stale.
+        harness.appState.handleScenePhase(.background)
+
+        let submission = Task { @MainActor in
+            await harness.appState.submitComposer(text: "Follow-up")
+        }
+        await parkedProbe.waitUntilSuspended()
+        // The race: the live busy edge lands while the stale-idle probe is
+        // suspended.
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        XCTAssertEqual(harness.appState.turnState, .running)
+        parkedProbe.resume()
+
+        let submitted = await submission.value
+        XCTAssertTrue(submitted)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(submitCount, 0, "No ordinary prompt.submit into the running turn")
+        XCTAssertEqual(steerCount, 1, "The text routed through the configured busy action")
+        XCTAssertTrue(
+            harness.appState.messages.isEmpty,
+            "No optimistic new-turn row is appended into the running turn"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
     }
 
     // MARK: - Harness

--- a/ConduitTests/AppStateForegroundLifecycleTests.swift
+++ b/ConduitTests/AppStateForegroundLifecycleTests.swift
@@ -199,6 +199,241 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         box.client.disconnect()
     }
 
+    // MARK: - C2. Stale transitional state under an authoritative idle probe
+
+    /// A recovery attempt parked mid-reconcile leaves the transitional
+    /// `.synchronizing` state behind even though the socket is healthy. The
+    /// next foreground cycle's authoritative idle observation must adopt
+    /// idle — composer usable, no resume, transcript untouched — instead of
+    /// settling the boundary around the stale state.
+    func testForegroundWithStaleSynchronizingAndAuthoritativeIdleAdoptsIdle() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        let parkedRefresh = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    await parkedRefresh.suspend()
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let seedMessages = [
+            ChatMessage(id: "user", role: .user, content: "Earlier", timestamp: "1")
+        ]
+        harness.appState.messages = seedMessages
+
+        // A previous recovery attempt (explicit re-resume) parks mid-reconcile
+        // with the transitional state showing. The task is deliberately not
+        // awaited: its unwinding is covered by the rotated-token guards.
+        Task { @MainActor in
+            await harness.appState.refreshActiveSession()
+        }
+        await parkedRefresh.waitUntilSuspended()
+        XCTAssertEqual(harness.appState.turnState, .synchronizing)
+        let resumeCountBeforeForeground = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(
+            resumeCount, resumeCountBeforeForeground,
+            "The foreground refresh must not issue any resume of its own"
+        )
+        XCTAssertEqual(
+            harness.appState.turnState, .idle,
+            "An authoritative idle observation must clear the stale transitional state"
+        )
+        XCTAssertTrue(
+            harness.appState.composerIsEnabled,
+            "The composer must be usable once the registry says idle"
+        )
+        XCTAssertFalse(harness.appState.turnStateIsStale)
+        XCTAssertEqual(harness.appState.messages, seedMessages, "The transcript must remain stable")
+        XCTAssertFalse(
+            harness.appState.activeChatScrollSessionIdentity.isReconciling,
+            "No reconciliation may remain open after the observational refresh"
+        )
+
+        // The abandoned refresh unwinds through its rotated-token guards; it
+        // must not undo the adopted idle state or the transcript.
+        parkedRefresh.resume()
+        await flushMainActor()
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        XCTAssertEqual(
+            harness.appState.messages, seedMessages,
+            "The abandoned refresh must not replace the transcript"
+        )
+        XCTAssertFalse(
+            harness.appState.activeChatScrollSessionIdentity.isReconciling
+        )
+        box.client.disconnect()
+    }
+
+    /// A recovery attempt parked while reconnecting (the ticket mint stands
+    /// in for a slow dashboard handoff) leaves `.reconnecting` behind even
+    /// though the socket is healthy. The next foreground cycle's
+    /// authoritative idle observation must adopt idle with the same
+    /// observational guarantees.
+    func testForegroundWithStaleReconnectingAndAuthoritativeIdleAdoptsIdle() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        let parkedReconnect = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                mintTicket: { _ in
+                    await parkedReconnect.suspend()
+                    return "ticket"
+                },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let seedMessages = [
+            ChatMessage(id: "user", role: .user, content: "Earlier", timestamp: "1")
+        ]
+        harness.appState.messages = seedMessages
+
+        // A previous connection/recovery attempt parks mid-reconnect, leaving
+        // the transitional state showing. The gate is deliberately never
+        // released: a mint that resolves in production proceeds into the
+        // reconnect cycle's own full authoritative sync (the automatic-work
+        // token is shared, not rotated), and pinning the post-release state
+        // would require stubbing the entire reconnect transport chain — the
+        // foreground adoption under test must not depend on either outcome.
+        Task { @MainActor in
+            await harness.appState.reconnectForRetry(purpose: .automaticReturn)
+        }
+        await parkedReconnect.waitUntilSuspended()
+        XCTAssertEqual(harness.appState.turnState, .reconnecting)
+        XCTAssertEqual(resumeCount, 0)
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(resumeCount, 0, "An idle healthy session must not be resumed")
+        XCTAssertEqual(
+            harness.appState.turnState, .idle,
+            "An authoritative idle observation must clear the stale transitional state"
+        )
+        XCTAssertTrue(
+            harness.appState.composerIsEnabled,
+            "The composer must be usable once the registry says idle"
+        )
+        XCTAssertFalse(harness.appState.turnStateIsStale)
+        XCTAssertEqual(harness.appState.messages, seedMessages, "The transcript must remain stable")
+        XCTAssertFalse(
+            harness.appState.activeChatScrollSessionIdentity.isReconciling,
+            "No reconciliation may remain open after the observational refresh"
+        )
+        box.client.disconnect()
+    }
+
+    /// The adopted idle baseline is the OLDER observation: a busy edge that
+    /// races the probe and lands in the boundary buffer must win when the
+    /// buffer is replayed, instead of being discarded by the idle adoption.
+    func testForegroundAdoptedIdleYieldsToNewerBufferedBusyEdge() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        let parkedProbe = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    await parkedProbe.suspend()
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        harness.appState.messages = [
+            ChatMessage(id: "user", role: .user, content: "Earlier", timestamp: "1")
+        ]
+
+        harness.appState.handleScenePhase(.background)
+        let activation = Task { @MainActor in
+            await runSceneActivation(harness)
+        }
+        // Hold the foreground activation at the probe, then deliver a newer
+        // busy edge while the reconciliation boundary is open.
+        await parkedProbe.waitUntilSuspended()
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        parkedProbe.resume()
+        await activation.value
+        await flushMainActor()
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(resumeCount, 0, "An idle healthy session must not be resumed")
+        XCTAssertEqual(
+            harness.appState.turnState, .running,
+            "The newer buffered busy edge must win over the adopted idle baseline"
+        )
+        XCTAssertTrue(
+            harness.appState.composerIsEnabled,
+            "A running turn keeps composer actions (stop/steer) available"
+        )
+        XCTAssertFalse(harness.appState.turnStateIsStale)
+        box.client.disconnect()
+    }
+
     // MARK: - D. inactive → active only
 
     func testInactiveToActiveCycleDoesNotResumeOrResetReasoning() async {

--- a/ConduitTests/AppStateForegroundLifecycleTests.swift
+++ b/ConduitTests/AppStateForegroundLifecycleTests.swift
@@ -1534,10 +1534,13 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         await runSceneActivation(harness)
 
         XCTAssertEqual(probeCount, 1)
-        XCTAssertEqual(transcriptReads, 3, "Freshness read + the reconcile's bounded read; no more")
         XCTAssertEqual(
-            resumeCount, resumesBeforeForeground + 2,
-            "Compact resume + the structural fallback's legacy re-resume"
+            transcriptReads, 2,
+            "Seed hydration + the foreground freshness read only — the hinted reconcile skips the history request"
+        )
+        XCTAssertEqual(
+            resumeCount, resumesBeforeForeground + 1,
+            "Exactly one authoritative noncompact resume — no compact attempt, no second resume"
         )
         XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101", "102", "103"])
         XCTAssertEqual(harness.appState.turnState, .idle)
@@ -1614,9 +1617,13 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         XCTAssertEqual(harness.appState.messages, messagesBefore)
         XCTAssertEqual(harness.appState.turnState, .idle)
         XCTAssertTrue(harness.appState.composerIsEnabled)
-        XCTAssertTrue(
+        XCTAssertFalse(
             harness.appState.turnStateIsStale,
-            "Freshness is unresolved: the stale marker must be retained"
+            "Turn-state staleness is resolved: the registry's idle answer was adopted"
+        )
+        XCTAssertTrue(
+            harness.appState.transcriptFreshnessIsStale,
+            "Transcript freshness is unresolved: the freshness marker must be retained"
         )
         box.client.disconnect()
     }
@@ -1688,9 +1695,13 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         XCTAssertEqual(resumeCount, resumesBeforeForeground, "No resume cascade")
         XCTAssertEqual(harness.appState.messages, messagesBefore)
         XCTAssertEqual(harness.appState.turnState, .running)
-        XCTAssertTrue(
+        XCTAssertFalse(
             harness.appState.turnStateIsStale,
-            "Freshness is unresolved on the running path too: the stale marker must be retained"
+            "Turn-state staleness is resolved: the registry's working answer was adopted"
+        )
+        XCTAssertTrue(
+            harness.appState.transcriptFreshnessIsStale,
+            "Transcript freshness is unresolved on the running path too: the freshness marker must be retained"
         )
         box.client.disconnect()
     }
@@ -3809,6 +3820,427 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
                 "Synthetic id \(syntheticID): the durable tail restored exactly once"
             )
         }
+    }
+
+    // MARK: - Round 8: locally-owned optimistic tails, freshness split, single structural resume
+
+    /// The NORMAL workflow: a real `submitComposer` turn starts with an
+    /// optimistic `local-*` user row that has NO durable id. Background +
+    /// foreground with the runtime still working on that same locally
+    /// submitted turn must stay observational — zero `session.resume`, zero
+    /// transcript replacement, the optimistic row and the live reasoning
+    /// segment survive, and later deltas extend the same turn.
+    func testForegroundNormalLocallySubmittedRunningTurnStaysObservational() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        var submitCount = 0
+        let seedPayload: [String: Any] = [
+            "messages": [
+                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+            ],
+            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+        ]
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    // Every read returns only the durable pre-turn history:
+                    // the in-flight turn has persisted nothing.
+                    return .payload(seedPayload)
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101"])
+
+        // The real submit path: optimistic user row, accepted prompt, live
+        // reasoning projection.
+        let submitted = await harness.appState.submitComposer(text: "Follow-up question")
+        XCTAssertTrue(submitted)
+        XCTAssertEqual(submitCount, 1)
+        XCTAssertEqual(harness.appState.messages.count, 3)
+        XCTAssertEqual(harness.appState.messages.last?.role, .user)
+        XCTAssertTrue(
+            harness.appState.messages.last?.id.hasPrefix("local-") == true,
+            "The visible user row must be the optimistic local row"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "Thinking."))
+        let segmentBefore = harness.appState.liveReasoningSegment
+        XCTAssertNotNil(segmentBefore)
+        let messagesBefore = harness.appState.messages
+        let resumesBeforeForeground = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(
+            transcriptReads, 2,
+            "One bounded freshness read; the durable frontier is unchanged"
+        )
+        XCTAssertEqual(
+            resumeCount, resumesBeforeForeground,
+            "The normal locally-submitted running turn must NOT pay a session.resume"
+        )
+        XCTAssertEqual(harness.appState.messages, messagesBefore, "No transcript replacement")
+        XCTAssertEqual(
+            harness.appState.liveReasoningSegment, segmentBefore,
+            "The live reasoning projection survives the foreground cycle"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertFalse(harness.appState.turnStateIsStale)
+        XCTAssertFalse(harness.appState.transcriptFreshnessIsStale)
+
+        // Future deltas extend the SAME turn — no reset, no replacement.
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: " More."))
+        XCTAssertEqual(
+            harness.appState.liveReasoningSegment?.id, segmentBefore?.id,
+            "Later deltas must extend the same live reasoning segment"
+        )
+        // The sidebar toggle synchronously flushes the coalesced live
+        // projection publish (the established deterministic-test pattern).
+        harness.appState.showSidebar = true
+        harness.appState.showSidebar = false
+        XCTAssertEqual(
+            harness.appState.liveReasoningSegment?.content, "Thinking. More.",
+            "The delta merged into the SAME segment's buffer"
+        )
+        box.client.disconnect()
+    }
+
+    /// A locally-submitted Turn A whose persisted evidence advanced past the
+    /// pre-turn frontier while suspended (A completed, another surface
+    /// started Turn B) must NOT keep the optimistic tail as same-turn
+    /// continuation: persisted advancement wins and forces the authoritative
+    /// attach, resetting Turn A's live projection in favor of Turn B's.
+    func testForegroundLocallyOwnedOptimisticTailYieldsToPersistedTurnB() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        var submitCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(
+                            object: ["running": .bool(resumeCount > 1)],
+                            inflight: resumeCount > 1
+                                ? .object(["text": .string("Turn B partial answer")])
+                                : nil
+                        )
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    // Turn A's rows AND Turn B's first row are persisted:
+                    // advancement beyond the locally-owned pre-turn frontier.
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "Turn A question", "timestamp": "3"],
+                            ["id": "103", "role": "assistant", "content": "Turn A answer", "timestamp": "4"],
+                            ["id": "104", "role": "user", "content": "Turn B question", "timestamp": "5"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 5]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+
+        let submitted = await harness.appState.submitComposer(text: "Turn A question")
+        XCTAssertTrue(submitted)
+        XCTAssertEqual(submitCount, 1)
+        XCTAssertEqual(harness.appState.turnState, .running)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "Turn A thinking."))
+        XCTAssertNotNil(harness.appState.liveReasoningSegment)
+        let resumesBeforeForeground = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 3, "Freshness read + the attach reconcile's bounded read")
+        XCTAssertEqual(
+            resumeCount, resumesBeforeForeground + 1,
+            "Persisted advancement behind an optimistic tail forces the authoritative attach"
+        )
+        XCTAssertEqual(
+            harness.appState.messages.map(\.id), ["100", "101", "102", "103", "104"],
+            "Turn A completion and Turn B prefix are visible after the attach"
+        )
+        XCTAssertNil(
+            harness.appState.liveReasoningSegment,
+            "The stale Turn A reasoning segment must not survive the attach"
+        )
+        XCTAssertEqual(
+            harness.appState.streamingText, "Turn B partial answer",
+            "Turn B's live projection is authoritative"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
+        box.client.disconnect()
+    }
+
+    /// A transient foreground freshness failure leaves
+    /// `transcriptFreshnessIsStale` set. The next NEW-TURN submit runs
+    /// exactly one bounded tail-only retry; when it proves advancement, the
+    /// missing rows merge BEFORE the optimistic user row appends, and the
+    /// send proceeds with zero resume.
+    func testPreSendFreshnessRetryMergesMissingRowsBeforeNewPrompt() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        var submitCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    if transcriptReads == 2 {
+                        // The foreground freshness read fails transiently.
+                        return .failed(DashboardTicketBridgeError.http(
+                            status: 503,
+                            detail: "temporarily unavailable"
+                        ))
+                    }
+                    // The pre-send retry proves the remote completed turn.
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "Remote question", "timestamp": "3"],
+                            ["id": "103", "role": "assistant", "content": "Remote answer", "timestamp": "4"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        let resumesBefore = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 2, "No foreground retry, no legacy fallback")
+        XCTAssertEqual(resumeCount, resumesBefore, "No resume on the transient path")
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101"])
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        XCTAssertFalse(harness.appState.turnStateIsStale)
+        XCTAssertTrue(harness.appState.transcriptFreshnessIsStale)
+
+        let submitted = await harness.appState.submitComposer(text: "Follow-up")
+        XCTAssertTrue(submitted)
+
+        XCTAssertEqual(submitCount, 1, "prompt.submit called exactly once")
+        XCTAssertEqual(transcriptReads, 3, "Exactly one bounded pre-send retry")
+        XCTAssertEqual(
+            resumeCount, resumesBefore,
+            "The merge needs no resume — the persisted source supplied the rows"
+        )
+        XCTAssertEqual(
+            harness.appState.messages.count, 5,
+            "Missing remote rows reconcile, then the optimistic user appends"
+        )
+        XCTAssertEqual(
+            Array(harness.appState.messages.map(\.id).prefix(4)), ["100", "101", "102", "103"],
+            "The remote rows land before the new prompt"
+        )
+        XCTAssertEqual(harness.appState.messages.last?.role, .user)
+        XCTAssertTrue(
+            harness.appState.messages.last?.id.hasPrefix("local-") == true,
+            "The new prompt appends last, after the reconciled rows"
+        )
+        XCTAssertFalse(
+            harness.appState.transcriptFreshnessIsStale,
+            "A proven advancement merge clears transcript freshness"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
+        box.client.disconnect()
+    }
+
+    /// A SECOND transient freshness failure at the pre-send gate must not
+    /// loop, must not fall back to full history, and must not silently
+    /// append a new-turn prompt into an unresolved ordering: the send is
+    /// blocked with a lightweight retryable message.
+    func testPreSendFreshnessRetryTransientFailureBlocksNewTurn() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        var submitCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    return .failed(DashboardTicketBridgeError.http(
+                        status: 503,
+                        detail: "temporarily unavailable"
+                    ))
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        let resumesBefore = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+        XCTAssertTrue(harness.appState.transcriptFreshnessIsStale)
+
+        let submitted = await harness.appState.submitComposer(text: "Follow-up")
+        XCTAssertFalse(submitted, "The blocked send must not report success")
+
+        XCTAssertEqual(submitCount, 0, "No prompt.submit into an unresolved ordering")
+        XCTAssertEqual(transcriptReads, 3, "Foreground read + one retry; no loop, no legacy fallback")
+        XCTAssertEqual(resumeCount, resumesBefore, "A transient failure never escalates to a resume")
+        XCTAssertEqual(
+            harness.appState.messages.map(\.id), ["100", "101"],
+            "The new-turn prompt must not append out of order"
+        )
+        XCTAssertTrue(
+            harness.appState.transcriptFreshnessIsStale,
+            "Freshness stays unresolved after the second transient failure"
+        )
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        XCTAssertTrue(harness.appState.composerIsEnabled)
+        XCTAssertFalse(harness.appState.activeChatScrollSessionIdentity.isReconciling)
+        box.client.disconnect()
     }
 
     // MARK: - Harness

--- a/ConduitTests/AppStateForegroundLifecycleTests.swift
+++ b/ConduitTests/AppStateForegroundLifecycleTests.swift
@@ -7356,6 +7356,239 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         box.client.disconnect()
     }
 
+    /// A steer whose RPC completes after the user switched conversations must
+    /// stay SUCCESSFUL (an accepted Hermes steer is never a local failure) but
+    /// must not mutate the current conversation's global lifecycle evidence.
+    /// Otherwise a late Session-A running claim contaminates Session B and
+    /// lets B's older ambiguous recovery resurrect accepted-turn ownership
+    /// over B's newer settled edge.
+    func testLateSteerFromPreviousConversationCannotOverwriteCurrentLifecycleEvidence() async {
+        let conversationA = session("stored-a")
+        let conversationB = session("stored-b")
+        var steerCount = 0
+        var submitCount = 0
+        var probeCount = 0
+        var transcriptReads = 0
+        var resumeCount = 0
+        let steerGate = LifecycleSuspension()
+        let probeGate = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [conversationA, conversationB] },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    // Stubbed so the transcriptReads assertions below are
+                    // live: any accidental verifier or debt read fails them.
+                    transcriptReads += 1
+                    return .payload([
+                        "messages": [],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 0]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    if submitCount == 1 {
+                        throw HermesError.timeout("prompt.submit")
+                    }
+                    return .accepted
+                },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    if probeCount == 1 {
+                        // B's ambiguous-recovery probe is parked.
+                        await probeGate.suspend()
+                    }
+                    // The stale registry snapshot still reports B committed-busy.
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-b",
+                        storedSessionId: "stored-b",
+                        status: "working"
+                    )]
+                },
+                steer: { _, _, _ in
+                    steerCount += 1
+                    if steerCount == 1 {
+                        // A's steer RPC is parked; B's whole recovery races it.
+                        await steerGate.suspend()
+                    }
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [conversationA, conversationB]
+        harness.appState.activeSessionId = conversationA.id
+        // A is running; the user steers into it.
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: conversationA.id, busy: true))
+        XCTAssertEqual(harness.appState.turnState, .running)
+
+        let steerSubmission = Task { @MainActor in
+            await harness.appState.submitComposer(text: "A correction")
+        }
+        await steerGate.waitUntilSuspended()
+
+        // The user switches to conversation B. A settle edge normalizes the
+        // shared turn state so B's text routes as an ordinary new turn.
+        harness.appState.activeSessionId = conversationB.id
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: conversationB.id, busy: false))
+        XCTAssertEqual(harness.appState.turnState, .idle)
+
+        // B's acknowledgement is ambiguous; its recovery probe parks.
+        let bSubmission = Task { @MainActor in
+            await harness.appState.submitComposer(text: "B prompt")
+        }
+        await probeGate.waitUntilSuspended()
+
+        // Newer authoritative evidence settles B while its recovery awaits.
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: conversationB.id, busy: false))
+        XCTAssertEqual(harness.appState.turnState, .idle)
+
+        // The parked Session-A steer completes successfully AFTER B's newer
+        // settle. It must still report success — without advancing B's
+        // lifecycle evidence to running.
+        steerGate.resume()
+        let steerSubmitted = await steerSubmission.value
+        XCTAssertTrue(
+            steerSubmitted,
+            "A successful steer stays successful across a conversation handoff"
+        )
+
+        // B's stale probe returns working. The newer settlement must win.
+        probeGate.resume()
+        let bSubmitted = await bSubmission.value
+
+        XCTAssertTrue(bSubmitted, "The accepted turn must not surface as a failed send")
+        XCTAssertEqual(submitCount, 1, "An accepted prompt must never be re-submitted")
+        XCTAssertEqual(steerCount, 1)
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(resumeCount, 0)
+        XCTAssertEqual(
+            transcriptReads, 0,
+            "A running registry row never consults the durable verifier"
+        )
+        XCTAssertEqual(
+            harness.appState.turnState, .idle,
+            "The newer settlement survives: no stale running stamp"
+        )
+        XCTAssertEqual(
+            harness.appState.messages.last?.content, "B prompt",
+            "The optimistic user row remains accepted"
+        )
+        XCTAssertNil(harness.appState.errorMessage)
+
+        // No hidden provenance leaked: a further settle with no resurrected
+        // marker records no ordering debt, so the next ordinary send needs no
+        // bounded read and no resume.
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: conversationB.id, busy: false))
+        let nextSubmitted = await harness.appState.submitComposer(text: "B next")
+        XCTAssertTrue(nextSubmitted)
+        XCTAssertEqual(submitCount, 2)
+        XCTAssertEqual(
+            transcriptReads, 0,
+            "No resurrected ownership: the later settle recorded no debt, so this send needs no bounded read"
+        )
+        XCTAssertEqual(
+            resumeCount, 0,
+            "No authoritative resume may follow the stale-evidence race"
+        )
+        XCTAssertEqual(harness.appState.messages.count, 2, "Both optimistic B rows remain")
+        box.client.disconnect()
+    }
+
+    /// Same-conversation alias rotation keeps the steer's lifecycle evidence:
+    /// a steer that begins for the stored session id and completes after the
+    /// runtime identity rotates (still the SAME conversation) must count as
+    /// authoritative running evidence. Observable through the recovery guard:
+    /// the evidence advance suppresses the acceptedRunning recovery's stale
+    /// clearing, so the boundary-written staleness survives.
+    func testSteerAfterSameConversationAliasRotationStillAdvancesLifecycleEvidence() async {
+        let active = session("stored-a", alternateIDs: ["runtime-a"])
+        var steerCount = 0
+        var submitCount = 0
+        var probeCount = 0
+        let steerGate = LifecycleSuspension()
+        let probeGate = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    throw HermesError.timeout("prompt.submit")
+                },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    if probeCount == 1 {
+                        // The ambiguous recovery's probe is parked.
+                        await probeGate.suspend()
+                    }
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                },
+                steer: { _, _, _ in
+                    steerCount += 1
+                    if steerCount == 1 {
+                        await steerGate.suspend()
+                    }
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+
+        let steerSubmission = Task { @MainActor in
+            await harness.appState.submitComposer(text: "A correction")
+        }
+        await steerGate.waitUntilSuspended()
+
+        // A settle edge, then the runtime identity rotates within the SAME
+        // conversation.
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: false))
+        harness.appState.activeSessionId = "runtime-a"
+
+        // An ambiguous send on the (aliased) conversation parks its recovery
+        // probe — the capture predates the parked steer's completion.
+        let submission = Task { @MainActor in
+            await harness.appState.submitComposer(text: "Ambiguous send")
+        }
+        await probeGate.waitUntilSuspended()
+        harness.appState.handleScenePhase(.background)
+        XCTAssertTrue(harness.appState.turnStateIsStale)
+
+        // The steer completes for the SAME conversation: its running evidence
+        // must advance.
+        steerGate.resume()
+        let steerSubmitted = await steerSubmission.value
+        XCTAssertTrue(steerSubmitted)
+
+        probeGate.resume()
+        let submitted = await submission.value
+
+        XCTAssertTrue(submitted, "The accepted turn must not surface as a failed send")
+        XCTAssertEqual(submitCount, 1, "An accepted prompt must never be re-submitted")
+        XCTAssertEqual(steerCount, 1)
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(
+            harness.appState.turnState, .running,
+            "The turn stays running-like for the accepted submission (from the pre-send optimistic stamp, not the suppressed recovery)"
+        )
+        XCTAssertTrue(
+            harness.appState.turnStateIsStale,
+            "The aliased steer advanced the evidence, so the recovery must not clear the boundary's staleness"
+        )
+        box.client.disconnect()
+    }
+
     // MARK: - Harness
 
     private func makeHarness(

--- a/ConduitTests/AppStateForegroundLifecycleTests.swift
+++ b/ConduitTests/AppStateForegroundLifecycleTests.swift
@@ -6252,6 +6252,676 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         XCTAssertEqual(harness.appState.turnState, .running)
     }
 
+    // MARK: - Round 13: `starting` never settles; lifecycle revisions order recovery stamps
+
+    /// The classification CONTRACT for ambiguous-submission recovery, pinned
+    /// as a pure matrix. `working`/`waiting` are authoritative committed-busy
+    /// state: they classify `.acceptedRunning` before the durable verifier is
+    /// consulted, regardless of transcript evidence — and regardless of which
+    /// client performed the probe, since ownership is not a classifier input
+    /// (regression C: a replacement/reconnected client's `working` row is
+    /// acceptedRunning, never acceptedSettled). `starting` NEVER classifies
+    /// `.acceptedSettled` or `.notAccepted`.
+    func testAmbiguousClassificationContractSplitRegistryStatuses() {
+        // committedBusy: a running registry row is never settled — the
+        // durable verdict is irrelevant (the verifier is not even consulted).
+        XCTAssertEqual(
+            AppState.classifyAmbiguousSubmission(
+                registryLiveness: .committedBusy,
+                transcript: .present
+            ),
+            .acceptedRunning
+        )
+        XCTAssertEqual(
+            AppState.classifyAmbiguousSubmission(
+                registryLiveness: .committedBusy,
+                transcript: .absent
+            ),
+            .acceptedRunning,
+            "A working/waiting row classifies acceptedRunning even when the durable tail cannot prove the row: the registry alone settles acceptance"
+        )
+        XCTAssertEqual(
+            AppState.classifyAmbiguousSubmission(
+                registryLiveness: .committedBusy,
+                transcript: .indeterminate
+            ),
+            .acceptedRunning
+        )
+
+        // starting: runtime present, liveness inconclusive.
+        XCTAssertEqual(
+            AppState.classifyAmbiguousSubmission(
+                registryLiveness: .starting,
+                transcript: .present
+            ),
+            .acceptedUnsettled,
+            "A durable submitted row under a starting runtime proves acceptance, never settlement"
+        )
+        XCTAssertEqual(
+            AppState.classifyAmbiguousSubmission(
+                registryLiveness: .starting,
+                transcript: .absent
+            ),
+            .unresolved,
+            "starting masks a committed turn that may not have reached the durable verification point: absent must stay unresolved, never notAccepted and never a resend"
+        )
+        XCTAssertEqual(
+            AppState.classifyAmbiguousSubmission(
+                registryLiveness: .starting,
+                transcript: .indeterminate
+            ),
+            .unresolved
+        )
+
+        // idle/absent: the durable transcript decides settled vs not-accepted.
+        for liveness in [AppState.AmbiguousRegistryLiveness.idle, .absent] {
+            XCTAssertEqual(
+                AppState.classifyAmbiguousSubmission(
+                    registryLiveness: liveness,
+                    transcript: .present
+                ),
+                .acceptedSettled
+            )
+            XCTAssertEqual(
+                AppState.classifyAmbiguousSubmission(
+                    registryLiveness: liveness,
+                    transcript: .absent
+                ),
+                .notAccepted
+            )
+            XCTAssertEqual(
+                AppState.classifyAmbiguousSubmission(
+                    registryLiveness: liveness,
+                    transcript: .indeterminate
+                ),
+                .unresolved
+            )
+        }
+    }
+
+    /// Regression A: an ambiguous prompt whose registry row reports
+    /// `starting` while the durable verifier proves the submitted user row.
+    /// The submission is ACCEPTED (never resent, optimistic row kept, no
+    /// failed-send restoration), but the turn is NOT settled: no idle stamp,
+    /// the turn stays running-like so the composer cannot ordinary-send a
+    /// fresh turn into the committed/building turn, and the next
+    /// authoritative registry/stream edges take over and settle it normally.
+    func testAmbiguousStartingRegistryWithDurableRowIsAcceptedUnsettled() async {
+        let active = session("stored-a")
+        var submitCount = 0
+        var steerCount = 0
+        var probeCount = 0
+        var transcriptReads = 0
+        var resumeCount = 0
+        var catalogCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    catalogCount += 1
+                    return [active]
+                },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        // The pre-submit hydration: two durable rows held.
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    // Recovery: the submitted user row persisted; the turn is
+                    // still building (no assistant output has landed).
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "Ambiguous send", "timestamp": "3"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 3]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    throw HermesError.timeout("prompt.submit")
+                },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "starting"
+                    )]
+                },
+                steer: { _, _, _ in
+                    steerCount += 1
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        // Establish durable provenance through the real hydration path.
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101"])
+        let resumesBeforeSubmit = resumeCount
+
+        let submitted = await harness.appState.submitComposer(text: "Ambiguous send")
+
+        // Accepted: never a failed send, never a resend, optimistic row kept.
+        XCTAssertTrue(
+            submitted,
+            "Durable acceptance under a starting runtime must not surface as a failed send"
+        )
+        XCTAssertEqual(submitCount, 1, "An accepted prompt must never be re-submitted")
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 2, "One bounded tail read decides the outcome")
+        XCTAssertEqual(
+            catalogCount, 0,
+            "No failed-send restoration may run for a durably accepted submission"
+        )
+        XCTAssertEqual(resumeCount, resumesBeforeSubmit)
+        XCTAssertEqual(
+            harness.appState.messages.last?.content, "Ambiguous send",
+            "The optimistic user row remains accepted"
+        )
+
+        // NOT settled: the turn stays running-like, so a follow-up routes
+        // through the busy action instead of a fresh ordinary prompt.submit.
+        XCTAssertEqual(
+            harness.appState.turnState, .running,
+            "A starting runtime must never stamp idle: settlement is unproven"
+        )
+        let busyRouted = await harness.appState.submitComposer(text: "Follow-up")
+        XCTAssertTrue(busyRouted)
+        XCTAssertEqual(steerCount, 1, "The follow-up must route through the configured busy action")
+        XCTAssertEqual(
+            submitCount, 1,
+            "No fresh ordinary turn may enter the committed/building turn"
+        )
+
+        // The next authoritative edges take over and settle normally.
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        XCTAssertEqual(harness.appState.turnState, .running, "A busy edge takes over cleanly")
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: false))
+        XCTAssertEqual(
+            harness.appState.turnState, .idle,
+            "The turn settles normally once the authoritative edge arrives"
+        )
+        box.client.disconnect()
+    }
+
+    /// Regression A, staleness half: the same `starting` + durable-present
+    /// recovery raced against a real staleness boundary. A scene dip while
+    /// the durable verifier is suspended marks the turn state stale; the
+    /// acceptedUnsettled resolution must keep the turn running-like WITHOUT
+    /// clearing that staleness as though settlement were proven (the
+    /// uncertainty survives until an authoritative edge resolves it).
+    func testAcceptedUnsettledPreservesStalenessFromNewerBoundary() async {
+        let active = session("stored-a")
+        var submitCount = 0
+        var probeCount = 0
+        var transcriptReads = 0
+        var catalogCount = 0
+        let parkedRead = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    // Recovery's bounded verification: parked until the test
+                    // has opened a staleness boundary against it.
+                    await parkedRead.suspend()
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "Ambiguous send", "timestamp": "3"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 3]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    throw HermesError.timeout("prompt.submit")
+                },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "starting"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101"])
+
+        let submission = Task { @MainActor in
+            await harness.appState.submitComposer(text: "Ambiguous send")
+        }
+        await parkedRead.waitUntilSuspended()
+        // The lifecycle boundary marks the state stale while the recovery's
+        // verifier is suspended.
+        harness.appState.handleScenePhase(.background)
+        XCTAssertTrue(harness.appState.turnStateIsStale)
+        parkedRead.resume()
+
+        let submitted = await submission.value
+
+        // Accepted — and NOT settled: no idle stamp, and the boundary's
+        // staleness must survive untouched (an acceptedRunning- or
+        // acceptedSettled-shaped stamp would clear it).
+        XCTAssertTrue(submitted, "Durable acceptance under a starting runtime must not surface as a failed send")
+        XCTAssertEqual(submitCount, 1, "An accepted prompt must never be re-submitted")
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 2)
+        XCTAssertEqual(catalogCount, 0, "No failed-send restoration may run")
+        XCTAssertEqual(harness.appState.turnState, .running, "The turn stays running-like")
+        XCTAssertTrue(
+            harness.appState.turnStateIsStale,
+            "The uncertainty must not be cleared as though settlement were proven"
+        )
+        XCTAssertEqual(
+            harness.appState.messages.last?.content, "Ambiguous send",
+            "The optimistic user row remains accepted"
+        )
+
+        // The next authoritative edges resolve the uncertainty normally.
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        XCTAssertEqual(harness.appState.turnState, .running)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: false))
+        XCTAssertEqual(harness.appState.turnState, .idle, "The authoritative settle edge resolves the turn")
+        box.client.disconnect()
+    }
+
+    /// Regression B: ambiguous prompt, registry `starting`, and the durable
+    /// verifier cannot yet prove the submitted row. `starting` is explicitly
+    /// inconclusive — the committed turn may not have reached the durable
+    /// verification point — so the outcome is the conservative unresolved
+    /// path (restore the unsent state exactly once), never acceptedSettled
+    /// and never notAccepted solely because `starting` was present.
+    func testAmbiguousStartingRegistryWithoutDurableRowStaysUnresolved() async {
+        let active = session("stored-a")
+        var submitCount = 0
+        var probeCount = 0
+        var transcriptReads = 0
+        var resumeCount = 0
+        var catalogCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    catalogCount += 1
+                    return [active]
+                },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [
+                            ChatMessage(id: "100", role: .user, content: "Earlier question", timestamp: "1"),
+                            ChatMessage(id: "101", role: .assistant, content: "Earlier answer", timestamp: "2")
+                        ],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    // Every read, including recovery's, sees only the
+                    // pre-submit tail: the submitted row is not provable.
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    throw HermesError.timeout("prompt.submit")
+                },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "starting"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101"])
+        let resumesBeforeSubmit = resumeCount
+
+        let submitted = await harness.appState.submitComposer(text: "Never delivered")
+
+        XCTAssertFalse(submitted, "Unprovable acceptance under a starting runtime restores conservatively")
+        XCTAssertEqual(submitCount, 1, "No blind retry may follow the ambiguous failure")
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(
+            transcriptReads, 3,
+            "Hydration, ambiguous verification, and the restore's compact resume each read once"
+        )
+        XCTAssertEqual(catalogCount, 1, "The unsent restoration runs exactly once")
+        XCTAssertEqual(resumeCount, resumesBeforeSubmit + 1)
+        XCTAssertEqual(
+            harness.appState.messages.map(\.id), ["100", "101"],
+            "The optimistic row is restored away exactly once"
+        )
+        XCTAssertTrue(
+            harness.appState.errorMessage?.contains("Failed to send") == true
+        )
+        box.client.disconnect()
+    }
+
+    /// Regression C (integration): the probe observes `working` while the
+    /// active client is REPLACED mid-recovery. The classification must remain
+    /// acceptedRunning — a running registry row is never settled — while the
+    /// ownership/epoch guards suppress stale local mutation after the
+    /// handoff. The submission stays accepted either way.
+    func testAmbiguousWorkingRowAfterClientReplacementIsAcceptedRunning() async {
+        let active = session("stored-a")
+        var submitCount = 0
+        var probeCount = 0
+        // Assigned after harness creation; the seam below only fires during
+        // the submission, long after setup has finished.
+        var appStateForProbe: AppState?
+        var replacementClient: HermesClient?
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    throw HermesError.timeout("prompt.submit")
+                },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    // The probe itself runs on the CAPTURED client; the
+                    // active client is replaced while that probe await is
+                    // suspended (a concurrent reconnect elsewhere), so the
+                    // classification observes probeClient != self.client.
+                    let replacement = HermesClient(
+                        connection: HermesConnection(
+                            baseUrl: "https://two.example",
+                            ticket: "replacement"
+                        ),
+                        profile: "default"
+                    )
+                    appStateForProbe?.client = replacement
+                    replacementClient = replacement
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        appStateForProbe = harness.appState
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        harness.appState.messages = [
+            ChatMessage(id: "earlier", role: .assistant, content: "Earlier", timestamp: "0")
+        ]
+
+        let submitted = await harness.appState.submitComposer(text: "Ambiguous send")
+
+        XCTAssertTrue(submitted, "A working registry row accepts the submission regardless of client replacement")
+        XCTAssertEqual(submitCount, 1, "An accepted prompt must never be re-submitted")
+        XCTAssertEqual(probeCount, 1)
+        // Ownership (the replaced client) suppresses every local lifecycle
+        // stamp after the handoff, so no settled state may leak through the
+        // real caller path either: the turn frame the optimistic pre-send
+        // stamp left must survive untouched. The classification itself
+        // (acceptedRunning for a working row, independent of client identity
+        // and durable evidence) is pinned by the contract matrix test.
+        XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertNil(harness.appState.errorMessage, "No failed-send error may surface for an accepted submission")
+        XCTAssertEqual(
+            harness.appState.messages.last?.content, "Ambiguous send",
+            "The optimistic user row remains accepted"
+        )
+        replacementClient?.disconnect()
+        box.client.disconnect()
+    }
+
+    /// Regression D: an `idle` registry snapshot drives the recovery toward
+    /// acceptedSettled, but a NEWER sessionBusy(true) lands while the durable
+    /// verifier is suspended. The newer running state must survive: the older
+    /// recovery result keeps the acceptance (no resend) but must NOT stamp
+    /// idle and must NOT clear staleness. Value equality cannot prove this —
+    /// the pre-send stamp already left turnState == .running, so a guard
+    /// comparing turnState values would pass here and wrongly stamp idle.
+    func testNewerBusyEdgeBeatsAcceptedSettledRecoveryStamp() async {
+        let active = session("stored-a")
+        var submitCount = 0
+        var probeCount = 0
+        var transcriptReads = 0
+        var catalogCount = 0
+        let parkedRead = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    // Recovery's bounded verification: parked until the test
+                    // has raced newer lifecycle edges against it.
+                    await parkedRead.suspend()
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "Ambiguous send", "timestamp": "3"],
+                            ["id": "103", "role": "assistant", "content": "Completed result", "timestamp": "4"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    throw HermesError.timeout("prompt.submit")
+                },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    // The registry had already gone absent when recovery
+                    // looked: without newer evidence this classifies
+                    // acceptedSettled.
+                    return []
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101"])
+
+        let submission = Task { @MainActor in
+            await harness.appState.submitComposer(text: "Ambiguous send")
+        }
+        await parkedRead.waitUntilSuspended()
+        // Newer live evidence arrives while the older recovery awaits: the
+        // session is running again, and the lifecycle boundary marks the
+        // state stale.
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        XCTAssertEqual(harness.appState.turnState, .running)
+        harness.appState.handleScenePhase(.background)
+        XCTAssertTrue(harness.appState.turnStateIsStale)
+        parkedRead.resume()
+
+        let submitted = await submission.value
+
+        XCTAssertTrue(submitted, "The submission stays accepted: no resend, no failed-send restoration")
+        XCTAssertEqual(submitCount, 1, "An accepted prompt must never be re-submitted")
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(catalogCount, 0, "No failed-send restoration may run")
+        XCTAssertEqual(
+            harness.appState.messages.last?.content, "Ambiguous send",
+            "The optimistic user row remains accepted"
+        )
+        XCTAssertEqual(
+            harness.appState.turnState, .running,
+            "The newer busy edge survives: the older recovery must NOT stamp idle"
+        )
+        XCTAssertTrue(
+            harness.appState.turnStateIsStale,
+            "The staleness written by the newer boundary must not be cleared by the older recovery result"
+        )
+        box.client.disconnect()
+    }
+
+    /// Regression E (the converse of D): the recovery probe observes
+    /// `working` (acceptedRunning), but a NEWER sessionBusy(false) settles
+    /// the turn while the probe is suspended. The newer idle settlement must
+    /// survive: the older recovery must not force running again and must not
+    /// clear the boundary's staleness. A running row also never needs the
+    /// durable verifier, so no transcript read may follow.
+    func testNewerSettleEdgeBeatsAcceptedRunningRecoveryStamp() async {
+        let active = session("stored-a")
+        var submitCount = 0
+        var probeCount = 0
+        var transcriptReads = 0
+        let parkedProbe = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [
+                            ChatMessage(id: "100", role: .user, content: "Earlier question", timestamp: "1")
+                        ],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 1]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    throw HermesError.timeout("prompt.submit")
+                },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    // The probe itself is parked: the registry says the turn
+                    // was working when ASKED, but newer edges land first.
+                    await parkedProbe.suspend()
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100"])
+
+        let submission = Task { @MainActor in
+            await harness.appState.submitComposer(text: "Ambiguous send")
+        }
+        await parkedProbe.waitUntilSuspended()
+        // The turn settled while the probe was suspended, and the settlement
+        // boundary marks the state stale.
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: false))
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        harness.appState.handleScenePhase(.background)
+        XCTAssertTrue(harness.appState.turnStateIsStale)
+        parkedProbe.resume()
+
+        let submitted = await submission.value
+
+        XCTAssertTrue(submitted, "The registry proved the submission was accepted: no resend")
+        XCTAssertEqual(submitCount, 1, "An accepted prompt must never be re-submitted")
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(
+            transcriptReads, 1,
+            "A running registry row never consults the durable verifier"
+        )
+        XCTAssertEqual(
+            harness.appState.messages.last?.content, "Ambiguous send",
+            "The optimistic user row remains accepted"
+        )
+        XCTAssertEqual(
+            harness.appState.turnState, .idle,
+            "The newer settle edge survives: the older recovery must NOT force running again"
+        )
+        XCTAssertTrue(
+            harness.appState.turnStateIsStale,
+            "The staleness written by the newer boundary must not be cleared by the older recovery result"
+        )
+        box.client.disconnect()
+    }
+
     // MARK: - Harness
 
     private func makeHarness(

--- a/ConduitTests/AppStateForegroundLifecycleTests.swift
+++ b/ConduitTests/AppStateForegroundLifecycleTests.swift
@@ -938,11 +938,22 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
                     return SessionResumeResult(
                         sessionId: sessionID,
                         messages: [],
-                        snapshot: SessionRuntimeSnapshot(object: [:])
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
                     )
                 },
                 persistedTranscript: { _, _ in
                     transcriptReads += 1
+                    if transcriptReads == 1 {
+                        // The pre-submit hydration: two durable rows held.
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    // Recovery: the accepted turn landed and settled.
                     return .payload([
                         "messages": [
                             ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
@@ -953,6 +964,7 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
                         "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
                     ])
                 },
+                refreshContext: { _, _ in },
                 sendPrompt: { _, _, _ in
                     submitCount += 1
                     throw HermesError.timeout("prompt.submit")
@@ -968,23 +980,23 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         let box = await installConnectedClient(into: harness)
         harness.appState.sessions = [active]
         harness.appState.activeSessionId = active.id
-        // Baseline the conversation already held before the submission.
-        harness.appState.messages = [
-            ChatMessage(id: "100", role: .user, content: "Earlier question", timestamp: "1"),
-            ChatMessage(id: "101", role: .assistant, content: "Earlier answer", timestamp: "2")
-        ]
+        // Establish durable provenance through the real hydration path.
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101"])
+        let resumesBeforeSubmit = resumeCount
 
         let submitted = await harness.appState.submitComposer(text: "Ambiguous send")
 
         XCTAssertTrue(submitted, "Transcript-proven acceptance must not surface as a failed send")
         XCTAssertEqual(submitCount, 1, "An accepted prompt must never be re-submitted")
         XCTAssertEqual(probeCount, 1)
-        XCTAssertEqual(transcriptReads, 1, "One bounded tail read decides the outcome")
+        XCTAssertEqual(transcriptReads, 2, "One bounded tail read decides the outcome")
         XCTAssertEqual(
             catalogCount, 0,
             "No failed-send restoration may run for a transcript-proven acceptance"
         )
-        XCTAssertEqual(resumeCount, 0)
+        XCTAssertEqual(resumeCount, resumesBeforeSubmit)
         XCTAssertEqual(
             harness.appState.messages.last?.content, "Ambiguous send",
             "The submitted turn stays; the transcript converges on the next bounded refresh"
@@ -1046,21 +1058,23 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         let box = await installConnectedClient(into: harness)
         harness.appState.sessions = [active]
         harness.appState.activeSessionId = active.id
-        harness.appState.messages = [
-            ChatMessage(id: "100", role: .user, content: "Earlier question", timestamp: "1"),
-            ChatMessage(id: "101", role: .assistant, content: "Earlier answer", timestamp: "2")
-        ]
+        // Establish durable provenance through the real hydration path: the
+        // pre-submit conversation durably holds rows 100 and 101.
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101"])
+        let resumesBeforeSubmit = resumeCount
 
         let submitted = await harness.appState.submitComposer(text: "Never delivered")
 
         XCTAssertFalse(submitted)
         XCTAssertEqual(submitCount, 1, "No blind retry may follow the ambiguous failure")
         XCTAssertEqual(
-            transcriptReads, 2,
-            "One bounded read decides acceptance; the restore's compact resume re-reads the tail"
+            transcriptReads, 3,
+            "Hydration, ambiguous verification, and the restore's compact resume each read once"
         )
         XCTAssertEqual(catalogCount, 1, "The unsent restoration runs exactly once")
-        XCTAssertEqual(resumeCount, 1)
+        XCTAssertEqual(resumeCount, resumesBeforeSubmit + 1)
         XCTAssertEqual(
             harness.appState.messages.map(\.id), ["100", "101"],
             "The optimistic row is restored away exactly once by the authoritative transcript"
@@ -1081,15 +1095,23 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
                 openSession: { _, sessionID, _ in
                     SessionResumeResult(
                         sessionId: sessionID,
-                        messages: [
-                            ChatMessage(id: "100", role: .user, content: "go on", timestamp: "1"),
-                            ChatMessage(id: "101", role: .assistant, content: "Earlier reply", timestamp: "2")
-                        ],
+                        messages: [],
                         snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
                     )
                 },
                 persistedTranscript: { _, _ in
                     transcriptReads += 1
+                    if transcriptReads == 1 {
+                        // Pre-submit hydration: the older identical "go on".
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "go on", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier reply", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    // Recovery: the tail advanced with a DIFFERENT newer ask.
                     return .payload([
                         "messages": [
                             ["id": "100", "role": "user", "content": "go on", "timestamp": "1"],
@@ -1114,15 +1136,15 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         let box = await installConnectedClient(into: harness)
         harness.appState.sessions = [active]
         harness.appState.activeSessionId = active.id
-        harness.appState.messages = [
-            ChatMessage(id: "100", role: .user, content: "go on", timestamp: "1"),
-            ChatMessage(id: "101", role: .assistant, content: "Earlier reply", timestamp: "2")
-        ]
+        // Establish durable provenance for the older identical "go on" row.
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101"])
 
         let submitted = await harness.appState.submitComposer(text: "go on")
 
         XCTAssertFalse(submitted, "The transcript advanced without this prompt: it was not accepted")
-        XCTAssertEqual(transcriptReads, 2)
+        XCTAssertEqual(transcriptReads, 3)
         XCTAssertEqual(
             harness.appState.messages.map(\.id), ["100", "101", "102", "103"],
             "Restoration converges on the authoritative tail even though only its older rows " +
@@ -1421,15 +1443,24 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
                 openSession: { _, sessionID, _ in
                     SessionResumeResult(
                         sessionId: sessionID,
-                        messages: [
-                            ChatMessage(id: "98", role: .user, content: "prior", timestamp: "0"),
-                            ChatMessage(id: "99", role: .assistant, content: "ack", timestamp: "1")
-                        ],
+                        messages: [],
                         snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
                     )
                 },
                 persistedTranscript: { _, _ in
                     transcriptReads += 1
+                    if transcriptReads == 1 {
+                        // Pre-submit hydration: two durable rows held.
+                        return .payload([
+                            "messages": [
+                                ["id": "98", "role": "user", "content": "prior", "timestamp": "0"],
+                                ["id": "99", "role": "assistant", "content": "ack", "timestamp": "1"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    // Recovery: an identical user row exists after the anchor,
+                    // but the conversation also held an optimistic local row.
                     return .payload([
                         "messages": [
                             ["id": "98", "role": "user", "content": "prior", "timestamp": "0"],
@@ -1439,6 +1470,7 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
                         "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 3]
                     ])
                 },
+                refreshContext: { _, _ in },
                 sendPrompt: { _, _, _ in
                     submitCount += 1
                     throw HermesError.timeout("prompt.submit")
@@ -1455,11 +1487,14 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         let box = await installConnectedClient(into: harness)
         harness.appState.sessions = [active]
         harness.appState.activeSessionId = active.id
-        harness.appState.messages = [
-            ChatMessage(id: "98", role: .user, content: "prior", timestamp: "0"),
-            ChatMessage(id: "99", role: .assistant, content: "ack", timestamp: "1"),
+        // Establish durable provenance for rows 98/99 through real hydration.
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        // Turn 1 was sent optimistically and never re-hydrated: its persisted
+        // twin's id is unknown to this conversation.
+        harness.appState.messages.append(
             ChatMessage(id: "local-123", role: .user, content: "continue", timestamp: "2")
-        ]
+        )
 
         let submitted = await harness.appState.submitComposer(text: "continue")
 
@@ -1468,7 +1503,7 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
             "An identical persisted row after the anchor cannot be attributed to this submission"
         )
         XCTAssertEqual(submitCount, 1, "No automatic resend")
-        XCTAssertEqual(transcriptReads, 2)
+        XCTAssertEqual(transcriptReads, 3)
         XCTAssertEqual(catalogCount, 1, "The conservative restoration runs exactly once")
         XCTAssertEqual(
             harness.appState.messages.filter { $0.role == .user && $0.content == "continue" }.count,
@@ -1486,6 +1521,7 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         var submitCount = 0
         var probeCount = 0
         var catalogCount = 0
+        var transcriptReads = 0
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 loadCatalog: { _, _ in
@@ -1496,11 +1532,25 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
                     SessionResumeResult(
                         sessionId: sessionID,
                         messages: [],
-                        snapshot: SessionRuntimeSnapshot(object: [:])
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
                     )
                 },
                 persistedTranscript: { _, _ in
-                    .payload([
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        // Pre-submit hydration: the first identical turn is
+                        // durably anchored (rows 501/502).
+                        return .payload([
+                            "messages": [
+                                ["id": "501", "role": "user", "content": "continue", "timestamp": "1"],
+                                ["id": "502", "role": "assistant", "content": "done", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    // Recovery: the tail advanced past the anchor with a NEW
+                    // identical user row (503) plus its response.
+                    return .payload([
                         "messages": [
                             ["id": "501", "role": "user", "content": "continue", "timestamp": "1"],
                             ["id": "502", "role": "assistant", "content": "done", "timestamp": "2"],
@@ -1510,6 +1560,7 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
                         "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
                     ])
                 },
+                refreshContext: { _, _ in },
                 sendPrompt: { _, _, _ in
                     submitCount += 1
                     throw HermesError.timeout("prompt.submit")
@@ -1524,10 +1575,11 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         let box = await installConnectedClient(into: harness)
         harness.appState.sessions = [active]
         harness.appState.activeSessionId = active.id
-        harness.appState.messages = [
-            ChatMessage(id: "501", role: .user, content: "continue", timestamp: "1"),
-            ChatMessage(id: "502", role: .assistant, content: "done", timestamp: "2")
-        ]
+        // Durably anchor the FIRST identical turn (rows 501/502) via real
+        // hydration; the verifier may then treat 503 as new.
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["501", "502"])
 
         let submitted = await harness.appState.submitComposer(text: "continue")
 
@@ -1570,6 +1622,7 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
                         "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 1]
                     ])
                 },
+                refreshContext: { _, _ in },
                 sendPrompt: { _, _, _ in
                     submitCount += 1
                     throw HermesError.timeout("prompt.submit")
@@ -1631,6 +1684,7 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
                         "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
                     ])
                 },
+                refreshContext: { _, _ in },
                 sendPrompt: { _, _, _ in
                     submitCount += 1
                     throw HermesError.timeout("prompt.submit")
@@ -1649,10 +1703,10 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         let box = await installConnectedClient(into: harness)
         harness.appState.sessions = [sessionA, sessionB]
         harness.appState.activeSessionId = sessionA.id
-        harness.appState.messages = [
-            ChatMessage(id: "100", role: .user, content: "Earlier question", timestamp: "1"),
-            ChatMessage(id: "101", role: .assistant, content: "Earlier answer", timestamp: "2")
-        ]
+        // Establish durable provenance through the real hydration path.
+        let opened = await harness.appState.openSession(sessionA.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101"])
 
         let submissionA = Task { @MainActor in
             await harness.appState.submitComposer(text: "A doomed send")
@@ -1680,6 +1734,154 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         )
         XCTAssertEqual(catalogCount, 0, "A's restoration is skipped under lost ownership")
         box.client.disconnect()
+    }
+
+    /// Round 4: the accepted turn generated so much activity that BOTH the
+    /// pre-submit durable anchor and the submitted row fell out of the newest
+    /// bounded page. Ordering evidence is gone — content absence from a
+    /// window cannot prove non-acceptance, so the outcome is indeterminate
+    /// (conservative restore, no resend, no false rejection claim).
+    func testAmbiguousPromptBeyondBoundedTailIsIndeterminate() async {
+        let active = session("stored-a")
+        var submitCount = 0
+        var transcriptReads = 0
+        var catalogCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    catalogCount += 1
+                    return [active]
+                },
+                openSession: { _, sessionID, _ in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        // Pre-submit hydration: one durable anchor row held.
+                        return .payload([
+                            "messages": [
+                                ["id": "500", "role": "assistant", "content": "anchor row", "timestamp": "1"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 1]
+                        ])
+                    }
+                    // Recovery: the newest page holds neither the anchor nor
+                    // the submitted user row — the accepted turn's activity
+                    // pushed both out of the window.
+                    return .payload([
+                        "messages": [
+                            ["id": "601", "role": "assistant", "content": "much later output", "timestamp": "9"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 1]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    throw HermesError.timeout("prompt.submit")
+                },
+                probeActiveSessions: { _ in
+                    [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["500"])
+
+        let submitted = await harness.appState.submitComposer(text: "continue")
+
+        XCTAssertFalse(
+            submitted,
+            "Without ordering evidence the submission must be treated as unresolved"
+        )
+        XCTAssertEqual(submitCount, 1, "No automatic resend of the ambiguous prompt")
+        XCTAssertEqual(transcriptReads, 3)
+        XCTAssertEqual(catalogCount, 1, "Exactly one conservative restoration")
+        XCTAssertFalse(
+            harness.appState.messages.contains { $0.role == .user && $0.content == "continue" },
+            "The unresolved submission is restored rather than kept as sent"
+        )
+        box.client.disconnect()
+    }
+
+    /// Synthetic visible ids (optimistic sends, live streaming completions,
+    /// positional fallbacks, reasoning/tool projections) carry no persisted
+    /// provenance and must never become overlap anchors — even when the tail
+    /// contains a matching user row that could be the older logical twin.
+    func testSyntheticVisibleIDsNeverBecomeDurableAnchors() async {
+        for syntheticID in [
+            "local-123",
+            "assistant-1700000000",
+            "3",
+            "reasoning-1700000001",
+            "tool-start-1700000002"
+        ] {
+            let harness = makeHarness(
+                lifecycleOperations: ChatResumeLifecycleOperations(
+                    loadCatalog: { _, _ in [self.session("stored-a")] },
+                    openSession: { _, sessionID, _ in
+                        SessionResumeResult(
+                            sessionId: sessionID,
+                            messages: [],
+                            snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                        )
+                    },
+                    persistedTranscript: { _, _ in
+                        .payload([
+                            "messages": [
+                                ["id": "501", "role": "user", "content": "continue", "timestamp": "5"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 1]
+                        ])
+                    },
+                    refreshContext: { _, _ in },
+                    sendPrompt: { _, _, _ in throw HermesError.timeout("prompt.submit") },
+                    probeActiveSessions: { _ in
+                        [LiveSessionStatus(
+                            runtimeSessionId: "runtime-a",
+                            storedSessionId: "stored-a",
+                            status: "idle"
+                        )]
+                    }
+                )
+            )
+            installDisconnectedClient(into: harness)
+            harness.appState.sessions = [session("stored-a")]
+            harness.appState.activeSessionId = "stored-a"
+            // The visible conversation holds ONLY a synthetic id: no positive
+            // persisted provenance exists.
+            harness.appState.messages = [
+                ChatMessage(id: syntheticID, role: .user, content: "continue", timestamp: "1")
+            ]
+
+            let submitted = await harness.appState.submitComposer(text: "continue")
+
+            XCTAssertFalse(
+                submitted,
+                "Synthetic id \(syntheticID) must not prove acceptance"
+            )
+            XCTAssertEqual(
+                harness.appState.turnState, .idle,
+                "Synthetic id \(syntheticID) must not adopt a running state"
+            )
+            XCTAssertEqual(
+                harness.appState.messages.last?.id, "501",
+                "Synthetic id \(syntheticID): the durable tail restored exactly once"
+            )
+        }
     }
 
     // MARK: - Harness

--- a/ConduitTests/AppStateForegroundLifecycleTests.swift
+++ b/ConduitTests/AppStateForegroundLifecycleTests.swift
@@ -434,6 +434,845 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         box.client.disconnect()
     }
 
+    // MARK: - Round 6: cross-surface transcript freshness
+
+    /// A turn another surface completed while Conduit was backgrounded is
+    /// invisible to the liveness probe (the runtime is idle). One bounded
+    /// persisted-tail read must merge the missed rows into the local
+    /// transcript on foreground — without a session.resume.
+    func testForegroundMergesRemoteCompletedTurnAfterBackground() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        // The seeding hydration: two durable rows held.
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    // A remote surface completed a turn while Conduit was
+                    // suspended: rows beyond the local durable frontier.
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "Remote question", "timestamp": "3"],
+                            ["id": "103", "role": "assistant", "content": "Remote answer", "timestamp": "4"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101"])
+        let resumesBeforeForeground = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 2, "One bounded freshness read decides the foreground")
+        XCTAssertEqual(
+            resumeCount, resumesBeforeForeground,
+            "Completed remote history must merge without a session.resume"
+        )
+        XCTAssertEqual(
+            harness.appState.messages.map(\.id), ["100", "101", "102", "103"],
+            "The remotely completed turn becomes visible immediately"
+        )
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        XCTAssertTrue(harness.appState.composerIsEnabled)
+        XCTAssertFalse(harness.appState.turnStateIsStale)
+        XCTAssertFalse(harness.appState.activeChatScrollSessionIdentity.isReconciling)
+        XCTAssertEqual(
+            harness.appState.persistedTranscriptWindow?.nextOffset, 4,
+            "The persisted window must re-anchor to the fetched page"
+        )
+        box.client.disconnect()
+    }
+
+    /// A turn another surface STARTED while Conduit was idle-and-backgrounded
+    /// is still running on foreground. The persisted tail supplies the rows
+    /// that already exist; the observational running adopt + buffered/live
+    /// events supply the rest. No resume.
+    func testForegroundAdoptsRemoteRunningTurnByMergingPersistedTail() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "Remote question", "timestamp": "3"],
+                            ["id": "103", "role": "assistant", "content": "Remote partial", "timestamp": "4"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101"])
+        let resumesBeforeForeground = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 2)
+        XCTAssertEqual(
+            resumeCount, resumesBeforeForeground,
+            "The persisted tail plus live events must attach without a resume"
+        )
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101", "102", "103"])
+        XCTAssertEqual(
+            harness.appState.turnState, .running,
+            "A working registry row adopts running once the transcript is fresh"
+        )
+        XCTAssertTrue(harness.appState.composerIsEnabled)
+        XCTAssertFalse(harness.appState.turnStateIsStale)
+
+        // The merged still-running turn completes live: the completion must
+        // finalize the merged persisted row IN PLACE (same durable id)
+        // instead of appending a duplicate twin.
+        harness.appState.handleStreamEvent(.messageComplete(
+            sessionId: active.id,
+            messageId: "103",
+            content: "Remote full answer",
+            reasoning: nil
+        ))
+        harness.appState.handleStreamEvent(.messageStart(sessionId: active.id))
+        XCTAssertEqual(
+            harness.appState.messages.filter { $0.id == "103" }.count, 1,
+            "The live completion must not duplicate the merged persisted row"
+        )
+        XCTAssertEqual(
+            harness.appState.messages.first(where: { $0.id == "103" })?.content,
+            "Remote full answer"
+        )
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101", "102", "103"])
+        box.client.disconnect()
+    }
+
+    /// The headline PR #122 behavior must not degrade: a Conduit-owned turn
+    /// that was running before the background transition continues on the
+    /// same runtime — fast observational path, zero freshness reads, zero
+    /// resumes, reasoning and transcript untouched.
+    func testForegroundOwnedTurnContinuityStaysFastPathObservational() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101"])
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "Thinking."))
+        let segmentBefore = harness.appState.liveReasoningSegment
+        let messagesBefore = harness.appState.messages
+        let resumesBeforeForeground = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(
+            transcriptReads, 1,
+            "Conduit-owned continuity must not trigger a freshness read"
+        )
+        XCTAssertEqual(resumeCount, resumesBeforeForeground, "Zero session.resume")
+        XCTAssertEqual(harness.appState.messages, messagesBefore, "No transcript replacement")
+        XCTAssertEqual(harness.appState.liveReasoningSegment, segmentBefore)
+        XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertFalse(harness.appState.turnStateIsStale)
+        box.client.disconnect()
+    }
+
+    /// A backgrounded idle conversation whose persisted tail did not advance:
+    /// the freshness read returns unchanged and the foreground stays a pure
+    /// observational no-op.
+    func testForegroundIdleBackgroundReturnWithNoRemoteActivityStaysObservational() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        let seedPayload: [String: Any] = [
+            "messages": [
+                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+            ],
+            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+        ]
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    return .payload(seedPayload)
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        let messagesBefore = harness.appState.messages
+        let resumesBeforeForeground = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 2)
+        XCTAssertEqual(resumeCount, resumesBeforeForeground, "Zero session.resume")
+        XCTAssertEqual(
+            harness.appState.messages, messagesBefore,
+            "An unchanged tail must not replace the transcript"
+        )
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        XCTAssertTrue(harness.appState.composerIsEnabled)
+        XCTAssertFalse(harness.appState.turnStateIsStale)
+        XCTAssertFalse(harness.appState.activeChatScrollSessionIdentity.isReconciling)
+        box.client.disconnect()
+    }
+
+    /// When the local durable frontier has rotated out of the newest bounded
+    /// page, freshness cannot be proven — the bounded resume refresh (the
+    /// existing reconcile, which re-anchors the whole conversation) must take
+    /// over instead of a false no-op.
+    func testForegroundFreshnessWithRotatedAnchorTakesBoundedRecovery() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    // Remote activity pushed the local frontier (rows 100/101)
+                    // out of the newest page entirely: no overlap anchor.
+                    let rotatedRows: [[String: Any]] = (200..<320).map { id in
+                        [
+                            "id": "\(id)",
+                            "role": "assistant",
+                            "content": "Remote row \(id)",
+                            "timestamp": "\(id)"
+                        ]
+                    }
+                    return .payload([
+                        "messages": rotatedRows,
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 120]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101"])
+        let resumesBeforeForeground = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 3, "Freshness read + the recovery reconcile's bounded read")
+        XCTAssertEqual(
+            resumeCount, resumesBeforeForeground + 1,
+            "Anchor-less freshness must take the bounded resume recovery exactly once"
+        )
+        XCTAssertEqual(harness.appState.messages.count, 120, "No remote rows may be lost")
+        XCTAssertEqual(harness.appState.messages.first?.id, "200")
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        XCTAssertTrue(harness.appState.composerIsEnabled)
+        XCTAssertFalse(harness.appState.activeChatScrollSessionIdentity.isReconciling)
+        box.client.disconnect()
+    }
+
+    /// Ordering invariant: the persisted tail is the OLDER observation. A
+    /// stream event that arrives while the freshness read is in flight is
+    /// buffered and replayed after the merge, so the final state reflects
+    /// snapshot first, newer live edge second.
+    func testForegroundFreshnessMergeYieldsToNewerBufferedBusyEdge() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        let parkedRead = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    // Hold the foreground freshness read open while a newer
+                    // live edge arrives.
+                    await parkedRead.suspend()
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "Remote question", "timestamp": "3"],
+                            ["id": "103", "role": "assistant", "content": "Remote answer", "timestamp": "4"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101"])
+
+        harness.appState.handleScenePhase(.background)
+        let activation = Task { @MainActor in
+            await runSceneActivation(harness)
+        }
+        await parkedRead.waitUntilSuspended()
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        parkedRead.resume()
+        await activation.value
+        await flushMainActor()
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 2)
+        XCTAssertEqual(resumeCount, 1, "The seeding reconcile owns the only resume")
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101", "102", "103"])
+        XCTAssertEqual(
+            harness.appState.turnState, .running,
+            "The newer buffered busy edge must win over the merged persisted snapshot"
+        )
+        XCTAssertTrue(harness.appState.composerIsEnabled)
+        XCTAssertFalse(harness.appState.turnStateIsStale)
+        box.client.disconnect()
+    }
+
+    /// The freshness arming is consumed by one foreground return: an overlay
+    /// dip after a completed background return must stay fully observational
+    /// (the socket survived the dip, live events kept flowing), with zero
+    /// freshness reads and zero resumes.
+    func testForegroundFreshnessRunsOncePerBackgroundNotOnOverlayDips() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "Remote question", "timestamp": "3"],
+                            ["id": "103", "role": "assistant", "content": "Remote answer", "timestamp": "4"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        let resumesBefore = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(transcriptReads, 2, "The armed background return runs the freshness check once")
+        XCTAssertFalse(harness.appState.foregroundFreshnessCheckArmed)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101", "102", "103"])
+        let resumesAfterBackgroundReturn = resumeCount
+
+        // Overlay dip: observational only — no third read, no resume.
+        harness.appState.handleScenePhase(.inactive)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 2)
+        XCTAssertEqual(
+            transcriptReads, 2,
+            "An overlay dip must not run the freshness check"
+        )
+        XCTAssertEqual(resumeCount, resumesAfterBackgroundReturn)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101", "102", "103"])
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        XCTAssertFalse(harness.appState.turnStateIsStale)
+        box.client.disconnect()
+    }
+
+    /// A composer submit landing during the bounded freshness read supersedes
+    /// the foreground refresh: `sendMessage`'s recovery-intent cancellation
+    /// advances the automatic-work epoch, so the freshness continuation's
+    /// ownership guard fails and it stands down WITHOUT merging. Persisted
+    /// rows can therefore never be appended after the newer optimistic row;
+    /// convergence belongs to the submission's own outcome and the next
+    /// bounded refresh.
+    func testForegroundFreshnessStandsDownWhenSubmissionOwnsTheTranscript() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        var submitCount = 0
+        let parkedRead = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    if transcriptReads == 2 {
+                        // Hold only the freshness read; the recovery
+                        // reconcile's own read must flow freely.
+                        await parkedRead.suspend()
+                    }
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "Remote question", "timestamp": "3"],
+                            ["id": "103", "role": "assistant", "content": "Remote answer", "timestamp": "4"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101"])
+        let resumesBefore = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        let activation = Task { @MainActor in
+            await runSceneActivation(harness)
+        }
+        await parkedRead.waitUntilSuspended()
+        let submitted = await harness.appState.submitComposer(text: "Mid-read send")
+        XCTAssertTrue(submitted)
+        parkedRead.resume()
+        await activation.value
+        await flushMainActor()
+
+        XCTAssertEqual(submitCount, 1)
+        XCTAssertEqual(
+            resumeCount, resumesBefore,
+            "The freshness continuation is token-dead: it must not resume"
+        )
+        XCTAssertEqual(
+            harness.appState.messages.map(\.id).first, "100",
+            "The seeded prefix stands"
+        )
+        XCTAssertEqual(
+            harness.appState.messages.last?.content, "Mid-read send",
+            "The optimistic local row stays the newest row — no inverted persisted append"
+        )
+        XCTAssertFalse(
+            harness.appState.messages.contains { $0.id == "102" || $0.id == "103" },
+            "The freshness merge must not append behind the newer local row"
+        )
+        XCTAssertEqual(
+            harness.appState.turnState, .running,
+            "The accepted submission owns the turn state"
+        )
+        XCTAssertFalse(harness.appState.activeChatScrollSessionIdentity.isReconciling)
+        box.client.disconnect()
+    }
+
+    /// A positively empty persisted page behind an idle runtime proves the
+    /// conversation has no rows at all: freshness is provably unchanged and
+    /// an empty local transcript stays a pure observational no-op.
+    func testForegroundArmedIdleWithPositivelyEmptyConversationStaysObservational() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    return .payload([
+                        "messages": [],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 0]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 1)
+        XCTAssertEqual(resumeCount, 0, "A provably empty conversation must not resume")
+        XCTAssertTrue(harness.appState.messages.isEmpty)
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        XCTAssertTrue(harness.appState.composerIsEnabled)
+        XCTAssertFalse(harness.appState.turnStateIsStale)
+        box.client.disconnect()
+    }
+
+    /// Local chat activity since the last hydration leaves the transcript
+    /// tail optimistically identified (the frontier cannot vouch for it), so
+    /// the append-only merge stands down: one bounded resume refresh per
+    /// background return converges the conversation. This pins the deliberate
+    /// cost of the conservative route on the most common sequence.
+    func testForegroundAfterLocalChatSinceHydrationTakesBoundedRecovery() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "Remote question", "timestamp": "3"],
+                            ["id": "103", "role": "assistant", "content": "Remote answer", "timestamp": "4"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+
+        // A locally streamed turn completes after the hydration: its row is
+        // optimistically identified, so the durable frontier cannot vouch
+        // for the transcript tail.
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.messageComplete(
+            sessionId: active.id,
+            messageId: nil,
+            content: "Locally streamed answer",
+            reasoning: nil
+        ))
+        harness.appState.handleStreamEvent(.messageStart(sessionId: active.id))
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: false))
+        XCTAssertEqual(harness.appState.messages.last?.role, .assistant)
+        XCTAssertNotEqual(
+            harness.appState.messages.last?.id, "102",
+            "The local completion row must be optimistically identified"
+        )
+        XCTAssertEqual(
+            harness.appState.turnState, .idle,
+            "The locally completed turn must settle before the background transition"
+        )
+        let resumesBefore = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 3, "Freshness read + the recovery reconcile's bounded read")
+        XCTAssertEqual(
+            resumeCount, resumesBefore + 1,
+            "An unanchored tail takes the bounded resume recovery exactly once"
+        )
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101", "102", "103"])
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        XCTAssertTrue(harness.appState.composerIsEnabled)
+        XCTAssertFalse(harness.appState.activeChatScrollSessionIdentity.isReconciling)
+        box.client.disconnect()
+    }
+
     // MARK: - D. inactive → active only
 
     func testInactiveToActiveCycleDoesNotResumeOrResetReasoning() async {

--- a/ConduitTests/AppStateForegroundLifecycleTests.swift
+++ b/ConduitTests/AppStateForegroundLifecycleTests.swift
@@ -1,0 +1,1196 @@
+import XCTest
+@testable import Conduit
+
+/// Regression coverage for the foreground lifecycle contract: a healthy
+/// foreground transition is observational (never a `session.resume` session
+/// replacement), an ambiguous `prompt.submit` acknowledgement is recovered
+/// through the authoritative runtime registry instead of a blind retry, and a
+/// stale local idle state is corrected before the next submission is routed.
+@MainActor
+final class AppStateForegroundLifecycleTests: XCTestCase {
+
+    // MARK: - A. Healthy socket + active turn
+
+    func testForegroundWithHealthySocketAndActiveTurnDoesNotResume() async {
+        let active = session("stored-a")
+        var healthChecks = 0
+        var probeCount = 0
+        var resumeCount = 0
+        var catalogCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    catalogCount += 1
+                    return [active]
+                },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in healthChecks += 1 },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let seedMessages = [
+            ChatMessage(id: "user", role: .user, content: "Question", timestamp: "1")
+        ]
+        harness.appState.messages = seedMessages
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(healthChecks, 1, "The foreground must verify the transport health once")
+        XCTAssertEqual(probeCount, 1, "The foreground must query the authoritative runtime registry")
+        XCTAssertEqual(resumeCount, 0, "A healthy foreground must never issue session.resume")
+        XCTAssertEqual(catalogCount, 0, "A healthy foreground must not reload the session catalog")
+        XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertEqual(harness.appState.activeSessionId, active.id)
+        XCTAssertEqual(harness.appState.messages, seedMessages, "Foregrounding must not replace the transcript")
+        XCTAssertFalse(harness.appState.turnStateIsStale)
+
+        // The stream gate is open again after the observational settle: later
+        // turn events land without a transcript replacement. The streaming
+        // projection publishes on a short coalescing cadence, so poll briefly.
+        harness.appState.handleStreamEvent(.messageDelta(sessionId: active.id, text: " more"))
+        let published = await waitForStreamingText(" more", in: harness.appState)
+        XCTAssertTrue(published, "The post-foreground delta must land in the streaming projection")
+        XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertFalse(
+            harness.appState.activeChatScrollSessionIdentity.isReconciling
+        )
+        box.client.disconnect()
+    }
+
+    /// Bounded wait for the coalesced streaming publish (33 ms cadence).
+    private func waitForStreamingText(
+        _ expected: String,
+        in appState: AppState,
+        timeout: TimeInterval = 3
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if appState.streamingText == expected { return true }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        return appState.streamingText == expected
+    }
+
+    // MARK: - B. Healthy socket + PR #121 live reasoning
+
+    func testForegroundPreservesLiveReasoningSegmentOnHealthySocket() async {
+        let active = session("stored-a")
+        var resumeCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        harness.appState.messages = [
+            ChatMessage(id: "user", role: .user, content: "Question", timestamp: "1")
+        ]
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "Step one."))
+        let segmentBefore = harness.appState.liveReasoningSegment
+        XCTAssertNotNil(segmentBefore)
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(
+            harness.appState.liveReasoningSegment, segmentBefore,
+            "A harmless foreground cycle must not settle or reset the live reasoning segment"
+        )
+        XCTAssertEqual(resumeCount, 0)
+
+        // Later reasoning deltas extend the SAME segment (a reset would nil
+        // the projection or mint a new segment id on the next delta).
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: " Step two."))
+        await flushMainActor()
+        XCTAssertEqual(harness.appState.liveReasoningSegment?.id, segmentBefore?.id)
+        XCTAssertNotNil(harness.appState.liveReasoningSegment)
+        // No duplicate settled thinking row may appear in the transcript.
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["user"])
+        box.client.disconnect()
+    }
+
+    // MARK: - C. Healthy idle session
+
+    func testForegroundWithHealthyIdleSessionIsObservationalNoOp() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let seedMessages = [
+            ChatMessage(id: "user", role: .user, content: "Earlier", timestamp: "1")
+        ]
+        harness.appState.messages = seedMessages
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(resumeCount, 0, "An idle healthy session must not be resumed")
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        XCTAssertEqual(harness.appState.messages, seedMessages, "The transcript must remain stable")
+        XCTAssertFalse(
+            harness.appState.activeChatScrollSessionIdentity.isReconciling,
+            "No reconciliation may remain open after the observational refresh"
+        )
+        XCTAssertFalse(harness.appState.turnStateIsStale)
+        box.client.disconnect()
+    }
+
+    // MARK: - D. inactive → active only
+
+    func testInactiveToActiveCycleDoesNotResumeOrResetReasoning() async {
+        let active = session("stored-a")
+        var resumeCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        harness.appState.messages = [
+            ChatMessage(id: "user", role: .user, content: "Question", timestamp: "1")
+        ]
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "Thinking."))
+        let segmentBefore = harness.appState.liveReasoningSegment
+        let returnSurfaceBefore = harness.appState.preferredReturnSurfaceRequest
+
+        harness.appState.handleScenePhase(.inactive)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(resumeCount, 0, "An overlay dip must not resume the session")
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["user"])
+        XCTAssertEqual(harness.appState.liveReasoningSegment, segmentBefore)
+        XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertEqual(
+            harness.appState.preferredReturnSurfaceRequest, returnSurfaceBefore,
+            "An inactive → active cycle is not a background return"
+        )
+        XCTAssertFalse(harness.appState.turnStateIsStale)
+        box.client.disconnect()
+    }
+
+    // MARK: - E. Dead socket
+
+    func testForegroundWithDeadTransportReconnectsAndResumesOnce() async {
+        let active = session("stored-a")
+        var connects = 0
+        var resumeCount = 0
+        var catalogCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                connectClient: { _ in connects += 1 },
+                loadCatalog: { _, _ in
+                    catalogCount += 1
+                    return [active]
+                },
+                mintTicket: { _ in "fresh-ticket" },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: "runtime-e",
+                        messages: [
+                            ChatMessage(
+                                id: "assistant-e",
+                                role: .assistant,
+                                content: "Recovered",
+                                timestamp: "2"
+                            )
+                        ],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                refreshContext: { _, _ in },
+                setBusyInputMode: { _, _ in },
+                loadProfiles: {},
+                loadBusyInputMode: { _ in },
+                loadProfileDisplayPreferences: {},
+                loadSlashCommands: {}
+            )
+        )
+        installDisconnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(connects, 1, "The dead transport must be reconnected exactly once")
+        XCTAssertEqual(resumeCount, 1, "Recovery must fall back to exactly one stored-session resume")
+        XCTAssertEqual(catalogCount, 1)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["assistant-e"])
+        XCTAssertEqual(harness.appState.turnState, .idle)
+    }
+
+    // MARK: - F. Gateway restart (runtime gone, stored session remains)
+
+    func testForegroundAfterGatewayRestartResumesStoredSessionOnce() async {
+        let active = session("stored-a", alternateIDs: ["runtime-old"])
+        var probeCount = 0
+        var resumeCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    XCTAssertEqual(sessionID, "stored-a")
+                    return SessionResumeResult(
+                        sessionId: "runtime-new",
+                        messages: [
+                            ChatMessage(
+                                id: "restored",
+                                role: .assistant,
+                                content: "After restart",
+                                timestamp: "3"
+                            )
+                        ],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    // The gateway restarted: no live runtime exists for this
+                    // session anymore.
+                    return []
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = "runtime-old"
+        harness.appState.messages = [
+            ChatMessage(id: "stale", role: .user, content: "Before restart", timestamp: "1")
+        ]
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(resumeCount, 1, "Exactly one stored-session resume must run")
+        XCTAssertEqual(
+            harness.appState.activeSessionId, "runtime-new",
+            "The resumed runtime id must become authoritative"
+        )
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["restored"])
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        box.client.disconnect()
+    }
+
+    // MARK: - G. Ordinary successful prompt
+
+    func testOrdinaryIdleSubmitStartsExactlyOneTurn() async {
+        var submitCount = 0
+        var probeCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return []
+                }
+            )
+        )
+        installDisconnectedClient(into: harness)
+        harness.appState.sessions = [session("stored-a")]
+        harness.appState.activeSessionId = "stored-a"
+
+        let submitted = await harness.appState.submitComposer(text: "Hello")
+
+        XCTAssertTrue(submitted)
+        XCTAssertEqual(submitCount, 1, "An ordinary submit must issue exactly one prompt.submit")
+        XCTAssertEqual(probeCount, 0, "Trusted state must not pay for an authoritative probe")
+        XCTAssertEqual(
+            harness.appState.messages.last?.content, "Hello",
+            "Exactly one optimistic user row is kept"
+        )
+        XCTAssertEqual(harness.appState.messages.filter { $0.role == .user }.count, 1)
+        XCTAssertEqual(harness.appState.turnState, .running)
+    }
+
+    // MARK: - H. Ambiguous acknowledgement, server proves the turn is running
+
+    func testAmbiguousPromptSubmissionWithRunningServerTurnIsAcceptedOnce() async {
+        let active = session("stored-a")
+        var submitCount = 0
+        var probeCount = 0
+        var resumeCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    // The RPC reached Hermes, but the acknowledgement was lost.
+                    throw HermesError.timeout("prompt.submit")
+                },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        harness.appState.messages = [
+            ChatMessage(id: "earlier", role: .assistant, content: "Earlier", timestamp: "0")
+        ]
+
+        let submitted = await harness.appState.submitComposer(text: "Ambiguous send")
+
+        XCTAssertTrue(submitted, "The accepted turn must not surface as a failed send")
+        XCTAssertEqual(submitCount, 1, "An accepted prompt must never be re-submitted")
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(resumeCount, 0, "The healthy transport must not be replaced")
+        XCTAssertEqual(
+            harness.appState.messages.last?.content, "Ambiguous send",
+            "The optimistic user row must remain"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
+        box.client.disconnect()
+    }
+
+    // MARK: - I. Ambiguous submit, server proves the prompt was not accepted
+
+    func testAmbiguousPromptSubmissionWithIdleServerRunsFailedSendRestorationOnce() async {
+        let active = session("stored-a")
+        var submitCount = 0
+        var probeCount = 0
+        var catalogCount = 0
+        var resumeCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    catalogCount += 1
+                    return [active]
+                },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [
+                            ChatMessage(
+                                id: "persisted",
+                                role: .assistant,
+                                content: "Persisted history",
+                                timestamp: "1"
+                            )
+                        ],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    throw HermesError.timeout("prompt.submit")
+                },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+
+        let submitted = await harness.appState.submitComposer(text: "Never delivered")
+
+        XCTAssertFalse(submitted, "A provably undelivered prompt is a failed send")
+        XCTAssertEqual(submitCount, 1, "No blind retry may follow the ambiguous failure")
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(catalogCount, 1, "The failed-send restoration must run exactly once")
+        XCTAssertEqual(resumeCount, 1)
+        XCTAssertEqual(
+            harness.appState.messages.map(\.id), ["persisted"],
+            "The optimistic row is restored away exactly once by the authoritative transcript"
+        )
+        XCTAssertTrue(
+            harness.appState.errorMessage?.contains("Failed to send") == true
+        )
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        box.client.disconnect()
+    }
+
+    // MARK: - J. Local idle / server running mismatch
+
+    func testStaleIdleSubmissionRoutesThroughConfiguredBusyAction() async {
+        let active = session("stored-a")
+        var submitCount = 0
+        var steerCount = 0
+        var probeCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    // The suspected production divergence: Hermes still runs
+                    // the session while Conduit believes it is idle.
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                },
+                steer: { _, _, _ in steerCount += 1 }
+            )
+        )
+        installDisconnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        // The lifecycle boundary marks the local turn state stale.
+        harness.appState.handleScenePhase(.background)
+
+        let submitted = await harness.appState.submitComposer(text: "Follow-up")
+
+        XCTAssertTrue(submitted)
+        XCTAssertEqual(probeCount, 1, "A stale idle state must be corrected before routing")
+        XCTAssertEqual(
+            submitCount, 0,
+            "The message must NOT be sent as an ordinary new-turn prompt.submit"
+        )
+        XCTAssertEqual(
+            steerCount, 1,
+            "The corrected busy session must route the message through the configured busy action"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertFalse(harness.appState.turnStateIsStale)
+    }
+
+    // MARK: - K. Two genuinely idle turns stay independent
+
+    func testSequentialIdleTurnsSubmitIndependently() async {
+        var submitTexts: [String] = []
+        var probeCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                sendPrompt: { _, _, text in
+                    submitTexts.append(text)
+                    return .accepted
+                },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return []
+                }
+            )
+        )
+        installDisconnectedClient(into: harness)
+        harness.appState.sessions = [session("stored-a")]
+        harness.appState.activeSessionId = "stored-a"
+
+        let first = await harness.appState.submitComposer(text: "Message A")
+        // Turn A completes authoritatively (server-driven busy=false edge).
+        harness.appState.handleStreamEvent(
+            .sessionBusy(sessionId: "stored-a", busy: false)
+        )
+        let second = await harness.appState.submitComposer(text: "Message B")
+
+        XCTAssertTrue(first)
+        XCTAssertTrue(second)
+        XCTAssertEqual(
+            submitTexts, ["Message A", "Message B"],
+            "Two idle turns must be two independent prompt submissions"
+        )
+        XCTAssertEqual(probeCount, 0, "No stale-state probe may run for trusted idle state")
+        XCTAssertEqual(
+            harness.appState.messages.filter { $0.role == .user }.map(\.content),
+            ["Message A", "Message B"],
+            "No client-side concatenation of the two submissions"
+        )
+    }
+
+    // MARK: - Prompt outcome typing (HermesClient seam-level)
+
+    func testPromptSubmissionOutcomeClassification() {
+        XCTAssertEqual(PromptSubmissionOutcome(gatewayStatus: "streaming"), .accepted)
+        XCTAssertEqual(PromptSubmissionOutcome(gatewayStatus: "steered"), .steered)
+        XCTAssertEqual(PromptSubmissionOutcome(gatewayStatus: "redirected"), .redirected)
+        XCTAssertEqual(PromptSubmissionOutcome(gatewayStatus: "queued"), .queued)
+        XCTAssertEqual(PromptSubmissionOutcome(gatewayStatus: "STREAMING"), .accepted)
+        XCTAssertEqual(PromptSubmissionOutcome(gatewayStatus: nil), .accepted)
+        XCTAssertFalse(PromptSubmissionOutcome.accepted.isBusySubmission)
+        XCTAssertTrue(PromptSubmissionOutcome.queued.isBusySubmission)
+        XCTAssertTrue(PromptSubmissionOutcome.steered.isBusySubmission)
+        XCTAssertTrue(PromptSubmissionOutcome.redirected.isBusySubmission)
+    }
+
+    func testLiveSessionStatusRowParsing() throws {
+        let row = try XCTUnwrap(LiveSessionStatus(from: [
+            "id": .string("runtime-1"),
+            "session_key": .string("stored-1"),
+            "status": .string("working"),
+            "last_active": .number(1234.5)
+        ]))
+        XCTAssertEqual(
+            row,
+            LiveSessionStatus(
+                runtimeSessionId: "runtime-1",
+                storedSessionId: "stored-1",
+                status: "working",
+                lastActive: 1234.5
+            )
+        )
+        XCTAssertTrue(row.isRunning)
+        XCTAssertTrue(
+            LiveSessionStatus(
+                runtimeSessionId: "r", storedSessionId: "s", status: "waiting"
+            ).isRunning,
+            "A pending decision keeps the turn live"
+        )
+        XCTAssertTrue(
+            LiveSessionStatus(
+                runtimeSessionId: "r", storedSessionId: "s", status: "starting"
+            ).isRunning,
+            "A turn accepted during agent build is committed busy"
+        )
+        XCTAssertFalse(
+            LiveSessionStatus(
+                runtimeSessionId: "r", storedSessionId: "s", status: "idle"
+            ).isRunning
+        )
+        XCTAssertNil(
+            LiveSessionStatus(from: ["session_key": .string("missing-runtime-id")]),
+            "A row without a runtime id cannot be matched"
+        )
+    }
+
+    // MARK: - Reviewer-hardening coverage
+
+    func testForegroundWithStartingRuntimeAdoptsObservationally() async {
+        let active = session("stored-a")
+        var resumeCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "starting"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        harness.appState.messages = [
+            ChatMessage(id: "user", role: .user, content: "Question", timestamp: "1")
+        ]
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(
+            resumeCount, 0,
+            "A starting runtime is committed busy — foreground must not resume"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
+        box.client.disconnect()
+    }
+
+    func testForegroundWithUnavailableProbeFallsBackToResumeRefresh() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [
+                            ChatMessage(
+                                id: "restored",
+                                role: .assistant,
+                                content: "From legacy refresh",
+                                timestamp: "2"
+                            )
+                        ],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    // An older gateway without session.active_list.
+                    throw HermesError.invalidResponse
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(resumeCount, 1, "An unreadable registry must fall back to the resume refresh")
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["restored"])
+        box.client.disconnect()
+    }
+
+    func testForegroundWithIdleProbeAndLocalRunningRecoversCompletedTurn() async {
+        let active = session("stored-a")
+        var resumeCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [
+                            ChatMessage(
+                                id: "completed",
+                                role: .assistant,
+                                content: "Finished while away",
+                                timestamp: "2"
+                            )
+                        ],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        harness.appState.messages = [
+            ChatMessage(id: "user", role: .user, content: "Question", timestamp: "1")
+        ]
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(
+            resumeCount, 1,
+            "A missed turn-end edge must recover through the authoritative transcript refresh"
+        )
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["completed"])
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        box.client.disconnect()
+    }
+
+    func testDefinitiveNotConnectedFailureSkipsAuthoritativeProbe() async {
+        var submitCount = 0
+        var probeCount = 0
+        var catalogCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    catalogCount += 1
+                    return [self.session("stored-a")]
+                },
+                openSession: { _, sessionID, _ in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    // rpc() throws notConnected before any bytes are written,
+                    // so the outcome is definitive, not ambiguous.
+                    throw HermesError.notConnected
+                },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return []
+                }
+            )
+        )
+        installDisconnectedClient(into: harness)
+        harness.appState.sessions = [session("stored-a")]
+        harness.appState.activeSessionId = "stored-a"
+
+        let submitted = await harness.appState.submitComposer(text: "Unsent")
+
+        XCTAssertFalse(submitted)
+        XCTAssertEqual(submitCount, 1)
+        XCTAssertEqual(
+            probeCount, 0,
+            "A provably undelivered prompt must not pay for an authoritative probe"
+        )
+        XCTAssertEqual(catalogCount, 1, "The ordinary failed-send restoration runs exactly once")
+        XCTAssertTrue(harness.appState.errorMessage?.contains("Failed to send") == true)
+    }
+
+    func testStaleIdleWithUnavailableProbeFallsThroughToOrdinarySend() async {
+        var submitCount = 0
+        var steerCount = 0
+        var probeCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    throw HermesError.invalidResponse
+                },
+                steer: { _, _, _ in steerCount += 1 }
+            )
+        )
+        installDisconnectedClient(into: harness)
+        harness.appState.sessions = [session("stored-a")]
+        harness.appState.activeSessionId = "stored-a"
+        harness.appState.handleScenePhase(.background)
+
+        let submitted = await harness.appState.submitComposer(text: "Direct send")
+
+        XCTAssertTrue(submitted, "An unreadable probe must not block the user")
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(
+            submitCount, 1,
+            "The submission falls through to the ordinary new-turn send"
+        )
+        XCTAssertEqual(steerCount, 0)
+        XCTAssertEqual(harness.appState.turnState, .running)
+    }
+
+    func testQueuedPromptOutcomeAdoptsAuthoritativeRunningState() async {
+        var submitCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    // Hermes was busy: the prompt joined the busy policy.
+                    return .queued
+                },
+                probeActiveSessions: { _ in [] }
+            )
+        )
+        installDisconnectedClient(into: harness)
+        harness.appState.sessions = [session("stored-a")]
+        harness.appState.activeSessionId = "stored-a"
+
+        let submitted = await harness.appState.submitComposer(text: "Queued send")
+
+        XCTAssertTrue(submitted)
+        XCTAssertEqual(submitCount, 1)
+        XCTAssertEqual(
+            harness.appState.turnState, .running,
+            "A busy-policy outcome proves the session was running server-side"
+        )
+        XCTAssertFalse(harness.appState.turnStateIsStale)
+    }
+
+    // MARK: - Harness
+
+    private func makeHarness(
+        lifecycleOperations: ChatResumeLifecycleOperations = .live
+    ) -> (
+        appState: AppState,
+        coordinator: ChatResumeCoordinator,
+        store: ChatResumeStore,
+        recoverySequence: ChatResumeRecoverySequence
+    ) {
+        let suite = "AppStateForegroundLifecycleTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Failed to create test UserDefaults suite")
+        }
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suite)
+        }
+        let store = ChatResumeStore(defaults: defaults)
+        let coordinator = ChatResumeCoordinator(store: store)
+        let recoverySequence = ChatResumeRecoverySequence()
+        // A fresh presentation cache per test: the shared singleton would let
+        // one test's optimistic rows leak into another test's resume merge.
+        let presentationCache = SessionPresentationCache(defaults: defaults)
+        let appState = AppState(
+            defaults: defaults,
+            chatResumeCoordinator: coordinator,
+            recoverySequence: recoverySequence,
+            loadSavedConnection: false,
+            clearSessionPresentationCache: {},
+            chatResumeLifecycleOperations: lifecycleOperations,
+            sessionPresentationCache: presentationCache
+        )
+        return (appState, coordinator, store, recoverySequence)
+    }
+
+    /// A real HermesClient whose handshake completed over a fake transport, so
+    /// `isConnected` is true without any network traffic. All RPCs in these
+    /// tests ride the lifecycle-operation seams.
+    @discardableResult
+    private func installConnectedClient(
+        into harness: (
+            appState: AppState,
+            coordinator: ChatResumeCoordinator,
+            store: ChatResumeStore,
+            recoverySequence: ChatResumeRecoverySequence
+        )
+    ) async -> ConnectedClientBox {
+        let transport = LifecycleFakeTransport()
+        let socket = LifecycleFakeSocket()
+        transport.nextSocket = { socket }
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        let client = HermesClient(
+            connection: connection,
+            profile: "default",
+            transportFactory: { transport }
+        )
+        harness.appState.connection = connection
+        harness.appState.client = client
+        let connectTask = Task { try await client.connect() }
+        transport.open(socket)
+        addTeardownBlock { client.disconnect() }
+        let box = ConnectedClientBox(
+            client: client,
+            socket: socket,
+            transport: transport,
+            connectTask: connectTask
+        )
+        connectedClientBox = box
+        // Deterministic handshake: the caller must observe `isConnected` as
+        // soon as this returns, or the ambiguous-submission path would treat
+        // the transport as dead and take the reconnect route.
+        try? await awaitCompletion(of: connectTask, "the fake handshake")
+        return box
+    }
+
+    private func installDisconnectedClient(
+        into harness: (
+            appState: AppState,
+            coordinator: ChatResumeCoordinator,
+            store: ChatResumeStore,
+            recoverySequence: ChatResumeRecoverySequence
+        )
+    ) {
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.connection = connection
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+    }
+
+    /// Awaits the scene-activation task (the handshake already settled in
+    /// `installConnectedClient`).
+    private func runSceneActivation(
+        _ harness: (
+            appState: AppState,
+            coordinator: ChatResumeCoordinator,
+            store: ChatResumeStore,
+            recoverySequence: ChatResumeRecoverySequence
+        )
+    ) async {
+        if let task = harness.appState.handleScenePhase(.active) {
+            await task.value
+        }
+    }
+
+    private var connectedClientBox: ConnectedClientBox?
+
+    private func flushMainActor() async {
+        for _ in 0..<10 { await Task.yield() }
+    }
+
+    private func session(
+        _ id: String,
+        alternateIDs: [String] = []
+    ) -> SessionSummary {
+        SessionSummary(
+            id: id,
+            alternateIds: alternateIDs,
+            title: id,
+            model: "Hermes",
+            updatedLabel: "now",
+            profile: "default",
+            source: .chat,
+            isActive: false,
+            isArchived: false,
+            lineageRootId: nil
+        )
+    }
+}
+
+/// Holds the fake-transport client for a test so the handshake can be awaited
+/// and the socket disconnected at teardown.
+@MainActor
+private final class ConnectedClientBox {
+    let client: HermesClient
+    let socket: LifecycleFakeSocket
+    let transport: LifecycleFakeTransport
+    let connectTask: Task<Void, Error>
+
+    init(
+        client: HermesClient,
+        socket: LifecycleFakeSocket,
+        transport: LifecycleFakeTransport,
+        connectTask: Task<Void, Error>
+    ) {
+        self.client = client
+        self.socket = socket
+        self.transport = transport
+        self.connectTask = connectTask
+    }
+}
+
+private struct LifecycleSyncTimedOut: Error {
+    let phase: String
+}
+
+/// Bounded wait for a spawned task to finish: a wedged phase fails the test
+/// naming it instead of suspending forever.
+@MainActor
+private func awaitCompletion(
+    of task: Task<Void, Error>,
+    _ phase: String,
+    timeout: TimeInterval = 10
+) async throws {
+    let finished = LifecycleGate()
+    let watcher = Task<Void, Never>.detached(priority: .userInitiated) {
+        _ = try? await task.value
+        finished.signal()
+    }
+    defer { watcher.cancel() }
+    try await finished.wait(phase, timeout: timeout)
+}
+
+/// Single-use bounded gate (mirrors the HermesClientTests helper).
+private final class LifecycleGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var signalled = false
+    private var continuation: CheckedContinuation<Bool, Never>?
+
+    func signal() {
+        lock.lock()
+        signalled = true
+        let continuation = self.continuation
+        self.continuation = nil
+        lock.unlock()
+        continuation?.resume(returning: false)
+    }
+
+    func wait(
+        _ phase: String,
+        timeout: TimeInterval,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let timedOut = await withCheckedContinuation { continuation in
+            lock.lock()
+            if signalled {
+                lock.unlock()
+                continuation.resume(returning: false)
+                return
+            }
+            self.continuation = continuation
+            lock.unlock()
+            Task<Void, Never>.detached(priority: .userInitiated) { [weak self] in
+                try? await Task.sleep(for: .seconds(timeout))
+                self?.fireDeadline()
+            }
+        }
+        if timedOut {
+            XCTFail("Timed out after \(timeout)s waiting for \(phase)", file: file, line: line)
+            throw LifecycleSyncTimedOut(phase: phase)
+        }
+    }
+
+    private func fireDeadline() {
+        lock.lock()
+        let continuation = self.continuation
+        self.continuation = nil
+        let signalled = self.signalled
+        lock.unlock()
+        if !signalled {
+            continuation?.resume(returning: true)
+        }
+    }
+}
+
+private final class LifecycleFakeSocket: HermesWebSocket {
+    var closeCode: URLSessionWebSocketTask.CloseCode = .invalid
+    private(set) var cancelled = false
+    var cancelErrorsReceive = true
+    private var receiveContinuation: CheckedContinuation<URLSessionWebSocketTask.Message, Error>?
+
+    func resume() {}
+
+    func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        self.closeCode = closeCode
+        cancelled = true
+        if cancelErrorsReceive {
+            receiveContinuation?.resume(throwing: URLError(.networkConnectionLost))
+            receiveContinuation = nil
+        }
+    }
+
+    func send(
+        _ message: URLSessionWebSocketTask.Message,
+        completionHandler: @escaping @Sendable (Error?) -> Void
+    ) {
+        completionHandler(nil)
+    }
+
+    func receive() async throws -> URLSessionWebSocketTask.Message {
+        try await withCheckedThrowingContinuation { continuation in
+            receiveContinuation = continuation
+        }
+    }
+}
+
+private final class LifecycleFakeTransport: HermesWebSocketTransport {
+    var nextSocket: (() -> LifecycleFakeSocket)?
+    private var openCallbacks: [ObjectIdentifier: () -> Void] = [:]
+    private var earlyOpenRequests = Set<ObjectIdentifier>()
+
+    func makeSocket(
+        request: URLRequest,
+        onOpen: @escaping (any HermesWebSocket) -> Void,
+        onCloseBeforeOpen: @escaping (any HermesWebSocket) -> Void
+    ) -> any HermesWebSocket {
+        let socket = nextSocket?() ?? LifecycleFakeSocket()
+        openCallbacks[ObjectIdentifier(socket)] = { onOpen(socket) }
+        if earlyOpenRequests.remove(ObjectIdentifier(socket)) != nil,
+           let callback = openCallbacks.removeValue(forKey: ObjectIdentifier(socket)) {
+            callback()
+        }
+        return socket
+    }
+
+    func invalidate() {}
+
+    /// Fire the handshake-open callback; buffered so it works whether the
+    /// socket has been made yet or not.
+    func open(_ socket: LifecycleFakeSocket) {
+        let key = ObjectIdentifier(socket)
+        if let callback = openCallbacks.removeValue(forKey: key) {
+            callback()
+        } else {
+            earlyOpenRequests.insert(key)
+        }
+    }
+}

--- a/ConduitTests/AppStateForegroundLifecycleTests.swift
+++ b/ConduitTests/AppStateForegroundLifecycleTests.swift
@@ -642,11 +642,11 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
             ).isRunning,
             "A pending decision keeps the turn live"
         )
-        XCTAssertTrue(
+        XCTAssertFalse(
             LiveSessionStatus(
                 runtimeSessionId: "r", storedSessionId: "s", status: "starting"
             ).isRunning,
-            "A turn accepted during agent build is committed busy"
+            "Starting also covers promptless agent pre-warm — not committed busy"
         )
         XCTAssertFalse(
             LiveSessionStatus(
@@ -661,7 +661,7 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
 
     // MARK: - Reviewer-hardening coverage
 
-    func testForegroundWithStartingRuntimeAdoptsObservationally() async {
+    func testForegroundWithStartingRuntimeLeavesStateStreamOwned() async {
         let active = session("stored-a")
         var resumeCount = 0
         let harness = makeHarness(
@@ -698,9 +698,16 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
 
         XCTAssertEqual(
             resumeCount, 0,
-            "A starting runtime is committed busy — foreground must not resume"
+            "A starting runtime must never manufacture a resume refresh"
         )
-        XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertEqual(
+            harness.appState.turnState, .running,
+            "A starting row is liveness-inconclusive: local state stays stream-owned"
+        )
+        XCTAssertTrue(
+            harness.appState.turnStateIsStale,
+            "An inconclusive probe must not mark the state trusted"
+        )
         box.client.disconnect()
     }
 
@@ -907,6 +914,491 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         XCTAssertFalse(harness.appState.turnStateIsStale)
     }
 
+    // MARK: - Round 2: ambiguous acceptance proven by the durable transcript
+
+    /// The headline fast-settle regression: the prompt was ACCEPTED, the turn
+    /// completed, and by the time recovery probed, the registry had already
+    /// gone absent. The durable transcript must prove acceptance instead of
+    /// the submission being restored as unsent.
+    func testAmbiguousAcceptedTurnCompletedBeforeProbeIsProvenByTranscript() async {
+        let active = session("stored-a")
+        var submitCount = 0
+        var probeCount = 0
+        var transcriptReads = 0
+        var resumeCount = 0
+        var catalogCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    catalogCount += 1
+                    return [active]
+                },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "Ambiguous send", "timestamp": "3"],
+                            ["id": "103", "role": "assistant", "content": "Completed result", "timestamp": "4"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
+                    ])
+                },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    throw HermesError.timeout("prompt.submit")
+                },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    // The turn completed and the runtime was reaped before
+                    // recovery looked: current liveness is absent.
+                    return []
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        // Baseline the conversation already held before the submission.
+        harness.appState.messages = [
+            ChatMessage(id: "100", role: .user, content: "Earlier question", timestamp: "1"),
+            ChatMessage(id: "101", role: .assistant, content: "Earlier answer", timestamp: "2")
+        ]
+
+        let submitted = await harness.appState.submitComposer(text: "Ambiguous send")
+
+        XCTAssertTrue(submitted, "Transcript-proven acceptance must not surface as a failed send")
+        XCTAssertEqual(submitCount, 1, "An accepted prompt must never be re-submitted")
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 1, "One bounded tail read decides the outcome")
+        XCTAssertEqual(
+            catalogCount, 0,
+            "No failed-send restoration may run for a transcript-proven acceptance"
+        )
+        XCTAssertEqual(resumeCount, 0)
+        XCTAssertEqual(
+            harness.appState.messages.last?.content, "Ambiguous send",
+            "The submitted turn stays; the transcript converges on the next bounded refresh"
+        )
+        XCTAssertEqual(harness.appState.turnState, .idle, "The turn settled before recovery looked")
+        XCTAssertFalse(harness.appState.turnStateIsStale)
+        box.client.disconnect()
+    }
+
+    /// The genuine not-accepted case keeps its coverage: registry idle AND
+    /// the durable transcript holds nothing beyond the submit-time baseline.
+    func testAmbiguousPromptAbsentFromDurableTranscriptRestoresOnce() async {
+        let active = session("stored-a")
+        var submitCount = 0
+        var transcriptReads = 0
+        var catalogCount = 0
+        var resumeCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    catalogCount += 1
+                    return [active]
+                },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [
+                            ChatMessage(id: "100", role: .user, content: "Earlier question", timestamp: "1"),
+                            ChatMessage(id: "101", role: .assistant, content: "Earlier answer", timestamp: "2")
+                        ],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    throw HermesError.timeout("prompt.submit")
+                },
+                probeActiveSessions: { _ in
+                    [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        harness.appState.messages = [
+            ChatMessage(id: "100", role: .user, content: "Earlier question", timestamp: "1"),
+            ChatMessage(id: "101", role: .assistant, content: "Earlier answer", timestamp: "2")
+        ]
+
+        let submitted = await harness.appState.submitComposer(text: "Never delivered")
+
+        XCTAssertFalse(submitted)
+        XCTAssertEqual(submitCount, 1, "No blind retry may follow the ambiguous failure")
+        XCTAssertEqual(
+            transcriptReads, 2,
+            "One bounded read decides acceptance; the restore's compact resume re-reads the tail"
+        )
+        XCTAssertEqual(catalogCount, 1, "The unsent restoration runs exactly once")
+        XCTAssertEqual(resumeCount, 1)
+        XCTAssertEqual(
+            harness.appState.messages.map(\.id), ["100", "101"],
+            "The optimistic row is restored away exactly once by the authoritative transcript"
+        )
+        XCTAssertTrue(harness.appState.errorMessage?.contains("Failed to send") == true)
+        box.client.disconnect()
+    }
+
+    /// A duplicate-text trap: the transcript advanced with rows that do not
+    /// carry the submitted text, while an OLDER identical user row exists.
+    /// Ordering (baseline ids) must decide, not content matching.
+    func testAmbiguousPromptWithDuplicateOlderTextIsProvenAbsentByOrdering() async {
+        let active = session("stored-a")
+        var transcriptReads = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [
+                            ChatMessage(id: "100", role: .user, content: "go on", timestamp: "1"),
+                            ChatMessage(id: "101", role: .assistant, content: "Earlier reply", timestamp: "2")
+                        ],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "go on", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier reply", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "Different newer ask", "timestamp": "3"],
+                            ["id": "103", "role": "assistant", "content": "Newer reply", "timestamp": "4"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in throw HermesError.timeout("prompt.submit") },
+                probeActiveSessions: { _ in
+                    [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        harness.appState.messages = [
+            ChatMessage(id: "100", role: .user, content: "go on", timestamp: "1"),
+            ChatMessage(id: "101", role: .assistant, content: "Earlier reply", timestamp: "2")
+        ]
+
+        let submitted = await harness.appState.submitComposer(text: "go on")
+
+        XCTAssertFalse(submitted, "The transcript advanced without this prompt: it was not accepted")
+        XCTAssertEqual(transcriptReads, 2)
+        XCTAssertEqual(
+            harness.appState.messages.map(\.id), ["100", "101", "102", "103"],
+            "Restoration converges on the authoritative tail even though only its older rows " +
+            "predate the submission — the newer rows prove this prompt never landed"
+        )
+        box.client.disconnect()
+    }
+
+    /// No usable durable source (bridge unavailable): acceptance can be
+    /// neither proven nor disproven — conservative restore, never a resend.
+    func testAmbiguousPromptWithUnreadableTranscriptRestoresConservatively() async {
+        var submitCount = 0
+        var probeCount = 0
+        var catalogCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    catalogCount += 1
+                    return [self.session("stored-a")]
+                },
+                openSession: { _, sessionID, _ in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in .unavailable },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    throw HermesError.timeout("prompt.submit")
+                },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        installDisconnectedClient(into: harness)
+        harness.appState.sessions = [session("stored-a")]
+        harness.appState.activeSessionId = "stored-a"
+
+        let submitted = await harness.appState.submitComposer(text: "Unverifiable send")
+
+        XCTAssertFalse(submitted)
+        XCTAssertEqual(submitCount, 1, "Unresolved acceptance must never become an automatic resend")
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(catalogCount, 1, "Exactly one conservative restoration")
+    }
+
+    // MARK: - Round 2: submission-owned stale-state correction
+
+    /// A probe started for session A must not mutate anything after the user
+    /// switched to session B: B's stale marker survives and B runs its own
+    /// authoritative correction before its send.
+    func testStaleIdleProbeSupersededBySessionHandoffDoesNotMutateNewSession() async {
+        let sessionA = session("stored-a")
+        let sessionB = session("stored-b")
+        var probeCalls = 0
+        var submitCount = 0
+        var steerTargets: [String] = []
+        let probeGate = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                probeActiveSessions: { _ in
+                    probeCalls += 1
+                    if probeCalls == 1 {
+                        await probeGate.suspend()
+                        return [LiveSessionStatus(
+                            runtimeSessionId: "runtime-a",
+                            storedSessionId: "stored-a",
+                            status: "working"
+                        )]
+                    }
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-b",
+                        storedSessionId: "stored-b",
+                        status: "working"
+                    )]
+                },
+                steer: { _, sessionID, _ in steerTargets.append(sessionID) }
+            )
+        )
+        installDisconnectedClient(into: harness)
+        harness.appState.sessions = [sessionA, sessionB]
+        harness.appState.activeSessionId = sessionA.id
+        harness.appState.handleScenePhase(.background)
+
+        let submissionA = Task { @MainActor in
+            await harness.appState.submitComposer(text: "A follow-up")
+        }
+        await probeGate.waitUntilSuspended()
+
+        // The user switches to session B while A's probe is suspended.
+        harness.appState.activeSessionId = sessionB.id
+        probeGate.resume()
+        let submittedA = await submissionA.value
+
+        XCTAssertFalse(submittedA, "A superseded submission must abort, not fall through")
+        XCTAssertEqual(submitCount, 0, "A's aborted submission must not send")
+        XCTAssertEqual(steerTargets, [], "A's result must not steer")
+        XCTAssertEqual(
+            harness.appState.turnState, .idle,
+            "A's running result must not be attributed to B"
+        )
+        XCTAssertTrue(
+            harness.appState.turnStateIsStale,
+            "B's stale marker must survive A's completed probe"
+        )
+
+        // B still performs its own authoritative probe before routing.
+        let submittedB = await harness.appState.submitComposer(text: "B follow-up")
+        XCTAssertTrue(submittedB)
+        XCTAssertEqual(probeCalls, 2)
+        XCTAssertEqual(steerTargets, ["stored-b"], "B routes through the configured busy action")
+        XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertFalse(harness.appState.turnStateIsStale)
+    }
+
+    /// A prompt outcome returned after the user switched sessions must not
+    /// adopt running state or clear staleness for the new session.
+    func testPromptOutcomeHandoffDoesNotMutateNewSessionState() async {
+        let sessionA = session("stored-a")
+        let sessionB = session("stored-b")
+        var submitCount = 0
+        let sendGate = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    if submitCount == 1 {
+                        await sendGate.suspend()
+                    }
+                    // Hermes was busy: a typed busy outcome for session A.
+                    return .queued
+                },
+                probeActiveSessions: { _ in [] }
+            )
+        )
+        installDisconnectedClient(into: harness)
+        harness.appState.sessions = [sessionA, sessionB]
+        harness.appState.activeSessionId = sessionA.id
+
+        let submissionA = Task { @MainActor in
+            await harness.appState.submitComposer(text: "A message")
+        }
+        await sendGate.waitUntilSuspended()
+
+        // Switch to B, let B go stale, and establish B's authoritative idle
+        // edge while A's RPC is still suspended.
+        harness.appState.activeSessionId = sessionB.id
+        harness.appState.handleScenePhase(.inactive)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: sessionB.id, busy: false))
+
+        sendGate.resume()
+        let submittedA = await submissionA.value
+
+        XCTAssertTrue(submittedA, "A's remotely accepted send stays a success")
+        XCTAssertEqual(submitCount, 1)
+        XCTAssertEqual(
+            harness.appState.turnState, .idle,
+            "A's busy outcome must not be misattributed to session B"
+        )
+        XCTAssertTrue(
+            harness.appState.turnStateIsStale,
+            "B's stale marker must not be cleared by A's outcome"
+        )
+    }
+
+    /// A starting runtime is not committed busy: the stale-idle correction
+    /// falls through to the ordinary send, whose typed outcome reconciles any
+    /// genuine busy race.
+    func testStaleIdleWithStartingRuntimeSendsOrdinaryTurn() async {
+        var submitCount = 0
+        var steerCount = 0
+        var probeCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "starting"
+                    )]
+                },
+                steer: { _, _, _ in steerCount += 1 }
+            )
+        )
+        installDisconnectedClient(into: harness)
+        harness.appState.sessions = [session("stored-a")]
+        harness.appState.activeSessionId = "stored-a"
+        harness.appState.handleScenePhase(.background)
+
+        let submitted = await harness.appState.submitComposer(text: "Go")
+
+        XCTAssertTrue(submitted)
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(steerCount, 0, "Starting alone must not route through busy steer")
+        XCTAssertEqual(submitCount, 1, "The submission falls through to the ordinary new-turn send")
+        XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertFalse(harness.appState.turnStateIsStale)
+    }
+
+    // MARK: - Round 2: foreground probe/event ordering
+
+    /// A turn-ending event that arrives while the foreground probe is in
+    /// flight is NEWER than the registry snapshot and must win: the settled
+    /// state is idle, not a falsely-resurrected running turn.
+    func testForegroundBufferedTurnEndWinsOverStaleRunningSnapshot() async {
+        let active = session("stored-a")
+        var resumeCount = 0
+        let probeGate = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    await probeGate.suspend()
+                    // The snapshot was taken before the turn ended.
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        harness.appState.messages = [
+            ChatMessage(id: "user", role: .user, content: "Question", timestamp: "1")
+        ]
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+
+        harness.appState.handleScenePhase(.background)
+        let sceneTask = harness.appState.handleScenePhase(.active)
+        await probeGate.waitUntilSuspended()
+
+        // The turn ENDS while the probe is still in flight: the newest edge.
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: false))
+        probeGate.resume()
+        await sceneTask?.value
+
+        XCTAssertEqual(
+            harness.appState.turnState, .idle,
+            "The newest authoritative event must win over the older registry snapshot"
+        )
+        XCTAssertEqual(resumeCount, 0, "The race must not manufacture a resume")
+        XCTAssertFalse(
+            harness.appState.activeChatScrollSessionIdentity.isReconciling
+        )
+        box.client.disconnect()
+    }
+
     // MARK: - Harness
 
     private func makeHarness(
@@ -1059,6 +1551,34 @@ private final class ConnectedClientBox {
 
 private struct LifecycleSyncTimedOut: Error {
     let phase: String
+}
+
+/// Suspend/resume gate for driving an in-flight RPC to a chosen point and
+/// releasing it after the test has raced a handoff against it.
+@MainActor
+private final class LifecycleSuspension {
+    private var suspension: CheckedContinuation<Void, Never>?
+    private var observer: CheckedContinuation<Void, Never>?
+
+    func suspend() async {
+        await withCheckedContinuation { continuation in
+            suspension = continuation
+            observer?.resume()
+            observer = nil
+        }
+    }
+
+    func waitUntilSuspended() async {
+        guard suspension == nil else { return }
+        await withCheckedContinuation { continuation in
+            observer = continuation
+        }
+    }
+
+    func resume() {
+        suspension?.resume()
+        suspension = nil
+    }
 }
 
 /// Bounded wait for a spawned task to finish: a wedged phase fails the test

--- a/ConduitTests/AppStateForegroundLifecycleTests.swift
+++ b/ConduitTests/AppStateForegroundLifecycleTests.swift
@@ -4818,6 +4818,20 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
                             "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
                         ])
                     }
+                    if transcriptReads == 3 {
+                        // Mandatory settled-tail check before Turn B. The
+                        // live-time observation already contained A's final
+                        // persisted row, so nothing follows frontier 103.
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                                ["id": "102", "role": "user", "content": "A", "timestamp": "3"],
+                                ["id": "103", "role": "assistant", "content": "Answer A", "timestamp": "4"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
+                        ])
+                    }
                     // Turn B's twin: only ONE new user boundary after the
                     // advanced ordering frontier (103).
                     return .payload([
@@ -4892,6 +4906,7 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         let submittedB = await harness.appState.submitComposer(text: "B")
         XCTAssertTrue(submittedB)
         XCTAssertEqual(submitCount, 2)
+        XCTAssertEqual(transcriptReads, 3, "One bounded settled-tail check before Turn B")
         XCTAssertEqual(harness.appState.turnState, .running)
         harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
         harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "B thinking."))
@@ -4903,7 +4918,7 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         await runSceneActivation(harness)
 
         XCTAssertEqual(probeCount, 2)
-        XCTAssertEqual(transcriptReads, 3, "One bounded freshness read per background return")
+        XCTAssertEqual(transcriptReads, 4, "Settled-tail check plus one bounded read per background return")
         XCTAssertEqual(
             resumeCount, 1,
             "Turn A's persisted rows must not be miscounted as foreign boundaries — Turn B stays observational"
@@ -5093,6 +5108,19 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
                             "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
                         ])
                     }
+                    if transcriptReads == 3 {
+                        // Mandatory settled-tail check before Turn B. The
+                        // earlier live observation already held A's final row.
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                                ["id": "102", "role": "user", "content": "A", "timestamp": "3"],
+                                ["id": "103", "role": "assistant", "content": "Answer A", "timestamp": "4"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
+                        ])
+                    }
                     // B completed while away; remote Turn C started: TWO
                     // boundaries after B's frozen baseline (103).
                     return .payload([
@@ -5153,6 +5181,7 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         let submittedB = await harness.appState.submitComposer(text: "B")
         XCTAssertTrue(submittedB)
         XCTAssertEqual(submitCount, 2)
+        XCTAssertEqual(transcriptReads, 3, "One bounded settled-tail check before Turn B")
         harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
         harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "B thinking."))
         XCTAssertNotNil(harness.appState.liveReasoningSegment)
@@ -5162,7 +5191,7 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         await runSceneActivation(harness)
 
         XCTAssertEqual(probeCount, 2)
-        XCTAssertEqual(transcriptReads, 4, "Freshness read + the attach reconcile's bounded read")
+        XCTAssertEqual(transcriptReads, 5, "Settled-tail check + freshness read + attach reconcile read")
         XCTAssertEqual(
             resumeCount, 2,
             "Two boundaries after B's frozen baseline force the authoritative attach"
@@ -5501,10 +5530,400 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         box.client.disconnect()
     }
 
-    /// An already-observed locally-owned turn (its foreground freshness read
-    /// advanced the frontier through its rows) creates NO ordering debt: the
-    /// next local submit performs no extra pre-send read.
-    func testAlreadyObservedLocalTurnCreatesNoExtraPreSendRead() async {
+    /// A settled-tail check may absorb only the already-observed local turn's
+    /// assistant/tool suffix. A canonical user boundary after the live-time
+    /// frontier proves another turn occurred and must be adopted before the
+    /// next local prompt is appended.
+    func testObservedRunningTurnWithRemoteActivityReconcilesBeforeNextTurn() async {
+        let active = session("stored-a")
+        var resumeCount = 0
+        var transcriptReads = 0
+        var submitCount = 0
+        let remoteTail: [[String: Any]] = [
+            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+            ["id": "102", "role": "user", "content": "A", "timestamp": "3"],
+            ["id": "103", "role": "assistant", "content": "Partial A", "timestamp": "4"],
+            ["id": "104", "role": "tool", "content": "Final tool A", "timestamp": "5"],
+            ["id": "105", "role": "user", "content": "Remote B", "timestamp": "6"],
+            ["id": "106", "role": "assistant", "content": "Remote B answer", "timestamp": "7"]
+        ]
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": Array(remoteTail.prefix(2)),
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    if transcriptReads == 2 {
+                        return .payload([
+                            "messages": Array(remoteTail.prefix(4)),
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
+                        ])
+                    }
+                    return .payload([
+                        "messages": remoteTail,
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 7]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+
+        let submittedA = await harness.appState.submitComposer(text: "A")
+        XCTAssertTrue(submittedA)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "A thinking."))
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+        XCTAssertEqual(resumeCount, 1)
+        XCTAssertEqual(transcriptReads, 2)
+
+        harness.appState.handleStreamEvent(.messageComplete(
+            sessionId: active.id,
+            messageId: nil,
+            content: "Answer A",
+            reasoning: nil
+        ))
+        harness.appState.handleStreamEvent(.messageStart(sessionId: active.id))
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: false))
+
+        let submittedC = await harness.appState.submitComposer(text: "Local C")
+        XCTAssertTrue(submittedC)
+
+        XCTAssertEqual(submitCount, 2, "Turn A plus exactly one reconciled local send")
+        XCTAssertEqual(transcriptReads, 4, "Settled-tail read plus authoritative reconcile read")
+        XCTAssertEqual(resumeCount, 2, "The remote user boundary forces authoritative recovery")
+        XCTAssertEqual(
+            harness.appState.messages.dropLast().map(\.id),
+            ["100", "101", "102", "103", "105", "106"],
+            "The remote user turn is visible; persisted tool rows remain presentation-filtered"
+        )
+        XCTAssertTrue(harness.appState.messages.last?.id.hasPrefix("local-") == true)
+        box.client.disconnect()
+    }
+
+    /// Hermes `prompt.submit` busy outcomes have distinct persistence
+    /// contracts. Redirect mutates the current live turn, so it cannot owe a
+    /// new canonical user boundary after that turn settles.
+    func testRedirectedBusySubmissionCreatesNoNewTurnOrderingDebt() async {
+        await assertBusyPromptOutcomeOrdering(
+            outcome: .redirected,
+            persistedRowsOnDebtRead: nil,
+            expectedTranscriptReads: 1,
+            expectedResumeCount: 1
+        )
+    }
+
+    /// Steer injects into the current run at a role-safe boundary and does not
+    /// persist an independent user turn.
+    func testSteeredBusySubmissionCreatesNoNewTurnOrderingDebt() async {
+        await assertBusyPromptOutcomeOrdering(
+            outcome: .steered,
+            persistedRowsOnDebtRead: nil,
+            expectedTranscriptReads: 2,
+            expectedResumeCount: 1
+        )
+    }
+
+    /// A non-deduplicated queue drains as a full turn. Because the typed
+    /// outcome cannot prove an exact boundary count, observing that user row
+    /// forces authoritative adoption before another local turn is appended.
+    func testQueuedBusySubmissionCanonicalTurnReconcilesBeforeNextSend() async {
+        await assertBusyPromptOutcomeOrdering(
+            outcome: .queued,
+            persistedRowsOnDebtRead: [
+                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                ["id": "102", "role": "user", "content": "Queued follow-up", "timestamp": "3"],
+                ["id": "103", "role": "assistant", "content": "Queued answer", "timestamp": "4"]
+            ],
+            expectedTranscriptReads: 3,
+            expectedResumeCount: 2
+        )
+    }
+
+    /// Hermes reports `.queued` even when `_enqueue_prompt` drops a text-only
+    /// duplicate of the in-flight prompt. The outcome therefore cannot create
+    /// an exact one-boundary debt; a bounded read with no new user row clears
+    /// the observation obligation without an authoritative resume.
+    func testQueuedBusySubmissionDroppedAsDuplicateCreatesNoImpossibleDebt() async {
+        await assertBusyPromptOutcomeOrdering(
+            outcome: .queued,
+            persistedRowsOnDebtRead: nil,
+            expectedTranscriptReads: 2,
+            expectedResumeCount: 1
+        )
+    }
+
+    /// A steer normally stays inside the live turn, but Hermes promotes a
+    /// late `pending_steer` to the queued next turn. If that canonical user
+    /// boundary appears, the zero-boundary observation obligation forces an
+    /// authoritative reconcile before the next local prompt.
+    func testSteeredBusySubmissionPromotedToTurnReconcilesBeforeNextSend() async {
+        await assertBusyPromptOutcomeOrdering(
+            outcome: .steered,
+            persistedRowsOnDebtRead: [
+                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                ["id": "102", "role": "user", "content": "Late steer", "timestamp": "3"],
+                ["id": "103", "role": "assistant", "content": "Late steer answer", "timestamp": "4"]
+            ],
+            expectedTranscriptReads: 3,
+            expectedResumeCount: 2
+        )
+    }
+
+    private func assertBusyPromptOutcomeOrdering(
+        outcome: PromptSubmissionOutcome,
+        persistedRowsOnDebtRead: [[String: Any]]?,
+        expectedTranscriptReads: Int,
+        expectedResumeCount: Int
+    ) async {
+        let active = session("stored-a")
+        var resumeCount = 0
+        var transcriptReads = 0
+        var submitCount = 0
+        let seedRows: [[String: Any]] = [
+            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+        ]
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    let rows = persistedRowsOnDebtRead ?? seedRows
+                    return .payload([
+                        "messages": transcriptReads == 1 ? seedRows : rows,
+                        "pagination": [
+                            "limit": 120,
+                            "offset": 0,
+                            "order": "latest",
+                            "returned": transcriptReads == 1 ? seedRows.count : rows.count
+                        ]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return submitCount == 1 ? outcome : .accepted
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in [] }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+
+        let submittedBusy = await harness.appState.submitComposer(text: "Busy-race follow-up")
+        XCTAssertTrue(submittedBusy)
+        XCTAssertEqual(harness.appState.turnState, .running)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: false))
+        XCTAssertEqual(harness.appState.turnState, .idle)
+
+        let submittedNext = await harness.appState.submitComposer(text: "Ordinary next turn")
+        XCTAssertTrue(submittedNext)
+        XCTAssertEqual(submitCount, 2)
+        XCTAssertEqual(transcriptReads, expectedTranscriptReads)
+        XCTAssertEqual(resumeCount, expectedResumeCount)
+        XCTAssertEqual(harness.appState.turnState, .running)
+        box.client.disconnect()
+    }
+
+    /// A running probe and persisted read remain older than stream events
+    /// buffered behind the foreground boundary. Even when a newer busy edge
+    /// confirms the same turn is live, the read certifies only its user
+    /// boundary; its later settle still causes one bounded tail catch-up.
+    func testRunningForegroundObservationWithBufferedBusyEdgeStillLeavesTailDebt() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        var submitCount = 0
+        let parkedRead = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    if transcriptReads == 2 {
+                        await parkedRead.suspend()
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                                ["id": "102", "role": "user", "content": "A", "timestamp": "3"],
+                                ["id": "103", "role": "assistant", "content": "Partial A", "timestamp": "4"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
+                        ])
+                    }
+                    if transcriptReads == 3 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                                ["id": "102", "role": "user", "content": "A", "timestamp": "3"],
+                                ["id": "103", "role": "assistant", "content": "Partial A", "timestamp": "4"],
+                                ["id": "104", "role": "tool", "content": "Final tool A", "timestamp": "5"],
+                                ["id": "105", "role": "assistant", "content": "Final A", "timestamp": "6"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 6]
+                        ])
+                    }
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "A", "timestamp": "3"],
+                            ["id": "103", "role": "assistant", "content": "Partial A", "timestamp": "4"],
+                            ["id": "104", "role": "tool", "content": "Final tool A", "timestamp": "5"],
+                            ["id": "105", "role": "assistant", "content": "Final A", "timestamp": "6"],
+                            ["id": "106", "role": "user", "content": "B", "timestamp": "7"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 7]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+
+        let submittedA = await harness.appState.submitComposer(text: "A")
+        XCTAssertTrue(submittedA)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "A thinking."))
+        harness.appState.handleScenePhase(.background)
+        let activationA = Task { @MainActor in await runSceneActivation(harness) }
+        await parkedRead.waitUntilSuspended()
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        parkedRead.resume()
+        await activationA.value
+        await flushMainActor()
+
+        XCTAssertEqual(resumeCount, 1)
+        XCTAssertEqual(transcriptReads, 2)
+        XCTAssertEqual(harness.appState.turnState, .running)
+
+        harness.appState.handleStreamEvent(.toolStart(
+            sessionId: active.id,
+            toolName: "read_file",
+            toolInput: nil
+        ))
+        harness.appState.handleStreamEvent(.toolComplete(
+            sessionId: active.id,
+            toolName: "read_file",
+            toolOutput: "Final tool A"
+        ))
+        harness.appState.handleStreamEvent(.messageComplete(
+            sessionId: active.id,
+            messageId: nil,
+            content: "Final A",
+            reasoning: nil
+        ))
+        harness.appState.handleStreamEvent(.messageStart(sessionId: active.id))
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: false))
+
+        let submittedB = await harness.appState.submitComposer(text: "B")
+        XCTAssertTrue(submittedB)
+        XCTAssertEqual(transcriptReads, 3, "Buffered busy edge must preserve one settled-tail read")
+        XCTAssertEqual(submitCount, 2)
+        XCTAssertEqual(resumeCount, 1)
+
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "B thinking."))
+        let segmentB = harness.appState.liveReasoningSegment
+        let messagesDuringB = harness.appState.messages
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(resumeCount, 1, "Turn B foreground remains observational")
+        XCTAssertEqual(harness.appState.messages, messagesDuringB)
+        XCTAssertEqual(harness.appState.liveReasoningSegment, segmentB)
+        box.client.disconnect()
+    }
+
+    /// Observing Turn A's user boundary while A is still running does not
+    /// certify A's final persisted tail. The next new-turn submit performs one
+    /// bounded settled-tail read, advances through assistant/tool-only rows,
+    /// and freezes Turn B's baseline after them so B's foreground remains
+    /// observational.
+    func testObservedRunningTurnReconcilesFinalPersistedTailBeforeNextTurn() async {
         let active = session("stored-a")
         var probeCount = 0
         var resumeCount = 0
@@ -5532,7 +5951,9 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
                         ])
                     }
                     if transcriptReads == 2 {
-                        // Turn A's foreground freshness read: twin + output.
+                        // Turn A's foreground freshness read while it is still
+                        // running: its user boundary and only the output that
+                        // had persisted so far.
                         return .payload([
                             "messages": [
                                 ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
@@ -5543,16 +5964,35 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
                             "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
                         ])
                     }
-                    // Turn B's twin (used only if B is backgrounded).
+                    if transcriptReads == 3 {
+                        // Turn A continued after the live-time observation.
+                        // This pre-send settled-tail read contains no new user
+                        // boundary after 103, only A's final durable tail.
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                                ["id": "102", "role": "user", "content": "A", "timestamp": "3"],
+                                ["id": "103", "role": "assistant", "content": "Partial answer A", "timestamp": "4"],
+                                ["id": "104", "role": "tool", "content": "Tool output A", "timestamp": "5"],
+                                ["id": "105", "role": "assistant", "content": "Final answer A", "timestamp": "6"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 6]
+                        ])
+                    }
+                    // Turn B's twin: exactly one canonical user boundary after
+                    // the settled-tail catch-up frontier at 105.
                     return .payload([
                         "messages": [
                             ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
                             ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
                             ["id": "102", "role": "user", "content": "A", "timestamp": "3"],
-                            ["id": "103", "role": "assistant", "content": "Answer A", "timestamp": "4"],
-                            ["id": "104", "role": "user", "content": "B", "timestamp": "5"]
+                            ["id": "103", "role": "assistant", "content": "Partial answer A", "timestamp": "4"],
+                            ["id": "104", "role": "tool", "content": "Tool output A", "timestamp": "5"],
+                            ["id": "105", "role": "assistant", "content": "Final answer A", "timestamp": "6"],
+                            ["id": "106", "role": "user", "content": "B", "timestamp": "7"]
                         ],
-                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 5]
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 7]
                     ])
                 },
                 refreshContext: { _, _ in },
@@ -5577,7 +6017,8 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         let opened = await harness.appState.openSession(active.id)
         XCTAssertTrue(opened)
 
-        // Turn A: background + foreground observes its rows (frontier 103).
+        // Turn A: background + foreground observes its boundary and partial
+        // persisted output through 103 while the turn is still live.
         let submittedA = await harness.appState.submitComposer(text: "A")
         XCTAssertTrue(submittedA)
         harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
@@ -5586,8 +6027,18 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         await runSceneActivation(harness)
         XCTAssertEqual(resumeCount, 1)
         XCTAssertEqual(transcriptReads, 2)
+        let segmentA = harness.appState.liveReasoningSegment
+        XCTAssertNotNil(segmentA)
 
-        // Settle A locally; the frontier already covered its boundary.
+        // A continues after that read and persists more tool/output rows.
+        harness.appState.handleStreamEvent(
+            .toolStart(sessionId: active.id, toolName: "read_file", toolInput: nil)
+        )
+        harness.appState.handleStreamEvent(
+            .toolComplete(sessionId: active.id, toolName: "read_file", toolOutput: "Tool output A")
+        )
+
+        // Settle A locally. No history read has yet observed its final tail.
         harness.appState.handleStreamEvent(.messageComplete(
             sessionId: active.id,
             messageId: nil,
@@ -5598,15 +6049,41 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: false))
         XCTAssertEqual(harness.appState.turnState, .idle)
 
-        // Turn B submits with NO extra pre-send read.
+        // Turn B performs exactly one settled-tail catch-up before freezing
+        // its ordering baseline, without replacing the visible transcript.
         let submittedB = await harness.appState.submitComposer(text: "B")
         XCTAssertTrue(submittedB)
         XCTAssertEqual(submitCount, 2)
         XCTAssertEqual(
-            transcriptReads, 2,
-            "An already-observed turn must not trigger a debt catch-up read"
+            transcriptReads, 3,
+            "A live-time boundary observation still requires one final-tail read"
         )
+        XCTAssertEqual(resumeCount, 1)
         XCTAssertEqual(harness.appState.turnState, .running)
+
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "B thinking."))
+        let segmentB = harness.appState.liveReasoningSegment
+        XCTAssertNotNil(segmentB)
+        let messagesDuringB = harness.appState.messages
+        let optimisticB = messagesDuringB.last
+        XCTAssertEqual(optimisticB?.role, .user)
+        XCTAssertTrue(optimisticB?.id.hasPrefix("local-") == true)
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(transcriptReads, 4)
+        XCTAssertEqual(
+            resumeCount, 1,
+            "B's foreground must not resume after A's final tail was re-anchored"
+        )
+        XCTAssertEqual(harness.appState.messages, messagesDuringB)
+        XCTAssertEqual(harness.appState.messages.last, optimisticB)
+        XCTAssertEqual(harness.appState.liveReasoningSegment, segmentB)
+
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: " More."))
+        XCTAssertEqual(harness.appState.liveReasoningSegment?.id, segmentB?.id)
         box.client.disconnect()
     }
 

--- a/ConduitTests/AppStateForegroundLifecycleTests.swift
+++ b/ConduitTests/AppStateForegroundLifecycleTests.swift
@@ -5260,6 +5260,356 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         box.client.disconnect()
     }
 
+    /// THE foreground-only lifecycle: Turn A is submitted, runs, and
+    /// settles entirely while Conduit stays foregrounded — no bounded
+    /// history read ever observes its durable rows. The settle records one
+    /// unit of local ordering debt, and Turn B's submit reconciles it with
+    /// exactly one bounded tail read BEFORE freezing B's ordering baseline.
+    /// B's foreground then sees only B's own boundary and stays
+    /// observational.
+    func testConsecutiveLocallyOwnedTurnsWithoutIntermediateFreshnessReadStayObservational() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        var submitCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    if transcriptReads == 2 {
+                        // The pre-send debt catch-up: Turn A's durable rows.
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                                ["id": "102", "role": "user", "content": "A", "timestamp": "3"],
+                                ["id": "103", "role": "assistant", "content": "Answer A", "timestamp": "4"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
+                        ])
+                    }
+                    // Turn B's twin: exactly ONE boundary after 103.
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "A", "timestamp": "3"],
+                            ["id": "103", "role": "assistant", "content": "Answer A", "timestamp": "4"],
+                            ["id": "104", "role": "user", "content": "B", "timestamp": "5"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 5]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101"])
+
+        // --- Turn A: runs and settles entirely in the foreground ---
+        let submittedA = await harness.appState.submitComposer(text: "A")
+        XCTAssertTrue(submittedA)
+        XCTAssertEqual(submitCount, 1)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "A thinking."))
+        harness.appState.handleStreamEvent(.messageComplete(
+            sessionId: active.id,
+            messageId: nil,
+            content: "Answer A",
+            reasoning: nil
+        ))
+        harness.appState.handleStreamEvent(.messageStart(sessionId: active.id))
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: false))
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        XCTAssertEqual(transcriptReads, 1, "No history read observed Turn A")
+
+        // --- Turn B: the debt catch-up read fires before B freezes its
+        // baseline, then B submits normally ---
+        let submittedB = await harness.appState.submitComposer(text: "B")
+        XCTAssertTrue(submittedB)
+        XCTAssertEqual(submitCount, 2, "prompt.submit exactly once for Turn B")
+        XCTAssertEqual(
+            transcriptReads, 2,
+            "Exactly one bounded debt catch-up read before Turn B"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "B thinking."))
+        let segmentB = harness.appState.liveReasoningSegment
+        XCTAssertNotNil(segmentB)
+        let messagesAfterB = harness.appState.messages
+
+        // --- Foreground during Turn B ---
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 3)
+        XCTAssertEqual(
+            resumeCount, 1,
+            "Turn A's persisted rows were anchored by the debt read — Turn B stays observational"
+        )
+        XCTAssertEqual(harness.appState.messages, messagesAfterB, "No transcript replacement")
+        XCTAssertEqual(harness.appState.liveReasoningSegment, segmentB)
+        XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertFalse(harness.appState.transcriptFreshnessIsStale)
+
+        // Future Turn B deltas extend the SAME segment.
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: " More."))
+        XCTAssertEqual(harness.appState.liveReasoningSegment?.id, segmentB?.id)
+        box.client.disconnect()
+    }
+
+    /// Local ordering debt that is EXCEEDED by persisted history proves
+    /// foreign activity: the authoritative reconcile runs before the local
+    /// send, the remote turn becomes visible, and only then does the new
+    /// local prompt append after it.
+    func testLocalOrderingDebtExceededByRemoteTurnForcesReconcile() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        var submitCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    // The debt read (and the recovery reconcile's own read)
+                    // see MORE boundaries than the one outstanding
+                    // locally-owned settled turn: remote B.
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "A", "timestamp": "3"],
+                            ["id": "103", "role": "assistant", "content": "Answer A", "timestamp": "4"],
+                            ["id": "104", "role": "user", "content": "Remote B", "timestamp": "5"],
+                            ["id": "105", "role": "assistant", "content": "Remote B answer", "timestamp": "6"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 6]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+
+        // Turn A: foreground-only lifecycle, settles, leaves debt = 1.
+        let submittedA = await harness.appState.submitComposer(text: "A")
+        XCTAssertTrue(submittedA)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.messageComplete(
+            sessionId: active.id,
+            messageId: nil,
+            content: "Answer A",
+            reasoning: nil
+        ))
+        harness.appState.handleStreamEvent(.messageStart(sessionId: active.id))
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: false))
+        XCTAssertEqual(harness.appState.turnState, .idle)
+
+        // The next local submit: the debt read proves foreign activity.
+        let submittedC = await harness.appState.submitComposer(text: "Local C")
+        XCTAssertTrue(submittedC)
+
+        XCTAssertEqual(submitCount, 2, "Turn A + one reconciled local send — no duplicates")
+        XCTAssertEqual(transcriptReads, 3, "Debt read + the recovery reconcile's bounded read")
+        XCTAssertEqual(
+            resumeCount, 2,
+            "Seed hydration + the authoritative recovery resume"
+        )
+        XCTAssertEqual(
+            harness.appState.messages.count, 7,
+            "The remote turn is visible and the local prompt appends after it"
+        )
+        XCTAssertEqual(harness.appState.messages.last?.role, .user)
+        XCTAssertTrue(
+            harness.appState.messages.last?.id.hasPrefix("local-") == true,
+            "The reconciled local prompt appends last"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
+        box.client.disconnect()
+    }
+
+    /// An already-observed locally-owned turn (its foreground freshness read
+    /// advanced the frontier through its rows) creates NO ordering debt: the
+    /// next local submit performs no extra pre-send read.
+    func testAlreadyObservedLocalTurnCreatesNoExtraPreSendRead() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        var submitCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    if transcriptReads == 2 {
+                        // Turn A's foreground freshness read: twin + output.
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                                ["id": "102", "role": "user", "content": "A", "timestamp": "3"],
+                                ["id": "103", "role": "assistant", "content": "Answer A", "timestamp": "4"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
+                        ])
+                    }
+                    // Turn B's twin (used only if B is backgrounded).
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "A", "timestamp": "3"],
+                            ["id": "103", "role": "assistant", "content": "Answer A", "timestamp": "4"],
+                            ["id": "104", "role": "user", "content": "B", "timestamp": "5"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 5]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+
+        // Turn A: background + foreground observes its rows (frontier 103).
+        let submittedA = await harness.appState.submitComposer(text: "A")
+        XCTAssertTrue(submittedA)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "A thinking."))
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+        XCTAssertEqual(resumeCount, 1)
+        XCTAssertEqual(transcriptReads, 2)
+
+        // Settle A locally; the frontier already covered its boundary.
+        harness.appState.handleStreamEvent(.messageComplete(
+            sessionId: active.id,
+            messageId: nil,
+            content: "Answer A",
+            reasoning: nil
+        ))
+        harness.appState.handleStreamEvent(.messageStart(sessionId: active.id))
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: false))
+        XCTAssertEqual(harness.appState.turnState, .idle)
+
+        // Turn B submits with NO extra pre-send read.
+        let submittedB = await harness.appState.submitComposer(text: "B")
+        XCTAssertTrue(submittedB)
+        XCTAssertEqual(submitCount, 2)
+        XCTAssertEqual(
+            transcriptReads, 2,
+            "An already-observed turn must not trigger a debt catch-up read"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
+        box.client.disconnect()
+    }
+
     /// The gate's second non-proceed arm: a recovery boundary
     /// (.reconnecting here) racing the pre-send freshness read proves
     /// neither liveness nor ordering — the send is blocked, not blind-sent

--- a/ConduitTests/AppStateForegroundLifecycleTests.swift
+++ b/ConduitTests/AppStateForegroundLifecycleTests.swift
@@ -1399,6 +1399,289 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         box.client.disconnect()
     }
 
+    // MARK: - Round 3: durable-anchor evidence model
+
+    /// Case A: the pre-submit conversation holds an optimistic local row
+    /// ("continue"), and the persisted tail contains an identical user row
+    /// (501) that may be that SAME send re-homed under a database id. The
+    /// verifier must not prove acceptance merely because "501" is not
+    /// "local-123": with a durable anchor present but local-only rows
+    /// outstanding, the outcome is indeterminate → conservative restore.
+    func testAmbiguousMatchingRowAfterAnchorWithLocalPredecessorIsIndeterminate() async {
+        let active = session("stored-a")
+        var submitCount = 0
+        var transcriptReads = 0
+        var catalogCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    catalogCount += 1
+                    return [active]
+                },
+                openSession: { _, sessionID, _ in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [
+                            ChatMessage(id: "98", role: .user, content: "prior", timestamp: "0"),
+                            ChatMessage(id: "99", role: .assistant, content: "ack", timestamp: "1")
+                        ],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    return .payload([
+                        "messages": [
+                            ["id": "98", "role": "user", "content": "prior", "timestamp": "0"],
+                            ["id": "99", "role": "assistant", "content": "ack", "timestamp": "1"],
+                            ["id": "501", "role": "user", "content": "continue", "timestamp": "5"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 3]
+                    ])
+                },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    throw HermesError.timeout("prompt.submit")
+                },
+                probeActiveSessions: { _ in
+                    [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        harness.appState.messages = [
+            ChatMessage(id: "98", role: .user, content: "prior", timestamp: "0"),
+            ChatMessage(id: "99", role: .assistant, content: "ack", timestamp: "1"),
+            ChatMessage(id: "local-123", role: .user, content: "continue", timestamp: "2")
+        ]
+
+        let submitted = await harness.appState.submitComposer(text: "continue")
+
+        XCTAssertFalse(
+            submitted,
+            "An identical persisted row after the anchor cannot be attributed to this submission"
+        )
+        XCTAssertEqual(submitCount, 1, "No automatic resend")
+        XCTAssertEqual(transcriptReads, 2)
+        XCTAssertEqual(catalogCount, 1, "The conservative restoration runs exactly once")
+        XCTAssertEqual(
+            harness.appState.messages.filter { $0.role == .user && $0.content == "continue" }.count,
+            1,
+            "The optimistic duplicate is restored away; exactly one user row remains"
+        )
+        box.client.disconnect()
+    }
+
+    /// Case B: the first identical turn is durably anchored (hydrated rows
+    /// 501/502) and the tail advances past that anchor with a NEW identical
+    /// user row (503) plus its response — acceptance is provable.
+    func testAmbiguousNewIdenticalRowBeyondDurableAnchorIsAcceptedSettled() async {
+        let active = session("stored-a")
+        var submitCount = 0
+        var probeCount = 0
+        var catalogCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    catalogCount += 1
+                    return [active]
+                },
+                openSession: { _, sessionID, _ in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    .payload([
+                        "messages": [
+                            ["id": "501", "role": "user", "content": "continue", "timestamp": "1"],
+                            ["id": "502", "role": "assistant", "content": "done", "timestamp": "2"],
+                            ["id": "503", "role": "user", "content": "continue", "timestamp": "3"],
+                            ["id": "504", "role": "assistant", "content": "done again", "timestamp": "4"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
+                    ])
+                },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    throw HermesError.timeout("prompt.submit")
+                },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    // The turn already completed and the runtime was reaped.
+                    return []
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        harness.appState.messages = [
+            ChatMessage(id: "501", role: .user, content: "continue", timestamp: "1"),
+            ChatMessage(id: "502", role: .assistant, content: "done", timestamp: "2")
+        ]
+
+        let submitted = await harness.appState.submitComposer(text: "continue")
+
+        XCTAssertTrue(submitted, "Durable ordering proves the second identical turn landed")
+        XCTAssertEqual(submitCount, 1, "No second prompt.submit")
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(catalogCount, 0, "No composer restoration for a proven acceptance")
+        XCTAssertEqual(
+            harness.appState.messages.last?.content, "continue",
+            "The optimistic row converges with the persisted transcript"
+        )
+        XCTAssertEqual(harness.appState.turnState, .idle, "The turn settled before recovery looked")
+        XCTAssertFalse(harness.appState.turnStateIsStale)
+        box.client.disconnect()
+    }
+
+    /// Case C: with NO durable pre-submit anchor at all, a matching persisted
+    /// row cannot be dated — indeterminate, never present.
+    func testAmbiguousMatchingRowWithoutDurableAnchorIsIndeterminate() async {
+        var submitCount = 0
+        var catalogCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    catalogCount += 1
+                    return [self.session("stored-a")]
+                },
+                openSession: { _, sessionID, _ in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    .payload([
+                        "messages": [
+                            ["id": "501", "role": "user", "content": "continue", "timestamp": "5"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 1]
+                    ])
+                },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    throw HermesError.timeout("prompt.submit")
+                },
+                probeActiveSessions: { _ in
+                    [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        installDisconnectedClient(into: harness)
+        harness.appState.sessions = [session("stored-a")]
+        harness.appState.activeSessionId = "stored-a"
+        harness.appState.messages = [
+            ChatMessage(id: "local-123", role: .user, content: "continue", timestamp: "2")
+        ]
+
+        let submitted = await harness.appState.submitComposer(text: "continue")
+
+        XCTAssertFalse(submitted, "Without a durable anchor the outcome must not claim acceptance")
+        XCTAssertEqual(submitCount, 1)
+        XCTAssertEqual(catalogCount, 1, "Conservative restoration exactly once")
+    }
+
+    // MARK: - Round 3: post-recovery presentation ownership
+
+    /// A failed-send error produced by session A's ambiguous recovery must
+    /// not paint the error (or any turn state) onto session B after the user
+    /// switched mid-recovery.
+    func testAmbiguousRecoveryErrorDoesNotLeakIntoHandedOffSession() async {
+        let sessionA = session("stored-a")
+        let sessionB = session("stored-b")
+        var submitCount = 0
+        var probeCount = 0
+        var catalogCount = 0
+        let probeGate = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in
+                    catalogCount += 1
+                    return [sessionA]
+                },
+                openSession: { _, sessionID, _ in
+                    SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                    ])
+                },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    throw HermesError.timeout("prompt.submit")
+                },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    await probeGate.suspend()
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [sessionA, sessionB]
+        harness.appState.activeSessionId = sessionA.id
+        harness.appState.messages = [
+            ChatMessage(id: "100", role: .user, content: "Earlier question", timestamp: "1"),
+            ChatMessage(id: "101", role: .assistant, content: "Earlier answer", timestamp: "2")
+        ]
+
+        let submissionA = Task { @MainActor in
+            await harness.appState.submitComposer(text: "A doomed send")
+        }
+        await probeGate.waitUntilSuspended()
+
+        // The user switches to session B while A's recovery is suspended.
+        harness.appState.activeSessionId = sessionB.id
+        harness.appState.handleScenePhase(.inactive)
+        harness.appState.errorMessage = "B-sentinel"
+
+        probeGate.resume()
+        let submittedA = await submissionA.value
+
+        XCTAssertFalse(submittedA)
+        XCTAssertEqual(submitCount, 1)
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(
+            harness.appState.errorMessage, "B-sentinel",
+            "A's stale send failure must not overwrite B's error surface"
+        )
+        XCTAssertTrue(
+            harness.appState.turnStateIsStale,
+            "B's stale marker must survive A's recovery"
+        )
+        XCTAssertEqual(catalogCount, 0, "A's restoration is skipped under lost ownership")
+        box.client.disconnect()
+    }
+
     // MARK: - Harness
 
     private func makeHarness(

--- a/ConduitTests/AppStateForegroundLifecycleTests.swift
+++ b/ConduitTests/AppStateForegroundLifecycleTests.swift
@@ -4667,10 +4667,15 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         box.client.disconnect()
     }
 
-    /// A brand-new conversation's first locally-submitted turn has NO
-    /// durable pre-submit anchor, so no boundary proof can exist even for
-    /// the expected twin — the conservative attach owns it.
-    func testForegroundFirstTurnWithoutDurableAnchorTakesAttach() async {
+    /// A brand-new conversation's first locally-submitted turn: the initial
+    /// hydration POSITIVELY proved the persisted transcript empty, which is
+    /// valid ordering evidence (distinct from unknown). The persisted twin
+    /// of the optimistic first-turn row — exactly ONE new canonical
+    /// user-turn boundary after a positively-empty baseline, with the
+    /// runtime still working — stays same-turn observational: zero
+    /// `session.resume`, zero transcript replacement, optimistic row and
+    /// live reasoning projection intact.
+    func testForegroundFirstTurnFromPositivelyEmptyBaselineStaysObservational() async {
         let active = session("stored-a")
         var probeCount = 0
         var resumeCount = 0
@@ -4678,18 +4683,12 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         var submitCount = 0
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
-                loadCatalog: { _, _ in [active] },
                 openSession: { _, sessionID, _ in
                     resumeCount += 1
                     return SessionResumeResult(
                         sessionId: sessionID,
                         messages: [],
-                        snapshot: SessionRuntimeSnapshot(
-                            object: ["running": .bool(resumeCount > 1)],
-                            inflight: resumeCount > 1
-                                ? .object(["text": .string("First turn partial")])
-                                : nil
-                        )
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
                     )
                 },
                 persistedTranscript: { _, _ in
@@ -4736,23 +4735,528 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         XCTAssertTrue(submitted)
         XCTAssertEqual(submitCount, 1)
         XCTAssertEqual(harness.appState.messages.count, 1)
+        XCTAssertTrue(
+            harness.appState.messages.last?.id.hasPrefix("local-") == true,
+            "The visible user row is the optimistic local row"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
         harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
         harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "Thinking."))
-        XCTAssertNotNil(harness.appState.liveReasoningSegment)
+        let segmentBefore = harness.appState.liveReasoningSegment
+        XCTAssertNotNil(segmentBefore)
+        let messagesBefore = harness.appState.messages
         let resumesBeforeForeground = resumeCount
 
         harness.appState.handleScenePhase(.background)
         await runSceneActivation(harness)
 
         XCTAssertEqual(probeCount, 1)
-        XCTAssertEqual(transcriptReads, 3)
+        XCTAssertEqual(transcriptReads, 2, "One bounded freshness read")
         XCTAssertEqual(
-            resumeCount, resumesBeforeForeground + 1,
-            "No durable anchor → no ordering proof → the attach owns the tail"
+            resumeCount, resumesBeforeForeground,
+            "A positively-empty baseline makes the first turn's twin provable — zero session.resume"
         )
-        XCTAssertEqual(harness.appState.messages.map(\.id), ["102"])
-        XCTAssertNil(harness.appState.liveReasoningSegment)
+        XCTAssertEqual(
+            harness.appState.messages, messagesBefore,
+            "The persisted twin is never merged behind the optimistic row"
+        )
+        XCTAssertEqual(harness.appState.liveReasoningSegment, segmentBefore)
         XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertFalse(harness.appState.transcriptFreshnessIsStale)
+
+        // Future deltas extend the SAME turn.
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: " More."))
+        XCTAssertEqual(harness.appState.liveReasoningSegment?.id, segmentBefore?.id)
+        harness.appState.showSidebar = true
+        harness.appState.showSidebar = false
+        XCTAssertEqual(harness.appState.liveReasoningSegment?.content, "Thinking. More.")
+        box.client.disconnect()
+    }
+
+    /// Consecutive locally-owned turns: the Turn A foreground's unchanged
+    /// verdict advances the persisted ordering frontier through Turn A's
+    /// persisted rows WITHOUT touching the visible transcript, so Turn B's
+    /// marker anchors past them — Turn B's foreground must not miscount
+    /// Turn A's rows as foreign user-turn boundaries. Both foregrounds stay
+    /// observational: zero `session.resume`.
+    func testConsecutiveLocallyOwnedTurnsAdvancePersistedOrderingFrontier() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        var submitCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    if transcriptReads == 2 {
+                        // Turn A's durable twin + output while A runs.
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                                ["id": "102", "role": "user", "content": "A", "timestamp": "3"],
+                                ["id": "103", "role": "assistant", "content": "Answer A", "timestamp": "4"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
+                        ])
+                    }
+                    // Turn B's twin: only ONE new user boundary after the
+                    // advanced ordering frontier (103).
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "A", "timestamp": "3"],
+                            ["id": "103", "role": "assistant", "content": "Answer A", "timestamp": "4"],
+                            ["id": "104", "role": "user", "content": "B", "timestamp": "5"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 5]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101"])
+
+        // --- Turn A ---
+        let submittedA = await harness.appState.submitComposer(text: "A")
+        XCTAssertTrue(submittedA)
+        XCTAssertEqual(submitCount, 1)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "A thinking."))
+        let segmentA = harness.appState.liveReasoningSegment
+        XCTAssertNotNil(segmentA)
+        let messagesAfterA = harness.appState.messages
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 2)
+        XCTAssertEqual(
+            resumeCount, 1,
+            "Turn A's foreground with its durable twin stays observational"
+        )
+        XCTAssertEqual(harness.appState.messages, messagesAfterA)
+        XCTAssertEqual(harness.appState.liveReasoningSegment, segmentA)
+        XCTAssertEqual(harness.appState.turnState, .running)
+
+        // Settle Turn A locally through the normal stream completion path.
+        harness.appState.handleStreamEvent(.messageComplete(
+            sessionId: active.id,
+            messageId: nil,
+            content: "Answer A",
+            reasoning: nil
+        ))
+        harness.appState.handleStreamEvent(.messageStart(sessionId: active.id))
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: false))
+        XCTAssertEqual(harness.appState.turnState, .idle)
+
+        // --- Turn B ---
+        let submittedB = await harness.appState.submitComposer(text: "B")
+        XCTAssertTrue(submittedB)
+        XCTAssertEqual(submitCount, 2)
+        XCTAssertEqual(harness.appState.turnState, .running)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "B thinking."))
+        let segmentB = harness.appState.liveReasoningSegment
+        XCTAssertNotNil(segmentB)
+        let messagesAfterB = harness.appState.messages
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 2)
+        XCTAssertEqual(transcriptReads, 3, "One bounded freshness read per background return")
+        XCTAssertEqual(
+            resumeCount, 1,
+            "Turn A's persisted rows must not be miscounted as foreign boundaries — Turn B stays observational"
+        )
+        XCTAssertEqual(harness.appState.messages, messagesAfterB, "No transcript replacement")
+        XCTAssertEqual(harness.appState.liveReasoningSegment, segmentB)
+        XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertFalse(harness.appState.transcriptFreshnessIsStale)
+
+        // Future Turn B deltas extend the SAME segment.
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: " More."))
+        XCTAssertEqual(harness.appState.liveReasoningSegment?.id, segmentB?.id)
+        box.client.disconnect()
+    }
+
+    /// Frontier advancement never weakens cross-surface protection: the
+    /// locally-owned marker's baseline is FROZEN at submit time, so after
+    /// Turn A's foreground advances the frontier through 103, a SECOND
+    /// background return where A completed and a remote Turn B started
+    /// still sees TWO boundaries against the frozen baseline and takes the
+    /// authoritative attach.
+    func testForegroundRemoteTurnBAfterFrontierAdvanceStillAttaches() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        var submitCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(
+                            object: ["running": .bool(resumeCount > 1)],
+                            inflight: resumeCount > 1
+                                ? .object(["text": .string("Turn B partial answer")])
+                                : nil
+                        )
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    if transcriptReads == 2 {
+                        // Turn A's twin + output while A runs.
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                                ["id": "102", "role": "user", "content": "A", "timestamp": "3"],
+                                ["id": "103", "role": "assistant", "content": "Answer A", "timestamp": "4"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
+                        ])
+                    }
+                    // A completed while away; a remote Turn B started: TWO
+                    // boundaries after the frozen baseline (101).
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "A", "timestamp": "3"],
+                            ["id": "103", "role": "assistant", "content": "Answer A", "timestamp": "4"],
+                            ["id": "104", "role": "user", "content": "Turn B question", "timestamp": "5"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 5]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+
+        // Turn A: foreground advances the ordering frontier through 103.
+        let submitted = await harness.appState.submitComposer(text: "A")
+        XCTAssertTrue(submitted)
+        XCTAssertEqual(submitCount, 1)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "Turn A thinking."))
+        XCTAssertNotNil(harness.appState.liveReasoningSegment)
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+        XCTAssertEqual(resumeCount, 1, "Turn A's own foreground stays observational")
+        XCTAssertEqual(transcriptReads, 2)
+
+        // Second background: A completes unobserved, remote Turn B starts.
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 2)
+        XCTAssertEqual(transcriptReads, 4, "Freshness read + the attach reconcile's bounded read")
+        XCTAssertEqual(
+            resumeCount, 2,
+            "A second user boundary after the FROZEN baseline forces the authoritative attach"
+        )
+        XCTAssertEqual(
+            harness.appState.messages.map(\.id), ["100", "101", "102", "103", "104"],
+            "Turn A completion and the remote Turn B prefix are visible"
+        )
+        XCTAssertNil(
+            harness.appState.liveReasoningSegment,
+            "The stale Turn A projection must not survive the attach"
+        )
+        XCTAssertEqual(
+            harness.appState.streamingText, "Turn B partial answer",
+            "The remote Turn B projection is authoritative"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
+        box.client.disconnect()
+    }
+
+    /// Local Turn A observed (frontier advanced), local Turn B submitted,
+    /// then B completes while backgrounded and a remote Turn C starts: TWO
+    /// boundaries after B's frozen baseline force the attach — advancing the
+    /// ordering frontier does not erase the second-boundary protection.
+    func testForegroundRemoteTurnCAfterLocalTurnBStillAttaches() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        var submitCount = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(
+                            object: ["running": .bool(resumeCount > 1)],
+                            inflight: resumeCount > 1
+                                ? .object(["text": .string("Turn C partial answer")])
+                                : nil
+                        )
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    if transcriptReads == 2 {
+                        // Turn A's twin + output while A runs.
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                                ["id": "102", "role": "user", "content": "A", "timestamp": "3"],
+                                ["id": "103", "role": "assistant", "content": "Answer A", "timestamp": "4"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 4]
+                        ])
+                    }
+                    // B completed while away; remote Turn C started: TWO
+                    // boundaries after B's frozen baseline (103).
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "A", "timestamp": "3"],
+                            ["id": "103", "role": "assistant", "content": "Answer A", "timestamp": "4"],
+                            ["id": "104", "role": "user", "content": "B", "timestamp": "5"],
+                            ["id": "105", "role": "assistant", "content": "Answer B", "timestamp": "6"],
+                            ["id": "106", "role": "user", "content": "Turn C question", "timestamp": "7"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 7]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+
+        // Turn A: foreground advances the ordering frontier through 103.
+        let submittedA = await harness.appState.submitComposer(text: "A")
+        XCTAssertTrue(submittedA)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "A thinking."))
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+        XCTAssertEqual(resumeCount, 1)
+
+        // Settle A locally, then submit Turn B.
+        harness.appState.handleStreamEvent(.messageComplete(
+            sessionId: active.id,
+            messageId: nil,
+            content: "Answer A",
+            reasoning: nil
+        ))
+        harness.appState.handleStreamEvent(.messageStart(sessionId: active.id))
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: false))
+        XCTAssertEqual(harness.appState.turnState, .idle)
+
+        let submittedB = await harness.appState.submitComposer(text: "B")
+        XCTAssertTrue(submittedB)
+        XCTAssertEqual(submitCount, 2)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "B thinking."))
+        XCTAssertNotNil(harness.appState.liveReasoningSegment)
+
+        // B completes while backgrounded; a remote Turn C starts.
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 2)
+        XCTAssertEqual(transcriptReads, 4, "Freshness read + the attach reconcile's bounded read")
+        XCTAssertEqual(
+            resumeCount, 2,
+            "Two boundaries after B's frozen baseline force the authoritative attach"
+        )
+        XCTAssertEqual(
+            harness.appState.messages.map(\.id), ["100", "101", "102", "103", "104", "105", "106"],
+            "Turn B completion and the remote Turn C prefix are visible"
+        )
+        XCTAssertNil(
+            harness.appState.liveReasoningSegment,
+            "The stale Turn B projection must not survive the attach"
+        )
+        XCTAssertEqual(
+            harness.appState.streamingText, "Turn C partial answer",
+            "The remote Turn C projection is authoritative"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
+        box.client.disconnect()
+    }
+
+    /// The twin can lag the read: a locally-owned first turn whose user row
+    /// has NOT persisted yet (the page is still positively empty) with the
+    /// runtime working stays observational — nothing new is persisted, so
+    /// there is nothing to attach to.
+    func testForegroundLocallyOwnedTurnTwinNotYetPersistedStaysObservational() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        var submitCount = 0
+        let emptyPage: [String: Any] = [
+            "messages": [],
+            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 0]
+        ]
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    return .payload(emptyPage)
+                },
+                refreshContext: { _, _ in },
+                sendPrompt: { _, _, _ in
+                    submitCount += 1
+                    return .accepted
+                },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertTrue(harness.appState.messages.isEmpty)
+
+        let submitted = await harness.appState.submitComposer(text: "First question")
+        XCTAssertTrue(submitted)
+        XCTAssertEqual(submitCount, 1)
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "Thinking."))
+        let segmentBefore = harness.appState.liveReasoningSegment
+        XCTAssertNotNil(segmentBefore)
+        let messagesBefore = harness.appState.messages
+        let resumesBeforeForeground = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 2)
+        XCTAssertEqual(
+            resumeCount, resumesBeforeForeground,
+            "An empty persisted tail behind a running locally-owned turn is not evidence of anything foreign"
+        )
+        XCTAssertEqual(harness.appState.messages, messagesBefore)
+        XCTAssertEqual(harness.appState.liveReasoningSegment, segmentBefore)
+        XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertFalse(harness.appState.transcriptFreshnessIsStale)
         box.client.disconnect()
     }
 

--- a/ConduitTests/AppStateForegroundLifecycleTests.swift
+++ b/ConduitTests/AppStateForegroundLifecycleTests.swift
@@ -16,6 +16,7 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         var healthChecks = 0
         var probeCount = 0
         var resumeCount = 0
+        var transcriptReads = 0
         var catalogCount = 0
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
@@ -28,8 +29,19 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
                     return SessionResumeResult(
                         sessionId: sessionID,
                         messages: [],
-                        snapshot: SessionRuntimeSnapshot(object: [:])
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
                     )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    // The bounded tail always matches what the device last
+                    // hydrated: same-turn continuity, provably unchanged.
+                    return .payload([
+                        "messages": [
+                            ["id": "user", "role": "user", "content": "Question", "timestamp": "1"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 1]
+                    ])
                 },
                 refreshContext: { _, _ in },
                 verifyTransportHealth: { _ in healthChecks += 1 },
@@ -46,18 +58,26 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         let box = await installConnectedClient(into: harness)
         harness.appState.sessions = [active]
         harness.appState.activeSessionId = active.id
+        // Seed through the real hydration path so the durable frontier covers
+        // the turn Conduit is about to own.
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
         let seedMessages = [
             ChatMessage(id: "user", role: .user, content: "Question", timestamp: "1")
         ]
-        harness.appState.messages = seedMessages
+        XCTAssertEqual(harness.appState.messages, seedMessages)
         harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        let resumesBeforeForeground = resumeCount
 
         harness.appState.handleScenePhase(.background)
         await runSceneActivation(harness)
 
         XCTAssertEqual(healthChecks, 1, "The foreground must verify the transport health once")
         XCTAssertEqual(probeCount, 1, "The foreground must query the authoritative runtime registry")
-        XCTAssertEqual(resumeCount, 0, "A healthy foreground must never issue session.resume")
+        XCTAssertEqual(
+            resumeCount, resumesBeforeForeground,
+            "A healthy foreground must never issue session.resume"
+        )
         XCTAssertEqual(catalogCount, 0, "A healthy foreground must not reload the session catalog")
         XCTAssertEqual(harness.appState.turnState, .running)
         XCTAssertEqual(harness.appState.activeSessionId, active.id)
@@ -103,8 +123,16 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
                     return SessionResumeResult(
                         sessionId: sessionID,
                         messages: [],
-                        snapshot: SessionRuntimeSnapshot(object: [:])
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
                     )
+                },
+                persistedTranscript: { _, _ in
+                    .payload([
+                        "messages": [
+                            ["id": "user", "role": "user", "content": "Question", "timestamp": "1"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 1]
+                    ])
                 },
                 refreshContext: { _, _ in },
                 verifyTransportHealth: { _ in },
@@ -120,13 +148,13 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         let box = await installConnectedClient(into: harness)
         harness.appState.sessions = [active]
         harness.appState.activeSessionId = active.id
-        harness.appState.messages = [
-            ChatMessage(id: "user", role: .user, content: "Question", timestamp: "1")
-        ]
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
         harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
         harness.appState.handleStreamEvent(.reasoningDelta(sessionId: active.id, text: "Step one."))
         let segmentBefore = harness.appState.liveReasoningSegment
         XCTAssertNotNil(segmentBefore)
+        let resumesBeforeForeground = resumeCount
 
         harness.appState.handleScenePhase(.background)
         await runSceneActivation(harness)
@@ -135,7 +163,10 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
             harness.appState.liveReasoningSegment, segmentBefore,
             "A harmless foreground cycle must not settle or reset the live reasoning segment"
         )
-        XCTAssertEqual(resumeCount, 0)
+        XCTAssertEqual(
+            resumeCount, resumesBeforeForeground,
+            "Proven same-turn continuity must not resume"
+        )
 
         // Later reasoning deltas extend the SAME segment (a reset would nil
         // the projection or mint a new segment id on the next delta).
@@ -154,6 +185,13 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         let active = session("stored-a")
         var probeCount = 0
         var resumeCount = 0
+        var transcriptReads = 0
+        let seedPayload: [String: Any] = [
+            "messages": [
+                ["id": "100", "role": "user", "content": "Earlier", "timestamp": "1"]
+            ],
+            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 1]
+        ]
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 openSession: { _, sessionID, _ in
@@ -161,8 +199,12 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
                     return SessionResumeResult(
                         sessionId: sessionID,
                         messages: [],
-                        snapshot: SessionRuntimeSnapshot(object: [:])
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
                     )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    return .payload(seedPayload)
                 },
                 refreshContext: { _, _ in },
                 verifyTransportHealth: { _ in },
@@ -179,18 +221,25 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         let box = await installConnectedClient(into: harness)
         harness.appState.sessions = [active]
         harness.appState.activeSessionId = active.id
-        let seedMessages = [
-            ChatMessage(id: "user", role: .user, content: "Earlier", timestamp: "1")
-        ]
-        harness.appState.messages = seedMessages
+        // Seed through the real hydration path so the freshness comparison
+        // has a durable frontier to anchor against.
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100"])
+        let messagesBefore = harness.appState.messages
+        let resumesBeforeForeground = resumeCount
 
         harness.appState.handleScenePhase(.background)
         await runSceneActivation(harness)
 
         XCTAssertEqual(probeCount, 1)
-        XCTAssertEqual(resumeCount, 0, "An idle healthy session must not be resumed")
+        XCTAssertEqual(transcriptReads, 2, "One bounded freshness read proves currency")
+        XCTAssertEqual(
+            resumeCount, resumesBeforeForeground,
+            "An idle healthy session must not be resumed"
+        )
         XCTAssertEqual(harness.appState.turnState, .idle)
-        XCTAssertEqual(harness.appState.messages, seedMessages, "The transcript must remain stable")
+        XCTAssertEqual(harness.appState.messages, messagesBefore, "The transcript must remain stable")
         XCTAssertFalse(
             harness.appState.activeChatScrollSessionIdentity.isReconciling,
             "No reconciliation may remain open after the observational refresh"
@@ -210,17 +259,35 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         let active = session("stored-a")
         var probeCount = 0
         var resumeCount = 0
-        let parkedRefresh = LifecycleSuspension()
+        var transcriptReads = 0
+        let parkedBranch = LifecycleSuspension()
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 openSession: { _, sessionID, _ in
                     resumeCount += 1
-                    await parkedRefresh.suspend()
                     return SessionResumeResult(
                         sessionId: sessionID,
                         messages: [],
-                        snapshot: SessionRuntimeSnapshot(object: [:])
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
                     )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                    ])
+                },
+                branchSession: { _, _, _, _, _ in
+                    // The branch parks mid-flight AFTER flipping the turn
+                    // state to .synchronizing — the transitional state the
+                    // foreground must normalize, without the frontier-wiping
+                    // reconcile a parked resume would run.
+                    await parkedBranch.suspend()
+                    throw HermesError.notConnected
                 },
                 refreshContext: { _, _ in },
                 verifyTransportHealth: { _ in },
@@ -237,18 +304,23 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         let box = await installConnectedClient(into: harness)
         harness.appState.sessions = [active]
         harness.appState.activeSessionId = active.id
+        // Seed through the real hydration path: durable frontier covers the
+        // transcript the freshness check will compare against.
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
         let seedMessages = [
-            ChatMessage(id: "user", role: .user, content: "Earlier", timestamp: "1")
+            ChatMessage(id: "100", role: .user, content: "Earlier question", timestamp: "1"),
+            ChatMessage(id: "101", role: .assistant, content: "Earlier answer", timestamp: "2")
         ]
-        harness.appState.messages = seedMessages
+        XCTAssertEqual(harness.appState.messages, seedMessages)
 
-        // A previous recovery attempt (explicit re-resume) parks mid-reconcile
+        // A previous recovery attempt (a conversation branch) parks mid-flight
         // with the transitional state showing. The task is deliberately not
         // awaited: its unwinding is covered by the rotated-token guards.
         Task { @MainActor in
-            await harness.appState.refreshActiveSession()
+            await harness.appState.branchFromAssistantMessage("101")
         }
-        await parkedRefresh.waitUntilSuspended()
+        await parkedBranch.waitUntilSuspended()
         XCTAssertEqual(harness.appState.turnState, .synchronizing)
         let resumeCountBeforeForeground = resumeCount
 
@@ -256,6 +328,7 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         await runSceneActivation(harness)
 
         XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 2, "One bounded freshness read proves currency")
         XCTAssertEqual(
             resumeCount, resumeCountBeforeForeground,
             "The foreground refresh must not issue any resume of its own"
@@ -275,14 +348,14 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
             "No reconciliation may remain open after the observational refresh"
         )
 
-        // The abandoned refresh unwinds through its rotated-token guards; it
+        // The abandoned branch unwinds through its rotated-token guards; it
         // must not undo the adopted idle state or the transcript.
-        parkedRefresh.resume()
+        parkedBranch.resume()
         await flushMainActor()
         XCTAssertEqual(harness.appState.turnState, .idle)
         XCTAssertEqual(
             harness.appState.messages, seedMessages,
-            "The abandoned refresh must not replace the transcript"
+            "The abandoned branch must not replace the transcript"
         )
         XCTAssertFalse(
             harness.appState.activeChatScrollSessionIdentity.isReconciling
@@ -299,6 +372,7 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         let active = session("stored-a")
         var probeCount = 0
         var resumeCount = 0
+        var transcriptReads = 0
         let parkedReconnect = LifecycleSuspension()
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
@@ -311,8 +385,17 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
                     return SessionResumeResult(
                         sessionId: sessionID,
                         messages: [],
-                        snapshot: SessionRuntimeSnapshot(object: [:])
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
                     )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier", "timestamp": "1"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 1]
+                    ])
                 },
                 refreshContext: { _, _ in },
                 verifyTransportHealth: { _ in },
@@ -329,30 +412,32 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         let box = await installConnectedClient(into: harness)
         harness.appState.sessions = [active]
         harness.appState.activeSessionId = active.id
-        let seedMessages = [
-            ChatMessage(id: "user", role: .user, content: "Earlier", timestamp: "1")
-        ]
-        harness.appState.messages = seedMessages
+        // Seed through the real hydration path so the freshness comparison has
+        // a durable frontier to anchor against.
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        let messagesBefore = harness.appState.messages
 
         // A previous connection/recovery attempt parks mid-reconnect, leaving
-        // the transitional state showing. The gate is deliberately never
-        // released: a mint that resolves in production proceeds into the
-        // reconnect cycle's own full authoritative sync (the automatic-work
-        // token is shared, not rotated), and pinning the post-release state
-        // would require stubbing the entire reconnect transport chain — the
-        // foreground adoption under test must not depend on either outcome.
+        // the transitional state showing. The gate is never released: the
+        // foreground adoption must not depend on how the abandoned attempt
+        // resolves.
         Task { @MainActor in
             await harness.appState.reconnectForRetry(purpose: .automaticReturn)
         }
         await parkedReconnect.waitUntilSuspended()
         XCTAssertEqual(harness.appState.turnState, .reconnecting)
-        XCTAssertEqual(resumeCount, 0)
+        let resumeCountBeforeForeground = resumeCount
 
         harness.appState.handleScenePhase(.background)
         await runSceneActivation(harness)
 
         XCTAssertEqual(probeCount, 1)
-        XCTAssertEqual(resumeCount, 0, "An idle healthy session must not be resumed")
+        XCTAssertEqual(transcriptReads, 2, "One bounded freshness read proves currency")
+        XCTAssertEqual(
+            resumeCount, resumeCountBeforeForeground,
+            "An idle healthy session must not be resumed"
+        )
         XCTAssertEqual(
             harness.appState.turnState, .idle,
             "An authoritative idle observation must clear the stale transitional state"
@@ -362,7 +447,7 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
             "The composer must be usable once the registry says idle"
         )
         XCTAssertFalse(harness.appState.turnStateIsStale)
-        XCTAssertEqual(harness.appState.messages, seedMessages, "The transcript must remain stable")
+        XCTAssertEqual(harness.appState.messages, messagesBefore, "The transcript must remain stable")
         XCTAssertFalse(
             harness.appState.activeChatScrollSessionIdentity.isReconciling,
             "No reconciliation may remain open after the observational refresh"
@@ -385,8 +470,16 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
                     return SessionResumeResult(
                         sessionId: sessionID,
                         messages: [],
-                        snapshot: SessionRuntimeSnapshot(object: [:])
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
                     )
+                },
+                persistedTranscript: { _, _ in
+                    .payload([
+                        "messages": [
+                            ["id": "user", "role": "user", "content": "Earlier", "timestamp": "1"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 1]
+                    ])
                 },
                 refreshContext: { _, _ in },
                 verifyTransportHealth: { _ in },
@@ -404,9 +497,11 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         let box = await installConnectedClient(into: harness)
         harness.appState.sessions = [active]
         harness.appState.activeSessionId = active.id
-        harness.appState.messages = [
-            ChatMessage(id: "user", role: .user, content: "Earlier", timestamp: "1")
-        ]
+        // Seed through the real hydration path so the freshness comparison has
+        // a durable frontier to anchor against.
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        let resumesBeforeForeground = resumeCount
 
         harness.appState.handleScenePhase(.background)
         let activation = Task { @MainActor in
@@ -421,7 +516,10 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         await flushMainActor()
 
         XCTAssertEqual(probeCount, 1)
-        XCTAssertEqual(resumeCount, 0, "An idle healthy session must not be resumed")
+        XCTAssertEqual(
+            resumeCount, resumesBeforeForeground,
+            "An idle healthy session must not be resumed"
+        )
         XCTAssertEqual(
             harness.appState.turnState, .running,
             "The newer buffered busy edge must win over the adopted idle baseline"
@@ -520,26 +618,51 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
             harness.appState.persistedTranscriptWindow?.nextOffset, 4,
             "The persisted window must re-anchor to the fetched page"
         )
+
+        // A live completion over a merged row finalizes it IN PLACE (same
+        // gateway id) instead of appending a duplicate twin.
+        harness.appState.handleStreamEvent(.messageComplete(
+            sessionId: active.id,
+            messageId: "103",
+            content: "Remote full answer",
+            reasoning: nil
+        ))
+        harness.appState.handleStreamEvent(.messageStart(sessionId: active.id))
+        XCTAssertEqual(
+            harness.appState.messages.filter { $0.id == "103" }.count, 1,
+            "The live completion must not duplicate the merged persisted row"
+        )
+        XCTAssertEqual(
+            harness.appState.messages.first(where: { $0.id == "103" })?.content,
+            "Remote full answer"
+        )
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101", "102", "103"])
         box.client.disconnect()
     }
 
     /// A turn another surface STARTED while Conduit was idle-and-backgrounded
-    /// is still running on foreground. The persisted tail supplies the rows
-    /// that already exist; the observational running adopt + buffered/live
-    /// events supply the rest. No resume.
-    func testForegroundAdoptsRemoteRunningTurnByMergingPersistedTail() async {
+    /// is still running on foreground. Persisted history alone cannot supply
+    /// the in-flight projection, so the authoritative attach runs: the compact
+    /// resume returns the live runtime state and the reconcile merges the
+    /// persisted prefix — exactly one session.resume.
+    func testForegroundAttachesRemoteRunningTurnAuthoritatively() async {
         let active = session("stored-a")
         var probeCount = 0
         var resumeCount = 0
         var transcriptReads = 0
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
                 openSession: { _, sessionID, _ in
                     resumeCount += 1
                     return SessionResumeResult(
                         sessionId: sessionID,
                         messages: [],
-                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                        // The attach resume returns the live runtime: the
+                        // remote turn is running.
+                        snapshot: SessionRuntimeSnapshot(
+                            object: ["running": .bool(resumeCount > 1)]
+                        )
                     )
                 },
                 persistedTranscript: { _, _ in
@@ -587,38 +710,26 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         await runSceneActivation(harness)
 
         XCTAssertEqual(probeCount, 1)
-        XCTAssertEqual(transcriptReads, 2)
+        XCTAssertEqual(transcriptReads, 2, "The attach reconcile performs its own bounded read")
         XCTAssertEqual(
-            resumeCount, resumesBeforeForeground,
-            "The persisted tail plus live events must attach without a resume"
+            resumeCount, resumesBeforeForeground + 1,
+            "A turn this device never owned attaches through the compact resume"
         )
         XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101", "102", "103"])
         XCTAssertEqual(
             harness.appState.turnState, .running,
-            "A working registry row adopts running once the transcript is fresh"
+            "The authoritative snapshot proves the remote turn is running"
         )
         XCTAssertTrue(harness.appState.composerIsEnabled)
         XCTAssertFalse(harness.appState.turnStateIsStale)
 
-        // The merged still-running turn completes live: the completion must
-        // finalize the merged persisted row IN PLACE (same durable id)
-        // instead of appending a duplicate twin.
-        harness.appState.handleStreamEvent(.messageComplete(
+        // Future stream events extend the attached turn.
+        harness.appState.handleStreamEvent(.messageDelta(
             sessionId: active.id,
-            messageId: "103",
-            content: "Remote full answer",
-            reasoning: nil
+            text: " and more"
         ))
-        harness.appState.handleStreamEvent(.messageStart(sessionId: active.id))
-        XCTAssertEqual(
-            harness.appState.messages.filter { $0.id == "103" }.count, 1,
-            "The live completion must not duplicate the merged persisted row"
-        )
-        XCTAssertEqual(
-            harness.appState.messages.first(where: { $0.id == "103" })?.content,
-            "Remote full answer"
-        )
-        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101", "102", "103"])
+        let published = await waitForStreamingText(" and more", in: harness.appState)
+        XCTAssertTrue(published, "Deltas must land on the attached live turn")
         box.client.disconnect()
     }
 
@@ -680,8 +791,8 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
 
         XCTAssertEqual(probeCount, 1)
         XCTAssertEqual(
-            transcriptReads, 1,
-            "Conduit-owned continuity must not trigger a freshness read"
+            transcriptReads, 2,
+            "One bounded freshness read proves same-turn continuity"
         )
         XCTAssertEqual(resumeCount, resumesBeforeForeground, "Zero session.resume")
         XCTAssertEqual(harness.appState.messages, messagesBefore, "No transcript replacement")
@@ -1270,6 +1381,737 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         XCTAssertEqual(harness.appState.turnState, .idle)
         XCTAssertTrue(harness.appState.composerIsEnabled)
         XCTAssertFalse(harness.appState.activeChatScrollSessionIdentity.isReconciling)
+        box.client.disconnect()
+    }
+
+    // MARK: - Round 7: tail-only freshness, source classification, authoritative attach
+
+    private let legacyShapedRows: [[String: Any]] = [
+        ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+        ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+        ["id": "102", "role": "user", "content": "Remote question", "timestamp": "3"],
+        ["id": "103", "role": "assistant", "content": "Remote answer", "timestamp": "4"]
+    ]
+
+    /// A backend that pages from the oldest end (a pagination echo WITHOUT
+    /// the `order=latest` contract) yields NO bounded freshness evidence, and
+    /// the freshness check must NOT escalate into the legacy whole-transcript
+    /// read. Arithmetic: seed(1) + freshness(2) + the recovery reconcile's
+    /// own bounded read(3) + its designed legacy one-shot re-read(4) = 4
+    /// calls. Had the FRESHNESS path performed a legacy fallback too, the
+    /// total would be 5.
+    func testForegroundFreshnessTailReadNeverFallsBackToLegacyHistory() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    // Oldest-anchored pagination echo: a pagination object
+                    // WITHOUT the `order=latest` contract.
+                    return .payload([
+                        "messages": self.legacyShapedRows,
+                        "pagination": ["limit": 120, "offset": 0, "returned": 4]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        let resumesBeforeForeground = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(
+            transcriptReads, 4,
+            "Exactly one freshness call (no legacy fallback) + the recovery reconcile's bounded read and its designed legacy re-read"
+        )
+        XCTAssertEqual(resumeCount, resumesBeforeForeground + 1)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101", "102", "103"])
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        XCTAssertTrue(harness.appState.composerIsEnabled)
+        box.client.disconnect()
+    }
+
+    /// A structurally absent messages endpoint (404-class) means there is no
+    /// bounded capability to compare with: the authoritative resume/reconcile
+    /// fallback runs exactly once instead of silently adopting a possibly
+    /// stale transcript as current.
+    func testForegroundFreshnessStructuralSourceAbsenceTakesAuthoritativeFallback() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, compact in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        // A legacy (non-compact) resume carries the transcript
+                        // itself — exactly what the structural fallback uses.
+                        messages: compact ? [] : [
+                            ChatMessage(id: "100", role: .user, content: "Earlier question", timestamp: "1"),
+                            ChatMessage(id: "101", role: .assistant, content: "Earlier answer", timestamp: "2"),
+                            ChatMessage(id: "102", role: .user, content: "Remote question", timestamp: "3"),
+                            ChatMessage(id: "103", role: .assistant, content: "Remote answer", timestamp: "4")
+                        ],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    return .failed(DashboardTicketBridgeError.http(
+                        status: 404,
+                        detail: "no session-messages endpoint"
+                    ))
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        let resumesBeforeForeground = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 3, "Freshness read + the reconcile's bounded read; no more")
+        XCTAssertEqual(
+            resumeCount, resumesBeforeForeground + 2,
+            "Compact resume + the structural fallback's legacy re-resume"
+        )
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101", "102", "103"])
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        XCTAssertTrue(harness.appState.composerIsEnabled)
+        XCTAssertFalse(harness.appState.activeChatScrollSessionIdentity.isReconciling)
+        box.client.disconnect()
+    }
+
+    /// A transiently failed bounded tail read must not claim currency, must
+    /// not escalate to a full-transcript read, and must not loop: the
+    /// authoritative liveness adopts while the stale marker is RETAINED so
+    /// the next authoritative source re-confirms.
+    func testForegroundFreshnessTransientFailureKeepsStaleMarker() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        let seedPayload: [String: Any] = [
+            "messages": [
+                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+            ],
+            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+        ]
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload(seedPayload)
+                    }
+                    return .failed(DashboardTicketBridgeError.http(
+                        status: 503,
+                        detail: "temporarily unavailable"
+                    ))
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "idle"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        let messagesBefore = harness.appState.messages
+        let resumesBeforeForeground = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(
+            transcriptReads, 2,
+            "The failed bounded read must not be retried or escalated to a full read"
+        )
+        XCTAssertEqual(resumeCount, resumesBeforeForeground, "No resume cascade")
+        XCTAssertEqual(harness.appState.messages, messagesBefore)
+        XCTAssertEqual(harness.appState.turnState, .idle)
+        XCTAssertTrue(harness.appState.composerIsEnabled)
+        XCTAssertTrue(
+            harness.appState.turnStateIsStale,
+            "Freshness is unresolved: the stale marker must be retained"
+        )
+        box.client.disconnect()
+    }
+
+    /// The transient-failure contract on the RUNNING liveness path: the
+    /// observational adopt clears the stale marker and the reconcile must
+    /// re-set it afterwards — a reorder would silently drop freshness
+    /// resolution exactly where the in-flight projection makes it most
+    /// valuable.
+    func testForegroundFreshnessTransientFailureOnRunningTurnKeepsStaleMarker() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        let midTurnPayload: [String: Any] = [
+            "messages": [
+                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                ["id": "102", "role": "user", "content": "Turn A question", "timestamp": "3"]
+            ],
+            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 3]
+        ]
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(true)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload(midTurnPayload)
+                    }
+                    return .failed(DashboardTicketBridgeError.http(
+                        status: 503,
+                        detail: "temporarily unavailable"
+                    ))
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.turnState, .running)
+        let messagesBefore = harness.appState.messages
+        let resumesBeforeForeground = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 2, "No retry, no escalation")
+        XCTAssertEqual(resumeCount, resumesBeforeForeground, "No resume cascade")
+        XCTAssertEqual(harness.appState.messages, messagesBefore)
+        XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertTrue(
+            harness.appState.turnStateIsStale,
+            "Freshness is unresolved on the running path too: the stale marker must be retained"
+        )
+        box.client.disconnect()
+    }
+
+    /// A remotely started RUNNING turn has an in-flight assistant/reasoning
+    /// prefix persisted history cannot supply. The authoritative attach (the
+    /// compact resume fast-path) returns that live projection on top of the
+    /// merged persisted prefix, and future deltas extend it.
+    func testForegroundRemoteRunningTurnAttachesUnpersistedLiveProjection() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        // The seeding resume finds the session idle; the
+                        // authoritative attach returns the live runtime with
+                        // the unpersisted in-flight projection.
+                        snapshot: SessionRuntimeSnapshot(
+                            object: ["running": .bool(resumeCount > 1)],
+                            inflight: resumeCount > 1
+                                ? .object(["text": .string("Remote partial answer")])
+                                : nil
+                        )
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 2]
+                        ])
+                    }
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "Remote question", "timestamp": "3"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 3]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        let resumesBeforeForeground = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 2)
+        XCTAssertEqual(resumeCount, resumesBeforeForeground + 1, "Exactly one authoritative attach resume")
+        XCTAssertEqual(
+            harness.appState.messages.map(\.id), ["100", "101", "102"],
+            "The remote persisted prefix is visible"
+        )
+        XCTAssertEqual(
+            harness.appState.streamingText, "Remote partial answer",
+            "The unpersisted in-flight prefix attaches through the resume"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
+
+        // Future deltas extend the attached projection.
+        harness.appState.handleStreamEvent(.messageDelta(
+            sessionId: active.id,
+            text: " continued"
+        ))
+        let published = await waitForStreamingText(
+            "Remote partial answer continued", in: harness.appState
+        )
+        XCTAssertTrue(published, "Future stream events continue the attached turn")
+        box.client.disconnect()
+    }
+
+    /// Turn A running before background, A completing and Turn B starting in
+    /// the SAME session while suspended: same-session identity is not
+    /// same-turn proof. The persisted tail advancement forces the
+    /// authoritative attach — B becomes authoritative with no stale Turn A
+    /// reasoning segment and no missing prefix.
+    func testForegroundTurnBInSameSessionIsNotContinuationOfTurnA() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [active] },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        // The seeding hydration happens MID-TURN-A: the
+                        // runtime was already working.
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(true)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    if transcriptReads == 1 {
+                        return .payload([
+                            "messages": [
+                                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                                ["id": "102", "role": "user", "content": "Turn A question", "timestamp": "3"]
+                            ],
+                            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 3]
+                        ])
+                    }
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                            ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                            ["id": "102", "role": "user", "content": "Turn A question", "timestamp": "3"],
+                            ["id": "103", "role": "assistant", "content": "Turn A answer", "timestamp": "4"],
+                            ["id": "104", "role": "user", "content": "Turn B question", "timestamp": "5"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 5]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.turnState, .running, "Turn A is Conduit-owned")
+        harness.appState.handleStreamEvent(.reasoningDelta(
+            sessionId: active.id,
+            text: "Turn A stale thinking"
+        ))
+        let staleSegment = harness.appState.liveReasoningSegment
+        XCTAssertNotNil(staleSegment)
+        let resumesBeforeForeground = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 3, "Freshness read + the attach reconcile's bounded read")
+        XCTAssertEqual(
+            resumeCount, resumesBeforeForeground + 1,
+            "Unprovable same-turn continuity takes the authoritative attach exactly once"
+        )
+        XCTAssertEqual(
+            harness.appState.messages.map(\.id),
+            ["100", "101", "102", "103", "104"],
+            "Turn A's completion and Turn B's prefix are both present"
+        )
+        XCTAssertNil(
+            harness.appState.liveReasoningSegment,
+            "Turn A's stale reasoning segment must not survive the authoritative attach"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
+        XCTAssertTrue(harness.appState.composerIsEnabled)
+        box.client.disconnect()
+    }
+
+    /// Genuine Conduit-owned continuation after a mid-turn rehydration: the
+    /// bounded freshness read proves same-turn continuity (unchanged tail),
+    /// so the fast observational path keeps zero resumes, zero transcript
+    /// replacement, and the identical live reasoning segment.
+    func testForegroundGenuineContinuationAfterMidTurnRehydrationStaysZeroResume() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        let midTurnPayload: [String: Any] = [
+            "messages": [
+                ["id": "100", "role": "user", "content": "Earlier question", "timestamp": "1"],
+                ["id": "101", "role": "assistant", "content": "Earlier answer", "timestamp": "2"],
+                ["id": "102", "role": "user", "content": "Turn A question", "timestamp": "3"]
+            ],
+            "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 3]
+        ]
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(true)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    return .payload(midTurnPayload)
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "working"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100", "101", "102"])
+        harness.appState.handleStreamEvent(.reasoningDelta(
+            sessionId: active.id,
+            text: "Continuing Turn A"
+        ))
+        let segmentBefore = harness.appState.liveReasoningSegment
+        XCTAssertNotNil(segmentBefore)
+        let messagesBefore = harness.appState.messages
+        let resumesBeforeForeground = resumeCount
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(transcriptReads, 2, "One bounded read proves same-turn continuity")
+        XCTAssertEqual(resumeCount, resumesBeforeForeground, "Zero session.resume")
+        XCTAssertEqual(harness.appState.messages, messagesBefore, "Zero transcript replacement")
+        XCTAssertEqual(
+            harness.appState.liveReasoningSegment?.id, segmentBefore?.id,
+            "The live reasoning projection is untouched"
+        )
+        XCTAssertEqual(harness.appState.turnState, .running)
+
+        // Future deltas continue the SAME segment.
+        harness.appState.handleStreamEvent(.reasoningDelta(
+            sessionId: active.id,
+            text: " and more"
+        ))
+        await flushMainActor()
+        XCTAssertEqual(harness.appState.liveReasoningSegment?.id, segmentBefore?.id)
+        box.client.disconnect()
+    }
+
+    /// `starting` is liveness-inconclusive — but a stale `.synchronizing`
+    /// left by an aborted recovery is not stream-owned state either. The
+    /// foreground normalizes it to a usable neutral baseline: composer
+    /// usable, starting never classified as running, zero reads.
+    func testForegroundStartingNormalizesStaleSynchronizingState() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        let parkedRefresh = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    if resumeCount > 1 {
+                        await parkedRefresh.suspend()
+                    }
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier", "timestamp": "1"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 1]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "starting"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+
+        Task { @MainActor in
+            await harness.appState.refreshActiveSession()
+        }
+        await parkedRefresh.waitUntilSuspended()
+        XCTAssertEqual(harness.appState.turnState, .synchronizing)
+
+        harness.appState.handleScenePhase(.background)
+        await runSceneActivation(harness)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(
+            harness.appState.turnState, .idle,
+            "A stale transitional state must normalize under a starting runtime"
+        )
+        XCTAssertTrue(
+            harness.appState.composerIsEnabled,
+            "The composer must not stay disabled on a starting runtime"
+        )
+        box.client.disconnect()
+    }
+
+    /// Same normalization for `.reconnecting`, and the ordering invariant: a
+    /// newer buffered busy edge still wins over the normalized baseline.
+    func testForegroundStartingNormalizesStaleReconnectingAndBusyEdgeWins() async {
+        let active = session("stored-a")
+        var probeCount = 0
+        var resumeCount = 0
+        var transcriptReads = 0
+        let parkedReconnect = LifecycleSuspension()
+        let probeGate = LifecycleSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                mintTicket: { _ in
+                    await parkedReconnect.suspend()
+                    return "ticket"
+                },
+                openSession: { _, sessionID, _ in
+                    resumeCount += 1
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                persistedTranscript: { _, _ in
+                    transcriptReads += 1
+                    return .payload([
+                        "messages": [
+                            ["id": "100", "role": "user", "content": "Earlier", "timestamp": "1"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 1]
+                    ])
+                },
+                refreshContext: { _, _ in },
+                verifyTransportHealth: { _ in },
+                probeActiveSessions: { _ in
+                    probeCount += 1
+                    await probeGate.suspend()
+                    return [LiveSessionStatus(
+                        runtimeSessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        status: "starting"
+                    )]
+                }
+            )
+        )
+        let box = await installConnectedClient(into: harness)
+        harness.appState.sessions = [active]
+        harness.appState.activeSessionId = active.id
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
+        XCTAssertEqual(harness.appState.messages.map(\.id), ["100"])
+
+        Task { @MainActor in
+            await harness.appState.reconnectForRetry(purpose: .automaticReturn)
+        }
+        await parkedReconnect.waitUntilSuspended()
+        XCTAssertEqual(harness.appState.turnState, .reconnecting)
+
+        harness.appState.handleScenePhase(.background)
+        let activation = Task { @MainActor in
+            await runSceneActivation(harness)
+        }
+        await probeGate.waitUntilSuspended()
+        // A turn starts remotely while the probe is in flight: the newer
+        // live edge must win over the normalized baseline.
+        harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        probeGate.resume()
+        await activation.value
+        await flushMainActor()
+
+        XCTAssertEqual(
+            harness.appState.turnState, .running,
+            "The newer buffered busy edge wins over the normalized baseline"
+        )
+        XCTAssertTrue(harness.appState.composerIsEnabled)
+        XCTAssertEqual(resumeCount, 1, "The seeding reconcile owns the only resume")
+        XCTAssertEqual(transcriptReads, 1, "A starting runtime performs no freshness read")
         box.client.disconnect()
     }
 
@@ -2451,8 +3293,16 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
                     return SessionResumeResult(
                         sessionId: sessionID,
                         messages: [],
-                        snapshot: SessionRuntimeSnapshot(object: [:])
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
                     )
+                },
+                persistedTranscript: { _, _ in
+                    .payload([
+                        "messages": [
+                            ["id": "user", "role": "user", "content": "Question", "timestamp": "1"]
+                        ],
+                        "pagination": ["limit": 120, "offset": 0, "order": "latest", "returned": 1]
+                    ])
                 },
                 refreshContext: { _, _ in },
                 verifyTransportHealth: { _ in },
@@ -2470,10 +3320,10 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
         let box = await installConnectedClient(into: harness)
         harness.appState.sessions = [active]
         harness.appState.activeSessionId = active.id
-        harness.appState.messages = [
-            ChatMessage(id: "user", role: .user, content: "Question", timestamp: "1")
-        ]
+        let opened = await harness.appState.openSession(active.id)
+        XCTAssertTrue(opened)
         harness.appState.handleStreamEvent(.sessionBusy(sessionId: active.id, busy: true))
+        let resumesBeforeForeground = resumeCount
 
         harness.appState.handleScenePhase(.background)
         let sceneTask = harness.appState.handleScenePhase(.active)
@@ -2488,7 +3338,10 @@ final class AppStateForegroundLifecycleTests: XCTestCase {
             harness.appState.turnState, .idle,
             "The newest authoritative event must win over the older registry snapshot"
         )
-        XCTAssertEqual(resumeCount, 0, "The race must not manufacture a resume")
+        XCTAssertEqual(
+            resumeCount, resumesBeforeForeground,
+            "The race must not manufacture a resume"
+        )
         XCTAssertFalse(
             harness.appState.activeChatScrollSessionIdentity.isReconciling
         )

--- a/ConduitTests/HermesClientTests.swift
+++ b/ConduitTests/HermesClientTests.swift
@@ -409,6 +409,108 @@ final class HermesClientTests: XCTestCase {
         client.disconnect()
     }
 
+    // MARK: - prompt.submit outcome + session.active_list probe
+
+    func testSendPromptReturnsTypedOutcomeFromGatewayStatus() async throws {
+        // Upstream `prompt.submit` never rejects a busy session: it applies
+        // the configured busy policy and reports steered/redirected/queued.
+        // The client must surface that status instead of discarding it.
+        for (gatewayStatus, expected) in [
+            ("streaming", PromptSubmissionOutcome.accepted),
+            ("steered", PromptSubmissionOutcome.steered),
+            ("redirected", PromptSubmissionOutcome.redirected),
+            ("queued", PromptSubmissionOutcome.queued)
+        ] {
+            let transport = FakeTransport()
+            let socket = FakeSocket()
+            transport.nextSocket = { socket }
+            let client = makeClient(transport: transport)
+            let connectTask = Task { try? await client.connect() }
+            transport.open(socket)
+            try await awaitCompletion(of: connectTask, "connect() to complete")
+
+            let sent = Gate()
+            socket.onSend = { sent.signal() }
+            let submitTask = Task<PromptSubmissionOutcome, Error> {
+                try await client.sendPrompt("sess-1", text: "Hello")
+            }
+            try await sent.wait("the prompt.submit request to be sent")
+
+            let request = try XCTUnwrap(
+                JSONSerialization.jsonObject(with: Data(try XCTUnwrap(socket.sentTexts.last).utf8)) as? [String: Any]
+            )
+            XCTAssertEqual(request["method"] as? String, "prompt.submit")
+            let params = try XCTUnwrap(request["params"] as? [String: Any])
+            XCTAssertEqual(params["session_id"] as? String, "sess-1")
+
+            let id = try XCTUnwrap(request["id"] as? Int)
+            let response: [String: Any] = [
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": ["status": gatewayStatus]
+            ]
+            socket.deliver(String(data: try JSONSerialization.data(withJSONObject: response), encoding: .utf8)!)
+
+            let outcome = try await awaitResult(of: submitTask, "the prompt.submit response")
+            XCTAssertEqual(outcome, expected)
+            client.disconnect()
+        }
+    }
+
+    func testActiveSessionsParsesRuntimeRegistryWithoutMutatingParams() async throws {
+        let transport = FakeTransport()
+        let socket = FakeSocket()
+        transport.nextSocket = { socket }
+        let client = makeClient(transport: transport)
+        let connectTask = Task { try? await client.connect() }
+        transport.open(socket)
+        try await awaitCompletion(of: connectTask, "connect() to complete")
+
+        let sent = Gate()
+        socket.onSend = { sent.signal() }
+        let probeTask = Task<[LiveSessionStatus], Error> { try await client.activeSessions() }
+        try await sent.wait("the session.active_list request to be sent")
+
+        let request = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(try XCTUnwrap(socket.sentTexts.last).utf8)) as? [String: Any]
+        )
+        XCTAssertEqual(request["method"] as? String, "session.active_list")
+
+        let id = try XCTUnwrap(request["id"] as? Int)
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": [
+                "sessions": [
+                    [
+                        "id": "runtime-1",
+                        "session_key": "stored-1",
+                        "status": "working",
+                        "last_active": 100.0
+                    ],
+                    [
+                        "id": "runtime-2",
+                        "session_key": "stored-2",
+                        "status": "idle"
+                    ],
+                    // Missing the runtime id entirely: unmatchable, dropped.
+                    ["session_key": "stored-broken", "status": "idle"]
+                ]
+            ]
+        ]
+        socket.deliver(String(data: try JSONSerialization.data(withJSONObject: response), encoding: .utf8)!)
+
+        let rows = try await awaitResult(of: probeTask, "the session.active_list response")
+        XCTAssertEqual(rows.count, 2, "Rows without a runtime id are dropped")
+        XCTAssertEqual(rows.first?.runtimeSessionId, "runtime-1")
+        XCTAssertEqual(rows.first?.storedSessionId, "stored-1")
+        XCTAssertEqual(rows.first?.status, "working")
+        XCTAssertTrue(rows.first?.isRunning == true)
+        XCTAssertEqual(rows.last?.status, "idle")
+        XCTAssertFalse(rows.last?.isRunning ?? true)
+        client.disconnect()
+    }
+
     // MARK: - Helpers
 
     private final class ResultBox<T>: @unchecked Sendable {

--- a/ConduitTests/HermesClientTests.swift
+++ b/ConduitTests/HermesClientTests.swift
@@ -475,6 +475,14 @@ final class HermesClientTests: XCTestCase {
             JSONSerialization.jsonObject(with: Data(try XCTUnwrap(socket.sentTexts.last).utf8)) as? [String: Any]
         )
         XCTAssertEqual(request["method"] as? String, "session.active_list")
+        // The registry read is a read-only, argument-free query. Under the
+        // default profile `scopeParams` collapses the empty `[:]` to nil, so
+        // the wire request carries NO `params` key at all — no session id and
+        // no focus/switch/resume parameters by construction.
+        XCTAssertNil(
+            request["params"],
+            "session.active_list must be sent without session-selection or mutation parameters"
+        )
 
         let id = try XCTUnwrap(request["id"] as? Int)
         let response: [String: Any] = [
@@ -508,6 +516,50 @@ final class HermesClientTests: XCTestCase {
         XCTAssertTrue(rows.first?.isRunning == true)
         XCTAssertEqual(rows.last?.status, "idle")
         XCTAssertFalse(rows.last?.isRunning ?? true)
+        client.disconnect()
+    }
+
+    func testActiveSessionsCarriesOnlyProfileContextForNonDefaultProfile() async throws {
+        // A non-default profile adds the same gateway-context `profile` key
+        // every other catalog read carries — still no session id and no
+        // focus/switch/resume parameters.
+        let transport = FakeTransport()
+        let socket = FakeSocket()
+        transport.nextSocket = { socket }
+        let client = makeClient(transport: transport, profile: "work")
+        let connectTask = Task { try? await client.connect() }
+        transport.open(socket)
+        try await awaitCompletion(of: connectTask, "connect() to complete")
+
+        let sent = Gate()
+        socket.onSend = { sent.signal() }
+        let probeTask = Task<[LiveSessionStatus], Error> { try await client.activeSessions() }
+        try await sent.wait("the session.active_list request to be sent")
+
+        let request = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(try XCTUnwrap(socket.sentTexts.last).utf8)) as? [String: Any]
+        )
+        XCTAssertEqual(request["method"] as? String, "session.active_list")
+        let params = try XCTUnwrap(request["params"] as? [String: Any])
+        XCTAssertEqual(
+            params["profile"] as? String, "work",
+            "The profile key is gateway context, matching every other catalog read"
+        )
+        XCTAssertEqual(
+            params.count, 1,
+            "session.active_list must carry no session id and no focus/switch/resume parameters"
+        )
+
+        let id = try XCTUnwrap(request["id"] as? Int)
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": ["sessions": []]
+        ]
+        socket.deliver(String(data: try JSONSerialization.data(withJSONObject: response), encoding: .utf8)!)
+
+        let rows = try await awaitResult(of: probeTask, "the session.active_list response")
+        XCTAssertTrue(rows.isEmpty)
         client.disconnect()
     }
 
@@ -546,9 +598,10 @@ final class HermesClientTests: XCTestCase {
         return try stored.get()
     }
 
-    private func makeClient(transport: FakeTransport) -> HermesClient {
+    private func makeClient(transport: FakeTransport, profile: String? = nil) -> HermesClient {
         HermesClient(
             connection: HermesConnection(baseUrl: "https://test.example", ticket: "ticket"),
+            profile: profile,
             transportFactory: { transport }
         )
     }


### PR DESCRIPTION
## Problem

Two user-visible symptoms, one lifecycle root:

1. **Foregrounding disrupts an active turn.** Start a Hermes turn, background the app, foreground it — the live turn's UI state is destroyed (streaming bubble, PR #121 `liveReasoningSegment`, transcript), and the turn can be genuinely disrupted.
2. **A follow-up silently does nothing, then merges into the next turn.** Send message A → no visible turn starts. Send message B → Hermes receives A+B as inputs to one turn.

## Root cause (verified against current `NousResearch/hermes-agent` main, not assumed)

**Conduit-side (the regression).** `handleScenePhase(.active)` ran the full `syncSession(.automaticReturn)` on *every* foreground — even over a healthy socket. That resets `turnState = .synchronizing`, re-derives the resume target from the catalog, calls `session.resume` — which upstream implements as **switch_session**, not a read — replaces `messages` from the REST transcript, and calls `resetReasoningTurn()`, nil-ing `liveReasoningSegment` and the streaming buffer mid-turn. A harmless background→foreground cycle manufactured a full semantic turn boundary.

**Server-side (real, only when the socket dies).** On WS death the gateway arms a 20s orphan reap (`dashboard.ws_orphan_reap_grace_s`) that **interrupts a running turn whose activity clock went stale** (`client-gone-{sid}` interrupt) — e.g. a long quiet LLM wait. `session.resume` while a client-gone interrupt settles answers `4009 "session disconnect interrupt settling"`.

**Swallowed follow-ups.** With local `turnState == .idle` while Hermes considered the session running, message A's `prompt.submit` hit the gateway's busy-submit handler — which **never rejects**: it returns `{"status": "steered" | "redirected" | "queued"}` (steer injects into the live turn; queue holds for the next drain). Conduit discarded that response entirely, so A vanished into the busy policy and B joined it.

**Contract notes from the upstream read** (relevant to review):

- `session.status` is NOT a structured liveness RPC — it returns a TUI-rendered `{"output": "…"}` string. The correct read-only probe is **`session.active_list`** (`{id, session_key, status: working|waiting|starting|idle, last_active}`), which upstream's own desktop uses to rehydrate liveness and documents as "does not resume, focus, or otherwise mutate a chat", authoritative about absence.
- `session.resume`'s fast path reuses a live runtime (no duplicate runtime is possible) and returns `running`/`inflight`/`session_key`; the cold path reports `running: false` and may schedule an auto-continue of an interrupted turn.

## The fix

### 1. Observational foreground refresh (`AppState.refreshForegroundOnHealthyTransport`)

Healthy-socket foreground becomes:

```
foreground → health-check (session.list) → session.active_list probe
→ reconcile running/idle → continue receiving the same turn
```

On a live+running probe with a hydrated transcript, Conduit adopts the state **observationally**: no transcript swap, no streaming-buffer reset, no reasoning-segment reset; only the events buffered while the reconciliation boundary was open are replayed, then the boundary settles. `session.resume` (the full sync) now runs **only when the probe proves it is required**:

- runtime absent (gateway restart / turn reaped) → exactly one stored-session resume, new runtime ID becomes authoritative;
- authoritative idle after a locally-running turn ended while away → transcript recovery;
- running runtime over an empty local transcript (failed hydration / turn started from another surface) → attach the live projection;
- probe unavailable (older gateway / transient failure) → legacy resume refresh, unchanged;
- dead transport → existing reconnect path, unchanged.

`.inactive → .active` cycles (Control Center, overlays) never resume: the probe is observational, and staleness never triggers a resume.

### 2. Typed prompt outcome (`HermesClient.sendPrompt`)

`sendPrompt` now returns `PromptSubmissionOutcome` (`accepted` / `steered` / `redirected` / `queued`) parsed from the gateway's actual response `status` — nothing invented; an unrecognized success shape defaults to `.accepted` (older gateways omit the field). A busy outcome proves the session was running server-side; Conduit adopts running state **under the submission-ownership guard** so a handoff mid-RPC cannot misattribute busy state to the newly active session.

### 3. Ambiguous-acknowledgement recovery

- **Definitive rejections** (restore immediately, no probe): structured `RpcError` (the gateway answered), and `notConnected` (`rpc()` throws before any bytes leave the device).
- **Ambiguous** (timeout / connectionClosed / URLError / cancellation / unknown `HermesError`): reconnect the transport if needed, then probe the registry. Live turn → **accepted; the optimistic user row and running turn are kept and the prompt is never re-sent**. Idle/absent → existing failed-send restoration, exactly once (skipped when the recovery reconnect's sync already restored the transcript). Unreadable registry → conservative restore.
- A recovery reconnect is a real transport recovery; its sync already settles the transcript authoritatively.

### 4. Stale local state correction (`turnStateIsStale`)

Set at lifecycle boundaries where edges can be missed (scene dips, reconnects, ambiguous submissions); cleared only by authoritative sources (registry probe, resume snapshot, typed prompt outcome). When local-idle is stale, `submitComposer` runs **one** read-only probe before routing: running → the configured `BusyInputMode` action (steer / interrupt), idle → ordinary send, unreadable → fall through rather than block the user. Trusted state never pays for a probe.

### 5. Instrumentation

OSLog category `TurnLifecycle` records foreground reason, transport retained vs reconnected, probe result, observation-vs-resume decision **with the reason**, and prompt outcome classification — ids only, never prompt text, credentials, or message content. "Why did Conduit call session.resume here?" is answerable from one device log; a healthy foreground's answer is "it did not."

## Invariants preserved

- PR #121 live reasoning projection and composer programmatic-revision/IME handling — untouched; the observational path never settles a live segment.
- PR #118 bounded tail transcript hydration and PR #120 transaction-derived stored/runtime/requested identity — the probe matches by any known identity (requested/stored/runtime aliases), so rotation is not mistaken for a dead runtime.
- Loaded-earlier prefix, presentation cache, pending clarify/approval restoration, YOLO reassertion, profile switching, notification routing, viewport restoration, busy-input steer/interrupt behavior, stream-event buffering during real reconciliation — all unchanged.
- `session.resume` on a live runtime reuses it upstream, so the resume-refresh fallback cannot create a duplicate runtime.

## Tests

New `AppStateForegroundLifecycleTests` (19 tests) covering the required matrix: healthy socket + active turn (resume count 0, transcript stable, events land), PR #121 reasoning segment survives + extends on the same segment id, healthy idle no-op, `inactive → active` only, dead-socket reconnect + single resume, gateway restart (absent probe → one stored resume, runtime re-homed), ordinary idle submit, ambiguous ack with server running (accepted once, no re-submit), ambiguous ack with server idle (restoration exactly once), local-idle/server-running mismatch routed through the configured busy action, two genuinely idle turns stay independent, `starting` status adopt, unavailable-probe fallback, missed-idle-edge recovery, definitive `notConnected` skips the probe, probe-unavailable fall-through, queued-outcome adoption, plus outcome/row-parsing classification. Two new wire-level `HermesClientTests` (`prompt.submit` status parsing, `session.active_list` row parsing). Seam updates in `AppStateChatResumeTests` for the typed `sendPrompt` result.

## Verification

- Focused suites (lifecycle, HermesClient, ChatResume, ReasoningStream, CompactResumeTranscript, ChatReturnSurface, SessionPresentationCache, ComposerDraftStore): **255/255**.
- Full `ConduitTests`: **1528/1528, 0 failures** (iPhone 17 Pro simulator, main-clone Mac worktree at this commit's tree).
- Release build: **BUILD SUCCEEDED**.
- `git diff --check` clean.
- Multi-model review cycle (3 reviewers) ran before opening; consolidated WARNINGS were applied (starting-status liveness, ownership guard on busy adoption, `notConnected` reclassified definitive, `String(describing:)` ticket-leak vector removed from logs, `.acceptedSettled` adopts running state, `.notAccepted` clears staleness, skip duplicate restoration after a recovery reconnect).

## Out of scope / notes

- UI-lane tests: hosted CI remains the UI gate (local Mac runner still has the known AX wedge).
- On-device manual matrix (turn continues across background/foreground during reasoning, tool calls, clarify/approval waits; rapid cycles produce no repeated resumes) still needs a real device — the repro depends on iOS scene suspension.
- Upstream is unmodified: this is a Conduit client lifecycle correction. The gateway's stale-activity client-gone interrupt (a real turn kill during long quiet waits after socket loss) is upstream behavior worth tracking separately.

---

# Round 2: correctness hardening (fa4ceb5)

A round-2 correctness pass was applied on top of the original fix. Architecture unchanged: healthy foreground remains observational, resume happens only when required, prompt outcomes stay typed, stale state is corrected via read-only probes, and PR #118/#120/#121 behavior is preserved.

## 1. Ambiguous acceptance is now proven against the durable transcript

`active_list` is authoritative about *current* runtime liveness only. An idle-or-absent row can no longer by itself classify an ambiguous `prompt.submit` as not-accepted — the accepted turn may have completed and been reaped before recovery looked. New flow:

```
registry running → acceptedRunning

registry idle / absent / starting
  ↓ bounded tail read (PR #118 order=latest page via the existing persisted-transcript source)
  ↓ proven by ORDERING first (a row the conversation did not hold at submit time),
  ↓ corroborated by user-role content — never content alone
submitted turn present   → acceptedSettled (composer stays cleared, no retry, no restoration)
transcript advanced without the submitted text / nothing new → notAccepted (restore once)
unreadable source / ambiguous growth → unresolved (conservative restore, never a resend)
```

Before submitting, `sendMessage` captures a `PromptTranscriptBaseline` (the id set + count of everything the conversation held), so duplicate-text sends are disambiguated by durable row identity rather than text matching. Durable-vs-positional id backends are shape-detected (a paginated page is only served when durable identity is present; the legacy one-shot falls back to transcript-growth + newest-user-row checks).

## 2. Submission-owned turn state across suspension points

`turnState` / `turnStateIsStale` writes in every new async path are owned by the originating submission:

- the probe alias set is captured **before** any await and never re-derived from the mutable active session afterwards;
- `correctStaleIdleTurnState`, typed prompt outcomes, and ambiguous recovery all re-check `ComposerSubmissionContext` ownership after each await;
- a probe/ outcome that completes after the user switched sessions mutates nothing — the new session keeps its own stale marker and runs its own correction.

## 3. `starting` re-verified upstream and demoted from busy routing

Upstream `_session_live_status` reports `starting` when `agent_build_started` is set with the ready event unset — and `_schedule_agent_build` arms the **same build for promptless `session.create` / cold-resume pre-warm**. Because the starting check precedes the running check, it can also transiently mask a committed running turn during the submit→agent-ready window. Hermes Desktop treats only `working`/`waiting` as busy. So `LiveSessionStatus.isRunning` covers `working|waiting` only:

- foreground on a `starting` row: no resume, no adoption — local state stays stream-owned (inconclusive, staleness preserved);
- stale-idle correction: falls through to the ordinary send, whose typed `prompt.submit` outcome reconciles any genuine busy race.

## 4. Foreground probe/event ordering

`adoptForegroundRunningState` now applies the probe baseline **first** and replays buffered events **second**: events that arrived while the probe was in flight are newer than the registry snapshot, so a buffered turn-ending edge settles the turn instead of being overwritten back to running. Covered by a dedicated race test (probe suspended → `sessionBusy(false)` buffered → snapshot says working → final state idle, no resume manufactured).

## Round-2 tests and verification

New tests: transcript-proven accepted-settled acceptance (the fast-settling-turn regression), transcript-proven absence with exact restore-once, duplicate-older-text ordering disambiguation, unreadable-transcript conservative restore, probe handoff (A's probe must not mutate B; B re-probes and routes busy), prompt-outcome handoff (A's queued outcome must not adopt running or clear B's stale marker), `starting` foreground stream-ownership + ordinary-send fall-through, and the foreground probe/event ordering race. Focused suites **269/269**; full `ConduitTests` **1536/1536, 0 failures**; Release build **BUILD SUCCEEDED**; `git diff --check` clean.

---

# Round 3: durable-anchor evidence model (0198767)

Final correctness pass on the ambiguous-delivery verifier:

- **Local optimistic ids are no longer used as persisted-baseline evidence.** Visible `ChatMessage.id` for an optimistic send (`local-…`) is a presentation identity; Hermes persists that row under a fresh database id. The old baseline could therefore mistake an OLDER identical send's persisted row for the new submission (false `acceptedSettled`).
- The baseline now separates **durable hydrated row ids** from **local-only rows** (`PromptTranscriptBaseline`), and the verifier locates the **newest durable overlap anchor** in the bounded tail: only rows strictly after that anchor are candidates for the submitted turn.
  - matching candidate + anchor present + no local-only rows outstanding → `acceptedSettled` (proven);
  - matching candidate but local-only rows outstanding (their persisted twins unknown) or no anchor at all → `.indeterminate` → conservative restore, never a resend;
  - no matching candidate → `.notAccepted` → restore once (content absence proves non-acceptance on every backend shape, including legacy positional-id one-shot responses).
- Normal sends gained **zero** additional network requests: the baseline is captured from already-held in-memory state; the tail read happens only on the ambiguous path.
- **Post-recovery presentation ownership:** the `Failed to send` error write is now submission-owned, so a recovery that resolves after the user switched conversations no longer paints A's stale-send error onto B.

New regression tests: local-predecessor indeterminate (case A), durable-anchor accepted-settled with identical consecutive texts (case B), no-anchor indeterminate (case C), the durable happy paths (case D, retained), and the recovery error-leak handoff. Focused **273/273**; full `ConduitTests` **1540/1540, 0 failures**; Release build **BUILD SUCCEEDED**; `git diff --check` clean.

---

# Round 4: durable provenance + anchor-less tails are inconclusive (85bd473)

Final narrow pass on the ambiguous-submit verifier:

- **A bounded tail without the durable overlap anchor is now always inconclusive.** An accepted turn can persist hundreds of rows after the submission, pushing both the pre-submit anchor and the submitted row out of the newest 120-row page. Absence from that window therefore proves nothing: no anchor in the tail → `.indeterminate` → conservative restore, never `.notAccepted`, never `.acceptedSettled`, never a resend. The legacy one-shot response remains the exception that positively represents the entire transcript (content absence → notAccepted).
- **Durable baseline membership is positive provenance, not id-shape guessing.** `PersistedSessionTranscript` now carries `durableRowIDs` — positively extracted from raw rows carrying `id`/`message_id`, populated only when the page passed the `order=latest` + durable-identity validation — and AppState adopts exactly that set from the latest accepted hydration. The prefix blacklist is gone: optimistic (`local-…`), streaming-completion (`assistant-…`), positional (`String(index)`), reasoning, and tool/review projection ids can never become anchors. Conversations without positively durable ids resolve ambiguous submissions as `.indeterminate`.
- Ordinary sends gained **zero** extra persisted-history requests: the baseline is captured from in-memory adopted state; the tail read still happens only on the ambiguous path.
- Post-recovery `errorMessage` writes are submission-owned (a failed send resolved after a handoff no longer paints B's error surface).

New tests: bounded-tail-without-anchor indeterminate case, and the synthetic-id provenance matrix (`local-` / `assistant-` / positional / `reasoning-` / `tool-start-`). Restructured verifier tests now establish provenance through the real hydration path. Focused **275/275**; full `ConduitTests` **1542/1542, 0 failures**; Release build **BUILD SUCCEEDED**; `git diff --check` clean.


---

# Round 5: authoritative idle adopts `.idle` + bounded liveness probes (43c6489)

Small lifecycle-correctness pass on the observational foreground refresh:

- **Authoritative idle now explicitly adopts idle.** The final probe branch (healthy socket, registry row not running) previously only settled the reconciliation boundary, so a stale `.synchronizing`/`.reconnecting` left by an aborted recovery attempt survived the cycle and kept the composer disabled even though the registry said idle. The branch now adopts idle via `setRunning(false)` — idempotent for `.idle`, preserving the `unsupportedGateway` marker — before settling, so a healthy foreground cycle always ends with a usable composer. Still observational: this path issues zero `session.resume`.
- **Newer buffered events still win over the adopted baseline.** The adopted idle is the older observation; events buffered while the boundary was open are replayed (`settleForegroundBoundary`) before settling, so a busy edge that raced the probe re-owns the state instead of being discarded.
- **`session.active_list` now uses the shared 8s liveness budget.** The probe sits on the foreground refresh and the pre-send stale-idle correction, so a stalled gateway fails it in 8s — the same budget `healthCheck()` already used, promoted to a single `livenessProbeTimeout` constant — instead of the generic 30s. Timeout behavior is unchanged: every caller treats it like any other probe failure (resume refresh / proceed with send / unresolved).
- **Wire contract pinned in tests:** `session.active_list` is argument-free under the default profile (no `params` key at all) and carries only the gateway `profile` context for non-default profiles — no session id, no focus/switch/resume parameters.

New regression tests: stale `.synchronizing` + authoritative idle (A), stale `.reconnecting` + authoritative idle (B), buffered busy edge wins over the adopted idle baseline (C), and the two wire-contract pins. Focused **51/51** (foreground 36 + HermesClient 15) plus chat-resume/reasoning suites (150/150 pre-amendment); full `ConduitTests` **1546/1546, 0 failures**; Release build **BUILD SUCCEEDED**; `git diff --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved message submission tracking when confirmation is delayed, incomplete, or ambiguous, reducing duplicate messages.
  - Improved conversation restoration and session handoff across foreground/background transitions.
  - Fixed recovery from interrupted synchronization or reconnection states.
  - Prevented stale or inconclusive session activity from incorrectly changing the local running state.
  - Improved handling of active session statuses and gateway-reported submission outcomes.

- **Reliability**
  - Added an 8-second timeout for connectivity and active-session checks to prevent prolonged waiting.
  - Added safeguards for refreshing and reconciling conversation updates after returning to the foreground.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

# Round 6: cross-surface transcript freshness (c723c43)

The observational foreground proved **liveness**, not **transcript freshness**: a turn another Hermes surface started or completed while Conduit was backgrounded stayed invisible until an explicit refresh, because a matching `session.active_list` row says nothing about whether the local transcript saw the persisted activity. This round closes that gap without restoring unconditional resume:

- **Scene-transition evidence.** `.background`/`.inactive` snapshot the session identities with a locally-running turn (continuity evidence); `.background` also arms exactly one bounded freshness check for the next foreground return. Overlay dips keep the socket alive, so they stay fully observational.
- **Conduit-owned turns keep the fast path.** Running before the transition + same runtime working after → unchanged observational adopt: zero reads, zero resumes, live reasoning and streaming projection untouched (the headline PR #122 behavior, now pinned by an explicit continuity test).
- **One bounded persisted-tail read decides the suspicious cases** (authoritative idle, or working without continuity evidence, after a real background). The existing `order=latest` page + durable-id provenance compare against the locally adopted frontier: anchor overlap with nothing newer → observational adopt; newer durable rows → the advancement merges into the local transcript (loaded-earlier prefix untouched, persisted window re-anchored) and the liveness adopts — **zero `session.resume`**, because the persisted history supplied everything a completed turn needs.
- **No ordering proof → conservative convergence.** Frontier rotated out of the page, legacy one-shot, foreign resolved id, unanchored optimistic tail, or no frontier → the existing bounded resume refresh re-anchors the whole conversation (and a live runtime's in-flight projection). Unreadable/missing history source → the prior observational behavior, never a resume cascade.
- **Ordering invariant intact:** the merge/snapshot is the older observation; buffered stream events replay after it. A submit landing during the read advances the automatic-work epoch, so the freshness continuation stands down instead of appending behind the newer optimistic row; streaming completions finalize merged rows in place by gateway id instead of appending twins.

New tests: remote-completed merge (A), remote-running merge + adopt (B) plus live completion after the merge, Conduit-owned continuity fast path (C), unchanged-tail no-op (D), rotated-anchor bounded recovery (E), buffered busy edge wins over the merged snapshot (F), dip-after-background stays observational (G), mid-read submit stand-down (H), positively-empty conversation (I), unanchored-tail bounded recovery (J). Focused **90/90** (foreground 46 + window 44) plus chat-resume/reasoning/client/coordinator suites; full `ConduitTests` **1556/1556, 0 failures**; Release build **BUILD SUCCEEDED**; `git diff --check` clean.


---

# Round 7: tail-only freshness, source classification, authoritative attach (9ed9e46)

Final hardening on the cross-surface freshness work:

- **The freshness read is provably tail-only.** A new `foregroundPersistedTailOutcome` requests exactly one bounded `order=latest offset=0` page and stops before the hydration helper's legacy one-shot re-read: a non-contract response yields inconclusive evidence, and only the authoritative resume/reconcile path ever performs a full hydration (pinned by call-arithmetic in tests — the freshness check adds exactly one request).
- **History-source failures are classified, not collapsed.** Structural absence (no endpoint, 404/410/501) → the bounded resume refresh exactly once (authoritative fallback, no loop). Transient failure (timeout, 429/5xx, bridge not ready) → the authoritative liveness adopts while the stale marker is RETAINED: freshness stays unresolved for the pre-send probe or the next background to re-confirm — no false "unchanged", no escalation, no retry.
- **Remote-running turns attach authoritatively.** Working/waiting without continuity evidence after a real background takes exactly one compact resume: the live in-flight assistant/reasoning projection plus the merged persisted prefix (persisted history alone cannot supply the inflight prefix). Same-session identity is no longer treated as same-turn proof — the continuity path runs the bounded tail read, keeping the zero-resume/zero-replacement fast path only for a provably unchanged tail (Turn A → Turn B in the same session is caught and re-attached).
- **`.starting` normalizes stale transitional state.** A starting runtime over a leftover `.synchronizing`/`.reconnecting` adopts a usable neutral baseline (starting is never classified as running; newer buffered edges still win).
- **TurnLifecycle logs no longer publish gateway error descriptions as public text** (three sites → `.private`).

New/updated tests: legacy-tail no-fallback call arithmetic, structural-404 fallback, transient-503 stale retention (idle + running variants), remote-running attach with unpersisted inflight prefix, Turn A→B same-session, genuine mid-turn-rehydration continuation, starting-over-transitional (busy edge still wins). Focused **55/55** foreground + window/compact-resume 44 + chat-resume/reasoning/client/coordinator suites; full `ConduitTests` **1565/1565, 0 failures**; Release build **BUILD SUCCEEDED**; `git diff --check` clean.

---

# Round 8: locally-owned optimistic tails, freshness/turn-state split, single structural resume

Three final correctness fixes (no redesign of the accepted round-5–7 mechanisms):

- **The normal locally-submitted running turn keeps the zero-resume foreground.** The freshness verifier previously required the transcript to END on a durably-anchored row, so an ordinary `submitComposer` turn — whose user row is the optimistic `local-<ts>` id — degraded to `inconclusive → session.resume` on the next background→foreground cycle, recreating the PR #121 regression. A small explicit `LocallyOwnedInFlightTurn` marker now records the optimistic user row when a locally-initiated, non-busy `prompt.submit` is accepted (and when ambiguity recovery proves `.acceptedRunning`); at use it must still be present, unpersisted, and head a fully-unpersisted suffix, with the local turn state agreeing. The verdict then reads: durable frontier anchor unchanged + no persisted candidates + runtime still working → observational continuation (zero resume, zero replacement, optimistic row and live reasoning segment survive; later deltas extend the same segment). Persisted advancement behind an optimistic tail always forces the authoritative attach — a remote Turn B that completed Turn A while away is still caught. Optimistic ids never enter `durablePersistedRowIDs`; no prompt-text comparison, no id-shape inference.
- **Transcript freshness uncertainty is tracked separately from turn-state staleness.** The transient foreground-read failure now sets `transcriptFreshnessIsStale` (the registry answer that was just adopted settles turn-state staleness; it can never prove transcript currency). The next NEW-TURN submit while idle runs exactly one bounded tail-only retry: unchanged → send; advanced → merge the missing persisted rows first, then append the prompt; a second transient failure blocks the send with "Unable to refresh this conversation. Try again." — no poll, no loop, no silent out-of-order append; structural absence takes the authoritative recovery before sending.
- **Structural history absence resumes exactly once.** The freshness verdict's new `.sourceUnavailable` case hints the authoritative refresh, which skips the compact-resume-then-doomed-history-read dance and performs one noncompact `session.resume` directly (previously: compact resume + 404 + second legacy resume).

Multi-model review findings applied: marker also recorded on the ambiguous `.acceptedRunning` path; marker survives `.synchronizing`/`.reconnecting` backgrounds (mid-recovery ≠ settled); busy-submission outcomes (`steered`/`queued`) no longer claim locally-owned continuity; the tail validator requires live local turn state; freshness evidence resets on sign-out/profile switch/conversation replacement/session open; recovery-supersession logs distinctly.

New/updated tests: `testForegroundNormalLocallySubmittedRunningTurnStaysObservational` (real `submitComposer` → running → background → foreground; zero resume, zero replacement, same reasoning segment extends), `testForegroundLocallyOwnedOptimisticTailYieldsToPersistedTurnB` (Turn A→remote Turn B attach), `testPreSendFreshnessRetryMergesMissingRowsBeforeNewPrompt`, `testPreSendFreshnessRetryTransientFailureBlocksNewTurn`, structural fallback updated to reads==2/resume+1, transient tests updated to the split flags. Focused suites **236/236** (foreground 59 + chat-resume + reasoning + compact-resume/window + coordinator + client); full `ConduitTests` **1569/1569, 0 failures**; Release build **BUILD SUCCEEDED**; `git diff --check` clean.

---

# Round 9: realistic persisted shape (user-turn boundaries) + pre-send busy-edge yield

Two final blockers, both found by testing against Hermes' REAL persisted behavior:

- **Locally-owned continuation now supports Hermes' turn-start persistence.** Hermes persists the user row at turn start (crash resilience), so the normal in-flight tail already contains the durable twin of Conduit's optimistic `local-<ts>` bubble — round 8's "nothing persisted yet" assumption classified the ordinary real-device path as inconclusive → resume → PR #121 reasoning reset. The marker now also captures the **pre-submit durable anchor** (the newest durably-proven row id, recorded in `sendMessage` before the optimistic append, reused by the ambiguous `.acceptedRunning` path). The bounded tail is classified by **canonical USER-turn boundaries** against that anchor — never raw row count, never text comparison: exactly ONE new `.user` row, and it must be the FIRST row after the anchor, while the runtime is still working/waiting → same locally-owned Turn A → observational continuation (zero resume, transcript untouched, twin never merged behind the optimistic bubble, live projection intact). A second user boundary — a later turn or a persisted steer — or a non-user first row takes the authoritative attach; no anchor or a rotated anchor stays inconclusive. The normalizer maps raw tool results to `.tool` and drops hidden scaffolding, so `.user` rows are real prompts. Optimistic ids remain non-durable.
- **The pre-send freshness gate yields to a busy edge racing its await.** The gate previously collapsed "ownership superseded" and "same conversation turned busy during the read" into one `.proceed` — a busy edge arriving mid-read would fall through to an ordinary `prompt.submit` into the running turn. Now: ownership/session change → `.proceed` (downstream guards own it, never a busy action on the newly selected session); same conversation now running → `.routeToBusySubmission` (steer/interrupt per `busyInputMode`, never ordinary send, no optimistic row appended); recovery-boundary states (`.synchronizing`/`.reconnecting`/unsupported) → blocked with the retryable message. The sibling stale-idle probe gets the same busy-edge re-route.

New tests: persisted user twin stays observational; Turn A's own persisted assistant/tool rows stay observational; missing twin (non-user first row) takes the attach; first turn without a durable anchor takes the attach; pre-send busy-edge race routes through steer; recovery-boundary race blocks; stale-idle probe busy-edge race routes through steer. Focused suites **243/243**; full `ConduitTests` **1576/1576, 0 failures**; Release build **BUILD SUCCEEDED**; `git diff --check` clean.

---

# Round 10: persisted ordering frontier, separate from visible provenance

Final pair of related fixes — both came from using the visible transcript's `durablePersistedRowIDs` as the only ordering baseline:

- **A `PersistedOrderingFrontier` now tracks ordering evidence separately from visible-row provenance.** The visible transcript may keep an optimistic `local-*` row whose durable twin a validated bounded read already observed; the optimistic row is never rewritten, the twin is never merged behind it, and the twin's id never enters `durablePersistedRowIDs` — the frontier is purely ordering metadata. It re-anchors on every authoritative reconcile adoption and advancement merge, advances on every validated `.unchanged` read, and resets on session/profile switch, conversation replacement, and sign-out.
- **A positively-empty persisted transcript is valid ordering evidence.** The first turn of an empty conversation — whose durable twin (102) exists while the runtime is working — stays observational with zero `session.resume` (previously: no anchor → inconclusive → resume). Emptiness is proven on the raw row view (a page whose rows all normalize away as hidden scaffolding is not empty), the classifier requires the page to be complete (`rawReturned`, not the normalized count), and unknown/legacy/rotated baselines stay inconclusive.
- **The frontier advances across locally-owned turns.** The `.unchanged` verdict carries the observed ordering frontier, so after Turn A's observational foreground the frontier knows Turn A's persisted rows (e.g. through 103) — Turn B's marker anchors past them and its foreground stays observational instead of miscounting Turn A's rows as foreign boundaries. The marker's baseline is **frozen at submit time**: a live marker never re-anchors, so our own turn's rows still count as boundaries against a foreign turn that starts after it — remote Turn B after local A, and remote Turn C after local B, still force the authoritative attach exactly once.
- The session-identity gate now runs before the empty-page branch, and the frontier anchors on the newest row the page positively proves durable.

New tests: first turn from a positively-empty baseline stays observational; twin-not-yet-persisted stays observational; consecutive locally-owned turns (A foreground advances through 103, A settles locally, B foreground zero-resume, same segment); remote Turn B after a frontier advance still attaches (frozen baseline); remote Turn C after local Turn B still attaches. Focused suites **247/247**; full `ConduitTests` **1580/1580, 0 failures**; Release build **BUILD SUCCEEDED**; `git diff --check` clean.

---

# Round 11: local ordering debt for foreground-only settled turns

The last lifecycle hole: a locally-owned turn can run and settle entirely in the foreground without any bounded history read observing its durable rows. The next local turn then froze a one-turn-behind ordering baseline, and its foreground counted the previous turn's persisted rows as foreign boundaries → `session.resume` → the PR #121 reasoning reset, on the most ordinary flow of all.

- **Local ordering debt.** When a locally-owned turn settles (normal stream completion, error, interruption, ambiguous `.acceptedSettled`, or a busy-submission row that persists as a new user boundary) and no validated read has positively observed its persisted boundary, Conduit records one unit of debt — a count, so several foreground-only settles accumulate. Debt only accrues for provable baselines: unknown/legacy conversations keep the pre-debt conservative-attach behavior and never block an ordinary send.
- **Lazy reconciliation at the next submit.** Before a new-turn prompt freezes its ordering baseline, one bounded `order=latest` tail read reconciles the debt: exactly the expected number of canonical user-turn boundaries after the frontier → satisfied, frontier advances, the turn submits; more → foreign activity → the authoritative reconcile runs first and the local prompt appends after the remote turn; fewer/rotated/unknown → conservative recovery. The debt read doubles as the transcript-freshness retry — one read, both concerns — and the submit-time baseline is still captured strictly after resolution.
- **Proof-quality:** positively-empty evidence now explicitly requires `page.rawReturned == 0` (plus normalized-empty, durable-empty, complete-page), and the pre-send gate verifies session identity before consuming any page.

New tests: foreground-only A → B zero-resume with exactly one debt read; debt exceeded by a remote turn forces the reconcile with the local prompt appending after; an already-observed turn creates no extra pre-send read. Focused suites **250/250**; full `ConduitTests` **1583/1583, 0 failures**; Release build **BUILD SUCCEEDED**; `git diff --check` clean.
