### PR TITLE
feat(ipad): optional persistent sessions sidebar

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -736,6 +736,15 @@ final class AppState: ObservableObject {
             }
         }
     }
+    /// Closes the modal sessions drawer if it is open. Session-opening flows
+    /// inside the sidebar call this unconditionally: in drawer mode it
+    /// dismisses the sheet, while in the iPad persistent-sidebar layout the
+    /// drawer is never presented (`showSidebar` stays false), so this is a
+    /// no-op and the persistent column remains visible.
+    func dismissSidebarDrawer() {
+        guard showSidebar else { return }
+        showSidebar = false
+    }
     @Published var showModelPicker = false
     @Published var showContextSheet = false
     @Published var showWorkspaceSheet = false

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -1371,9 +1371,11 @@ private struct AppearanceSettingsDetail: View {
     @EnvironmentObject private var appState: AppState
     let theme: ThemePreference
     let saveTheme: (ThemePreference) -> Void
+    @AppStorage("conduit.ipadPersistentSidebar") private var iPadPersistentSidebar = false
     @State private var selected: ThemePreference
     @State private var isChangingIcon = false
     init(theme: ThemePreference, saveTheme: @escaping (ThemePreference) -> Void) { self.theme = theme; self.saveTheme = saveTheme; _selected = State(initialValue: theme) }
+    private var isPad: Bool { UIDevice.current.userInterfaceIdiom == .pad }
     var body: some View {
         SettingsDetailContainer {
             ConduitSettingsSection(title: "Theme", symbol: "circle.lefthalf.filled", tint: .conduitAccent) {
@@ -1426,6 +1428,16 @@ private struct AppearanceSettingsDetail: View {
                         .disabled(isChangingIcon)
                         .accessibilityLabel("Use \(choice.title.lowercased()) app icon")
                     }
+                }
+            }
+
+            if isPad {
+                ConduitSettingsSection(title: "Layout", symbol: "sidebar.left", tint: .conduitAura) {
+                    Toggle("Persistent session sidebar", isOn: $iPadPersistentSidebar)
+                        .tint(.conduitAccent)
+                    Text("Keep Sessions, Cron, and Kanban visible beside the current conversation when the window is wide enough.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
                 }
             }
         }.navigationTitle("Appearance")

--- a/Conduit/Views/RootView.swift
+++ b/Conduit/Views/RootView.swift
@@ -38,80 +38,23 @@ struct RootView: View {
 
 struct MainView: View {
     @EnvironmentObject var appState: AppState
+    @AppStorage("conduit.ipadPersistentSidebar") private var prefersPersistentSidebar = false
+    @State private var availableWindowWidth: CGFloat = 0
     @State private var settingsPresentation: SettingsSnapshot?
     @State private var shouldPresentSettingsAfterSidebarDismissal = false
 
+    private var sidebarPresentation: SidebarPresentation {
+        SidebarLayoutPolicy.resolvePresentation(
+            idiom: UIDevice.current.userInterfaceIdiom,
+            prefersPersistentSidebar: prefersPersistentSidebar,
+            availableWidth: availableWindowWidth
+        )
+    }
+
+    private var isPersistentSidebarActive: Bool { sidebarPresentation == .persistent }
+
     var body: some View {
-        NavigationStack {
-            ZStack {
-                ConduitBackdrop()
-                ChatView()
-            }
-            .overlay(alignment: .leading) { EdgePanGesture { appState.showSidebar = true }.frame(width: 25).ignoresSafeArea() }
-            .navigationTitle("")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbarBackground(.hidden, for: .navigationBar)
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button {
-                        appState.showSidebar = true
-                    } label: {
-                        Image(systemName: "line.3.horizontal")
-                            .font(.system(size: 16, weight: .semibold))
-                            .frame(width: 40, height: 40)
-                    }
-                    .conduitGlassControl(cornerRadius: 20, tint: .conduitAccent.opacity(0.10))
-                    .accessibilityLabel("Open sessions")
-                }
-                ToolbarItem(placement: .principal) {
-                    Button {
-                        appState.requestChatScrollToTop()
-                    } label: {
-                        Text(appState.activeSessionTitle)
-                            .font(.subheadline.weight(.semibold))
-                            .lineLimit(1)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 7)
-                            .conduitGlassSurface(cornerRadius: 16, tint: .conduitAccent.opacity(0.06))
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(appState.activeSessionTitle)
-                    .accessibilityHint("Scroll to top of conversation")
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button {
-                        Task { await appState.refreshActiveSession() }
-                    } label: {
-                        Image(systemName: "arrow.clockwise")
-                            .font(.system(size: 15, weight: .semibold))
-                            .rotationEffect(.degrees(appState.isChatRefreshing ? 360 : 0))
-                            .animation(
-                                appState.isChatRefreshing
-                                    ? .linear(duration: 0.75).repeatForever(autoreverses: false)
-                                    : .default,
-                                value: appState.isChatRefreshing
-                            )
-                            .frame(width: 40, height: 40)
-                    }
-                    .conduitGlassControl(cornerRadius: 20, tint: .conduitAccent.opacity(0.10))
-                    .disabled(!appState.isConnected || appState.isChatRefreshing)
-                    .accessibilityLabel("Refresh conversation")
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    ConnectionStatusIndicator()
-                }
-            }
-        }
-        .sheet(isPresented: $appState.showSidebar, onDismiss: presentSettingsAfterSidebarDismissal) {
-            SidebarView(onRequestSettings: {
-                shouldPresentSettingsAfterSidebarDismissal = true
-                appState.showSidebar = false
-            })
-                .presentationDetents([.large])
-                .transaction { transaction in
-                    transaction.animation = .easeInOut(duration: 0.15)
-                }
-        }
+        sidebarLayoutContent
         .sheet(isPresented: $appState.showModelPicker) {
             ModelPickerView()
                 .presentationDetents([.medium, .large])
@@ -173,6 +116,8 @@ struct MainView: View {
             )
                 .presentationDetents([.large])
         }
+        .background(windowWidthReader)
+        .onPreferenceChange(MainViewWindowWidthKey.self) { availableWindowWidth = $0 }
         .task(id: voiceCapabilityRefreshKey) {
             await appState.refreshVoiceCapabilities()
         }
@@ -189,6 +134,124 @@ struct MainView: View {
         }
     }
 
+    /// Routes the sidebar between its two presentations: the existing chat
+    /// shell with the modal drawer, or — on wide iPad windows with the
+    /// Appearance opt-in — the same SidebarView as a persistent leading
+    /// column beside the chat.
+    @ViewBuilder
+    private var sidebarLayoutContent: some View {
+        if isPersistentSidebarActive {
+            HStack(spacing: 0) {
+                SidebarView(
+                    onRequestSettings: presentSettingsFromPersistentSidebar,
+                    presentation: .persistent
+                )
+                .frame(width: SidebarLayoutMetrics.persistentSidebarWidth)
+
+                Divider()
+                    .ignoresSafeArea(.container, edges: .vertical)
+
+                chatNavigationContent
+            }
+        } else {
+            chatNavigationContent
+        }
+    }
+
+    /// The existing chat shell, shared by both sidebar layouts so the drawer
+    /// and the persistent column render the identical conversation surface.
+    /// Only the drawer affordances (hamburger and left-edge swipe) hide while
+    /// the persistent sidebar is visible.
+    private var chatNavigationContent: some View {
+        NavigationStack {
+            ZStack {
+                ConduitBackdrop()
+                ChatView()
+            }
+            .overlay(alignment: .leading) {
+                if !isPersistentSidebarActive {
+                    EdgePanGesture { appState.showSidebar = true }
+                        .frame(width: 25)
+                        .ignoresSafeArea()
+                }
+            }
+            .navigationTitle("")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(.hidden, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    if !isPersistentSidebarActive {
+                        Button {
+                            appState.showSidebar = true
+                        } label: {
+                            Image(systemName: "line.3.horizontal")
+                                .font(.system(size: 16, weight: .semibold))
+                                .frame(width: 40, height: 40)
+                        }
+                        .conduitGlassControl(cornerRadius: 20, tint: .conduitAccent.opacity(0.10))
+                        .accessibilityLabel("Open sessions")
+                    }
+                }
+                ToolbarItem(placement: .principal) {
+                    Button {
+                        appState.requestChatScrollToTop()
+                    } label: {
+                        Text(appState.activeSessionTitle)
+                            .font(.subheadline.weight(.semibold))
+                            .lineLimit(1)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 7)
+                            .conduitGlassSurface(cornerRadius: 16, tint: .conduitAccent.opacity(0.06))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(appState.activeSessionTitle)
+                    .accessibilityHint("Scroll to top of conversation")
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        Task { await appState.refreshActiveSession() }
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.system(size: 15, weight: .semibold))
+                            .rotationEffect(.degrees(appState.isChatRefreshing ? 360 : 0))
+                            .animation(
+                                appState.isChatRefreshing
+                                    ? .linear(duration: 0.75).repeatForever(autoreverses: false)
+                                    : .default,
+                                value: appState.isChatRefreshing
+                            )
+                            .frame(width: 40, height: 40)
+                    }
+                    .conduitGlassControl(cornerRadius: 20, tint: .conduitAccent.opacity(0.10))
+                    .disabled(!appState.isConnected || appState.isChatRefreshing)
+                    .accessibilityLabel("Refresh conversation")
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    ConnectionStatusIndicator()
+                }
+            }
+        }
+        .sheet(isPresented: $appState.showSidebar, onDismiss: presentSettingsAfterSidebarDismissal) {
+            SidebarView(onRequestSettings: presentSettingsFromDrawer)
+                .presentationDetents([.large])
+                .transaction { transaction in
+                    transaction.animation = .easeInOut(duration: 0.15)
+                }
+        }
+    }
+
+    private func presentSettingsFromDrawer() {
+        shouldPresentSettingsAfterSidebarDismissal = true
+        appState.showSidebar = false
+    }
+
+    /// Persistent mode keeps the sidebar visible, so Settings opens directly
+    /// instead of waiting for the drawer sheet to dismiss first.
+    private func presentSettingsFromPersistentSidebar() {
+        appState.isSettingsSheetPresented = true
+        settingsPresentation = appState.makeSettingsSnapshot()
+    }
+
     private func presentSettingsAfterSidebarDismissal() {
         guard shouldPresentSettingsAfterSidebarDismissal else { return }
         shouldPresentSettingsAfterSidebarDismissal = false
@@ -199,15 +262,36 @@ struct MainView: View {
     /// Presents the sessions drawer for a preferred-return-surface request.
     /// Consumption semantics (defer-while-pending, claim-once-per-request,
     /// drop on precedence losers) live in AppState so they survive MainView
-    /// teardown; this layer only owns the actual sheet presentation.
+    /// teardown; this layer only owns the actual sheet presentation. An
+    /// active persistent sidebar already shows Sessions, so the request is
+    /// consumed without opening a redundant drawer.
     private func presentPreferredReturnSurfaceIfNeeded() {
         guard appState.claimPreferredReturnSurfacePresentation() else { return }
-        guard !appState.showSidebar else { return }
+        guard SidebarLayoutPolicy.shouldPresentDrawerForReturnSurface(
+            persistentSidebarActive: isPersistentSidebarActive,
+            drawerPresented: appState.showSidebar
+        ) else { return }
         appState.showSidebar = true
+    }
+
+    private var windowWidthReader: some View {
+        GeometryReader { proxy in
+            Color.clear.preference(key: MainViewWindowWidthKey.self, value: proxy.size.width)
+        }
     }
 
     private var voiceCapabilityRefreshKey: String {
         "\(appState.isConnected):\(appState.activeProfile)"
+    }
+}
+
+/// Reports the width of the window hosting MainView so the sidebar layout
+/// decision tracks Split View, Stage Manager, and window resizing.
+private struct MainViewWindowWidthKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
     }
 }
 

