### PR TITLE
feat(setup): guided Connection Setup wizard replaces the placeholder shell

### DIFF
--- a/Conduit/Services/ConnectionSetupFlow.swift
+++ b/Conduit/Services/ConnectionSetupFlow.swift
@@ -25,6 +25,16 @@ enum ConnectionAccessMethod: Equatable, CaseIterable {
     case lan
     case tailscale
     case reverseProxy
+
+    /// The wizard card's user-facing title. Single source of truth so the
+    /// copy-safety tests cover the shipped strings, not local literals.
+    var displayTitle: String {
+        switch self {
+        case .lan: return "I’m on the same network as Hermes"
+        case .tailscale: return "Tailscale"
+        case .reverseProxy: return "I already have a domain or reverse proxy"
+        }
+    }
 }
 
 /// One screen of the guided flow.
@@ -150,7 +160,9 @@ struct ConnectionSetupFlow: Equatable {
     }
 
     /// Answering Yes moves on; No / I don't know keep the question on screen
-    /// with its Ask Hermes guidance until the user confirms readiness.
+    /// with its Ask Hermes guidance until the user confirms readiness. The
+    /// recorded answer is never rewritten by the confirmation — "ready" is a
+    /// navigation action, not a retroactive Yes.
     mutating func answerDashboard(_ answer: ConnectionSetupAnswer) {
         dashboardAnswer = answer
         if answer == .yes {
@@ -161,7 +173,7 @@ struct ConnectionSetupFlow: Equatable {
     /// The "Dashboard is ready" continuation after the No / I don't know
     /// guidance.
     mutating func confirmDashboardReady() {
-        answerDashboard(.yes)
+        advance(to: .credentials)
     }
 
     mutating func answerCredentials(_ answer: ConnectionSetupAnswer) {
@@ -173,12 +185,12 @@ struct ConnectionSetupFlow: Equatable {
 
     /// The continuation after the credentials No / I don't know guidance.
     mutating func confirmCredentialsReady() {
-        answerCredentials(.yes)
+        advance(to: .accessMethod)
     }
 
     mutating func selectAccessMethod(_ method: ConnectionAccessMethod) {
         accessMethod = method
-        advance(to: step(for: method))
+        advance(to: Self.step(for: method))
     }
 
     /// "I have the connection details" on a branch screen. This round lands
@@ -188,13 +200,22 @@ struct ConnectionSetupFlow: Equatable {
     }
 
     /// Topic switching on the troubleshooting surfaces (TLS ⇄ Cloudflare).
-    /// Ignored for wizard destinations, which route through the questions.
+    /// Switching REPLACES the current troubleshooting step rather than
+    /// pushing, so repeated flips never grow the back path; Back then exits
+    /// troubleshooting toward whatever preceded it. Ignored for wizard
+    /// destinations, which route through the questions.
     mutating func showTroubleshooting(_ destination: ConnectionHelpDestination) {
         guard destination == .tls || destination == .cloudflare else { return }
-        advance(to: Self.entryStep(for: destination))
+        let target = Self.entryStep(for: destination)
+        guard target != step else { return }
+        if let last = path.last, last == .tlsTroubleshooting || last == .cloudflareTroubleshooting {
+            path[path.count - 1] = target
+        } else {
+            path.append(target)
+        }
     }
 
-    func step(for method: ConnectionAccessMethod) -> ConnectionSetupStep {
+    static func step(for method: ConnectionAccessMethod) -> ConnectionSetupStep {
         switch method {
         case .lan: return .lan
         case .tailscale: return .tailscale

--- a/Conduit/Services/ConnectionSetupFlow.swift
+++ b/Conduit/Services/ConnectionSetupFlow.swift
@@ -1,0 +1,209 @@
+//
+//  ConnectionSetupFlow.swift
+//  Conduit
+//
+//  The guided Connection Setup wizard's state model. Deliberately SwiftUI-free
+//  so the routing rules — entry destinations, question transitions, access
+//  method branches, back navigation — are unit-testable without hosting a
+//  view. The view layer renders whatever step the model is on and never makes
+//  routing decisions itself.
+//
+
+import Foundation
+
+/// The answer offered on each guided readiness question.
+enum ConnectionSetupAnswer: Equatable {
+    case yes
+    case no
+    case unknown
+}
+
+/// Supported ways for this device to reach a self-hosted Hermes dashboard.
+/// Deliberately a closed set: there is no public-IP/open-port path, and
+/// Conduit supports self-hosted Hermes only.
+enum ConnectionAccessMethod: Equatable, CaseIterable {
+    case lan
+    case tailscale
+    case reverseProxy
+}
+
+/// One screen of the guided flow.
+enum ConnectionSetupStep: Equatable {
+    // The three core questions.
+    case dashboard
+    case credentials
+    case accessMethod
+
+    // Access-method branch screens (informational shells this round).
+    case lan
+    case tailscale
+    case reverseProxy
+    case detailsReady
+
+    // Direct troubleshooting surfaces (failure-driven entries).
+    case tlsTroubleshooting
+    case cloudflareTroubleshooting
+}
+
+/// Copyable "Ask Hermes" prompts. Each prompt asks Hermes to keep dashboard
+/// authentication enabled — enforced by `ConnectionSetupFlowTests`, which pin
+/// the safety phrases and forbid exposure/port language.
+enum ConnectionSetupPrompt: CaseIterable {
+    case dashboardNotRunning
+    case dashboardUnknown
+    case credentialsMissing
+    case credentialsUnknown
+    case lanDetails
+    case tailscaleServe
+    case reverseProxyDetails
+
+    var title: String {
+        switch self {
+        case .dashboardNotRunning: return "Ask Hermes to set up the dashboard"
+        case .dashboardUnknown: return "Ask Hermes to check the dashboard"
+        case .credentialsMissing: return "Ask Hermes to set up dashboard credentials"
+        case .credentialsUnknown: return "Ask Hermes to check your dashboard sign-in"
+        case .lanDetails: return "Ask Hermes for your connection details"
+        case .tailscaleServe: return "Ask Hermes to configure Tailscale Serve"
+        case .reverseProxyDetails: return "Ask Hermes to confirm your HTTPS address"
+        }
+    }
+
+    var text: String {
+        switch self {
+        case .dashboardNotRunning:
+            return "Please set up or start the Hermes dashboard for me. Make sure it requires authentication, "
+                + "and tell me which port it is using when it is ready. Do not disable authentication."
+        case .dashboardUnknown:
+            return "Please check whether the Hermes dashboard is currently running. If it is, tell me which port it uses. "
+                + "If it is not running, set it up or start it. Make sure dashboard authentication remains enabled."
+        case .credentialsMissing:
+            return "Please check the authentication configuration for my Hermes dashboard. "
+                + "If dashboard login credentials have not been configured yet, set them up securely and tell me what "
+                + "username and password I should use with Hermes Conduit. Do not disable authentication."
+        case .credentialsUnknown:
+            return "Does my Hermes dashboard require authentication? If so, tell me what username and password I should "
+                + "use with Hermes Conduit. If authentication is not configured, set it up securely. Do not disable authentication."
+        case .lanDetails:
+            return "Please make sure the Hermes dashboard is reachable from other devices on my local network, then tell me "
+                + "the local IP address or hostname and the dashboard port I should use with Hermes Conduit. "
+                + "Keep dashboard authentication enabled."
+        case .tailscaleServe:
+            return "Please check whether the Hermes dashboard is running. Make sure Tailscale is available on this machine, "
+                + "then configure Tailscale Serve so I can securely access the dashboard from my iPhone or iPad. "
+                + "Keep dashboard authentication enabled. When it is ready, tell me the hostname/address and port I should use "
+                + "with Hermes Conduit."
+        case .reverseProxyDetails:
+            return "Please confirm the HTTPS URL I should use to access the Hermes dashboard through my existing reverse proxy, "
+                + "including any custom port or path prefix. Also confirm that dashboard authentication remains enabled."
+        }
+    }
+}
+
+/// The wizard's state: a navigation path of steps plus the answers collected
+/// along the way. All mutations are explicit transitions so tests can drive
+/// the exact routing contract.
+struct ConnectionSetupFlow: Equatable {
+    private(set) var path: [ConnectionSetupStep]
+    private(set) var dashboardAnswer: ConnectionSetupAnswer?
+    private(set) var credentialsAnswer: ConnectionSetupAnswer?
+    private(set) var accessMethod: ConnectionAccessMethod?
+
+    /// The screen currently presented.
+    var step: ConnectionSetupStep { path.last ?? .dashboard }
+
+    var canGoBack: Bool { path.count > 1 }
+
+    /// "Step N of 3" for the core questions; `nil` on branch and
+    /// troubleshooting screens, which sit outside the numbered sequence.
+    var progressLabel: String? {
+        switch step {
+        case .dashboard: return "Step 1 of 3"
+        case .credentials: return "Step 2 of 3"
+        case .accessMethod: return "Step 3 of 3"
+        case .lan, .tailscale, .reverseProxy, .detailsReady,
+             .tlsTroubleshooting, .cloudflareTroubleshooting:
+            return nil
+        }
+    }
+
+    init(entry: ConnectionHelpDestination = .start) {
+        path = [Self.entryStep(for: entry)]
+    }
+
+    /// Failure-driven Round-1 destinations land at sensible parts of the
+    /// assistant; `.tls` and `.cloudflare` stay direct troubleshooting
+    /// surfaces rather than wizard questions.
+    static func entryStep(for destination: ConnectionHelpDestination) -> ConnectionSetupStep {
+        switch destination {
+        case .start, .dashboard: return .dashboard
+        case .credentials: return .credentials
+        case .network: return .accessMethod
+        case .tls: return .tlsTroubleshooting
+        case .cloudflare: return .cloudflareTroubleshooting
+        }
+    }
+
+    mutating func back() {
+        guard canGoBack else { return }
+        path.removeLast()
+    }
+
+    /// Answering Yes moves on; No / I don't know keep the question on screen
+    /// with its Ask Hermes guidance until the user confirms readiness.
+    mutating func answerDashboard(_ answer: ConnectionSetupAnswer) {
+        dashboardAnswer = answer
+        if answer == .yes {
+            advance(to: .credentials)
+        }
+    }
+
+    /// The "Dashboard is ready" continuation after the No / I don't know
+    /// guidance.
+    mutating func confirmDashboardReady() {
+        answerDashboard(.yes)
+    }
+
+    mutating func answerCredentials(_ answer: ConnectionSetupAnswer) {
+        credentialsAnswer = answer
+        if answer == .yes {
+            advance(to: .accessMethod)
+        }
+    }
+
+    /// The continuation after the credentials No / I don't know guidance.
+    mutating func confirmCredentialsReady() {
+        answerCredentials(.yes)
+    }
+
+    mutating func selectAccessMethod(_ method: ConnectionAccessMethod) {
+        accessMethod = method
+        advance(to: step(for: method))
+    }
+
+    /// "I have the connection details" on a branch screen. This round lands
+    /// on an honest placeholder; the details form itself is later work.
+    mutating func confirmDetailsReady() {
+        advance(to: .detailsReady)
+    }
+
+    /// Topic switching on the troubleshooting surfaces (TLS ⇄ Cloudflare).
+    /// Ignored for wizard destinations, which route through the questions.
+    mutating func showTroubleshooting(_ destination: ConnectionHelpDestination) {
+        guard destination == .tls || destination == .cloudflare else { return }
+        advance(to: Self.entryStep(for: destination))
+    }
+
+    func step(for method: ConnectionAccessMethod) -> ConnectionSetupStep {
+        switch method {
+        case .lan: return .lan
+        case .tailscale: return .tailscale
+        case .reverseProxy: return .reverseProxy
+        }
+    }
+
+    private mutating func advance(to step: ConnectionSetupStep) {
+        guard step != self.step else { return }
+        path.append(step)
+    }
+}

--- a/Conduit/Views/AskHermesPromptView.swift
+++ b/Conduit/Views/AskHermesPromptView.swift
@@ -15,6 +15,7 @@ struct AskHermesPromptView: View {
     let prompt: String
 
     @State private var copied = false
+    @State private var copyCount = 0
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -32,6 +33,7 @@ struct AskHermesPromptView: View {
                 Button {
                     UIPasteboard.general.string = prompt
                     copied = true
+                    copyCount += 1
                 } label: {
                     Label("Copy Prompt", systemImage: copied ? "checkmark" : "doc.on.doc")
                         .font(.footnote.weight(.semibold))
@@ -43,10 +45,6 @@ struct AskHermesPromptView: View {
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                         .accessibilityIdentifier("setup.copied-confirmation")
-                        .task {
-                            try? await Task.sleep(for: .seconds(2))
-                            copied = false
-                        }
                 }
             }
             .buttonStyle(.borderless)
@@ -54,5 +52,12 @@ struct AskHermesPromptView: View {
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
         .conduitGlassSurface(cornerRadius: 18, tint: .conduitAura.opacity(0.06))
+        // Keyed to the copy count so each tap restarts the confirmation
+        // window instead of inheriting an earlier tap's deadline.
+        .task(id: copyCount) {
+            guard copyCount > 0 else { return }
+            try? await Task.sleep(for: .seconds(2))
+            copied = false
+        }
     }
 }

--- a/Conduit/Views/AskHermesPromptView.swift
+++ b/Conduit/Views/AskHermesPromptView.swift
@@ -1,0 +1,58 @@
+//
+//  AskHermesPromptView.swift
+//  Conduit
+//
+//  A copyable "Ask Hermes" prompt card used across the Connection Setup
+//  wizard. Purely clipboard-based: nothing is ever sent to Hermes from here,
+//  and the prompts contain no secrets.
+//
+
+import SwiftUI
+import UIKit
+
+struct AskHermesPromptView: View {
+    let title: String
+    let prompt: String
+
+    @State private var copied = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label(title, systemImage: "sparkles")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.conduitAccent)
+
+            Text(prompt)
+                .font(.subheadline)
+                .fixedSize(horizontal: false, vertical: true)
+                .textSelection(.enabled)
+                .accessibilityIdentifier("setup.prompt-text")
+
+            HStack(spacing: 8) {
+                Button {
+                    UIPasteboard.general.string = prompt
+                    copied = true
+                } label: {
+                    Label("Copy Prompt", systemImage: copied ? "checkmark" : "doc.on.doc")
+                        .font(.footnote.weight(.semibold))
+                }
+                .accessibilityIdentifier("setup.copy-prompt")
+
+                if copied {
+                    Text("Copied")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .accessibilityIdentifier("setup.copied-confirmation")
+                        .task {
+                            try? await Task.sleep(for: .seconds(2))
+                            copied = false
+                        }
+                }
+            }
+            .buttonStyle(.borderless)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .conduitGlassSurface(cornerRadius: 18, tint: .conduitAura.opacity(0.06))
+    }
+}

--- a/Conduit/Views/AskHermesPromptView.swift
+++ b/Conduit/Views/AskHermesPromptView.swift
@@ -52,12 +52,38 @@ struct AskHermesPromptView: View {
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
         .conduitGlassSurface(cornerRadius: 18, tint: .conduitAura.opacity(0.06))
-        // Keyed to the copy count so each tap restarts the confirmation
-        // window instead of inheriting an earlier tap's deadline.
+        // Keyed to the copy count so each tap replaces the previous
+        // confirmation task (SwiftUI cancels the old one on id change).
         .task(id: copyCount) {
             guard copyCount > 0 else { return }
-            try? await Task.sleep(for: .seconds(2))
-            copied = false
+            await Self.runCopiedConfirmation {
+                copied = false
+            }
         }
+    }
+
+    /// The "Copied" confirmation window. Cancellation-aware by contract:
+    /// when a newer copy tap replaces this task, SwiftUI cancels the sleeping
+    /// task, and a cancelled task must return WITHOUT clearing — only the
+    /// currently active confirmation may reset the flag. MainActor-isolated
+    /// because onExpire mutates view state. Sleep and duration are injectable
+    /// so the cancellation race has deterministic unit coverage; any error
+    /// from the sleep (in practice, cancellation) leaves the flag untouched.
+    @MainActor
+    static func runCopiedConfirmation(
+        duration: Duration = .seconds(2),
+        sleep: (Duration) async throws -> Void = { try await Task.sleep(for: $0) },
+        onExpire: @escaping () -> Void
+    ) async {
+        do {
+            try await sleep(duration)
+        } catch {
+            return
+        }
+        // A sleep that resolved in the same tick its task was cancelled is
+        // still a replaced task: it must not win the race against the
+        // confirmation that replaced it.
+        guard !Task.isCancelled else { return }
+        onExpire()
     }
 }

--- a/Conduit/Views/ConnectionSetupView.swift
+++ b/Conduit/Views/ConnectionSetupView.swift
@@ -2,28 +2,28 @@
 //  ConnectionSetupView.swift
 //  Conduit
 //
-//  Round-1 shell for the Connection Setup Assistant. This is deliberately
-//  NOT the guided onboarding yet: it establishes the presentation mechanism
-//  the assistant will fill in — a destination-routed help surface reachable
-//  from the login card's entry point and from classified login failures —
-//  and offers static quick checks per destination.
+//  Round-2 guided Connection Setup wizard. The routing lives in
+//  ConnectionSetupFlow (unit-tested); this view renders the model's current
+//  step and forwards taps as model transitions. Round 1's TLS and Cloudflare
+//  quick checks remain available as direct troubleshooting surfaces, reachable
+//  from failure-driven help destinations.
+//
+//  The assistant is strictly opt-in: it opens only from the login card's
+//  entry point or a Troubleshoot Connection action, never automatically, and
+//  stores no completion state.
 //
 
 import SwiftUI
 
-/// Placeholder shell for the Connection Setup Assistant. `initialDestination`
-/// comes from the login card's entry point (`.start`) or from a classified
-/// login failure's help destination, so later rounds can build the guided
-/// flows without touching error classification again.
 struct ConnectionSetupView: View {
     let initialDestination: ConnectionHelpDestination
 
     @Environment(\.dismiss) private var dismiss
-    @State private var destination: ConnectionHelpDestination
+    @State private var flow: ConnectionSetupFlow
 
     init(initialDestination: ConnectionHelpDestination) {
         self.initialDestination = initialDestination
-        _destination = State(initialValue: initialDestination)
+        _flow = State(initialValue: ConnectionSetupFlow(entry: initialDestination))
     }
 
     var body: some View {
@@ -37,6 +37,16 @@ struct ConnectionSetupView: View {
             .navigationTitle("Connection Setup")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
+                if flow.canGoBack {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button {
+                            flow.back()
+                        } label: {
+                            Label("Back", systemImage: "chevron.left")
+                        }
+                        .accessibilityIdentifier("setup.back")
+                    }
+                }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { dismiss() }
                         .accessibilityIdentifier("connection-setup.done")
@@ -45,22 +55,279 @@ struct ConnectionSetupView: View {
         }
     }
 
+    // MARK: - Step routing
+
+    @ViewBuilder
     private var content: some View {
+        switch flow.step {
+        case .dashboard: dashboardStep
+        case .credentials: credentialsStep
+        case .accessMethod: accessMethodStep
+        case .lan: lanBranch
+        case .tailscale: tailscaleBranch
+        case .reverseProxy: reverseProxyBranch
+        case .detailsReady: detailsReadyStep
+        case .tlsTroubleshooting: troubleshootingStep(.tls)
+        case .cloudflareTroubleshooting: troubleshootingStep(.cloudflare)
+        }
+    }
+
+    // MARK: - Step 1: Dashboard readiness
+
+    private var dashboardStep: some View {
+        readinessQuestion(
+            progress: flow.progressLabel,
+            question: "Is your Hermes dashboard running?",
+            explanation: "Hermes Conduit connects to a Hermes dashboard you (or your assistant) run yourself. "
+                + "The dashboard has to be up before Conduit can reach it.",
+            selectedAnswer: flow.dashboardAnswer,
+            onAnswer: { flow.answerDashboard($0) },
+            guidance: { dashboardGuidance }
+        )
+    }
+
+    @ViewBuilder
+    private var dashboardGuidance: some View {
+        switch flow.dashboardAnswer {
+        case .no:
+            AskHermesPromptView(title: ConnectionSetupPrompt.dashboardNotRunning.title, prompt: ConnectionSetupPrompt.dashboardNotRunning.text)
+            continueButton("Dashboard is ready") { flow.confirmDashboardReady() }
+                .accessibilityIdentifier("setup.continue")
+        case .unknown:
+            AskHermesPromptView(title: ConnectionSetupPrompt.dashboardUnknown.title, prompt: ConnectionSetupPrompt.dashboardUnknown.text)
+            continueButton("Dashboard is ready") { flow.confirmDashboardReady() }
+                .accessibilityIdentifier("setup.continue")
+        default:
+            EmptyView()
+        }
+    }
+
+    // MARK: - Step 2: Dashboard credentials
+
+    private var credentialsStep: some View {
+        readinessQuestion(
+            progress: flow.progressLabel,
+            question: "Do you have your Hermes dashboard login credentials?",
+            explanation: "This means the Hermes dashboard username and password you sign in with — not Tailscale, "
+                + "Cloudflare, or Apple credentials.",
+            selectedAnswer: flow.credentialsAnswer,
+            onAnswer: { flow.answerCredentials($0) },
+            guidance: { credentialsGuidance }
+        )
+    }
+
+    @ViewBuilder
+    private var credentialsGuidance: some View {
+        switch flow.credentialsAnswer {
+        case .no:
+            AskHermesPromptView(title: ConnectionSetupPrompt.credentialsMissing.title, prompt: ConnectionSetupPrompt.credentialsMissing.text)
+            continueButton("Credentials are ready") { flow.confirmCredentialsReady() }
+                .accessibilityIdentifier("setup.continue")
+        case .unknown:
+            AskHermesPromptView(title: ConnectionSetupPrompt.credentialsUnknown.title, prompt: ConnectionSetupPrompt.credentialsUnknown.text)
+            continueButton("Credentials are ready") { flow.confirmCredentialsReady() }
+                .accessibilityIdentifier("setup.continue")
+        default:
+            EmptyView()
+        }
+    }
+
+    // MARK: - Step 3: Access method
+
+    private var accessMethodStep: some View {
         VStack(alignment: .leading, spacing: 18) {
-            Text("Guided setup for your self-hosted Hermes dashboard is coming here. Meanwhile, these quick checks cover the most common causes of failed connections.")
+            if let progress = flow.progressLabel {
+                stepLabel(progress)
+            }
+            Text("How will this iPhone or iPad reach Hermes?")
+                .font(.title3.weight(.semibold))
+            Text("Pick how Conduit should reach your self-hosted Hermes dashboard. You can change this later.")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
 
-            Picker("Topic", selection: $destination) {
-                ForEach(ConnectionHelpDestination.allCases) { topic in
-                    Text(topic.displayName).tag(topic)
+            methodCard(
+                title: "I’m on the same network as Hermes",
+                supporting: "Use this when Conduit and the Hermes machine are on the same home or local network.",
+                identifier: "setup.method-lan"
+            ) {
+                flow.selectAccessMethod(.lan)
+            }
+
+            methodCard(
+                title: "Tailscale",
+                supporting: "Use Tailscale when you want to reach Hermes securely while away from home.",
+                badge: "Recommended for remote access",
+                identifier: "setup.method-tailscale"
+            ) {
+                flow.selectAccessMethod(.tailscale)
+            }
+
+            methodCard(
+                title: "I already have a domain or reverse proxy",
+                supporting: "Use this if you already access Hermes through an HTTPS hostname you manage.",
+                identifier: "setup.method-reverseProxy"
+            ) {
+                flow.selectAccessMethod(.reverseProxy)
+            }
+
+            notSureGuidance
+        }
+    }
+
+    @State private var showNotSureGuidance = false
+
+    private var notSureGuidance: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Button {
+                showNotSureGuidance.toggle()
+            } label: {
+                HStack {
+                    Label("I’m not sure", systemImage: "questionmark.circle")
+                        .font(.subheadline.weight(.semibold))
+                    Spacer()
+                    Image(systemName: showNotSureGuidance ? "chevron.up" : "chevron.down")
+                        .font(.caption.weight(.semibold))
                 }
+                .foregroundStyle(.primary)
+            }
+            .accessibilityIdentifier("setup.method-notsure")
+
+            if showNotSureGuidance {
+                VStack(alignment: .leading, spacing: 10) {
+                    guidanceBullet("Using Conduit at home, on the same network as the Hermes machine? Choose Same Network.")
+                    guidanceBullet("Need access away from home without existing remote access? Choose Tailscale — the simplest secure option.")
+                    guidanceBullet("Already operating an HTTPS domain or reverse proxy for Hermes? Choose Existing Domain.")
+                }
+                .padding(.top, 2)
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .conduitGlassSurface(cornerRadius: 18, tint: .conduitAura.opacity(0.06))
+    }
+
+    // MARK: - LAN branch
+
+    private var lanBranch: some View {
+        branchShell(
+            title: "Same network as Hermes",
+            intro: "Here is what you will need to connect Conduit over your local network:",
+            needs: [
+                "The Hermes dashboard is running.",
+                "You have dashboard login credentials.",
+                "You know the Hermes machine’s LAN IP address or local hostname.",
+                "You know the dashboard port.",
+                "This device is on the same reachable network."
+            ],
+            prompt: .lanDetails
+        )
+    }
+
+    // MARK: - Tailscale branch
+
+    private var tailscaleBranch: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text("Reach Hermes with Tailscale")
+                .font(.title3.weight(.semibold))
+            Text("Tailscale gives you secure access from anywhere, including the recommended Tailscale Serve path:")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(alignment: .leading, spacing: 12) {
+                numberedStep(1, "Tailscale is installed on the Hermes machine.")
+                numberedStep(2, "Tailscale is installed on this iPhone or iPad.")
+                numberedStep(3, "Both are signed in to the same tailnet.")
+                numberedStep(4, "The Hermes dashboard is running.")
+                numberedStep(5, "Hermes configures Tailscale Serve for the dashboard.")
+                numberedStep(6, "Hermes tells you the address to enter into Conduit.")
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .conduitGlassSurface(cornerRadius: 18, tint: .conduitAura.opacity(0.06))
+
+            Text("Conduit never installs or configures Tailscale, and it doesn’t assume an address or port — Hermes tells you what to use.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            AskHermesPromptView(title: ConnectionSetupPrompt.tailscaleServe.title, prompt: ConnectionSetupPrompt.tailscaleServe.text)
+            continueButton("I have the connection details") { flow.confirmDetailsReady() }
+                .accessibilityIdentifier("setup.details-ready")
+        }
+    }
+
+    // MARK: - Reverse-proxy branch
+
+    private var reverseProxyBranch: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text("Use your existing HTTPS domain")
+                .font(.title3.weight(.semibold))
+            Text("This branch is only for HTTPS infrastructure you already operate — Conduit does not guide you through creating one.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(alignment: .leading, spacing: 12) {
+                Text("You will need:")
+                    .font(.subheadline.weight(.semibold))
+                guidanceBullet("Your existing HTTPS Hermes dashboard URL — for example https://hermes.example.com, https://hermes.example.com:9443, or https://example.com/hermes.")
+                guidanceBullet("Any custom port.")
+                guidanceBullet("Any path prefix your proxy uses.")
+                guidanceBullet("Your dashboard login credentials.")
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .conduitGlassSurface(cornerRadius: 18, tint: .conduitAura.opacity(0.06))
+
+            Text("Conduit will not ask you to expose a raw public port, create firewall rules, or bypass certificate checks.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            AskHermesPromptView(title: ConnectionSetupPrompt.reverseProxyDetails.title, prompt: ConnectionSetupPrompt.reverseProxyDetails.text)
+            continueButton("I have the connection details") { flow.confirmDetailsReady() }
+                .accessibilityIdentifier("setup.details-ready")
+        }
+    }
+
+    // MARK: - Details-ready placeholder
+
+    private var detailsReadyStep: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text("Details ready")
+                .font(.title3.weight(.semibold))
+            Text("Collecting your Hermes address and port inside this assistant arrives in a future update.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Text("Meanwhile, tap Done and enter your dashboard address directly in the login form — the guidance above covers exactly what to enter, and Conduit accepts custom ports and path prefixes there.")
+                .font(.subheadline)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    // MARK: - Troubleshooting surfaces (Round-1 content retained)
+
+    private func troubleshootingStep(_ topic: ConnectionHelpDestination) -> some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Picker("Topic", selection: topicBinding) {
+                Text(ConnectionHelpDestination.tls.displayName).tag(ConnectionHelpDestination.tls)
+                Text(ConnectionHelpDestination.cloudflare.displayName).tag(ConnectionHelpDestination.cloudflare)
             }
             .font(.subheadline)
+            .accessibilityIdentifier("setup.troubleshooting-picker")
+
+            Text(topic == .tls
+                ? "Checks for HTTPS and certificate problems when connecting to your dashboard."
+                : "Checks for Cloudflare Access service-token problems when connecting to your dashboard.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
 
             VStack(alignment: .leading, spacing: 14) {
-                ForEach(Array(destination.checks.enumerated()), id: \.offset) { _, check in
+                ForEach(Array(topic.checks.enumerated()), id: \.offset) { _, check in
                     HStack(alignment: .top, spacing: 10) {
                         Image(systemName: "checkmark.circle")
                             .font(.footnote)
@@ -77,9 +344,185 @@ struct ConnectionSetupView: View {
             .conduitGlassSurface(cornerRadius: 18, tint: .conduitAura.opacity(0.06))
         }
     }
+
+    private var topicBinding: Binding<ConnectionHelpDestination> {
+        Binding(
+            get: { flow.step == .cloudflareTroubleshooting ? .cloudflare : .tls },
+            set: { flow.showTroubleshooting($0) }
+        )
+    }
+
+    // MARK: - Reusable pieces
+
+    private func readinessQuestion(
+        progress: String?,
+        question: String,
+        explanation: String,
+        selectedAnswer: ConnectionSetupAnswer?,
+        onAnswer: @escaping (ConnectionSetupAnswer) -> Void,
+        @ViewBuilder guidance: () -> some View
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 18) {
+            if let progress {
+                stepLabel(progress)
+            }
+            Text(question)
+                .font(.title3.weight(.semibold))
+            Text(explanation)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            answerRow("Yes", selected: selectedAnswer == .yes, identifier: "setup.answer-yes") {
+                onAnswer(.yes)
+            }
+            answerRow("No", selected: selectedAnswer == .no, identifier: "setup.answer-no") {
+                onAnswer(.no)
+            }
+            answerRow("I don’t know", selected: selectedAnswer == .unknown, identifier: "setup.answer-unknown") {
+                onAnswer(.unknown)
+            }
+
+            guidance()
+        }
+    }
+
+    private func answerRow(
+        _ label: String,
+        selected: Bool,
+        identifier: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack {
+                Text(label)
+                    .font(.subheadline.weight(.semibold))
+                Spacer()
+                if selected {
+                    Image(systemName: "checkmark")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(.conduitAccent)
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .conduitGlassSurface(cornerRadius: 14, tint: .conduitAura.opacity(0.06))
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(identifier)
+    }
+
+    private func methodCard(
+        title: String,
+        supporting: String,
+        badge: String? = nil,
+        identifier: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text(title)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.primary)
+                        .multilineTextAlignment(.leading)
+                    Spacer()
+                }
+                if let badge {
+                    Text(badge)
+                        .font(.caption.weight(.semibold))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(.conduitAccent.opacity(0.15), in: Capsule())
+                        .foregroundStyle(.conduitAccent)
+                }
+                Text(supporting)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .conduitGlassSurface(cornerRadius: 16, tint: .conduitAura.opacity(0.06))
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(identifier)
+    }
+
+    private func branchShell(
+        title: String,
+        intro: String,
+        needs: [String],
+        prompt: ConnectionSetupPrompt
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text(title)
+                .font(.title3.weight(.semibold))
+            Text(intro)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(alignment: .leading, spacing: 12) {
+                ForEach(Array(needs.enumerated()), id: \.offset) { _, need in
+                    guidanceBullet(need)
+                }
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .conduitGlassSurface(cornerRadius: 18, tint: .conduitAura.opacity(0.06))
+
+            AskHermesPromptView(title: prompt.title, prompt: prompt.text)
+            continueButton("I have the connection details") { flow.confirmDetailsReady() }
+                .accessibilityIdentifier("setup.details-ready")
+        }
+    }
+
+    private func numberedStep(_ number: Int, _ text: String) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Text("\(number).")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.conduitAccent)
+            Text(text)
+                .font(.subheadline)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func stepLabel(_ text: String) -> some View {
+        Text(text)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.conduitAccent)
+            .accessibilityIdentifier("setup.step-label")
+    }
+
+    private func continueButton(_ label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(.subheadline.weight(.semibold))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(.conduitAccent)
+    }
+
+    private func guidanceBullet(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "circle.fill")
+                .font(.system(size: 5))
+                .foregroundStyle(.conduitAccent)
+                .padding(.top, 6)
+            Text(text)
+                .font(.subheadline)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
 }
 
-// MARK: - Per-destination quick checks
+// MARK: - Round-1 troubleshooting content (retained)
 
 extension ConnectionHelpDestination {
     var displayName: String {
@@ -93,9 +536,9 @@ extension ConnectionHelpDestination {
         }
     }
 
-    /// Static quick checks shown in the Round-1 shell. Safe-by-construction:
-    /// never recommends exposing the dashboard to the public internet or
-    /// weakening HTTPS. The guided walkthroughs (later rounds) replace these.
+    /// Static quick checks shown on the troubleshooting surfaces. Safe by
+    /// construction: never recommends exposing the dashboard to the public
+    /// internet or weakening HTTPS.
     var checks: [String] {
         switch self {
         case .start:

--- a/Conduit/Views/ConnectionSetupView.swift
+++ b/Conduit/Views/ConnectionSetupView.swift
@@ -16,13 +16,11 @@
 import SwiftUI
 
 struct ConnectionSetupView: View {
-    let initialDestination: ConnectionHelpDestination
-
     @Environment(\.dismiss) private var dismiss
     @State private var flow: ConnectionSetupFlow
+    @State private var showNotSureGuidance = false
 
     init(initialDestination: ConnectionHelpDestination) {
-        self.initialDestination = initialDestination
         _flow = State(initialValue: ConnectionSetupFlow(entry: initialDestination))
     }
 
@@ -147,7 +145,7 @@ struct ConnectionSetupView: View {
                 .fixedSize(horizontal: false, vertical: true)
 
             methodCard(
-                title: "I’m on the same network as Hermes",
+                title: ConnectionAccessMethod.lan.displayTitle,
                 supporting: "Use this when Conduit and the Hermes machine are on the same home or local network.",
                 identifier: "setup.method-lan"
             ) {
@@ -155,7 +153,7 @@ struct ConnectionSetupView: View {
             }
 
             methodCard(
-                title: "Tailscale",
+                title: ConnectionAccessMethod.tailscale.displayTitle,
                 supporting: "Use Tailscale when you want to reach Hermes securely while away from home.",
                 badge: "Recommended for remote access",
                 identifier: "setup.method-tailscale"
@@ -164,7 +162,7 @@ struct ConnectionSetupView: View {
             }
 
             methodCard(
-                title: "I already have a domain or reverse proxy",
+                title: ConnectionAccessMethod.reverseProxy.displayTitle,
                 supporting: "Use this if you already access Hermes through an HTTPS hostname you manage.",
                 identifier: "setup.method-reverseProxy"
             ) {
@@ -174,8 +172,6 @@ struct ConnectionSetupView: View {
             notSureGuidance
         }
     }
-
-    @State private var showNotSureGuidance = false
 
     private var notSureGuidance: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -536,36 +532,14 @@ extension ConnectionHelpDestination {
         }
     }
 
-    /// Static quick checks shown on the troubleshooting surfaces. Safe by
-    /// construction: never recommends exposing the dashboard to the public
-    /// internet or weakening HTTPS.
+    /// Static quick checks shown on the troubleshooting surfaces. Only the
+    /// TLS and Cloudflare topics are reachable (they are the direct
+    /// troubleshooting entries); the other destinations route to wizard
+    /// questions, so they carry no checks. Safe by construction: never
+    /// recommends exposing the dashboard to the public internet or weakening
+    /// HTTPS.
     var checks: [String] {
         switch self {
-        case .start:
-            return [
-                "The dashboard address should look like https://hermes.example — include any path prefix your reverse proxy uses (for example https://example.com/hermes).",
-                "Open the same address in Safari on this device. If the dashboard doesn’t load there, what you see is the same wall Conduit hits.",
-                "Remote dashboards must use HTTPS. Plain HTTP works only for localhost, private LAN addresses, and Tailscale."
-            ]
-        case .dashboard:
-            return [
-                "Confirm the address points at the Hermes dashboard itself, not another service on the same host.",
-                "Include custom ports (for example https://hermes.example:9119) and any reverse-proxy path prefix.",
-                "If the dashboard moved or its certificate changed, re-enter the full address from scratch."
-            ]
-        case .credentials:
-            return [
-                "Conduit needs the username and password you use to sign in to the Hermes dashboard — not a Cloudflare or Tailscale account.",
-                "Try signing in on the dashboard’s own web page to confirm the account still works.",
-                "If the password was rejected after a dashboard change, reset it where your dashboard manages users."
-            ]
-        case .network:
-            return [
-                "Make sure the Hermes dashboard is actually running on its host machine.",
-                "This device must be on the same network as the dashboard, or connected through Tailscale or a VPN. Tailscale Serve also gives you HTTPS for free.",
-                "Mobile hotspots and guest Wi-Fi often block device-to-device traffic — try another network.",
-                "Avoid opening the dashboard port directly to the internet; prefer Tailscale or an authenticated reverse proxy."
-            ]
         case .tls:
             return [
                 "If you use your own certificate authority, install and trust its root certificate on this device (Settings → General → VPN & Device Management → Certificate Trust Settings).",
@@ -578,6 +552,8 @@ extension ConnectionHelpDestination {
                 "Make sure a Service Auth policy allows that token to reach this Access application.",
                 "Or turn off \"Use Cloudflare Access service token\" to sign in interactively through the in-app browser."
             ]
+        case .start, .dashboard, .credentials, .network:
+            return []
         }
     }
 }

--- a/ConduitTests/AskHermesPromptViewTests.swift
+++ b/ConduitTests/AskHermesPromptViewTests.swift
@@ -33,6 +33,45 @@ final class AskHermesPromptViewTests: XCTestCase {
         )
     }
 
+    func testPostSleepCancellationGuardPreventsClearingCopied() async {
+        // Case 2, distinct from the throwing-sleep test above: the injected
+        // sleep completes SUCCESSFULLY after the surrounding task was already
+        // cancelled, so execution passes the do/catch and reaches the
+        // post-sleep `Task.isCancelled` guard. Removing that guard makes this
+        // test fail. The fake sleep suspends on a continuation so the
+        // cancel-before-resume ordering is fully deterministic.
+        let suspension = SleepSuspension()
+        let entered = expectation(description: "fake sleep suspended")
+        var cleared = false
+
+        let window = Task {
+            await AskHermesPromptView.runCopiedConfirmation(
+                // The fake sleep ignores its duration — cancellation ordering,
+                // not timing, is what this test controls.
+                duration: .seconds(2),
+                sleep: { _ in
+                    await withCheckedContinuation { continuation in
+                        suspension.suspend(continuation)
+                        entered.fulfill()
+                    }
+                },
+                onExpire: { cleared = true }
+            )
+        }
+
+        await fulfillment(of: [entered], timeout: 5)
+        window.cancel()
+        // Fail loudly instead of hanging if the sleep never suspended.
+        XCTAssertTrue(suspension.isSuspended, "fake sleep must be suspended before cancel/resume")
+        suspension.resume()
+        await window.value
+
+        XCTAssertFalse(
+            cleared,
+            "A cancelled task whose sleep completed successfully must still not clear the newer confirmation"
+        )
+    }
+
     func testUncancelledConfirmationWindowClearsCopiedOnExpiry() async {
         // The active (uncancelled) confirmation task is the only thing that
         // may reset `copied`, and it does so when its window expires.
@@ -45,5 +84,32 @@ final class AskHermesPromptViewTests: XCTestCase {
             cleared,
             "An uncancelled confirmation task must clear the copied flag on expiry"
         )
+    }
+}
+
+/// Lock/continuation glue so the fake sleep can suspend deterministically
+/// until the test chooses to resume it after cancelling the window task.
+private final class SleepSuspension: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    var isSuspended: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return continuation != nil
+    }
+
+    func suspend(_ continuation: CheckedContinuation<Void, Never>) {
+        lock.lock()
+        self.continuation = continuation
+        lock.unlock()
+    }
+
+    func resume() {
+        lock.lock()
+        let pending = continuation
+        continuation = nil
+        lock.unlock()
+        pending?.resume()
     }
 }

--- a/ConduitTests/AskHermesPromptViewTests.swift
+++ b/ConduitTests/AskHermesPromptViewTests.swift
@@ -1,0 +1,49 @@
+//
+//  AskHermesPromptViewTests.swift
+//  Conduit
+//
+//  Deterministic coverage for the Copy Prompt confirmation race: when a
+//  second copy tap replaces the confirmation task, SwiftUI cancels the
+//  first task's sleep — and that cancellation must NOT clear the second
+//  tap's fresh confirmation. The sleep is injected, so both outcomes are
+//  exercised without real timers.
+//
+
+import XCTest
+@testable import Conduit
+
+final class AskHermesPromptViewTests: XCTestCase {
+    func testCancelledConfirmationWindowDoesNotClearCopied() async {
+        // The real cancellation mechanism: the window's own Task.sleep is
+        // cancelled mid-sleep (as SwiftUI does when a second tap replaces
+        // the task). Deterministic — cancellation during the sleep always
+        // throws, so no timing is involved.
+        var cleared = false
+        let window = Task {
+            await AskHermesPromptView.runCopiedConfirmation(
+                duration: .seconds(3600),
+                onExpire: { cleared = true }
+            )
+        }
+        window.cancel()
+        await window.value
+        XCTAssertFalse(
+            cleared,
+            "A cancelled confirmation task must not clear the replacement tap's fresh confirmation"
+        )
+    }
+
+    func testUncancelledConfirmationWindowClearsCopiedOnExpiry() async {
+        // The active (uncancelled) confirmation task is the only thing that
+        // may reset `copied`, and it does so when its window expires.
+        var cleared = false
+        await AskHermesPromptView.runCopiedConfirmation(
+            duration: .seconds(0),
+            onExpire: { cleared = true }
+        )
+        XCTAssertTrue(
+            cleared,
+            "An uncancelled confirmation task must clear the copied flag on expiry"
+        )
+    }
+}

--- a/ConduitTests/ConnectionSetupFlowTests.swift
+++ b/ConduitTests/ConnectionSetupFlowTests.swift
@@ -48,7 +48,25 @@ final class ConnectionSetupFlowTests: XCTestCase {
 
         flow.confirmDashboardReady()
         XCTAssertEqual(flow.step, .credentials)
-        XCTAssertEqual(flow.dashboardAnswer, .yes)
+        XCTAssertEqual(
+            flow.dashboardAnswer, .no,
+            "Confirming readiness is navigation — it must not rewrite the recorded answer to Yes"
+        )
+    }
+
+    func testAnswerSurvivesConfirmAndBackRoundTrip() {
+        // Answer No, confirm ready, go Back: the recorded answer and its
+        // Ask Hermes guidance state must be exactly what the user said.
+        var flow = ConnectionSetupFlow(entry: .start)
+        flow.answerDashboard(.no)
+        flow.confirmDashboardReady()
+        flow.back()
+        XCTAssertEqual(flow.step, .dashboard)
+        XCTAssertEqual(flow.dashboardAnswer, .no, "Back must restore the original No answer, not a fabricated Yes")
+
+        // Re-confirming from the restored state advances cleanly again.
+        flow.confirmDashboardReady()
+        XCTAssertEqual(flow.step, .credentials)
     }
 
     func testDashboardUnknownThenConfirmAdvances() {
@@ -75,7 +93,24 @@ final class ConnectionSetupFlowTests: XCTestCase {
 
         flow.confirmCredentialsReady()
         XCTAssertEqual(flow.step, .accessMethod)
-        XCTAssertEqual(flow.credentialsAnswer, .yes)
+        XCTAssertEqual(
+            flow.credentialsAnswer, .no,
+            "Confirming readiness is navigation — it must not rewrite the recorded answer to Yes"
+        )
+    }
+
+    func testRepeatedConfirmationsAreIdempotent() {
+        var flow = ConnectionSetupFlow(entry: .start)
+        flow.answerDashboard(.yes)
+        flow.answerCredentials(.yes)
+        flow.selectAccessMethod(.lan)
+        flow.confirmDetailsReady()
+        XCTAssertEqual(flow.step, .detailsReady)
+        // Double-taps on a continue/confirm button must not push duplicates.
+        flow.confirmDetailsReady()
+        flow.confirmDetailsReady()
+        XCTAssertEqual(flow.step, .detailsReady)
+        XCTAssertEqual(flow.path.count, 5, "Path must stay entry step + one entry per real navigation")
     }
 
     func testEntryAtCredentialsSkipsDashboardQuestion() {
@@ -145,12 +180,19 @@ final class ConnectionSetupFlowTests: XCTestCase {
 
     // MARK: - Troubleshooting topic switching
 
-    func testTroubleshootingTopicsSwitchBetweenEachOther() {
-        var tlsFlow = ConnectionSetupFlow(entry: .tls)
-        tlsFlow.showTroubleshooting(.cloudflare)
-        XCTAssertEqual(tlsFlow.step, .cloudflareTroubleshooting)
-        tlsFlow.back()
-        XCTAssertEqual(tlsFlow.step, .tlsTroubleshooting)
+    func testTroubleshootingTopicsReplaceEachOtherInsteadOfStacking() {
+        // A topic switch is replacement, not navigation: flipping TLS ⇄
+        // Cloudflare repeatedly must never grow the back path.
+        var flow = ConnectionSetupFlow(entry: .tls)
+        flow.showTroubleshooting(.cloudflare)
+        XCTAssertEqual(flow.step, .cloudflareTroubleshooting)
+        XCTAssertEqual(flow.path.count, 1)
+        XCTAssertFalse(flow.canGoBack, "Back after a topic replacement leaves troubleshooting entirely")
+        flow.showTroubleshooting(.tls)
+        XCTAssertEqual(flow.step, .tlsTroubleshooting)
+        XCTAssertEqual(flow.path.count, 1)
+        flow.showTroubleshooting(.tls)
+        XCTAssertEqual(flow.step, .tlsTroubleshooting, "Same-topic switch is a no-op")
     }
 
     func testWizardDestinationsDoNotJumpOutOfTheQuestionSequence() {
@@ -174,6 +216,16 @@ final class ConnectionSetupFlowTests: XCTestCase {
 
         flow.selectAccessMethod(.lan)
         XCTAssertNil(flow.progressLabel, "Branch screens sit outside the numbered question sequence")
+
+        // Non-question entries are unnumbered too.
+        XCTAssertNil(ConnectionSetupFlow(entry: .tls).progressLabel)
+        XCTAssertNil(ConnectionSetupFlow(entry: .cloudflare).progressLabel)
+        var detailsFlow = ConnectionSetupFlow(entry: .start)
+        detailsFlow.answerDashboard(.yes)
+        detailsFlow.answerCredentials(.yes)
+        detailsFlow.selectAccessMethod(.lan)
+        detailsFlow.confirmDetailsReady()
+        XCTAssertNil(detailsFlow.progressLabel)
     }
 
     // MARK: - Ask Hermes prompt safety
@@ -213,13 +265,11 @@ final class ConnectionSetupFlowTests: XCTestCase {
     }
 
     func testGuidanceMethodLabelsContainNoExposureLanguage() {
-        // The strings the wizard itself shows for the three methods must stay
-        // free of public-exposure framing.
-        let labels = [
-            "I’m on the same network as Hermes",
-            "Tailscale",
-            "I already have a domain or reverse proxy"
-        ]
+        // The shipped card titles come from the model's displayTitle — the
+        // same strings the wizard renders — so this guards real copy, not
+        // local literals.
+        let labels = ConnectionAccessMethod.allCases.map { $0.displayTitle }
+        XCTAssertEqual(labels.count, 3)
         for label in labels {
             let lowered = label.lowercased()
             XCTAssertFalse(lowered.contains("public"))

--- a/ConduitTests/ConnectionSetupFlowTests.swift
+++ b/ConduitTests/ConnectionSetupFlowTests.swift
@@ -1,0 +1,229 @@
+//
+//  ConnectionSetupFlowTests.swift
+//  Conduit
+//
+//  Routing and safety coverage for the guided Connection Setup wizard model:
+//  destination entry points, question transitions, access-method branches,
+//  back navigation, and the Ask Hermes prompt safety phrases.
+//
+
+import XCTest
+@testable import Conduit
+
+final class ConnectionSetupFlowTests: XCTestCase {
+    // MARK: - Entry destinations
+
+    func testManualEntryBeginsAtDashboard() {
+        XCTAssertEqual(ConnectionSetupFlow(entry: .start).step, .dashboard)
+    }
+
+    func testFailureDestinationsMapToSensibleWizardEntries() {
+        XCTAssertEqual(ConnectionSetupFlow.entryStep(for: .start), .dashboard)
+        XCTAssertEqual(ConnectionSetupFlow.entryStep(for: .dashboard), .dashboard)
+        XCTAssertEqual(ConnectionSetupFlow.entryStep(for: .credentials), .credentials)
+        XCTAssertEqual(ConnectionSetupFlow.entryStep(for: .network), .accessMethod)
+        XCTAssertEqual(ConnectionSetupFlow.entryStep(for: .tls), .tlsTroubleshooting)
+        XCTAssertEqual(ConnectionSetupFlow.entryStep(for: .cloudflare), .cloudflareTroubleshooting)
+    }
+
+    func testTLSAndCloudflareEntriesOpenTroubleshootingDirectly() {
+        XCTAssertEqual(ConnectionSetupFlow(entry: .tls).step, .tlsTroubleshooting)
+        XCTAssertEqual(ConnectionSetupFlow(entry: .cloudflare).step, .cloudflareTroubleshooting)
+    }
+
+    // MARK: - Core question transitions
+
+    func testDashboardYesAdvancesToCredentials() {
+        var flow = ConnectionSetupFlow(entry: .start)
+        flow.answerDashboard(.yes)
+        XCTAssertEqual(flow.step, .credentials)
+        XCTAssertEqual(flow.dashboardAnswer, .yes)
+    }
+
+    func testDashboardNoAndUnknownStayWithGuidanceUntilConfirmedReady() {
+        var flow = ConnectionSetupFlow(entry: .start)
+        flow.answerDashboard(.no)
+        XCTAssertEqual(flow.step, .dashboard, "No must keep the question up with its Ask Hermes guidance")
+        XCTAssertEqual(flow.dashboardAnswer, .no)
+
+        flow.confirmDashboardReady()
+        XCTAssertEqual(flow.step, .credentials)
+        XCTAssertEqual(flow.dashboardAnswer, .yes)
+    }
+
+    func testDashboardUnknownThenConfirmAdvances() {
+        var flow = ConnectionSetupFlow(entry: .start)
+        flow.answerDashboard(.unknown)
+        XCTAssertEqual(flow.step, .dashboard)
+        flow.confirmDashboardReady()
+        XCTAssertEqual(flow.step, .credentials)
+    }
+
+    func testCredentialsYesAdvancesToAccessMethod() {
+        var flow = ConnectionSetupFlow(entry: .start)
+        flow.answerDashboard(.yes)
+        flow.answerCredentials(.yes)
+        XCTAssertEqual(flow.step, .accessMethod)
+    }
+
+    func testCredentialsNoAndUnknownStayWithGuidanceUntilConfirmedReady() {
+        var flow = ConnectionSetupFlow(entry: .start)
+        flow.answerDashboard(.yes)
+        flow.answerCredentials(.no)
+        XCTAssertEqual(flow.step, .credentials)
+        XCTAssertEqual(flow.credentialsAnswer, .no)
+
+        flow.confirmCredentialsReady()
+        XCTAssertEqual(flow.step, .accessMethod)
+        XCTAssertEqual(flow.credentialsAnswer, .yes)
+    }
+
+    func testEntryAtCredentialsSkipsDashboardQuestion() {
+        var flow = ConnectionSetupFlow(entry: .credentials)
+        XCTAssertEqual(flow.step, .credentials)
+        flow.answerCredentials(.yes)
+        XCTAssertEqual(flow.step, .accessMethod)
+        XCTAssertNil(flow.dashboardAnswer, "Entering mid-wizard must not invent answers for skipped questions")
+    }
+
+    // MARK: - Access methods
+
+    func testAccessMethodChoicesRouteToTheirBranches() {
+        for (method, expectedStep) in [
+            (ConnectionAccessMethod.lan, ConnectionSetupStep.lan),
+            (ConnectionAccessMethod.tailscale, ConnectionSetupStep.tailscale),
+            (ConnectionAccessMethod.reverseProxy, ConnectionSetupStep.reverseProxy)
+        ] {
+            var flow = ConnectionSetupFlow(entry: .start)
+            flow.answerDashboard(.yes)
+            flow.answerCredentials(.yes)
+            flow.selectAccessMethod(method)
+            XCTAssertEqual(flow.step, expectedStep, "\(method) must route to \(expectedStep)")
+            XCTAssertEqual(flow.accessMethod, method)
+        }
+    }
+
+    func testSupportedMethodSetIsExactlyTheSafeThree() {
+        // Closed set: LAN, Tailscale, existing reverse proxy. There is no
+        // public-IP/open-port method anywhere in the model.
+        XCTAssertEqual(
+            Set(ConnectionAccessMethod.allCases),
+            [.lan, .tailscale, .reverseProxy]
+        )
+    }
+
+    func testDetailsReadyFollowsBranchConfirmation() {
+        var flow = ConnectionSetupFlow(entry: .start)
+        flow.answerDashboard(.yes)
+        flow.answerCredentials(.yes)
+        flow.selectAccessMethod(.tailscale)
+        flow.confirmDetailsReady()
+        XCTAssertEqual(flow.step, .detailsReady)
+    }
+
+    // MARK: - Back navigation
+
+    func testBackWalksThePathWithoutLosingEntryStep() {
+        var flow = ConnectionSetupFlow(entry: .start)
+        XCTAssertFalse(flow.canGoBack, "The entry step has nowhere to go back to")
+        flow.back()
+        XCTAssertEqual(flow.step, .dashboard, "Back on the entry step must be a no-op")
+
+        flow.answerDashboard(.yes)
+        flow.answerCredentials(.yes)
+        flow.selectAccessMethod(.tailscale)
+        XCTAssertTrue(flow.canGoBack)
+
+        flow.back()
+        XCTAssertEqual(flow.step, .accessMethod)
+        flow.back()
+        XCTAssertEqual(flow.step, .credentials)
+        flow.back()
+        XCTAssertEqual(flow.step, .dashboard)
+        XCTAssertFalse(flow.canGoBack)
+    }
+
+    // MARK: - Troubleshooting topic switching
+
+    func testTroubleshootingTopicsSwitchBetweenEachOther() {
+        var tlsFlow = ConnectionSetupFlow(entry: .tls)
+        tlsFlow.showTroubleshooting(.cloudflare)
+        XCTAssertEqual(tlsFlow.step, .cloudflareTroubleshooting)
+        tlsFlow.back()
+        XCTAssertEqual(tlsFlow.step, .tlsTroubleshooting)
+    }
+
+    func testWizardDestinationsDoNotJumpOutOfTheQuestionSequence() {
+        // The troubleshooting switch is only for the tls/cloudflare surfaces;
+        // it must not be usable to skip straight to branches.
+        var flow = ConnectionSetupFlow(entry: .start)
+        flow.showTroubleshooting(.network)
+        XCTAssertEqual(flow.step, .dashboard)
+    }
+
+    // MARK: - Progress labeling
+
+    func testProgressLabelsCoverTheThreeCoreQuestions() {
+        XCTAssertEqual(ConnectionSetupFlow(entry: .start).progressLabel, "Step 1 of 3")
+
+        var flow = ConnectionSetupFlow(entry: .start)
+        flow.answerDashboard(.yes)
+        XCTAssertEqual(flow.progressLabel, "Step 2 of 3")
+        flow.answerCredentials(.yes)
+        XCTAssertEqual(flow.progressLabel, "Step 3 of 3")
+
+        flow.selectAccessMethod(.lan)
+        XCTAssertNil(flow.progressLabel, "Branch screens sit outside the numbered question sequence")
+    }
+
+    // MARK: - Ask Hermes prompt safety
+
+    func testEveryPromptPreservesDashboardAuthentication() {
+        for prompt in ConnectionSetupPrompt.allCases {
+            let text = prompt.text.lowercased()
+            XCTAssertTrue(
+                text.contains("authentication"),
+                "\(prompt) prompt never mentions authentication: \(prompt.text)"
+            )
+            XCTAssertTrue(
+                text.contains("enabled") || text.contains("disable") || text.contains("requires authentication"),
+                "\(prompt) prompt must explicitly ask Hermes to keep authentication on: \(prompt.text)"
+            )
+        }
+    }
+
+    func testTailscalePromptReferencesTailscaleServe() {
+        XCTAssertTrue(
+            ConnectionSetupPrompt.tailscaleServe.text.contains("Tailscale Serve"),
+            "The Tailscale branch prompt must include the Tailscale Serve configuration path"
+        )
+    }
+
+    func testNoPromptRequestsPublicExposureOrHardCodedPorts() {
+        let forbidden = ["public internet", "port forward", "port-forward", "firewall", "expose", "8080", "9119", "443"]
+        for prompt in ConnectionSetupPrompt.allCases {
+            let text = prompt.text.lowercased()
+            for phrase in forbidden {
+                XCTAssertFalse(
+                    text.contains(phrase),
+                    "\(prompt) prompt must not contain '\(phrase)': \(prompt.text)"
+                )
+            }
+        }
+    }
+
+    func testGuidanceMethodLabelsContainNoExposureLanguage() {
+        // The strings the wizard itself shows for the three methods must stay
+        // free of public-exposure framing.
+        let labels = [
+            "I’m on the same network as Hermes",
+            "Tailscale",
+            "I already have a domain or reverse proxy"
+        ]
+        for label in labels {
+            let lowered = label.lowercased()
+            XCTAssertFalse(lowered.contains("public"))
+            XCTAssertFalse(lowered.contains("open port"))
+        }
+    }
+}

--- a/ConduitUITests/ConnectionSetupUITests.swift
+++ b/ConduitUITests/ConnectionSetupUITests.swift
@@ -1,0 +1,154 @@
+import XCTest
+
+/// Round-2 Connection Setup wizard UI coverage: the guided flow opens from the
+/// login card's entry point, walks Dashboard → Credentials → Access Method,
+/// supports back navigation, shows Copy Prompt on the No / I don't know
+/// paths, and reaches the Tailscale branch. Everything runs offline — no
+/// step performs network I/O.
+final class ConnectionSetupUITests: XCTestCase {
+    private enum Identity {
+        static let connectionSetup = "login.connection-setup"
+        static let done = "connection-setup.done"
+        static let back = "setup.back"
+        static let answerYes = "setup.answer-yes"
+        static let answerNo = "setup.answer-no"
+        static let answerUnknown = "setup.answer-unknown"
+        static let copyPrompt = "setup.copy-prompt"
+        static let methodTailscale = "setup.method-tailscale"
+        static let stepLabel = "setup.step-label"
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    private func openSetup(_ app: XCUIApplication) {
+        let serverField = app.textFields["login.server-url"]
+        XCTAssertTrue(serverField.waitForExistence(timeout: 10), "Login screen did not appear. Tree:\n\(app.debugDescription)")
+
+        let setup = app.buttons[Identity.connectionSetup]
+        XCTAssertTrue(setup.waitForExistence(timeout: 5), "Connection Setup entry point missing. Tree:\n\(app.debugDescription)")
+        if !setup.isHittable { app.swipeDown() }
+        XCTAssertTrue(pollHittability(of: setup, timeout: 5))
+        setup.tap()
+    }
+
+    private func stepLabel(_ app: XCUIApplication, _ expected: String) {
+        let label = app.staticTexts[Identity.stepLabel]
+        XCTAssertTrue(
+            label.waitForExistence(timeout: 5) && label.label == expected,
+            "Expected step '\(expected)', saw '\(label.exists ? label.label : "none")'. Tree:\n\(app.debugDescription)"
+        )
+    }
+
+    func testWizardAdvancesThroughQuestionsToTailscaleBranchAndBack() throws {
+        let app = XCUIApplication()
+        app.launch()
+        openSetup(app)
+
+        // Step 1: dashboard readiness, answered No → Ask Hermes guidance.
+        stepLabel(app, "Step 1 of 3")
+        let no = app.buttons[Identity.answerNo]
+        XCTAssertTrue(no.waitForExistence(timeout: 5), "Dashboard answers missing. Tree:\n\(app.debugDescription)")
+        if !no.isHittable { app.swipeUp() }
+        no.tap()
+
+        let copyPrompt = app.buttons[Identity.copyPrompt]
+        XCTAssertTrue(copyPrompt.waitForExistence(timeout: 5), "Copy Prompt must appear on the No path")
+        if !copyPrompt.isHittable { app.swipeUp() }
+        copyPrompt.tap()
+        XCTAssertTrue(
+            app.staticTexts["setup.copied-confirmation"].waitForExistence(timeout: 3),
+            "Copying must confirm to the user"
+        )
+
+        let continueButton = app.buttons["setup.continue"]
+        XCTAssertTrue(continueButton.waitForExistence(timeout: 3))
+        if !continueButton.isHittable { app.swipeUp() }
+        XCTAssertTrue(pollHittability(of: continueButton, timeout: 3))
+        continueButton.tap()
+
+        // Step 2: credentials, answered Yes.
+        stepLabel(app, "Step 2 of 3")
+        let yes = app.buttons[Identity.answerYes]
+        XCTAssertTrue(yes.waitForExistence(timeout: 5))
+        if !yes.isHittable { app.swipeUp() }
+        yes.tap()
+
+        // Step 3: access method, choose Tailscale.
+        stepLabel(app, "Step 3 of 3")
+        let tailscale = app.buttons[Identity.methodTailscale]
+        XCTAssertTrue(tailscale.waitForExistence(timeout: 5), "Tailscale method card missing. Tree:\n\(app.debugDescription)")
+        if !tailscale.isHittable { app.swipeUp() }
+        XCTAssertTrue(pollHittability(of: tailscale, timeout: 3))
+        tailscale.tap()
+
+        // Tailscale branch mentions Tailscale Serve.
+        let serve = app.staticTexts.matching(
+            NSPredicate(format: "label CONTAINS 'Tailscale Serve'")
+        ).firstMatch
+        XCTAssertTrue(serve.waitForExistence(timeout: 5), "Tailscale branch must present the Tailscale Serve path")
+
+        // Back navigation returns through the wizard.
+        let back = app.buttons[Identity.back]
+        XCTAssertTrue(back.waitForExistence(timeout: 5))
+        back.tap()
+        stepLabel(app, "Step 3 of 3")
+
+        back.tap()
+        stepLabel(app, "Step 2 of 3")
+
+        let done = app.buttons[Identity.done]
+        XCTAssertTrue(done.waitForExistence(timeout: 5))
+        done.tap()
+        XCTAssertTrue(
+            serverFieldAgain(app).waitForExistence(timeout: 5),
+            "Done must return to the login form"
+        )
+    }
+
+    func testDontKnowPathShowsCopyPromptAndCompactsStayScrollable() throws {
+        let app = XCUIApplication()
+        app.launch()
+        openSetup(app)
+
+        stepLabel(app, "Step 1 of 3")
+        let unknown = app.buttons[Identity.answerUnknown]
+        XCTAssertTrue(unknown.waitForExistence(timeout: 5))
+        if !unknown.isHittable { app.swipeUp() }
+        unknown.tap()
+
+        let copyPrompt = app.buttons[Identity.copyPrompt]
+        XCTAssertTrue(copyPrompt.waitForExistence(timeout: 5), "Copy Prompt must appear on the I don't know path")
+
+        // Compact layout: the continue action below the prompt must remain
+        // reachable by scrolling.
+        let continueButton = app.buttons["setup.continue"]
+        XCTAssertTrue(continueButton.waitForExistence(timeout: 3))
+        var hittable = continueButton.isHittable
+        var attempts = 0
+        while !hittable, attempts < 3 {
+            app.swipeUp()
+            hittable = continueButton.isHittable
+            attempts += 1
+        }
+        XCTAssertTrue(hittable, "Continue must stay reachable on a compact iPhone layout")
+
+        continueButton.tap()
+        stepLabel(app, "Step 2 of 3")
+    }
+
+    private func serverFieldAgain(_ app: XCUIApplication) -> XCUIElement {
+        app.textFields["login.server-url"]
+    }
+
+    /// XCUIElement has no waitForHittability; poll isHittable on a deadline.
+    private func pollHittability(of element: XCUIElement, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if element.isHittable { return true }
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+        return element.isHittable
+    }
+}

--- a/ConduitUITests/ConnectionSetupUITests.swift
+++ b/ConduitUITests/ConnectionSetupUITests.swift
@@ -34,11 +34,16 @@ final class ConnectionSetupUITests: XCTestCase {
     }
 
     private func stepLabel(_ app: XCUIApplication, _ expected: String) {
+        // Poll rather than assert once: during the NavigationStack push/pop
+        // transition both steps can be mounted, so the first snapshot may
+        // still show the outgoing label.
         let label = app.staticTexts[Identity.stepLabel]
-        XCTAssertTrue(
-            label.waitForExistence(timeout: 5) && label.label == expected,
-            "Expected step '\(expected)', saw '\(label.exists ? label.label : "none")'. Tree:\n\(app.debugDescription)"
-        )
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            if label.exists, label.label == expected { return }
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+        XCTFail("Expected step '\(expected)', saw '\(label.exists ? label.label : "none")'. Tree:\n\(app.debugDescription)")
     }
 
     func testWizardAdvancesThroughQuestionsToTailscaleBranchAndBack() throws {


### PR DESCRIPTION
## Round 2: Connection Setup Assistant — real guided flow

Builds on #131 (merged, `920ecea`): the failure-classification layer, typed failure handoff, and placeholder shell it shipped are preserved and extended, not redesigned. This round **replaces the placeholder with a genuinely useful guided wizard**; the final Host/Port form and staged live connection test remain later-round work.

### Setup-flow model (testable, SwiftUI-free)

`ConnectionSetupFlow` (`Conduit/Services/ConnectionSetupFlow.swift`) owns all routing: a navigation path of `ConnectionSetupStep`s plus recorded answers. The view renders the model's current step and forwards taps as transitions — no ad-hoc SwiftUI navigation state. Round-1 failure destinations map into the wizard: `.start`/`.dashboard` → dashboard question, `.credentials` → credentials, `.network` → access method, `.tls`/`.cloudflare` → retained direct troubleshooting surfaces.

### The three questions

1. **"Is your Hermes dashboard running?"** — Yes advances; No / I don't know show a copyable **Ask Hermes** prompt (the spec's exact copy) plus a "Dashboard is ready" continuation.
2. **"Do you have your Hermes dashboard login credentials?"** — same pattern, with the clarification that these are dashboard credentials, not Tailscale/Cloudflare/Apple credentials.
3. **"How will this iPhone or iPad reach Hermes?"** — three method cards plus "I'm not sure" decision guidance.

### Access methods (closed set — no public-IP/open-port path exists)

- **I'm on the same network as Hermes** → LAN branch: checklist of what's needed + Ask Hermes prompt for local IP/hostname and port.
- **Tailscale** (badged *Recommended for remote access*) → branch explicitly walks the six-step **Tailscale Serve** path (installed both ends, same tailnet, Hermes configures Serve, Hermes tells you the address). Conduit never installs/configures Tailscale and assumes no address or port.
- **I already have a domain or reverse proxy** → explicitly only for existing HTTPS infrastructure; lists the needed URL/port/path-prefix/credentials and the spec's example shapes; states Conduit will not ask you to expose a raw public port, create firewall rules, or bypass certificate checks.

All seven Ask Hermes prompts (clipboard-only via the reusable `AskHermesPromptView`, nothing auto-sent) require Hermes to keep dashboard authentication enabled — pinned by tests that also forbid exposure language ("public internet", "firewall", "expose", "port forward") and hard-coded ports (8080/9119/443).

### UX and constraints honored

`NavigationStack`-based, "Step N of 3" progress on the three questions, Back/Done, scrolling throughout, Dynamic-Type friendly. "I have the connection details" lands on an honest **Details ready** placeholder (in-assistant detail entry is future work; the login form accepts the values today). The assistant opens **only** from the login card's entry point or a Troubleshoot Connection action — never automatically — and stores no completion state. The expert URL field, `ConnectionURLPolicy`, TLS diagnostics, 429 handling, Cloudflare behavior, login scroll/keyboard behavior, and the typed failure handoff are untouched.

### Review gate

3-reviewer cycle: **APPROVE / APPROVE / REQUEST-CHANGES**, zero blockers. Fixed before push: readiness confirmation was overwriting a recorded "No" with `.yes` (breaking Back-state fidelity and hiding guidance) — confirmation is now pure navigation with a round-trip test; troubleshooting topic switches replace rather than stack the back path; the "Copied" confirmation restarts per tap; method titles moved into the model so copy-safety tests guard shipped strings; UI step assertions poll through push/pop transitions. One suggestion **rejected**: rewording the credentials prompts to avoid asking Hermes for username/password in chat — the spec fixes that wording.

### Verification (Mac build host, iPhone 17 Pro simulator)

- `ConnectionSetupFlowTests` **22/22** (new) · `ConnectionFailureTests` 43/43 · `AppStatePendingLoginFailureTests` 10/10 · `ConnectionSetupUITests` **2/2** (new: full wizard walk to the Tailscale branch and back; Don't-know path + compact scrollability) · `LoginKeyboardUITests` 4/4 (Round-1 regression) — **0 failures**, all offline.
- `plan-tests.py validate` OK; branched from current `main` (970aed5).

### Deferred to later rounds (per spec)

Host+Port fields, credentials entry inside the wizard, serverUrl synthesis, scheme inference, Tailscale auto-detection, service discovery, reachability probes, staged connection testing, auto-populating LoginView, Settings entry, QR import, diagnostics export, Retry-After countdown, public-IP setup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a guided connection setup wizard with readiness questions and progress tracking.
  - Added LAN, Tailscale, and reverse proxy setup paths.
  - Added guidance for credentials, connection details, and TLS/Cloudflare troubleshooting.
  - Added copyable Hermes prompts with confirmation feedback.
  - Added answer-based branching, back navigation, and completion returning to the login form.

- **Bug Fixes**
  - Improved handling of uncertain connection-method and troubleshooting choices.
  - Prevented cancelled prompt confirmations from clearing active copy confirmations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->