### PR TITLE
feat(setup): test the proposed connection before accepting it

### DIFF
--- a/Conduit/Services/ConnectionSetupFlow.swift
+++ b/Conduit/Services/ConnectionSetupFlow.swift
@@ -50,6 +50,9 @@ enum ConnectionSetupStep: Equatable {
     case reverseProxy
     case connectionDetails
     case loginCredentials
+    /// Round 4: the staged connection test between credentials and Review.
+    /// Review is only reachable through a current successful test.
+    case connectionTest
     case review
 
     // Direct troubleshooting surfaces (failure-driven entries).
@@ -122,7 +125,28 @@ struct ConnectionSetupFlow: Equatable {
     private(set) var path: [ConnectionSetupStep]
     private(set) var dashboardAnswer: ConnectionSetupAnswer?
     private(set) var credentialsAnswer: ConnectionSetupAnswer?
-    var draft: ConnectionSetupDraft
+    /// Session-only form values. Every mutation — from flow transitions or
+    /// direct view bindings — bumps `draftRevision`, which is the anchor for
+    /// invalidating a previous connection-test success (Round 4).
+    var draft: ConnectionSetupDraft {
+        didSet { draftRevision += 1 }
+    }
+    private(set) var draftRevision = 0
+    /// Round 4: the staged connection-test state, driven by probe events.
+    private(set) var testState = ConnectionSetupTestState()
+    /// Generation token for test runs. Any new run, cancellation, or stale
+    /// reset bumps it, so a late completion from an obsolete run can never
+    /// overwrite newer state (the same race class Conduit has been burned by
+    /// elsewhere).
+    private(set) var testGeneration = 0
+    /// The draft revision a successful test validated; nil while untested.
+    private(set) var testSucceededAtRevision: Int?
+    /// The login card's in-memory Cloudflare service token, inherited for the
+    /// probe only. Bound to `inheritedCloudflareOriginURL`: it is applied to
+    /// the test ONLY while the draft's address stays same-origin, and is
+    /// never displayed, edited, or persisted by the wizard.
+    private(set) var inheritedCloudflareAccess: CloudflareAccessCredentials?
+    private(set) var inheritedCloudflareOriginURL: String
     private(set) var validationError: ConnectionSetupValidationError?
     private let entry: ConnectionHelpDestination
 
@@ -140,15 +164,22 @@ struct ConnectionSetupFlow: Equatable {
         case .dashboard: return "Step 1 of 3"
         case .credentials: return "Step 2 of 3"
         case .accessMethod: return "Step 3 of 3"
-        case .lan, .tailscale, .reverseProxy, .connectionDetails, .loginCredentials, .review,
+        case .lan, .tailscale, .reverseProxy, .connectionDetails, .loginCredentials, .connectionTest, .review,
              .tlsTroubleshooting, .cloudflareTroubleshooting:
             return nil
         }
     }
 
-    init(entry: ConnectionHelpDestination = .start, draft: ConnectionSetupDraft = ConnectionSetupDraft()) {
+    init(
+        entry: ConnectionHelpDestination = .start,
+        draft: ConnectionSetupDraft = ConnectionSetupDraft(),
+        inheritedCloudflareAccess: CloudflareAccessCredentials? = nil,
+        inheritedCloudflareOriginURL: String = ""
+    ) {
         self.entry = entry
         self.draft = draft
+        self.inheritedCloudflareAccess = inheritedCloudflareAccess
+        self.inheritedCloudflareOriginURL = inheritedCloudflareOriginURL
         path = [Self.entryStep(for: entry)]
     }
 
@@ -240,7 +271,15 @@ struct ConnectionSetupFlow: Equatable {
         guard step == .loginCredentials else { return }
         do {
             _ = try draft.result()
-            advance(to: .review)
+            advance(to: .connectionTest)
+            // A test result validated against an OLDER draft must never
+            // authorize this fresh entry: edits bump the revision, so any
+            // stale success (or leftover failure display) resets to untested.
+            if testSucceededAtRevision != draftRevision {
+                testGeneration += 1
+                testState = ConnectionSetupTestState()
+                testSucceededAtRevision = nil
+            }
         } catch let error as ConnectionSetupValidationError {
             if error != .credentialsRequired {
                 advance(to: draft.usesExistingAddress || draft.accessMethod != nil ? .connectionDetails : .accessMethod)
@@ -249,9 +288,11 @@ struct ConnectionSetupFlow: Equatable {
         } catch { record(error) }
     }
 
-    /// Revalidate at the handoff boundary; producing values has no side effects.
+    /// Revalidate at the handoff boundary; producing values has no side
+    /// effects. Acceptance requires a connection test that succeeded against
+    /// the CURRENT draft — an untested configuration is never handed off.
     mutating func complete() -> ConnectionSetupResult? {
-        guard step == .review else { return nil }
+        guard step == .review, hasCurrentSuccessfulTest else { return nil }
         do { return try draft.result() }
         catch { record(error); return nil }
     }
@@ -271,6 +312,91 @@ struct ConnectionSetupFlow: Equatable {
 
     private mutating func record(_ error: Error) {
         validationError = error as? ConnectionSetupValidationError ?? .policy(.invalidURL)
+    }
+
+    // MARK: - Round 4: staged connection test
+
+    /// True only when the test ran to completion successfully against the
+    /// CURRENT draft. Any draft edit (address, port, scheme, username,
+    /// password, access method) immediately invalidates a prior success —
+    /// the revision no longer matches, so Review can no longer authorize
+    /// the old result.
+    var hasCurrentSuccessfulTest: Bool {
+        testState.authentication == .succeeded && testSucceededAtRevision == draftRevision
+    }
+
+    /// The inherited Cloudflare token, ONLY when it is same-origin with the
+    /// draft's current address. A service token entered for one dashboard is
+    /// never sent to a different origin during the test (Round-3 origin
+    /// safety); the wizard never sends a token it cannot origin-verify.
+    func cloudflareAccessForDraft() -> CloudflareAccessCredentials? {
+        guard let access = inheritedCloudflareAccess, access.isConfigured else { return nil }
+        let origin = inheritedCloudflareOriginURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !origin.isEmpty, let result = try? draft.result() else { return nil }
+        return LoginCloudflareHandoff.sameOrigin(result.serverURL, origin) ? access : nil
+    }
+
+    /// Starts a staged test run: resets prior results and returns the new
+    /// generation token, or nil when a test cannot start. Tests never queue:
+    /// the wrong step or an already-running probe is a deterministic no-op
+    /// (the view also disables the Test button while running).
+    mutating func beginTest() -> Int? {
+        guard step == .connectionTest, !testState.isRunning else { return nil }
+        testGeneration += 1
+        testState = ConnectionSetupTestState()
+        testSucceededAtRevision = nil
+        return testGeneration
+    }
+
+    /// Applies one probe event to the staged state. Events from an obsolete
+    /// generation — superseded by cancellation, a newer run, or a draft
+    /// reset — are ignored, so a late completion can never overwrite newer
+    /// state. The final success seals the result at the current draft
+    /// revision and advances to Review.
+    mutating func applyTestEvent(_ event: ConnectionSetupTestEvent, generation: Int) {
+        guard generation == testGeneration, step == .connectionTest else { return }
+        testState.apply(event)
+        if event == .succeeded(.authentication) {
+            testSucceededAtRevision = draftRevision
+            advance(to: .review)
+        }
+    }
+
+    /// Cancels in-flight test work: any running stage resets to untested and
+    /// the generation invalidates so late probe events are dropped. A
+    /// completed success or failure display is left untouched — cancelling
+    /// only retracts unfinished work.
+    mutating func cancelTest() {
+        guard testState.isRunning else { return }
+        testGeneration += 1
+        testState = ConnectionSetupTestState()
+        testSucceededAtRevision = nil
+    }
+
+    /// Failure remediation: leave the test screen for the step that owns the
+    /// failed inputs (connection details for transport/dashboard failures,
+    /// credentials for authentication failures). Falls back to inserting the
+    /// details step after credentials for the short auth-recovery route,
+    /// which enters the wizard past the details screen.
+    mutating func editAfterFailedTest(_ target: ConnectionSetupStep) {
+        guard step == .connectionTest,
+              target == .connectionDetails || target == .loginCredentials else { return }
+        if let index = path.lastIndex(of: target) {
+            path.removeSubrange(path.index(after: index)...)
+        } else if let credentialsIndex = path.lastIndex(of: .loginCredentials) {
+            path.removeSubrange(path.index(after: credentialsIndex)...)
+            advance(to: target)
+        } else {
+            advance(to: target)
+        }
+        validationError = nil
+    }
+
+    /// Continue from the test screen to Review when a current successful
+    /// test exists (e.g. after returning Back from Review).
+    mutating func continueToReview() {
+        guard step == .connectionTest, hasCurrentSuccessfulTest else { return }
+        advance(to: .review)
     }
 
     /// Topic switching on the troubleshooting surfaces (TLS ⇄ Cloudflare).

--- a/Conduit/Services/ConnectionSetupFlow.swift
+++ b/Conduit/Services/ConnectionSetupFlow.swift
@@ -411,7 +411,9 @@ struct ConnectionSetupFlow: Equatable {
     /// credentials for authentication failures). Falls back to inserting the
     /// details step after credentials for the short auth-recovery route,
     /// which enters the wizard past the details screen. Leaving the test
-    /// step also invalidates any in-flight run's generation.
+    /// step also invalidates any in-flight run's generation and resets the
+    /// staged state, so no leftover failure display or terminal outcome can
+    /// outlive the remediation.
     mutating func editAfterFailedTest(_ target: ConnectionSetupStep) {
         guard step == .connectionTest,
               target == .connectionDetails || target == .loginCredentials else { return }
@@ -425,6 +427,8 @@ struct ConnectionSetupFlow: Equatable {
         }
         validationError = nil
         testGeneration += 1
+        testState = ConnectionSetupTestState()
+        testSucceededAtRevision = nil
     }
 
     /// Continue from the test screen to Review when a current qualifying

--- a/Conduit/Services/ConnectionSetupFlow.swift
+++ b/Conduit/Services/ConnectionSetupFlow.swift
@@ -289,10 +289,12 @@ struct ConnectionSetupFlow: Equatable {
     }
 
     /// Revalidate at the handoff boundary; producing values has no side
-    /// effects. Acceptance requires a connection test that succeeded against
-    /// the CURRENT draft — an untested configuration is never handed off.
+    /// effects. Acceptance requires a connection test that validated the
+    /// CURRENT draft — either fully-tested native auth, or the supported
+    /// interactive sign-in outcome after successful dashboard detection. An
+    /// untested configuration is never handed off.
     mutating func complete() -> ConnectionSetupResult? {
-        guard step == .review, hasCurrentSuccessfulTest else { return nil }
+        guard step == .review, canUseSettings else { return nil }
         do { return try draft.result() }
         catch { record(error); return nil }
     }
@@ -324,6 +326,32 @@ struct ConnectionSetupFlow: Equatable {
         testState.allSucceeded && testSucceededAtRevision == draftRevision
     }
 
+    /// The same fact as `hasCurrentSuccessfulTest`, named for the auth-mode
+    /// distinction the interactive outcome introduced: native password
+    /// authentication fully succeeded (login + ticket) against the current
+    /// draft. Never true for the interactive outcome — there, the user has
+    /// not authenticated yet.
+    var fullyAuthenticated: Bool { hasCurrentSuccessfulTest }
+
+    /// The supported interactive-auth terminal outcome against the CURRENT
+    /// draft: server and dashboard succeeded and authentication stopped at
+    /// "browser sign-in required". Draft edits invalidate it exactly like a
+    /// native success, and it is deliberately not a failure — so the
+    /// recovery-plan machinery never treats it as one.
+    var hasCurrentInteractiveAuthOutcome: Bool {
+        testState.requiresInteractiveSignIn && testSucceededAtRevision == draftRevision
+    }
+
+    /// Review / "Use These Settings" authorization. Exactly two states
+    /// qualify: fully tested native auth, or interactive sign-in required
+    /// after successful dashboard detection. There is deliberately no
+    /// generic "use without testing" bypass — both qualifying states have
+    /// verified transport, dashboard identity, and the expected auth
+    /// behavior; only the user's own auth step can remain.
+    var canUseSettings: Bool {
+        hasCurrentSuccessfulTest || hasCurrentInteractiveAuthOutcome
+    }
+
     /// The inherited Cloudflare token, ONLY when it is same-origin with the
     /// draft's current address. A service token entered for one dashboard is
     /// never sent to a different origin during the test (Round-3 origin
@@ -350,15 +378,19 @@ struct ConnectionSetupFlow: Equatable {
     /// Applies one probe event to the staged state, returning whether it was
     /// applied. Events from an obsolete generation — superseded by
     /// cancellation, a newer run, or a draft reset — are ignored, so a late
-    /// completion can never overwrite newer state. The final success seals
-    /// the result at the current draft revision and advances to Review.
+    /// completion can never overwrite newer state. A terminal event (full
+    /// native success, or the interactive sign-in outcome) seals the result
+    /// at the current draft revision and advances to Review.
     @discardableResult
     mutating func applyTestEvent(_ event: ConnectionSetupTestEvent, generation: Int) -> Bool {
         guard generation == testGeneration, step == .connectionTest else { return false }
         testState.apply(event)
-        if event == .succeeded(.authentication) {
+        switch event {
+        case .succeeded(.authentication), .requiresInteractiveSignIn(.authentication):
             testSucceededAtRevision = draftRevision
             advance(to: .review)
+        default:
+            break
         }
         return true
     }
@@ -395,10 +427,10 @@ struct ConnectionSetupFlow: Equatable {
         testGeneration += 1
     }
 
-    /// Continue from the test screen to Review when a current successful
+    /// Continue from the test screen to Review when a current qualifying
     /// test exists (e.g. after returning Back from Review).
     mutating func continueToReview() {
-        guard step == .connectionTest, hasCurrentSuccessfulTest else { return }
+        guard step == .connectionTest, canUseSettings else { return }
         advance(to: .review)
     }
 

--- a/Conduit/Services/ConnectionSetupFlow.swift
+++ b/Conduit/Services/ConnectionSetupFlow.swift
@@ -316,13 +316,12 @@ struct ConnectionSetupFlow: Equatable {
 
     // MARK: - Round 4: staged connection test
 
-    /// True only when the test ran to completion successfully against the
-    /// CURRENT draft. Any draft edit (address, port, scheme, username,
-    /// password, access method) immediately invalidates a prior success —
-    /// the revision no longer matches, so Review can no longer authorize
-    /// the old result.
+    /// True only when every stage succeeded against the CURRENT draft. Any
+    /// draft edit (address, port, scheme, username, password, access method)
+    /// immediately invalidates a prior success — the revision no longer
+    /// matches, so Review can no longer authorize the old result.
     var hasCurrentSuccessfulTest: Bool {
-        testState.authentication == .succeeded && testSucceededAtRevision == draftRevision
+        testState.allSucceeded && testSucceededAtRevision == draftRevision
     }
 
     /// The inherited Cloudflare token, ONLY when it is same-origin with the
@@ -348,18 +347,20 @@ struct ConnectionSetupFlow: Equatable {
         return testGeneration
     }
 
-    /// Applies one probe event to the staged state. Events from an obsolete
-    /// generation — superseded by cancellation, a newer run, or a draft
-    /// reset — are ignored, so a late completion can never overwrite newer
-    /// state. The final success seals the result at the current draft
-    /// revision and advances to Review.
-    mutating func applyTestEvent(_ event: ConnectionSetupTestEvent, generation: Int) {
-        guard generation == testGeneration, step == .connectionTest else { return }
+    /// Applies one probe event to the staged state, returning whether it was
+    /// applied. Events from an obsolete generation — superseded by
+    /// cancellation, a newer run, or a draft reset — are ignored, so a late
+    /// completion can never overwrite newer state. The final success seals
+    /// the result at the current draft revision and advances to Review.
+    @discardableResult
+    mutating func applyTestEvent(_ event: ConnectionSetupTestEvent, generation: Int) -> Bool {
+        guard generation == testGeneration, step == .connectionTest else { return false }
         testState.apply(event)
         if event == .succeeded(.authentication) {
             testSucceededAtRevision = draftRevision
             advance(to: .review)
         }
+        return true
     }
 
     /// Cancels in-flight test work: any running stage resets to untested and
@@ -377,7 +378,8 @@ struct ConnectionSetupFlow: Equatable {
     /// failed inputs (connection details for transport/dashboard failures,
     /// credentials for authentication failures). Falls back to inserting the
     /// details step after credentials for the short auth-recovery route,
-    /// which enters the wizard past the details screen.
+    /// which enters the wizard past the details screen. Leaving the test
+    /// step also invalidates any in-flight run's generation.
     mutating func editAfterFailedTest(_ target: ConnectionSetupStep) {
         guard step == .connectionTest,
               target == .connectionDetails || target == .loginCredentials else { return }
@@ -390,6 +392,7 @@ struct ConnectionSetupFlow: Equatable {
             advance(to: target)
         }
         validationError = nil
+        testGeneration += 1
     }
 
     /// Continue from the test screen to Review when a current successful

--- a/Conduit/Services/ConnectionSetupTest.swift
+++ b/Conduit/Services/ConnectionSetupTest.swift
@@ -1,0 +1,387 @@
+//
+//  ConnectionSetupTest.swift
+//  Conduit
+//
+//  Round 4 of the Connection Setup assistant: a staged connection test that
+//  runs before the user accepts the wizard's settings. The state model is
+//  SwiftUI-free and reducer-driven so stage transitions, invalidation, and
+//  stale-result handling are unit-testable without hosting a view.
+//
+//  The probe ORCHESTRATES the production authentication machinery — it never
+//  reimplements URL construction, request bodies, Cloudflare headers, or
+//  status classification. Stage 1 (transport) and stage 2 (Hermes dashboard
+//  confirmation) ride on the same provider-discovery request the normal
+//  login flow performs first; stage 3 is the full native connect (password
+//  login + ws-ticket mint). The milestone for "Login successful" is exactly
+//  the milestone normal login reaches before it would commit anything — and
+//  the probe commits nothing: no cookie store write, no Keychain, no
+//  AppState mutation, no websocket, no screen changes. The resulting ticket
+//  and transaction cookies are discarded here.
+//
+
+import Foundation
+import os
+
+/// The sequential stages of a setup connection test. One source of truth for
+/// ordering, copy, and accessibility state.
+enum ConnectionSetupTestStage: Equatable, CaseIterable, Identifiable {
+    case server
+    case dashboard
+    case authentication
+
+    var id: Self { self }
+
+    /// The stable objective label: what pending and failed rows show, and
+    /// what success confirms. Used for VoiceOver too, so a row's meaning
+    /// never depends on icon or color alone.
+    var objectiveLabel: String {
+        switch self {
+        case .server: return "Dashboard reachable"
+        case .dashboard: return "Hermes dashboard found"
+        case .authentication: return "Authentication"
+        }
+    }
+
+    /// The in-progress phrase for the row currently being checked.
+    var runningLabel: String {
+        switch self {
+        case .server: return "Checking server…"
+        case .dashboard: return "Checking dashboard…"
+        case .authentication: return "Authenticating…"
+        }
+    }
+
+    /// The confirmation phrase for a passed stage.
+    var successLabel: String {
+        switch self {
+        case .server: return "Dashboard reachable"
+        case .dashboard: return "Hermes dashboard found"
+        case .authentication: return "Login successful"
+        }
+    }
+
+    /// Stable identifier fragment (UI-test handles), not user-facing.
+    var identifierName: String {
+        switch self {
+        case .server: return "server"
+        case .dashboard: return "dashboard"
+        case .authentication: return "authentication"
+        }
+    }
+}
+
+/// Per-stage result of the staged test.
+enum ConnectionSetupStageState: Equatable {
+    case pending
+    case running
+    case succeeded
+    case failed(ConnectionFailure)
+
+    /// VoiceOver state word, so success/failure is never communicated by
+    /// icon or color alone.
+    var accessibilityState: String {
+        switch self {
+        case .pending: return "waiting"
+        case .running: return "checking"
+        case .succeeded: return "passed"
+        case .failed: return "failed"
+        }
+    }
+}
+
+/// One probe progress report, applied to `ConnectionSetupTestState` by the
+/// flow model. Carries the classified failure, never raw errors or server
+/// response text.
+enum ConnectionSetupTestEvent: Equatable {
+    case started(ConnectionSetupTestStage)
+    case succeeded(ConnectionSetupTestStage)
+    case failed(ConnectionSetupTestStage, ConnectionFailure)
+}
+
+/// The staged test's state: one source of truth for all three stages.
+/// Prior successes stay successful when a later stage fails; untouched
+/// future stages stay pending. SwiftUI never infers any of this from button
+/// titles or local booleans.
+struct ConnectionSetupTestState: Equatable {
+    var server = ConnectionSetupStageState.pending
+    var dashboard = ConnectionSetupStageState.pending
+    var authentication = ConnectionSetupStageState.pending
+
+    /// The completion announcement (one per run, not per stage transition).
+    static let readyMessage = "This connection is ready to use."
+
+    subscript(stage: ConnectionSetupTestStage) -> ConnectionSetupStageState {
+        get {
+            switch stage {
+            case .server: return server
+            case .dashboard: return dashboard
+            case .authentication: return authentication
+            }
+        }
+        set {
+            switch stage {
+            case .server: server = newValue
+            case .dashboard: dashboard = newValue
+            case .authentication: authentication = newValue
+            }
+        }
+    }
+
+    /// Pure reducer: folds one probe event into the state. Out-of-order or
+    /// duplicate events degrade gracefully instead of corrupting the list.
+    mutating func apply(_ event: ConnectionSetupTestEvent) {
+        switch event {
+        case .started(let stage):
+            guard self[stage] != .running else { return }
+            self[stage] = .running
+        case .succeeded(let stage):
+            self[stage] = .succeeded
+        case .failed(let stage, let failure):
+            self[stage] = .failed(failure)
+        }
+    }
+
+    var allSucceeded: Bool {
+        ConnectionSetupTestStage.allCases.allSatisfy { self[$0] == .succeeded }
+    }
+
+    var isRunning: Bool {
+        ConnectionSetupTestStage.allCases.contains { self[$0] == .running }
+    }
+
+    /// The first failed stage in run order, if any.
+    var failedStage: ConnectionSetupTestStage? {
+        ConnectionSetupTestStage.allCases.first { stage in
+            if case .failed = self[stage] { return true }
+            return false
+        }
+    }
+
+    /// The classified failure of `failedStage`.
+    var failedFailure: ConnectionFailure? {
+        guard let stage = failedStage, case .failed(let failure) = self[stage] else { return nil }
+        return failure
+    }
+
+    /// The visible row label for a stage in its current state.
+    func rowLabel(for stage: ConnectionSetupTestStage) -> String {
+        switch self[stage] {
+        case .running: return stage.runningLabel
+        case .succeeded: return stage.successLabel
+        case .pending, .failed: return stage.objectiveLabel
+        }
+    }
+
+    /// The complete VoiceOver label for a stage row.
+    func accessibilityLabel(for stage: ConnectionSetupTestStage) -> String {
+        "\(stage.objectiveLabel), \(self[stage].accessibilityState)"
+    }
+}
+
+/// What the wizard offers after a failed stage: the step that owns the
+/// failed inputs, and whether an immediate retry may be offered. Pure so the
+/// recovery policy is unit-testable — in particular, rate limiting is a
+/// password-login throttle and must never invite an immediate retry.
+struct ConnectionSetupTestRecoveryPlan: Equatable {
+    let remediationStep: ConnectionSetupStep
+    let remediationLabel: String
+    let offersRetry: Bool
+
+    static func plan(
+        for stage: ConnectionSetupTestStage,
+        failure: ConnectionFailure
+    ) -> ConnectionSetupTestRecoveryPlan {
+        switch stage {
+        case .server, .dashboard:
+            return ConnectionSetupTestRecoveryPlan(
+                remediationStep: .connectionDetails,
+                remediationLabel: "Edit Connection Details",
+                offersRetry: failure != .rateLimited
+            )
+        case .authentication:
+            // Retry is never the primary action after rejected credentials:
+            // blind retries feed the rate limiter. Edit comes first.
+            return ConnectionSetupTestRecoveryPlan(
+                remediationStep: .loginCredentials,
+                remediationLabel: "Edit Credentials",
+                offersRetry: failure != .rateLimited
+            )
+        }
+    }
+}
+
+/// Performs the staged connection test. MainActor-isolated so progress
+/// events apply to the flow model synchronously and in order, exactly like
+/// every other wizard state mutation.
+@MainActor
+protocol ConnectionSetupTesting {
+    func runTest(
+        result: ConnectionSetupResult,
+        cloudflareAccess: CloudflareAccessCredentials?,
+        onEvent: @escaping (ConnectionSetupTestEvent) -> Void
+    ) async
+}
+
+/// The production probe. Reuses `NativeAuthClient` unchanged for every
+/// request — including its redirect policy, Cloudflare header application,
+/// transport policy, and status classification via
+/// `ConnectionFailureClassifier`. One user-requested test equals exactly one
+/// discovery request, one password-login attempt, and one ticket mint.
+struct ConnectionSetupProbe: ConnectionSetupTesting {
+    private static let logger = Logger(subsystem: "com.milim.relay", category: "connection-setup-test")
+
+    /// Test-only seam: routes the real client through a URLProtocol stub.
+    /// Production callers leave this nil.
+    var sessionConfiguration: URLSessionConfiguration?
+
+    func runTest(
+        result: ConnectionSetupResult,
+        cloudflareAccess: CloudflareAccessCredentials?,
+        onEvent: @escaping (ConnectionSetupTestEvent) -> Void
+    ) async {
+        let client = NativeAuthClient(
+            baseURL: result.serverURL,
+            cloudflareAccess: cloudflareAccess,
+            sessionConfiguration: sessionConfiguration
+        )
+
+        // Stages 1 and 2 share one request — the same provider discovery the
+        // login flow performs first. A transport error proves nothing about
+        // the server and fails at the server stage; a typed discovery answer
+        // means an HTTP response DID arrive, so transport is proven and the
+        // failure belongs to the dashboard stage.
+        onEvent(.started(.server))
+        let providers: [[String: Any]]
+        do {
+            providers = try await client.authProviders()
+        } catch {
+            guard !Self.wasCancelled(error) else { return }
+            if let authError = error as? AuthClientError {
+                if case .invalidURL = authError {
+                    Self.reportFailure(.server, ConnectionFailureClassifier.classify(authError), to: onEvent)
+                    return
+                }
+                onEvent(.succeeded(.server))
+                onEvent(.started(.dashboard))
+                Self.reportFailure(.dashboard, ConnectionFailureClassifier.classify(authError), to: onEvent)
+                return
+            }
+            Self.reportFailure(.server, ConnectionFailureClassifier.classify(error), to: onEvent)
+            return
+        }
+        onEvent(.succeeded(.server))
+
+        // Stage 2: the discovery response must name a password-capable
+        // provider — the same compatibility check the login flow applies
+        // before native login. An arbitrary website answering 200 carries no
+        // such provider, and 200 alone is never success.
+        onEvent(.started(.dashboard))
+        guard providers.contains(where: { $0["supports_password"] as? Bool == true }) else {
+            Self.reportFailure(.dashboard, .unexpectedServerResponse, to: onEvent)
+            return
+        }
+        onEvent(.succeeded(.dashboard))
+
+        // Stage 3: the full native credential proof — password login plus the
+        // ws-ticket mint that proves the session is actually usable. This is
+        // the exact milestone normal login requires before it would commit
+        // cookies. The transaction (ticket + transaction cookies) is
+        // deliberately discarded: the test persists nothing and connects
+        // nothing.
+        onEvent(.started(.authentication))
+        do {
+            // Deliberately discarded: commitCookies() is never called, so the
+            // transaction never reaches the shared cookie store.
+            _ = try await client.connect(username: result.username, password: result.password)
+            onEvent(.succeeded(.authentication))
+        } catch {
+            guard !Self.wasCancelled(error) else { return }
+            Self.reportFailure(.authentication, ConnectionFailureClassifier.classify(error), to: onEvent)
+        }
+    }
+
+    private static func reportFailure(
+        _ stage: ConnectionSetupTestStage,
+        _ failure: ConnectionFailure,
+        to onEvent: (ConnectionSetupTestEvent) -> Void
+    ) {
+        // The classification is a semantic enum — safe at public privacy;
+        // credentials, tickets, and response bodies are never logged.
+        logger.error("Connection test failed at \(stage.objectiveLabel, privacy: .public): \(String(describing: failure), privacy: .public)")
+        onEvent(.failed(stage, failure))
+    }
+
+    private static func wasCancelled(_ error: Error) -> Bool {
+        if error is CancellationError { return true }
+        if let urlError = error as? URLError, urlError.code == .cancelled { return true }
+        return false
+    }
+}
+
+#if DEBUG
+/// UI-test-only probe stub: deterministic staged outcomes selected by the
+/// `-CONNECTION_SETUP_TEST_RESULT` launch argument, so UI tests never depend
+/// on a real Hermes server. Compiled out of release builds; production code
+/// never references it.
+struct ConnectionSetupTestProbeStub: ConnectionSetupTesting {
+    enum Script: String {
+        case success
+        case serverHostNotFound = "server:hostNotFound"
+        case dashboardUnexpected = "dashboard:unexpectedServerResponse"
+        case authRejected = "auth:authenticationRejected"
+        case authRateLimited = "auth:rateLimited"
+
+        func run(_ onEvent: (ConnectionSetupTestEvent) -> Void) {
+            switch self {
+            case .success:
+                onEvent(.started(.server))
+                onEvent(.succeeded(.server))
+                onEvent(.started(.dashboard))
+                onEvent(.succeeded(.dashboard))
+                onEvent(.started(.authentication))
+                onEvent(.succeeded(.authentication))
+            case .serverHostNotFound:
+                onEvent(.started(.server))
+                onEvent(.failed(.server, .hostNotFound))
+            case .dashboardUnexpected:
+                onEvent(.started(.server))
+                onEvent(.succeeded(.server))
+                onEvent(.started(.dashboard))
+                onEvent(.failed(.dashboard, .unexpectedServerResponse))
+            case .authRejected:
+                onEvent(.started(.server))
+                onEvent(.succeeded(.server))
+                onEvent(.started(.dashboard))
+                onEvent(.succeeded(.dashboard))
+                onEvent(.started(.authentication))
+                onEvent(.failed(.authentication, .authenticationRejected))
+            case .authRateLimited:
+                onEvent(.started(.server))
+                onEvent(.succeeded(.server))
+                onEvent(.started(.dashboard))
+                onEvent(.succeeded(.dashboard))
+                onEvent(.started(.authentication))
+                onEvent(.failed(.authentication, .rateLimited))
+            }
+        }
+
+        static func fromLaunchArguments() -> ConnectionSetupTestProbeStub? {
+            let arguments = ProcessInfo.processInfo.arguments
+            guard let index = arguments.firstIndex(of: "-CONNECTION_SETUP_TEST_RESULT"),
+                  index + 1 < arguments.count,
+                  let script = Script(rawValue: arguments[index + 1]) else { return nil }
+            return ConnectionSetupTestProbeStub(script: script)
+        }
+    }
+
+    let script: Script
+
+    func runTest(
+        result: ConnectionSetupResult,
+        cloudflareAccess: CloudflareAccessCredentials?,
+        onEvent: @escaping (ConnectionSetupTestEvent) -> Void
+    ) async {
+        script.run(onEvent)
+    }
+}
+#endif

--- a/Conduit/Services/ConnectionSetupTest.swift
+++ b/Conduit/Services/ConnectionSetupTest.swift
@@ -127,16 +127,20 @@ struct ConnectionSetupTestState: Equatable {
         }
     }
 
-    /// Pure reducer: folds one probe event into the state. Out-of-order or
-    /// duplicate events degrade gracefully instead of corrupting the list.
+    /// Pure reducer: folds one probe event into the state. Stage progress is
+    /// monotonic within a run — a terminal stage never reverts — so
+    /// out-of-order or duplicate events degrade gracefully instead of
+    /// corrupting the list.
     mutating func apply(_ event: ConnectionSetupTestEvent) {
         switch event {
         case .started(let stage):
-            guard self[stage] != .running else { return }
+            guard self[stage] == .pending else { return }
             self[stage] = .running
         case .succeeded(let stage):
+            guard self[stage] == .running else { return }
             self[stage] = .succeeded
         case .failed(let stage, let failure):
+            guard self[stage] == .pending || self[stage] == .running else { return }
             self[stage] = .failed(failure)
         }
     }
@@ -276,7 +280,7 @@ struct ConnectionSetupProbe: ConnectionSetupTesting {
         // before native login. An arbitrary website answering 200 carries no
         // such provider, and 200 alone is never success.
         onEvent(.started(.dashboard))
-        guard providers.contains(where: { $0["supports_password"] as? Bool == true }) else {
+        guard HermesProviderCheck.supportsPassword(providers) else {
             Self.reportFailure(.dashboard, .unexpectedServerResponse, to: onEvent)
             return
         }
@@ -375,6 +379,10 @@ struct ConnectionSetupTestProbeStub: ConnectionSetupTesting {
     }
 
     let script: Script
+
+    static func fromLaunchArguments() -> ConnectionSetupTestProbeStub? {
+        Script.fromLaunchArguments()
+    }
 
     func runTest(
         result: ConnectionSetupResult,

--- a/Conduit/Services/ConnectionSetupTest.swift
+++ b/Conduit/Services/ConnectionSetupTest.swift
@@ -318,9 +318,21 @@ struct ConnectionSetupProbe: ConnectionSetupTesting {
         // website answering 200 (unrecognized body) and a recognizable
         // provider answer with no password provider are both NOT Hermes
         // password dashboards — and neither is the interactive-auth signal,
-        // which only the redirect classification below may produce.
+        // which only the redirect classification above may produce.
         onEvent(.started(.dashboard))
         switch discovery {
+        case .interactiveSignInRequired:
+            // The dashboard requires interactive (browser) sign-in. The
+            // probe has verified everything it can — transport and dashboard
+            // identity plus the expected auth behavior — and reports the
+            // supported terminal outcome. It stays side-effect-free: no
+            // native login attempt, no ticket mint, no WebView, no
+            // cookie/Keychain writes. The actual sign-in happens in
+            // LoginView over the normal handoff.
+            onEvent(.succeeded(.dashboard))
+            onEvent(.started(.authentication))
+            onEvent(.requiresInteractiveSignIn(.authentication))
+            return
         case .unrecognized:
             Self.reportFailure(.dashboard, .unexpectedServerResponse, to: onEvent)
             return
@@ -329,39 +341,25 @@ struct ConnectionSetupProbe: ConnectionSetupTesting {
                 Self.reportFailure(.dashboard, .unexpectedServerResponse, to: onEvent)
                 return
             }
-        case .interactiveSignInRequired:
-            break
         }
         onEvent(.succeeded(.dashboard))
 
-        guard case .interactiveSignInRequired = discovery else {
-            // Stage 3: the full native credential proof — password login
-            // plus the ws-ticket mint that proves the session is actually
-            // usable. This is the exact milestone normal login requires
-            // before it would commit cookies. The transaction (ticket +
-            // transaction cookies) is deliberately discarded: the test
-            // persists nothing and connects nothing.
-            onEvent(.started(.authentication))
-            do {
-                // Deliberately discarded: commitCookies() is never called,
-                // so the transaction never reaches the shared cookie store.
-                _ = try await client.connect(username: result.username, password: result.password)
-                onEvent(.succeeded(.authentication))
-            } catch {
-                guard !Self.wasCancelled(error) else { return }
-                Self.reportFailure(.authentication, ConnectionFailureClassifier.classify(error), to: onEvent)
-            }
-            return
-        }
-
-        // The dashboard requires interactive (browser) sign-in. The probe
-        // has verified everything it can — transport and dashboard identity
-        // plus the expected auth behavior — and reports the supported
-        // terminal outcome. It stays side-effect-free: no native login
-        // attempt, no ticket mint, no WebView, no cookie/Keychain writes.
-        // The actual sign-in happens in LoginView over the normal handoff.
+        // Stage 3: the full native credential proof — password login plus
+        // the ws-ticket mint that proves the session is actually usable.
+        // This is the exact milestone normal login requires before it would
+        // commit cookies. The transaction (ticket + transaction cookies) is
+        // deliberately discarded: the test persists nothing and connects
+        // nothing.
         onEvent(.started(.authentication))
-        onEvent(.requiresInteractiveSignIn(.authentication))
+        do {
+            // Deliberately discarded: commitCookies() is never called, so
+            // the transaction never reaches the shared cookie store.
+            _ = try await client.connect(username: result.username, password: result.password)
+            onEvent(.succeeded(.authentication))
+        } catch {
+            guard !Self.wasCancelled(error) else { return }
+            Self.reportFailure(.authentication, ConnectionFailureClassifier.classify(error), to: onEvent)
+        }
     }
 
     private static func reportFailure(

--- a/Conduit/Services/ConnectionSetupTest.swift
+++ b/Conduit/Services/ConnectionSetupTest.swift
@@ -12,11 +12,16 @@
 //  status classification. Stage 1 (transport) and stage 2 (Hermes dashboard
 //  confirmation) ride on the same provider-discovery request the normal
 //  login flow performs first; stage 3 is the full native connect (password
-//  login + ws-ticket mint). The milestone for "Login successful" is exactly
-//  the milestone normal login reaches before it would commit anything — and
-//  the probe commits nothing: no cookie store write, no Keychain, no
-//  AppState mutation, no websocket, no screen changes. The resulting ticket
-//  and transaction cookies are discarded here.
+//  login + ws-ticket mint) for password-capable dashboards. A dashboard that
+//  answers discovery with an unauthenticated redirect to a sign-in page has
+//  proven everything the probe can test and ends the run in the supported
+//  `requiresInteractiveSignIn` outcome: no native login, no ticket, no
+//  WebView — the actual sign-in happens in LoginView after the handoff.
+//  The milestone for "Login successful" is exactly the milestone normal
+//  login reaches before it would commit anything — and the probe commits
+//  nothing: no cookie store write, no Keychain, no AppState mutation, no
+//  websocket, no screen changes. The resulting ticket and transaction
+//  cookies are discarded here.
 //
 
 import Foundation
@@ -75,6 +80,11 @@ enum ConnectionSetupStageState: Equatable {
     case pending
     case running
     case succeeded
+    /// The dashboard answered, but authentication must continue
+    /// interactively in the browser after the handoff. A supported terminal
+    /// outcome — explicitly NOT a success (the user has not authenticated)
+    /// and NOT a failure (nothing went wrong).
+    case requiresInteractiveSignIn
     case failed(ConnectionFailure)
 
     /// VoiceOver state word, so success/failure is never communicated by
@@ -84,6 +94,7 @@ enum ConnectionSetupStageState: Equatable {
         case .pending: return "waiting"
         case .running: return "checking"
         case .succeeded: return "passed"
+        case .requiresInteractiveSignIn: return "browser sign-in required"
         case .failed: return "failed"
         }
     }
@@ -95,6 +106,11 @@ enum ConnectionSetupStageState: Equatable {
 enum ConnectionSetupTestEvent: Equatable {
     case started(ConnectionSetupTestStage)
     case succeeded(ConnectionSetupTestStage)
+    /// Terminal supported outcome: the dashboard requires interactive
+    /// (browser) sign-in. Emitted once, at the authentication stage, after
+    /// server and dashboard have succeeded. No password login, ticket mint,
+    /// or WebView follows inside the probe.
+    case requiresInteractiveSignIn(ConnectionSetupTestStage)
     case failed(ConnectionSetupTestStage, ConnectionFailure)
 }
 
@@ -109,6 +125,13 @@ struct ConnectionSetupTestState: Equatable {
 
     /// The completion announcement (one per run, not per stage transition).
     static let readyMessage = "This connection is ready to use."
+
+    /// The interactive-auth completion announcement and Review copy. The
+    /// user has NOT authenticated: the message says what happens next
+    /// instead of claiming success. Never may this state render "Login
+    /// successful".
+    static let interactiveReadyMessage = "This dashboard uses browser-based sign-in. "
+        + "Conduit will open the sign-in page after you return to the login screen."
 
     subscript(stage: ConnectionSetupTestStage) -> ConnectionSetupStageState {
         get {
@@ -139,6 +162,9 @@ struct ConnectionSetupTestState: Equatable {
         case .succeeded(let stage):
             guard self[stage] == .running else { return }
             self[stage] = .succeeded
+        case .requiresInteractiveSignIn(let stage):
+            guard self[stage] == .pending || self[stage] == .running else { return }
+            self[stage] = .requiresInteractiveSignIn
         case .failed(let stage, let failure):
             guard self[stage] == .pending || self[stage] == .running else { return }
             self[stage] = .failed(failure)
@@ -151,6 +177,15 @@ struct ConnectionSetupTestState: Equatable {
 
     var isRunning: Bool {
         ConnectionSetupTestStage.allCases.contains { self[$0] == .running }
+    }
+
+    /// The staged test ended in the supported interactive-auth outcome:
+    /// server and dashboard succeeded, and authentication stopped at
+    /// "browser sign-in required" — never a success, never a failure.
+    var requiresInteractiveSignIn: Bool {
+        server == .succeeded
+            && dashboard == .succeeded
+            && authentication == .requiresInteractiveSignIn
     }
 
     /// The first failed stage in run order, if any.
@@ -172,6 +207,7 @@ struct ConnectionSetupTestState: Equatable {
         switch self[stage] {
         case .running: return stage.runningLabel
         case .succeeded: return stage.successLabel
+        case .requiresInteractiveSignIn: return "Browser sign-in required"
         case .pending, .failed: return stage.objectiveLabel
         }
     }
@@ -229,8 +265,10 @@ protocol ConnectionSetupTesting {
 /// The production probe. Reuses `NativeAuthClient` unchanged for every
 /// request — including its redirect policy, Cloudflare header application,
 /// transport policy, and status classification via
-/// `ConnectionFailureClassifier`. One user-requested test equals exactly one
-/// discovery request, one password-login attempt, and one ticket mint.
+/// `ConnectionFailureClassifier`. A password-capable dashboard sees exactly
+/// one discovery request, one password-login attempt, and one ticket mint;
+/// an interactive-auth dashboard sees exactly one discovery request and
+/// nothing else.
 struct ConnectionSetupProbe: ConnectionSetupTesting {
     private static let logger = Logger(subsystem: "com.milim.relay", category: "connection-setup-test")
 
@@ -255,9 +293,9 @@ struct ConnectionSetupProbe: ConnectionSetupTesting {
         // means an HTTP response DID arrive, so transport is proven and the
         // failure belongs to the dashboard stage.
         onEvent(.started(.server))
-        let providers: [[String: Any]]
+        let discovery: AuthProviderDiscoveryResult
         do {
-            providers = try await client.authProviders()
+            discovery = try await client.authProviderDiscovery()
         } catch {
             guard !Self.wasCancelled(error) else { return }
             if let authError = error as? AuthClientError {
@@ -275,33 +313,55 @@ struct ConnectionSetupProbe: ConnectionSetupTesting {
         }
         onEvent(.succeeded(.server))
 
-        // Stage 2: the discovery response must name a password-capable
-        // provider — the same compatibility check the login flow applies
-        // before native login. An arbitrary website answering 200 carries no
-        // such provider, and 200 alone is never success.
+        // Stage 2: the discovery answer must identify a Hermes dashboard
+        // with the authentication shape the probe can exercise. An arbitrary
+        // website answering 200 (unrecognized body) and a recognizable
+        // provider answer with no password provider are both NOT Hermes
+        // password dashboards — and neither is the interactive-auth signal,
+        // which only the redirect classification below may produce.
         onEvent(.started(.dashboard))
-        guard HermesProviderCheck.supportsPassword(providers) else {
+        switch discovery {
+        case .unrecognized:
             Self.reportFailure(.dashboard, .unexpectedServerResponse, to: onEvent)
             return
+        case .providers(let providers):
+            guard HermesProviderCheck.supportsPassword(providers) else {
+                Self.reportFailure(.dashboard, .unexpectedServerResponse, to: onEvent)
+                return
+            }
+        case .interactiveSignInRequired:
+            break
         }
         onEvent(.succeeded(.dashboard))
 
-        // Stage 3: the full native credential proof — password login plus the
-        // ws-ticket mint that proves the session is actually usable. This is
-        // the exact milestone normal login requires before it would commit
-        // cookies. The transaction (ticket + transaction cookies) is
-        // deliberately discarded: the test persists nothing and connects
-        // nothing.
-        onEvent(.started(.authentication))
-        do {
-            // Deliberately discarded: commitCookies() is never called, so the
-            // transaction never reaches the shared cookie store.
-            _ = try await client.connect(username: result.username, password: result.password)
-            onEvent(.succeeded(.authentication))
-        } catch {
-            guard !Self.wasCancelled(error) else { return }
-            Self.reportFailure(.authentication, ConnectionFailureClassifier.classify(error), to: onEvent)
+        guard case .interactiveSignInRequired = discovery else {
+            // Stage 3: the full native credential proof — password login
+            // plus the ws-ticket mint that proves the session is actually
+            // usable. This is the exact milestone normal login requires
+            // before it would commit cookies. The transaction (ticket +
+            // transaction cookies) is deliberately discarded: the test
+            // persists nothing and connects nothing.
+            onEvent(.started(.authentication))
+            do {
+                // Deliberately discarded: commitCookies() is never called,
+                // so the transaction never reaches the shared cookie store.
+                _ = try await client.connect(username: result.username, password: result.password)
+                onEvent(.succeeded(.authentication))
+            } catch {
+                guard !Self.wasCancelled(error) else { return }
+                Self.reportFailure(.authentication, ConnectionFailureClassifier.classify(error), to: onEvent)
+            }
+            return
         }
+
+        // The dashboard requires interactive (browser) sign-in. The probe
+        // has verified everything it can — transport and dashboard identity
+        // plus the expected auth behavior — and reports the supported
+        // terminal outcome. It stays side-effect-free: no native login
+        // attempt, no ticket mint, no WebView, no cookie/Keychain writes.
+        // The actual sign-in happens in LoginView over the normal handoff.
+        onEvent(.started(.authentication))
+        onEvent(.requiresInteractiveSignIn(.authentication))
     }
 
     private static func reportFailure(
@@ -330,6 +390,7 @@ struct ConnectionSetupProbe: ConnectionSetupTesting {
 struct ConnectionSetupTestProbeStub: ConnectionSetupTesting {
     enum Script: String {
         case success
+        case interactiveSignInRequired = "auth:interactiveSignInRequired"
         case serverHostNotFound = "server:hostNotFound"
         case dashboardUnexpected = "dashboard:unexpectedServerResponse"
         case authRejected = "auth:authenticationRejected"
@@ -344,6 +405,13 @@ struct ConnectionSetupTestProbeStub: ConnectionSetupTesting {
                 onEvent(.succeeded(.dashboard))
                 onEvent(.started(.authentication))
                 onEvent(.succeeded(.authentication))
+            case .interactiveSignInRequired:
+                onEvent(.started(.server))
+                onEvent(.succeeded(.server))
+                onEvent(.started(.dashboard))
+                onEvent(.succeeded(.dashboard))
+                onEvent(.started(.authentication))
+                onEvent(.requiresInteractiveSignIn(.authentication))
             case .serverHostNotFound:
                 onEvent(.started(.server))
                 onEvent(.failed(.server, .hostNotFound))

--- a/Conduit/Services/NativeAuthClient.swift
+++ b/Conduit/Services/NativeAuthClient.swift
@@ -87,7 +87,7 @@ struct NativeAuthConnection {
 /// is an unexpected server response. Collapsing them back into "an empty
 /// provider list" would re-create the ambiguity that made browser-auth
 /// deployments unclassifiable.
-enum AuthProviderDiscoveryResult: Equatable {
+enum AuthProviderDiscoveryResult {
     /// The dashboard answered `/api/auth/providers` with recognizable Hermes
     /// provider JSON. The array may be empty (a valid Hermes answer meaning
     /// "no providers configured") or name non-password providers only.
@@ -100,6 +100,22 @@ enum AuthProviderDiscoveryResult: Equatable {
     /// auth/provider structure: malformed JSON, a JSON object without a
     /// `providers` array, or arbitrary web content.
     case unrecognized
+}
+
+extension AuthProviderDiscoveryResult: Equatable {
+    /// Provider arrays are dictionaries of JSON values, so structural
+    /// equality goes through NSArray/NSDictionary's recursive isEqual.
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.interactiveSignInRequired, .interactiveSignInRequired),
+             (.unrecognized, .unrecognized):
+            return true
+        case (.providers(let lhsProviders), .providers(let rhsProviders)):
+            return (lhsProviders as NSArray).isEqual(to: rhsProviders)
+        default:
+            return false
+        }
+    }
 }
 
 /// The single definition of "this dashboard offers password login", shared by

--- a/Conduit/Services/NativeAuthClient.swift
+++ b/Conduit/Services/NativeAuthClient.swift
@@ -80,6 +80,15 @@ struct NativeAuthConnection {
     }
 }
 
+/// The single definition of "this dashboard offers password login", shared by
+/// the normal login flow and the Connection Setup probe so the compatibility
+/// check can never drift between them.
+enum HermesProviderCheck {
+    static func supportsPassword(_ providers: [[String: Any]]) -> Bool {
+        providers.contains { $0["supports_password"] as? Bool == true }
+    }
+}
+
 /// URLSession-based Hermes dashboard authentication. Automatic URLSession
 /// cookie handling is disabled: each login transaction captures its own
 /// response cookies, scopes them to the exact ticket URL, and returns them for

--- a/Conduit/Services/NativeAuthClient.swift
+++ b/Conduit/Services/NativeAuthClient.swift
@@ -104,7 +104,9 @@ enum AuthProviderDiscoveryResult {
 
 extension AuthProviderDiscoveryResult: Equatable {
     /// Provider arrays are dictionaries of JSON values, so structural
-    /// equality goes through NSArray/NSDictionary's recursive isEqual.
+    /// equality goes through NSArray/NSDictionary's recursive isEqual. This
+    /// conformance exists for tests and the typed switch above; production
+    /// code never compares provider arrays for equality.
     static func == (lhs: Self, rhs: Self) -> Bool {
         switch (lhs, rhs) {
         case (.interactiveSignInRequired, .interactiveSignInRequired),
@@ -171,9 +173,19 @@ struct NativeAuthClient {
         }
         switch http.statusCode {
         case 301, 302, 303, 307, 308:
-            // The SecureRedirectDelegate cancels cross-origin redirects, so a
-            // 3xx final response here is the edge bouncing us to its sign-in
-            // page. Without a configured token that is the expected
+            // A redirect response without a Location header cannot drive a
+            // browser login — it is a broken server response, not an auth
+            // mode. Classify it as discovery failure like any other
+            // non-Hermes answer.
+            guard http.value(forHTTPHeaderField: "Location") != nil else {
+                throw AuthClientError.providerDiscoveryFailed(
+                    status: http.statusCode,
+                    detail: "Redirect without Location"
+                )
+            }
+            // The SecureRedirectDelegate cancels cross-origin redirects, so
+            // a 3xx final response here is the edge bouncing us to its
+            // sign-in page. Without a configured token that is the expected
             // interactive-auth signal. With an actually configured service
             // token it means Cloudflare rejected that token — say so instead
             // of presenting the same login page that should have been

--- a/Conduit/Services/NativeAuthClient.swift
+++ b/Conduit/Services/NativeAuthClient.swift
@@ -80,6 +80,28 @@ struct NativeAuthConnection {
     }
 }
 
+/// What provider discovery learned about a dashboard's sign-in modes. The
+/// two zero-provider shapes are deliberately different outcomes: an
+/// unauthenticated redirect to a sign-in page is the NORMAL interactive-auth
+/// signal, while a 2xx answer without recognizable Hermes provider structure
+/// is an unexpected server response. Collapsing them back into "an empty
+/// provider list" would re-create the ambiguity that made browser-auth
+/// deployments unclassifiable.
+enum AuthProviderDiscoveryResult: Equatable {
+    /// The dashboard answered `/api/auth/providers` with recognizable Hermes
+    /// provider JSON. The array may be empty (a valid Hermes answer meaning
+    /// "no providers configured") or name non-password providers only.
+    case providers([[String: Any]])
+    /// Discovery was answered by a redirect to a sign-in page — the expected
+    /// unauthenticated behavior of a dashboard/edge that routes to
+    /// interactive (browser) authentication.
+    case interactiveSignInRequired
+    /// A 2xx response arrived, but it carries no recognizable Hermes
+    /// auth/provider structure: malformed JSON, a JSON object without a
+    /// `providers` array, or arbitrary web content.
+    case unrecognized
+}
+
 /// The single definition of "this dashboard offers password login", shared by
 /// the normal login flow and the Connection Setup probe so the compatibility
 /// check can never drift between them.
@@ -125,7 +147,7 @@ struct NativeAuthClient {
         self.session = URLSession(configuration: configuration, delegate: redirectDelegate, delegateQueue: nil)
     }
 
-    func authProviders() async throws -> [[String: Any]] {
+    func authProviderDiscovery() async throws -> AuthProviderDiscoveryResult {
         let request = try request(path: "/api/auth/providers")
         let result = try await perform(request)
         guard let http = result.response as? HTTPURLResponse else {
@@ -136,17 +158,17 @@ struct NativeAuthClient {
             // The SecureRedirectDelegate cancels cross-origin redirects, so a
             // 3xx final response here is the edge bouncing us to its sign-in
             // page. Without a configured token that is the expected
-            // interactive-auth signal (empty list → WebView fallback). With
-            // an actually configured service token it means Cloudflare
-            // rejected that token — say so instead of presenting the same
-            // login page that should have been bypassed. Match
-            // `applying(to:)`'s configuration state: a non-nil but empty
-            // credentials value sends no headers and must fall back too.
+            // interactive-auth signal. With an actually configured service
+            // token it means Cloudflare rejected that token — say so instead
+            // of presenting the same login page that should have been
+            // bypassed. Match `applying(to:)`'s configuration state: a
+            // non-nil but empty credentials value sends no headers and must
+            // fall back too.
             if cloudflareAccess?.isConfigured == true,
                Self.redirectsToCloudflareAccessLogin(http) {
                 throw AuthClientError.cloudflareServiceTokenRejected
             }
-            return []
+            return .interactiveSignInRequired
         default:
             break
         }
@@ -157,10 +179,18 @@ struct NativeAuthClient {
             )
         }
 
-        if let json = try? JSONSerialization.jsonObject(with: result.data) as? [String: Any] {
-            return json["providers"] as? [[String: Any]] ?? []
+        // A 2xx answer only means "Hermes providers" when the body carries
+        // the provider array. An empty array is a valid Hermes answer; a
+        // body without the array (arbitrary web content, malformed JSON) is
+        // an unrecognized server response and must never read as the
+        // interactive-auth signal.
+        guard let json = try? JSONSerialization.jsonObject(with: result.data) as? [String: Any] else {
+            return .unrecognized
         }
-        return []
+        guard let providers = json["providers"] as? [[String: Any]] else {
+            return .unrecognized
+        }
+        return .providers(providers)
     }
 
     func login(username: String, password: String) async throws -> [HTTPCookie] {

--- a/Conduit/Views/ConnectionSetupForm.swift
+++ b/Conduit/Views/ConnectionSetupForm.swift
@@ -155,9 +155,10 @@ struct ConnectionSetupForm: View {
             if let failure = flow.testState.failedFailure,
                let stage = flow.testState.failedStage {
                 failedTestRecovery(stage: stage, failure: failure)
-            } else if flow.hasCurrentSuccessfulTest {
-                // Reachable after returning Back from Review: the passing
-                // result is still current, so continue without re-testing.
+            } else if flow.canUseSettings {
+                // Reachable after returning Back from Review: a passing or
+                // interactive outcome is still current, so continue without
+                // re-testing.
                 Button("Continue") { flow.continueToReview() }
                     .buttonStyle(.borderedProminent)
                     .tint(.conduitAccent)
@@ -204,12 +205,22 @@ struct ConnectionSetupForm: View {
         VStack(alignment: .leading, spacing: 20) {
             Text("Review").font(.title2.weight(.semibold))
             // The staged result that authorizes this screen: a current
-            // successful test, shown with its per-stage outcomes.
-            if flow.hasCurrentSuccessfulTest {
+            // successful test or the interactive-auth outcome, shown with
+            // its per-stage outcomes.
+            if flow.canUseSettings {
                 ConnectionSetupStageList(state: flow.testState)
-                Text(ConnectionSetupTestState.readyMessage)
-                    .font(.headline)
-                    .accessibilityIdentifier("setup.test.ready")
+                if flow.testState.requiresInteractiveSignIn {
+                    // The user has NOT authenticated: say what happens next
+                    // instead of claiming success. Never "Login successful".
+                    Text(ConnectionSetupTestState.interactiveReadyMessage)
+                        .font(.headline)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier("setup.test.interactive-ready")
+                } else {
+                    Text(ConnectionSetupTestState.readyMessage)
+                        .font(.headline)
+                        .accessibilityIdentifier("setup.test.ready")
+                }
             }
             // Revalidate for rendering only: a draft that stopped validating
             // after reaching Review must never silently blank the card.
@@ -247,7 +258,7 @@ struct ConnectionSetupForm: View {
     }
 
     private var reviewIsValid: Bool {
-        guard flow.hasCurrentSuccessfulTest else { return false }
+        guard flow.canUseSettings else { return false }
         if case .success = flow.reviewState() { return true }
         return false
     }
@@ -354,6 +365,14 @@ struct ConnectionSetupStageRow: View {
             Image(systemName: "checkmark.circle.fill")
                 .font(.footnote)
                 .foregroundStyle(.green)
+                .padding(.top, 2)
+        case .requiresInteractiveSignIn:
+            // An open circle in the accent color: deliberately not a
+            // checkmark (the user has not authenticated) and not an error
+            // mark (nothing failed). Text and VoiceOver carry the meaning.
+            Image(systemName: "circle")
+                .font(.footnote)
+                .foregroundStyle(.conduitAccent)
                 .padding(.top, 2)
         case .failed:
             Image(systemName: "xmark.circle.fill")

--- a/Conduit/Views/ConnectionSetupForm.swift
+++ b/Conduit/Views/ConnectionSetupForm.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Form rendering only: navigation and final validation stay in the flow.
 struct ConnectionSetupForm: View {
     @Binding var flow: ConnectionSetupFlow
+    let onStartTest: () -> Void
     let onComplete: (ConnectionSetupResult) -> Void
     @FocusState private var focusedField: Field?
 
@@ -15,6 +16,7 @@ struct ConnectionSetupForm: View {
                     switch flow.step {
                     case .connectionDetails: details
                     case .loginCredentials: credentials
+                    case .connectionTest: connectionTest
                     case .review: review
                     default: EmptyView()
                     }
@@ -134,17 +136,86 @@ struct ConnectionSetupForm: View {
                     .accessibilityLabel("Dashboard password")
             }.id(Field.password)
             validationNotice
-            nextButton("Review") { flow.submitCredentials() }
+            nextButton("Test Connection") { flow.submitCredentials() }
+        }
+    }
+
+    // MARK: - Round 4: staged connection test
+
+    @ViewBuilder
+    private var connectionTest: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text("Test connection").font(.title2.weight(.semibold))
+            Text("Conduit will check the dashboard address and try your credentials now. Nothing is saved, and Conduit won’t connect yet — you’ll confirm everything on the Review screen.")
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            ConnectionSetupStageList(state: flow.testState)
+
+            if let failure = flow.testState.failedFailure,
+               let stage = flow.testState.failedStage {
+                failedTestRecovery(stage: stage, failure: failure)
+            } else if flow.hasCurrentSuccessfulTest {
+                // Reachable after returning Back from Review: the passing
+                // result is still current, so continue without re-testing.
+                Button("Continue") { flow.continueToReview() }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.conduitAccent)
+                    .accessibilityIdentifier("setup.test.continue")
+            } else if !flow.testState.isRunning {
+                Button("Test Connection") { onStartTest() }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.conduitAccent)
+                    .frame(maxWidth: .infinity)
+                    .disabled(flow.testState.isRunning)
+                    .accessibilityIdentifier("setup.test.run")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func failedTestRecovery(stage: ConnectionSetupTestStage, failure: ConnectionFailure) -> some View {
+        let plan = ConnectionSetupTestRecoveryPlan.plan(for: stage, failure: failure)
+        VStack(alignment: .leading, spacing: 12) {
+            // The stable classified copy — never a raw error string.
+            Text(failure.userMessage)
+                .font(.subheadline)
+                .fixedSize(horizontal: false, vertical: true)
+                .accessibilityIdentifier("setup.test.failure")
+            HStack(spacing: 16) {
+                Button(plan.remediationLabel) {
+                    flow.editAfterFailedTest(plan.remediationStep)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.conduitAccent)
+                .accessibilityIdentifier(
+                    plan.remediationStep == .connectionDetails ? "setup.test.edit-details" : "setup.test.edit-credentials"
+                )
+                if plan.offersRetry {
+                    Button("Try Again") { onStartTest() }
+                        .buttonStyle(.bordered)
+                        .accessibilityIdentifier("setup.test.retry")
+                }
+            }
+            .font(.subheadline.weight(.semibold))
         }
     }
 
     private var review: some View {
         VStack(alignment: .leading, spacing: 20) {
             Text("Review").font(.title2.weight(.semibold))
+            // The staged result that authorizes this screen: a current
+            // successful test, shown with its per-stage outcomes.
+            if flow.hasCurrentSuccessfulTest {
+                ConnectionSetupStageList(state: flow.testState)
+                Text(ConnectionSetupTestState.readyMessage)
+                    .font(.headline)
+                    .accessibilityIdentifier("setup.test.ready")
+            }
             // Revalidate for rendering only: a draft that stopped validating
             // after reaching Review must never silently blank the card.
             reviewContent
-            Text("These settings will fill the login form. You’ll tap Connect there when you’re ready. This assistant has not tested the connection.")
+            Text("These settings will fill the login form. You’ll tap Connect there when you’re ready.")
                 .foregroundStyle(.secondary)
             validationNotice
             Button("Use these settings") {
@@ -177,6 +248,7 @@ struct ConnectionSetupForm: View {
     }
 
     private var reviewIsValid: Bool {
+        guard flow.hasCurrentSuccessfulTest else { return false }
         if case .success = flow.reviewState() { return true }
         return false
     }
@@ -220,5 +292,72 @@ struct ConnectionSetupForm: View {
     }
     private var portBinding: Binding<String> {
         flow.accessMethod == .lan ? $flow.draft.lan.port : $flow.draft.tailscale.port
+    }
+}
+
+/// The staged connection-test diagnostic list: one row per stage with a
+/// state marker. Meaning is carried by text and VoiceOver state words, never
+/// by color alone.
+struct ConnectionSetupStageList: View {
+    let state: ConnectionSetupTestState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ForEach(ConnectionSetupTestStage.allCases) { stage in
+                ConnectionSetupStageRow(
+                    stage: stage,
+                    stageState: state[stage],
+                    label: state.rowLabel(for: stage)
+                )
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .conduitGlassSurface(cornerRadius: 18, tint: .conduitAura.opacity(0.06))
+    }
+}
+
+struct ConnectionSetupStageRow: View {
+    let stage: ConnectionSetupTestStage
+    let stageState: ConnectionSetupStageState
+    let label: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            marker
+            Text(label)
+                .font(.subheadline.weight(stageState == .pending ? .regular : .semibold))
+            Spacer(minLength: 0)
+        }
+        // One VoiceOver element per stage: the objective name plus a state
+        // word, so success/failure never rides on icon or color alone.
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(state.accessibilityLabel(for: stage))
+        .accessibilityIdentifier("setup.test.stage.\(stage.identifierName)")
+    }
+
+    @ViewBuilder
+    private var marker: some View {
+        switch stageState {
+        case .pending:
+            Image(systemName: "circle")
+                .font(.footnote)
+                .foregroundStyle(.tertiary)
+                .padding(.top, 2)
+        case .running:
+            ProgressView()
+                .controlSize(.small)
+                .padding(.top, 3)
+        case .succeeded:
+            Image(systemName: "checkmark.circle.fill")
+                .font(.footnote)
+                .foregroundStyle(.green)
+                .padding(.top, 2)
+        case .failed:
+            Image(systemName: "xmark.circle.fill")
+                .font(.footnote)
+                .foregroundStyle(.red)
+                .padding(.top, 2)
+        }
     }
 }

--- a/Conduit/Views/ConnectionSetupForm.swift
+++ b/Conduit/Views/ConnectionSetupForm.swift
@@ -136,7 +136,7 @@ struct ConnectionSetupForm: View {
                     .accessibilityLabel("Dashboard password")
             }.id(Field.password)
             validationNotice
-            nextButton("Test Connection") { flow.submitCredentials() }
+            nextButton("Continue") { flow.submitCredentials() }
         }
     }
 
@@ -167,7 +167,6 @@ struct ConnectionSetupForm: View {
                     .buttonStyle(.borderedProminent)
                     .tint(.conduitAccent)
                     .frame(maxWidth: .infinity)
-                    .disabled(flow.testState.isRunning)
                     .accessibilityIdentifier("setup.test.run")
             }
         }
@@ -307,7 +306,8 @@ struct ConnectionSetupStageList: View {
                 ConnectionSetupStageRow(
                     stage: stage,
                     stageState: state[stage],
-                    label: state.rowLabel(for: stage)
+                    label: state.rowLabel(for: stage),
+                    accessibilityLabel: state.accessibilityLabel(for: stage)
                 )
             }
         }
@@ -321,6 +321,7 @@ struct ConnectionSetupStageRow: View {
     let stage: ConnectionSetupTestStage
     let stageState: ConnectionSetupStageState
     let label: String
+    let accessibilityLabel: String
 
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
@@ -330,9 +331,10 @@ struct ConnectionSetupStageRow: View {
             Spacer(minLength: 0)
         }
         // One VoiceOver element per stage: the objective name plus a state
-        // word, so success/failure never rides on icon or color alone.
+        // word, so success/failure never rides on icon or color alone. The
+        // format comes from the model, which pins it in tests.
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(stage.objectiveLabel), \(stageState.accessibilityState)")
+        .accessibilityLabel(accessibilityLabel)
         .accessibilityIdentifier("setup.test.stage.\(stage.identifierName)")
     }
 

--- a/Conduit/Views/ConnectionSetupForm.swift
+++ b/Conduit/Views/ConnectionSetupForm.swift
@@ -332,7 +332,7 @@ struct ConnectionSetupStageRow: View {
         // One VoiceOver element per stage: the objective name plus a state
         // word, so success/failure never rides on icon or color alone.
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel(state.accessibilityLabel(for: stage))
+        .accessibilityLabel("\(stage.objectiveLabel), \(stageState.accessibilityState)")
         .accessibilityIdentifier("setup.test.stage.\(stage.identifierName)")
     }
 

--- a/Conduit/Views/ConnectionSetupView.swift
+++ b/Conduit/Views/ConnectionSetupView.swift
@@ -14,26 +14,50 @@
 //
 
 import SwiftUI
+import UIKit
 
 struct ConnectionSetupView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var flow: ConnectionSetupFlow
     @State private var showNotSureGuidance = false
+    /// The in-flight staged-test task. Cancelled on any exit from the test
+    /// screen and on dismissal; late probe events are additionally dropped
+    /// by the flow's generation guard, so correctness never relies on view
+    /// destruction.
+    @State private var testTask: Task<Void, Never>?
     private let onComplete: (ConnectionSetupResult) -> Void
+    private let prober: any ConnectionSetupTesting
 
-    init(initialDestination: ConnectionHelpDestination,
-         initialDraft: ConnectionSetupDraft = ConnectionSetupDraft(),
-         onComplete: @escaping (ConnectionSetupResult) -> Void) {
-        _flow = State(initialValue: ConnectionSetupFlow(entry: initialDestination, draft: initialDraft))
+    init(
+        initialDestination: ConnectionHelpDestination,
+        initialDraft: ConnectionSetupDraft = ConnectionSetupDraft(),
+        initialCloudflareAccess: CloudflareAccessCredentials? = nil,
+        initialCloudflareOriginURL: String = "",
+        onComplete: @escaping (ConnectionSetupResult) -> Void
+    ) {
+        _flow = State(initialValue: ConnectionSetupFlow(
+            entry: initialDestination,
+            draft: initialDraft,
+            inheritedCloudflareAccess: initialCloudflareAccess,
+            inheritedCloudflareOriginURL: initialCloudflareOriginURL
+        ))
         self.onComplete = onComplete
+        self.prober = Self.makeProber()
+    }
+
+    private static func makeProber() -> any ConnectionSetupTesting {
+        #if DEBUG
+        if let stub = ConnectionSetupTestProbeStub.fromLaunchArguments() { return stub }
+        #endif
+        return ConnectionSetupProbe()
     }
 
     var body: some View {
         NavigationStack {
             Group {
                 switch flow.step {
-                case .connectionDetails, .loginCredentials, .review:
-                    ConnectionSetupForm(flow: $flow) { result in
+                case .connectionDetails, .loginCredentials, .connectionTest, .review:
+                    ConnectionSetupForm(flow: $flow, onStartTest: { startTestRun() }) { result in
                         onComplete(result)
                         dismiss()
                     }
@@ -46,6 +70,13 @@ struct ConnectionSetupView: View {
                 }
             }
             .accessibilityIdentifier("connection-setup.content")
+            .onChange(of: flow.step) { _, newStep in
+                // Leaving the test screen for any editable step cancels the
+                // probe; a success advance to Review does not.
+                guard newStep != .connectionTest, newStep != .review else { return }
+                stopTestRun()
+            }
+            .onDisappear { stopTestRun() }
             .navigationTitle("Connection Setup")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -67,6 +98,41 @@ struct ConnectionSetupView: View {
         }
     }
 
+    // MARK: - Staged connection test
+
+    private func startTestRun() {
+        guard let run = try? flow.draft.result(),
+              let generation = flow.beginTest() else { return }
+        let access = flow.cloudflareAccessForDraft()
+        let prober = prober
+        let flow = $flow
+        testTask?.cancel()
+        testTask = Task { @MainActor in
+            await prober.runTest(result: run, cloudflareAccess: access, onEvent: { event in
+                flow.wrappedValue.applyTestEvent(event, generation: generation)
+                // One completion announcement per run; individual stage
+                // transitions stay quiet.
+                switch event {
+                case .succeeded(.authentication):
+                    UIAccessibility.post(
+                        notification: .announcement,
+                        argument: ConnectionSetupTestState.readyMessage
+                    )
+                case .failed(_, let failure):
+                    UIAccessibility.post(notification: .announcement, argument: failure.userTitle)
+                default:
+                    break
+                }
+            })
+        }
+    }
+
+    private func stopTestRun() {
+        testTask?.cancel()
+        testTask = nil
+        flow.cancelTest()
+    }
+
     // MARK: - Step routing
 
     @ViewBuilder
@@ -78,7 +144,7 @@ struct ConnectionSetupView: View {
         case .lan: lanBranch
         case .tailscale: tailscaleBranch
         case .reverseProxy: reverseProxyBranch
-        case .connectionDetails, .loginCredentials, .review: EmptyView()
+        case .connectionDetails, .loginCredentials, .connectionTest, .review: EmptyView()
         case .tlsTroubleshooting: troubleshootingStep(.tls)
         case .cloudflareTroubleshooting: troubleshootingStep(.cloudflare)
         }

--- a/Conduit/Views/ConnectionSetupView.swift
+++ b/Conduit/Views/ConnectionSetupView.swift
@@ -120,6 +120,11 @@ struct ConnectionSetupView: View {
                         notification: .announcement,
                         argument: ConnectionSetupTestState.readyMessage
                     )
+                case .requiresInteractiveSignIn(.authentication):
+                    UIAccessibility.post(
+                        notification: .announcement,
+                        argument: ConnectionSetupTestState.interactiveReadyMessage
+                    )
                 case .failed(_, let failure):
                     UIAccessibility.post(notification: .announcement, argument: failure.userTitle)
                 default:

--- a/Conduit/Views/ConnectionSetupView.swift
+++ b/Conduit/Views/ConnectionSetupView.swift
@@ -109,7 +109,9 @@ struct ConnectionSetupView: View {
         testTask?.cancel()
         testTask = Task { @MainActor in
             await prober.runTest(result: run, cloudflareAccess: access, onEvent: { event in
-                flow.wrappedValue.applyTestEvent(event, generation: generation)
+                // Announce only events the model actually applied — dropped
+                // stale events never speak.
+                guard flow.wrappedValue.applyTestEvent(event, generation: generation) else { return }
                 // One completion announcement per run; individual stage
                 // transitions stay quiet.
                 switch event {

--- a/Conduit/Views/LoginView.swift
+++ b/Conduit/Views/LoginView.swift
@@ -108,7 +108,12 @@ struct LoginView: View {
         .sheet(item: $connectionSetupDestination) { destination in
             ConnectionSetupView(
                 initialDestination: destination,
-                initialDraft: ConnectionSetupDraft(existingServerURL: serverUrl, username: username, password: password)
+                initialDraft: ConnectionSetupDraft(existingServerURL: serverUrl, username: username, password: password),
+                // The probe may reuse this same-origin service token; the
+                // wizard re-verifies the origin itself before sending it and
+                // never displays, edits, or persists it.
+                initialCloudflareAccess: configuredCloudflareAccess,
+                initialCloudflareOriginURL: serverUrl
             ) { result in
                 // The tested handoff mapping: clears the in-memory Cloudflare
                 // token BEFORE the new address lands whenever the origin

--- a/Conduit/Views/LoginView.swift
+++ b/Conduit/Views/LoginView.swift
@@ -479,7 +479,7 @@ struct LoginView: View {
             let access = configuredCloudflareAccess
             let client = NativeAuthClient(baseURL: serverUrl, cloudflareAccess: access)
             let providers = try await client.authProviders()
-            guard providers.contains(where: { $0["supports_password"] as? Bool == true }) else {
+            guard HermesProviderCheck.supportsPassword(providers) else {
                 showWebView = true
                 if let access { KeychainHelper.saveCloudflareAccess(access, origin: serverUrl) }
                 return

--- a/Conduit/Views/LoginView.swift
+++ b/Conduit/Views/LoginView.swift
@@ -478,8 +478,23 @@ struct LoginView: View {
         do {
             let access = configuredCloudflareAccess
             let client = NativeAuthClient(baseURL: serverUrl, cloudflareAccess: access)
-            let providers = try await client.authProviders()
-            guard HermesProviderCheck.supportsPassword(providers) else {
+            // Provider discovery is typed: only the unauthenticated redirect
+            // is THE interactive sign-in signal. A recognizable Hermes
+            // provider answer without password support (none configured, or
+            // only OAuth providers) intentionally routes to the browser too
+            // — an explicit decision, not the old "empty list" ambiguity. An
+            // unrecognized 2xx body keeps the same browser fallback it
+            // always had.
+            let requiresBrowserSignIn: Bool
+            switch try await client.authProviderDiscovery() {
+            case .interactiveSignInRequired:
+                requiresBrowserSignIn = true
+            case .providers(let providers):
+                requiresBrowserSignIn = !HermesProviderCheck.supportsPassword(providers)
+            case .unrecognized:
+                requiresBrowserSignIn = true
+            }
+            if requiresBrowserSignIn {
                 showWebView = true
                 if let access { KeychainHelper.saveCloudflareAccess(access, origin: serverUrl) }
                 return

--- a/ConduitTests/ConnectionSetupFlowTests.swift
+++ b/ConduitTests/ConnectionSetupFlowTests.swift
@@ -34,7 +34,11 @@ final class ConnectionSetupFlowTests: XCTestCase {
         flow.draft.username = "eric"
         flow.draft.password = "in-memory-fixture"
         flow.submitCredentials()
+        XCTAssertEqual(flow.step, .connectionTest, "Credentials now lead to the staged connection test")
+        StagedTestDriver.runSuccessfulTest(on: &flow)
         XCTAssertEqual(flow.step, .review)
+        flow.back()
+        XCTAssertEqual(flow.step, .connectionTest)
         flow.back()
         XCTAssertEqual(flow.step, .loginCredentials)
         XCTAssertTrue(flow.draft.password == "in-memory-fixture")
@@ -43,6 +47,8 @@ final class ConnectionSetupFlowTests: XCTestCase {
         flow.draft.lan.port = "9120"
         flow.submitDetails()
         flow.submitCredentials()
+        XCTAssertEqual(flow.step, .connectionTest)
+        StagedTestDriver.runSuccessfulTest(on: &flow)
         let result = try XCTUnwrap(flow.complete())
         XCTAssertEqual(result.serverURL, "http://192.168.1.28:9120")
         XCTAssertEqual(result.username, "eric")
@@ -79,7 +85,8 @@ final class ConnectionSetupFlowTests: XCTestCase {
         XCTAssertEqual(flow.step, .loginCredentials)
         flow.draft.password = "updated-fixture"
         flow.submitCredentials()
-        XCTAssertEqual(flow.step, .review)
+        XCTAssertEqual(flow.step, .connectionTest)
+        StagedTestDriver.runSuccessfulTest(on: &flow)
         XCTAssertEqual(try XCTUnwrap(flow.complete()).serverURL, "https://example.com:9443/hermes")
         XCTAssertNil(flow.dashboardAnswer)
         XCTAssertNil(flow.accessMethod)
@@ -97,6 +104,8 @@ final class ConnectionSetupFlowTests: XCTestCase {
         flow.draft.existingServerURL = "https://remote.example/hermes"
         flow.submitDetails()
         flow.submitCredentials()
+        XCTAssertEqual(flow.step, .connectionTest)
+        StagedTestDriver.runSuccessfulTest(on: &flow)
         XCTAssertEqual(try XCTUnwrap(flow.complete()).serverURL, "https://remote.example/hermes")
     }
 
@@ -360,6 +369,8 @@ final class ConnectionSetupFlowTests: XCTestCase {
         flow.draft.username = "eric"
         flow.draft.password = "fixture"
         flow.submitCredentials()
+        XCTAssertEqual(flow.step, .connectionTest)
+        StagedTestDriver.runSuccessfulTest(on: &flow)
         XCTAssertEqual(flow.step, .review)
 
         guard case .success(let result) = flow.reviewState() else {
@@ -377,8 +388,9 @@ final class ConnectionSetupFlowTests: XCTestCase {
         XCTAssertEqual(error, .credentialsRequired)
         XCTAssertEqual(error.message, ConnectionSetupValidationError.credentialsRequired.message)
         XCTAssertEqual(flow.step, .review)
-        XCTAssertEqual(flow.path.count, 5, "Render-time revalidation must never mutate the path")
+        XCTAssertEqual(flow.path.count, 6, "Render-time revalidation must never mutate the path")
         XCTAssertNil(flow.validationError, "Render-time revalidation is pure and records nothing")
+        XCTAssertFalse(flow.hasCurrentSuccessfulTest, "The edit also invalidates the staged test")
     }
 
     // MARK: - Ask Hermes prompt safety

--- a/ConduitTests/ConnectionSetupTestTests.swift
+++ b/ConduitTests/ConnectionSetupTestTests.swift
@@ -440,22 +440,22 @@ final class ConnectionSetupTestTests: XCTestCase {
     }
 
     func testProbeFullSuccessEmitsTheExactStagedSequence() async {
-        let events = await runProbe("http://probe-success.example")
+        let events = await runProbe("https://probe-success.example")
         XCTAssertEqual(events, StagedTestDriver.successEvents)
     }
 
     func testProbeDNSFailureMapsToHostNotFoundAtServerStage() async {
-        let events = await runProbe("http://probe-dns.example")
+        let events = await runProbe("https://probe-dns.example")
         XCTAssertEqual(events, [.started(.server), .failed(.server, .hostNotFound)])
     }
 
     func testProbeRefusedMapsToConnectionRefusedAtServerStage() async {
-        let events = await runProbe("http://probe-refused.example")
+        let events = await runProbe("https://probe-refused.example")
         XCTAssertEqual(events, [.started(.server), .failed(.server, .connectionRefused)])
     }
 
     func testProbeTimeoutMapsToTimedOutAtServerStage() async {
-        let events = await runProbe("http://probe-timeout.example")
+        let events = await runProbe("https://probe-timeout.example")
         XCTAssertEqual(events, [.started(.server), .failed(.server, .timedOut)])
     }
 
@@ -475,7 +475,7 @@ final class ConnectionSetupTestTests: XCTestCase {
     }
 
     func testProbeDashboard5xxMapsToDashboardUnavailableAfterTransportSuccess() async {
-        let events = await runProbe("http://probe-5xx.example")
+        let events = await runProbe("https://probe-5xx.example")
         XCTAssertEqual(events, [
             .started(.server),
             .succeeded(.server),
@@ -487,7 +487,7 @@ final class ConnectionSetupTestTests: XCTestCase {
     func testProbeNonHermesWebsiteMapsToUnexpectedServerResponse() async {
         // A 200 response without a password-capable provider is never a
         // Hermes dashboard, and never success.
-        let events = await runProbe("http://probe-foreign.example")
+        let events = await runProbe("https://probe-foreign.example")
         XCTAssertEqual(events, [
             .started(.server),
             .succeeded(.server),
@@ -497,14 +497,14 @@ final class ConnectionSetupTestTests: XCTestCase {
     }
 
     func testProbeRejectedCredentialsMapToAuthenticationRejected() async {
-        let events = await runProbe("http://probe-auth401.example")
+        let events = await runProbe("https://probe-auth401.example")
         XCTAssertEqual(events, Array(StagedTestDriver.successEvents.prefix(5)) + [
             .failed(.authentication, .authenticationRejected)
         ])
     }
 
     func testProbeLogin429MapsToRateLimited() async {
-        let events = await runProbe("http://probe-auth429.example")
+        let events = await runProbe("https://probe-auth429.example")
         XCTAssertEqual(events, Array(StagedTestDriver.successEvents.prefix(5)) + [
             .failed(.authentication, .rateLimited)
         ])
@@ -513,7 +513,7 @@ final class ConnectionSetupTestTests: XCTestCase {
     func testProbeTicketFailureMapsToSessionTicketFailure() async {
         // Password accepted, but no host-scoped session cookie survived —
         // the existing session-ticket semantics, not "wrong password".
-        let events = await runProbe("http://probe-cookieless.example")
+        let events = await runProbe("https://probe-cookieless.example")
         XCTAssertEqual(events, Array(StagedTestDriver.successEvents.prefix(5)) + [
             .failed(.authentication, .sessionTicketFailure)
         ])
@@ -543,7 +543,7 @@ final class ConnectionSetupTestTests: XCTestCase {
         let task = Task { @MainActor in
             await probe.runTest(
                 result: ConnectionSetupResult(
-                    serverURL: "http://probe-hang.example",
+                    serverURL: "https://probe-hang.example",
                     username: "probe-user",
                     password: "probe-password-fixture"
                 ),
@@ -561,8 +561,8 @@ final class ConnectionSetupTestTests: XCTestCase {
 
     @MainActor
     func testSuccessfulProbePersistsNothingAndMakesExactlyOneAuthAttempt() async {
-        let fixtureURL = URL(string: "http://probe-success.example/")!
-        _ = await runProbe("http://probe-success.example")
+        let fixtureURL = URL(string: "https://probe-success.example/")!
+        _ = await runProbe("https://probe-success.example")
 
         let jarCookies = HTTPCookieStorage.shared.cookies(for: fixtureURL) ?? []
         XCTAssertTrue(

--- a/ConduitTests/ConnectionSetupTestTests.swift
+++ b/ConduitTests/ConnectionSetupTestTests.swift
@@ -366,10 +366,11 @@ final class ConnectionSetupTestTests: XCTestCase {
     func testAccessibilityLabelsCarryStateWordsNotJustIcons() {
         var state = ConnectionSetupTestState()
         XCTAssertEqual(state.accessibilityLabel(for: .server), "Dashboard reachable, waiting")
-        state.apply(.started(.dashboard))
-        XCTAssertEqual(state.accessibilityLabel(for: .dashboard), "Hermes dashboard found, checking")
+        state.apply(.started(.server))
         state.apply(.succeeded(.server))
         XCTAssertEqual(state.accessibilityLabel(for: .server), "Dashboard reachable, passed")
+        state.apply(.started(.dashboard))
+        XCTAssertEqual(state.accessibilityLabel(for: .dashboard), "Hermes dashboard found, checking")
         state.apply(.failed(.authentication, .authenticationRejected))
         XCTAssertEqual(state.accessibilityLabel(for: .authentication), "Authentication, failed")
     }
@@ -402,6 +403,16 @@ final class ConnectionSetupTestTests: XCTestCase {
     }
 
     // MARK: - Probe orchestration (spec 20) — real NativeAuthClient through URLProtocol
+
+    override func setUp() {
+        super.setUp()
+        SetupProbeURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        SetupProbeURLProtocol.reset()
+        super.tearDown()
+    }
 
     private static func makeProbeConfiguration() -> URLSessionConfiguration {
         let configuration = URLSessionConfiguration.ephemeral
@@ -456,6 +467,11 @@ final class ConnectionSetupTestTests: XCTestCase {
     func testProbeTLSBadDateMapsToTLSBadDateAtServerStage() async {
         let events = await runProbe("https://probe-tlsdate.example")
         XCTAssertEqual(events, [.started(.server), .failed(.server, .tlsBadDate)])
+    }
+
+    func testProbeTLSHandshakeFailureMapsToTLSFailureAtServerStage() async {
+        let events = await runProbe("https://probe-tlsfailure.example")
+        XCTAssertEqual(events, [.started(.server), .failed(.server, .tlsFailure)])
     }
 
     func testProbeDashboard5xxMapsToDashboardUnavailableAfterTransportSuccess() async {
@@ -554,12 +570,80 @@ final class ConnectionSetupTestTests: XCTestCase {
             "The probe must never commit cookies to the shared store: \(jarCookies.map(\.name))"
         )
         XCTAssertEqual(
-            SetupProbeURLProtocol.requestCount(forPath: "/auth/password-login"),
+            SetupProbeURLProtocol.requestCount(forPath: "/auth/password-login", host: "probe-success.example"),
             1,
             "One user-requested test equals exactly one authentication attempt"
         )
-        XCTAssertEqual(SetupProbeURLProtocol.requestCount(forPath: "/api/auth/ws-ticket"), 1)
-        XCTAssertEqual(SetupProbeURLProtocol.requestCount(forPath: "/api/auth/providers"), 1)
+        XCTAssertEqual(
+            SetupProbeURLProtocol.requestCount(forPath: "/api/auth/ws-ticket", host: "probe-success.example"), 1
+        )
+        XCTAssertEqual(
+            SetupProbeURLProtocol.requestCount(forPath: "/api/auth/providers", host: "probe-success.example"), 1
+        )
+    }
+
+    // MARK: - Inherited Cloudflare token origin gate (spec 9/18)
+
+    private func makeOriginGateFlow(
+        existingServerURL: String,
+        origin: String,
+        access: CloudflareAccessCredentials?
+    ) -> ConnectionSetupFlow {
+        ConnectionSetupFlow(
+            entry: .credentials,
+            draft: ConnectionSetupDraft(
+                existingServerURL: existingServerURL,
+                username: "probe-user",
+                password: "in-memory-fixture"
+            ),
+            inheritedCloudflareAccess: access,
+            inheritedCloudflareOriginURL: origin
+        )
+    }
+
+    func testInheritedCloudflareTokenIsUsedOnlySameOrigin() {
+        let token = CloudflareAccessCredentials(clientID: "gate-client-id", clientSecret: "gate-client-secret")
+        let address = "https://hermes.example:9443"
+
+        // Same origin (including an added path prefix): token applies.
+        let sameOrigin = makeOriginGateFlow(existingServerURL: address, origin: address, access: token)
+        XCTAssertEqual(sameOrigin.cloudflareAccessForDraft(), token)
+        let pathPrefixed = makeOriginGateFlow(
+            existingServerURL: "\(address)/hermes", origin: address, access: token
+        )
+        XCTAssertEqual(pathPrefixed.cloudflareAccessForDraft(), token)
+
+        // A different host, scheme, or effective port never receives it.
+        let otherHost = makeOriginGateFlow(existingServerURL: address, origin: "https://other.example:9443", access: token)
+        XCTAssertNil(otherHost.cloudflareAccessForDraft())
+        let otherScheme = makeOriginGateFlow(existingServerURL: address, origin: "http://hermes.example:9443", access: token)
+        XCTAssertNil(otherScheme.cloudflareAccessForDraft())
+        let otherPort = makeOriginGateFlow(existingServerURL: address, origin: "https://hermes.example", access: token)
+        XCTAssertNil(otherPort.cloudflareAccessForDraft())
+
+        // No recorded origin, or an unconfigured token: nothing is sent.
+        let noOrigin = makeOriginGateFlow(existingServerURL: address, origin: "", access: token)
+        XCTAssertNil(noOrigin.cloudflareAccessForDraft())
+        let unconfigured = makeOriginGateFlow(
+            existingServerURL: address, origin: address,
+            access: CloudflareAccessCredentials(clientID: "  ", clientSecret: "")
+        )
+        XCTAssertNil(unconfigured.cloudflareAccessForDraft())
+        let noToken = makeOriginGateFlow(existingServerURL: address, origin: address, access: nil)
+        XCTAssertNil(noToken.cloudflareAccessForDraft())
+    }
+
+    func testEditingTheDraftAwayFromTheTokenOriginDropsTheToken() {
+        let token = CloudflareAccessCredentials(clientID: "gate-client-id", clientSecret: "gate-client-secret")
+        var flow = makeOriginGateFlow(
+            existingServerURL: "https://hermes.example:9443", origin: "https://hermes.example:9443", access: token
+        )
+        XCTAssertEqual(flow.cloudflareAccessForDraft(), token)
+
+        // The user edits the dashboard address inside the wizard: the token
+        // must not follow it to the new origin.
+        flow.draft.existingServerURL = "https://elsewhere.example:9443"
+        XCTAssertNil(flow.cloudflareAccessForDraft(), "A service token is never sent cross-origin")
     }
 }
 
@@ -583,6 +667,7 @@ private final class SetupProbeURLProtocol: URLProtocol {
         "probe-timeout.example",
         "probe-tls.example",
         "probe-tlsdate.example",
+        "probe-tlsfailure.example",
         "probe-5xx.example",
         "probe-foreign.example",
         "probe-auth401.example",
@@ -638,10 +723,19 @@ private final class SetupProbeURLProtocol: URLProtocol {
 
     // MARK: - Inspection
 
-    static func requestCount(forPath path: String) -> Int {
+    /// Clears all recorded traffic so per-test exact-count assertions are
+    /// independent of execution order.
+    static func reset() {
         lock.lock()
         defer { lock.unlock() }
-        return requestRecords.filter { $0.url?.path == path }.count
+        responseRecords.removeAll()
+        requestRecords.removeAll()
+    }
+
+    static func requestCount(forPath path: String, host: String) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return requestRecords.filter { $0.url?.path == path && $0.url?.host == host }.count
     }
 
     static func requestHeader(forPath path: String, name: String) -> String? {
@@ -671,6 +765,7 @@ private final class SetupProbeURLProtocol: URLProtocol {
         case "probe-timeout.example": return URLError(.timedOut)
         case "probe-tls.example": return URLError(.serverCertificateUntrusted)
         case "probe-tlsdate.example": return URLError(.serverCertificateHasBadDate)
+        case "probe-tlsfailure.example": return URLError(.secureConnectionFailed)
         default: return nil
         }
     }

--- a/ConduitTests/ConnectionSetupTestTests.swift
+++ b/ConduitTests/ConnectionSetupTestTests.swift
@@ -694,7 +694,7 @@ private final class SetupProbeURLProtocol: URLProtocol {
             // Never completes: the cancellation test cancels the task.
             return
         }
-        if let transportError = Self.transportError(for: url.host) {
+        if let transportError = Self.transportError(for: url.host ?? "") {
             client?.urlProtocol(self, didFailWithError: transportError)
             return
         }

--- a/ConduitTests/ConnectionSetupTestTests.swift
+++ b/ConduitTests/ConnectionSetupTestTests.swift
@@ -1,0 +1,773 @@
+//
+//  ConnectionSetupTestTests.swift
+//  Conduit
+//
+//  Round-4 staged connection test coverage: the state machine reducer, the
+//  flow's test-gating and invalidation rules, the recovery/retry policy,
+//  copy pins, and the probe's orchestration boundary (failure mapping and
+//  side-effect freedom) against the real NativeAuthClient through a
+//  URLProtocol stub.
+//
+
+import XCTest
+@testable import Conduit
+
+/// Drives a real staged-test success through the flow model's event reducer,
+/// so flow tests exercise the same path the probe and view use.
+enum StagedTestDriver {
+    static let successEvents: [ConnectionSetupTestEvent] = [
+        .started(.server), .succeeded(.server),
+        .started(.dashboard), .succeeded(.dashboard),
+        .started(.authentication), .succeeded(.authentication)
+    ]
+
+    /// Runs a full successful test on a flow sitting at `.connectionTest`.
+    /// Returns the generation token used.
+    @discardableResult
+    static func runSuccessfulTest(on flow: inout ConnectionSetupFlow) -> Int? {
+        guard let generation = flow.beginTest() else { return nil }
+        for event in successEvents {
+            flow.applyTestEvent(event, generation: generation)
+        }
+        return generation
+    }
+}
+
+final class ConnectionSetupTestTests: XCTestCase {
+    // MARK: - Flow factory
+
+    /// A flow sitting at `.connectionTest` via the full LAN walk.
+    private func makeFlowAtTestStep(
+        username: String = "probe-user",
+        password: String = "in-memory-fixture"
+    ) -> ConnectionSetupFlow {
+        var flow = ConnectionSetupFlow(entry: .network)
+        flow.selectAccessMethod(.lan)
+        flow.confirmDetailsReady()
+        flow.draft.lan.host = "192.168.1.28"
+        flow.draft.lan.port = "9119"
+        flow.submitDetails()
+        flow.draft.username = username
+        flow.draft.password = password
+        flow.submitCredentials()
+        XCTAssertEqual(flow.step, .connectionTest)
+        return flow
+    }
+
+    /// A flow at `.connectionTest` via the short auth-recovery route
+    /// (credentials entry with an existing expert address).
+    private func makeAuthRecoveryFlowAtTestStep() -> ConnectionSetupFlow {
+        var flow = ConnectionSetupFlow(entry: .credentials, draft: ConnectionSetupDraft(
+            existingServerURL: "https://hermes.example:9443",
+            username: "probe-user",
+            password: "in-memory-fixture"
+        ))
+        flow.answerCredentials(.yes)
+        XCTAssertEqual(flow.step, .loginCredentials)
+        flow.submitCredentials()
+        XCTAssertEqual(flow.step, .connectionTest)
+        return flow
+    }
+
+    // MARK: - State machine (spec 19)
+
+    func testFullSuccessSequenceReachesAcceptableState() {
+        var flow = makeFlowAtTestStep()
+        guard let generation = flow.beginTest() else { return XCTFail("beginTest must start on the test step") }
+
+        flow.applyTestEvent(.started(.server), generation: generation)
+        XCTAssertEqual(flow.testState.server, .running)
+        flow.applyTestEvent(.succeeded(.server), generation: generation)
+        XCTAssertEqual(flow.testState.server, .succeeded)
+        flow.applyTestEvent(.started(.dashboard), generation: generation)
+        XCTAssertEqual(flow.testState.dashboard, .running)
+        flow.applyTestEvent(.succeeded(.dashboard), generation: generation)
+        XCTAssertEqual(flow.testState.dashboard, .succeeded)
+        flow.applyTestEvent(.started(.authentication), generation: generation)
+        XCTAssertEqual(flow.testState.authentication, .running)
+        flow.applyTestEvent(.succeeded(.authentication), generation: generation)
+
+        XCTAssertTrue(flow.testState.allSucceeded)
+        XCTAssertEqual(flow.step, .review, "The final success advances to Review")
+        XCTAssertTrue(flow.hasCurrentSuccessfulTest)
+        XCTAssertNotNil(flow.complete(), "A current successful test authorizes acceptance")
+    }
+
+    func testReachabilityFailureKeepsLaterStagesPending() {
+        var flow = makeFlowAtTestStep()
+        let generation = flow.beginTest()
+        flow.applyTestEvent(.started(.server), generation: generation!)
+        flow.applyTestEvent(.failed(.server, .connectionRefused), generation: generation!)
+
+        XCTAssertEqual(flow.testState.server, .failed(.connectionRefused))
+        XCTAssertEqual(flow.testState.dashboard, .pending)
+        XCTAssertEqual(flow.testState.authentication, .pending)
+        XCTAssertEqual(flow.testState.failedFailure, .connectionRefused)
+        XCTAssertEqual(flow.testState.failedStage, .server)
+        XCTAssertEqual(flow.step, .connectionTest, "A failure must not navigate")
+        XCTAssertNil(flow.complete())
+    }
+
+    func testDashboardFailureKeepsAuthenticationPendingAndServerSuccess() {
+        var flow = makeFlowAtTestStep()
+        let generation = flow.beginTest()
+        flow.applyTestEvent(.started(.server), generation: generation!)
+        flow.applyTestEvent(.succeeded(.server), generation: generation!)
+        flow.applyTestEvent(.started(.dashboard), generation: generation!)
+        flow.applyTestEvent(.failed(.dashboard, .unexpectedServerResponse), generation: generation!)
+
+        XCTAssertEqual(flow.testState.server, .succeeded, "Prior success must remain visible")
+        XCTAssertEqual(flow.testState.dashboard, .failed(.unexpectedServerResponse))
+        XCTAssertEqual(flow.testState.authentication, .pending)
+        XCTAssertEqual(flow.testState.failedStage, .dashboard)
+    }
+
+    func testAuthenticationFailurePreservesPriorSuccesses() {
+        var flow = makeFlowAtTestStep()
+        let generation = flow.beginTest()
+        for event in StagedTestDriver.successEvents.prefix(4) {
+            flow.applyTestEvent(event, generation: generation!)
+        }
+        flow.applyTestEvent(.failed(.authentication, .authenticationRejected), generation: generation!)
+
+        XCTAssertEqual(flow.testState.server, .succeeded)
+        XCTAssertEqual(flow.testState.dashboard, .succeeded)
+        XCTAssertEqual(flow.testState.authentication, .failed(.authenticationRejected))
+        XCTAssertEqual(flow.step, .connectionTest)
+        XCTAssertNil(flow.complete())
+    }
+
+    func testRetryRestartsCleanAndIgnoresTheOldGeneration() {
+        var flow = makeFlowAtTestStep()
+        let firstGeneration = flow.beginTest()
+        flow.applyTestEvent(.started(.server), generation: firstGeneration!)
+        flow.applyTestEvent(.failed(.server, .timedOut), generation: firstGeneration!)
+
+        // Retry: a clean staged rerun with a fresh generation.
+        let secondGeneration = flow.beginTest()
+        XCTAssertNotNil(secondGeneration)
+        XCTAssertNotEqual(firstGeneration, secondGeneration)
+        XCTAssertEqual(flow.testState, ConnectionSetupTestState(), "Retry must reset every stage to untested")
+
+        // A late event from the abandoned run is dropped.
+        flow.applyTestEvent(.succeeded(.server), generation: firstGeneration!)
+        XCTAssertEqual(flow.testState.server, .pending)
+    }
+
+    func testBeginTestIsGuardedOffTheTestStep() {
+        var flow = makeFlowAtTestStep()
+        StagedTestDriver.runSuccessfulTest(on: &flow)
+        XCTAssertEqual(flow.step, .review)
+        XCTAssertNil(flow.beginTest(), "No test may start from Review")
+
+        var fresh = ConnectionSetupFlow(entry: .start)
+        XCTAssertNil(fresh.beginTest())
+    }
+
+    func testBeginTestRejectsConcurrentRuns() {
+        var flow = makeFlowAtTestStep()
+        let first = flow.beginTest()
+        XCTAssertNotNil(first)
+        flow.applyTestEvent(.started(.server), generation: first!)
+        XCTAssertNil(flow.beginTest(), "Tests never queue: one run at a time")
+    }
+
+    func testCancellationResetsRunningStagesAndDropsLateEvents() {
+        var flow = makeFlowAtTestStep()
+        let generation = flow.beginTest()
+        flow.applyTestEvent(.started(.server), generation: generation!)
+
+        flow.cancelTest()
+        XCTAssertEqual(flow.testState, ConnectionSetupTestState(), "A cancelled run resets to untested")
+        flow.applyTestEvent(.succeeded(.server), generation: generation!)
+        XCTAssertEqual(flow.testState.server, .pending, "Late events from the cancelled run are dropped")
+
+        // A completed (non-running) state survives cancelTest untouched.
+        StagedTestDriver.runSuccessfulTest(on: &flow)
+        flow.cancelTest()
+        XCTAssertTrue(flow.hasCurrentSuccessfulTest, "Cancelling never retracts a finished success")
+    }
+
+    func testEventsStopApplyingAfterTheSuccessAdvance() {
+        var flow = makeFlowAtTestStep()
+        StagedTestDriver.runSuccessfulTest(on: &flow)
+        XCTAssertEqual(flow.step, .review)
+        // A same-generation event arriving after the advance is dropped.
+        let generation = flow.testGeneration
+        flow.applyTestEvent(.failed(.authentication, .authenticationRejected), generation: generation)
+        XCTAssertTrue(flow.hasCurrentSuccessfulTest)
+    }
+
+    func testCompleteRequiresACurrentSuccessfulTest() throws {
+        var flow = makeFlowAtTestStep()
+        XCTAssertNil(flow.complete(), "Untested configuration is never handed off")
+
+        StagedTestDriver.runSuccessfulTest(on: &flow)
+        let result = try XCTUnwrap(flow.complete())
+        XCTAssertEqual(result.serverURL, "http://192.168.1.28:9119")
+    }
+
+    // MARK: - Edit invalidation (spec 14)
+
+    func testDraftEditInvalidatesPreviousSuccessAndResetsOnReentry() {
+        var flow = makeFlowAtTestStep()
+        StagedTestDriver.runSuccessfulTest(on: &flow)
+        XCTAssertTrue(flow.hasCurrentSuccessfulTest)
+
+        // Back to credentials and edit: the success is immediately invalid.
+        flow.back()
+        XCTAssertEqual(flow.step, .connectionTest)
+        XCTAssertTrue(flow.hasCurrentSuccessfulTest, "Back alone does not invalidate")
+        flow.back()
+        XCTAssertEqual(flow.step, .loginCredentials)
+        flow.draft.username = "changed-user"
+        XCTAssertFalse(flow.hasCurrentSuccessfulTest, "Any draft edit invalidates the success")
+
+        flow.submitCredentials()
+        XCTAssertEqual(flow.step, .connectionTest)
+        XCTAssertEqual(flow.testState, ConnectionSetupTestState(), "Re-entry with a stale success resets to untested")
+        XCTAssertNil(flow.complete())
+    }
+
+    func testStaleLateFailureCannotOverwriteNewerSuccessfulRun() {
+        var flow = makeFlowAtTestStep()
+        // Test A begins with the old credentials.
+        let generationA = flow.beginTest()
+        flow.applyTestEvent(.started(.server), generation: generationA!)
+
+        // The user edits credentials and starts Test B.
+        flow.back()
+        flow.draft.password = "newer-fixture"
+        flow.submitCredentials()
+        let generationB = flow.beginTest()
+        XCTAssertNotNil(generationB)
+        XCTAssertNotEqual(generationA, generationB)
+
+        // Test A finishes late with a rejection — dropped.
+        flow.applyTestEvent(.failed(.authentication, .authenticationRejected), generation: generationA!)
+        XCTAssertEqual(flow.testState.failedStage, nil)
+
+        // Test B succeeds; the final state remains successful.
+        for event in StagedTestDriver.successEvents {
+            flow.applyTestEvent(event, generation: generationB!)
+        }
+        XCTAssertEqual(flow.step, .review)
+        XCTAssertTrue(flow.hasCurrentSuccessfulTest)
+
+        // Even a later stale event cannot corrupt the finished run.
+        flow.back()
+        flow.applyTestEvent(.failed(.server, .hostNotFound), generation: generationA!)
+        XCTAssertTrue(flow.hasCurrentSuccessfulTest)
+        XCTAssertNil(flow.testState.failedStage)
+    }
+
+    // MARK: - Recovery routing (spec 11/12/17)
+
+    func testEditAfterFailedTestPopsToConnectionDetails() {
+        var flow = makeFlowAtTestStep()
+        let generation = flow.beginTest()
+        flow.applyTestEvent(.failed(.server, .hostNotFound), generation: generation!)
+        let pathCount = flow.path.count
+
+        flow.editAfterFailedTest(.connectionDetails)
+        XCTAssertEqual(flow.step, .connectionDetails)
+        XCTAssertEqual(flow.path.count, pathCount - 2, "The path truncates back to details")
+    }
+
+    func testEditAfterFailedTestInsertsDetailsOnTheShortcutRoute() {
+        var flow = makeAuthRecoveryFlowAtTestStep()
+        let generation = flow.beginTest()
+        flow.applyTestEvent(.failed(.dashboard, .dashboardUnavailable), generation: generation!)
+
+        flow.editAfterFailedTest(.connectionDetails)
+        XCTAssertEqual(flow.step, .connectionDetails)
+        flow.back()
+        XCTAssertEqual(flow.step, .loginCredentials, "The inserted details step walks back to credentials")
+    }
+
+    func testEditAfterFailedTestTargetsCredentials() {
+        var flow = makeFlowAtTestStep()
+        let generation = flow.beginTest()
+        flow.applyTestEvent(.failed(.authentication, .authenticationRejected), generation: generation!)
+
+        flow.editAfterFailedTest(.loginCredentials)
+        XCTAssertEqual(flow.step, .loginCredentials)
+    }
+
+    func testEditAfterFailedTestIsGuarded() {
+        var flow = makeFlowAtTestStep()
+        // Only from the test step, and only to the two editable steps.
+        flow.back()
+        flow.editAfterFailedTest(.connectionDetails)
+        XCTAssertEqual(flow.step, .loginCredentials, "Guarded off the test step")
+
+        flow.submitCredentials()
+        flow.editAfterFailedTest(.review)
+        XCTAssertEqual(flow.step, .connectionTest, "Only details/credentials are valid remediation targets")
+    }
+
+    func testContinueToReviewRequiresCurrentSuccess() {
+        var flow = makeFlowAtTestStep()
+        flow.continueToReview()
+        XCTAssertEqual(flow.step, .connectionTest, "No continue without a successful test")
+
+        StagedTestDriver.runSuccessfulTest(on: &flow)
+        XCTAssertEqual(flow.step, .review)
+        flow.back()
+        flow.continueToReview()
+        XCTAssertEqual(flow.step, .review, "A current success allows continuing without re-testing")
+    }
+
+    // MARK: - Recovery plan policy
+
+    func testAuthenticationRecoveryTargetsCredentialsAndKeepsRetrySecondary() {
+        let plan = ConnectionSetupTestRecoveryPlan.plan(for: .authentication, failure: .authenticationRejected)
+        XCTAssertEqual(plan.remediationStep, .loginCredentials)
+        XCTAssertEqual(plan.remediationLabel, "Edit Credentials")
+        XCTAssertTrue(plan.offersRetry, "Retry stays available but is never the primary action")
+    }
+
+    func testRateLimitingNeverOffersARetryAction() {
+        for stage in ConnectionSetupTestStage.allCases {
+            let plan = ConnectionSetupTestRecoveryPlan.plan(for: stage, failure: .rateLimited)
+            XCTAssertFalse(plan.offersRetry, "\(stage) rate limiting must not invite an immediate retry")
+        }
+    }
+
+    func testTransportFailuresTargetConnectionDetails() {
+        let transportFailures: [ConnectionFailure] = [
+            .hostNotFound, .unreachable, .connectionRefused, .timedOut,
+            .offline, .tlsUntrusted, .tlsBadDate, .tlsFailure, .insecureTransport, .invalidAddress
+        ]
+        for failure in transportFailures {
+            let plan = ConnectionSetupTestRecoveryPlan.plan(for: .server, failure: failure)
+            XCTAssertEqual(plan.remediationStep, .connectionDetails, "\(failure) is fixed at the details step")
+            XCTAssertTrue(plan.offersRetry)
+        }
+        let plan = ConnectionSetupTestRecoveryPlan.plan(for: .dashboard, failure: .dashboardUnavailable)
+        XCTAssertEqual(plan.remediationStep, .connectionDetails)
+    }
+
+    // MARK: - Copy and accessibility pins (spec 10/24)
+
+    func testStageCopyMatchesTheShippedContract() {
+        XCTAssertEqual(ConnectionSetupTestStage.server.objectiveLabel, "Dashboard reachable")
+        XCTAssertEqual(ConnectionSetupTestStage.server.runningLabel, "Checking server…")
+        XCTAssertEqual(ConnectionSetupTestStage.server.successLabel, "Dashboard reachable")
+        XCTAssertEqual(ConnectionSetupTestStage.dashboard.objectiveLabel, "Hermes dashboard found")
+        XCTAssertEqual(ConnectionSetupTestStage.dashboard.runningLabel, "Checking dashboard…")
+        XCTAssertEqual(ConnectionSetupTestStage.dashboard.successLabel, "Hermes dashboard found")
+        XCTAssertEqual(ConnectionSetupTestStage.authentication.objectiveLabel, "Authentication")
+        XCTAssertEqual(ConnectionSetupTestStage.authentication.runningLabel, "Authenticating…")
+        XCTAssertEqual(ConnectionSetupTestStage.authentication.successLabel, "Login successful")
+        XCTAssertEqual(ConnectionSetupTestState.readyMessage, "This connection is ready to use.")
+    }
+
+    func testAccessibilityLabelsCarryStateWordsNotJustIcons() {
+        var state = ConnectionSetupTestState()
+        XCTAssertEqual(state.accessibilityLabel(for: .server), "Dashboard reachable, waiting")
+        state.apply(.started(.dashboard))
+        XCTAssertEqual(state.accessibilityLabel(for: .dashboard), "Hermes dashboard found, checking")
+        state.apply(.succeeded(.server))
+        XCTAssertEqual(state.accessibilityLabel(for: .server), "Dashboard reachable, passed")
+        state.apply(.failed(.authentication, .authenticationRejected))
+        XCTAssertEqual(state.accessibilityLabel(for: .authentication), "Authentication, failed")
+    }
+
+    func testRowLabelsFollowStageState() {
+        var state = ConnectionSetupTestState()
+        XCTAssertEqual(state.rowLabel(for: .authentication), "Authentication")
+        state.apply(.started(.authentication))
+        XCTAssertEqual(state.rowLabel(for: .authentication), "Authenticating…")
+        state.apply(.succeeded(.authentication))
+        XCTAssertEqual(state.rowLabel(for: .authentication), "Login successful")
+    }
+
+    func testTestCopyContainsNoExposureOrCredentialLanguage() {
+        var allStrings = [
+            ConnectionSetupTestState.readyMessage
+        ]
+        for stage in ConnectionSetupTestStage.allCases {
+            allStrings.append(contentsOf: [stage.objectiveLabel, stage.runningLabel, stage.successLabel])
+        }
+        let forbidden = ["password", "secret", "token", "public", "port forward", "firewall", "expose"]
+        for string in allStrings {
+            for phrase in forbidden {
+                XCTAssertFalse(
+                    string.lowercased().contains(phrase),
+                    "Stage copy must not contain '\(phrase)': \(string)"
+                )
+            }
+        }
+    }
+
+    // MARK: - Probe orchestration (spec 20) — real NativeAuthClient through URLProtocol
+
+    private static func makeProbeConfiguration() -> URLSessionConfiguration {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [SetupProbeURLProtocol.self]
+        return configuration
+    }
+
+    @MainActor
+    private func runProbe(
+        _ baseURL: String,
+        cloudflareAccess: CloudflareAccessCredentials? = nil
+    ) async -> [ConnectionSetupTestEvent] {
+        let probe = ConnectionSetupProbe(sessionConfiguration: Self.makeProbeConfiguration())
+        var events: [ConnectionSetupTestEvent] = []
+        await probe.runTest(
+            result: ConnectionSetupResult(
+                serverURL: baseURL,
+                username: "probe-user",
+                password: "probe-password-fixture"
+            ),
+            cloudflareAccess: cloudflareAccess,
+            onEvent: { events.append($0) }
+        )
+        return events
+    }
+
+    func testProbeFullSuccessEmitsTheExactStagedSequence() async {
+        let events = await runProbe("http://probe-success.example")
+        XCTAssertEqual(events, StagedTestDriver.successEvents)
+    }
+
+    func testProbeDNSFailureMapsToHostNotFoundAtServerStage() async {
+        let events = await runProbe("http://probe-dns.example")
+        XCTAssertEqual(events, [.started(.server), .failed(.server, .hostNotFound)])
+    }
+
+    func testProbeRefusedMapsToConnectionRefusedAtServerStage() async {
+        let events = await runProbe("http://probe-refused.example")
+        XCTAssertEqual(events, [.started(.server), .failed(.server, .connectionRefused)])
+    }
+
+    func testProbeTimeoutMapsToTimedOutAtServerStage() async {
+        let events = await runProbe("http://probe-timeout.example")
+        XCTAssertEqual(events, [.started(.server), .failed(.server, .timedOut)])
+    }
+
+    func testProbeTLSUntrustedMapsToTLSUntrustedAtServerStage() async {
+        let events = await runProbe("https://probe-tls.example")
+        XCTAssertEqual(events, [.started(.server), .failed(.server, .tlsUntrusted)])
+    }
+
+    func testProbeTLSBadDateMapsToTLSBadDateAtServerStage() async {
+        let events = await runProbe("https://probe-tlsdate.example")
+        XCTAssertEqual(events, [.started(.server), .failed(.server, .tlsBadDate)])
+    }
+
+    func testProbeDashboard5xxMapsToDashboardUnavailableAfterTransportSuccess() async {
+        let events = await runProbe("http://probe-5xx.example")
+        XCTAssertEqual(events, [
+            .started(.server),
+            .succeeded(.server),
+            .started(.dashboard),
+            .failed(.dashboard, .dashboardUnavailable)
+        ])
+    }
+
+    func testProbeNonHermesWebsiteMapsToUnexpectedServerResponse() async {
+        // A 200 response without a password-capable provider is never a
+        // Hermes dashboard, and never success.
+        let events = await runProbe("http://probe-foreign.example")
+        XCTAssertEqual(events, [
+            .started(.server),
+            .succeeded(.server),
+            .started(.dashboard),
+            .failed(.dashboard, .unexpectedServerResponse)
+        ])
+    }
+
+    func testProbeRejectedCredentialsMapToAuthenticationRejected() async {
+        let events = await runProbe("http://probe-auth401.example")
+        XCTAssertEqual(events, Array(StagedTestDriver.successEvents.prefix(5)) + [
+            .failed(.authentication, .authenticationRejected)
+        ])
+    }
+
+    func testProbeLogin429MapsToRateLimited() async {
+        let events = await runProbe("http://probe-auth429.example")
+        XCTAssertEqual(events, Array(StagedTestDriver.successEvents.prefix(5)) + [
+            .failed(.authentication, .rateLimited)
+        ])
+    }
+
+    func testProbeTicketFailureMapsToSessionTicketFailure() async {
+        // Password accepted, but no host-scoped session cookie survived —
+        // the existing session-ticket semantics, not "wrong password".
+        let events = await runProbe("http://probe-cookieless.example")
+        XCTAssertEqual(events, Array(StagedTestDriver.successEvents.prefix(5)) + [
+            .failed(.authentication, .sessionTicketFailure)
+        ])
+    }
+
+    func testProbeAppliesTheInheritedCloudflareTokenAndClassifiesRejection() async {
+        let events = await runProbe(
+            "https://probe-cfreject.example",
+            cloudflareAccess: CloudflareAccessCredentials(clientID: "probe-client-id", clientSecret: "probe-client-secret")
+        )
+        XCTAssertEqual(events, [
+            .started(.server),
+            .succeeded(.server),
+            .started(.dashboard),
+            .failed(.dashboard, .cloudflareTokenRejected)
+        ])
+        // The token reached the dashboard origin with the discovery request.
+        XCTAssertEqual(
+            SetupProbeURLProtocol.requestHeader(forPath: "/api/auth/providers", name: "CF-Access-Client-Id"),
+            "probe-client-id"
+        )
+    }
+
+    func testCancelledProbeStaysSilentAfterItsStartEvent() async throws {
+        let probe = ConnectionSetupProbe(sessionConfiguration: Self.makeProbeConfiguration())
+        var events: [ConnectionSetupTestEvent] = []
+        let task = Task { @MainActor in
+            await probe.runTest(
+                result: ConnectionSetupResult(
+                    serverURL: "http://probe-hang.example",
+                    username: "probe-user",
+                    password: "probe-password-fixture"
+                ),
+                cloudflareAccess: nil,
+                onEvent: { events.append($0) }
+            )
+        }
+        try await Task.sleep(nanoseconds: 200_000_000)
+        task.cancel()
+        await task.value
+        XCTAssertEqual(events, [.started(.server)], "Cancellation must emit no failure events")
+    }
+
+    // MARK: - Side-effect freedom (spec 21)
+
+    @MainActor
+    func testSuccessfulProbePersistsNothingAndMakesExactlyOneAuthAttempt() async {
+        let fixtureURL = URL(string: "http://probe-success.example/")!
+        _ = await runProbe("http://probe-success.example")
+
+        let jarCookies = HTTPCookieStorage.shared.cookies(for: fixtureURL) ?? []
+        XCTAssertTrue(
+            jarCookies.isEmpty,
+            "The probe must never commit cookies to the shared store: \(jarCookies.map(\.name))"
+        )
+        XCTAssertEqual(
+            SetupProbeURLProtocol.requestCount(forPath: "/auth/password-login"),
+            1,
+            "One user-requested test equals exactly one authentication attempt"
+        )
+        XCTAssertEqual(SetupProbeURLProtocol.requestCount(forPath: "/api/auth/ws-ticket"), 1)
+        XCTAssertEqual(SetupProbeURLProtocol.requestCount(forPath: "/api/auth/providers"), 1)
+    }
+}
+
+// MARK: - URLProtocol stub (fixture hosts disjoint from NativeAuthClientTests)
+
+private final class SetupProbeURLProtocol: URLProtocol {
+    private struct ResponseRecord {
+        let host: String
+        let statusCode: Int?
+        let headers: [String: String]
+    }
+
+    private static let lock = NSLock()
+    private static var responseRecords: [ResponseRecord] = []
+    private static var requestRecords: [URLRequest] = []
+
+    private static let fixtureHosts: Set<String> = [
+        "probe-success.example",
+        "probe-dns.example",
+        "probe-refused.example",
+        "probe-timeout.example",
+        "probe-tls.example",
+        "probe-tlsdate.example",
+        "probe-5xx.example",
+        "probe-foreign.example",
+        "probe-auth401.example",
+        "probe-auth429.example",
+        "probe-cookieless.example",
+        "probe-cfreject.example",
+        "probe-hang.example"
+    ]
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        guard let host = request.url?.host else { return false }
+        return fixtureHosts.contains(host)
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+        Self.record(request: request)
+        if url.host == "probe-hang.example" {
+            // Never completes: the cancellation test cancels the task.
+            return
+        }
+        if let transportError = Self.transportError(for: url.host) {
+            client?.urlProtocol(self, didFailWithError: transportError)
+            return
+        }
+        let fixture = Self.fixture(for: request)
+        Self.record(
+            host: url.host ?? "",
+            statusCode: fixture?.statusCode,
+            headers: fixture?.headers ?? [:]
+        )
+        guard let fixture,
+              let response = HTTPURLResponse(
+                  url: url,
+                  statusCode: fixture.statusCode,
+                  httpVersion: "HTTP/1.1",
+                  headerFields: fixture.headers
+              ) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: fixture.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    // MARK: - Inspection
+
+    static func requestCount(forPath path: String) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return requestRecords.filter { $0.url?.path == path }.count
+    }
+
+    static func requestHeader(forPath path: String, name: String) -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return requestRecords.last(where: { $0.url?.path == path })?.value(forHTTPHeaderField: name)
+    }
+
+    private static func record(request: URLRequest) {
+        lock.lock()
+        requestRecords.append(request)
+        lock.unlock()
+    }
+
+    private static func record(host: String, statusCode: Int?, headers: [String: String]) {
+        lock.lock()
+        responseRecords.append(ResponseRecord(host: host, statusCode: statusCode, headers: headers))
+        lock.unlock()
+    }
+
+    // MARK: - Fixtures
+
+    private static func transportError(for host: String) -> URLError? {
+        switch host {
+        case "probe-dns.example": return URLError(.cannotFindHost)
+        case "probe-refused.example": return URLError(.cannotConnectToHost)
+        case "probe-timeout.example": return URLError(.timedOut)
+        case "probe-tls.example": return URLError(.serverCertificateUntrusted)
+        case "probe-tlsdate.example": return URLError(.serverCertificateHasBadDate)
+        default: return nil
+        }
+    }
+
+    private struct Fixture {
+        let statusCode: Int
+        let headers: [String: String]
+        let body: Data
+    }
+
+    private static func fixture(for request: URLRequest) -> Fixture? {
+        guard let host = request.url?.host else { return nil }
+        let providers = Fixture(
+            statusCode: 200,
+            headers: ["Content-Type": "application/json"],
+            body: Data(#"{"providers":[{"name":"basic","supports_password":true}]}"#.utf8)
+        )
+        let acceptedLogin = Fixture(
+            statusCode: 200,
+            headers: [
+                "Content-Type": "application/json",
+                "Set-Cookie": "hermes_session_at=probe-session-token; Path=/; HttpOnly"
+            ],
+            body: Data(#"{"ok":true}"#.utf8)
+        )
+        let ticket = Fixture(
+            statusCode: 200,
+            headers: ["Content-Type": "application/json"],
+            body: Data(#"{"ticket":"probe-ticket"}"#.utf8)
+        )
+
+        switch host {
+        case "probe-success.example":
+            switch request.url?.path {
+            case "/api/auth/providers": return providers
+            case "/auth/password-login": return acceptedLogin
+            case "/api/auth/ws-ticket": return ticket
+            default: return nil
+            }
+        case "probe-cookieless.example":
+            switch request.url?.path {
+            case "/api/auth/providers": return providers
+            case "/auth/password-login":
+                // Only a foreign-domain cookie: exact-host acceptance drops it.
+                return Fixture(
+                    statusCode: 200,
+                    headers: [
+                        "Content-Type": "application/json",
+                        "Set-Cookie": "foreign_session=unusable; Domain=probe-foreign-domain.invalid; Path=/"
+                    ],
+                    body: Data(#"{"ok":true}"#.utf8)
+                )
+            default: return nil
+            }
+        case "probe-auth401.example":
+            switch request.url?.path {
+            case "/api/auth/providers": return providers
+            case "/auth/password-login":
+                return Fixture(
+                    statusCode: 401,
+                    headers: ["Content-Type": "application/json"],
+                    body: Data(#"{"detail":"Invalid credentials"}"#.utf8)
+                )
+            default: return nil
+            }
+        case "probe-auth429.example":
+            switch request.url?.path {
+            case "/api/auth/providers": return providers
+            case "/auth/password-login":
+                return Fixture(
+                    statusCode: 429,
+                    headers: ["Content-Type": "application/json"],
+                    body: Data(#"{"detail":"Too many attempts"}"#.utf8)
+                )
+            default: return nil
+            }
+        case "probe-5xx.example":
+            return Fixture(
+                statusCode: 500,
+                headers: ["Content-Type": "application/json"],
+                body: Data(#"{"error":"origin unavailable"}"#.utf8)
+            )
+        case "probe-foreign.example":
+            // An arbitrary website: 200 with HTML, no Hermes providers.
+            return Fixture(
+                statusCode: 200,
+                headers: ["Content-Type": "text/html"],
+                body: Data("<html><body>not hermes</body></html>".utf8)
+            )
+        case "probe-cfreject.example":
+            return Fixture(
+                statusCode: 302,
+                headers: ["Location": "https://probe-tenant.cloudflareaccess.com/cdn-cgi/access/login"],
+                body: Data()
+            )
+        default:
+            return nil
+        }
+    }
+}

--- a/ConduitTests/ConnectionSetupTestTests.swift
+++ b/ConduitTests/ConnectionSetupTestTests.swift
@@ -261,6 +261,161 @@ final class ConnectionSetupTestTests: XCTestCase {
         XCTAssertNil(flow.testState.failedStage)
     }
 
+    // MARK: - Interactive sign-in outcome (flow model)
+
+    /// The staged interactive-auth run: server and dashboard succeed and
+    /// authentication stops at "browser sign-in required".
+    static let interactiveAuthEvents: [ConnectionSetupTestEvent] = [
+        .started(.server), .succeeded(.server),
+        .started(.dashboard), .succeeded(.dashboard),
+        .started(.authentication),
+        .requiresInteractiveSignIn(.authentication)
+    ]
+
+    @discardableResult
+    private static func runInteractiveTest(on flow: inout ConnectionSetupFlow) -> Int? {
+        guard let generation = flow.beginTest() else { return nil }
+        for event in interactiveAuthEvents {
+            flow.applyTestEvent(event, generation: generation)
+        }
+        return generation
+    }
+
+    func testInteractiveOutcomeAdvancesToReviewAsDistinctTerminalState() {
+        var flow = makeFlowAtTestStep()
+        ConnectionSetupTestTests.runInteractiveTest(on: &flow)
+
+        XCTAssertEqual(flow.step, .review, "The supported interactive outcome advances to Review")
+        XCTAssertEqual(flow.testState.server, .succeeded)
+        XCTAssertEqual(flow.testState.dashboard, .succeeded)
+        XCTAssertEqual(flow.testState.authentication, .requiresInteractiveSignIn)
+        XCTAssertNil(flow.testState.failedStage, "Interactive auth is not a failure")
+        XCTAssertFalse(flow.testState.allSucceeded, "Authentication is never marked succeeded")
+        XCTAssertFalse(flow.hasCurrentSuccessfulTest)
+        XCTAssertFalse(flow.fullyAuthenticated, "The user has not authenticated yet")
+        XCTAssertTrue(flow.hasCurrentInteractiveAuthOutcome)
+        XCTAssertTrue(flow.canUseSettings, "The validated configuration may still be handed off")
+        XCTAssertNotNil(flow.complete())
+    }
+
+    func testNativeSuccessIsFullyAuthenticatedWhileInteractiveIsNot() {
+        var native = makeFlowAtTestStep()
+        StagedTestDriver.runSuccessfulTest(on: &native)
+        XCTAssertTrue(native.canUseSettings)
+        XCTAssertTrue(native.fullyAuthenticated)
+        XCTAssertFalse(native.hasCurrentInteractiveAuthOutcome)
+
+        var interactive = makeFlowAtTestStep()
+        ConnectionSetupTestTests.runInteractiveTest(on: &interactive)
+        XCTAssertTrue(interactive.canUseSettings)
+        XCTAssertFalse(interactive.fullyAuthenticated)
+        XCTAssertTrue(interactive.hasCurrentInteractiveAuthOutcome)
+    }
+
+    func testUntestedAndFailedConfigurationsCannotUseSettings() {
+        var untested = makeFlowAtTestStep()
+        XCTAssertFalse(untested.canUseSettings)
+        XCTAssertFalse(untested.fullyAuthenticated)
+        XCTAssertFalse(untested.hasCurrentInteractiveAuthOutcome)
+        XCTAssertNil(untested.complete())
+
+        var failed = makeFlowAtTestStep()
+        let generation = failed.beginTest()
+        failed.applyTestEvent(.started(.server), generation: generation!)
+        failed.applyTestEvent(.failed(.server, .hostNotFound), generation: generation!)
+        XCTAssertFalse(failed.canUseSettings)
+        XCTAssertNil(failed.complete())
+    }
+
+    func testDraftEditInvalidatesInteractiveOutcomeLikeNativeSuccess() {
+        var flow = makeFlowAtTestStep()
+        ConnectionSetupTestTests.runInteractiveTest(on: &flow)
+        XCTAssertTrue(flow.hasCurrentInteractiveAuthOutcome)
+
+        flow.back()
+        flow.back()
+        flow.draft.username = "changed-user"
+        XCTAssertFalse(flow.hasCurrentInteractiveAuthOutcome, "An edit invalidates the interactive authorization")
+        XCTAssertFalse(flow.canUseSettings)
+
+        flow.submitCredentials()
+        XCTAssertEqual(flow.step, .connectionTest)
+        XCTAssertEqual(flow.testState, ConnectionSetupTestState(), "Re-entry with a stale outcome resets to untested")
+        XCTAssertNil(flow.complete())
+    }
+
+    func testStaleInteractiveCompletionCannotOverwriteNewerNativeSuccess() {
+        var flow = makeFlowAtTestStep()
+        // Run A starts and reaches the authentication stage.
+        let generationA = flow.beginTest()
+        for event in ConnectionSetupTestTests.interactiveAuthEvents.prefix(5) {
+            flow.applyTestEvent(event, generation: generationA!)
+        }
+        // The user edits the server address; Run B tests natively and wins.
+        flow.back()
+        flow.back()
+        flow.draft.lan.host = "192.168.1.29"
+        flow.submitDetails()
+        flow.submitCredentials()
+        let generationB = flow.beginTest()
+        XCTAssertNotEqual(generationA, generationB)
+        for event in StagedTestDriver.successEvents {
+            flow.applyTestEvent(event, generation: generationB!)
+        }
+        XCTAssertEqual(flow.step, .review)
+        XCTAssertTrue(flow.hasCurrentSuccessfulTest)
+
+        // Run A's interactive completion arrives late: dropped.
+        flow.back()
+        let applied = flow.applyTestEvent(
+            .requiresInteractiveSignIn(.authentication), generation: generationA!
+        )
+        XCTAssertFalse(applied, "A stale interactive completion must never apply")
+        XCTAssertTrue(flow.hasCurrentSuccessfulTest, "Run B stays authoritative")
+        XCTAssertFalse(flow.hasCurrentInteractiveAuthOutcome)
+        XCTAssertTrue(flow.canUseSettings)
+    }
+
+    func testStaleNativeSuccessCannotOverwriteNewerInteractiveOutcome() {
+        var flow = makeFlowAtTestStep()
+        // Run A (native) gets partway, then the user edits and Run B ends in
+        // the interactive outcome.
+        let generationA = flow.beginTest()
+        flow.applyTestEvent(.started(.server), generation: generationA!)
+        flow.back()
+        flow.back()
+        flow.draft.lan.host = "192.168.1.29"
+        flow.submitDetails()
+        flow.submitCredentials()
+        ConnectionSetupTestTests.runInteractiveTest(on: &flow)
+        XCTAssertEqual(flow.step, .review)
+        XCTAssertTrue(flow.hasCurrentInteractiveAuthOutcome)
+
+        // Run A's native success arrives late: dropped, the interactive
+        // outcome stays authoritative.
+        flow.back()
+        for event in StagedTestDriver.successEvents {
+            let applied = flow.applyTestEvent(event, generation: generationA!)
+            XCTAssertFalse(applied)
+        }
+        XCTAssertTrue(flow.hasCurrentInteractiveAuthOutcome)
+        XCTAssertFalse(flow.fullyAuthenticated)
+        XCTAssertTrue(flow.canUseSettings)
+    }
+
+    func testReducerKeepsInteractiveOutcomeMonotonic() {
+        var state = ConnectionSetupTestState()
+        state.apply(.started(.authentication))
+        state.apply(.requiresInteractiveSignIn(.authentication))
+        XCTAssertEqual(state.authentication, .requiresInteractiveSignIn)
+        // A terminal stage never reverts, whatever arrives later.
+        state.apply(.failed(.authentication, .authenticationRejected))
+        state.apply(.succeeded(.authentication))
+        state.apply(.started(.authentication))
+        state.apply(.requiresInteractiveSignIn(.authentication))
+        XCTAssertEqual(state.authentication, .requiresInteractiveSignIn)
+    }
+
     // MARK: - Recovery routing (spec 11/12/17)
 
     func testEditAfterFailedTestPopsToConnectionDetails() {
@@ -361,6 +516,25 @@ final class ConnectionSetupTestTests: XCTestCase {
         XCTAssertEqual(ConnectionSetupTestStage.authentication.runningLabel, "Authenticating…")
         XCTAssertEqual(ConnectionSetupTestStage.authentication.successLabel, "Login successful")
         XCTAssertEqual(ConnectionSetupTestState.readyMessage, "This connection is ready to use.")
+        XCTAssertEqual(
+            ConnectionSetupTestState.interactiveReadyMessage,
+            "This dashboard uses browser-based sign-in. "
+                + "Conduit will open the sign-in page after you return to the login screen."
+        )
+    }
+
+    func testInteractiveOutcomeCopyNeverClaimsAuthentication() {
+        var state = ConnectionSetupTestState()
+        state.apply(.started(.authentication))
+        state.apply(.requiresInteractiveSignIn(.authentication))
+
+        XCTAssertEqual(
+            state.rowLabel(for: .authentication),
+            "Browser sign-in required",
+            "The interactive row must never read as Login successful"
+        )
+        XCTAssertEqual(state.accessibilityLabel(for: .authentication), "Authentication, browser sign-in required")
+        XCTAssertNotEqual(state.rowLabel(for: .authentication), ConnectionSetupTestStage.authentication.successLabel)
     }
 
     func testAccessibilityLabelsCarryStateWordsNotJustIcons() {
@@ -386,7 +560,9 @@ final class ConnectionSetupTestTests: XCTestCase {
 
     func testTestCopyContainsNoExposureOrCredentialLanguage() {
         var allStrings = [
-            ConnectionSetupTestState.readyMessage
+            ConnectionSetupTestState.readyMessage,
+            ConnectionSetupTestState.interactiveReadyMessage,
+            "Browser sign-in required"
         ]
         for stage in ConnectionSetupTestStage.allCases {
             allStrings.append(contentsOf: [stage.objectiveLabel, stage.runningLabel, stage.successLabel])
@@ -557,6 +733,63 @@ final class ConnectionSetupTestTests: XCTestCase {
         XCTAssertEqual(events, [.started(.server)], "Cancellation must emit no failure events")
     }
 
+    // MARK: - Interactive sign-in outcome
+
+    func testProbeInteractiveSignInEmitsDistinctTerminalOutcomeWithDiscoveryOnlyTraffic() async {
+        // A dashboard whose edge redirects provider discovery to a sign-in
+        // page has proven everything the probe can verify. The run ends in
+        // the supported interactive outcome: server and dashboard succeed,
+        // authentication stops at "browser sign-in required", and the probe
+        // performs EXACTLY ONE request — provider discovery. No native
+        // credential attempt, no ticket mint, no cookie store write.
+        let events = await runProbe("https://probe-interactive.example")
+        XCTAssertEqual(events, [
+            .started(.server),
+            .succeeded(.server),
+            .started(.dashboard),
+            .succeeded(.dashboard),
+            .started(.authentication),
+            .requiresInteractiveSignIn(.authentication)
+        ])
+        let host = "probe-interactive.example"
+        XCTAssertEqual(SetupProbeURLProtocol.requestCount(forPath: "/api/auth/providers", host: host), 1)
+        XCTAssertEqual(
+            SetupProbeURLProtocol.requestCount(forPath: "/auth/password-login", host: host), 0,
+            "Interactive-auth discovery must never attempt password login"
+        )
+        XCTAssertEqual(
+            SetupProbeURLProtocol.requestCount(forPath: "/api/auth/ws-ticket", host: host), 0,
+            "Interactive-auth discovery must never mint a ticket"
+        )
+        let jarCookies = HTTPCookieStorage.shared.cookies(for: URL(string: "https://\(host)/")!) ?? []
+        XCTAssertTrue(jarCookies.isEmpty, "The probe commits nothing, interactive outcome included")
+    }
+
+    func testProbeProviderLess200IsUnexpectedServerResponseNotInteractive() async {
+        // A 200 with a valid but empty providers array is recognizable
+        // Hermes structure with no password capability: an unexpected server
+        // response for the probe, never the interactive-auth outcome.
+        let events = await runProbe("https://probe-empty-providers.example")
+        XCTAssertEqual(events, [
+            .started(.server),
+            .succeeded(.server),
+            .started(.dashboard),
+            .failed(.dashboard, .unexpectedServerResponse)
+        ])
+    }
+
+    func testProbeMalformed200IsUnexpectedServerResponseNotInteractive() async {
+        // Arbitrary website content: an unexpected server response, never
+        // the interactive-auth outcome.
+        let events = await runProbe("https://probe-malformed.example")
+        XCTAssertEqual(events, [
+            .started(.server),
+            .succeeded(.server),
+            .started(.dashboard),
+            .failed(.dashboard, .unexpectedServerResponse)
+        ])
+    }
+
     // MARK: - Side-effect freedom (spec 21)
 
     @MainActor
@@ -674,7 +907,10 @@ private final class SetupProbeURLProtocol: URLProtocol {
         "probe-auth429.example",
         "probe-cookieless.example",
         "probe-cfreject.example",
-        "probe-hang.example"
+        "probe-hang.example",
+        "probe-interactive.example",
+        "probe-empty-providers.example",
+        "probe-malformed.example"
     ]
 
     override class func canInit(with request: URLRequest) -> Bool {
@@ -860,6 +1096,30 @@ private final class SetupProbeURLProtocol: URLProtocol {
                 statusCode: 302,
                 headers: ["Location": "https://probe-tenant.cloudflareaccess.com/cdn-cgi/access/login"],
                 body: Data()
+            )
+        case "probe-interactive.example":
+            // The unauthenticated interactive-auth signal: the edge bounces
+            // provider discovery to a sign-in page (cross-origin, so the
+            // redirect delegate cancels it and the 302 is the final answer).
+            return Fixture(
+                statusCode: 302,
+                headers: ["Location": "https://sso.probe-interactive.example/signin"],
+                body: Data()
+            )
+        case "probe-empty-providers.example":
+            // Valid Hermes provider JSON with zero providers: recognizable
+            // structure, never the interactive-auth signal.
+            return Fixture(
+                statusCode: 200,
+                headers: ["Content-Type": "application/json"],
+                body: Data(#"{"providers":[]}"#.utf8)
+            )
+        case "probe-malformed.example":
+            // Arbitrary website content answered 200.
+            return Fixture(
+                statusCode: 200,
+                headers: ["Content-Type": "text/html"],
+                body: Data("<html><body>not hermes</body></html>".utf8)
             )
         default:
             return nil

--- a/ConduitTests/ConnectionSetupTestTests.swift
+++ b/ConduitTests/ConnectionSetupTestTests.swift
@@ -93,11 +93,11 @@ final class ConnectionSetupTestTests: XCTestCase {
         XCTAssertNotNil(flow.complete(), "A current successful test authorizes acceptance")
     }
 
-    func testReachabilityFailureKeepsLaterStagesPending() {
+    func testReachabilityFailureKeepsLaterStagesPending() throws {
         var flow = makeFlowAtTestStep()
-        let generation = flow.beginTest()
-        flow.applyTestEvent(.started(.server), generation: generation!)
-        flow.applyTestEvent(.failed(.server, .connectionRefused), generation: generation!)
+        let generation = try XCTUnwrap(flow.beginTest())
+        flow.applyTestEvent(.started(.server), generation: generation)
+        flow.applyTestEvent(.failed(.server, .connectionRefused), generation: generation)
 
         XCTAssertEqual(flow.testState.server, .failed(.connectionRefused))
         XCTAssertEqual(flow.testState.dashboard, .pending)
@@ -108,13 +108,13 @@ final class ConnectionSetupTestTests: XCTestCase {
         XCTAssertNil(flow.complete())
     }
 
-    func testDashboardFailureKeepsAuthenticationPendingAndServerSuccess() {
+    func testDashboardFailureKeepsAuthenticationPendingAndServerSuccess() throws {
         var flow = makeFlowAtTestStep()
-        let generation = flow.beginTest()
-        flow.applyTestEvent(.started(.server), generation: generation!)
-        flow.applyTestEvent(.succeeded(.server), generation: generation!)
-        flow.applyTestEvent(.started(.dashboard), generation: generation!)
-        flow.applyTestEvent(.failed(.dashboard, .unexpectedServerResponse), generation: generation!)
+        let generation = try XCTUnwrap(flow.beginTest())
+        flow.applyTestEvent(.started(.server), generation: generation)
+        flow.applyTestEvent(.succeeded(.server), generation: generation)
+        flow.applyTestEvent(.started(.dashboard), generation: generation)
+        flow.applyTestEvent(.failed(.dashboard, .unexpectedServerResponse), generation: generation)
 
         XCTAssertEqual(flow.testState.server, .succeeded, "Prior success must remain visible")
         XCTAssertEqual(flow.testState.dashboard, .failed(.unexpectedServerResponse))
@@ -122,13 +122,13 @@ final class ConnectionSetupTestTests: XCTestCase {
         XCTAssertEqual(flow.testState.failedStage, .dashboard)
     }
 
-    func testAuthenticationFailurePreservesPriorSuccesses() {
+    func testAuthenticationFailurePreservesPriorSuccesses() throws {
         var flow = makeFlowAtTestStep()
-        let generation = flow.beginTest()
+        let generation = try XCTUnwrap(flow.beginTest())
         for event in StagedTestDriver.successEvents.prefix(4) {
-            flow.applyTestEvent(event, generation: generation!)
+            flow.applyTestEvent(event, generation: generation)
         }
-        flow.applyTestEvent(.failed(.authentication, .authenticationRejected), generation: generation!)
+        flow.applyTestEvent(.failed(.authentication, .authenticationRejected), generation: generation)
 
         XCTAssertEqual(flow.testState.server, .succeeded)
         XCTAssertEqual(flow.testState.dashboard, .succeeded)
@@ -137,11 +137,11 @@ final class ConnectionSetupTestTests: XCTestCase {
         XCTAssertNil(flow.complete())
     }
 
-    func testRetryRestartsCleanAndIgnoresTheOldGeneration() {
+    func testRetryRestartsCleanAndIgnoresTheOldGeneration() throws {
         var flow = makeFlowAtTestStep()
-        let firstGeneration = flow.beginTest()
-        flow.applyTestEvent(.started(.server), generation: firstGeneration!)
-        flow.applyTestEvent(.failed(.server, .timedOut), generation: firstGeneration!)
+        let firstGeneration = try XCTUnwrap(flow.beginTest())
+        flow.applyTestEvent(.started(.server), generation: firstGeneration)
+        flow.applyTestEvent(.failed(.server, .timedOut), generation: firstGeneration)
 
         // Retry: a clean staged rerun with a fresh generation.
         let secondGeneration = flow.beginTest()
@@ -150,7 +150,7 @@ final class ConnectionSetupTestTests: XCTestCase {
         XCTAssertEqual(flow.testState, ConnectionSetupTestState(), "Retry must reset every stage to untested")
 
         // A late event from the abandoned run is dropped.
-        flow.applyTestEvent(.succeeded(.server), generation: firstGeneration!)
+        flow.applyTestEvent(.succeeded(.server), generation: firstGeneration)
         XCTAssertEqual(flow.testState.server, .pending)
     }
 
@@ -164,22 +164,21 @@ final class ConnectionSetupTestTests: XCTestCase {
         XCTAssertNil(fresh.beginTest())
     }
 
-    func testBeginTestRejectsConcurrentRuns() {
+    func testBeginTestRejectsConcurrentRuns() throws {
         var flow = makeFlowAtTestStep()
-        let first = flow.beginTest()
-        XCTAssertNotNil(first)
-        flow.applyTestEvent(.started(.server), generation: first!)
+        let first = try XCTUnwrap(flow.beginTest())
+        flow.applyTestEvent(.started(.server), generation: first)
         XCTAssertNil(flow.beginTest(), "Tests never queue: one run at a time")
     }
 
-    func testCancellationResetsRunningStagesAndDropsLateEvents() {
+    func testCancellationResetsRunningStagesAndDropsLateEvents() throws {
         var flow = makeFlowAtTestStep()
-        let generation = flow.beginTest()
-        flow.applyTestEvent(.started(.server), generation: generation!)
+        let generation = try XCTUnwrap(flow.beginTest())
+        flow.applyTestEvent(.started(.server), generation: generation)
 
         flow.cancelTest()
         XCTAssertEqual(flow.testState, ConnectionSetupTestState(), "A cancelled run resets to untested")
-        flow.applyTestEvent(.succeeded(.server), generation: generation!)
+        flow.applyTestEvent(.succeeded(.server), generation: generation)
         XCTAssertEqual(flow.testState.server, .pending, "Late events from the cancelled run are dropped")
 
         // A completed (non-running) state survives cancelTest untouched.
@@ -229,34 +228,33 @@ final class ConnectionSetupTestTests: XCTestCase {
         XCTAssertNil(flow.complete())
     }
 
-    func testStaleLateFailureCannotOverwriteNewerSuccessfulRun() {
+    func testStaleLateFailureCannotOverwriteNewerSuccessfulRun() throws {
         var flow = makeFlowAtTestStep()
         // Test A begins with the old credentials.
-        let generationA = flow.beginTest()
-        flow.applyTestEvent(.started(.server), generation: generationA!)
+        let generationA = try XCTUnwrap(flow.beginTest())
+        flow.applyTestEvent(.started(.server), generation: generationA)
 
         // The user edits credentials and starts Test B.
         flow.back()
         flow.draft.password = "newer-fixture"
         flow.submitCredentials()
-        let generationB = flow.beginTest()
-        XCTAssertNotNil(generationB)
+        let generationB = try XCTUnwrap(flow.beginTest())
         XCTAssertNotEqual(generationA, generationB)
 
         // Test A finishes late with a rejection — dropped.
-        flow.applyTestEvent(.failed(.authentication, .authenticationRejected), generation: generationA!)
+        flow.applyTestEvent(.failed(.authentication, .authenticationRejected), generation: generationA)
         XCTAssertEqual(flow.testState.failedStage, nil)
 
         // Test B succeeds; the final state remains successful.
         for event in StagedTestDriver.successEvents {
-            flow.applyTestEvent(event, generation: generationB!)
+            flow.applyTestEvent(event, generation: generationB)
         }
         XCTAssertEqual(flow.step, .review)
         XCTAssertTrue(flow.hasCurrentSuccessfulTest)
 
         // Even a later stale event cannot corrupt the finished run.
         flow.back()
-        flow.applyTestEvent(.failed(.server, .hostNotFound), generation: generationA!)
+        flow.applyTestEvent(.failed(.server, .hostNotFound), generation: generationA)
         XCTAssertTrue(flow.hasCurrentSuccessfulTest)
         XCTAssertNil(flow.testState.failedStage)
     }
@@ -312,7 +310,7 @@ final class ConnectionSetupTestTests: XCTestCase {
         XCTAssertTrue(interactive.hasCurrentInteractiveAuthOutcome)
     }
 
-    func testUntestedAndFailedConfigurationsCannotUseSettings() {
+    func testUntestedAndFailedConfigurationsCannotUseSettings() throws {
         var untested = makeFlowAtTestStep()
         XCTAssertFalse(untested.canUseSettings)
         XCTAssertFalse(untested.fullyAuthenticated)
@@ -320,9 +318,9 @@ final class ConnectionSetupTestTests: XCTestCase {
         XCTAssertNil(untested.complete())
 
         var failed = makeFlowAtTestStep()
-        let generation = failed.beginTest()
-        failed.applyTestEvent(.started(.server), generation: generation!)
-        failed.applyTestEvent(.failed(.server, .hostNotFound), generation: generation!)
+        let generation = try XCTUnwrap(failed.beginTest())
+        failed.applyTestEvent(.started(.server), generation: generation)
+        failed.applyTestEvent(.failed(.server, .hostNotFound), generation: generation)
         XCTAssertFalse(failed.canUseSettings)
         XCTAssertNil(failed.complete())
     }
@@ -344,12 +342,12 @@ final class ConnectionSetupTestTests: XCTestCase {
         XCTAssertNil(flow.complete())
     }
 
-    func testStaleInteractiveCompletionCannotOverwriteNewerNativeSuccess() {
+    func testStaleInteractiveCompletionCannotOverwriteNewerNativeSuccess() throws {
         var flow = makeFlowAtTestStep()
         // Run A starts and reaches the authentication stage.
-        let generationA = flow.beginTest()
+        let generationA = try XCTUnwrap(flow.beginTest())
         for event in ConnectionSetupTestTests.interactiveAuthEvents.prefix(5) {
-            flow.applyTestEvent(event, generation: generationA!)
+            flow.applyTestEvent(event, generation: generationA)
         }
         // The user edits the server address; Run B tests natively and wins.
         flow.back()
@@ -357,10 +355,10 @@ final class ConnectionSetupTestTests: XCTestCase {
         flow.draft.lan.host = "192.168.1.29"
         flow.submitDetails()
         flow.submitCredentials()
-        let generationB = flow.beginTest()
+        let generationB = try XCTUnwrap(flow.beginTest())
         XCTAssertNotEqual(generationA, generationB)
         for event in StagedTestDriver.successEvents {
-            flow.applyTestEvent(event, generation: generationB!)
+            flow.applyTestEvent(event, generation: generationB)
         }
         XCTAssertEqual(flow.step, .review)
         XCTAssertTrue(flow.hasCurrentSuccessfulTest)
@@ -368,7 +366,7 @@ final class ConnectionSetupTestTests: XCTestCase {
         // Run A's interactive completion arrives late: dropped.
         flow.back()
         let applied = flow.applyTestEvent(
-            .requiresInteractiveSignIn(.authentication), generation: generationA!
+            .requiresInteractiveSignIn(.authentication), generation: generationA
         )
         XCTAssertFalse(applied, "A stale interactive completion must never apply")
         XCTAssertTrue(flow.hasCurrentSuccessfulTest, "Run B stays authoritative")
@@ -376,12 +374,12 @@ final class ConnectionSetupTestTests: XCTestCase {
         XCTAssertTrue(flow.canUseSettings)
     }
 
-    func testStaleNativeSuccessCannotOverwriteNewerInteractiveOutcome() {
+    func testStaleNativeSuccessCannotOverwriteNewerInteractiveOutcome() throws {
         var flow = makeFlowAtTestStep()
         // Run A (native) gets partway, then the user edits and Run B ends in
         // the interactive outcome.
-        let generationA = flow.beginTest()
-        flow.applyTestEvent(.started(.server), generation: generationA!)
+        let generationA = try XCTUnwrap(flow.beginTest())
+        flow.applyTestEvent(.started(.server), generation: generationA)
         flow.back()
         flow.back()
         flow.draft.lan.host = "192.168.1.29"
@@ -395,7 +393,7 @@ final class ConnectionSetupTestTests: XCTestCase {
         // outcome stays authoritative.
         flow.back()
         for event in StagedTestDriver.successEvents {
-            let applied = flow.applyTestEvent(event, generation: generationA!)
+            let applied = flow.applyTestEvent(event, generation: generationA)
             XCTAssertFalse(applied)
         }
         XCTAssertTrue(flow.hasCurrentInteractiveAuthOutcome)
@@ -418,10 +416,10 @@ final class ConnectionSetupTestTests: XCTestCase {
 
     // MARK: - Recovery routing (spec 11/12/17)
 
-    func testEditAfterFailedTestPopsToConnectionDetails() {
+    func testEditAfterFailedTestPopsToConnectionDetails() throws {
         var flow = makeFlowAtTestStep()
-        let generation = flow.beginTest()
-        flow.applyTestEvent(.failed(.server, .hostNotFound), generation: generation!)
+        let generation = try XCTUnwrap(flow.beginTest())
+        flow.applyTestEvent(.failed(.server, .hostNotFound), generation: generation)
         let pathCount = flow.path.count
 
         flow.editAfterFailedTest(.connectionDetails)
@@ -429,10 +427,10 @@ final class ConnectionSetupTestTests: XCTestCase {
         XCTAssertEqual(flow.path.count, pathCount - 2, "The path truncates back to details")
     }
 
-    func testEditAfterFailedTestInsertsDetailsOnTheShortcutRoute() {
+    func testEditAfterFailedTestInsertsDetailsOnTheShortcutRoute() throws {
         var flow = makeAuthRecoveryFlowAtTestStep()
-        let generation = flow.beginTest()
-        flow.applyTestEvent(.failed(.dashboard, .dashboardUnavailable), generation: generation!)
+        let generation = try XCTUnwrap(flow.beginTest())
+        flow.applyTestEvent(.failed(.dashboard, .dashboardUnavailable), generation: generation)
 
         flow.editAfterFailedTest(.connectionDetails)
         XCTAssertEqual(flow.step, .connectionDetails)
@@ -440,10 +438,10 @@ final class ConnectionSetupTestTests: XCTestCase {
         XCTAssertEqual(flow.step, .loginCredentials, "The inserted details step walks back to credentials")
     }
 
-    func testEditAfterFailedTestTargetsCredentials() {
+    func testEditAfterFailedTestTargetsCredentials() throws {
         var flow = makeFlowAtTestStep()
-        let generation = flow.beginTest()
-        flow.applyTestEvent(.failed(.authentication, .authenticationRejected), generation: generation!)
+        let generation = try XCTUnwrap(flow.beginTest())
+        flow.applyTestEvent(.failed(.authentication, .authenticationRejected), generation: generation)
 
         flow.editAfterFailedTest(.loginCredentials)
         XCTAssertEqual(flow.step, .loginCredentials)

--- a/ConduitTests/NativeAuthClientIntegrationTests.swift
+++ b/ConduitTests/NativeAuthClientIntegrationTests.swift
@@ -507,11 +507,14 @@ final class NativeAuthClientIntegrationTests: XCTestCase {
         }
         defer { server.stop() }
 
-        let providers = try await NativeAuthClient(
+        let discovery = try await NativeAuthClient(
             baseURL: "http://127.0.0.1:\(server.port)",
             sessionConfiguration: realSessionConfiguration()
-        ).authProviders()
+        ).authProviderDiscovery()
 
+        guard case .providers(let providers) = discovery else {
+            return XCTFail("Expected a same-origin redirect to resolve to providers, got \(discovery)")
+        }
         XCTAssertEqual(providers.count, 1)
         XCTAssertEqual(providers.first?["name"] as? String, "basic")
         XCTAssertNotNil(server.lastRequest(path: "/api/auth/providers/redirected"))

--- a/ConduitTests/NativeAuthClientTests.swift
+++ b/ConduitTests/NativeAuthClientTests.swift
@@ -126,6 +126,48 @@ final class NativeAuthClientTests: XCTestCase {
         XCTAssertEqual(discovery, .unrecognized)
     }
 
+    func testProviderDiscoveryWrongElementShapeIsUnrecognized() async throws {
+        let client = NativeAuthClient(
+            baseURL: "https://wrongshape.example",
+            sessionConfiguration: makeSessionConfiguration()
+        )
+
+        let discovery = try await client.authProviderDiscovery()
+
+        XCTAssertEqual(discovery, .unrecognized)
+    }
+
+    func testProviderDiscoveryNonDictionaryRootIsUnrecognized() async throws {
+        let client = NativeAuthClient(
+            baseURL: "https://arrayroot.example",
+            sessionConfiguration: makeSessionConfiguration()
+        )
+
+        let discovery = try await client.authProviderDiscovery()
+
+        XCTAssertEqual(discovery, .unrecognized)
+    }
+
+    func testProviderDiscoveryRedirectWithoutLocationIsDiscoveryFailure() async throws {
+        // A 3xx without a Location header cannot drive a browser login: it
+        // is a broken server response, never the interactive-auth signal.
+        let client = NativeAuthClient(
+            baseURL: "https://locationless.example",
+            sessionConfiguration: makeSessionConfiguration()
+        )
+
+        do {
+            _ = try await client.authProviderDiscovery()
+            return XCTFail("Expected a Location-less redirect to fail discovery")
+        } catch let error as AuthClientError {
+            guard case .providerDiscoveryFailed(let status, let detail) = error else {
+                return XCTFail("Expected providerDiscoveryFailed, got \(error)")
+            }
+            XCTAssertEqual(status, 302)
+            XCTAssertEqual(detail, "Redirect without Location")
+        }
+    }
+
     func testProviderDiscoveryPreservesNonRedirect3xxResponses() async throws {
         let client = NativeAuthClient(
             baseURL: "https://multiple.example",
@@ -532,7 +574,10 @@ private final class NativeAuthURLProtocol: URLProtocol {
             "cftoken.example",
             "empty-providers.example",
             "malformed.example",
-            "nokey.example"
+            "nokey.example",
+            "wrongshape.example",
+            "arrayroot.example",
+            "locationless.example"
         ].contains(host)
     }
 
@@ -766,6 +811,15 @@ private final class NativeAuthURLProtocol: URLProtocol {
         case "nokey.example":
             // JSON without a providers array.
             return Fixture(statusCode: 200, headers: [:], body: Data(#"{"ok":true}"#.utf8))
+        case "wrongshape.example":
+            // A providers key whose elements are not dictionaries.
+            return Fixture(statusCode: 200, headers: [:], body: Data(#"{"providers":["basic"]}"#.utf8))
+        case "arrayroot.example":
+            // A non-dictionary JSON root.
+            return Fixture(statusCode: 200, headers: [:], body: Data("[]".utf8))
+        case "locationless.example":
+            // A redirect-shaped answer with no Location header.
+            return Fixture(statusCode: 302, headers: [:], body: Data())
         case "headers.example":
             let hasExpectedHeaders = request.value(forHTTPHeaderField: "CF-Access-Client-Id") == "test-client-id"
                 && request.value(forHTTPHeaderField: "CF-Access-Client-Secret") == "test-client-secret"

--- a/ConduitTests/NativeAuthClientTests.swift
+++ b/ConduitTests/NativeAuthClientTests.swift
@@ -70,15 +70,15 @@ final class NativeAuthClientTests: XCTestCase {
         )
     }
 
-    func testProviderDiscoveryRedirectFallsBackToWebView() async throws {
+    func testProviderDiscoveryRedirectFallsBackToInteractiveSignIn() async throws {
         let client = NativeAuthClient(
             baseURL: "https://redirect.example",
             sessionConfiguration: makeSessionConfiguration()
         )
 
-        let providers = try await client.authProviders()
+        let discovery = try await client.authProviderDiscovery()
 
-        XCTAssertTrue(providers.isEmpty)
+        XCTAssertEqual(discovery, .interactiveSignInRequired, "An unauthenticated redirect is THE interactive-auth signal")
         XCTAssertEqual(NativeAuthURLProtocol.responseStatusCode(for: "redirect.example"), 302)
         XCTAssertEqual(
             NativeAuthURLProtocol.responseHeader(for: "redirect.example", name: "Location"),
@@ -88,6 +88,44 @@ final class NativeAuthClientTests: XCTestCase {
         XCTAssertEqual(NativeAuthURLProtocol.requestCount(for: "tenant.cloudflareaccess.com"), 0)
     }
 
+    func testProviderDiscovery200WithEmptyProviderArrayIsNotInteractiveSignIn() async throws {
+        // A 200 whose providers array is empty is a valid Hermes answer with
+        // zero providers — recognizable structure, NOT the interactive-auth
+        // redirect signal.
+        let client = NativeAuthClient(
+            baseURL: "https://empty-providers.example",
+            sessionConfiguration: makeSessionConfiguration()
+        )
+
+        let discovery = try await client.authProviderDiscovery()
+
+        XCTAssertEqual(discovery, .providers([]))
+    }
+
+    func testProviderDiscovery200WithMalformedBodyIsUnrecognized() async throws {
+        // Arbitrary web content (or malformed JSON) answered 200: never
+        // interactive auth, never providers.
+        let client = NativeAuthClient(
+            baseURL: "https://malformed.example",
+            sessionConfiguration: makeSessionConfiguration()
+        )
+
+        let discovery = try await client.authProviderDiscovery()
+
+        XCTAssertEqual(discovery, .unrecognized)
+    }
+
+    func testProviderDiscovery200WithoutProvidersKeyIsUnrecognized() async throws {
+        let client = NativeAuthClient(
+            baseURL: "https://nokey.example",
+            sessionConfiguration: makeSessionConfiguration()
+        )
+
+        let discovery = try await client.authProviderDiscovery()
+
+        XCTAssertEqual(discovery, .unrecognized)
+    }
+
     func testProviderDiscoveryPreservesNonRedirect3xxResponses() async throws {
         let client = NativeAuthClient(
             baseURL: "https://multiple.example",
@@ -95,7 +133,7 @@ final class NativeAuthClientTests: XCTestCase {
         )
 
         do {
-            _ = try await client.authProviders()
+            _ = try await client.authProviderDiscovery()
             XCTFail("Expected provider discovery to fail for a non-redirect 3xx response")
         } catch let error as AuthClientError {
             guard case .providerDiscoveryFailed(_, let detail) = error else {
@@ -111,8 +149,11 @@ final class NativeAuthClientTests: XCTestCase {
             sessionConfiguration: makeSessionConfiguration()
         )
 
-        let providers = try await client.authProviders()
+        let discovery = try await client.authProviderDiscovery()
 
+        guard case .providers(let providers) = discovery else {
+            return XCTFail("Expected a password provider answer, got \(discovery)")
+        }
         XCTAssertEqual(providers.count, 1)
         XCTAssertEqual(providers[0]["name"] as? String, "basic")
         XCTAssertEqual(providers[0]["supports_password"] as? Bool, true)
@@ -125,7 +166,7 @@ final class NativeAuthClientTests: XCTestCase {
         )
 
         do {
-            _ = try await client.authProviders()
+            _ = try await client.authProviderDiscovery()
             XCTFail("Expected provider discovery to fail for a server error")
         } catch let error as AuthClientError {
             guard case .providerDiscoveryFailed(_, let detail) = error else {
@@ -146,8 +187,11 @@ final class NativeAuthClientTests: XCTestCase {
             sessionConfiguration: makeSessionConfiguration()
         )
 
-        let providers = try await client.authProviders()
+        let discovery = try await client.authProviderDiscovery()
 
+        guard case .providers(let providers) = discovery else {
+            return XCTFail("Expected a provider answer, got \(discovery)")
+        }
         XCTAssertEqual(providers.count, 1)
         XCTAssertEqual(providers[0]["name"] as? String, "basic")
     }
@@ -163,9 +207,9 @@ final class NativeAuthClientTests: XCTestCase {
             sessionConfiguration: makeSessionConfiguration()
         )
 
-        let providers = try await client.authProviders()
+        let discovery = try await client.authProviderDiscovery()
 
-        XCTAssertTrue(providers.isEmpty, "Unconfigured credentials must keep the WebView fallback signal")
+        XCTAssertEqual(discovery, .interactiveSignInRequired, "Unconfigured credentials must keep the interactive-auth fallback signal")
         XCTAssertNil(
             NativeAuthURLProtocol.requestHeader(forPath: "/api/auth/providers", name: "CF-Access-Client-Id"),
             "Unconfigured credentials must send no service-token id"
@@ -188,7 +232,7 @@ final class NativeAuthClientTests: XCTestCase {
         )
 
         do {
-            _ = try await client.authProviders()
+            _ = try await client.authProviderDiscovery()
             XCTFail("Expected the Cloudflare redirect despite a configured token to be a typed rejection")
         } catch let error as AuthClientError {
             guard case .cloudflareServiceTokenRejected = error else {
@@ -222,11 +266,12 @@ final class NativeAuthClientTests: XCTestCase {
             sessionConfiguration: makeSessionConfiguration()
         )
 
-        let providers = try await client.authProviders()
+        let discovery = try await client.authProviderDiscovery()
 
         // A redirect from a non-Cloudflare edge is not evidence the service
-        // token was rejected; the WebView fallback must stay available.
-        XCTAssertTrue(providers.isEmpty)
+        // token was rejected; the interactive-auth fallback must stay
+        // available.
+        XCTAssertEqual(discovery, .interactiveSignInRequired)
     }
 
     func testServiceTokenAppliesToLoginAndTicketRequests() async throws {
@@ -241,7 +286,7 @@ final class NativeAuthClientTests: XCTestCase {
 
         // The full shipped connect sequence: LoginView probes providers
         // first, then connects natively, then mints the ticket.
-        _ = try await client.authProviders()
+        _ = try await client.authProviderDiscovery()
         let connection = try await client.connect(username: "chris", password: "correct-password")
 
         XCTAssertEqual(connection.ticket, "fresh-ticket")
@@ -305,7 +350,7 @@ final class NativeAuthClientTests: XCTestCase {
             sessionConfiguration: makeSessionConfiguration()
         )
 
-        _ = try await client.authProviders()
+        _ = try await client.authProviderDiscovery()
         let connection = try await client.connect(username: "chris", password: "correct-password")
 
         XCTAssertEqual(connection.ticket, "lan-ticket")
@@ -484,7 +529,10 @@ private final class NativeAuthURLProtocol: URLProtocol {
             "cookieless.example",
             "cfreject.example",
             "ssoedge.example",
-            "cftoken.example"
+            "cftoken.example",
+            "empty-providers.example",
+            "malformed.example",
+            "nokey.example"
         ].contains(host)
     }
 
@@ -704,6 +752,20 @@ private final class NativeAuthURLProtocol: URLProtocol {
             default:
                 return nil
             }
+        case "empty-providers.example":
+            // Recognizable Hermes structure with zero providers: a valid
+            // answer, never the interactive-auth signal.
+            return Fixture(statusCode: 200, headers: [:], body: Data(#"{"providers":[]}"#.utf8))
+        case "malformed.example":
+            // Arbitrary web content answered 200.
+            return Fixture(
+                statusCode: 200,
+                headers: ["Content-Type": "text/html"],
+                body: Data("<html><body>not hermes</body></html>".utf8)
+            )
+        case "nokey.example":
+            // JSON without a providers array.
+            return Fixture(statusCode: 200, headers: [:], body: Data(#"{"ok":true}"#.utf8))
         case "headers.example":
             let hasExpectedHeaders = request.value(forHTTPHeaderField: "CF-Access-Client-Id") == "test-client-id"
                 && request.value(forHTTPHeaderField: "CF-Access-Client-Secret") == "test-client-secret"

--- a/ConduitUITests/ConnectionSetupTestConnectionUITests.swift
+++ b/ConduitUITests/ConnectionSetupTestConnectionUITests.swift
@@ -100,12 +100,14 @@ final class ConnectionSetupTestConnectionUITests: XCTestCase {
 
     func testInteractiveSignInOutcomeShowsBrowserSignInAndHandsOff() {
         // A dashboard whose discovery redirects to a sign-in page ends the
-        // staged test in the supported interactive outcome: server and
-        // dashboard pass, authentication shows "Browser sign-in required"
-        // (never "Login successful"), and Use These Settings performs the
-        // normal Round-3 handoff back to LoginView — where the user taps
-        // Connect and the existing WebView flow runs. No real browser login
-        // is automated here.
+        // staged test in the supported interactive outcome. The terminal
+        // event AUTO-ADVANCES the flow to Review, so the assertions below
+        // run against Review directly: server and dashboard pass,
+        // authentication shows "Browser sign-in required" (never "Login
+        // successful"), and Use These Settings performs the normal Round-3
+        // handoff back to LoginView — where the user taps Connect and the
+        // existing WebView flow runs. No real browser login is automated
+        // here.
         let app = XCUIApplication()
         app.launchArguments += ["-CONNECTION_SETUP_TEST_RESULT", "auth:interactiveSignInRequired"]
         app.launch()
@@ -113,27 +115,35 @@ final class ConnectionSetupTestConnectionUITests: XCTestCase {
         walkToTestScreen(app)
         tapVisible(app.buttons[Identity.testRun], in: app)
 
-        // The staged list shows the two verified stages plus the
-        // interactive outcome on the authentication row.
-        XCTAssertTrue(row(app, Identity.stageServer).waitForExistence(timeout: 5))
-        XCTAssertTrue(row(app, Identity.stageDashboard).exists)
-        XCTAssertTrue(row(app, Identity.stageAuthentication).exists)
-        let authRow = row(app, Identity.stageAuthentication)
-        XCTAssertTrue(authRow.label.contains("Browser sign-in required"), "Got: \(authRow.label)")
-        XCTAssertFalse(
-            authRow.label.contains("Login successful"),
-            "Interactive auth must never claim the user signed in"
-        )
-        XCTAssertFalse(app.staticTexts["setup.test.ready"].exists, "The native ready message must not appear")
-
-        // Review shows the browser-based sign-in explanation.
-        tapVisible(app.buttons[Identity.testContinue], in: app)
+        // Review, reached by auto-advance, shows the browser-based sign-in
+        // explanation and the interactive authentication row.
         let interactiveReady = app.staticTexts["setup.test.interactive-ready"]
         XCTAssertTrue(interactiveReady.waitForExistence(timeout: 5))
         XCTAssertTrue(
             interactiveReady.label.contains("browser-based sign-in"),
             "Got: \(interactiveReady.label)"
         )
+        XCTAssertFalse(
+            app.staticTexts["setup.test.ready"].exists,
+            "The native ready message must not appear for interactive auth"
+        )
+        let authRow = row(app, Identity.stageAuthentication)
+        XCTAssertTrue(authRow.exists)
+        XCTAssertTrue(authRow.label.contains("Browser sign-in required"), "Got: \(authRow.label)")
+        XCTAssertFalse(
+            authRow.label.contains("Login successful"),
+            "Interactive auth must never claim the user signed in"
+        )
+
+        // Back from Review shows the still-current outcome on the test
+        // screen with a Continue action that returns to Review.
+        tapVisible(app.buttons[Identity.back], in: app)
+        XCTAssertTrue(app.buttons[Identity.testContinue].waitForExistence(timeout: 5))
+        XCTAssertTrue(
+            row(app, Identity.stageAuthentication).label.contains("Browser sign-in required")
+        )
+        tapVisible(app.buttons[Identity.testContinue], in: app)
+        XCTAssertTrue(app.staticTexts["setup.test.interactive-ready"].waitForExistence(timeout: 5))
 
         // The Round-3 typed handoff is unchanged: fields populate, nothing
         // connects automatically.

--- a/ConduitUITests/ConnectionSetupTestConnectionUITests.swift
+++ b/ConduitUITests/ConnectionSetupTestConnectionUITests.swift
@@ -98,6 +98,54 @@ final class ConnectionSetupTestConnectionUITests: XCTestCase {
         XCTAssertTrue(app.buttons["setup.test.edit-credentials"].exists)
     }
 
+    func testInteractiveSignInOutcomeShowsBrowserSignInAndHandsOff() {
+        // A dashboard whose discovery redirects to a sign-in page ends the
+        // staged test in the supported interactive outcome: server and
+        // dashboard pass, authentication shows "Browser sign-in required"
+        // (never "Login successful"), and Use These Settings performs the
+        // normal Round-3 handoff back to LoginView — where the user taps
+        // Connect and the existing WebView flow runs. No real browser login
+        // is automated here.
+        let app = XCUIApplication()
+        app.launchArguments += ["-CONNECTION_SETUP_TEST_RESULT", "auth:interactiveSignInRequired"]
+        app.launch()
+
+        walkToTestScreen(app)
+        tapVisible(app.buttons[Identity.testRun], in: app)
+
+        // The staged list shows the two verified stages plus the
+        // interactive outcome on the authentication row.
+        XCTAssertTrue(row(app, Identity.stageServer).waitForExistence(timeout: 5))
+        XCTAssertTrue(row(app, Identity.stageDashboard).exists)
+        XCTAssertTrue(row(app, Identity.stageAuthentication).exists)
+        let authRow = row(app, Identity.stageAuthentication)
+        XCTAssertTrue(authRow.label.contains("Browser sign-in required"), "Got: \(authRow.label)")
+        XCTAssertFalse(
+            authRow.label.contains("Login successful"),
+            "Interactive auth must never claim the user signed in"
+        )
+        XCTAssertFalse(app.staticTexts["setup.test.ready"].exists, "The native ready message must not appear")
+
+        // Review shows the browser-based sign-in explanation.
+        tapVisible(app.buttons[Identity.testContinue], in: app)
+        let interactiveReady = app.staticTexts["setup.test.interactive-ready"]
+        XCTAssertTrue(interactiveReady.waitForExistence(timeout: 5))
+        XCTAssertTrue(
+            interactiveReady.label.contains("browser-based sign-in"),
+            "Got: \(interactiveReady.label)"
+        )
+
+        // The Round-3 typed handoff is unchanged: fields populate, nothing
+        // connects automatically.
+        tapVisible(app.buttons[Identity.useSettings], in: app)
+        let server = app.textFields["login.server-url"]
+        XCTAssertTrue(server.waitForExistence(timeout: 5))
+        XCTAssertEqual(server.value as? String, "http://192.168.1.28:9119")
+        XCTAssertEqual(app.textFields["login.username"].value as? String, "round4-user")
+        XCTAssertTrue(app.buttons["Connect"].isEnabled)
+        XCTAssertFalse(app.staticTexts["Connecting..."].exists)
+    }
+
     // MARK: - Walk helpers
 
     /// Opens setup and walks Dashboard → Credentials → LAN → details →

--- a/ConduitUITests/ConnectionSetupTestConnectionUITests.swift
+++ b/ConduitUITests/ConnectionSetupTestConnectionUITests.swift
@@ -1,0 +1,164 @@
+import XCTest
+
+/// Round-4 Connection Setup UI coverage: the staged connection-test screen
+/// between credentials and Review. Both tests run against the deterministic
+/// stub probe selected by the `-CONNECTION_SETUP_TEST_RESULT` launch
+/// argument (DEBUG-only) — no test depends on a real Hermes server.
+final class ConnectionSetupTestConnectionUITests: XCTestCase {
+    private enum Identity {
+        static let answerYes = "setup.answer-yes"
+        static let methodLan = "setup.method-lan"
+        static let detailsReady = "setup.details-ready"
+        static let next = "setup.next"
+        static let back = "setup.back"
+        static let testRun = "setup.test.run"
+        static let testContinue = "setup.test.continue"
+        static let stageServer = "setup.test.stage.server"
+        static let stageDashboard = "setup.test.stage.dashboard"
+        static let stageAuthentication = "setup.test.stage.authentication"
+        static let useSettings = "setup.use-settings"
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testStagedTestSuccessShowsAllStagesAndEnablesHandoff() {
+        let app = XCUIApplication()
+        app.launchArguments += ["-CONNECTION_SETUP_TEST_RESULT", "success"]
+        app.launch()
+
+        walkToTestScreen(app)
+        tapVisible(app.buttons[Identity.testRun], in: app)
+
+        // On success the wizard advances to Review, which shows every passed
+        // stage plus the ready message. The password is never rendered as
+        // text anywhere.
+        XCTAssertTrue(app.staticTexts["setup.test.ready"].waitForExistence(timeout: 5))
+        XCTAssertTrue(row(app, Identity.stageServer).exists)
+        XCTAssertTrue(row(app, Identity.stageDashboard).exists)
+        XCTAssertTrue(row(app, Identity.stageAuthentication).exists)
+        XCTAssertFalse(app.staticTexts["round4-private-fixture"].exists)
+
+        // The Round-3 typed handoff is unchanged: fields populate, nothing
+        // connects automatically.
+        tapVisible(app.buttons[Identity.useSettings], in: app)
+        let server = app.textFields["login.server-url"]
+        XCTAssertTrue(server.waitForExistence(timeout: 5))
+        XCTAssertEqual(server.value as? String, "http://192.168.1.28:9119")
+        XCTAssertEqual(app.textFields["login.username"].value as? String, "round4-user")
+        XCTAssertTrue(app.buttons["Connect"].isEnabled)
+        XCTAssertFalse(app.staticTexts["Connecting..."].exists)
+    }
+
+    func testAuthenticationFailureKeepsPriorStagesAndOffersEditCredentials() {
+        let app = XCUIApplication()
+        app.launchArguments += ["-CONNECTION_SETUP_TEST_RESULT", "auth:authenticationRejected"]
+        app.launch()
+
+        walkToTestScreen(app)
+        tapVisible(app.buttons[Identity.testRun], in: app)
+
+        // The failed test stays on the test screen: the two successful
+        // stages remain visible, and the classified credential guidance
+        // appears with Edit Credentials as the primary recovery action.
+        XCTAssertTrue(app.staticTexts["setup.test.failure"].waitForExistence(timeout: 5))
+        XCTAssertTrue(row(app, Identity.stageServer).exists)
+        XCTAssertTrue(row(app, Identity.stageDashboard).exists)
+        XCTAssertTrue(row(app, Identity.stageAuthentication).exists)
+        let failure = app.staticTexts["setup.test.failure"]
+        XCTAssertEqual(
+            failure.label,
+            "Hermes rejected that username or password. Check your dashboard credentials and try again."
+        )
+        XCTAssertTrue(app.buttons["setup.test.edit-credentials"].exists)
+        // Retry exists but is never the primary action after rejected
+        // credentials.
+        XCTAssertTrue(app.buttons["setup.test.retry"].exists)
+
+        tapVisible(app.buttons["setup.test.edit-credentials"], in: app)
+        let username = app.textFields["setup.username"]
+        XCTAssertTrue(username.waitForExistence(timeout: 5))
+        XCTAssertEqual(username.value as? String, "round4-user", "Edits return to the entered credentials")
+    }
+
+    func testRateLimitedTestOffersNoRetryAction() {
+        let app = XCUIApplication()
+        app.launchArguments += ["-CONNECTION_SETUP_TEST_RESULT", "auth:rateLimited"]
+        app.launch()
+
+        walkToTestScreen(app)
+        tapVisible(app.buttons[Identity.testRun], in: app)
+
+        XCTAssertTrue(app.staticTexts["setup.test.failure"].waitForExistence(timeout: 5))
+        XCTAssertFalse(
+            app.buttons["setup.test.retry"].exists,
+            "Rate limiting must not invite an immediate retry"
+        )
+        XCTAssertTrue(app.buttons["setup.test.edit-credentials"].exists)
+    }
+
+    // MARK: - Walk helpers
+
+    /// Opens setup and walks Dashboard → Credentials → LAN → details →
+    /// credentials, landing on the staged test screen.
+    private func walkToTestScreen(_ app: XCUIApplication) {
+        let serverField = app.textFields["login.server-url"]
+        XCTAssertTrue(serverField.waitForExistence(timeout: 10), "Login screen did not appear. Tree:\n\(app.debugDescription)")
+        let setup = app.buttons["login.connection-setup"]
+        XCTAssertTrue(setup.waitForExistence(timeout: 5))
+        if !setup.isHittable { app.swipeDown() }
+        setup.tap()
+
+        tapVisible(app.buttons[Identity.answerYes], in: app)
+        tapVisible(app.buttons[Identity.answerYes], in: app)
+        tapVisible(app.buttons[Identity.methodLan], in: app)
+        tapVisible(app.buttons[Identity.detailsReady], in: app)
+
+        let host = app.textFields["setup.host"]
+        tapVisible(host, in: app)
+        host.typeText("192.168.1.28")
+        let port = app.textFields["setup.port"]
+        tapVisible(port, in: app)
+        port.typeText("9119")
+        dismissKeyboard(app)
+        tapVisible(app.buttons[Identity.next], in: app)
+
+        let username = app.textFields["setup.username"]
+        tapVisible(username, in: app)
+        username.typeText("round4-user")
+        let password = app.secureTextFields["setup.password"]
+        tapVisible(password, in: app)
+        password.typeText("round4-private-fixture")
+        tapVisible(app.buttons[Identity.next], in: app)
+
+        XCTAssertTrue(app.buttons[Identity.testRun].waitForExistence(timeout: 5), "Test screen did not appear. Tree:\n\(app.debugDescription)")
+        XCTAssertTrue(row(app, Identity.stageServer).exists)
+        XCTAssertTrue(row(app, Identity.stageDashboard).exists)
+        XCTAssertTrue(row(app, Identity.stageAuthentication).exists)
+    }
+
+    /// Stage rows are single combined accessibility elements, so query by
+    /// identifier across element types.
+    private func row(_ app: XCUIApplication, _ identifier: String) -> XCUIElement {
+        app.descendants(matching: .any).matching(identifier: identifier).firstMatch
+    }
+
+    private func tapVisible(_ element: XCUIElement, in app: XCUIApplication) {
+        XCTAssertTrue(element.waitForExistence(timeout: 5))
+        for _ in 0..<6 {
+            if element.isHittable { break }
+            app.swipeUp()
+        }
+        XCTAssertTrue(element.isHittable)
+        element.tap()
+    }
+
+    /// Tap the keyboard toolbar's Done control when present, so a Continue
+    /// button that would sit behind the keyboard window is tapped for real.
+    private func dismissKeyboard(_ app: XCUIApplication) {
+        let done = app.buttons["setup.keyboard-done"]
+        guard done.waitForExistence(timeout: 2) else { return }
+        done.tap()
+    }
+}

--- a/ConduitUITests/ConnectionSetupTestConnectionUITests.swift
+++ b/ConduitUITests/ConnectionSetupTestConnectionUITests.swift
@@ -129,9 +129,14 @@ final class ConnectionSetupTestConnectionUITests: XCTestCase {
         )
         let authRow = row(app, Identity.stageAuthentication)
         XCTAssertTrue(authRow.exists)
-        XCTAssertTrue(authRow.label.contains("Browser sign-in required"), "Got: \(authRow.label)")
+        // Stage rows expose their combined accessibility label (objective
+        // name + lowercase state word), so match case-insensitively.
+        XCTAssertTrue(
+            authRow.label.lowercased().contains("browser sign-in required"),
+            "Got: \(authRow.label)"
+        )
         XCTAssertFalse(
-            authRow.label.contains("Login successful"),
+            authRow.label.lowercased().contains("login successful"),
             "Interactive auth must never claim the user signed in"
         )
 
@@ -140,7 +145,7 @@ final class ConnectionSetupTestConnectionUITests: XCTestCase {
         tapVisible(app.buttons[Identity.back], in: app)
         XCTAssertTrue(app.buttons[Identity.testContinue].waitForExistence(timeout: 5))
         XCTAssertTrue(
-            row(app, Identity.stageAuthentication).label.contains("Browser sign-in required")
+            row(app, Identity.stageAuthentication).label.lowercased().contains("browser sign-in required")
         )
         tapVisible(app.buttons[Identity.testContinue], in: app)
         XCTAssertTrue(app.staticTexts["setup.test.interactive-ready"].waitForExistence(timeout: 5))

--- a/ConduitUITests/ConnectionSetupUITests.swift
+++ b/ConduitUITests/ConnectionSetupUITests.swift
@@ -24,6 +24,9 @@ final class ConnectionSetupUITests: XCTestCase {
 
     func testLANDetailsValidationReviewAndHandoffWithoutConnecting() {
         let app = XCUIApplication()
+        // The staged connection test runs against a deterministic stub probe:
+        // UI tests never depend on a real Hermes server.
+        app.launchArguments += ["-CONNECTION_SETUP_TEST_RESULT", "success"]
         app.launch()
         openSetup(app)
         tapVisible(app.buttons[Identity.answerYes], in: app)
@@ -54,13 +57,25 @@ final class ConnectionSetupUITests: XCTestCase {
         tapVisible(password, in: app)
         password.typeText("round3-private-fixture")
         tapVisible(app.buttons["setup.next"], in: app)
+        // The staged test screen sits between credentials and Review.
+        XCTAssertTrue(app.buttons["setup.test.run"].waitForExistence(timeout: 5))
+        tapVisible(app.buttons["setup.test.run"], in: app)
+        XCTAssertTrue(app.staticTexts["setup.test.ready"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.staticTexts["http://192.168.1.28:9119"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.staticTexts["Entered"].exists)
         XCTAssertFalse(app.staticTexts["round3-private-fixture"].exists)
         tapVisible(app.buttons[Identity.back], in: app)
+        // Back from Review lands on the test screen, which still shows the
+        // passing result.
+        XCTAssertTrue(app.buttons["setup.test.continue"].waitForExistence(timeout: 5))
+        tapVisible(app.buttons[Identity.back], in: app)
         XCTAssertTrue(password.waitForExistence(timeout: 5))
-        // Retained password permits Review without re-entry; never read its value.
+        // Retained password permits the test screen without re-entry; never
+        // read its value. No edits happened, so the success stays current.
         tapVisible(app.buttons["setup.next"], in: app)
+        XCTAssertTrue(app.buttons["setup.test.continue"].waitForExistence(timeout: 5))
+        tapVisible(app.buttons["setup.test.continue"], in: app)
+        XCTAssertTrue(app.staticTexts["setup.test.ready"].waitForExistence(timeout: 5))
         tapVisible(app.buttons["setup.use-settings"], in: app)
         let server = app.textFields["login.server-url"]
         XCTAssertTrue(server.waitForExistence(timeout: 5))
@@ -76,7 +91,9 @@ final class ConnectionSetupUITests: XCTestCase {
         XCTAssertEqual(app.textFields["setup.url"].value as? String, "http://192.168.1.28:9119")
         tapVisible(app.buttons["setup.next"], in: app)
         tapVisible(app.buttons["setup.next"], in: app)
-        XCTAssertTrue(app.staticTexts["Entered"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.buttons["setup.test.run"].waitForExistence(timeout: 5))
+        tapVisible(app.buttons["setup.test.run"], in: app)
+        XCTAssertTrue(app.staticTexts["Entered"].waitForExistence(timeout: 5))
     }
 
     func testTailscaleServeDetailEntryUsesHTTPSWithoutDefaultPort() {


### PR DESCRIPTION
## Round 4: test the proposed connection before accepting it

Rounds 1–3 built the guided Connection Setup wizard (failure taxonomy → wizard → route-specific entry, credentials, URL synthesis, Review, typed handoff). Round 4 closes the remaining gap: **the wizard can now prove the proposed settings actually work before the user accepts them**, with per-stage diagnosis instead of a generic failure banner.

```
Details → Credentials → Test Connection → Review (only after success) → Use These Settings
```

### Probe architecture — orchestration, not reimplementation

`ConnectionSetupProbe` (the only `ConnectionSetupTesting` conformer in production) drives the **existing `NativeAuthClient` unchanged** — same URL construction, transport policy, redirect policy, Cloudflare header application, cookie rules, and status classification. No new endpoints, no second auth implementation.

| Stage | Copy (running → success) | What proves it |
|---|---|---|
| 1 · server | `Checking server…` → `Dashboard reachable` | The provider-discovery request (`GET /api/auth/providers`) returning any HTTP response — transport errors classify from `URLError` codes via the existing classifier |
| 2 · dashboard | `Checking dashboard…` → `Hermes dashboard found` | The same response names a password-capable provider — the **exact** `supports_password` check the normal login performs (now one shared helper, `HermesProviderCheck`, used by both `LoginView` and the probe). 200 alone is never success; a 5xx at discovery proves transport but fails this stage as `.dashboardUnavailable`; a non-Hermes 200 fails as `.unexpectedServerResponse` |
| 3 · authentication | `Authenticating…` → `Login successful` | The full native `connect()`: password login **plus** the ws-ticket mint — the same milestone normal login reaches before it would commit anything |

"Login successful" therefore means what it means everywhere else in Conduit: not just a 200 on password-login, but a usable session artifact.

### Side-effect protections

The probe is a pure validation operation:

- `NativeAuthConnection.commitCookies()` is **never called** — the ticket and transaction cookies are discarded; the shared cookie store is untouched (asserted by test).
- No Keychain writes, no `AppState` mutation, no `HermesClient`/websocket connection, no `lastDashboardURL` update, no session restore, no screen changes, no dismissal.
- **One user-requested test = one discovery request + one password-login attempt + one ticket mint** (asserted by exact request counts). No automatic retries — the rate-limit model is untouched.
- The login card's in-memory Cloudflare service token may be reused by the probe, but only after `cloudflareAccessForDraft()` re-verifies same-origin against the token's recorded origin **on every run**; any host/scheme/port mismatch (including edits made inside the wizard) drops the token. The wizard still collects no Cloudflare fields and persists nothing; the Round-3 origin-safe handoff is unchanged.

### State model, invalidation, and stale-result safety

- `ConnectionSetupTestState` is a SwiftUI-free reducer over `started/succeeded/failed` events per stage. Prior successes stay green when a later stage fails; untouched stages stay pending; the reducer is monotonic (a terminal stage never reverts).
- **Edit invalidation:** every draft mutation bumps a revision (`didSet`). A success is sealed at the revision it validated; `Use These Settings` is authorized only by a test whose revision still matches the current draft. Editing address, port, scheme, username, password, or access method immediately invalidates the previous success, and re-entering the test step resets to untested.
- **Stale results:** each run carries a generation token. Cancellation, a newer run, or a draft reset bumps it, so a late completion from an obsolete run can never overwrite newer state — pinned by a deterministic regression test for the exact burn-recipe (old run finishes late after a newer run succeeded). Cancellation uses task cancellation *plus* the generation guard; correctness never relies on view destruction.

### Failure handling

- Failures render the stable `ConnectionFailure` copy — never raw `URLError`/Foundation strings. The failed stage is highlighted; earlier successes remain visible.
- Recovery: transport/dashboard failures offer **Edit Connection Details** (primary) + **Try Again**; authentication failures make **Edit Credentials** primary (retry is secondary, never the path of least resistance); **rate limiting offers no retry action at all**.
- Retry is always an explicit, user-requested full rerun (acceptable per spec §12), starting clean from stage 1.
- TLS failures keep the existing safe guidance; there is no bypass, no "Continue Anyway", no certificate exception anywhere.

### UI behavior

- New `connectionTest` step between credentials and Review. Back/edit behavior is preserved; success auto-advances to Review, which shows the passing stage list, "This connection is ready to use.", and the enabled **Use These Settings** — the Round-3 typed handoff, unchanged. The user still taps Connect on the login form themselves.
- The stage list renders pending/running/succeeded/failed states with distinct markers, and VoiceOver reads "Dashboard reachable, passed"-style labels (state carried by words, not color), with one completion announcement per run.
- Untested configurations cannot be accepted: Review is only reachable through a current successful test, and `complete()` enforces it independently.
- The `-CONNECTION_SETUP_TEST_RESULT` launch-argument probe stub is `#if DEBUG`-only — release builds contain none of it, and no fake endpoint exists in any production path.

### Tests

New `ConnectionSetupTestTests` (~40 tests): full success sequence, per-stage failures preserving prior stages, retry resets, concurrency guard, cancellation semantics, events-after-advance guard, edit invalidation + reset-on-reentry, the stale-late-failure race, remediation routing, rate-limit retry policy, copy/accessibility pins, and the probe's failure mappings (DNS, refused, timeout, TLS-untrusted, TLS-bad-date, TLS-handshake, 5xx, non-Hermes, 401, 429, ticket failure, Cloudflare rejection) against the **real** `NativeAuthClient` through a URLProtocol stub, plus side-effect freedom (cookie jar unchanged, exact request counts) and the Cloudflare origin gate (same-origin applies; host/scheme/port mismatch, empty origin, unconfigured, and post-edit cross-origin all drop the token).

Updated `ConnectionSetupFlowTests` for the new step; new `ConnectionSetupTestConnectionUITests` (success, auth-rejected, rate-limited) using the DEBUG stub — no UI test touches a real server.

### Intentionally deferred (spec §27)


## Round 4.1 — interactive sign-in compatibility (74417f2)

Provider discovery previously used an empty provider list as the interactive-auth signal, so the staged probe collapsed three different situations into `Unexpected server response` and a Hermes deployment that routes to browser sign-in could never pass Connection Setup even though normal LoginView connects fine.

- **Typed discovery:** `NativeAuthClient.authProviders()` is now `authProviderDiscovery()` returning `AuthProviderDiscoveryResult` — `.interactiveSignInRequired` (the unauthenticated redirect to a sign-in page), `.providers(...)` (a recognizable Hermes provider answer, possibly empty or non-password), `.unrecognized` (a 2xx body without recognizable provider structure: malformed JSON, missing/wrong-shape `providers`). A configured Cloudflare service token rejected by an Access login redirect still throws `.cloudflareServiceTokenRejected`; a redirect without a `Location` header is a discovery failure, never interactive.
- **LoginView** consumes the typed result with identical external behavior: redirect, unrecognized, or no-password-provider answers open the browser; password-capable providers continue to native login.
- **Probe:** an interactive-auth dashboard ends the run in a supported terminal outcome — server ✓, dashboard ✓, authentication = "Browser sign-in required". The probe performs exactly one request (provider discovery): no native login, no ticket mint, no WebView, no cookie/Keychain writes. Provider-less or malformed 2xx still fails `Unexpected server response`; 5xx still fails `Dashboard unavailable`; a rejected service token keeps its Cloudflare troubleshooting path.
- **Completion authorization:** `canUseSettings = fullyAuthenticated || hasCurrentInteractiveAuthOutcome`. Both are revision-sealed and generation-guarded: any draft edit invalidates them, stale terminal events (either kind) are dropped. There is no generic skip-testing bypass — both qualifying outcomes have verified transport, dashboard identity, and expected auth behavior; only the user's own sign-in remains, and it happens in LoginView over the unchanged Round-3 handoff (Use These Settings fills the form; Connect is still manual).
- **UI:** Review shows ✓ Dashboard reachable, ✓ Hermes dashboard found, ○ Browser sign-in required with an explanation that Conduit opens the sign-in page after returning to the login screen. It never says "Login successful".

Validation: full iOS unit suite 1901/1901 on the final head; focused auth/setup suites 195/195 (NativeAuthClientTests, ConnectionSetupTestTests, ConnectionSetupFlowTests, ConnectionFailureTests, CloudflareAccessTests, LoginCloudflareHandoffTests, ConnectionSetupDraftTests); planner validation OK; `git diff --check` clean. Local Mac UI-runner is environmentally wedged (pre-existing; origin/main fails worse) — the hosted CI UI lane is the gate. Three-model review completed; all BLOCKER/WARNING findings resolved.

Bonjour/mDNS, Tailscale API integration, QR setup, Settings entry point, certificate installation, websocket smoke test, automatic Connect, and the "Use Without Testing" escape hatch (omitted — the probe is a strict prefix of the normal login path, and the wizard is never the only way in).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a staged connection test between credential entry and review.
  * Connection checks now report server, dashboard, and authentication stages with recovery guidance.
  * Review is available after a successful test or when browser-based sign-in is required.
  * Reuses valid same-origin Cloudflare Access credentials.
  * Added accessibility labels and announcements for test progress and results.
  * Browser sign-in outcomes provide clear messaging and continue to Review.

* **Bug Fixes**
  * Editing connection details invalidates previous test results.
  * Improved recovery for authentication failures, rate limits, and other connection errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

