### PR TITLE
feat(login): classify connection failures and add Connection Setup entry point

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2468,10 +2468,35 @@ final class AppState: ObservableObject {
         }
     }
 
-    /// Forces the sign-in screen with a message destined for the login card.
-    /// Internal (not private) so the typed pending-failure handoff contract
-    /// stays unit-testable.
+    /// Classification seam for the silent-renewal sign-in handoff: when a
+    /// saved-password re-auth was attempted and failed, that error (429
+    /// throttle, 401 rejection, 503 outage) explains far more than the bare
+    /// bridge signInRequired. The winning error is classified — never
+    /// rendered via errorDescription. Internal for unit testing.
+    static func silentRenewalSignInFailure(
+        reauthError: Error?,
+        bridgeError: Error
+    ) -> ConnectionFailurePresentation {
+        .presenting(ConnectionFailureClassifier.classify(reauthError ?? bridgeError))
+    }
+
+    /// Forces the sign-in screen with a classified failure presentation.
+    /// Prefer this overload whenever the failure derives from an Error — the
+    /// full presentation (title, actions, help routing) reaches the login
+    /// card untouched.
+    func requireSignIn(failure: ConnectionFailurePresentation) {
+        performSignInRequired(pendingFailure: failure)
+    }
+
+    /// Forces the sign-in screen with a human-authored notice message. Only
+    /// for genuinely hand-written strings — Error-derived text must go
+    /// through requireSignIn(failure:) so it is classified, never rendered
+    /// raw.
     func requireSignIn(message: String) {
+        performSignInRequired(pendingFailure: .notice(title: "Sign-in didn’t complete", message: message))
+    }
+
+    private func performSignInRequired(pendingFailure: ConnectionFailurePresentation) {
         cancelChatResumeTransportRecovery()
         invalidateReconciliation()
         cancelSecondaryProfileTitleRecovery()
@@ -2499,11 +2524,7 @@ final class AppState: ObservableObject {
         // connected-era error from resurfacing stale after re-login.
         errorMessage = nil
         showLogin = true
-        // Typed handoff to the login card (consumed once there). Deliberately
-        // NOT errorMessage: that string feeds the connected composer banner,
-        // where a stale sign-in message would outlive the successful
-        // re-login that follows this screen.
-        pendingLoginFailure = .notice(title: "Sign-in didn’t complete", message: message)
+        pendingLoginFailure = pendingFailure
     }
 
     // MARK: - Authoritative reconciliation
@@ -4352,6 +4373,7 @@ final class AppState: ObservableObject {
         } catch {
             guard refreshTransportContinuation() else { return }
             if let bridgeError = error as? DashboardTicketBridgeError, case .signInRequired = bridgeError {
+                var silentRenewalReauthError: Error?
                 if let credentials = KeychainHelper.loadCredentials(),
                    credentials.baseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/")) == savedConnection.baseUrl.trimmingCharacters(in: CharacterSet(charactersIn: "/")) {
                     do {
@@ -4376,12 +4398,22 @@ final class AppState: ObservableObject {
                         return
                     } catch {
                         guard refreshTransportContinuation() else { return }
-                        // This only determines whether recovery can be silent.
-                        // Preserve the saved credentials for the login screen.
+                        // The silent re-auth failure (429 throttle, 401
+                        // rejection, 503 outage…) is the most diagnostic
+                        // explanation for the forced sign-in; carry it to the
+                        // classifier. This only determines whether recovery
+                        // can be silent. Preserve the saved credentials for
+                        // the login screen.
+                        silentRenewalReauthError = error
                     }
                 }
                 guard refreshTransportContinuation() else { return }
-                requireSignIn(message: error.localizedDescription)
+                requireSignIn(
+                    failure: Self.silentRenewalSignInFailure(
+                        reauthError: silentRenewalReauthError,
+                        bridgeError: error
+                    )
+                )
             } else {
                 guard refreshTransportContinuation() else { return }
                 isConnected = false

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2159,11 +2159,16 @@ final class AppState: ObservableObject {
         if cancelsResumeRestoration {
             cancelChatResumeTransportRecovery()
         }
-        guard let normalizedBaseURL = try? ConnectionURLPolicy.normalizedBaseURL(conn.baseUrl) else {
+        // Preserve which URL-policy rule failed instead of reporting every
+        // normalization failure as insecure transport.
+        let normalizedBaseURL: String
+        do {
+            normalizedBaseURL = try ConnectionURLPolicy.normalizedBaseURL(conn.baseUrl)
+        } catch {
             isConnecting = false
             isConnected = false
             showLogin = true
-            errorMessage = ConnectionURLPolicyError.insecureTransport.localizedDescription
+            errorMessage = error.localizedDescription
             return
         }
         prepareChatResumeForConnection(to: normalizedBaseURL)
@@ -2436,8 +2441,11 @@ final class AppState: ObservableObject {
         } catch {
             // A rejected saved password falls back to the native login screen
             // without erasing it, allowing the user to correct the account.
+            // Classified copy instead of raw Foundation strings.
             showLogin = true
-            errorMessage = error.localizedDescription
+            errorMessage = ConnectionFailurePresentation
+                .presenting(ConnectionFailureClassifier.classify(error))
+                .message
         }
     }
 

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -755,6 +755,14 @@ final class AppState: ObservableObject {
     /// tell whether Settings owns the surface across a background/foreground cycle.
     @Published var isSettingsSheetPresented = false
     @Published var errorMessage: String?
+    /// A classified sign-in failure awaiting presentation on the login card.
+    /// Typed (not a string) so LoginView renders the full presentation —
+    /// title, actions, help routing — and delivered as a publisher so the
+    /// handoff works even when LoginView is already mounted (onReceive fires
+    /// on new emissions and replays the current value on mount). Consumed
+    /// once by LoginView; never read by the connected composer banner, so a
+    /// sign-in failure cannot resurface stale over a healthy session.
+    @Published var pendingLoginFailure: ConnectionFailurePresentation?
     @Published var showLogin = true
     @Published private(set) var composerPrefillText = ""
     @Published private(set) var composerPrefillToken = UUID()
@@ -2160,7 +2168,8 @@ final class AppState: ObservableObject {
             cancelChatResumeTransportRecovery()
         }
         // Preserve which URL-policy rule failed instead of reporting every
-        // normalization failure as insecure transport.
+        // normalization failure as insecure transport, and hand the login
+        // card a typed classified presentation rather than a string.
         let normalizedBaseURL: String
         do {
             normalizedBaseURL = try ConnectionURLPolicy.normalizedBaseURL(conn.baseUrl)
@@ -2168,7 +2177,7 @@ final class AppState: ObservableObject {
             isConnecting = false
             isConnected = false
             showLogin = true
-            errorMessage = error.localizedDescription
+            pendingLoginFailure = .presenting(ConnectionFailureClassifier.classify(error))
             return
         }
         prepareChatResumeForConnection(to: normalizedBaseURL)
@@ -2441,11 +2450,10 @@ final class AppState: ObservableObject {
         } catch {
             // A rejected saved password falls back to the native login screen
             // without erasing it, allowing the user to correct the account.
-            // Classified copy instead of raw Foundation strings.
+            // The typed classified handoff replaces the old string write, so
+            // the composer banner never inherits a stale sign-in message.
             showLogin = true
-            errorMessage = ConnectionFailurePresentation
-                .presenting(ConnectionFailureClassifier.classify(error))
-                .message
+            pendingLoginFailure = .presenting(ConnectionFailureClassifier.classify(error))
         }
     }
 
@@ -2458,7 +2466,10 @@ final class AppState: ObservableObject {
         }
     }
 
-    private func requireSignIn(message: String) {
+    /// Forces the sign-in screen with a message destined for the login card.
+    /// Internal (not private) so the typed pending-failure handoff contract
+    /// stays unit-testable.
+    func requireSignIn(message: String) {
         cancelChatResumeTransportRecovery()
         invalidateReconciliation()
         cancelSecondaryProfileTitleRecovery()
@@ -2482,7 +2493,11 @@ final class AppState: ObservableObject {
         turnState = .idle
         retireOutstandingPreferredReturnSurfaceRequests()
         showLogin = true
-        errorMessage = message
+        // Typed handoff to the login card (consumed once there). Deliberately
+        // NOT errorMessage: that string feeds the connected composer banner,
+        // where a stale sign-in message would outlive the successful
+        // re-login that follows this screen.
+        pendingLoginFailure = .notice(title: "Sign-in didn’t complete", message: message)
     }
 
     // MARK: - Authoritative reconciliation

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2475,9 +2475,10 @@ final class AppState: ObservableObject {
     /// rendered via errorDescription. Internal for unit testing.
     static func silentRenewalSignInFailure(
         reauthError: Error?,
-        bridgeError: Error
+        bridgeError: DashboardTicketBridgeError
     ) -> ConnectionFailurePresentation {
-        .presenting(ConnectionFailureClassifier.classify(reauthError ?? bridgeError))
+        .presenting(reauthError.map(ConnectionFailureClassifier.classify)
+            ?? ConnectionFailureClassifier.classify(bridgeError))
     }
 
     /// Forces the sign-in screen with a classified failure presentation.
@@ -4396,6 +4397,11 @@ final class AppState: ObservableObject {
                         )
                         guard refreshTransportContinuation() else { return }
                         return
+                    } catch is CancellationError {
+                        // A superseded reconnect owns the flow from here; do
+                        // not force the user to the sign-in card for an
+                        // intentional cancellation.
+                        return
                     } catch {
                         guard refreshTransportContinuation() else { return }
                         // The silent re-auth failure (429 throttle, 401
@@ -4411,7 +4417,7 @@ final class AppState: ObservableObject {
                 requireSignIn(
                     failure: Self.silentRenewalSignInFailure(
                         reauthError: silentRenewalReauthError,
-                        bridgeError: error
+                        bridgeError: bridgeError
                     )
                 )
             } else {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2249,6 +2249,8 @@ final class AppState: ObservableObject {
             handedOffAutomaticIntent = continuation.handedOffAutomaticIntent
             isConnected = true
             isConnecting = false
+            // A fresh healthy session never inherits an older banner error.
+            errorMessage = nil
             reconnectAttempts = 0
             connectedAt = Date()
             KeychainHelper.saveConnection(conn)
@@ -2492,6 +2494,10 @@ final class AppState: ObservableObject {
         KeychainHelper.clearConnection()
         turnState = .idle
         retireOutstandingPreferredReturnSurfaceRequests()
+        // The banner content belonged to the session being torn down; with
+        // the LoginView onAppear consume gone, this is what keeps a
+        // connected-era error from resurfacing stale after re-login.
+        errorMessage = nil
         showLogin = true
         // Typed handoff to the login card (consumed once there). Deliberately
         // NOT errorMessage: that string feeds the connected composer banner,
@@ -4400,6 +4406,8 @@ final class AppState: ObservableObject {
                   let activeClient = self.client, activeClient === client else { return }
             isConnected = true
             isConnecting = false
+            // A fresh healthy session never inherits an older banner error.
+            errorMessage = nil
             reconnectAttempts = 0
             connectedAt = Date()
             guard let continuation = await synchronizeTransportContinuation(

--- a/Conduit/Services/ConnectionFailure.swift
+++ b/Conduit/Services/ConnectionFailure.swift
@@ -1,0 +1,281 @@
+//
+//  ConnectionFailure.swift
+//  Conduit
+//
+//  Semantic classification of failed login/connection attempts (Round 1 of
+//  the Connection Setup foundation). The login UI must never present raw
+//  Foundation error strings: every failure that can surface on the login
+//  screen is classified here from its underlying error TYPE or transport
+//  code — never from localized text — and mapped to user-facing copy plus a
+//  Connection Help destination for the future Connection Setup Assistant.
+//
+
+import Foundation
+
+/// The semantic failure categories the login/connection pipeline can produce.
+enum ConnectionFailure: Equatable {
+    // Address/transport policy (ConnectionURLPolicy).
+    case invalidAddress
+    case insecureTransport
+
+    // Network reachability.
+    case hostNotFound
+    case unreachable
+    case connectionRefused
+    case timedOut
+    case offline
+
+    // TLS (classified, never bypassed — issue #129).
+    case tlsUntrusted
+    case tlsBadDate
+    case tlsFailure
+
+    // Authentication stages.
+    case authenticationRejected
+    /// Hermes throttles `/auth/password-login` (10 attempts / 60s / client
+    /// IP, HTTP 429). Distinct from `.authenticationRejected`: a throttle is
+    /// not a wrong password, and the copy must not invite immediate retries.
+    case rateLimited
+    case cloudflareTokenRejected
+    case sessionTicketFailure
+
+    // Server-side responses.
+    case dashboardUnavailable
+    case unexpectedServerResponse
+
+    case unknown
+}
+
+/// Maps the errors that can escape the login pipeline onto `ConnectionFailure`
+/// by inspecting error types and `URLError` codes — never localized strings.
+enum ConnectionFailureClassifier {
+    /// Authentication stage context: the same HTTP status means different
+    /// things at provider discovery than at password login. A 401 during
+    /// provider discovery is NOT evidence of bad credentials.
+    private enum AuthStage {
+        case providerDiscovery
+        case passwordLogin
+    }
+
+    static func classify(_ error: Error) -> ConnectionFailure {
+        if let policyError = error as? ConnectionURLPolicyError {
+            return classify(policyError)
+        }
+        if let authError = error as? AuthClientError {
+            return classify(authError)
+        }
+        if let urlError = error as? URLError {
+            return classify(urlError)
+        }
+        // URLSession surfaces transport failures as NSError values in the
+        // NSURLErrorDomain (e.g. injected through URLProtocol test seams).
+        // Recover the typed error so classification stays code-based even
+        // for bridged errors.
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain {
+            return classify(URLError(URLError.Code(rawValue: nsError.code)))
+        }
+        return .unknown
+    }
+
+    static func classify(_ policyError: ConnectionURLPolicyError) -> ConnectionFailure {
+        switch policyError {
+        case .invalidURL: return .invalidAddress
+        case .insecureTransport: return .insecureTransport
+        }
+    }
+
+    static func classify(_ authError: AuthClientError) -> ConnectionFailure {
+        switch authError {
+        case .invalidURL:
+            return .invalidAddress
+        case .loginFailed(let status, _):
+            return classifyHTTPStatus(status, stage: .passwordLogin)
+        case .ticketFailed:
+            // The password was accepted; whatever failed now is not a
+            // credentials problem. Never present this as "wrong password".
+            return .sessionTicketFailure
+        case .providerDiscoveryFailed(let status, _):
+            return classifyHTTPStatus(status, stage: .providerDiscovery)
+        case .cloudflareServiceTokenRejected:
+            return .cloudflareTokenRejected
+        }
+    }
+
+    static func classify(_ urlError: URLError) -> ConnectionFailure {
+        switch urlError.code {
+        case .badURL:
+            return .invalidAddress
+        case .appTransportSecurityRequiresSecureConnection:
+            return .insecureTransport
+        case .cannotFindHost, .dnsLookupFailed:
+            return .hostNotFound
+        case .cannotConnectToHost:
+            return .connectionRefused
+        case .timedOut:
+            return .timedOut
+        case .notConnectedToInternet, .internationalRoamingOff, .dataNotAllowed:
+            return .offline
+        case .networkConnectionLost:
+            return .unreachable
+        case .serverCertificateHasBadDate, .serverCertificateNotYetValid:
+            return .tlsBadDate
+        case .serverCertificateUntrusted, .serverCertificateHasUnknownRoot:
+            return .tlsUntrusted
+        case .secureConnectionFailed:
+            return .tlsFailure
+        default:
+            return .unknown
+        }
+    }
+
+    private static func classifyHTTPStatus(_ status: Int?, stage: AuthStage) -> ConnectionFailure {
+        guard let status else { return .unexpectedServerResponse }
+        if status == 429 {
+            // Hermes throttles password login per client IP. A throttle is
+            // never bad credentials, at any stage.
+            return .rateLimited
+        }
+        if stage == .passwordLogin, status == 401 || status == 403 {
+            // Only the password-authentication stage may claim "bad
+            // credentials"; 401s elsewhere are a misrouted/odd deployment.
+            return .authenticationRejected
+        }
+        if (500...599).contains(status) {
+            return .dashboardUnavailable
+        }
+        return .unexpectedServerResponse
+    }
+}
+
+/// Where the (future) Connection Setup Assistant should land when the user
+/// asks for help with a classified failure. The assistant itself does not
+/// exist yet; the destination is carried so adding it does not redesign
+/// error classification.
+enum ConnectionHelpDestination: Equatable, Hashable, Identifiable, CaseIterable {
+    case start
+    case dashboard
+    case credentials
+    case network
+    case tls
+    case cloudflare
+
+    var id: Self { self }
+}
+
+/// The login screen's presentation of one failure: concise user-facing copy
+/// plus, for classified connection failures, recovery actions. Validation
+/// notices (missing fields, empty URL) carry no actions.
+struct ConnectionFailurePresentation: Equatable {
+    let title: String
+    let message: String
+    let helpDestination: ConnectionHelpDestination?
+    /// Whether Try Again / Troubleshoot Connection actions accompany this
+    /// failure.
+    let offersRecoveryActions: Bool
+
+    /// Presentation for a classified connection failure, with recovery
+    /// actions and the classified help destination. Rate limiting is the one
+    /// exception: a "Try Again" button would encourage exactly the immediate
+    /// retry Hermes just throttled, so it offers no actions at all.
+    static func presenting(_ failure: ConnectionFailure) -> ConnectionFailurePresentation {
+        ConnectionFailurePresentation(
+            title: failure.userTitle,
+            message: failure.userMessage,
+            helpDestination: failure.helpDestination,
+            offersRecoveryActions: failure != .rateLimited
+        )
+    }
+
+    /// A validation notice (form-state feedback, not a connection failure).
+    /// No recovery actions: the fix is editing the form, not retrying.
+    static func notice(title: String, message: String = "") -> ConnectionFailurePresentation {
+        ConnectionFailurePresentation(
+            title: title,
+            message: message,
+            helpDestination: nil,
+            offersRecoveryActions: false
+        )
+    }
+}
+
+// MARK: - User-facing copy
+
+extension ConnectionFailure {
+    var userTitle: String {
+        switch self {
+        case .invalidAddress: return "Check the dashboard address"
+        case .insecureTransport: return "Insecure dashboard address"
+        case .hostNotFound: return "Dashboard not found"
+        case .unreachable, .connectionRefused: return "Couldn’t reach Hermes"
+        case .timedOut: return "Connection timed out"
+        case .offline: return "No network connection"
+        case .tlsUntrusted: return "Secure connection failed"
+        case .tlsBadDate: return "Certificate date problem"
+        case .tlsFailure: return "Secure connection failed"
+        case .authenticationRejected: return "Login failed"
+        case .rateLimited: return "Too many login attempts"
+        case .cloudflareTokenRejected: return "Cloudflare rejected the service token"
+        case .sessionTicketFailure: return "Could not start the session"
+        case .dashboardUnavailable: return "Dashboard unavailable"
+        case .unexpectedServerResponse: return "Unexpected response"
+        case .unknown: return "Couldn’t connect"
+        }
+    }
+
+    var userMessage: String {
+        switch self {
+        case .invalidAddress:
+            return "That doesn’t look like a dashboard URL Conduit can use. Check it for typos — it should look like https://hermes.example."
+        case .insecureTransport:
+            return "Remote dashboards must use HTTPS. Plain HTTP is only accepted for local addresses like localhost, private LAN IPs, and Tailscale."
+        case .hostNotFound:
+            return "Conduit could not find that host. Check the dashboard address and try again."
+        case .unreachable, .connectionRefused:
+            return "Conduit could not connect to the dashboard at this address. Make sure the dashboard is running and that this device can reach it."
+        case .timedOut:
+            return "The dashboard did not respond in time. Check the address, the network connection, and whether the Hermes dashboard is running."
+        case .offline:
+            return "This device doesn’t appear to have a network connection. Reconnect to Wi-Fi or cellular and try again."
+        case .tlsUntrusted:
+            return "Conduit reached the server, but iOS does not trust its TLS certificate. If you use your own certificate authority, make sure its root certificate is installed and trusted on this device."
+        case .tlsBadDate:
+            return "The dashboard certificate is expired or not yet valid. Check the certificate dates and this device’s date and time."
+        case .tlsFailure:
+            return "Conduit could not establish a secure connection to the dashboard. The server’s TLS certificate may be misconfigured."
+        case .authenticationRejected:
+            return "Hermes rejected that username or password. Check your dashboard credentials and try again."
+        case .rateLimited:
+            return "Hermes temporarily blocked additional login attempts. Wait about a minute before trying again."
+        case .cloudflareTokenRejected:
+            return "Cloudflare Access did not accept the configured service token. "
+                + "Verify the Client ID / Secret and that the token is allowed by a "
+                + "Service Auth policy for this Access application, or turn off "
+                + "\"Use Cloudflare Access service token\" to sign in interactively."
+        case .sessionTicketFailure:
+            return "Signing in succeeded, but Conduit could not start a Hermes session. The dashboard may be busy or restarting — try again."
+        case .dashboardUnavailable:
+            return "The dashboard is reachable but reported a server error. It may be restarting or unhealthy — try again in a moment."
+        case .unexpectedServerResponse:
+            return "The dashboard responded in a way Conduit didn’t expect. Make sure the address points at a Hermes dashboard."
+        case .unknown:
+            return "Something went wrong while connecting to the dashboard. Try again."
+        }
+    }
+
+    /// Where Troubleshoot Connection should land. `nil` where help would be
+    /// misleading (unknown failures) — no action is offered in that case.
+    var helpDestination: ConnectionHelpDestination? {
+        switch self {
+        case .invalidAddress: return .start
+        case .insecureTransport: return .dashboard
+        case .hostNotFound, .unreachable, .connectionRefused, .timedOut, .offline: return .network
+        case .tlsUntrusted, .tlsBadDate, .tlsFailure: return .tls
+        case .authenticationRejected: return .credentials
+        case .rateLimited: return nil
+        case .cloudflareTokenRejected: return .cloudflare
+        case .sessionTicketFailure, .dashboardUnavailable, .unexpectedServerResponse: return .dashboard
+        case .unknown: return nil
+        }
+    }
+}

--- a/Conduit/Services/ConnectionFailure.swift
+++ b/Conduit/Services/ConnectionFailure.swift
@@ -284,7 +284,7 @@ extension ConnectionFailure {
         case .rateLimited:
             return "Hermes temporarily blocked additional login attempts. Wait about a minute before trying again."
         case .loginRequired:
-            return "Your dashboard session has expired. Sign in again to reconnect."
+            return "Conduit needs you to sign in to the dashboard to reconnect."
         case .cloudflareTokenRejected:
             return "Cloudflare Access did not accept the configured service token. "
                 + "Verify the Client ID / Secret and that the token is allowed by a "

--- a/Conduit/Services/ConnectionFailure.swift
+++ b/Conduit/Services/ConnectionFailure.swift
@@ -36,6 +36,10 @@ enum ConnectionFailure: Equatable {
     /// IP, HTTP 429). Distinct from `.authenticationRejected`: a throttle is
     /// not a wrong password, and the copy must not invite immediate retries.
     case rateLimited
+    /// The dashboard bridge reports the WebKit session is gone (interactive
+    /// sign-in has expired or never happened). The login form itself is the
+    /// remedy — no troubleshooting destination would help.
+    case loginRequired
     case cloudflareTokenRejected
     case sessionTicketFailure
 
@@ -55,6 +59,9 @@ enum ConnectionFailureClassifier {
     private enum AuthStage {
         case providerDiscovery
         case passwordLogin
+        /// Dashboard-ticket bridge requests (WebKit-side ticket minting):
+        /// like provider discovery, a 401/403 here is never bad credentials.
+        case ticketMint
     }
 
     static func classify(_ error: Error) -> ConnectionFailure {
@@ -66,6 +73,9 @@ enum ConnectionFailureClassifier {
         }
         if let urlError = error as? URLError {
             return classify(urlError)
+        }
+        if let bridgeError = error as? DashboardTicketBridgeError {
+            return classify(bridgeError)
         }
         // URLSession surfaces transport failures as NSError values in the
         // NSURLErrorDomain (e.g. injected through URLProtocol test seams).
@@ -99,6 +109,20 @@ enum ConnectionFailureClassifier {
             return classifyHTTPStatus(status, stage: .providerDiscovery)
         case .cloudflareServiceTokenRejected:
             return .cloudflareTokenRejected
+        }
+    }
+
+    /// Dashboard-ticket bridge failures. signInRequired means the WebKit
+    /// sign-in session is gone — the login form itself is the remedy, so it
+    /// must classify as login-required rather than degrade to unknown.
+    static func classify(_ bridgeError: DashboardTicketBridgeError) -> ConnectionFailure {
+        switch bridgeError {
+        case .signInRequired:
+            return .loginRequired
+        case .http(let status, _):
+            return classifyHTTPStatus(status, stage: .ticketMint)
+        case .notReady, .requestFailed, .oversizedResponse:
+            return .unexpectedServerResponse
         }
     }
 
@@ -226,6 +250,7 @@ extension ConnectionFailure {
         case .tlsFailure: return "Secure connection failed"
         case .authenticationRejected: return "Login failed"
         case .rateLimited: return "Too many login attempts"
+        case .loginRequired: return "Sign-in required"
         case .cloudflareTokenRejected: return "Cloudflare rejected the service token"
         case .sessionTicketFailure: return "Could not start the session"
         case .dashboardUnavailable: return "Dashboard unavailable"
@@ -258,6 +283,8 @@ extension ConnectionFailure {
             return "Hermes rejected that username or password. Check your dashboard credentials and try again."
         case .rateLimited:
             return "Hermes temporarily blocked additional login attempts. Wait about a minute before trying again."
+        case .loginRequired:
+            return "Your dashboard session has expired. Sign in again to reconnect."
         case .cloudflareTokenRejected:
             return "Cloudflare Access did not accept the configured service token. "
                 + "Verify the Client ID / Secret and that the token is allowed by a "
@@ -284,6 +311,7 @@ extension ConnectionFailure {
         case .tlsUntrusted, .tlsBadDate, .tlsFailure: return .tls
         case .authenticationRejected: return .credentials
         case .rateLimited: return nil
+        case .loginRequired: return nil
         case .cloudflareTokenRejected: return .cloudflare
         case .sessionTicketFailure, .dashboardUnavailable, .unexpectedServerResponse: return .dashboard
         case .unknown: return nil

--- a/Conduit/Services/ConnectionFailure.swift
+++ b/Conduit/Services/ConnectionFailure.swift
@@ -118,6 +118,11 @@ enum ConnectionFailureClassifier {
             return .offline
         case .networkConnectionLost:
             return .unreachable
+        case .badServerResponse, .httpTooManyRedirects:
+            // NativeAuthClient.perform throws badServerResponse when no
+            // usable response arrives — a dashboard-behavior problem, not an
+            // unknown one.
+            return .unexpectedServerResponse
         case .serverCertificateHasBadDate, .serverCertificateNotYetValid:
             return .tlsBadDate
         case .serverCertificateUntrusted, .serverCertificateHasUnknownRoot:
@@ -253,7 +258,7 @@ extension ConnectionFailure {
                 + "Service Auth policy for this Access application, or turn off "
                 + "\"Use Cloudflare Access service token\" to sign in interactively."
         case .sessionTicketFailure:
-            return "Signing in succeeded, but Conduit could not start a Hermes session. The dashboard may be busy or restarting — try again."
+            return "Signing in succeeded, but Conduit could not start a Hermes session. The dashboard may be busy, restarting, or it did not accept the new session — try again."
         case .dashboardUnavailable:
             return "The dashboard is reachable but reported a server error. It may be restarting or unhealthy — try again in a moment."
         case .unexpectedServerResponse:

--- a/Conduit/Services/ConnectionFailure.swift
+++ b/Conduit/Services/ConnectionFailure.swift
@@ -136,15 +136,21 @@ enum ConnectionFailureClassifier {
 
     private static func classifyHTTPStatus(_ status: Int?, stage: AuthStage) -> ConnectionFailure {
         guard let status else { return .unexpectedServerResponse }
-        if status == 429 {
-            // Hermes throttles password login per client IP. A throttle is
-            // never bad credentials, at any stage.
-            return .rateLimited
-        }
-        if stage == .passwordLogin, status == 401 || status == 403 {
+        if stage == .passwordLogin {
+            // Only the endpoint Hermes actually throttles (/auth/password-login,
+            // 10 req/60s/IP) may claim the login-cooldown presentation. A 429
+            // from any other auth endpoint is unexpected server behavior, not
+            // a login cooldown — and retrying it does not consume the
+            // password-login budget, so its presentation keeps recovery
+            // actions.
+            if status == 429 {
+                return .rateLimited
+            }
             // Only the password-authentication stage may claim "bad
             // credentials"; 401s elsewhere are a misrouted/odd deployment.
-            return .authenticationRejected
+            if status == 401 || status == 403 {
+                return .authenticationRejected
+            }
         }
         if (500...599).contains(status) {
             return .dashboardUnavailable

--- a/Conduit/Services/NativeAuthClient.swift
+++ b/Conduit/Services/NativeAuthClient.swift
@@ -18,9 +18,13 @@ struct DashboardCredentials: Codable, Equatable {
 
 enum AuthClientError: LocalizedError {
     case invalidURL
-    case loginFailed(String)
-    case ticketFailed(String)
-    case providerDiscoveryFailed(String)
+    /// `status` is the HTTP status the dashboard answered with, or `nil` when
+    /// no HTTP response arrived. Carried on the error (rather than folded
+    /// into `detail`) so failure classification is code-based: 401/403 at the
+    /// password stage mean rejected credentials, while 5xx does not.
+    case loginFailed(status: Int?, detail: String)
+    case ticketFailed(status: Int?, detail: String)
+    case providerDiscoveryFailed(status: Int?, detail: String)
     /// A configured Cloudflare Access service token did not satisfy the
     /// edge: provider discovery was still answered with a redirect to the
     /// Cloudflare Access login page. Distinct from `.loginFailed`/`.ticketFailed`
@@ -32,11 +36,21 @@ enum AuthClientError: LocalizedError {
         switch self {
         case .invalidURL:
             return "Invalid dashboard URL."
-        case .loginFailed(let detail):
-            return "Login failed: \(detail)"
-        case .ticketFailed(let detail):
-            return "Could not get session ticket: \(detail)"
-        case .providerDiscoveryFailed(let detail):
+        case .loginFailed(let status, _):
+            // Never expose a bare "HTTP 401" as the credential-rejection
+            // message; other statuses keep the status for diagnosis (the
+            // presentation layer owns user-facing copy). 429 must not read
+            // as a credentials problem wherever this string surfaces.
+            if status == 429 {
+                return "Too many login attempts. Try again shortly."
+            }
+            if let status, !(401...403).contains(status) {
+                return "Login failed: HTTP \(status)"
+            }
+            return "Login failed. Check your dashboard credentials and try again."
+        case .ticketFailed(_, let detail):
+            return "Could not start the Hermes session: \(detail)"
+        case .providerDiscoveryFailed(_, let detail):
             return "Could not check dashboard sign-in options: \(detail)"
         case .cloudflareServiceTokenRejected:
             return "Cloudflare Access did not accept the configured service token. "
@@ -101,7 +115,7 @@ struct NativeAuthClient {
         let request = try request(path: "/api/auth/providers")
         let result = try await perform(request)
         guard let http = result.response as? HTTPURLResponse else {
-            throw AuthClientError.providerDiscoveryFailed("No response")
+            throw AuthClientError.providerDiscoveryFailed(status: nil, detail: "No response")
         }
         switch http.statusCode {
         case 301, 302, 303, 307, 308:
@@ -123,7 +137,10 @@ struct NativeAuthClient {
             break
         }
         guard (200...299).contains(http.statusCode) else {
-            throw AuthClientError.providerDiscoveryFailed(parseError(result.data) ?? "HTTP \(http.statusCode)")
+            throw AuthClientError.providerDiscoveryFailed(
+                status: http.statusCode,
+                detail: parseError(result.data) ?? "HTTP \(http.statusCode)"
+            )
         }
 
         if let json = try? JSONSerialization.jsonObject(with: result.data) as? [String: Any] {
@@ -144,13 +161,16 @@ struct NativeAuthClient {
 
         let result = try await perform(request)
         guard let http = result.response as? HTTPURLResponse else {
-            throw AuthClientError.loginFailed("No response")
+            throw AuthClientError.loginFailed(status: nil, detail: "No response")
         }
         guard (200...299).contains(http.statusCode) else {
-            throw AuthClientError.loginFailed(parseError(result.data) ?? "HTTP \(http.statusCode)")
+            throw AuthClientError.loginFailed(
+                status: http.statusCode,
+                detail: parseError(result.data) ?? "HTTP \(http.statusCode)"
+            )
         }
         guard http.url != nil else {
-            throw AuthClientError.loginFailed("Response URL missing")
+            throw AuthClientError.loginFailed(status: http.statusCode, detail: "Response URL missing")
         }
 
         // Redirect responses may set the session before the final JSON landing.
@@ -177,15 +197,18 @@ struct NativeAuthClient {
 
         let result = try await perform(request)
         guard let http = result.response as? HTTPURLResponse else {
-            throw AuthClientError.ticketFailed("No response")
+            throw AuthClientError.ticketFailed(status: nil, detail: "No response")
         }
         guard (200...299).contains(http.statusCode) else {
-            throw AuthClientError.ticketFailed(parseError(result.data) ?? "HTTP \(http.statusCode)")
+            throw AuthClientError.ticketFailed(
+                status: http.statusCode,
+                detail: parseError(result.data) ?? "HTTP \(http.statusCode)"
+            )
         }
         guard let json = try? JSONSerialization.jsonObject(with: result.data) as? [String: Any],
               let ticket = json["ticket"] as? String,
               !ticket.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw AuthClientError.ticketFailed("No ticket in response")
+            throw AuthClientError.ticketFailed(status: http.statusCode, detail: "No ticket in response")
         }
 
         // A deployment may rotate its session while minting the ticket. Keep
@@ -206,7 +229,8 @@ struct NativeAuthClient {
             // Fail here so an operator sees why, instead of an
             // indistinguishable ticket 401 downstream.
             throw AuthClientError.ticketFailed(
-                "Login succeeded but no host-scoped session cookie was accepted"
+                status: nil,
+                detail: "Login succeeded but no host-scoped session cookie was accepted"
             )
         }
         return try await mintWsTicket(authenticatedCookies: authenticatedCookies)

--- a/Conduit/Services/NativeAuthClient.swift
+++ b/Conduit/Services/NativeAuthClient.swift
@@ -44,7 +44,12 @@ enum AuthClientError: LocalizedError {
             if status == 429 {
                 return "Too many login attempts. Try again shortly."
             }
-            if let status, !(401...403).contains(status) {
+            guard let status else {
+                // No HTTP response arrived; the credentials were never
+                // evaluated and must not be blamed.
+                return "Login failed: no response from the dashboard."
+            }
+            if !(401...403).contains(status) {
                 return "Login failed: HTTP \(status)"
             }
             return "Login failed. Check your dashboard credentials and try again."

--- a/Conduit/Views/ConnectionSetupView.swift
+++ b/Conduit/Views/ConnectionSetupView.swift
@@ -1,0 +1,140 @@
+//
+//  ConnectionSetupView.swift
+//  Conduit
+//
+//  Round-1 shell for the Connection Setup Assistant. This is deliberately
+//  NOT the guided onboarding yet: it establishes the presentation mechanism
+//  the assistant will fill in — a destination-routed help surface reachable
+//  from the login card's entry point and from classified login failures —
+//  and offers static quick checks per destination.
+//
+
+import SwiftUI
+
+/// Placeholder shell for the Connection Setup Assistant. `initialDestination`
+/// comes from the login card's entry point (`.start`) or from a classified
+/// login failure's help destination, so later rounds can build the guided
+/// flows without touching error classification again.
+struct ConnectionSetupView: View {
+    let initialDestination: ConnectionHelpDestination
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var destination: ConnectionHelpDestination
+
+    init(initialDestination: ConnectionHelpDestination) {
+        self.initialDestination = initialDestination
+        _destination = State(initialValue: initialDestination)
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                content
+                    .padding(20)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .accessibilityIdentifier("connection-setup.content")
+            .navigationTitle("Connection Setup")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .accessibilityIdentifier("connection-setup.done")
+                }
+            }
+        }
+    }
+
+    private var content: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text("Guided setup for your self-hosted Hermes dashboard is coming here. Meanwhile, these quick checks cover the most common causes of failed connections.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Picker("Topic", selection: $destination) {
+                ForEach(ConnectionHelpDestination.allCases) { topic in
+                    Text(topic.displayName).tag(topic)
+                }
+            }
+            .font(.subheadline)
+
+            VStack(alignment: .leading, spacing: 14) {
+                ForEach(Array(destination.checks.enumerated()), id: \.offset) { _, check in
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "checkmark.circle")
+                            .font(.footnote)
+                            .foregroundStyle(.conduitAccent)
+                            .padding(.top, 2)
+                        Text(check)
+                            .font(.subheadline)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .conduitGlassSurface(cornerRadius: 18, tint: .conduitAura.opacity(0.06))
+        }
+    }
+}
+
+// MARK: - Per-destination quick checks
+
+extension ConnectionHelpDestination {
+    var displayName: String {
+        switch self {
+        case .start: return "Getting started"
+        case .dashboard: return "Dashboard address"
+        case .credentials: return "Credentials"
+        case .network: return "Network & reachability"
+        case .tls: return "HTTPS & certificates"
+        case .cloudflare: return "Cloudflare Access"
+        }
+    }
+
+    /// Static quick checks shown in the Round-1 shell. Safe-by-construction:
+    /// never recommends exposing the dashboard to the public internet or
+    /// weakening HTTPS. The guided walkthroughs (later rounds) replace these.
+    var checks: [String] {
+        switch self {
+        case .start:
+            return [
+                "The dashboard address should look like https://hermes.example — include any path prefix your reverse proxy uses (for example https://example.com/hermes).",
+                "Open the same address in Safari on this device. If the dashboard doesn’t load there, what you see is the same wall Conduit hits.",
+                "Remote dashboards must use HTTPS. Plain HTTP works only for localhost, private LAN addresses, and Tailscale."
+            ]
+        case .dashboard:
+            return [
+                "Confirm the address points at the Hermes dashboard itself, not another service on the same host.",
+                "Include custom ports (for example https://hermes.example:9119) and any reverse-proxy path prefix.",
+                "If the dashboard moved or its certificate changed, re-enter the full address from scratch."
+            ]
+        case .credentials:
+            return [
+                "Conduit needs the username and password you use to sign in to the Hermes dashboard — not a Cloudflare or Tailscale account.",
+                "Try signing in on the dashboard’s own web page to confirm the account still works.",
+                "If the password was rejected after a dashboard change, reset it where your dashboard manages users."
+            ]
+        case .network:
+            return [
+                "Make sure the Hermes dashboard is actually running on its host machine.",
+                "This device must be on the same network as the dashboard, or connected through Tailscale or a VPN. Tailscale Serve also gives you HTTPS for free.",
+                "Mobile hotspots and guest Wi-Fi often block device-to-device traffic — try another network.",
+                "Avoid opening the dashboard port directly to the internet; prefer Tailscale or an authenticated reverse proxy."
+            ]
+        case .tls:
+            return [
+                "If you use your own certificate authority, install and trust its root certificate on this device (Settings → General → VPN & Device Management → Certificate Trust Settings).",
+                "Check the server certificate’s expiration and validity dates.",
+                "Confirm this device’s date and time are correct."
+            ]
+        case .cloudflare:
+            return [
+                "Verify the Client ID and Secret belong to a Cloudflare Access service token for this application.",
+                "Make sure a Service Auth policy allows that token to reach this Access application.",
+                "Or turn off \"Use Cloudflare Access service token\" to sign in interactively through the in-app browser."
+            ]
+        }
+    }
+}

--- a/Conduit/Views/LoginView.swift
+++ b/Conduit/Views/LoginView.swift
@@ -87,6 +87,14 @@ struct LoginView: View {
             }
         }
         .onAppear {
+            // A classified sign-in failure from AppState (e.g. a rejected
+            // saved password at launch, or requireSignIn) surfaces here once
+            // and is consumed, so it cannot resurface stale in the connected
+            // composer banner later.
+            if let message = appState.errorMessage, !message.isEmpty {
+                failure = .notice(title: "Sign-in didn’t complete", message: message)
+                appState.errorMessage = nil
+            }
             guard serverUrl.isEmpty else { return }
             serverUrl = appState.lastDashboardURL
             if let access = KeychainHelper.loadCloudflareAccess(for: serverUrl) {
@@ -313,6 +321,7 @@ struct LoginView: View {
                                 Button("Try Again") {
                                     Task { await connect() }
                                 }
+                                .disabled(isConnecting)
                                 .accessibilityIdentifier("login.error.try-again")
 
                                 if let destination = failure.helpDestination {
@@ -382,6 +391,10 @@ struct LoginView: View {
 
     @MainActor
     private func connect() async {
+        // The Connect button is disabled while connecting, but Try Again and
+        // the return-key chain also reach this method: never let a second
+        // auth sequence run concurrently (Hermes throttles password login).
+        guard !isConnecting else { return }
         let cleaned = serverUrl.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !cleaned.isEmpty else {
             // The return-key chain can reach submit without the Connect
@@ -410,7 +423,10 @@ struct LoginView: View {
         do {
             normalized = try ConnectionURLPolicy.normalizedBaseURL(cleaned)
         } catch {
-            Self.logger.error("Login URL normalization failed: \(String(describing: error), privacy: .public)")
+            // Log the type-safe classification, never the raw error: its
+            // associated values can carry server-provided detail text that
+            // must not reach the unified log unredacted.
+            Self.logger.error("Login URL normalization failed: \(String(describing: ConnectionFailureClassifier.classify(error)), privacy: .public)")
             failure = .presenting(ConnectionFailureClassifier.classify(error))
             return
         }
@@ -447,7 +463,7 @@ struct LoginView: View {
         } catch is CancellationError {
             return
         } catch {
-            Self.logger.error("Login connection failed: \(String(describing: error), privacy: .public)")
+            Self.logger.error("Login connection failed: \(String(describing: ConnectionFailureClassifier.classify(error)), privacy: .public)")
             failure = .presenting(ConnectionFailureClassifier.classify(error))
         }
     }

--- a/Conduit/Views/LoginView.swift
+++ b/Conduit/Views/LoginView.swift
@@ -98,7 +98,9 @@ struct LoginView: View {
         .onReceive(appState.$pendingLoginFailure) { pending in
             // Typed handoff from AppState (rejected saved password,
             // requireSignIn). Unlike an onAppear string read, this fires even
-            // when the login card is already mounted. Consume once.
+            // when the login card is already mounted; @Published guarantees
+            // the current value replays to this new subscriber on mount, so
+            // both orderings are covered. Consume once.
             guard let pending else { return }
             failure = pending
             appState.pendingLoginFailure = nil
@@ -125,9 +127,12 @@ struct LoginView: View {
                 },
                 onError: { classifiedFailure, detail in
                     // Fixed classified copy only — the dashboard-provided
-                    // detail is diagnostic (default os privacy redacts it in
-                    // release builds) and never reaches the login card.
-                    Self.logger.error("Auth WebView sign-in error: \(detail)")
+                    // detail is logged for diagnosis (default os privacy
+                    // redacts it in release builds) and never reaches the
+                    // login card.
+                    Self.logger.error(
+                        "Auth WebView sign-in error: \(String(describing: classifiedFailure), privacy: .public) detail: \(detail)"
+                    )
                     failure = .presenting(classifiedFailure)
                 }
             )

--- a/Conduit/Views/LoginView.swift
+++ b/Conduit/Views/LoginView.swift
@@ -619,10 +619,11 @@ struct AuthWebView: UIViewRepresentable {
     /// callback so the deferral contract stays unit-testable.
     static func reportConstructionFailure(
         _ onError: @escaping (ConnectionFailure, String) -> Void,
-        detail: String
+        detail: String,
+        failure: ConnectionFailure = .invalidAddress
     ) {
         DispatchQueue.main.async {
-            onError(.invalidAddress, detail)
+            onError(failure, detail)
         }
     }
 

--- a/Conduit/Views/LoginView.swift
+++ b/Conduit/Views/LoginView.swift
@@ -87,14 +87,6 @@ struct LoginView: View {
             }
         }
         .onAppear {
-            // A classified sign-in failure from AppState (e.g. a rejected
-            // saved password at launch, or requireSignIn) surfaces here once
-            // and is consumed, so it cannot resurface stale in the connected
-            // composer banner later.
-            if let message = appState.errorMessage, !message.isEmpty {
-                failure = .notice(title: "Sign-in didn’t complete", message: message)
-                appState.errorMessage = nil
-            }
             guard serverUrl.isEmpty else { return }
             serverUrl = appState.lastDashboardURL
             if let access = KeychainHelper.loadCloudflareAccess(for: serverUrl) {
@@ -102,6 +94,14 @@ struct LoginView: View {
                 cloudflareClientID = access.clientID
                 cloudflareClientSecret = access.clientSecret
             }
+        }
+        .onReceive(appState.$pendingLoginFailure) { pending in
+            // Typed handoff from AppState (rejected saved password,
+            // requireSignIn). Unlike an onAppear string read, this fires even
+            // when the login card is already mounted. Consume once.
+            guard let pending else { return }
+            failure = pending
+            appState.pendingLoginFailure = nil
         }
         .sheet(item: $connectionSetupDestination) { destination in
             ConnectionSetupView(initialDestination: destination)
@@ -123,8 +123,12 @@ struct LoginView: View {
                     await appState.connect(with: HermesConnection(baseUrl: baseUrl, ticket: ticket))
                 }
                 },
-                onError: { message in
-                    failure = .notice(title: "Sign-in didn’t complete", message: message)
+                onError: { classifiedFailure, detail in
+                    // Fixed classified copy only — the dashboard-provided
+                    // detail is diagnostic (default os privacy redacts it in
+                    // release builds) and never reaches the login card.
+                    Self.logger.error("Auth WebView sign-in error: \(detail)")
+                    failure = .presenting(classifiedFailure)
                 }
             )
         }
@@ -572,7 +576,10 @@ struct AuthWebView: UIViewRepresentable {
     let url: String
     let cloudflareAccess: CloudflareAccessCredentials?
     let onTicket: (String, String) -> Void
-    let onError: (String) -> Void
+    /// Classified failure + raw diagnostic detail. The dashboard controls the
+    /// detail text (e.g. `payload["error"]`), so it is never rendered — the
+    /// login card shows only the fixed copy for the classification.
+    let onError: (ConnectionFailure, String) -> Void
 
     func makeUIView(context: Context) -> WKWebView {
         let normalized = try? ConnectionURLPolicy.normalizedBaseURL(url)
@@ -589,13 +596,13 @@ struct AuthWebView: UIViewRepresentable {
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
         guard let normalized else {
-            onError(ConnectionURLPolicyError.invalidURL.localizedDescription)
+            onError(.invalidAddress, "dashboard URL failed normalization in AuthWebView")
             return webView
         }
         if let request = try? Self.dashboardRequest(normalizedBaseURL: normalized, cloudflareAccess: cloudflareAccess) {
             webView.load(request)
         } else {
-            onError(ConnectionURLPolicyError.invalidURL.localizedDescription)
+            onError(.invalidAddress, "dashboard sign-in request construction failed")
         }
         return webView
     }
@@ -693,8 +700,13 @@ struct AuthWebView: UIViewRepresentable {
             let status = payload["status"] as? Int ?? 0
             guard status != 401 else { return } // The dashboard is still showing its sign-in route.
             guard let ticket = payload["ticket"] as? String, !ticket.isEmpty else {
+                // The classification is Conduit's, never the payload's: a
+                // completed dashboard sign-in that fails to mint a ticket is
+                // a session-ticket failure regardless of what the payload
+                // says. Payload text is carried as diagnostic detail only.
                 let detail = payload["error"] as? String
-                parent.onError(detail ?? "Unable to start the Hermes session\(status == 0 ? "" : " (\(status))").")
+                    ?? "Unable to start the Hermes session\(status == 0 ? "" : " (\(status))")"
+                parent.onError(.sessionTicketFailure, detail)
                 return
             }
             // Persist the HttpOnly dashboard session before dismissing this

--- a/Conduit/Views/LoginView.swift
+++ b/Conduit/Views/LoginView.swift
@@ -9,8 +9,11 @@
 
 import SwiftUI
 import WebKit
+import os
 
 struct LoginView: View {
+    private static let logger = Logger(subsystem: "com.milim.relay", category: "login")
+
     @EnvironmentObject var appState: AppState
     @Environment(\.colorScheme) private var colorScheme
     @State private var serverUrl = ""
@@ -23,7 +26,13 @@ struct LoginView: View {
     @State var cloudflareClientSecret = ""
     @State private var isConnecting = false
     @State private var showWebView = false
-    @State private var error: String?
+    /// The presented failure state: classified connection failures with
+    /// recovery actions, or plain validation notices. The view never renders
+    /// raw Foundation error strings directly.
+    @State private var failure: ConnectionFailurePresentation?
+    /// Non-nil presents the Connection Setup shell, pre-seeded with the
+    /// classified help destination (or `.start` from the entry point).
+    @State private var connectionSetupDestination: ConnectionHelpDestination?
     /// Set only by the user's Cloudflare toggle (never by the onAppear
     /// Keychain restore), so a returning saved-token user is not scrolled
     /// away from the top of the form every time the login screen appears.
@@ -86,6 +95,9 @@ struct LoginView: View {
                 cloudflareClientSecret = access.clientSecret
             }
         }
+        .sheet(item: $connectionSetupDestination) { destination in
+            ConnectionSetupView(initialDestination: destination)
+        }
         .sheet(isPresented: $showWebView) {
             AuthWebView(
                 url: serverUrl,
@@ -104,7 +116,7 @@ struct LoginView: View {
                 }
                 },
                 onError: { message in
-                    error = message
+                    failure = .notice(title: "Sign-in didn’t complete", message: message)
                 }
             )
         }
@@ -141,6 +153,37 @@ struct LoginView: View {
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.conduitAccent)
 
+                // Connection Setup entry point (visible, secondary to
+                // Connect, never auto-opened). Round 1 opens the shell;
+                // the guided assistant fills it in later.
+                Button {
+                    connectionSetupDestination = .start
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: "questionmark.circle")
+                            .font(.body)
+                            .foregroundStyle(.conduitAccent)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text("Need help connecting?")
+                                .font(.footnote.weight(.semibold))
+                                .foregroundStyle(.primary)
+                            Text("Set up your Hermes connection")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer(minLength: 0)
+                        Image(systemName: "chevron.right")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.tertiary)
+                    }
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .conduitGlassSurface(cornerRadius: 14, tint: .conduitAura.opacity(0.06))
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("login.connection-setup")
+
                 TextField("https://hermes.example", text: $serverUrl)
                     .textContentType(.URL)
                     .textInputAutocapitalization(.never)
@@ -159,6 +202,7 @@ struct LoginView: View {
                     .textContentType(.username)
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
+                    .accessibilityIdentifier("login.username")
                     .submitLabel(LoginField.username.submitKeyboardLabel(cloudflareTokenEntryEnabled: cloudflareEnabled))
                     .focused($focusedField, equals: .username)
                     .onSubmit { handleSubmit(from: .username) }
@@ -169,6 +213,7 @@ struct LoginView: View {
 
                 SecureField("Password", text: $password)
                     .textContentType(.password)
+                    .accessibilityIdentifier("login.password")
                     .submitLabel(LoginField.password.submitKeyboardLabel(cloudflareTokenEntryEnabled: cloudflareEnabled))
                     .focused($focusedField, equals: .password)
                     .onSubmit { handleSubmit(from: .password) }
@@ -245,14 +290,40 @@ struct LoginView: View {
                     }
                 }
                 .padding(.horizontal, 2)
-                if let error {
-                    HStack(alignment: .top, spacing: 8) {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .font(.footnote)
-                        Text(error)
-                            .font(.footnote)
-                            .multilineTextAlignment(.leading)
-                            .fixedSize(horizontal: false, vertical: true)
+                if let failure {
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack(alignment: .top, spacing: 8) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .font(.footnote)
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(failure.title)
+                                    .font(.footnote.weight(.semibold))
+                                    .multilineTextAlignment(.leading)
+                                    .accessibilityIdentifier("login.error.title")
+                                if !failure.message.isEmpty {
+                                    Text(failure.message)
+                                        .font(.footnote)
+                                        .multilineTextAlignment(.leading)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                }
+                            }
+                        }
+                        if failure.offersRecoveryActions {
+                            HStack(spacing: 16) {
+                                Button("Try Again") {
+                                    Task { await connect() }
+                                }
+                                .accessibilityIdentifier("login.error.try-again")
+
+                                if let destination = failure.helpDestination {
+                                    Button("Troubleshoot Connection") {
+                                        connectionSetupDestination = destination
+                                    }
+                                    .accessibilityIdentifier("login.error.troubleshoot")
+                                }
+                            }
+                            .font(.footnote.weight(.semibold))
+                        }
                     }
                     .foregroundStyle(.red)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -317,7 +388,7 @@ struct LoginView: View {
             // button ever being enabled (e.g. a whitespace-only URL).
             // Surface the standard invalid-URL feedback instead of a silent
             // no-op.
-            error = ConnectionURLPolicyError.invalidURL.localizedDescription
+            failure = .notice(title: "Enter a valid dashboard URL.")
             focusedField = .server
             return
         }
@@ -327,17 +398,25 @@ struct LoginView: View {
         // password value itself is sent untrimmed.
         guard !username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
               !password.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            error = "Enter your dashboard username and password."
+            failure = .notice(title: "Enter your dashboard username and password.")
             focusedField = username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? .username : .password
             return
         }
-        guard let normalized = try? ConnectionURLPolicy.normalizedBaseURL(cleaned) else {
-            error = ConnectionURLPolicyError.insecureTransport.localizedDescription
+        // Preserve WHICH URL-policy rule failed: a malformed address and an
+        // insecure remote transport are different mistakes with different
+        // fixes, so they classify differently instead of collapsing into one
+        // insecure-transport message.
+        let normalized: String
+        do {
+            normalized = try ConnectionURLPolicy.normalizedBaseURL(cleaned)
+        } catch {
+            Self.logger.error("Login URL normalization failed: \(String(describing: error), privacy: .public)")
+            failure = .presenting(ConnectionFailureClassifier.classify(error))
             return
         }
         serverUrl = normalized
         appState.rememberDashboardURL(serverUrl)
-        error = nil
+        failure = nil
         isConnecting = true
         defer { isConnecting = false }
 
@@ -368,7 +447,8 @@ struct LoginView: View {
         } catch is CancellationError {
             return
         } catch {
-            self.error = error.localizedDescription
+            Self.logger.error("Login connection failed: \(String(describing: error), privacy: .public)")
+            failure = .presenting(ConnectionFailureClassifier.classify(error))
         }
     }
 

--- a/Conduit/Views/LoginView.swift
+++ b/Conduit/Views/LoginView.swift
@@ -601,15 +601,29 @@ struct AuthWebView: UIViewRepresentable {
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
         guard let normalized else {
-            onError(.invalidAddress, "dashboard URL failed normalization in AuthWebView")
+            Self.reportConstructionFailure(onError, detail: "dashboard URL failed normalization in AuthWebView")
             return webView
         }
         if let request = try? Self.dashboardRequest(normalizedBaseURL: normalized, cloudflareAccess: cloudflareAccess) {
             webView.load(request)
         } else {
-            onError(.invalidAddress, "dashboard sign-in request construction failed")
+            Self.reportConstructionFailure(onError, detail: "dashboard sign-in request construction failed")
         }
         return webView
+    }
+
+    /// Construction-time failures cannot synchronously mutate the owning
+    /// view's state: makeUIView runs inside SwiftUI's representable update
+    /// pass, and an immediate onError would write LoginView @State mid-render.
+    /// Report on the next main-runloop turn instead. Static with an injected
+    /// callback so the deferral contract stays unit-testable.
+    static func reportConstructionFailure(
+        _ onError: @escaping (ConnectionFailure, String) -> Void,
+        detail: String
+    ) {
+        DispatchQueue.main.async {
+            onError(.invalidAddress, detail)
+        }
     }
 
     /// The dashboard sign-in request the WebView boots with. Extracted so the

--- a/ConduitTests/AppStatePendingLoginFailureTests.swift
+++ b/ConduitTests/AppStatePendingLoginFailureTests.swift
@@ -88,6 +88,7 @@ final class AppStatePendingLoginFailureTests: XCTestCase {
             "A reconnect 429 must not surface raw AuthClientError.errorDescription"
         )
         XCTAssertEqual(presentation.offersRecoveryActions, false)
+        XCTAssertNil(presentation.helpDestination)
     }
 
     func testSilentRenewal401And503DoNotSurfaceRawErrorDescription() {
@@ -118,15 +119,33 @@ final class AppStatePendingLoginFailureTests: XCTestCase {
         XCTAssertFalse(outagePresentation.message.contains("HTTP 503"))
     }
 
-    func testSilentRenewalWithoutReauthAttemptStillClassifiesBridgeError() {
+    func testSilentRenewalWithoutReauthAttemptClassifiesBridgeSignInRequiredAsLoginRequired() {
         // No saved credentials → no re-auth attempt: the bare bridge
-        // signInRequired still gets a classified (graceful) presentation.
+        // signInRequired means the WebKit session expired. That must read as
+        // sign-in-required copy — never the unknown "Couldn't connect"
+        // degradation, and never a raw error string.
         let presentation = AppState.silentRenewalSignInFailure(
             reauthError: nil,
             bridgeError: DashboardTicketBridgeError.signInRequired
         )
-        XCTAssertFalse(presentation.title.isEmpty)
+        XCTAssertEqual(presentation.title, "Sign-in required")
+        XCTAssertEqual(
+            presentation.message,
+            "Your dashboard session has expired. Sign in again to reconnect."
+        )
         XCTAssertNil(presentation.helpDestination)
+    }
+
+    func testSilentRenewalOfflineReauthClassifiesAsOfflineWithNetworkHelp() {
+        // Reconnect during a Wi-Fi blip: the most visible non-HTTP reauth
+        // scenario gets the offline presentation, not unknown.
+        let presentation = AppState.silentRenewalSignInFailure(
+            reauthError: URLError(.notConnectedToInternet),
+            bridgeError: DashboardTicketBridgeError.signInRequired
+        )
+        XCTAssertEqual(presentation.title, "No network connection")
+        XCTAssertEqual(presentation.helpDestination, .network)
+        XCTAssertTrue(presentation.offersRecoveryActions)
     }
 
     func testRequireSignInFailureOverloadPreservesFullPresentation() {

--- a/ConduitTests/AppStatePendingLoginFailureTests.swift
+++ b/ConduitTests/AppStatePendingLoginFailureTests.swift
@@ -43,11 +43,28 @@ final class AppStatePendingLoginFailureTests: XCTestCase {
         )
         XCTAssertEqual(appState.pendingLoginFailure?.message, "Hermes rejected the saved session.")
         XCTAssertNil(appState.pendingLoginFailure?.helpDestination)
-        XCTAssertFalse(appState.pendingLoginFailure?.offersRecoveryActions ?? true)
+        XCTAssertEqual(appState.pendingLoginFailure?.offersRecoveryActions, false)
         XCTAssertNil(
             appState.errorMessage,
             "Login-bound failures must not leak into the connected composer banner"
         )
+    }
+
+    func testConnectPolicyFailureHandsOffTypedPendingFailure() async {
+        // The AppState.connect URL-policy guard is the third login-bound
+        // handoff site: a connection attempt whose base URL fails policy must
+        // land on the login card as a typed classified presentation — never
+        // as a raw string in errorMessage.
+        let appState = makeAppState()
+
+        await appState.connect(with: HermesConnection(baseUrl: "not a dashboard url", ticket: "ticket"))
+
+        XCTAssertTrue(appState.showLogin)
+        XCTAssertFalse(appState.isConnected)
+        XCTAssertFalse(appState.isConnecting)
+        XCTAssertEqual(appState.pendingLoginFailure?.title, "Check the dashboard address")
+        XCTAssertEqual(appState.pendingLoginFailure?.helpDestination, .start)
+        XCTAssertNil(appState.errorMessage)
     }
 
     func testPendingLoginFailureCarriesFullClassifiedPresentation() {

--- a/ConduitTests/AppStatePendingLoginFailureTests.swift
+++ b/ConduitTests/AppStatePendingLoginFailureTests.swift
@@ -1,0 +1,68 @@
+//
+//  AppStatePendingLoginFailureTests.swift
+//  Conduit
+//
+//  Regression coverage for the typed AppState → LoginView sign-in failure
+//  handoff. The old contract wrote a formatted string into
+//  `errorMessage`, which nothing on the login screen rendered and which the
+//  connected composer banner could later resurface stale. The handoff is now
+//  a typed `pendingLoginFailure` presentation, consumed once by LoginView.
+//
+
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class AppStatePendingLoginFailureTests: XCTestCase {
+    // MARK: - Harness
+
+    private func makeAppState() -> AppState {
+        let suite = "AppStatePendingLoginFailureTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Failed to create test UserDefaults suite")
+        }
+        addTeardownBlock { defaults.removePersistentDomain(forName: suite) }
+        return AppState(
+            defaults: defaults,
+            loadSavedConnection: false
+        )
+    }
+
+    // MARK: - requireSignIn typed handoff
+
+    func testRequireSignInHandsOffTypedPendingFailureInsteadOfStringError() {
+        let appState = makeAppState()
+
+        appState.requireSignIn(message: "Hermes rejected the saved session.")
+
+        XCTAssertTrue(appState.showLogin, "requireSignIn must land on the login screen")
+        XCTAssertEqual(
+            appState.pendingLoginFailure?.title,
+            "Sign-in didn’t complete",
+            "The requireSignIn handoff must arrive as a typed presentation, not a bare string"
+        )
+        XCTAssertEqual(appState.pendingLoginFailure?.message, "Hermes rejected the saved session.")
+        XCTAssertNil(appState.pendingLoginFailure?.helpDestination)
+        XCTAssertFalse(appState.pendingLoginFailure?.offersRecoveryActions ?? true)
+        XCTAssertNil(
+            appState.errorMessage,
+            "Login-bound failures must not leak into the connected composer banner"
+        )
+    }
+
+    func testPendingLoginFailureCarriesFullClassifiedPresentation() {
+        // The typed handoff preserves title/actions/destination — the round-1
+        // string handoff discarded all of that on the restore path.
+        let appState = makeAppState()
+        appState.pendingLoginFailure = .presenting(.authenticationRejected)
+
+        XCTAssertEqual(appState.pendingLoginFailure?.title, "Login failed")
+        XCTAssertEqual(appState.pendingLoginFailure?.helpDestination, .credentials)
+        XCTAssertTrue(appState.pendingLoginFailure?.offersRecoveryActions ?? false)
+    }
+
+    func testPendingLoginFailureStartsNilSoStaleFailuresCannotResurface() {
+        // A fresh login appearance must not inherit an older failure.
+        XCTAssertNil(makeAppState().pendingLoginFailure)
+    }
+}

--- a/ConduitTests/AppStatePendingLoginFailureTests.swift
+++ b/ConduitTests/AppStatePendingLoginFailureTests.swift
@@ -67,6 +67,93 @@ final class AppStatePendingLoginFailureTests: XCTestCase {
         XCTAssertNil(appState.errorMessage)
     }
 
+    // MARK: - Silent-renewal sign-in handoff
+
+    func testSilentRenewal429ClassifiesAsRateLimitedWithoutRawErrorDescription() {
+        let reauthError = AuthClientError.loginFailed(
+            status: 429,
+            detail: "Too many login attempts. Try again shortly."
+        )
+        let presentation = AppState.silentRenewalSignInFailure(
+            reauthError: reauthError,
+            bridgeError: DashboardTicketBridgeError.signInRequired
+        )
+        XCTAssertEqual(presentation.title, "Too many login attempts")
+        XCTAssertEqual(
+            presentation.message,
+            "Hermes temporarily blocked additional login attempts. Wait about a minute before trying again."
+        )
+        XCTAssertNotEqual(
+            presentation.message, reauthError.errorDescription,
+            "A reconnect 429 must not surface raw AuthClientError.errorDescription"
+        )
+        XCTAssertEqual(presentation.offersRecoveryActions, false)
+    }
+
+    func testSilentRenewal401And503DoNotSurfaceRawErrorDescription() {
+        // 401 during silent re-auth: the password was already known-good at
+        // some point, but the endpoint rejection is still the best
+        // explanation — presented as classified copy, never the raw string.
+        let rejection = AuthClientError.loginFailed(status: 401, detail: "HTTP 401")
+        let rejectedPresentation = AppState.silentRenewalSignInFailure(
+            reauthError: rejection,
+            bridgeError: DashboardTicketBridgeError.signInRequired
+        )
+        XCTAssertEqual(rejectedPresentation.title, "Login failed")
+        XCTAssertEqual(
+            rejectedPresentation.message,
+            "Hermes rejected that username or password. Check your dashboard credentials and try again."
+        )
+        XCTAssertNotEqual(rejectedPresentation.message, rejection.errorDescription)
+
+        // 503: server outage, distinct copy, raw "Login failed: HTTP 503"
+        // must never reach the card.
+        let outage = AuthClientError.loginFailed(status: 503, detail: "HTTP 503")
+        let outagePresentation = AppState.silentRenewalSignInFailure(
+            reauthError: outage,
+            bridgeError: DashboardTicketBridgeError.signInRequired
+        )
+        XCTAssertEqual(outagePresentation.title, "Dashboard unavailable")
+        XCTAssertNotEqual(outagePresentation.message, outage.errorDescription)
+        XCTAssertFalse(outagePresentation.message.contains("HTTP 503"))
+    }
+
+    func testSilentRenewalWithoutReauthAttemptStillClassifiesBridgeError() {
+        // No saved credentials → no re-auth attempt: the bare bridge
+        // signInRequired still gets a classified (graceful) presentation.
+        let presentation = AppState.silentRenewalSignInFailure(
+            reauthError: nil,
+            bridgeError: DashboardTicketBridgeError.signInRequired
+        )
+        XCTAssertFalse(presentation.title.isEmpty)
+        XCTAssertNil(presentation.helpDestination)
+    }
+
+    func testRequireSignInFailureOverloadPreservesFullPresentation() {
+        // The failure overload must carry the presentation through untouched
+        // (title, actions, destination) — unlike the message overload, which
+        // wraps hand-written strings in a generic notice.
+        let appState = makeAppState()
+        let presentation = AppState.silentRenewalSignInFailure(
+            reauthError: AuthClientError.loginFailed(status: 429, detail: "Too many login attempts"),
+            bridgeError: DashboardTicketBridgeError.signInRequired
+        )
+
+        appState.requireSignIn(failure: presentation)
+
+        XCTAssertTrue(appState.showLogin)
+        XCTAssertEqual(appState.pendingLoginFailure, presentation)
+        XCTAssertNil(appState.errorMessage)
+    }
+
+    func testRequireSignInMessageOverloadWrapsHumanAuthoredStringsAsNotice() {
+        let appState = makeAppState()
+        appState.requireSignIn(message: "Your dashboard session ended.")
+
+        XCTAssertEqual(appState.pendingLoginFailure?.title, "Sign-in didn’t complete")
+        XCTAssertEqual(appState.pendingLoginFailure?.message, "Your dashboard session ended.")
+    }
+
     func testPendingLoginFailureCarriesFullClassifiedPresentation() {
         // The typed handoff preserves title/actions/destination — the round-1
         // string handoff discarded all of that on the restore path.

--- a/ConduitTests/AppStatePendingLoginFailureTests.swift
+++ b/ConduitTests/AppStatePendingLoginFailureTests.swift
@@ -121,9 +121,10 @@ final class AppStatePendingLoginFailureTests: XCTestCase {
 
     func testSilentRenewalWithoutReauthAttemptClassifiesBridgeSignInRequiredAsLoginRequired() {
         // No saved credentials → no re-auth attempt: the bare bridge
-        // signInRequired means the WebKit session expired. That must read as
-        // sign-in-required copy — never the unknown "Couldn't connect"
-        // degradation, and never a raw error string.
+        // signInRequired covers both an expired WebKit session and no usable
+        // sign-in session at all, so the copy must stay neutral — never the
+        // unknown "Couldn't connect" degradation, never a raw error string,
+        // and no expiration claim either way.
         let presentation = AppState.silentRenewalSignInFailure(
             reauthError: nil,
             bridgeError: DashboardTicketBridgeError.signInRequired

--- a/ConduitTests/AppStatePendingLoginFailureTests.swift
+++ b/ConduitTests/AppStatePendingLoginFailureTests.swift
@@ -131,7 +131,7 @@ final class AppStatePendingLoginFailureTests: XCTestCase {
         XCTAssertEqual(presentation.title, "Sign-in required")
         XCTAssertEqual(
             presentation.message,
-            "Your dashboard session has expired. Sign in again to reconnect."
+            "Conduit needs you to sign in to the dashboard to reconnect."
         )
         XCTAssertNil(presentation.helpDestination)
     }

--- a/ConduitTests/AuthWebViewNavigationPolicyTests.swift
+++ b/ConduitTests/AuthWebViewNavigationPolicyTests.swift
@@ -52,6 +52,28 @@ final class AuthWebViewNavigationPolicyTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(received.first).1, "construction failed")
     }
 
+    func testConstructionFailurePassesExplicitFailureThroughDeferredReport() throws {
+        // The seam's failure parameter defaults to .invalidAddress (both
+        // current call sites are address-class), but an explicit failure must
+        // pass through untouched so a future construction failure of another
+        // class is not silently misclassified.
+        let reported = expectation(description: "deferred onError")
+        var received: (ConnectionFailure, String)?
+
+        AuthWebView.reportConstructionFailure(
+            { failure, detail in
+                received = (failure, detail)
+                reported.fulfill()
+            },
+            detail: "handshake collapsed",
+            failure: .tlsFailure
+        )
+        wait(for: [reported], timeout: 2)
+
+        XCTAssertEqual(try XCTUnwrap(received).0, .tlsFailure)
+        XCTAssertEqual(try XCTUnwrap(received).1, "handshake collapsed")
+    }
+
     // MARK: - Subframes (Turnstile / identity-provider operation)
 
     func testSubframeAboutBlankAndSrcdocAreAllowedForTurnstile() throws {

--- a/ConduitTests/AuthWebViewNavigationPolicyTests.swift
+++ b/ConduitTests/AuthWebViewNavigationPolicyTests.swift
@@ -27,6 +27,31 @@ final class AuthWebViewNavigationPolicyTests: XCTestCase {
         )
     }
 
+    // MARK: - Construction-failure deferral
+
+    func testConstructionFailureReportsOnNextMainRunloopTurnNotSynchronously() throws {
+        // makeUIView runs inside SwiftUI's representable update pass; a
+        // synchronous onError would mutate LoginView @State mid-render. The
+        // report must be deferred to the next main-runloop turn.
+        let reported = expectation(description: "deferred onError")
+        var received: [(ConnectionFailure, String)] = []
+
+        AuthWebView.reportConstructionFailure({ failure, detail in
+            received.append((failure, detail))
+            reported.fulfill()
+        }, detail: "construction failed")
+
+        XCTAssertTrue(
+            received.isEmpty,
+            "Construction failures must not invoke onError synchronously during the representable update pass"
+        )
+        waitForExpectations(timeout: 2)
+
+        XCTAssertEqual(received.count, 1)
+        XCTAssertEqual(try XCTUnwrap(received.first).0, .invalidAddress)
+        XCTAssertEqual(try XCTUnwrap(received.first).1, "construction failed")
+    }
+
     // MARK: - Subframes (Turnstile / identity-provider operation)
 
     func testSubframeAboutBlankAndSrcdocAreAllowedForTurnstile() throws {

--- a/ConduitTests/ConnectionFailureTests.swift
+++ b/ConduitTests/ConnectionFailureTests.swift
@@ -1,0 +1,375 @@
+//
+//  ConnectionFailureTests.swift
+//  Conduit
+//
+//  Unit coverage for the login connection-failure classification and
+//  presentation layer. Classification must be driven by real error types
+//  and Foundation error codes — never by localized-description text.
+//
+
+import XCTest
+@testable import Conduit
+
+final class ConnectionFailureTests: XCTestCase {
+    // MARK: - URL policy failures (real throw path)
+
+    func testMalformedURLClassifiesAsInvalidAddressPresentation() {
+        do {
+            _ = try ConnectionURLPolicy.normalizedBaseURL("not a dashboard url")
+            return XCTFail("Expected malformed URL to be rejected")
+        } catch {
+            let failure = ConnectionFailureClassifier.classify(error)
+            XCTAssertEqual(failure, .invalidAddress)
+            let presentation = ConnectionFailurePresentation.presenting(failure)
+            XCTAssertEqual(presentation.title, "Check the dashboard address")
+            XCTAssertFalse(presentation.message.isEmpty)
+            XCTAssertEqual(presentation.helpDestination, .start)
+            XCTAssertTrue(presentation.offersRecoveryActions)
+        }
+    }
+
+    func testForbiddenRemoteHTTPClassifiesAsInsecureTransportPresentation() {
+        do {
+            _ = try ConnectionURLPolicy.normalizedBaseURL("http://203.0.113.10:9119")
+            return XCTFail("Expected remote plain HTTP to be rejected")
+        } catch {
+            let failure = ConnectionFailureClassifier.classify(error)
+            XCTAssertEqual(failure, .insecureTransport)
+            let presentation = ConnectionFailurePresentation.presenting(failure)
+            XCTAssertEqual(presentation.title, "Insecure dashboard address")
+            // The message must explain the HTTPS rule without recommending
+            // opening firewall ports.
+            XCTAssertTrue(presentation.message.contains("HTTPS"))
+            XCTAssertFalse(
+                presentation.message.lowercased().contains("firewall"),
+                "Insecure-transport guidance must not suggest opening ports"
+            )
+            XCTAssertEqual(presentation.helpDestination, .dashboard)
+        }
+    }
+
+    func testLocalHTTPRemainsAllowedByPolicy() {
+        // The transport policy itself must not be broadened or narrowed by
+        // the classification work.
+        XCTAssertNoThrow(try ConnectionURLPolicy.normalizedBaseURL("http://127.0.0.1:9119"))
+        XCTAssertNoThrow(try ConnectionURLPolicy.normalizedBaseURL("http://192.168.1.42:9119"))
+        XCTAssertNoThrow(try ConnectionURLPolicy.normalizedBaseURL("http://100.64.0.10"))
+    }
+
+    // MARK: - URLError codes (real Foundation codes)
+
+    func testCannotFindHostClassifiesAsHostNotFoundWithNetworkHelp() {
+        let presentation = ConnectionFailurePresentation.presenting(
+            ConnectionFailureClassifier.classify(URLError(.cannotFindHost))
+        )
+        XCTAssertEqual(presentation.title, "Dashboard not found")
+        XCTAssertEqual(presentation.helpDestination, .network)
+        XCTAssertTrue(presentation.offersRecoveryActions)
+    }
+
+    func testDNSLookupFailureClassifiesAsHostNotFound() {
+        XCTAssertEqual(ConnectionFailureClassifier.classify(URLError(.dnsLookupFailed)), .hostNotFound)
+    }
+
+    func testCannotConnectToHostClassifiesAsRefusedStylePresentation() {
+        let presentation = ConnectionFailurePresentation.presenting(
+            ConnectionFailureClassifier.classify(URLError(.cannotConnectToHost))
+        )
+        XCTAssertEqual(presentation.title, "Couldn’t reach Hermes")
+        XCTAssertEqual(
+            presentation.message,
+            "Conduit could not connect to the dashboard at this address. Make sure the dashboard is running and that this device can reach it."
+        )
+        XCTAssertEqual(presentation.helpDestination, .network)
+    }
+
+    func testTimedOutClassifiesAsTimeoutPresentation() {
+        let presentation = ConnectionFailurePresentation.presenting(
+            ConnectionFailureClassifier.classify(URLError(.timedOut))
+        )
+        XCTAssertEqual(presentation.title, "Connection timed out")
+        XCTAssertEqual(presentation.helpDestination, .network)
+    }
+
+    func testNotConnectedToInternetClassifiesAsOffline() {
+        XCTAssertEqual(ConnectionFailureClassifier.classify(URLError(.notConnectedToInternet)), .offline)
+    }
+
+    func testNetworkConnectionLostClassifiesAsUnreachable() {
+        XCTAssertEqual(ConnectionFailureClassifier.classify(URLError(.networkConnectionLost)), .unreachable)
+    }
+
+    func testCertificateUntrustedClassifiesAsTLSTrustPresentation() {
+        let presentation = ConnectionFailurePresentation.presenting(
+            ConnectionFailureClassifier.classify(URLError(.serverCertificateUntrusted))
+        )
+        XCTAssertEqual(presentation.title, "Secure connection failed")
+        XCTAssertTrue(
+            presentation.message.contains("iOS does not trust its TLS certificate"),
+            "Untrusted-certificate copy must point at trust/installation guidance"
+        )
+        XCTAssertEqual(presentation.helpDestination, .tls)
+    }
+
+    func testCertificateUnknownRootClassifiesAsTLSUntrusted() {
+        XCTAssertEqual(
+            ConnectionFailureClassifier.classify(URLError(.serverCertificateHasUnknownRoot)),
+            .tlsUntrusted
+        )
+    }
+
+    func testCertificateBadDateClassifiesAsCertificateDatePresentation() {
+        let badDateCodes: [URLError.Code] = [.serverCertificateHasBadDate, .serverCertificateNotYetValid]
+        for code in badDateCodes {
+            let presentation = ConnectionFailurePresentation.presenting(
+                ConnectionFailureClassifier.classify(URLError(code))
+            )
+            XCTAssertEqual(presentation.title, "Certificate date problem")
+            XCTAssertTrue(presentation.message.contains("expired or not yet valid"))
+            XCTAssertEqual(presentation.helpDestination, .tls)
+        }
+    }
+
+    func testGenericSecureConnectionFailedClassifiesAsGenericTLSPresentation() {
+        let presentation = ConnectionFailurePresentation.presenting(
+            ConnectionFailureClassifier.classify(URLError(.secureConnectionFailed))
+        )
+        XCTAssertEqual(presentation.title, "Secure connection failed")
+        XCTAssertNotEqual(presentation.message, URLError(.secureConnectionFailed).localizedDescription)
+        XCTAssertEqual(presentation.helpDestination, .tls)
+    }
+
+    func testBridgedNSURLErrorDomainNSErrorClassifiesByCode() {
+        // URLSession can deliver transport failures as NSError values; the
+        // classifier must recover the code instead of degrading to unknown.
+        let bridged = NSError(
+            domain: NSURLErrorDomain,
+            code: URLError.Code.cannotFindHost.rawValue
+        )
+        XCTAssertEqual(ConnectionFailureClassifier.classify(bridged), .hostNotFound)
+    }
+
+    // MARK: - Authentication stages
+
+    func testPasswordAuth401ClassifiesAsAuthenticationRejectedWithCredentialsHelp() {
+        let presentation = ConnectionFailurePresentation.presenting(
+            ConnectionFailureClassifier.classify(
+                AuthClientError.loginFailed(status: 401, detail: "HTTP 401")
+            )
+        )
+        XCTAssertEqual(presentation.title, "Login failed")
+        XCTAssertEqual(
+            presentation.message,
+            "Hermes rejected that username or password. Check your dashboard credentials and try again."
+        )
+        XCTAssertFalse(presentation.message.contains("HTTP 401"), "Raw status must not be the user-facing message")
+        XCTAssertEqual(presentation.helpDestination, .credentials)
+    }
+
+    func testPasswordAuth403ClassifiesAsAuthenticationRejected() {
+        XCTAssertEqual(
+            ConnectionFailureClassifier.classify(AuthClientError.loginFailed(status: 403, detail: "Forbidden")),
+            .authenticationRejected
+        )
+    }
+
+    func testPasswordAuthServerErrorIsNotPresentedAsBadCredentials() {
+        let presentation = ConnectionFailurePresentation.presenting(
+            ConnectionFailureClassifier.classify(
+                AuthClientError.loginFailed(status: 503, detail: "HTTP 503")
+            )
+        )
+        XCTAssertEqual(presentation.title, "Dashboard unavailable")
+        XCTAssertEqual(presentation.helpDestination, .dashboard)
+        XCTAssertFalse(presentation.message.contains("password"))
+    }
+
+    func testTicketStageFailureIsNeverPresentedAsBadCredentials() {
+        // Even a 401 at the ticket stage: the password was already accepted,
+        // so credentials guidance would be wrong. 429 stays distinct too —
+        // the ticket endpoint is not the rate-limited login endpoint.
+        for status in [401, 429, 500, 502] {
+            let presentation = ConnectionFailurePresentation.presenting(
+                ConnectionFailureClassifier.classify(
+                    AuthClientError.ticketFailed(status: status, detail: "HTTP \(status)")
+                )
+            )
+            XCTAssertEqual(presentation.title, "Could not start the session")
+            XCTAssertNotEqual(presentation.helpDestination, .credentials)
+            XCTAssertFalse(presentation.message.lowercased().contains("username or password"))
+        }
+    }
+
+    // MARK: - Password-login rate limiting (HTTP 429)
+
+    func testPasswordAuth429ClassifiesAsRateLimited() {
+        let failure = ConnectionFailureClassifier.classify(
+            AuthClientError.loginFailed(status: 429, detail: "Too many login attempts. Try again shortly.")
+        )
+        XCTAssertEqual(failure, .rateLimited)
+    }
+
+    func testRateLimitedPresentationIsStableCopyWithoutCredentialBlame() {
+        let presentation = ConnectionFailurePresentation.presenting(.rateLimited)
+        XCTAssertEqual(presentation.title, "Too many login attempts")
+        XCTAssertEqual(
+            presentation.message,
+            "Hermes temporarily blocked additional login attempts. Wait about a minute before trying again."
+        )
+        XCTAssertFalse(
+            presentation.message.lowercased().contains("username"),
+            "Rate limiting must not be presented as wrong credentials"
+        )
+        XCTAssertFalse(
+            presentation.message.lowercased().contains("password"),
+            "Rate limiting must not be presented as wrong credentials"
+        )
+        XCTAssertNil(presentation.helpDestination)
+    }
+
+    func testRateLimitedPresentationOffersNoImmediateRetryAction() {
+        // A Try Again button would encourage exactly the rapid retry Hermes
+        // just throttled; the copy alone must carry the "wait" guidance.
+        let presentation = ConnectionFailurePresentation.presenting(
+            ConnectionFailureClassifier.classify(
+                AuthClientError.loginFailed(status: 429, detail: "Too many login attempts")
+            )
+        )
+        XCTAssertFalse(presentation.offersRecoveryActions)
+    }
+
+    func testTicketStage429DoesNotAdoptRateLimitedLoginCopy() {
+        let presentation = ConnectionFailurePresentation.presenting(
+            ConnectionFailureClassifier.classify(
+                AuthClientError.ticketFailed(status: 429, detail: "HTTP 429")
+            )
+        )
+        XCTAssertEqual(presentation.title, "Could not start the session")
+        XCTAssertNotEqual(presentation.title, "Too many login attempts")
+    }
+
+    func testAuthClient429ErrorDescriptionDoesNotBlameCredentials() {
+        let description = AuthClientError.loginFailed(
+            status: 429,
+            detail: "Too many login attempts. Try again shortly."
+        ).errorDescription
+        XCTAssertEqual(description, "Too many login attempts. Try again shortly.")
+    }
+
+    func testPasswordAuth401And403RemainAuthenticationRejectedNextToRateLimiting() {
+        // The 429 branch must not swallow the genuine credential rejections.
+        for status in [401, 403] {
+            XCTAssertEqual(
+                ConnectionFailureClassifier.classify(
+                    AuthClientError.loginFailed(status: status, detail: "HTTP \(status)")
+                ),
+                .authenticationRejected
+            )
+        }
+    }
+
+    func testProviderDiscoveryFailureDoesNotImplyBadCredentials() {
+        // A 401/403 during provider discovery is a misrouted or odd
+        // deployment, not evidence the credentials are wrong.
+        for status in [401, 403, 404] {
+            let presentation = ConnectionFailurePresentation.presenting(
+                ConnectionFailureClassifier.classify(
+                    AuthClientError.providerDiscoveryFailed(status: status, detail: "HTTP \(status)")
+                )
+            )
+            XCTAssertEqual(presentation.title, "Unexpected response")
+            XCTAssertNotEqual(presentation.helpDestination, .credentials)
+        }
+    }
+
+    func testProviderDiscoveryServerErrorClassifiesAsDashboardUnavailable() {
+        let presentation = ConnectionFailurePresentation.presenting(
+            ConnectionFailureClassifier.classify(
+                AuthClientError.providerDiscoveryFailed(status: 500, detail: "boom")
+            )
+        )
+        XCTAssertEqual(presentation.title, "Dashboard unavailable")
+        XCTAssertEqual(presentation.helpDestination, .dashboard)
+    }
+
+    func testProviderDiscovery429AlsoClassifiesAsRateLimited() {
+        // The documented throttle targets /auth/password-login, but a 429
+        // from any auth endpoint is a throttle, never bad credentials.
+        let presentation = ConnectionFailurePresentation.presenting(
+            ConnectionFailureClassifier.classify(
+                AuthClientError.providerDiscoveryFailed(status: 429, detail: "HTTP 429")
+            )
+        )
+        XCTAssertEqual(presentation.title, "Too many login attempts")
+        XCTAssertNotEqual(presentation.helpDestination, .credentials)
+    }
+
+    func testDiscoveryWithoutHTTPResponseClassifiesAsUnexpectedServerResponse() {
+        XCTAssertEqual(
+            ConnectionFailureClassifier.classify(
+                AuthClientError.providerDiscoveryFailed(status: nil, detail: "No response")
+            ),
+            .unexpectedServerResponse
+        )
+    }
+
+    func testCloudflareTokenRejectionPreservesSpecializedGuidance() {
+        let presentation = ConnectionFailurePresentation.presenting(
+            ConnectionFailureClassifier.classify(AuthClientError.cloudflareServiceTokenRejected)
+        )
+        XCTAssertEqual(presentation.title, "Cloudflare rejected the service token")
+        XCTAssertTrue(presentation.message.contains("Client ID / Secret"))
+        XCTAssertTrue(presentation.message.contains("Service Auth policy"))
+        XCTAssertTrue(presentation.message.contains("sign in interactively"))
+        XCTAssertEqual(presentation.helpDestination, .cloudflare)
+    }
+
+    func testAuthInvalidURLClassifiesAsInvalidAddress() {
+        XCTAssertEqual(
+            ConnectionFailureClassifier.classify(AuthClientError.invalidURL),
+            .invalidAddress
+        )
+    }
+
+    // MARK: - Unknown errors degrade gracefully
+
+    func testUnknownErrorDegradesGracefullyWithoutDebugCopy() {
+        struct OpaqueError: Error {}
+
+        let raw = OpaqueError()
+        let presentation = ConnectionFailurePresentation.presenting(
+            ConnectionFailureClassifier.classify(raw)
+        )
+
+        XCTAssertEqual(ConnectionFailureClassifier.classify(raw), .unknown)
+        XCTAssertNil(presentation.helpDestination, "Unknown failures must not invent a misleading help destination")
+        XCTAssertFalse(presentation.title.isEmpty)
+        XCTAssertFalse(presentation.message.isEmpty)
+        XCTAssertNotEqual(presentation.message, String(describing: raw))
+    }
+
+    func testUnknownURLErrorCodeHasNoHelpDestination() {
+        let presentation = ConnectionFailurePresentation.presenting(
+            ConnectionFailureClassifier.classify(URLError(.unknown))
+        )
+        XCTAssertEqual(presentation.title, "Couldn’t connect")
+        XCTAssertNil(presentation.helpDestination)
+    }
+
+    // MARK: - Presentation models
+
+    func testValidationNoticeOffersNoRecoveryActions() {
+        let notice = ConnectionFailurePresentation.notice(title: "Enter your dashboard username and password.")
+        XCTAssertEqual(notice.title, "Enter your dashboard username and password.")
+        XCTAssertTrue(notice.message.isEmpty)
+        XCTAssertNil(notice.helpDestination)
+        XCTAssertFalse(notice.offersRecoveryActions)
+    }
+
+    func testConnectionFailurePresentationCarriesDestinationAndActions() {
+        let presentation = ConnectionFailurePresentation.presenting(.timedOut)
+        XCTAssertTrue(presentation.offersRecoveryActions)
+        XCTAssertEqual(presentation.helpDestination, .network)
+        XCTAssertEqual(presentation.title, "Connection timed out")
+    }
+}

--- a/ConduitTests/ConnectionFailureTests.swift
+++ b/ConduitTests/ConnectionFailureTests.swift
@@ -327,16 +327,31 @@ final class ConnectionFailureTests: XCTestCase {
         XCTAssertEqual(presentation.helpDestination, .dashboard)
     }
 
-    func testProviderDiscovery429AlsoClassifiesAsRateLimited() {
-        // The documented throttle targets /auth/password-login, but a 429
-        // from any auth endpoint is a throttle, never bad credentials.
-        let presentation = ConnectionFailurePresentation.presenting(
-            ConnectionFailureClassifier.classify(
-                AuthClientError.providerDiscoveryFailed(status: 429, detail: "HTTP 429")
-            )
+    func testProviderDiscovery429DoesNotAdoptLoginCooldownPresentation() {
+        // Only /auth/password-login is throttled by Hermes (10/60s/IP). A 429
+        // from provider discovery is unexpected server behavior — not a login
+        // cooldown — and retrying it consumes no password-login budget, so
+        // the login-cooldown presentation (no actions) must not apply.
+        let failure = ConnectionFailureClassifier.classify(
+            AuthClientError.providerDiscoveryFailed(status: 429, detail: "HTTP 429")
         )
+        XCTAssertEqual(failure, .unexpectedServerResponse)
+        let presentation = ConnectionFailurePresentation.presenting(failure)
+        XCTAssertEqual(presentation.title, "Unexpected response")
+        XCTAssertNotEqual(presentation.title, "Too many login attempts")
+        XCTAssertFalse(presentation.message.contains("Wait about a minute"))
+        XCTAssertTrue(presentation.offersRecoveryActions)
+    }
+
+    func testPasswordLogin429StillAdoptsLoginCooldownPresentation() {
+        // The stage-gating above must not dilute the real throttled endpoint.
+        let failure = ConnectionFailureClassifier.classify(
+            AuthClientError.loginFailed(status: 429, detail: "Too many login attempts. Try again shortly.")
+        )
+        XCTAssertEqual(failure, .rateLimited)
+        let presentation = ConnectionFailurePresentation.presenting(failure)
         XCTAssertEqual(presentation.title, "Too many login attempts")
-        XCTAssertNotEqual(presentation.helpDestination, .credentials)
+        XCTAssertFalse(presentation.offersRecoveryActions)
     }
 
     func testDiscoveryWithoutHTTPResponseClassifiesAsUnexpectedServerResponse() {
@@ -402,6 +417,36 @@ final class ConnectionFailureTests: XCTestCase {
         XCTAssertFalse(
             description?.lowercased().contains("credentials") ?? true,
             "A no-response login failure must not read as a credentials problem"
+        )
+    }
+
+    // MARK: - AuthWebView failure routing (fixed classified copy)
+
+    func testAuthWebViewTicketFailurePresentationIsFixedClassifiedCopy() {
+        // The dashboard controls the ticket-payload text (payload["error"]).
+        // The login card must render only Conduit's fixed session-ticket
+        // copy — the exact-equality assertions break if payload text is ever
+        // interpolated into the presentation again.
+        let presentation = ConnectionFailurePresentation.presenting(.sessionTicketFailure)
+        XCTAssertEqual(presentation.title, "Could not start the session")
+        XCTAssertEqual(
+            presentation.message,
+            "Signing in succeeded, but Conduit could not start a Hermes session. The dashboard may be busy, restarting, or it did not accept the new session — try again."
+        )
+        XCTAssertEqual(presentation.helpDestination, .dashboard)
+        XCTAssertTrue(presentation.offersRecoveryActions)
+    }
+
+    func testAuthWebViewNormalizationFailureClassifiesAsInvalidAddress() {
+        // AuthWebView's request-construction failures classify through the
+        // same ConnectionURLPolicyError mapping as the login form.
+        XCTAssertEqual(
+            ConnectionFailureClassifier.classify(ConnectionURLPolicyError.invalidURL),
+            .invalidAddress
+        )
+        XCTAssertEqual(
+            ConnectionFailurePresentation.presenting(.invalidAddress).title,
+            "Check the dashboard address"
         )
     }
 

--- a/ConduitTests/ConnectionFailureTests.swift
+++ b/ConduitTests/ConnectionFailureTests.swift
@@ -99,6 +99,41 @@ final class ConnectionFailureTests: XCTestCase {
         XCTAssertEqual(ConnectionFailureClassifier.classify(URLError(.networkConnectionLost)), .unreachable)
     }
 
+    func testBadURLClassifiesAsInvalidAddress() {
+        XCTAssertEqual(ConnectionFailureClassifier.classify(URLError(.badURL)), .invalidAddress)
+    }
+
+    func testATSErrorClassifiesAsInsecureTransport() {
+        XCTAssertEqual(
+            ConnectionFailureClassifier.classify(URLError(.appTransportSecurityRequiresSecureConnection)),
+            .insecureTransport
+        )
+    }
+
+    func testOfflineFamilyCodesClassifyAsOffline() {
+        // notConnectedToInternet is covered above; pin the rest of the family.
+        XCTAssertEqual(ConnectionFailureClassifier.classify(URLError(.dataNotAllowed)), .offline)
+        XCTAssertEqual(ConnectionFailureClassifier.classify(URLError(.internationalRoamingOff)), .offline)
+    }
+
+    func testBadServerResponseClassifiesAsUnexpectedServerResponse() {
+        // NativeAuthClient.perform throws this when no usable response
+        // arrives; it must not degrade to the unknown bucket.
+        XCTAssertEqual(ConnectionFailureClassifier.classify(URLError(.badServerResponse)), .unexpectedServerResponse)
+    }
+
+    func testCancelledURLErrorClassifiesAsUnknownNotCredentials() {
+        // LoginView intercepts CancellationError before classification (and
+        // NativeAuthClient converts URLError.cancelled into CancellationError),
+        // so a cancelled transport that ever escaped would land here: generic
+        // copy, never a credentials or rate-limit claim. This pins that.
+        let presentation = ConnectionFailurePresentation.presenting(
+            ConnectionFailureClassifier.classify(URLError(.cancelled))
+        )
+        XCTAssertEqual(presentation.title, "Couldn’t connect")
+        XCTAssertNotEqual(presentation.helpDestination, .credentials)
+    }
+
     func testCertificateUntrustedClassifiesAsTLSTrustPresentation() {
         let presentation = ConnectionFailurePresentation.presenting(
             ConnectionFailureClassifier.classify(URLError(.serverCertificateUntrusted))
@@ -353,7 +388,21 @@ final class ConnectionFailureTests: XCTestCase {
             ConnectionFailureClassifier.classify(URLError(.unknown))
         )
         XCTAssertEqual(presentation.title, "Couldn’t connect")
+        // Try-only behavior: recovery actions render, but no Troubleshoot
+        // button without a trustworthy destination.
+        XCTAssertTrue(presentation.offersRecoveryActions)
         XCTAssertNil(presentation.helpDestination)
+    }
+
+    func testAuthClientNoResponseLoginFailureDoesNotBlameCredentials() {
+        let description = AuthClientError.loginFailed(
+            status: nil,
+            detail: "No response"
+        ).errorDescription
+        XCTAssertFalse(
+            description?.lowercased().contains("credentials") ?? true,
+            "A no-response login failure must not read as a credentials problem"
+        )
     }
 
     // MARK: - Presentation models

--- a/ConduitTests/NativeAuthClientIntegrationTests.swift
+++ b/ConduitTests/NativeAuthClientIntegrationTests.swift
@@ -427,7 +427,7 @@ final class NativeAuthClientIntegrationTests: XCTestCase {
             ).connect(username: "chris", password: "correct-password")
             return XCTFail("Expected a ticket response without a ticket to fail")
         } catch let error as AuthClientError {
-            guard case .ticketFailed(let detail) = error else {
+            guard case .ticketFailed(_, let detail) = error else {
                 return XCTFail("Expected ticket failure, got \(error)")
             }
             XCTAssertEqual(detail, "No ticket in response")

--- a/ConduitTests/NativeAuthClientTests.swift
+++ b/ConduitTests/NativeAuthClientTests.swift
@@ -60,7 +60,7 @@ final class NativeAuthClientTests: XCTestCase {
             _ = try await client.connect(username: "chris", password: "correct-password")
             return XCTFail("Expected the ticket request without an applicable login cookie to be rejected")
         } catch let error as AuthClientError {
-            guard case .ticketFailed(let detail) = error else {
+            guard case .ticketFailed(_, let detail) = error else {
                 return XCTFail("Expected ticket failure, got \(error)")
             }
             XCTAssertEqual(detail, "Unauthorized")
@@ -98,7 +98,7 @@ final class NativeAuthClientTests: XCTestCase {
             _ = try await client.authProviders()
             XCTFail("Expected provider discovery to fail for a non-redirect 3xx response")
         } catch let error as AuthClientError {
-            guard case .providerDiscoveryFailed(let detail) = error else {
+            guard case .providerDiscoveryFailed(_, let detail) = error else {
                 return XCTFail("Expected provider discovery failure, got \(error)")
             }
             XCTAssertEqual(detail, "HTTP 300")
@@ -128,7 +128,7 @@ final class NativeAuthClientTests: XCTestCase {
             _ = try await client.authProviders()
             XCTFail("Expected provider discovery to fail for a server error")
         } catch let error as AuthClientError {
-            guard case .providerDiscoveryFailed(let detail) = error else {
+            guard case .providerDiscoveryFailed(_, let detail) = error else {
                 return XCTFail("Expected provider discovery failure, got \(error)")
             }
             XCTAssertEqual(detail, "origin unavailable")
@@ -390,7 +390,7 @@ final class NativeAuthClientTests: XCTestCase {
             _ = try await client.connect(username: "chris", password: "correct-password")
             XCTFail("Expected connect to fail when no host-scoped session cookie is accepted")
         } catch let error as AuthClientError {
-            guard case .ticketFailed(let detail) = error else {
+            guard case .ticketFailed(_, let detail) = error else {
                 return XCTFail("Expected ticket failure, got \(error)")
             }
             XCTAssertEqual(detail, "Login succeeded but no host-scoped session cookie was accepted")

--- a/ConduitUITests/LoginKeyboardUITests.swift
+++ b/ConduitUITests/LoginKeyboardUITests.swift
@@ -24,6 +24,10 @@ final class LoginKeyboardUITests: XCTestCase {
         static let cloudflareClientID = "login.cloudflare-client-id"
         static let cloudflareClientSecret = "login.cloudflare-client-secret"
         static let connect = "login.connect"
+        static let connectionSetup = "login.connection-setup"
+        static let errorTitle = "login.error.title"
+        static let troubleshoot = "login.error.troubleshoot"
+        static let connectionSetupDone = "connection-setup.done"
     }
 
     override func setUpWithError() throws {
@@ -84,6 +88,166 @@ final class LoginKeyboardUITests: XCTestCase {
         XCTAssertTrue(
             pollHittability(of: connect, timeout: 5),
             "Connect must remain reachable with the keyboard visible"
+        )
+    }
+
+    // MARK: - Connection Setup affordance (Round 1)
+
+    /// The permanent "Need help connecting?" affordance must be visible near
+    /// the top of the login card and open the Connection Setup shell without
+    /// touching any other control.
+    func testConnectionSetupAffordanceIsReachableAndOpensShell() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        let serverField = app.textFields[Identity.serverURL]
+        XCTAssertTrue(serverField.waitForExistence(timeout: 10), "Login screen did not appear. Tree:\n\(app.debugDescription)")
+
+        let setup = app.buttons[Identity.connectionSetup]
+        XCTAssertTrue(
+            setup.waitForExistence(timeout: 5),
+            "Connection Setup affordance must be visible on the login card. Tree:\n\(app.debugDescription)"
+        )
+        if !setup.isHittable { app.swipeDown() }
+        XCTAssertTrue(pollHittability(of: setup, timeout: 5), "Connection Setup affordance must be hittable at the top of the login card")
+
+        setup.tap()
+        let sheetDone = app.buttons[Identity.connectionSetupDone]
+        XCTAssertTrue(
+            sheetDone.waitForExistence(timeout: 5),
+            "Connection Setup sheet must open from the affordance. Tree:\n\(app.debugDescription)"
+        )
+
+        sheetDone.tap()
+        XCTAssertTrue(
+            serverField.waitForExistence(timeout: 5),
+            "Dismissing the Connection Setup sheet must return to the login form"
+        )
+    }
+
+    /// Fills the username/password fields so the Connect button is enabled
+    /// (its trimmed-presence rule disables it while either is empty).
+    private func fillRequiredCredentials(_ app: XCUIApplication) throws {
+        let username = app.textFields["login.username"]
+        XCTAssertTrue(username.waitForExistence(timeout: 5), "Username field did not appear. Tree:\n\(app.debugDescription)")
+        username.tap()
+        username.typeText("ui-test-user")
+
+        let password = app.secureTextFields["login.password"]
+        XCTAssertTrue(password.waitForExistence(timeout: 5), "Password field did not appear. Tree:\n\(app.debugDescription)")
+        password.tap()
+        password.typeText("ui-test-password")
+    }
+
+    /// Types text after clearing any existing content. The login screen
+    /// prefills the server URL from the last saved dashboard address
+    /// (LoginView.onAppear), so appended typing would form an unpredictable
+    /// value. Deletes past the start of an empty field are no-ops, so the
+    /// overshooting delete count lands on exactly `text` no matter where the
+    /// tap placed the cursor.
+    private func clearAndType(_ text: String, into field: XCUIElement) {
+        field.tap()
+        field.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: 60))
+        field.typeText(text)
+    }
+
+    /// Dismisses the keyboard via its toolbar Done affordance. XCUI can
+    /// report controls under the keyboard window as hittable, so a raw tap
+    /// lands on the keyboard instead of the control (observed directly:
+    /// Connect at y≈498 behind a keyboard starting at y=491 reported
+    /// hittable). Waiting for the Done button to disappear means Connect is
+    /// genuinely tappable afterwards.
+    private func dismissKeyboard(_ app: XCUIApplication) {
+        let done = app.buttons["Done"]
+        guard done.waitForExistence(timeout: 3) else { return }
+        done.tap()
+        let deadline = Date().addingTimeInterval(3)
+        while Date() < deadline, done.exists {
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+    }
+
+    /// A malformed dashboard URL classifies locally (no network I/O) into the
+    /// invalid-address failure: the error presentation must show actionable
+    /// copy and a Troubleshoot action that lands in the Connection Setup
+    /// shell — and it must not trap Connect below the keyboard/viewport.
+    func testMalformedURLShowsActionableErrorWithTroubleshootAndConnectStaysReachable() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        let serverField = app.textFields[Identity.serverURL]
+        XCTAssertTrue(serverField.waitForExistence(timeout: 10), "Login screen did not appear. Tree:\n\(app.debugDescription)")
+        // No scheme → invalidURL policy failure; classification never hits
+        // the network, so this stays deterministic offline. Any prefilled
+        // dashboard address is cleared first.
+        clearAndType("not-a-dashboard-url", into: serverField)
+        try fillRequiredCredentials(app)
+        dismissKeyboard(app)
+
+        let connect = app.buttons[Identity.connect]
+        XCTAssertTrue(connect.waitForExistence(timeout: 5))
+        if !connect.isHittable { app.swipeUp() }
+        XCTAssertTrue(pollHittability(of: connect, timeout: 5), "Connect must be reachable to submit the malformed URL")
+        connect.tap()
+
+        let errorTitle = app.staticTexts[Identity.errorTitle]
+        XCTAssertTrue(
+            errorTitle.waitForExistence(timeout: 5),
+            "Classified invalid-address failure must appear. Tree:\n\(app.debugDescription)"
+        )
+        XCTAssertEqual(errorTitle.label, "Check the dashboard address")
+
+        let troubleshoot = app.buttons[Identity.troubleshoot]
+        XCTAssertTrue(troubleshoot.waitForExistence(timeout: 5), "Invalid-address failure must offer Troubleshoot Connection")
+        if !troubleshoot.isHittable { app.swipeUp() }
+        XCTAssertTrue(pollHittability(of: troubleshoot, timeout: 5))
+        troubleshoot.tap()
+        XCTAssertTrue(
+            app.buttons[Identity.connectionSetupDone].waitForExistence(timeout: 5),
+            "Troubleshoot Connection must open the Connection Setup shell"
+        )
+        app.buttons[Identity.connectionSetupDone].tap()
+
+        XCTAssertTrue(serverField.waitForExistence(timeout: 5), "Dismissing the sheet must return to the login form")
+        if !connect.isHittable { app.swipeUp() }
+        XCTAssertTrue(
+            pollHittability(of: connect, timeout: 5),
+            "Connect must remain reachable under the multiline error presentation"
+        )
+    }
+
+    /// Remote plain HTTP classifies locally into the insecure-transport
+    /// failure (still no network I/O: the policy rejects before any request),
+    /// with its own title distinct from the malformed-URL case.
+    func testRemotePlainHTTPShowsInsecureTransportErrorAndConnectStaysReachable() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        let serverField = app.textFields[Identity.serverURL]
+        XCTAssertTrue(serverField.waitForExistence(timeout: 10), "Login screen did not appear. Tree:\n\(app.debugDescription)")
+        // TEST-NET-3 documentation address: never routed, and the transport
+        // policy rejects it before any connection attempt.
+        clearAndType("http://203.0.113.10:9119", into: serverField)
+        try fillRequiredCredentials(app)
+        dismissKeyboard(app)
+
+        let connect = app.buttons[Identity.connect]
+        XCTAssertTrue(connect.waitForExistence(timeout: 5))
+        if !connect.isHittable { app.swipeUp() }
+        XCTAssertTrue(pollHittability(of: connect, timeout: 5), "Connect must be reachable to submit the insecure URL")
+        connect.tap()
+
+        let errorTitle = app.staticTexts[Identity.errorTitle]
+        XCTAssertTrue(
+            errorTitle.waitForExistence(timeout: 5),
+            "Classified insecure-transport failure must appear. Tree:\n\(app.debugDescription)"
+        )
+        XCTAssertEqual(errorTitle.label, "Insecure dashboard address")
+
+        if !connect.isHittable { app.swipeUp() }
+        XCTAssertTrue(
+            pollHittability(of: connect, timeout: 5),
+            "Connect must remain reachable under the insecure-transport error presentation"
         )
     }
 


### PR DESCRIPTION
## Round 1: Connection Setup foundation — failure classification, actionable login errors, entry point

First slice of the Connection Setup work (issue #129 is the TLS driver). This round does **not** build the guided assistant — it establishes the classification, presentation, and routing infrastructure later rounds will use, and fixes the known login error-taxonomy bugs.

### What changed

**1. URL-policy error preservation (bug fix).** `LoginView.connect()` used `try?` around `ConnectionURLPolicy.normalizedBaseURL(...)` and reported *insecure-transport* for every normalization failure. The policy error is now preserved: a malformed address classifies as invalid-address ("Check the dashboard address"), forbidden remote plain HTTP as insecure-transport — each with its own guidance. `AppState.connect` had the same bug (every policy failure reported as insecure transport); fixed. No transport-policy widening.

**2. `ConnectionFailure` classification layer** (`Conduit/Services/ConnectionFailure.swift`). The login view no longer renders `error.localizedDescription`. Classification is driven by error **types** and `URLError` codes only — never localized text — including recovery of bridged `NSURLErrorDomain` NSErrors by code. `AuthClientError` cases now carry `status: Int?` alongside the diagnostic detail so stage semantics survive to the classifier:

- 401/403 at **password login** → `authenticationRejected` (credentials help)
- 401/403 during **provider discovery** or **ticket minting** → *never* bad credentials (unexpected-response / session-ticket categories)
- **HTTP 429** → `rateLimited` (see below)
- 5xx → `dashboardUnavailable`; missing/undecodable response → `unexpectedServerResponse`

**3. Rate limiting (explicit requirement).** Hermes throttles `/auth/password-login` (10 req / 60 s / client IP). 429 classifies as `rateLimited` with stable copy — *"Too many login attempts"* / *"Hermes temporarily blocked additional login attempts. Wait about a minute before trying again."* — no credential blame, and **no recovery actions at all** (a Try Again button would encourage exactly the rapid retry Hermes just throttled). `connect()` also gained a re-entrancy guard (Try Again / return key can no longer start a second concurrent password auth while one is in flight).

**4. Issue #129 — TLS, classified not bypassed.** `serverCertificateUntrusted`/`HasUnknownRoot` → untrusted-CA guidance; `HasBadDate`/`NotYetValid` → certificate-date guidance; `secureConnectionFailed` → generic TLS. There is **no** certificate bypass, no "Continue Anyway", no trust override, no URLSession trust delegate — iOS trust validation is untouched, and the tests pin that stance.

**5. Failure presentation model.** `ConnectionFailurePresentation` (title / message / `helpDestination` / recovery-actions flag) keeps all routing logic out of `LoginView`. Classified failures render Try Again + Troubleshoot Connection; validation notices render without actions; unknown failures render generic copy with **no** help destination (never a misleading one).

**6. Connection Setup entry point + shell.** A permanent, visually secondary **"Need help connecting? — Set up your Hermes connection"** affordance sits directly under the *Connect a Hermes dashboard* heading (`login.connection-setup`) and opens `ConnectionSetupView` — a destination-routed shell with per-topic quick checks (start / dashboard / credentials / network / TLS / cloudflare). It never opens automatically, all checks are safe-by-construction (explicitly warns against opening ports to the internet), and Troubleshoot opens the same sheet pre-routed to the classified destination.

**7. Saved-credential restore path.** A rejected saved password at launch now surfaces its classified message once on the login card (`onAppear` consumes `appState.errorMessage`), instead of being invisible on the login screen and resurfacing stale in the connected composer banner.

### Explicitly unchanged

The expert single-URL field (custom ports, path prefixes, Cloudflare/reverse-proxy), the Cloudflare token flow and WebView fallback, the issue-#117 keyboard/scroll architecture, the transport policy, and everything deferred to later rounds (guided flows, Host+Port controls, Ask-Hermes prompts, Settings entry).

### Audit note (repeated password-auth paths)

The only automatic password-login path is silent session renewal during reconnect (`AppState`, `.signInRequired` → saved credentials): **one** attempt per event, falling to `requireSignIn` on failure — no retry loop. Launch-time restore is one attempt per launch. No path can rapidly consume the 10/60s budget; no lifecycle changes made.

### Multi-model review gate

3-reviewer cycle (code-reviewer / second-reviewer / third-reviewer): **APPROVE / APPROVE-with-warnings / COMMENT, zero BLOCKERs.** Applied: connect() re-entrancy guard + Try Again disabled while connecting; log the type-safe classification instead of raw errors (server-provided `detail` must not reach the unified log unredacted); consume-once of `appState.errorMessage` on the login card; `badServerResponse`/`httpTooManyRedirects` → unexpected-server-response; `loginFailed(status: nil)` no longer blames credentials; generalized session-ticket copy; +6 tests pinning the reviewers' flagged gaps. Rejected with evidence: the suggested optional-binding form of `URLError.Code(rawValue:)` does not compile on this SDK (failable variant was removed); the 429 `errorDescription` is not dead copy (`requireSignIn` renders it).

### Verification (Mac build host, iPhone 17 Pro simulator, branch head)

- `ConnectionFailureTests` **40/40** (new) · `NativeAuthClientTests` 19/19 · `NativeAuthClientIntegrationTests` 10/10 · `CloudflareAccessTests` 27/27 · `TurnstileSubframeBoundaryTests` 75/75 · `ConnectionURLPolicyOriginTests` 22/22 · `AuthWebViewNavigationPolicyTests` 11/11 · `LoginFieldNavigationTests` 5/5 · `SecurityBoundaryTests` 9/9
- `LoginKeyboardUITests` **4/4** — the 3 new UI tests cover the entry point opening/closing the shell and two offline-classified error presentations (malformed URL → troubleshooting routing; remote plain HTTP → insecure-transport) with Connect proven reachable under the multiline error; the pre-existing issue-#117 keyboard test still passes
- `plan-tests.py validate` OK (new suites auto-discovered); rebased cleanly onto current `main` (8271aeb)


### Review-followup round (stage-gated 429, typed handoff, classified WebView errors)

A follow-up pass (71d0776) addressing CodeRabbit + a second internal review cycle:

- **429 is stage-gated:** only `/auth/password-login` 429s get the login-cooldown presentation (that is the endpoint Hermes throttles). A 429 during provider discovery classifies as unexpected-response **with** recovery actions, since retrying discovery consumes no password-login budget.
- **Typed AppState→LoginView handoff:** `pendingLoginFailure: ConnectionFailurePresentation?` (published, consumed once via `onReceive`) replaces the string `errorMessage` handoff on all three login-bound sites — the connect URL-policy guard, saved-credential restore, and `requireSignIn` — so the card renders the full presentation and the handoff works even when LoginView is already mounted. None of those sites write `errorMessage` anymore, and `requireSignIn`/connect-success clear it, so a sign-in failure can never resurface stale in the connected composer banner.
- **AuthWebView errors are classified:** `onError` now carries `(ConnectionFailure, String)`; dashboard-controlled ticket-payload text is diagnostic-only (logged, redacted in release) and the card shows fixed copy — regression-pinned by exact-equality tests.
- **CodeRabbit HTTPS suggestion rejected** (thread replied): requiring HTTPS for LAN password login would break the supported self-hosted expert path without adding real security; the transport policy is unchanged, per the settled #109/#113/#117 lineage.

Second gate cycle: COMMENT / APPROVE / REQUEST-CHANGES, zero blockers; the majority warning (stale `errorMessage` surviving re-login once the onAppear consume was removed) was fixed with explicit clears at `requireSignIn` and both connect-success boundaries. Suites re-run green after the fixes: 43 ConnectionFailureTests + 4 AppStatePendingLoginFailureTests (new) + 19 NativeAuthClientTests + 10 NativeAuthClientIntegrationTests + 4 LoginKeyboardUITests, 0 failures (one transient all-UI-fail run with empty-window app launches was resolved by the standard simulator shutdown/boot recovery and did not reproduce).

### Known round-2 items

`Retry-After` is ignored — the rate-limit copy hard-codes Hermes' current ~60-second window and would need revisiting if the server constant changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Connection Setup Assistant with destination-specific troubleshooting guidance.
  * Added recovery actions and a troubleshooting entry point for connection and login issues.
  * Improved accessibility support for login and connection setup controls.

* **Bug Fixes**
  * Connection errors now provide more accurate, actionable messages.
  * Authentication failures distinguish rate limits, credential issues, server errors, and connectivity problems.
  * URL validation now reports specific policy failures instead of generic transport errors.
  * Resolved stale sign-in errors after successful connections.
  * Canceled session renewals no longer unnecessarily force the sign-in screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