--- a/Conduit/Views/RootView.swift
+++ b/Conduit/Views/RootView.swift
@@ -118,6 +118,13 @@ struct MainView: View {
         }
         .background(windowWidthReader)
         .onPreferenceChange(MainViewWindowWidthKey.self) { availableWindowWidth = $0 }
+        .onChange(of: isPersistentSidebarActive) { _, persistentActive in
+            // Hard invariant: the persistent layout must never coexist with
+            // showSidebar == true — that flag suppresses streaming/reasoning
+            // publication. A resize, rotation, or the Appearance toggle can
+            // activate the persistent layout while the drawer is presented.
+            if persistentActive { appState.dismissSidebarDrawer() }
+        }
         .task(id: voiceCapabilityRefreshKey) {
             await appState.refreshVoiceCapabilities()
         }

--- a/Conduit/Views/SidebarLayout.swift
+++ b/Conduit/Views/SidebarLayout.swift
@@ -28,9 +28,7 @@ enum SidebarLayoutMetrics {
     /// Stage Manager, and narrow resizable windows stay usable.
     static let minimumChatWidth: CGFloat = 430
     /// Windows narrower than this never activate the persistent layout.
-    static var minimumPersistentLayoutWidth: CGFloat {
-        persistentSidebarWidth + minimumChatWidth
-    }
+    static let minimumPersistentLayoutWidth: CGFloat = persistentSidebarWidth + minimumChatWidth
 }
 
 enum SidebarLayoutPolicy {

--- a/Conduit/Views/SidebarLayout.swift
+++ b/Conduit/Views/SidebarLayout.swift
@@ -1,0 +1,63 @@
+//
+//  SidebarLayout.swift
+//  Conduit
+//
+//  Presentation policy for the sessions sidebar. iPhone and compact iPad
+//  windows keep the modal drawer; wide iPad windows with the user opt-in
+//  host the same SidebarView as a persistent leading column. The decision
+//  logic is pure so it can be tested without hosting UI.
+//
+
+import SwiftUI
+
+/// How the sessions sidebar is currently presented.
+enum SidebarPresentation {
+    /// Modal drawer presented as a sheet over the chat (`appState.showSidebar`).
+    case drawer
+    /// Persistent column beside the chat on wide iPad windows. Part of the
+    /// root layout — it never touches `appState.showSidebar`.
+    case persistent
+}
+
+/// Centralized metrics for the persistent sidebar layout.
+enum SidebarLayoutMetrics {
+    /// Width of the persistent sidebar column.
+    static let persistentSidebarWidth: CGFloat = 320
+    /// Minimum width the conversation column keeps beside the persistent
+    /// sidebar. Below this the layout falls back to the drawer so Split View,
+    /// Stage Manager, and narrow resizable windows stay usable.
+    static let minimumChatWidth: CGFloat = 430
+    /// Windows narrower than this never activate the persistent layout.
+    static var minimumPersistentLayoutWidth: CGFloat {
+        persistentSidebarWidth + minimumChatWidth
+    }
+}
+
+enum SidebarLayoutPolicy {
+    /// Resolves how the sessions sidebar should be presented.
+    ///
+    /// iPhone always uses the drawer. iPad uses the persistent column only
+    /// when the user opted in AND the window is wide enough to keep a usable
+    /// conversation beside it.
+    static func resolvePresentation(
+        idiom: UIUserInterfaceIdiom,
+        prefersPersistentSidebar: Bool,
+        availableWidth: CGFloat
+    ) -> SidebarPresentation {
+        guard idiom == .pad, prefersPersistentSidebar else { return .drawer }
+        guard availableWidth >= SidebarLayoutMetrics.minimumPersistentLayoutWidth else { return .drawer }
+        return .persistent
+    }
+
+    /// Whether a preferred-return-surface request should present the modal
+    /// drawer. An active persistent sidebar already *is* the Sessions
+    /// surface, so it consumes the request without opening a redundant
+    /// drawer; drawer layouts behave exactly as before.
+    static func shouldPresentDrawerForReturnSurface(
+        persistentSidebarActive: Bool,
+        drawerPresented: Bool
+    ) -> Bool {
+        if persistentSidebarActive { return false }
+        return !drawerPresented
+    }
+}

--- a/Conduit/Views/SidebarView.swift
+++ b/Conduit/Views/SidebarView.swift
@@ -10,6 +10,10 @@ import SwiftUI
 struct SidebarView: View {
     @EnvironmentObject var appState: AppState
     let onRequestSettings: () -> Void
+    /// Drawer mode keeps the current modal-sheet behavior; persistent mode
+    /// renders the same content as a fixed root-layout column with no close
+    /// control and no dismissal.
+    var presentation: SidebarPresentation = .drawer
     @AppStorage("conduit.sidebarTab") private var selectedTabRaw = SidebarTab.sessions.rawValue
 
     private var selectedTab: SidebarTab {
@@ -68,15 +72,17 @@ struct SidebarView: View {
                             .conduitGlassControl(cornerRadius: 18)
                             .accessibilityLabel("Settings")
 
-                            Button {
-                                dismiss()
-                            } label: {
-                                Image(systemName: "xmark")
-                                    .font(.system(size: 15, weight: .semibold))
-                                    .frame(width: 44, height: 44)
+                            if presentation == .drawer {
+                                Button {
+                                    dismiss()
+                                } label: {
+                                    Image(systemName: "xmark")
+                                        .font(.system(size: 15, weight: .semibold))
+                                        .frame(width: 44, height: 44)
+                                }
+                                .conduitGlassControl(cornerRadius: 18)
+                                .accessibilityLabel("Close sessions")
                             }
-                            .conduitGlassControl(cornerRadius: 18)
-                            .accessibilityLabel("Close sessions")
                         }
                     }
 
@@ -174,7 +180,7 @@ struct SessionList: View {
             HStack(spacing: 10) {
                 Button {
                     Haptics.medium()
-                    appState.showSidebar = false
+                    appState.dismissSidebarDrawer()
                     Task { await appState.createNewSession() }
                 } label: {
                     HStack(spacing: 6) {
@@ -449,7 +455,7 @@ struct SessionList: View {
     private func sessionRow(_ session: SessionSummary) -> some View {
         Button {
             Haptics.light()
-            appState.showSidebar = false
+            appState.dismissSidebarDrawer()
             appState.requestOpenSession(session.id)
         } label: {
             SessionRow(
@@ -785,7 +791,7 @@ private struct ProjectSessionsSheet: View {
                             Section(lane.title) {
                                 ForEach(lane.sessions) { session in
                                     Button {
-                                        appState.showSidebar = false
+                                        appState.dismissSidebarDrawer()
                                         dismiss()
                                         appState.requestOpenSession(session.id)
                                     } label: {
@@ -810,7 +816,7 @@ private struct ProjectSessionsSheet: View {
                 if let path = project.primaryPath, !path.isEmpty {
                     ToolbarItem(placement: .topBarLeading) {
                         Button {
-                            appState.showSidebar = false
+                            appState.dismissSidebarDrawer()
                             dismiss()
                             Task { await appState.createNewSession(cwd: path) }
                         } label: {
@@ -1068,7 +1074,7 @@ struct CronList: View {
                 Section("Recent runs") {
                     ForEach(appState.activeProfileCronSessions.prefix(20)) { session in
                     Button {
-                        appState.showSidebar = false
+                        appState.dismissSidebarDrawer()
                         appState.requestOpenSession(session.id)
                     } label: {
                         SessionRow(session: session, isSelected: session.id == appState.activeSessionId).contentShape(Rectangle())
@@ -1160,7 +1166,7 @@ private struct CronJobDetailSheet: View {
                         ConduitSettingsSection(title: "Run history", symbol: "clock.arrow.circlepath", tint: .conduitAura) {
                             if appState.cronRuns.isEmpty { Text("This job has not run yet.").font(.footnote).foregroundStyle(.secondary) }
                             ForEach(appState.cronRuns) { run in
-                                Button { appState.showSidebar = false; dismiss(); appState.requestOpenSession(run.id) } label: {
+                                Button { appState.dismissSidebarDrawer(); dismiss(); appState.requestOpenSession(run.id) } label: {
                                     HStack { VStack(alignment: .leading) { Text(run.title ?? run.preview ?? run.id).lineLimit(1); Text(run.model ?? "Hermes").font(.caption).foregroundStyle(.secondary) }; Spacer(); Text(run.lastActive.map(String.init) ?? "").font(.caption2).foregroundStyle(.tertiary) }
                                 }
                                 .buttonStyle(.plain)

--- a/ConduitTests/SidebarLayoutTests.swift
+++ b/ConduitTests/SidebarLayoutTests.swift
@@ -1,0 +1,167 @@
+//
+//  SidebarLayoutTests.swift
+//  Conduit
+//
+//  Coverage for the iPad persistent-sidebar layout policy and the drawer
+//  dismissal helper shared by the sidebar's session-opening flows.
+//
+
+import XCTest
+@testable import Conduit
+
+final class SidebarLayoutTests: XCTestCase {
+    private let phone = UIUserInterfaceIdiom.phone
+    private let pad = UIUserInterfaceIdiom.pad
+
+    private func resolve(
+        _ idiom: UIUserInterfaceIdiom,
+        prefersPersistentSidebar: Bool,
+        availableWidth: CGFloat
+    ) -> SidebarPresentation {
+        SidebarLayoutPolicy.resolvePresentation(
+            idiom: idiom,
+            prefersPersistentSidebar: prefersPersistentSidebar,
+            availableWidth: availableWidth
+        )
+    }
+
+    // MARK: - Layout resolution
+
+    func testPhoneUsesDrawerRegardlessOfPreferenceOrWidth() {
+        for prefersPersistentSidebar in [false, true] {
+            for width: CGFloat in [0, 320, 430, 768, 1024, 1366] {
+                XCTAssertEqual(
+                    resolve(phone, prefersPersistentSidebar: prefersPersistentSidebar, availableWidth: width),
+                    .drawer,
+                    "iPhone must keep the drawer (preference \(prefersPersistentSidebar), width \(width))."
+                )
+            }
+        }
+    }
+
+    func testIPadWithPreferenceOffUsesDrawerAtAnyWidth() {
+        for width: CGFloat in [0, 512, 683, 750, 768, 1024, 1366] {
+            XCTAssertEqual(
+                resolve(pad, prefersPersistentSidebar: false, availableWidth: width),
+                .drawer,
+                "Opt-out must keep the drawer at width \(width)."
+            )
+        }
+    }
+
+    func testIPadWithPreferenceOnAndWideWindowUsesPersistentSidebar() {
+        // Full-screen landscape, full-screen portrait (768), and wide
+        // Split View / Stage Manager tiles all clear the threshold.
+        for width: CGFloat in [768, 834, 1024, 1194, 1366] {
+            XCTAssertEqual(
+                resolve(pad, prefersPersistentSidebar: true, availableWidth: width),
+                .persistent,
+                "Wide iPad window (\(width)) with the opt-in should host the persistent sidebar."
+            )
+        }
+    }
+
+    func testIPadWithPreferenceOnAndNarrowWindowFallsBackToDrawer() {
+        // Split View halves, small Stage Manager tiles, and undetermined
+        // pre-layout widths must keep the drawer.
+        for width: CGFloat in [0, 320, 417, 512, 683, 749] {
+            XCTAssertEqual(
+                resolve(pad, prefersPersistentSidebar: true, availableWidth: width),
+                .drawer,
+                "Narrow iPad window (\(width)) must fall back to the drawer."
+            )
+        }
+    }
+
+    func testPersistentThresholdKeepsMinimumChatWidth() {
+        XCTAssertEqual(
+            SidebarLayoutMetrics.minimumPersistentLayoutWidth,
+            SidebarLayoutMetrics.persistentSidebarWidth + SidebarLayoutMetrics.minimumChatWidth
+        )
+
+        let threshold = SidebarLayoutMetrics.minimumPersistentLayoutWidth
+        XCTAssertEqual(
+            resolve(pad, prefersPersistentSidebar: true, availableWidth: threshold),
+            .persistent,
+            "A window exactly at the threshold still leaves the minimum chat width."
+        )
+        XCTAssertEqual(
+            resolve(pad, prefersPersistentSidebar: true, availableWidth: threshold - 1),
+            .drawer,
+            "One point below the threshold would squeeze the chat column."
+        )
+    }
+
+    // MARK: - Return surface
+
+    func testReturnSurfaceSkipsDrawerWhilePersistentSidebarIsActive() {
+        XCTAssertFalse(
+            SidebarLayoutPolicy.shouldPresentDrawerForReturnSurface(
+                persistentSidebarActive: true,
+                drawerPresented: false
+            ),
+            "The persistent sidebar already shows Sessions; no drawer may open over it."
+        )
+        XCTAssertFalse(
+            SidebarLayoutPolicy.shouldPresentDrawerForReturnSurface(
+                persistentSidebarActive: true,
+                drawerPresented: true
+            )
+        )
+    }
+
+    func testReturnSurfacePreservesDrawerBehaviorWhenPersistentIsInactive() {
+        XCTAssertTrue(
+            SidebarLayoutPolicy.shouldPresentDrawerForReturnSurface(
+                persistentSidebarActive: false,
+                drawerPresented: false
+            ),
+            "Drawer layouts keep opening the sessions drawer for return-surface requests."
+        )
+        XCTAssertFalse(
+            SidebarLayoutPolicy.shouldPresentDrawerForReturnSurface(
+                persistentSidebarActive: false,
+                drawerPresented: true
+            ),
+            "An already-presented drawer is not re-presented."
+        )
+    }
+
+    // MARK: - Drawer dismissal helper
+
+    @MainActor
+    func testDismissSidebarDrawerClosesOpenDrawer() {
+        let state = makeAppState()
+        state.showSidebar = true
+
+        state.dismissSidebarDrawer()
+
+        XCTAssertFalse(state.showSidebar)
+    }
+
+    @MainActor
+    func testDismissSidebarDrawerIsNoOpWhenDrawerIsClosed() {
+        let state = makeAppState()
+
+        // Session-opening flows call this unconditionally; in the persistent
+        // layout the drawer is never presented, so the helper must leave
+        // showSidebar untouched rather than force a publication flush.
+        state.dismissSidebarDrawer()
+
+        XCTAssertFalse(state.showSidebar)
+    }
+
+    @MainActor
+    private func makeAppState() -> AppState {
+        let suite = "SidebarLayoutTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Failed to create test UserDefaults suite")
+        }
+        addTeardownBlock { defaults.removePersistentDomain(forName: suite) }
+        return AppState(
+            defaults: defaults,
+            loadSavedConnection: false,
+            chatResumeLifecycleOperations: .live
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Adds an **opt-in persistent sessions sidebar for iPad**: with the new Appearance toggle enabled and the window wide enough, the existing Sessions / Cron / Kanban sidebar becomes a permanent left column beside the conversation instead of a modal drawer. iPhone behavior is untouched, and iPad without the opt-in (or with a narrow window) behaves exactly as today.

## Design

### Preference (device-local)

- `@AppStorage("conduit.ipadPersistentSidebar")`, default **off** — existing users keep the drawer.
- Surface: `AppearanceSettingsDetail` → new "Layout" section, shown **only** when `UIDevice.current.userInterfaceIdiom == .pad`. A normal `Toggle`; copy states the width condition ("…when the window is wide enough").
- Entirely device-local; nothing is added to the Hermes profile/config.

### Layout decision (pure + centralized)

`Conduit/Views/SidebarLayout.swift` (new) holds all decision logic so it is testable without hosting UI:

- `SidebarPresentation` — `.drawer` / `.persistent`
- `SidebarLayoutMetrics` — `persistentSidebarWidth = 320`, `minimumChatWidth = 430`, `minimumPersistentLayoutWidth = 750` (single source of truth for the threshold)
- `SidebarLayoutPolicy.resolvePresentation(idiom:prefersPersistentSidebar:availableWidth:)` — `.persistent` only for **pad + opt-in + width ≥ 750**. Full-screen portrait iPad (768) qualifies; Split View halves (≤683), Stage Manager tiles, and Slide Over stay on the drawer. Exactly 750 still leaves the 430 pt minimum chat column; 749 falls back.
- `SidebarLayoutPolicy.shouldPresentDrawerForReturnSurface(persistentSidebarActive:drawerPresented:)` — return-surface presentation rule (below).

MainView measures its window via a background `GeometryReader` → `PreferenceKey` (iOS 17-compatible; `onGeometryChange` is iOS 18+), so rotation, Split View divider drags, and window resizing re-resolve the layout live.

### One SidebarView, one chat shell

- The persistent branch is `HStack(spacing: 0) { SidebarView(presentation: .persistent) | Divider | chat }`; the drawer branch is the existing shell with the existing `.sheet(isPresented: $appState.showSidebar)`.
- The chat `NavigationStack`, backdrop, and toolbar are a single shared computed view — **no duplicated chat toolbar**. The hamburger and left-edge `EdgePanGesture` are conditional inside the shared shell: hidden while the persistent sidebar is visible, restored verbatim in drawer/compact mode. The iPhone path is unchanged line-for-line.
- `SidebarView` gains a `presentation` parameter (default `.drawer`, so every existing call site is untouched). Persistent mode hides the X close button; nothing else about the sidebar is redesigned. A 1 pt `Divider` (extended through the safe areas) is the only added framing; the sidebar's existing backdrop already bleeds edge-to-edge.

### `appState.showSidebar` semantics preserved

`showSidebar`'s `didSet` cancels/flushes streaming and reasoning publication, so it must keep meaning *transient drawer presentation*. The persistent column **never** sets it:

- All six in-sidebar session-opening flows (New Chat, session rows, project sheet rows + new-conversation, Cron recent runs, Cron job run history) now call the new `AppState.dismissSidebarDrawer()` — a guard-then-close helper that is a no-op when the drawer isn't presented. Drawer mode behaves identically; persistent mode leaves the column visible while the conversation opens.
- A transition guard (`.onChange(of: isPersistentSidebarActive)`) dismisses the drawer if the layout flips to persistent while the sheet is open (rotation past the threshold, Split View drag, or enabling the toggle) — otherwise `showSidebar` would stay `true` with no sheet, silently suppressing streaming publication.

### Settings and preferred return surface

- Drawer mode: tap Settings → close drawer → present Settings (existing sequencing, unchanged).
- Persistent mode: tap Settings → sidebar stays visible → the same `SettingsView` sheet presents directly (`isSettingsSheetPresented` set before the snapshot, matching existing precedence semantics).
- `presentPreferredReturnSurfaceIfNeeded` still claims the request exactly once via `claimPreferredReturnSurfacePresentation()` (consumption/deferral semantics untouched in AppState), then consults the policy: an active persistent sidebar consumes the request without opening a redundant drawer; drawer layouts re-present exactly as before.

## Scope exclusions

- No `NavigationSplitView` conversion, no app-wide navigation redesign, no second session list, no session state moved out of `AppState`, no Settings/SidebarView redesign, no Hermes server/profile changes, no phone UI changes, no unrelated cleanup.

## Tests

New `ConduitTests/SidebarLayoutTests` (9 tests, no UI host):

- phone ± preference at any width → drawer
- iPad + preference off at any width → drawer
- iPad + preference on + wide (768/834/1024/1194/1366) → persistent
- iPad + preference on + narrow (0/320/417/512/683/749) → drawer
- threshold identity + exact 750 (persistent) / 749 (drawer) boundary
- return-surface: persistent active → never presents the drawer; drawer layout → presents unless already presented
- `dismissSidebarDrawer()`: closes an open drawer; no-op when closed (persistent mode requires no `showSidebar` activity)

## Verification

- `python scripts/plan-tests.py validate` → OK, `SidebarLayoutTests` discovered; `python -m unittest discover -s scripts/tests` → 73 tests OK.
- `git diff --check` clean (no lint/format tooling in repo).
- Mac build host (bundle → temp worktree at `ef1fd45` → `xcodegen generate` → focused `xcodebuild test`, iPhone 17 Pro simulator, signing disabled): **all 9 `SidebarLayoutTests` passed; all 23 `ChatReturnSurfaceTests` passed** (the drawer/return-surface suite most affected by this area). Several runs exited 65 with `** TEST FAILED **` but **zero assertion failures** — the host's known AURemoteIO coreaudio deadlock killed the app host mid-run; per established practice the started-but-unreported cases were re-run in smaller batches and every one passed (final solo run `TEST SUCCEEDED`).
- Diff reviewed specifically for accidental iPhone-path changes (none — the compact shell's modifiers and order are identical).
- Review gate: 3-model cycle run on this exact diff; reviewer 1 REQUEST CHANGES (transition guard + one NIT — both fixed), reviewer 2 APPROVE (two suggestions rejected as out of scope / mismatched to code; noted in thread). Hosted CI remains the authoritative full-suite gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional persistent sessions sidebar layout for iPad on sufficiently wide windows.
  * Added a Layout setting to enable or disable the persistent sidebar.
  * Sidebar presentation now adapts between a persistent column and a dismissible drawer based on device and available space.
  * Selecting a session from the sidebar now dismisses the drawer when applicable.

* **Bug Fixes**
  * Prevented drawer state from remaining active when the persistent sidebar is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->