### PR TITLE
Harden conversation identity across session boundaries

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -3124,7 +3124,8 @@ final class AppState: ObservableObject {
         automaticWorkToken: ChatResumeAutomaticWorkToken? = nil,
         automaticSyncOperationID: UUID? = nil,
         requiredViewportTransitionGeneration: UInt64? = nil,
-        historySourceUnavailable: Bool = false
+        historySourceUnavailable: Bool = false,
+        presentationMigrationSessionIDs: Set<String> = []
     ) async -> Bool {
         guard automaticChatResumeWorkIsCurrent(
             automaticWorkToken,
@@ -3345,8 +3346,14 @@ final class AppState: ObservableObject {
                     // now, and the alias keys are retired so a later
                     // re-attribution of a runtime id to a different
                     // conversation can never inherit this presentation.
+                    // `presentationMigrationSessionIDs` are notification
+                    // presentation sources — untrusted as identity, so they
+                    // were never added to the accepted set; now that
+                    // admission HAS succeeded they are legitimate migration
+                    // sources for the pending decision cards they carried.
                     let runtimeAliases = acceptedSessionIDs
                         .union([result.sessionId, sessionId])
+                        .union(presentationMigrationSessionIDs)
                         .subtracting([admittedDurable])
                     sessionPresentationCache.consolidateUnderDurableKey(
                         profile: profile,
@@ -3400,10 +3407,18 @@ final class AppState: ObservableObject {
                 // Desktop keeps its live projection during an active turn. Seed
                 // the same durable presentation details first so the completed
                 // portion of a backgrounded turn does not lose its timestamps.
+                // Durable-owned: writes land on the durable key only, so the
+                // alias keys consolidation just retired stay retired.
+                let presentationDurableID = context?.resolvedDurableSessionId
+                    ?? referenceIdentity.durableSessionID
+                    ?? sessionId
                 sessionPresentationCache.save(
                     transcript.messages,
                     profile: profile,
-                    sessionIDs: [sessionId, result.sessionId, transcript.resolvedSessionId].compactMap { $0 }
+                    sessionIDs: Self.durableOwnedPresentationIDs(
+                        [sessionId, result.sessionId, transcript.resolvedSessionId].compactMap { $0 },
+                        durableSessionID: presentationDurableID
+                    )
                 )
             }
             // A compact resume ships no persisted transcript, so the REST rows
@@ -6485,7 +6500,8 @@ final class AppState: ObservableObject {
 
     private func openSession(
         _ sessionId: String,
-        reusing viewportTransitionGeneration: UInt64?
+        reusing viewportTransitionGeneration: UInt64?,
+        presentationMigrationSessionIDs: Set<String> = []
     ) async -> Bool {
         guard let client else { return false }
         let previousTurnState = turnState
@@ -6532,7 +6548,8 @@ final class AppState: ObservableObject {
             token: token,
             acceptedSessionIDs: acceptedSessionIDs,
             conversationIdentity: openedIdentity,
-            requiredViewportTransitionGeneration: transitionGeneration
+            requiredViewportTransitionGeneration: transitionGeneration,
+            presentationMigrationSessionIDs: presentationMigrationSessionIDs
         )
         guard chatViewportTransitionIsCurrent(generation: transitionGeneration) else {
             return false
@@ -6633,7 +6650,14 @@ final class AppState: ObservableObject {
         }
         let opened = await openSession(
             route.resumeTargetID,
-            reusing: transitionGeneration
+            reusing: transitionGeneration,
+            // The push-named runtime id is a PRESENTATION MIGRATION SOURCE,
+            // never an identity alias: a pending decision card recorded
+            // under it before the open must be promoted into the admitted
+            // durable conversation now that admission succeeded. On a
+            // rejected open nothing migrates (the hook only runs on
+            // admission success).
+            presentationMigrationSessionIDs: [requestedID]
         )
         // Commit the payload's dual identity as positive evidence only once
         // the open actually succeeded — a failed resume (e.g. the durable
@@ -6651,11 +6675,41 @@ final class AppState: ObservableObject {
                 )
             }
         }
+        if !opened, let decision = target.decision,
+           let evictionKey = Self.pendingDecisionEvictionKey(for: decision) {
+            // The claim was rejected: evict the pre-open card from the
+            // push-named runtime key. Without this, the stale card would
+            // still sit under that runtime id and a LATER legitimate open
+            // of the true owner would promote it into the wrong durable
+            // conversation.
+            sessionPresentationCache.removePendingDecision(
+                key: evictionKey,
+                profile: activeProfile,
+                sessionIDs: [requestedID]
+            )
+        }
         guard notificationOpenAttemptIsCurrent(
             id: notificationAttemptID,
             transitionGeneration: transitionGeneration
         ) else { return false }
         return opened
+    }
+
+    /// The stable decision key a push-delivered card was recorded under
+    /// (`approval:<sessionKey>` / `clarify:<requestId>`) — used to evict a
+    /// pre-open card when its open is rejected. Batch clarifies share the
+    /// scalar key shape via their relay request id.
+    private static func pendingDecisionEvictionKey(
+        for decision: PendingDecisionPayload
+    ) -> String? {
+        switch decision {
+        case .approval(let sessionKey, _, _):
+            return "approval:\(sessionKey)"
+        case .clarify(let requestId, _, _):
+            return "clarify:\(requestId)"
+        case .clarifyBatch(let requestId, _):
+            return "clarify:\(requestId)"
+        }
     }
 
     /// Caches a push-delivered decision card so the resume merge can restore

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -1025,6 +1025,7 @@ final class AppState: ObservableObject {
     private var projectsRequestGeneration = 0
     private let sessionPresentationCache: SessionPresentationCache
     private let sessionYoloStore: SessionYoloStore
+    private let conversationIdentityIndex: ConversationIdentityIndex
     private var sessionYoloWriteRevision: UInt64 = 0
     private var sessionYoloWriteRevisions: [ChatScrollSessionKey: UInt64] = [:]
     /// Sessions whose user-initiated YOLO write is awaiting its RPC, tracked
@@ -1267,6 +1268,7 @@ final class AppState: ObservableObject {
         chatResumeLifecycleOperations: ChatResumeLifecycleOperations = .live,
         sessionPresentationCache: SessionPresentationCache = .shared,
         sessionYoloStore: SessionYoloStore? = nil,
+        conversationIdentityIndex: ConversationIdentityIndex? = nil,
         presentationCacheDebounceSuspension: (@Sendable (Duration) async throws -> Void)? = nil
     ) {
         self.presentationCacheDebounceSuspension =
@@ -1275,6 +1277,7 @@ final class AppState: ObservableObject {
         self.defaults = defaults
         self.sessionPresentationCache = sessionPresentationCache
         self.sessionYoloStore = sessionYoloStore ?? SessionYoloStore(defaults: defaults)
+        self.conversationIdentityIndex = conversationIdentityIndex ?? ConversationIdentityIndex()
         self.chatResumeCoordinator = chatResumeCoordinator
             ?? ChatResumeCoordinator(store: ChatResumeStore(defaults: defaults))
         self.recoverySequence = recoverySequence
@@ -1995,6 +1998,12 @@ final class AppState: ObservableObject {
         defaults.removeObject(forKey: reviewSummaryCacheKey)
         defaults.removeObject(forKey: knownProfilesKey)
         clearSessionPresentationCache()
+        // Identity evidence and per-session overrides are keyed only by
+        // (profile, session id); without this clear they would leak between
+        // Hermes servers whose strings collide. Same boundary that clears
+        // the resume store, titles, pins, and review cache.
+        conversationIdentityIndex.removeAll()
+        sessionYoloStore.clearAllOverrides()
         return true
     }
 
@@ -2767,6 +2776,9 @@ final class AppState: ObservableObject {
             }
             sessions = allSessions.filter { $0.source != .cron }
             cronSessions = allSessions.filter { $0.source == .cron }
+            // Labeled rows are positive identity evidence; commit them so
+            // notification routing survives a later catalog omission.
+            conversationIdentityIndex.recordCatalogIdentity(allSessions, profile: profile)
 
             guard automaticChatResumeWorkIsCurrent(
                 automaticWorkToken,
@@ -3277,6 +3289,31 @@ final class AppState: ObservableObject {
                     || referenceIdentity.durableSessionID == established {
                     context?.resolvedDurableSessionId = established
                 }
+                // Commit the admitted result as positive evidence in the
+                // shared identity index: the returned runtime id (and the
+                // requested id, when it differs) positively route to the
+                // conversation's durable identity.
+                let admittedDurable = context?.resolvedDurableSessionId
+                    ?? referenceIdentity.durableSessionID
+                if let admittedDurable, !admittedDurable.isEmpty {
+                    for admittedRuntimeID in [result.sessionId, sessionId] {
+                        conversationIdentityIndex.record(
+                            runtimeID: admittedRuntimeID,
+                            durableID: admittedDurable,
+                            profile: profile,
+                            source: .resume
+                        )
+                    }
+                }
+                // A live voice turn captured the pre-rebind runtime; the
+                // admitted alias keeps its assistant stream flowing — but
+                // only when the reconciled conversation IS the voice turn's
+                // conversation (positive id overlap), never another one.
+                voiceConversationController.extendAssistantSessionIDs(
+                    [result.sessionId],
+                    ofConversationContaining: referenceIdentity.acceptedSessionIDs
+                        .union([sessionId])
+                )
             }
             reconciliation = context
             refreshActiveChatScrollSessionIdentity(isReconciling: true)
@@ -3676,6 +3713,19 @@ final class AppState: ObservableObject {
             }
 
             let storedID = created.storedSessionId ?? runtimeSessionID
+            // The create response's runtime/stored semantics are verified
+            // here (the summary is built from the same response), so the
+            // pair is positive identity evidence.
+            if let runtime = ChatScrollIdentityNormalization.sessionID(runtimeSessionID),
+               let durable = ChatScrollIdentityNormalization.sessionID(storedID),
+               runtime != durable {
+                conversationIdentityIndex.record(
+                    runtimeID: runtime,
+                    durableID: durable,
+                    profile: activeProfile,
+                    source: .create
+                )
+            }
             let summary = SessionSummary(
                 id: storedID,
                 alternateIds: [runtimeSessionID, created.storedSessionId]
@@ -5973,6 +6023,9 @@ final class AppState: ObservableObject {
             )
             sessions = allSessions.filter { $0.source != .cron }
             cronSessions = allSessions.filter { $0.source == .cron }
+            // Labeled rows are positive identity evidence; commit them so
+            // notification routing survives a later catalog omission.
+            conversationIdentityIndex.recordCatalogIdentity(allSessions, profile: profile)
             if let activeSessionId { updateActiveSessionTitle(for: activeSessionId) }
             if let activeClient {
                 Task { [weak self] in
@@ -6168,9 +6221,14 @@ final class AppState: ObservableObject {
                 method: "DELETE"
             )
             guard profile == activeProfile else { return false }
+            let deletedSessionIDs = Set([session.id] + session.alternateIds)
             sessionYoloStore.clearOverride(
                 for: profile,
                 sessionIDs: [session.id] + session.alternateIds
+            )
+            revokeDeletedConversationIdentity(
+                sessionIDs: deletedSessionIDs,
+                profile: profile
             )
             removeSessionFromLiveCatalog(session)
             archivedSessions.removeAll { sessionMatches($0, session) }
@@ -6186,6 +6244,21 @@ final class AppState: ObservableObject {
 
     func isSessionMutationInFlight(_ session: SessionSummary) -> Bool {
         sessionMutationID == session.id
+    }
+
+    /// Explicit deletion revokes the conversation's identity: index
+    /// mappings, scroll/resume state, and cached presentation (with any
+    /// pending cards) must not survive under any of its aliases.
+    func revokeDeletedConversationIdentity(sessionIDs: Set<String>, profile: String) {
+        conversationIdentityIndex.removeSessionIDs(sessionIDs, profile: profile)
+        chatResumeCoordinator.removeSessions(
+            profile: profile,
+            sessionIDs: Array(sessionIDs)
+        )
+        sessionPresentationCache.removeSessions(
+            profile: profile,
+            sessionIDs: Array(sessionIDs)
+        )
     }
 
     private func encodedSessionID(_ sessionID: String) -> String {
@@ -6435,9 +6508,17 @@ final class AppState: ObservableObject {
             return false
         }
         let requestedID = target.sessionId
-        let resumableID = NotificationSessionResolver.resumableSessionID(
-            for: requestedID,
-            in: sessions + cronSessions
+        // The fresh catalog was just published (its labeled rows are already
+        // committed to the identity index), so resolution runs through the
+        // evidence hierarchy: explicit durable id from the payload, catalog
+        // alias, confirmed index alias — and only then the legacy raw
+        // runtime resume. An unknown runtime id is never reinterpreted as
+        // some other conversation's durable id.
+        let route = NotificationSessionResolver.route(
+            target: target,
+            catalog: sessions + cronSessions,
+            identityIndex: conversationIdentityIndex,
+            profile: activeProfile
         )
         // A decision raised while the app was backgrounded is delivered as a
         // structured payload on the notification (the one-shot gateway stream
@@ -6445,12 +6526,32 @@ final class AppState: ObservableObject {
         // stored IDs so the upcoming resume's `merge` restores the card
         // regardless of which identity the gateway resumes against.
         if let decision = target.decision {
-            recordNotificationDecision(decision, sessionIDs: [resumableID, requestedID])
+            var routedIDs = [route.resumeTargetID, requestedID]
+            if let durable = route.durableSessionID {
+                routedIDs.append(durable)
+            }
+            recordNotificationDecision(decision, sessionIDs: routedIDs)
         }
         let opened = await openSession(
-            resumableID,
+            route.resumeTargetID,
             reusing: transitionGeneration
         )
+        // Commit the payload's dual identity as positive evidence only once
+        // the open actually succeeded — a failed resume (e.g. the durable
+        // conversation was deleted server-side) must not leave a mapping
+        // that dead-routes future notifications.
+        if opened, let durable = route.durableSessionID {
+            if let conflict = conversationIdentityIndex.record(
+                runtimeID: requestedID,
+                durableID: durable,
+                profile: activeProfile,
+                source: .notification
+            ) {
+                sessionCatalogLog.fault(
+                    "Notification identity conflict: runtime \(requestedID, privacy: .public) keeps confirmed durable \(conflict.confirmedDurableID, privacy: .public); payload claimed \(durable, privacy: .public)"
+                )
+            }
+        }
         guard notificationOpenAttemptIsCurrent(
             id: notificationAttemptID,
             transitionGeneration: transitionGeneration
@@ -6704,6 +6805,21 @@ final class AppState: ObservableObject {
                 isArchived: false,
                 lineageRootId: parentSessionId
             )
+            // A branch is its own durable conversation: its response ids are
+            // positive evidence for the BRANCH only. They must never alias
+            // the source conversation, and the source keeps its own mappings.
+            if let runtime = ChatScrollIdentityNormalization.sessionID(branched.sessionId),
+               let durable = ChatScrollIdentityNormalization.sessionID(
+                   branched.storedSessionId ?? branched.sessionId
+               ),
+               runtime != durable {
+                conversationIdentityIndex.record(
+                    runtimeID: runtime,
+                    durableID: durable,
+                    profile: activeProfile,
+                    source: .branch
+                )
+            }
             sessions = [summary] + sessions.map { existing in
                 var updated = existing
                 updated.isActive = false

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -1060,14 +1060,36 @@ final class AppState: ObservableObject {
         ISO8601DateFormatter().string(from: Date())
     }
 
+    /// Durable-owned presentation persistence: once the conversation's
+    /// durable identity is positively established (a catalog-confirmed or
+    /// admission-established canonical), the durable key is the only key
+    /// presentation writes land under — runtime aliases are never
+    /// re-persisted, so a flush can never recreate an alias copy that
+    /// `consolidateUnderDurableKey` retired. Without a durable id
+    /// (runtime-only conversations) the supplied ids pass through unchanged.
+    static func durableOwnedPresentationIDs(
+        _ ids: [String],
+        durableSessionID: String?
+    ) -> [String] {
+        guard let durableSessionID = ChatScrollIdentityNormalization.sessionID(durableSessionID) else {
+            return ids
+        }
+        // A lookup may need the whole alias set, but a WRITE does not: the
+        // durable key owns the persisted record.
+        return [durableSessionID]
+    }
+
     /// Hermes can omit UI-only fields from persisted history. Retain a bounded
     /// local record so a reload does not drop a timestamp or tool preview.
     private func cacheMessagePresentation(for sessionIDs: [String] = []) {
-        let ids = sessionIDs + [
-            activeSessionId,
-            reconciliation?.requestedSessionId,
-            reconciliation?.resolvedSessionId
-        ].compactMap { $0 }
+        let ids = Self.durableOwnedPresentationIDs(
+            sessionIDs + [
+                activeSessionId,
+                reconciliation?.requestedSessionId,
+                reconciliation?.resolvedSessionId
+            ].compactMap { $0 },
+            durableSessionID: activeChatScrollSessionIdentity.canonicalSessionID
+        )
         let restorationKeys: Set<String>? = {
             guard let restorationGuard = restoredPendingDecisionCardsAwaitingConfirmation,
                   restorationGuard.profile == activeProfile,
@@ -3289,21 +3311,48 @@ final class AppState: ObservableObject {
                     || referenceIdentity.durableSessionID == established {
                     context?.resolvedDurableSessionId = established
                 }
-                // Commit the admitted result as positive evidence in the
-                // shared identity index: the returned runtime id (and the
-                // requested id, when it differs) positively route to the
-                // conversation's durable identity.
+                // Commit the admitted result as FRESH AUTHORITATIVE evidence
+                // in the shared identity index: the app just accepted this
+                // resume into conversation-owned state, so the index must
+                // agree — a historical conflicting mapping for the same
+                // runtime id is rebound here, never kept (split-brain is
+                // unacceptable between the selected conversation and the
+                // index).
+                //
+                // Durable candidates in priority order: an explicitly
+                // established stored id from the response, the selected
+                // conversation's established durable id, and finally the
+                // RESUME TARGET itself — the request was addressed by that
+                // stored id, so it is the durable the app is acting on (for
+                // a runtime-addressed resume the mapping degenerates to a
+                // self-mapping, which the index skips as information-free).
+                let requestedDurableCandidate: String? = sessionId
                 let admittedDurable = context?.resolvedDurableSessionId
                     ?? referenceIdentity.durableSessionID
+                    ?? requestedDurableCandidate
                 if let admittedDurable, !admittedDurable.isEmpty {
                     for admittedRuntimeID in [result.sessionId, sessionId] {
-                        conversationIdentityIndex.record(
+                        conversationIdentityIndex.recordAuthoritative(
                             runtimeID: admittedRuntimeID,
                             durableID: admittedDurable,
                             profile: profile,
                             source: .resume
                         )
                     }
+                    // Durable-owned presentation: the durable key is the
+                    // only persistent presentation key for this
+                    // conversation. Runtime-keyed records migrate into it
+                    // now, and the alias keys are retired so a later
+                    // re-attribution of a runtime id to a different
+                    // conversation can never inherit this presentation.
+                    let runtimeAliases = acceptedSessionIDs
+                        .union([result.sessionId, sessionId])
+                        .subtracting([admittedDurable])
+                    sessionPresentationCache.consolidateUnderDurableKey(
+                        profile: profile,
+                        durableSessionID: admittedDurable,
+                        runtimeAliases: Array(runtimeAliases)
+                    )
                 }
                 // A live voice turn captured the pre-rebind runtime; the
                 // admitted alias keeps its assistant stream flowing — but
@@ -3715,11 +3764,13 @@ final class AppState: ObservableObject {
             let storedID = created.storedSessionId ?? runtimeSessionID
             // The create response's runtime/stored semantics are verified
             // here (the summary is built from the same response), so the
-            // pair is positive identity evidence.
+            // pair is fresh authoritative evidence: the created conversation
+            // is being adopted into the catalog below, and the index must
+            // agree rather than keep any historical mapping for the runtime.
             if let runtime = ChatScrollIdentityNormalization.sessionID(runtimeSessionID),
                let durable = ChatScrollIdentityNormalization.sessionID(storedID),
                runtime != durable {
-                conversationIdentityIndex.record(
+                conversationIdentityIndex.recordAuthoritative(
                     runtimeID: runtime,
                     durableID: durable,
                     profile: activeProfile,
@@ -3886,10 +3937,18 @@ final class AppState: ObservableObject {
             : []
         let shouldPersistMergedPresentation = gatewayConfirmsActiveTurn
             || !unconfirmedPendingDecisionKeys.isEmpty
+        // Persisted presentation is durable-owned: once this conversation's
+        // canonical/durable id is established, alias keys are not re-created
+        // by writes (the merge lookup above stays a tolerant superset).
+        let persistedSessionIDs = Self.durableOwnedPresentationIDs(
+            sessionIDs,
+            durableSessionID: reconciliation?.resolvedDurableSessionId
+                ?? activeChatScrollSessionIdentity.canonicalSessionID
+        )
         sessionPresentationCache.save(
             shouldPersistMergedPresentation ? messages : result.messages,
             profile: activeProfile,
-            sessionIDs: sessionIDs,
+            sessionIDs: persistedSessionIDs,
             preservePendingDecisionCards: gatewayConfirmsActiveTurn || !unconfirmedPendingDecisionKeys.isEmpty,
             unconfirmedPendingDecisionKeys: unconfirmedPendingDecisionKeys
         )
@@ -5217,6 +5276,24 @@ final class AppState: ObservableObject {
         }
     }
 
+    /// `session.active_list` rows are the gateway's live registry: every row
+    /// naming both a runtime and a stored id is fresh authoritative routing
+    /// evidence (the same authority class as a catalog snapshot), recorded
+    /// through the explicit authoritative rebind. The write is strictly
+    /// OBSERVATIONAL — recording rows never mutates the selected
+    /// conversation, and the healthy-foreground rule (observe the registry,
+    /// never resume without cause) is untouched.
+    func recordActiveListEvidence(_ rows: [LiveSessionStatus], profile: String) {
+        for row in rows {
+            conversationIdentityIndex.recordAuthoritative(
+                runtimeID: row.runtimeSessionId,
+                durableID: row.storedSessionId,
+                profile: profile,
+                source: .activeList
+            )
+        }
+    }
+
     /// Read-only registry probe for the active conversation. Matches a row by
     /// ANY identity the conversation is known under (requested, stored, and
     /// runtime aliases), so a runtime-id rotation cannot be mistaken for a
@@ -5225,6 +5302,8 @@ final class AppState: ObservableObject {
         requestedSessionID: String,
         using client: HermesClient
     ) async -> ForegroundRuntimeProbe {
+        let evidenceProfile = activeProfile
+        let evidenceServerIdentity = defaults.string(forKey: chatResumeServerIdentityKey)
         do {
             let rows: [LiveSessionStatus]
             if let probeActiveSessions = chatResumeLifecycleOperations.probeActiveSessions {
@@ -5232,6 +5311,17 @@ final class AppState: ObservableObject {
             } else {
                 rows = try await client.activeSessions()
             }
+            // Currency fence: rows observed before a SERVER change must not
+            // repopulate the index scope that change cleared. The fence is
+            // the committed server identity — the exact boundary
+            // prepareChatResumeForConnection uses — so a same-server client
+            // replacement (reconnect, possibly re-addressed) stays valid
+            // while a real server switch discards its in-flight rows.
+            guard evidenceProfile == activeProfile,
+                  defaults.string(forKey: chatResumeServerIdentityKey) == evidenceServerIdentity else {
+                return .unavailable("Probe superseded by connection change")
+            }
+            recordActiveListEvidence(rows, profile: evidenceProfile)
             let acceptedIDs = acceptedIdentitySessionIDs(forRequested: requestedSessionID)
             if let row = rows.first(where: {
                 acceptedIDs.contains($0.runtimeSessionId) || acceptedIDs.contains($0.storedSessionId)
@@ -6522,15 +6612,24 @@ final class AppState: ObservableObject {
         )
         // A decision raised while the app was backgrounded is delivered as a
         // structured payload on the notification (the one-shot gateway stream
-        // event was missed). Cache it under both the runtime and resolved
-        // stored IDs so the upcoming resume's `merge` restores the card
-        // regardless of which identity the gateway resumes against.
+        // event was missed). The card is recorded BEFORE the open — the
+        // upcoming resume's `merge` restores it into the live transcript —
+        // but persisted ONLY under the identity the push itself named
+        // (`requestedID`): that id provably belonged to the notified
+        // conversation at push time. The payload's durable claim is NOT
+        // written while unproven — a rejected open must not leave a card
+        // under a durable it merely claimed. When the open succeeds, the
+        // admitted resume's consolidation migrates the card to the durable
+        // key and retires the runtime key.
         if let decision = target.decision {
-            var routedIDs = [route.resumeTargetID, requestedID]
-            if let durable = route.durableSessionID {
-                routedIDs.append(durable)
-            }
-            recordNotificationDecision(decision, sessionIDs: routedIDs)
+            let knownKeys = route.durableSessionID.map { durable in
+                [route.resumeTargetID, requestedID, durable]
+            } ?? [route.resumeTargetID, requestedID]
+            recordNotificationDecision(
+                decision,
+                sessionIDs: knownKeys,
+                cacheSessionIDs: [requestedID]
+            )
         }
         let opened = await openSession(
             route.resumeTargetID,
@@ -6566,10 +6665,14 @@ final class AppState: ObservableObject {
     /// The decision's session key must match one of the routed session
     /// identities — a mismatched key could not be answered via
     /// `approval.respond` and would only duplicate or contradict the live card.
+    /// `cacheSessionIDs` is the (durable-owned) key set the card persists
+    /// under; `sessionIDs` remains the answerability guard.
     private func recordNotificationDecision(
         _ decision: PendingDecisionPayload,
-        sessionIDs: [String]
+        sessionIDs: [String],
+        cacheSessionIDs: [String]? = nil
     ) {
+        let persistedIDs = cacheSessionIDs ?? sessionIDs
         switch decision {
         case let .approval(sessionKey, description, choices):
             // Compare trimmed on both sides: the payload parser trims the
@@ -6600,7 +6703,7 @@ final class AppState: ObservableObject {
             sessionPresentationCache.recordPendingDecision(
                 message,
                 profile: activeProfile,
-                sessionIDs: sessionIDs
+                sessionIDs: persistedIDs
             )
         case let .clarify(requestId, question, choices):
             // Relay-delivered clarify: the plugin middleware minted this id and
@@ -6624,7 +6727,7 @@ final class AppState: ObservableObject {
             sessionPresentationCache.recordPendingDecision(
                 message,
                 profile: activeProfile,
-                sessionIDs: sessionIDs
+                sessionIDs: persistedIDs
             )
         case let .clarifyBatch(requestId, questions):
             // Batch relay decision (current notifier): the SAME batch
@@ -6641,7 +6744,7 @@ final class AppState: ObservableObject {
             sessionPresentationCache.recordPendingDecision(
                 message,
                 profile: activeProfile,
-                sessionIDs: sessionIDs
+                sessionIDs: persistedIDs
             )
         }
     }
@@ -6806,14 +6909,15 @@ final class AppState: ObservableObject {
                 lineageRootId: parentSessionId
             )
             // A branch is its own durable conversation: its response ids are
-            // positive evidence for the BRANCH only. They must never alias
-            // the source conversation, and the source keeps its own mappings.
+            // fresh authoritative evidence for the BRANCH only (adopted into
+            // the catalog below). They must never alias the source
+            // conversation, and the source keeps its own mappings.
             if let runtime = ChatScrollIdentityNormalization.sessionID(branched.sessionId),
                let durable = ChatScrollIdentityNormalization.sessionID(
                    branched.storedSessionId ?? branched.sessionId
                ),
                runtime != durable {
-                conversationIdentityIndex.record(
+                conversationIdentityIndex.recordAuthoritative(
                     runtimeID: runtime,
                     durableID: durable,
                     profile: activeProfile,
@@ -7151,6 +7255,8 @@ final class AppState: ObservableObject {
         // Capture the probe identity BEFORE the await — never re-derive it
         // from the mutable active session afterwards.
         let acceptedIDs = acceptedIdentitySessionIDs(forRequested: sessionId)
+        let evidenceProfile = activeProfile
+        let evidenceServerIdentity = defaults.string(forKey: chatResumeServerIdentityKey)
         let rows: [LiveSessionStatus]
         do {
             if let probeActiveSessions = chatResumeLifecycleOperations.probeActiveSessions {
@@ -7158,6 +7264,16 @@ final class AppState: ObservableObject {
             } else {
                 rows = try await client.activeSessions()
             }
+            // Currency fence (see probeForegroundRuntime): a server change
+            // during the await discards its in-flight rows.
+            guard evidenceProfile == activeProfile,
+                  defaults.string(forKey: chatResumeServerIdentityKey) == evidenceServerIdentity else {
+                lifecycleLog.notice(
+                    "submitComposer: stale-idle probe superseded by connection change; no evidence recorded"
+                )
+                return false
+            }
+            recordActiveListEvidence(rows, profile: evidenceProfile)
         } catch {
             // The registry could not be read (older gateway, transient
             // failure). Proceed with the ordinary send rather than blocking
@@ -8038,6 +8154,8 @@ final class AppState: ObservableObject {
         let lifecycleEvidence = turnLifecycleEvidence
         // The alias set was captured from the ORIGINAL submission before any
         // await; it is never re-derived from the mutable active session here.
+        let evidenceProfile = activeProfile
+        let evidenceServerIdentity = defaults.string(forKey: chatResumeServerIdentityKey)
         let rows: [LiveSessionStatus]
         do {
             if let probeActiveSessions = chatResumeLifecycleOperations.probeActiveSessions {
@@ -8045,6 +8163,13 @@ final class AppState: ObservableObject {
             } else {
                 rows = try await probeClient.activeSessions()
             }
+            // Currency fence (see probeForegroundRuntime): a server change
+            // during the await discards its in-flight rows.
+            guard evidenceProfile == activeProfile,
+                  defaults.string(forKey: chatResumeServerIdentityKey) == evidenceServerIdentity else {
+                return (.unresolved, reconnected, lifecycleEvidence)
+            }
+            recordActiveListEvidence(rows, profile: evidenceProfile)
         } catch {
             return (.unresolved, reconnected, lifecycleEvidence)
         }

--- a/Conduit/Services/ChatResumeCoordinator.swift
+++ b/Conduit/Services/ChatResumeCoordinator.swift
@@ -239,6 +239,44 @@ final class ChatResumeCoordinator {
 
     func removeSessions(profile: String, sessionIDs: [String]) {
         store.removeSessions(profile: profile, sessionIDs: sessionIDs)
+        // Explicit deletion revokes restoration authority in memory as well
+        // as on disk: a conversation deleted while an automatic restoration
+        // targets it must never have that restoration published, completed,
+        // or resurrected. Scoped strictly to the deleted identities — pending
+        // work for any other conversation is untouched.
+        let normalizedProfile = ChatScrollIdentityNormalization.profile(profile)
+        let ids = Set(sessionIDs.compactMap(ChatScrollIdentityNormalization.sessionID))
+        guard let normalizedProfile, !ids.isEmpty else { return }
+        var invalidated = false
+        if let pendingKey = pendingSessionKey,
+           pendingKey.profile == normalizedProfile,
+           ids.contains(pendingKey.sessionID) {
+            // Staged (not yet published) automatic-return work for the
+            // deleted conversation, including its fallback-selection state.
+            pendingSessionKey = nil
+            pendingFallbackSelection = false
+            invalidated = true
+        }
+        if let restoration = pendingRestoration,
+           restoration.sessionKey.profile == normalizedProfile,
+           ids.contains(restoration.sessionKey.sessionID) {
+            // A published request: clearing it makes isCurrent(generation:)
+            // fail, so a late completion/abandon of the stale generation
+            // cannot resurrect navigation into the deleted conversation.
+            pendingRestoration = nil
+            invalidated = true
+        }
+        guard invalidated else { return }
+        // The deleted conversation can no longer own the freeze: unfreeze so
+        // viewport recording resumes for whatever is selected next.
+        viewportIsFrozen = false
+        // Abort in-flight automatic work that could still publish navigation
+        // for the deleted conversation. The epoch is deliberately coarse —
+        // deletion is rare, an aborted automatic sync re-runs against the
+        // live catalog, and per-conversation epochs would buy precision this
+        // path never needs.
+        automaticCancellationEpoch &+= 1
+        if automaticCancellationEpoch == 0 { automaticCancellationEpoch = 1 }
     }
 
     func flush() {

--- a/Conduit/Services/ChatResumeCoordinator.swift
+++ b/Conduit/Services/ChatResumeCoordinator.swift
@@ -237,6 +237,10 @@ final class ChatResumeCoordinator {
         store.clearResumeState()
     }
 
+    func removeSessions(profile: String, sessionIDs: [String]) {
+        store.removeSessions(profile: profile, sessionIDs: sessionIDs)
+    }
+
     func flush() {
         pendingFlushTask?.cancel()
         pendingFlushTask = nil

--- a/Conduit/Services/ChatResumeStore.swift
+++ b/Conduit/Services/ChatResumeStore.swift
@@ -133,6 +133,31 @@ final class ChatResumeStore {
         persist()
     }
 
+    /// Removes every trace of the given sessions inside `profile`: their
+    /// scroll snapshots, and the profile's last-selected pointer when it
+    /// names one of them. The delete path calls this so a deleted
+    /// conversation cannot leave restorable state behind under any of its
+    /// identities.
+    func removeSessions(profile: String, sessionIDs: [String]) {
+        let normalizedProfile = ChatScrollIdentityNormalization.profile(profile)
+        let ids = Set(sessionIDs.compactMap(ChatScrollIdentityNormalization.sessionID))
+        guard let normalizedProfile, !ids.isEmpty else { return }
+        var changed = false
+        let before = payload.snapshots.count
+        payload.snapshots.removeAll {
+            $0.key.profile == normalizedProfile && ids.contains($0.key.sessionID)
+        }
+        changed = changed || payload.snapshots.count != before
+        if let last = payload.lastSessionIDsByProfile[normalizedProfile],
+           ids.contains(last) {
+            payload.lastSessionIDsByProfile.removeValue(forKey: normalizedProfile)
+            changed = true
+        }
+        if changed {
+            persist()
+        }
+    }
+
     func flush() {
         persist()
     }

--- a/Conduit/Services/ChatScrollState.swift
+++ b/Conduit/Services/ChatScrollState.swift
@@ -349,7 +349,10 @@ enum ChatMessageScrollTargets {
     }
 }
 
-private enum ChatScrollIdentityNormalization {
+/// Canonical identity normalization shared by every session-keyed store:
+/// profiles trim and case-fold, session ids trim. Internal so the resume
+/// store, identity index, and AppState speak the same normalized language.
+enum ChatScrollIdentityNormalization {
     static func profile(_ profile: String?) -> String? {
         guard let value = profile?.trimmingCharacters(in: .whitespacesAndNewlines),
               !value.isEmpty else { return nil }

--- a/Conduit/Services/ConversationIdentityIndex.swift
+++ b/Conduit/Services/ConversationIdentityIndex.swift
@@ -25,15 +25,27 @@ private let conversationIdentityLog = Logger(
 /// timestamps, title equality, string resemblance, and profile co-membership
 /// are NEVER evidence, and no caller may synthesize a mapping from them.
 ///
-/// Conflict policy: when new evidence claims a runtime id for a different
-/// durable conversation than the confirmed mapping, the mapping is not
-/// silently rewritten — the conflict is returned to the caller for its own
-/// policy decision and logged by id only. Catalog refreshes are the one
-/// authoritative exception (`recordCatalogIdentity`): the live registry is
-/// the freshest evidence about what a runtime id currently routes to, and a
-/// re-attribution observed there is a routing identity change, not alias
-/// noise. Suspended operations are unaffected either way: they hold their
-/// own captured alias sets and can never gain ownership through this index.
+/// Authority rules — who may establish, and who may REBIND a mapping that
+/// historical evidence already confirmed. Callers pick the API by authority,
+/// never by convenience:
+///
+///     Evidence                          API                   May establish?  May rebind?
+///     -------------------------------------------------------------------------------------
+///     historical confirmed alias        record(...)           yes             no
+///     dual-ID notification payload      record(...)           yes             no
+///     admitted session.resume           recordAuthoritative() yes             yes
+///     authoritative catalog snapshot    recordCatalogIdentity yes             yes (first claim per snapshot)
+///     session.active_list row           recordAuthoritative() yes             yes
+///     verified create result            recordAuthoritative() yes             yes (created conversation)
+///     verified branch result            recordAuthoritative() yes             yes (branched conversation)
+///
+/// The rule behind the table: when the app has already ACCEPTED fresh
+/// routing evidence into conversation-owned state (an admitted resume, the
+/// live registry, a response the catalog now reflects), the index must not
+/// disagree with it — the app cannot say one thing while its own shared
+/// index says another. Historical observations and unverified payload
+/// claims, by contrast, never overwrite a fresher confirmed mapping; they
+/// surface a conflict for the caller to log and resolve.
 ///
 /// Scope: every mapping is keyed by the normalized profile. Runtime ids from
 /// one profile can never establish or resolve ownership in another, and
@@ -78,6 +90,11 @@ final class ConversationIdentityIndex {
     /// Returns the existing mapping as a conflict when different positive
     /// evidence is already confirmed; the confirmed mapping stays and the
     /// caller decides what the disagreement means for its own flow.
+    ///
+    /// This is the LOW-authority API: historical observations and dual-ID
+    /// notification payloads (see the authority table in the type docs).
+    /// Fresh evidence the app has already adopted into conversation-owned
+    /// state must go through `recordAuthoritative` instead.
     @discardableResult
     func record(
         runtimeID: String,
@@ -105,6 +122,49 @@ final class ConversationIdentityIndex {
             conversationIdentityLog.fault(
                 "Identity conflict: runtime \(normalizedRuntime, privacy: .public) confirmed for \(confirmed, privacy: .public), incoming evidence (\(source.rawValue, privacy: .public)) claims \(normalizedDurable, privacy: .public) — keeping confirmed mapping"
             )
+            return conflict
+        }
+        runtimeToDurable[normalizedProfile, default: [:]][normalizedRuntime] = normalizedDurable
+        conversationIdentityLog.debug(
+            "Confirmed alias: runtime \(normalizedRuntime, privacy: .public) → durable \(normalizedDurable, privacy: .public) (\(source.rawValue, privacy: .public))"
+        )
+        return nil
+    }
+
+    /// Records FRESH authoritative routing evidence the app has already
+    /// accepted into conversation-owned state: an admitted `session.resume`
+    /// result, a `session.active_list` row, a verified create/branch
+    /// response. Where it disagrees with a historical confirmed mapping, the
+    /// rebind WINS — the app cannot act on one answer while its shared index
+    /// holds another — and the displaced mapping is returned and logged as
+    /// the conflict record. Suspended operations are unaffected: they hold
+    /// capture-time alias sets and can never gain ownership through the
+    /// rebind.
+    @discardableResult
+    func recordAuthoritative(
+        runtimeID: String,
+        durableID: String,
+        profile: String,
+        source: EvidenceSource
+    ) -> IdentityConflict? {
+        guard let normalizedProfile = ChatScrollIdentityNormalization.profile(profile),
+              let normalizedRuntime = ChatScrollIdentityNormalization.sessionID(runtimeID),
+              let normalizedDurable = ChatScrollIdentityNormalization.sessionID(durableID),
+              normalizedRuntime != normalizedDurable else {
+            return nil
+        }
+        if let confirmed = runtimeToDurable[normalizedProfile]?[normalizedRuntime] {
+            guard confirmed != normalizedDurable else { return nil }
+            let conflict = IdentityConflict(
+                runtimeID: normalizedRuntime,
+                confirmedDurableID: confirmed,
+                incomingDurableID: normalizedDurable,
+                source: source
+            )
+            conversationIdentityLog.fault(
+                "Authoritative rebind: runtime \(normalizedRuntime, privacy: .public) \(confirmed, privacy: .public) → \(normalizedDurable, privacy: .public) (\(source.rawValue, privacy: .public)); suspended work keeps its captured sets"
+            )
+            runtimeToDurable[normalizedProfile]?[normalizedRuntime] = normalizedDurable
             return conflict
         }
         runtimeToDurable[normalizedProfile, default: [:]][normalizedRuntime] = normalizedDurable

--- a/Conduit/Services/ConversationIdentityIndex.swift
+++ b/Conduit/Services/ConversationIdentityIndex.swift
@@ -1,0 +1,187 @@
+import Foundation
+import OSLog
+
+private let conversationIdentityLog = Logger(
+    subsystem: "com.milim.conduit",
+    category: "ConversationIdentityIndex"
+)
+
+/// Profile-scoped index of POSITIVELY confirmed runtime→durable conversation
+/// mappings. It answers exactly two questions:
+///
+///     What durable conversation is runtime-a positively known to belong to?
+///     (lookups — consumers such as notification routing)
+///
+/// and nothing more. It is NOT a second session state machine:
+/// `ConversationIdentity` remains the ownership value, and the index only
+/// centralizes the alias evidence that used to live exclusively inside
+/// per-operation `acceptedSessionIDs` captures, so it survives across
+/// operations instead of dying with each capture.
+///
+/// Evidence policy: mappings are recorded ONLY from positively verified
+/// sources (admitted resume results, explicitly labeled catalog rows,
+/// `session.active_list` rows, verified create/branch responses, and
+/// notification payloads that carry both identities). Catalog ordering,
+/// timestamps, title equality, string resemblance, and profile co-membership
+/// are NEVER evidence, and no caller may synthesize a mapping from them.
+///
+/// Conflict policy: when new evidence claims a runtime id for a different
+/// durable conversation than the confirmed mapping, the mapping is not
+/// silently rewritten — the conflict is returned to the caller for its own
+/// policy decision and logged by id only. Catalog refreshes are the one
+/// authoritative exception (`recordCatalogIdentity`): the live registry is
+/// the freshest evidence about what a runtime id currently routes to, and a
+/// re-attribution observed there is a routing identity change, not alias
+/// noise. Suspended operations are unaffected either way: they hold their
+/// own captured alias sets and can never gain ownership through this index.
+///
+/// Scope: every mapping is keyed by the normalized profile. Runtime ids from
+/// one profile can never establish or resolve ownership in another, and
+/// `removeAll()` (the server-change boundary) drops everything so mappings
+/// from one Hermes server are never usable on another.
+@MainActor
+final class ConversationIdentityIndex {
+    /// Where a recorded mapping came from. Mirrors the diagnostics
+    /// vocabulary; ids are the only content ever logged with it.
+    enum EvidenceSource: String {
+        case catalog
+        case resume
+        case activeList = "active_list"
+        case create
+        case branch
+        case notification
+    }
+
+    /// An incoming positive claim disagreed with the confirmed mapping for a
+    /// runtime id. Reported to the caller; never silently resolved.
+    struct IdentityConflict: Equatable {
+        let runtimeID: String
+        let confirmedDurableID: String
+        let incomingDurableID: String
+        let source: EvidenceSource
+    }
+
+    private var runtimeToDurable: [String: [String: String]] = [:]
+
+    func durableID(
+        forRuntime runtimeID: String,
+        profile: String
+    ) -> String? {
+        guard let normalizedProfile = ChatScrollIdentityNormalization.profile(profile),
+              let normalizedRuntime = ChatScrollIdentityNormalization.sessionID(runtimeID) else {
+            return nil
+        }
+        return runtimeToDurable[normalizedProfile]?[normalizedRuntime]
+    }
+
+    /// Records positive evidence that `runtimeID` routes to `durableID`.
+    /// Returns the existing mapping as a conflict when different positive
+    /// evidence is already confirmed; the confirmed mapping stays and the
+    /// caller decides what the disagreement means for its own flow.
+    @discardableResult
+    func record(
+        runtimeID: String,
+        durableID: String,
+        profile: String,
+        source: EvidenceSource
+    ) -> IdentityConflict? {
+        guard let normalizedProfile = ChatScrollIdentityNormalization.profile(profile),
+              let normalizedRuntime = ChatScrollIdentityNormalization.sessionID(runtimeID),
+              let normalizedDurable = ChatScrollIdentityNormalization.sessionID(durableID) else {
+            return nil
+        }
+        guard normalizedRuntime != normalizedDurable else {
+            // Self-mappings carry no routing information.
+            return nil
+        }
+        if let confirmed = runtimeToDurable[normalizedProfile]?[normalizedRuntime] {
+            guard confirmed != normalizedDurable else { return nil }
+            let conflict = IdentityConflict(
+                runtimeID: normalizedRuntime,
+                confirmedDurableID: confirmed,
+                incomingDurableID: normalizedDurable,
+                source: source
+            )
+            conversationIdentityLog.fault(
+                "Identity conflict: runtime \(normalizedRuntime, privacy: .public) confirmed for \(confirmed, privacy: .public), incoming evidence (\(source.rawValue, privacy: .public)) claims \(normalizedDurable, privacy: .public) — keeping confirmed mapping"
+            )
+            return conflict
+        }
+        runtimeToDurable[normalizedProfile, default: [:]][normalizedRuntime] = normalizedDurable
+        conversationIdentityLog.debug(
+            "Confirmed alias: runtime \(normalizedRuntime, privacy: .public) → durable \(normalizedDurable, privacy: .public) (\(source.rawValue, privacy: .public))"
+        )
+        return nil
+    }
+
+    /// Records explicitly labeled catalog rows. The live registry is the
+    /// freshest authority on what a runtime id currently routes to, so a
+    /// disagreement here overwrites the stale confirmed mapping (a routing
+    /// identity change, logged by id) instead of keeping it. Within ONE
+    /// snapshot the FIRST claim wins — the committed catalog can contain
+    /// cached rows merged after fresh ones, and routing (`catalog.first`)
+    /// reads that same order, so the index must not pin a later stale row
+    /// the resolver would never route to. Catalog rows without a stored id
+    /// contribute nothing: their primary id is already the legacy durable
+    /// identity, so the self-mapping is information-free. Rows labeled with
+    /// a different profile are skipped (nil stays caller-scoped).
+    func recordCatalogIdentity(_ catalog: [SessionSummary], profile: String) {
+        guard let normalizedProfile = ChatScrollIdentityNormalization.profile(profile) else {
+            return
+        }
+        var claimedInSnapshot = Set<String>()
+        for row in catalog {
+            if let rowProfile = ChatScrollIdentityNormalization.profile(row.profile ?? ""),
+               rowProfile != normalizedProfile {
+                continue
+            }
+            guard let stored = ChatScrollIdentityNormalization.sessionID(row.storedSessionId) else {
+                continue
+            }
+            let runtimeIDs = Set(
+                ([row.id] + row.alternateIds)
+                    .compactMap(ChatScrollIdentityNormalization.sessionID)
+            ).subtracting([stored])
+            for runtimeID in runtimeIDs.sorted() {
+                if let confirmed = runtimeToDurable[normalizedProfile]?[runtimeID],
+                   confirmed != stored {
+                    conversationIdentityLog.fault(
+                        "Identity conflict: runtime \(runtimeID, privacy: .public) confirmed for \(confirmed, privacy: .public), catalog row \(stored, privacy: .public) claims it — \(claimedInSnapshot.contains(runtimeID) ? "ignored, earlier row in this snapshot won" : "routing identity changed")"
+                    )
+                }
+                guard !claimedInSnapshot.contains(runtimeID) else { continue }
+                claimedInSnapshot.insert(runtimeID)
+                // default: so a first catalog commit into an empty profile
+                // scope actually lands (chained optional assignment into a
+                // missing key is a silent no-op).
+                runtimeToDurable[normalizedProfile, default: [:]][runtimeID] = stored
+            }
+        }
+    }
+
+    /// Removes every mapping touching any of `sessionIDs` (as runtime or as
+    /// durable) inside `profile`. The delete path uses this so a deleted
+    /// conversation's aliases cannot route anything to it afterward.
+    func removeSessionIDs(_ sessionIDs: Set<String>, profile: String) {
+        guard let normalizedProfile = ChatScrollIdentityNormalization.profile(profile) else {
+            return
+        }
+        let ids = Set(sessionIDs.compactMap(ChatScrollIdentityNormalization.sessionID))
+        guard !ids.isEmpty, var scoped = runtimeToDurable[normalizedProfile] else { return }
+        scoped = scoped.filter { runtimeID, durableID in
+            !ids.contains(runtimeID) && !ids.contains(durableID)
+        }
+        if scoped.isEmpty {
+            runtimeToDurable.removeValue(forKey: normalizedProfile)
+        } else {
+            runtimeToDurable[normalizedProfile] = scoped
+        }
+    }
+
+    /// Drops every mapping in every profile. The server-change boundary
+    /// calls this: mappings confirmed against one Hermes server must never
+    /// answer lookups against another.
+    func removeAll() {
+        runtimeToDurable.removeAll()
+    }
+}

--- a/Conduit/Services/PushNotificationService.swift
+++ b/Conduit/Services/PushNotificationService.swift
@@ -4,7 +4,16 @@ import UserNotifications
 
 struct ConduitNotificationTarget: Equatable, Identifiable {
     let profile: String?
+    /// The runtime identity the notification names. Hermes notifications
+    /// identify the live routing session; this is never treated as a durable
+    /// conversation id on its own.
     let sessionId: String
+    /// The durable conversation identity when the payload explicitly carries
+    /// one (`stored_session_id`, or Hermes-native `session_key`). Optional:
+    /// older notifier builds send routing only, and a nil value must degrade
+    /// to alias resolution — never to reinterpreting the runtime id as
+    /// durable.
+    let durableSessionID: String?
     let type: String?
     /// Structured decision content carried alongside a decision notification.
     /// Lets Conduit render an answerable card from the push payload alone when
@@ -16,11 +25,13 @@ struct ConduitNotificationTarget: Equatable, Identifiable {
     init(
         profile: String?,
         sessionId: String,
+        durableSessionID: String? = nil,
         type: String?,
         decision: PendingDecisionPayload? = nil
     ) {
         self.profile = profile
         self.sessionId = sessionId
+        self.durableSessionID = durableSessionID
         self.type = type
         self.decision = decision
     }
@@ -127,23 +138,93 @@ enum RelayTransportPolicy {
     }
 }
 
+/// MainActor-scoped like the identity index it consults; every caller
+/// (AppState routing, notification handling, tests) already runs there.
+@MainActor
 enum NotificationSessionResolver {
-    /// Hermes notifications identify a live runtime session, while
-    /// `session.resume` is keyed by the durable stored session. Catalog rows
-    /// retain both identities so a notification can be routed without asking
-    /// the gateway to resume a runtime-only key.
-    static func resumableSessionID(
-        for notificationSessionID: String,
-        in sessions: [SessionSummary]
-    ) -> String {
-        let normalizedID = notificationSessionID.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !normalizedID.isEmpty else { return normalizedID }
-        guard let session = sessions.first(where: { session in
-            session.id == normalizedID || session.alternateIds.contains(normalizedID)
-        }) else {
-            return normalizedID
+    /// How a notification's routing identity was resolved to the conversation
+    /// it opens. The basis is diagnostics vocabulary: it names the evidence
+    /// source that decided the route, never the conversation's content.
+    enum RouteBasis: Equatable {
+        /// The payload explicitly carried the durable id.
+        case explicitDurable
+        /// A live catalog row positively contains the runtime id.
+        case catalogAlias
+        /// The shared identity index holds a positively confirmed mapping.
+        case confirmedAlias
+        /// No positive durable evidence exists. The notification's own
+        /// runtime id is resumed directly — the legacy behavior, and the
+        /// only id this route may name: an unknown runtime identity is never
+        /// reinterpreted as some other conversation's durable id.
+        case legacyRuntime
+    }
+
+    struct Route: Equatable {
+        /// The id a `session.resume` should address.
+        let resumeTargetID: String
+        /// The positively established durable identity, when one exists.
+        let durableSessionID: String?
+        let basis: RouteBasis
+    }
+
+    /// Resolves a notification target to the conversation it should open.
+    ///
+    /// Priority is the evidence hierarchy: an explicit durable id outranks
+    /// everything; a live catalog row containing the runtime id is next (the
+    /// freshest positive alias evidence); the confirmed identity index
+    /// fills the gap a stale or omitted catalog leaves; and only when NO
+    /// positive durable evidence exists does the raw runtime id flow
+    /// through. There is deliberately no newest-chat, ordering, or
+    /// similarity fallback: a notification can only ever open the
+    /// conversation its payload named.
+    static func route(
+        target: ConduitNotificationTarget,
+        catalog: [SessionSummary],
+        identityIndex: ConversationIdentityIndex,
+        profile: String
+    ) -> Route {
+        let runtimeID = target.sessionId.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let durable = target.durableSessionID?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !durable.isEmpty {
+            return Route(
+                resumeTargetID: durable,
+                durableSessionID: durable,
+                basis: .explicitDurable
+            )
         }
-        return session.storedSessionId ?? session.id
+        // Catalog rows are scoped like the rest of identity resolution: an
+        // explicitly labeled foreign-profile row never routes this profile's
+        // notification (nil stays caller-scoped).
+        if let row = catalog.first(where: { row in
+            if let rowProfile = row.profile?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased(),
+               !rowProfile.isEmpty,
+               rowProfile != profile.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+                return false
+            }
+            return row.id == runtimeID || row.alternateIds.contains(runtimeID)
+        }) {
+            let durable = (row.storedSessionId ?? row.id)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return Route(
+                resumeTargetID: durable,
+                durableSessionID: durable,
+                basis: .catalogAlias
+            )
+        }
+        if let confirmed = identityIndex.durableID(forRuntime: runtimeID, profile: profile) {
+            return Route(
+                resumeTargetID: confirmed,
+                durableSessionID: confirmed,
+                basis: .confirmedAlias
+            )
+        }
+        return Route(
+            resumeTargetID: runtimeID,
+            durableSessionID: nil,
+            basis: .legacyRuntime
+        )
     }
 }
 
@@ -581,14 +662,32 @@ final class PushNotificationService: ObservableObject {
         }
         guard let sessionId = payload["session_id"] as? String,
               !sessionId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        let durableSessionID = Self.routingDurableSessionID(from: payload)
         let profile = (payload["profile"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
         let type = (payload["type"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
         return ConduitNotificationTarget(
             profile: profile?.isEmpty == false ? profile : nil,
             sessionId: sessionId,
+            durableSessionID: durableSessionID,
             type: type?.isEmpty == false ? type : nil,
             decision: pendingDecision(from: payload)
         )
+    }
+
+    /// The durable conversation id a routing payload may explicitly carry
+    /// (`stored_session_id`, or the Hermes-native `session_key` spelling).
+    /// Only a top-level routing field counts: an approval card's
+    /// `decision.session_key` is the answer key for `approval.respond`, not
+    /// this conversation's routing identity, and must not be promoted into
+    /// one. Older notifier builds send neither field; nil degrades to alias
+    /// resolution.
+    private static func routingDurableSessionID(from payload: [String: Any]) -> String? {
+        for key in ["stored_session_id", "session_key"] {
+            guard let value = payload[key] as? String else { continue }
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { return trimmed }
+        }
+        return nil
     }
 
     /// Parses the structured decision content the relay forwards alongside a

--- a/Conduit/Services/SessionPresentationCache.swift
+++ b/Conduit/Services/SessionPresentationCache.swift
@@ -299,9 +299,26 @@ final class SessionPresentationCache {
             let pendingApprovals = cached.compactMap(\.approval).filter {
                 Self.isPendingDecision($0.status)
             }
-            for approval in pendingApprovals where !merged.contains(where: {
-                $0.approval?.sessionId == approval.sessionId
-            }) {
+            // Hermes approvals are a single gate per conversation. When the
+            // gateway transcript already announces a pending approval under
+            // ANY identity of this conversation (the supplied lookup set),
+            // a promoted push card for the same gate — keyed by the durable
+            // id after routing rewrite — would render as a duplicate.
+            let suppliedIDs = Set(sessionIDs.map {
+                $0.trimmingCharacters(in: .whitespacesAndNewlines)
+            })
+            let gatewayAnnouncesPendingGate = merged.contains { message in
+                guard let approval = message.approval else { return false }
+                return Self.isPendingDecision(approval.status)
+                    && suppliedIDs.contains(
+                        approval.sessionId.trimmingCharacters(in: .whitespacesAndNewlines)
+                    )
+            }
+            for approval in pendingApprovals {
+                if gatewayAnnouncesPendingGate { break }
+                guard !merged.contains(where: {
+                    $0.approval?.sessionId == approval.sessionId
+                }) else { continue }
                 let cachedMessage = cached.last { $0.approval?.sessionId == approval.sessionId }
                 merged.append(ChatMessage(
                     id: cachedMessage?.id ?? "approval-\(approval.sessionId)",
@@ -592,21 +609,26 @@ final class SessionPresentationCache {
     /// Durable-owned persistence: once this conversation's durable identity
     /// is positively established, the durable key is its ONLY persistent
     /// presentation key. Moves the conversation's cached presentation from
-    /// its runtime-alias keys into the durable key — on establishment (no
-    /// durable record yet) the FRESHEST alias record migrates so runtime-only
-    /// history is not lost; when a durable record already exists it is the
-    /// live write and stays — then REMOVES every alias key. Retiring the
-    /// mutable runtime keys is the point: a runtime id the gateway later
-    /// re-attributes to a different conversation must not carry this
-    /// conversation's timestamps, attachments, tool metadata, or pending
-    /// decision cards with it.
+    /// its runtime-alias keys into the durable key, then REMOVES every alias
+    /// key. Retiring the mutable runtime keys is the point: a runtime id the
+    /// gateway later re-attributes to a different conversation must not
+    /// carry this conversation's timestamps, attachments, tool metadata, or
+    /// pending decision cards with it.
     ///
-    /// Migrated approval cards have their embedded `sessionId` rewritten from
-    /// a retired runtime alias to the durable id, so answering a restored
-    /// card dispatches to the durable session even after a later rotation —
-    /// never to whatever the old runtime id routes to by then. Clarify
-    /// request ids are relay-minted (`conduit-push-…`), not session ids, and
-    /// are never rewritten.
+    /// Merge semantics when the durable record already exists: the durable
+    /// record stays AUTHORITATIVE for transcript presentation — an alias
+    /// snapshot never overwrites its timestamps, tool metadata, or rows.
+    /// Only NEW pending decision content (approval/clarify/batch by stable
+    /// decision key, deduped) is promoted from alias records — the fresh
+    /// notification-delivered card must survive, the stale alias transcript
+    /// must not leak. On establishment (no durable record yet) the FRESHEST
+    /// alias record migrates whole so runtime-only history is not lost.
+    ///
+    /// Approval cards whose embedded `sessionId` names a retired runtime
+    /// alias are rewritten to the durable id, so answering a restored card
+    /// dispatches to the durable session even after later rotations.
+    /// Clarify request ids are relay-minted (`conduit-push-…`), not session
+    /// ids, and are never rewritten.
     func consolidateUnderDurableKey(
         profile: String,
         durableSessionID: String,
@@ -630,6 +652,14 @@ final class SessionPresentationCache {
                 rewriteRoutingIdentities(in: &freshest, durableSessionID: durableSessionID, runtimeAliases: runtimeAliases)
                 store[durableKey] = freshest
             }
+        } else {
+            promotePendingDecisionsFromAliases(
+                into: &store,
+                durableKey: durableKey,
+                aliasKeys: aliasKeys,
+                durableSessionID: durableSessionID,
+                runtimeAliases: runtimeAliases
+            )
         }
         var changed = store[durableKey] != nil
         for aliasKey in aliasKeys where store.removeValue(forKey: aliasKey) != nil {
@@ -645,6 +675,91 @@ final class SessionPresentationCache {
             store[durableKey] = durableSession
         }
         persist(store)
+    }
+
+    /// Promotes NEW pending decision presentation from alias records into an
+    /// existing durable record. The durable transcript rows, timestamps, and
+    /// tool metadata are never touched: only pending decisions the durable
+    /// record does not already hold (deduped by stable decision key, after
+    /// routing-identity rewrite) are appended, and the bounded
+    /// unconfirmed-expiry marker is adopted when the durable record has none.
+    private func promotePendingDecisionsFromAliases(
+        into store: inout [String: CachedSession],
+        durableKey: String,
+        aliasKeys: Set<String>,
+        durableSessionID: String,
+        runtimeAliases: [String]
+    ) {
+        guard var durableSession = store[durableKey] else { return }
+        let aliases = Set(runtimeAliases.map {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines)
+        })
+        var knownKeys = Set(durableSession.messages.compactMap(decisionKey(for:)))
+        var promoted = false
+        // The freshest unconfirmed marker among aliases that actually
+        // contributed a card. Markers from cardless aliases are ignored:
+        // adopting one could expire the just-promoted card immediately.
+        var freshestContributedMarker: Date?
+        for aliasKey in aliasKeys {
+            guard let aliasEntry = store[aliasKey] else { continue }
+            var aliasContributed = false
+            for message in aliasEntry.messages {
+                guard pendingDecisionKey(for: message) != nil else { continue }
+                var candidate = message
+                // Rewrite BEFORE dedup so a runtime-keyed card cannot
+                // duplicate a decision the durable record already holds
+                // under the durable id.
+                if let approval = candidate.approval,
+                   aliases.contains(approval.sessionId) {
+                    candidate.approval?.sessionId = durableSessionID
+                }
+                let key = decisionKey(for: candidate)
+                guard let key else { continue }
+                if let existingIndex = durableSession.messages.firstIndex(where: {
+                    decisionKey(for: $0) == key
+                }) {
+                    // Same decision already persisted. The durable row stays
+                    // authoritative unless its unconfirmed marker has
+                    // expired — a dead durable card is replaced by the fresh
+                    // alias copy rather than duplicated or silently dropped.
+                    if isUnconfirmedPendingDecisionExpired(
+                        since: durableSession.unconfirmedPendingDecisionAt
+                    ) {
+                        durableSession.messages[existingIndex] = candidate
+                        aliasContributed = true
+                    }
+                    continue
+                }
+                durableSession.messages.append(candidate)
+                knownKeys.insert(key)
+                promoted = true
+                aliasContributed = true
+            }
+            // Replacement (the duplicate branch above) counts as promotion:
+            // without it a fresh alias copy of an expired durable card would
+            // be discarded and the marker refresh skipped.
+            if aliasContributed { promoted = true }
+            guard aliasContributed,
+                  let aliasMarker = aliasEntry.unconfirmedPendingDecisionAt else { continue }
+            if freshestContributedMarker == nil || aliasMarker > freshestContributedMarker! {
+                freshestContributedMarker = aliasMarker
+            }
+        }
+        guard promoted else { return }
+        // Expiry semantics: only touch the marker when cards were promoted.
+        // Adopt the freshest contributing marker when the durable record has
+        // none, and REFRESH an expired durable marker — a stale marker would
+        // make merge strip the freshly promoted card on the next read,
+        // silently losing it after successful promotion. A live durable
+        // marker is left alone: legitimately-expired durable cards without
+        // fresh arrivals stay expired.
+        if let freshestContributedMarker,
+           durableSession.unconfirmedPendingDecisionAt == nil
+            || isUnconfirmedPendingDecisionExpired(since: durableSession.unconfirmedPendingDecisionAt) {
+            durableSession.unconfirmedPendingDecisionAt = freshestContributedMarker
+        }
+        durableSession.updatedAt = now()
+        store[durableKey] = durableSession
     }
 
     /// Points migrated approval cards at the durable session id when they

--- a/Conduit/Services/SessionPresentationCache.swift
+++ b/Conduit/Services/SessionPresentationCache.swift
@@ -566,6 +566,28 @@ final class SessionPresentationCache {
         persist(store)
     }
 
+    /// Removes the cached records for the given sessions inside `profile`,
+    /// across every identity they were written under. The delete path calls
+    /// this so a deleted conversation cannot resurrect its presentation
+    /// (including any pending decision cards) from a stale alias.
+    func removeSessions(profile: String, sessionIDs: [String]) {
+        let prefix = normalized(profile) + "|"
+        let ids = Set(sessionIDs.compactMap {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : $0
+        })
+        guard !ids.isEmpty else { return }
+        var store = load()
+        var changed = false
+        for sessionID in ids {
+            let cacheKey = prefix + sessionID.trimmingCharacters(in: .whitespacesAndNewlines)
+            if store.removeValue(forKey: cacheKey) != nil {
+                changed = true
+            }
+        }
+        guard changed else { return }
+        persist(store)
+    }
+
     private func load() -> [String: CachedSession] {
         guard let data = defaults.data(forKey: storageKey),
               let decoded = try? JSONDecoder().decode([String: CachedSession].self, from: data) else {

--- a/Conduit/Services/SessionPresentationCache.swift
+++ b/Conduit/Services/SessionPresentationCache.swift
@@ -567,9 +567,10 @@ final class SessionPresentationCache {
     }
 
     /// Removes the cached records for the given sessions inside `profile`,
-    /// across every identity they were written under. The delete path calls
-    /// this so a deleted conversation cannot resurrect its presentation
-    /// (including any pending decision cards) from a stale alias.
+    /// for exactly the keys passed (callers must pass every alias — see
+    /// `revokeDeletedConversationIdentity`). The delete path calls this so a
+    /// deleted conversation cannot resurrect its presentation (including any
+    /// pending decision cards) from a stale alias.
     func removeSessions(profile: String, sessionIDs: [String]) {
         let prefix = normalized(profile) + "|"
         let ids = Set(sessionIDs.compactMap {
@@ -586,6 +587,90 @@ final class SessionPresentationCache {
         }
         guard changed else { return }
         persist(store)
+    }
+
+    /// Durable-owned persistence: once this conversation's durable identity
+    /// is positively established, the durable key is its ONLY persistent
+    /// presentation key. Moves the conversation's cached presentation from
+    /// its runtime-alias keys into the durable key — on establishment (no
+    /// durable record yet) the FRESHEST alias record migrates so runtime-only
+    /// history is not lost; when a durable record already exists it is the
+    /// live write and stays — then REMOVES every alias key. Retiring the
+    /// mutable runtime keys is the point: a runtime id the gateway later
+    /// re-attributes to a different conversation must not carry this
+    /// conversation's timestamps, attachments, tool metadata, or pending
+    /// decision cards with it.
+    ///
+    /// Migrated approval cards have their embedded `sessionId` rewritten from
+    /// a retired runtime alias to the durable id, so answering a restored
+    /// card dispatches to the durable session even after a later rotation —
+    /// never to whatever the old runtime id routes to by then. Clarify
+    /// request ids are relay-minted (`conduit-push-…`), not session ids, and
+    /// are never rewritten.
+    func consolidateUnderDurableKey(
+        profile: String,
+        durableSessionID: String,
+        runtimeAliases: [String]
+    ) {
+        let durableKey = key(profile: profile, sessionID: durableSessionID)
+        let aliasKeys = Set(
+            runtimeAliases.map { key(profile: profile, sessionID: $0) }
+        ).subtracting([durableKey])
+        guard !aliasKeys.isEmpty else { return }
+        var store = load()
+        if store[durableKey] == nil {
+            let freshest = aliasKeys
+                .compactMap { store[$0] }
+                .max { lhs, rhs in
+                    lhs.updatedAt == rhs.updatedAt
+                        ? lhs.messages.count < rhs.messages.count
+                        : lhs.updatedAt < rhs.updatedAt
+                }
+            if var freshest {
+                rewriteRoutingIdentities(in: &freshest, durableSessionID: durableSessionID, runtimeAliases: runtimeAliases)
+                store[durableKey] = freshest
+            }
+        }
+        var changed = store[durableKey] != nil
+        for aliasKey in aliasKeys where store.removeValue(forKey: aliasKey) != nil {
+            changed = true
+        }
+        guard changed else { return }
+        if var durableSession = store[durableKey] {
+            rewriteRoutingIdentities(
+                in: &durableSession,
+                durableSessionID: durableSessionID,
+                runtimeAliases: runtimeAliases
+            )
+            store[durableKey] = durableSession
+        }
+        persist(store)
+    }
+
+    /// Points migrated approval cards at the durable session id when they
+    /// were keyed by one of the retired runtime aliases. Clarify request ids
+    /// live in a different namespace and are intentionally untouched.
+    private func rewriteRoutingIdentities(
+        in session: inout CachedSession,
+        durableSessionID: String,
+        runtimeAliases: [String]
+    ) {
+        let aliases = Set(runtimeAliases.map {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines)
+        })
+        var mutated = false
+        for index in session.messages.indices {
+            var message = session.messages[index]
+            if let approval = message.approval,
+               aliases.contains(approval.sessionId) {
+                message.approval?.sessionId = durableSessionID
+                session.messages[index] = message
+                mutated = true
+            }
+        }
+        if mutated {
+            session.updatedAt = now()
+        }
     }
 
     private func load() -> [String: CachedSession] {

--- a/Conduit/Services/SessionYoloStore.swift
+++ b/Conduit/Services/SessionYoloStore.swift
@@ -133,6 +133,16 @@ final class SessionYoloStore {
         clearOverride(for: profile, sessionIDs: [sessionID])
     }
 
+    /// Drops every override in every profile. The server-change boundary
+    /// calls this: overrides are keyed only by (profile, session id), so
+    /// without the clear, one Hermes server's choices would leak into a
+    /// different server whose profile and session strings happen to collide.
+    func clearAllOverrides() {
+        guard !payload.overrides.isEmpty else { return }
+        payload.overrides = [:]
+        persist()
+    }
+
     func clearOverride(for profile: String, sessionIDs: [String]) {
         var changed = false
         for sessionID in sessionIDs {

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -44,7 +44,12 @@ final class VoiceConversationController: ObservableObject {
     private var isVoiceSessionActive = false
     private var isAwaitingVoiceAssistant = false
     private var awaitedAssistantResponseStarted = false
-    private var expectedAssistantSessionID: String?
+    /// Every session id POSITIVELY confirmed to route this conversation's
+    /// assistant stream: the id captured at `beginVoiceTurn` plus any runtime
+    /// rebind admitted while the turn is live. Hermes events carry runtime
+    /// routing ids, so raw equality with the captured id alone would silently
+    /// drop the assistant's voice the moment a resume rebinds the runtime.
+    private var expectedAssistantSessionIDs: Set<String> = []
     private var operationGeneration: UInt64 = 0
     private var utteranceTask: Task<Void, Never>?
     private var bargeInTask: Task<Void, Never>?
@@ -88,9 +93,27 @@ final class VoiceConversationController: ObservableObject {
         isVoiceSessionActive = true
         isAwaitingVoiceAssistant = false
         awaitedAssistantResponseStarted = false
-        expectedAssistantSessionID = sessionID
+        expectedAssistantSessionIDs = [sessionID]
         conversationTranscript.removeAll(keepingCapacity: true)
         activeAssistantTranscriptEntryID = nil
+    }
+
+    /// Adds session ids an admitted resume positively rebound to this
+    /// conversation while the voice turn is live (runtime-old → runtime-new).
+    /// `ofConversationContaining` is the reconciled conversation's accepted
+    /// id set: the extension only applies when the turn's captured ids
+    /// POSITIVELY overlap it, so a reconcile belonging to a different
+    /// conversation can never inject its runtime into this turn's ownership.
+    /// Inactive sessions ignore the call: a fresh turn's capture starts from
+    /// its own id only.
+    func extendAssistantSessionIDs(
+        _ sessionIDs: Set<String>,
+        ofConversationContaining knownIDs: Set<String>
+    ) {
+        guard isVoiceSessionActive,
+              !expectedAssistantSessionIDs.isEmpty,
+              !expectedAssistantSessionIDs.isDisjoint(with: knownIDs) else { return }
+        expectedAssistantSessionIDs.formUnion(sessionIDs.filter { !$0.isEmpty })
     }
 
     func endVoiceSession() { stop() }
@@ -184,7 +207,7 @@ final class VoiceConversationController: ObservableObject {
         isVoiceSessionActive = false
         isAwaitingVoiceAssistant = false
         awaitedAssistantResponseStarted = false
-        expectedAssistantSessionID = nil
+        expectedAssistantSessionIDs = []
         state = .idle
     }
 
@@ -349,8 +372,7 @@ final class VoiceConversationController: ObservableObject {
         }
         guard isVoiceSessionActive,
               isAwaitingVoiceAssistant,
-              let expectedAssistantSessionID,
-              sessionID == expectedAssistantSessionID else { return }
+              expectedAssistantSessionIDs.contains(sessionID) else { return }
         if case .idle = state { return }
         if case .failed = state { return }
         switch event {

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -2326,6 +2326,157 @@ final class AppStateChatResumeTests: XCTestCase {
         )
     }
 
+    func testAdmittedResumeRebindsStaleIndexMappingToSelectedConversation() async {
+        // The exact split-brain repro: the index holds a historical
+        // runtime-x → stored-b mapping, the catalog temporarily omits
+        // runtime-x, and resume(stored-a) is admitted returning runtime-x
+        // with no stored id (legacy rebind). The app adopted runtime-x for
+        // stored-a — the index must agree afterwards, never keep stored-b.
+        var requests: [String] = []
+        let index = ConversationIdentityIndex()
+        index.record(
+            runtimeID: "runtime-x",
+            durableID: "stored-b",
+            profile: "default",
+            source: .resume
+        )
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [] },
+                openSession: { _, sessionID, _ in
+                    requests.append(sessionID)
+                    return SessionResumeResult(
+                        sessionId: "runtime-x",
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)])
+                    )
+                },
+                refreshContext: { _, _ in }
+            ),
+            conversationIdentityIndex: index
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+        harness.appState.activeSessionId = "stored-a"
+
+        await harness.appState.syncSession()
+
+        XCTAssertEqual(requests, ["stored-a"])
+        XCTAssertEqual(harness.appState.activeSessionId, "runtime-x")
+        XCTAssertEqual(
+            index.durableID(forRuntime: "runtime-x", profile: "default"),
+            "stored-a",
+            "After an admitted resume the index and the selected conversation must agree"
+        )
+    }
+
+    func testStaleDualIdentityNotificationIsRejectedWithoutPoisoningIndex() async {
+        // Live truth: runtime-x belongs to stored-b (authoritative registry
+        // + catalog). A stale push claims runtime-x + stored-a. The routing
+        // attempt follows the payload, resume/admission rejects the
+        // contradiction, the open fails — and the index still says runtime-x
+        // → stored-b.
+        var requests: [String] = []
+        let index = ConversationIdentityIndex()
+        index.recordAuthoritative(
+            runtimeID: "runtime-x",
+            durableID: "stored-b",
+            profile: "default",
+            source: .activeList
+        )
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [
+                    self.session("stored-b", storedID: "stored-b", alternateIDs: ["runtime-x"])
+                ] },
+                openSession: { _, sessionID, _ in
+                    requests.append(sessionID)
+                    return SessionResumeResult(
+                        sessionId: "runtime-x",
+                        storedSessionId: "stored-b",
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            ),
+            conversationIdentityIndex: index
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.connection = connection
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+
+        let opened = await harness.appState.openNotificationTarget(
+            ConduitNotificationTarget(
+                profile: nil,
+                sessionId: "runtime-x",
+                durableSessionID: "stored-a",
+                type: nil
+            )
+        )
+
+        XCTAssertFalse(opened, "The payload's stale durable claim contradicts live truth and must fail")
+        XCTAssertEqual(requests, ["stored-a"], "The attempt followed the payload's explicit durable id")
+        XCTAssertEqual(
+            index.durableID(forRuntime: "runtime-x", profile: "default"),
+            "stored-b",
+            "The rejected navigation must not poison the authoritative mapping"
+        )
+        XCTAssertEqual(
+            harness.appState.activeSessionId, "stored-a",
+            "The rejected open does not navigate to stored-b (foreign durable ownership)"
+        )
+        XCTAssertNotEqual(
+            harness.appState.activeChatScrollSessionIdentity.canonicalSessionID, "stored-b",
+            "The rejected claim must not re-home the scroll canonical onto stored-b"
+        )
+    }
+
+    func testActiveListEvidenceIsRecordedAndRemainsObservational() {
+        // The live registry feeds the index (authoritative), and unrelated
+        // rows never change the selected conversation: recording is
+        // observational only.
+        let index = ConversationIdentityIndex()
+        let harness = makeHarness(conversationIdentityIndex: index)
+        harness.appState.sessions = [self.session("kept-selected")]
+        harness.appState.activeSessionId = "kept-selected"
+
+        harness.appState.recordActiveListEvidence(
+            [
+                LiveSessionStatus(
+                    runtimeSessionId: "runtime-x",
+                    storedSessionId: "stored-a",
+                    status: "working"
+                ),
+                LiveSessionStatus(
+                    runtimeSessionId: "runtime-unrelated",
+                    storedSessionId: "stored-unrelated",
+                    status: "idle"
+                ),
+            ],
+            profile: "default"
+        )
+
+        XCTAssertEqual(index.durableID(forRuntime: "runtime-x", profile: "default"), "stored-a")
+        XCTAssertEqual(index.durableID(forRuntime: "runtime-unrelated", profile: "default"), "stored-unrelated")
+        XCTAssertEqual(
+            harness.appState.activeSessionId, "kept-selected",
+            "Registry rows must never navigate or reselect"
+        )
+        // Foreign-profile isolation at the same boundary.
+        index.recordAuthoritative(
+            runtimeID: "runtime-x",
+            durableID: "stored-work",
+            profile: "work",
+            source: .activeList
+        )
+        XCTAssertEqual(
+            index.durableID(forRuntime: "runtime-x", profile: "default"),
+            "stored-a",
+            "Another profile's registry rows cannot reattribute this profile's runtime"
+        )
+    }
+
     func testCancelledAutomaticSyncRestoresComposerStateAfterCatalogReturns() async {
         let gate = ControlledSuspension()
         let catalog = [session("stored-b"), session("stored-a")]
@@ -4847,11 +4998,13 @@ final class AppStateChatResumeTests: XCTestCase {
 
     private func session(
         _ id: String,
+        storedID: String? = nil,
         alternateIDs: [String] = [],
         profile: String = "default"
     ) -> SessionSummary {
         SessionSummary(
             id: id,
+            storedSessionId: storedID,
             alternateIds: alternateIDs,
             title: id,
             model: "Hermes",

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -2034,6 +2034,298 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertEqual(harness.appState.sessions.map(\.id), [sessionA.id, sessionC.id])
     }
 
+    func testNotificationWithExplicitDurableIdentityOpensDurableConversationWithoutCatalog() async {
+        // A payload that carries both identities must route by the durable
+        // id without needing the catalog to rediscover it — a stale or empty
+        // catalog may never block explicit identity.
+        var requests: [String] = []
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [] },
+                openSession: { _, sessionID, _ in
+                    requests.append(sessionID)
+                    return SessionResumeResult(
+                        sessionId: "runtime-a",
+                        storedSessionId: "stored-a",
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            )
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.connection = connection
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+
+        let opened = await harness.appState.openNotificationTarget(
+            ConduitNotificationTarget(
+                profile: nil,
+                sessionId: "runtime-a",
+                durableSessionID: "stored-a",
+                type: nil
+            )
+        )
+
+        XCTAssertTrue(opened)
+        XCTAssertEqual(requests, ["stored-a"], "The explicit durable id is the resume target")
+        XCTAssertEqual(harness.appState.activeSessionId, "runtime-a")
+        XCTAssertEqual(harness.appState.activeChatScrollSessionIdentity.canonicalSessionID, "stored-a")
+    }
+
+    func testRuntimeOnlyNotificationUsesConfirmedIndexAliasWhenCatalogOmitsRuntime() async {
+        // Older payload (runtime id only), and the refreshed catalog does not
+        // contain runtime-a. The confirmed runtime→durable mapping recorded
+        // by an earlier admitted resume must still route to stored-a.
+        var requests: [String] = []
+        let index = ConversationIdentityIndex()
+        index.record(
+            runtimeID: "runtime-a",
+            durableID: "stored-a",
+            profile: "default",
+            source: .resume
+        )
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [] },
+                openSession: { _, sessionID, _ in
+                    requests.append(sessionID)
+                    return SessionResumeResult(
+                        sessionId: "runtime-a",
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            ),
+            conversationIdentityIndex: index
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.connection = connection
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+
+        let opened = await harness.appState.openNotificationTarget(
+            ConduitNotificationTarget(profile: nil, sessionId: "runtime-a", type: nil)
+        )
+
+        XCTAssertTrue(opened)
+        XCTAssertEqual(requests, ["stored-a"], "The confirmed alias routes without the catalog")
+    }
+
+    func testUnknownRuntimeNotificationDoesNotReinterpretAsDurableConversation() async {
+        // A runtime id with no positive durable evidence resumes ITSELF.
+        // It must never fall through to another catalog row — there is no
+        // newest-chat, ordering, or similarity fallback in notification
+        // routing.
+        var requests: [String] = []
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [self.session("stored-z")] },
+                openSession: { _, sessionID, _ in
+                    requests.append(sessionID)
+                    return SessionResumeResult(
+                        sessionId: sessionID,
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            )
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.connection = connection
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+
+        let opened = await harness.appState.openNotificationTarget(
+            ConduitNotificationTarget(profile: nil, sessionId: "runtime-unknown", type: nil)
+        )
+
+        XCTAssertTrue(opened)
+        XCTAssertEqual(requests, ["runtime-unknown"], "Only the named id may be resumed")
+        XCTAssertEqual(harness.appState.activeSessionId, "runtime-unknown")
+    }
+
+    func testNotificationOpenCommitsAdmittedRuntimeDurableEvidenceToSharedIndex() async {
+        // After a notification open establishes the runtime→durable mapping,
+        // the shared index answers later lookups even when the catalog then
+        // omits the runtime alias.
+        let index = ConversationIdentityIndex()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [self.session("stored-a")] },
+                openSession: { _, sessionID, _ in
+                    SessionResumeResult(
+                        sessionId: "runtime-new",
+                        storedSessionId: "stored-a",
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            ),
+            conversationIdentityIndex: index
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.connection = connection
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+
+        let opened = await harness.appState.openNotificationTarget(
+            ConduitNotificationTarget(profile: nil, sessionId: "runtime-new", type: nil)
+        )
+        XCTAssertTrue(opened)
+
+        // Catalog row stored-a carries no runtime-new alias; only the
+        // admitted resume result could have established the mapping.
+        harness.appState.sessions = [self.session("stored-a")]
+        XCTAssertEqual(
+            index.durableID(forRuntime: "runtime-new", profile: "default"),
+            "stored-a",
+            "The admitted resume must commit its evidence to the shared index"
+        )
+        // A different profile must not see it.
+        XCTAssertNil(index.durableID(forRuntime: "runtime-new", profile: "work"))
+    }
+
+    func testServerChangeClearsIdentityIndexAndSessionScopedOverrides() async {
+        // Server A and server B both know profile "default" with the same
+        // session strings. Nothing confirmed against A may answer lookups
+        // after the connection moves to B.
+        let index = ConversationIdentityIndex()
+        index.record(
+            runtimeID: "runtime-a",
+            durableID: "stored-a",
+            profile: "default",
+            source: .resume
+        )
+        let yoloDefaultsSuite = "AppStateChatResumeTests.yolo.\(UUID().uuidString)"
+        guard let yoloDefaults = UserDefaults(suiteName: yoloDefaultsSuite) else {
+            XCTFail("Could not create yolo defaults suite")
+            return
+        }
+        addTeardownBlock { yoloDefaults.removePersistentDomain(forName: yoloDefaultsSuite) }
+        let yoloStore = SessionYoloStore(defaults: yoloDefaults)
+        yoloStore.setOverride(true, for: "default", sessionID: "stored-a")
+
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [self.session("stored-a", alternateIDs: ["runtime-a"])] },
+                openSession: { _, sessionID, _ in
+                    SessionResumeResult(
+                        sessionId: "runtime-a",
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            ),
+            conversationIdentityIndex: index,
+            sessionYoloStore: yoloStore
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.connection = connection
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+        harness.appState.sessions = [self.session("stored-a", alternateIDs: ["runtime-a"])]
+        harness.appState.activeSessionId = "runtime-a"
+        harness.store.setLastSessionID("stored-a", for: "default")
+        harness.defaults.set("https://a.example", forKey: "conduit.chatResumeServerIdentity.v1")
+
+        let changed = harness.appState.prepareChatResumeForConnection(to: "https://b.example")
+        XCTAssertTrue(changed)
+
+        XCTAssertNil(
+            index.durableID(forRuntime: "runtime-a", profile: "default"),
+            "Identity evidence from server A must not survive the server change"
+        )
+        XCTAssertNil(
+            yoloStore.storedOverride(for: "default", sessionID: "stored-a"),
+            "Session-scoped overrides must not leak between servers"
+        )
+        XCTAssertNil(harness.appState.activeSessionId)
+        XCTAssertNil(harness.store.lastSessionID(for: "default"))
+    }
+
+    func testDeleteRevokesIdentityIndexMappingsAndPersistedConversationState() async {
+        // Explicit deletion revokes identity: the index mapping, the scroll
+        // snapshot, the last-selected pointer, and the cached presentation
+        // (with any pending card) must all go.
+        let index = ConversationIdentityIndex()
+        index.record(
+            runtimeID: "runtime-a",
+            durableID: "stored-a",
+            profile: "default",
+            source: .resume
+        )
+        let cacheSuite = "conduit.tests.identity-delete-\(UUID().uuidString)"
+        guard let cacheDefaults = UserDefaults(suiteName: cacheSuite) else {
+            XCTFail("Could not create cache defaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: cacheDefaults)
+        defer {
+            cache.clear()
+            cacheDefaults.removePersistentDomain(forName: cacheSuite)
+        }
+        cache.recordPendingDecision(
+            ChatMessage(
+                id: "approval-stored-a",
+                role: .approval,
+                content: "Approve?",
+                timestamp: "1",
+                approval: ApprovalActivity(
+                    sessionId: "stored-a",
+                    command: "",
+                    description: "Approve?",
+                    choices: ["once", "deny"],
+                    allowPermanent: false,
+                    smartDenied: false,
+                    status: .pending,
+                    choice: nil,
+                    error: nil
+                )
+            ),
+            profile: "default",
+            sessionIDs: ["stored-a", "runtime-a"]
+        )
+        let harness = makeHarness(
+            sessionPresentationCache: cache,
+            conversationIdentityIndex: index
+        )
+        harness.coordinator.rememberSessionID("stored-a", for: "default")
+        harness.store.save(
+            ChatScrollSnapshot(anchorMessageID: "anchor", followsLatest: false),
+            for: ChatScrollSessionKey(profile: "default", sessionID: "stored-a"),
+            at: Date()
+        )
+
+        harness.appState.revokeDeletedConversationIdentity(
+            sessionIDs: ["stored-a", "runtime-a"],
+            profile: "default"
+        )
+
+        XCTAssertNil(
+            index.durableID(forRuntime: "runtime-a", profile: "default"),
+            "A deleted conversation's aliases must not route anything afterward"
+        )
+        XCTAssertNil(
+            harness.store.snapshot(for: ChatScrollSessionKey(profile: "default", sessionID: "stored-a")),
+            "The deleted conversation's scroll snapshot is removed"
+        )
+        XCTAssertNil(
+            harness.store.lastSessionID(for: "default"),
+            "The deleted conversation cannot stay the last-selected conversation"
+        )
+        let remainingCards = cache.merge(
+            [ChatMessage(id: "probe", role: .assistant, content: "Probe", timestamp: "")],
+            profile: "default",
+            sessionIDs: ["stored-a"],
+            includePendingApprovals: true
+        )
+        XCTAssertNil(
+            remainingCards.first?.approval,
+            "The deleted conversation's cached pending card is removed"
+        )
+    }
+
     func testCancelledAutomaticSyncRestoresComposerStateAfterCatalogReturns() async {
         let gate = ControlledSuspension()
         let catalog = [session("stored-b"), session("stored-a")]
@@ -4441,7 +4733,9 @@ final class AppStateChatResumeTests: XCTestCase {
         reconnectScheduler: ChatResumeReconnectScheduler? = nil,
         reconnectExecutor: ChatResumeReconnectExecutor? = nil,
         lifecycleOperations: ChatResumeLifecycleOperations = .live,
-        sessionPresentationCache: SessionPresentationCache = .shared
+        sessionPresentationCache: SessionPresentationCache = .shared,
+        conversationIdentityIndex: ConversationIdentityIndex? = nil,
+        sessionYoloStore: SessionYoloStore? = nil
     ) -> (
         appState: AppState,
         coordinator: ChatResumeCoordinator,
@@ -4473,7 +4767,9 @@ final class AppStateChatResumeTests: XCTestCase {
             reconnectScheduler: reconnectScheduler,
             reconnectExecutor: reconnectExecutor,
             chatResumeLifecycleOperations: lifecycleOperations,
-            sessionPresentationCache: sessionPresentationCache
+            sessionPresentationCache: sessionPresentationCache,
+            sessionYoloStore: sessionYoloStore,
+            conversationIdentityIndex: conversationIdentityIndex
         )
         return (appState, coordinator, store, recoverySequence, cacheClearSpy, defaults, suite)
     }

--- a/ConduitTests/AppStateChatResumeTests.swift
+++ b/ConduitTests/AppStateChatResumeTests.swift
@@ -2374,8 +2374,9 @@ final class AppStateChatResumeTests: XCTestCase {
         // Live truth: runtime-x belongs to stored-b (authoritative registry
         // + catalog). A stale push claims runtime-x + stored-a. The routing
         // attempt follows the payload, resume/admission rejects the
-        // contradiction, the open fails — and the index still says runtime-x
-        // → stored-b.
+        // contradiction, the open fails — the index still says runtime-x
+        // → stored-b, and NEITHER durable conversation's presentation cache
+        // is touched by the rejected promotion attempt.
         var requests: [String] = []
         let index = ConversationIdentityIndex()
         index.recordAuthoritative(
@@ -2384,6 +2385,24 @@ final class AppStateChatResumeTests: XCTestCase {
             profile: "default",
             source: .activeList
         )
+        let cacheSuite = "conduit.tests.promotion-rejected-\(UUID().uuidString)"
+        guard let cacheDefaults = UserDefaults(suiteName: cacheSuite) else {
+            XCTFail("Could not create cache defaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: cacheDefaults)
+        defer {
+            cache.clear()
+            cacheDefaults.removePersistentDomain(forName: cacheSuite)
+        }
+        let transcriptA = [
+            ChatMessage(id: "a-row", role: .assistant, content: "A presentation", timestamp: "a-ts")
+        ]
+        let transcriptB = [
+            ChatMessage(id: "b-row", role: .assistant, content: "B presentation", timestamp: "b-ts")
+        ]
+        cache.save(transcriptA, profile: "default", sessionIDs: ["stored-a"])
+        cache.save(transcriptB, profile: "default", sessionIDs: ["stored-b"])
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
                 loadCatalog: { _, _ in [
@@ -2400,6 +2419,7 @@ final class AppStateChatResumeTests: XCTestCase {
                 },
                 refreshContext: { _, _ in }
             ),
+            sessionPresentationCache: cache,
             conversationIdentityIndex: index
         )
         let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
@@ -2411,7 +2431,12 @@ final class AppStateChatResumeTests: XCTestCase {
                 profile: nil,
                 sessionId: "runtime-x",
                 durableSessionID: "stored-a",
-                type: nil
+                type: "approval.needed",
+                decision: .approval(
+                    sessionKey: "runtime-x",
+                    description: "Stale push approval",
+                    choices: ["once", "deny"]
+                )
             )
         )
 
@@ -2429,6 +2454,103 @@ final class AppStateChatResumeTests: XCTestCase {
         XCTAssertNotEqual(
             harness.appState.activeChatScrollSessionIdentity.canonicalSessionID, "stored-b",
             "The rejected claim must not re-home the scroll canonical onto stored-b"
+        )
+        // Neither durable conversation inherited anything from the rejected
+        // promotion attempt: stored-a's and stored-b's cached presentation
+        // are exactly what they were, with no pending card injected.
+        XCTAssertTrue(
+            cache.merge(transcriptA, profile: "default", sessionIDs: ["stored-a"], includePendingApprovals: true)
+                .filter { $0.role == .approval }.isEmpty,
+            "The claimed durable (stored-a) must not gain the rejected card"
+        )
+        XCTAssertEqual(
+            cache.merge(transcriptB, profile: "default", sessionIDs: ["stored-b"], includePendingApprovals: true)
+                .first?.timestamp,
+            "b-ts",
+            "stored-b's durable presentation is unchanged"
+        )
+        XCTAssertTrue(
+            cache.storedPendingDecisionKeys(profile: "default", sessionIDs: ["stored-a", "stored-b"]).isEmpty,
+            "No pending decision from the rejected push lives under either durable key"
+        )
+    }
+
+    func testRejectedPushResidueCannotPromoteIntoTrueOwnerOnLaterOpen() async {
+        // The rejection-eviction invariant, extended: the rejected push's
+        // card was pre-recorded under runtime-x. A LATER legitimate open of
+        // stored-b (runtime-x's true owner) must not promote that stale card
+        // into stored-b — the rejection evicted it.
+        let index = ConversationIdentityIndex()
+        index.recordAuthoritative(
+            runtimeID: "runtime-x",
+            durableID: "stored-b",
+            profile: "default",
+            source: .activeList
+        )
+        let cacheSuite = "conduit.tests.promotion-eviction-\(UUID().uuidString)"
+        guard let cacheDefaults = UserDefaults(suiteName: cacheSuite) else {
+            XCTFail("Could not create cache defaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: cacheDefaults)
+        defer {
+            cache.clear()
+            cacheDefaults.removePersistentDomain(forName: cacheSuite)
+        }
+        cache.save(
+            [ChatMessage(id: "b-row", role: .assistant, content: "B transcript", timestamp: "b-ts")],
+            profile: "default",
+            sessionIDs: ["stored-b"]
+        )
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [
+                    self.session("stored-b", storedID: "stored-b", alternateIDs: ["runtime-x"])
+                ] },
+                openSession: { _, sessionID, _ in
+                    SessionResumeResult(
+                        sessionId: "runtime-x",
+                        storedSessionId: "stored-b",
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            ),
+            sessionPresentationCache: cache,
+            conversationIdentityIndex: index
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.connection = connection
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+
+        // 1. The stale push is rejected by identity admission.
+        let opened = await harness.appState.openNotificationTarget(
+            ConduitNotificationTarget(
+                profile: nil,
+                sessionId: "runtime-x",
+                durableSessionID: "stored-a",
+                type: "approval.needed",
+                decision: .approval(
+                    sessionKey: "runtime-x",
+                    description: "Stale push approval",
+                    choices: ["once", "deny"]
+                )
+            )
+        )
+        XCTAssertFalse(opened)
+
+        // 2. A later legitimate open of the true owner (stored-b) must not
+        // surface the rejected card.
+        let openedOwner = await harness.appState.openSession("stored-b")
+        XCTAssertTrue(openedOwner)
+        XCTAssertTrue(
+            harness.appState.messages.filter { $0.role == .approval }.isEmpty,
+            "The rejected push's card must not surface in the true owner's transcript"
+        )
+        XCTAssertTrue(
+            cache.storedPendingDecisionKeys(profile: "default", sessionIDs: ["stored-b"]).isEmpty,
+            "And it must not have been promoted into stored-b's durable cache"
         )
     }
 
@@ -2474,6 +2596,173 @@ final class AppStateChatResumeTests: XCTestCase {
             index.durableID(forRuntime: "runtime-x", profile: "default"),
             "stored-a",
             "Another profile's registry rows cannot reattribute this profile's runtime"
+        )
+    }
+
+    func testConfirmedAliasNotificationDecisionSurvivesRotatedRuntimePromotion() async {
+        // The promotion case: a confirmedAlias notification carries a pending
+        // approval under runtime-old; the resume of stored-a is admitted and
+        // returns a ROTATED runtime (runtime-new) that was never in the
+        // accepted set. The pre-open card (cached under runtime-old) must be
+        // promoted into the durable conversation and answer there, the
+        // runtime keys must be retired, and the index must keep both runtimes
+        // pointing at stored-a.
+        let index = ConversationIdentityIndex()
+        index.record(
+            runtimeID: "runtime-old",
+            durableID: "stored-a",
+            profile: "default",
+            source: .resume
+        )
+        let cacheSuite = "conduit.tests.promotion-rotated-\(UUID().uuidString)"
+        guard let cacheDefaults = UserDefaults(suiteName: cacheSuite) else {
+            XCTFail("Could not create cache defaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: cacheDefaults)
+        defer {
+            cache.clear()
+            cacheDefaults.removePersistentDomain(forName: cacheSuite)
+        }
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [] },
+                openSession: { _, sessionID, _ in
+                    SessionResumeResult(
+                        sessionId: "runtime-new",
+                        storedSessionId: "stored-a",
+                        messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            ),
+            sessionPresentationCache: cache,
+            conversationIdentityIndex: index
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.connection = connection
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+
+        let opened = await harness.appState.openNotificationTarget(
+            ConduitNotificationTarget(
+                profile: nil,
+                sessionId: "runtime-old",
+                type: "approval.needed",
+                decision: .approval(
+                    sessionKey: "runtime-old",
+                    description: "Push approval",
+                    choices: ["once", "deny"]
+                )
+            )
+        )
+
+        XCTAssertTrue(opened)
+        let card = harness.appState.messages.first { $0.role == .approval }
+        XCTAssertEqual(card?.approval?.description, "Push approval", "The push card is restored into the transcript")
+        XCTAssertEqual(
+            card?.approval?.sessionId, "stored-a",
+            "The promoted card answers against the durable session"
+        )
+        XCTAssertEqual(
+            harness.appState.activeSessionId, "runtime-new",
+            "The admitted rotated runtime is the live selection"
+        )
+        // Durable cache: the card lives under stored-a; neither runtime key
+        // remains an independent presentation owner.
+        XCTAssertEqual(
+            cache.storedPendingDecisionKeys(profile: "default", sessionIDs: ["stored-a"]),
+            ["approval:stored-a"]
+        )
+        XCTAssertTrue(cache.storedPendingDecisionKeys(profile: "default", sessionIDs: ["runtime-old"]).isEmpty)
+        XCTAssertTrue(cache.storedPendingDecisionKeys(profile: "default", sessionIDs: ["runtime-new"]).isEmpty)
+        // Identity: both runtimes belong to stored-a.
+        XCTAssertEqual(index.durableID(forRuntime: "runtime-old", profile: "default"), "stored-a")
+        XCTAssertEqual(index.durableID(forRuntime: "runtime-new", profile: "default"), "stored-a")
+    }
+
+    func testExistingDurableCacheGainsNotificationApprovalUnderDurableKey() async {
+        // The durable record already holds presentation when the
+        // notification arrives. The open must keep the existing durable
+        // presentation, promote the fresh pending approval into the durable
+        // key, route it to stored-a, retire the runtime key, and never
+        // duplicate the card.
+        let cacheSuite = "conduit.tests.promotion-existing-\(UUID().uuidString)"
+        guard let cacheDefaults = UserDefaults(suiteName: cacheSuite) else {
+            XCTFail("Could not create cache defaults suite")
+            return
+        }
+        let cache = SessionPresentationCache(defaults: cacheDefaults)
+        defer {
+            cache.clear()
+            cacheDefaults.removePersistentDomain(forName: cacheSuite)
+        }
+        let durableTranscript = [
+            ChatMessage(id: "d1", role: .assistant, content: "Existing durable row", timestamp: "durable-ts")
+        ]
+        cache.save(durableTranscript, profile: "default", sessionIDs: ["stored-a"])
+        let index = ConversationIdentityIndex()
+        index.record(
+            runtimeID: "runtime-x",
+            durableID: "stored-a",
+            profile: "default",
+            source: .resume
+        )
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                loadCatalog: { _, _ in [] },
+                openSession: { _, sessionID, _ in
+                    // A real resume of stored-a returns the conversation's
+                    // own rows (Hermes compact shape: no cached timestamps).
+                    SessionResumeResult(
+                        sessionId: "runtime-x",
+                        storedSessionId: "stored-a",
+                        messages: [
+                            ChatMessage(id: "d1", role: .assistant, content: "Existing durable row", timestamp: "")
+                        ],
+                        snapshot: SessionRuntimeSnapshot(object: [:])
+                    )
+                },
+                refreshContext: { _, _ in }
+            ),
+            sessionPresentationCache: cache,
+            conversationIdentityIndex: index
+        )
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        harness.appState.connection = connection
+        harness.appState.client = HermesClient(connection: connection, profile: "default")
+
+        let opened = await harness.appState.openNotificationTarget(
+            ConduitNotificationTarget(
+                profile: nil,
+                sessionId: "runtime-x",
+                type: "approval.needed",
+                decision: .approval(
+                    sessionKey: "runtime-x",
+                    description: "Newest approval",
+                    choices: ["once", "deny"]
+                )
+            )
+        )
+
+        XCTAssertTrue(opened)
+        // Existing durable presentation survives: the resumed row is
+        // enriched from the durable key (had consolidation dropped or
+        // replaced it, the timestamp would be lost).
+        XCTAssertEqual(
+            harness.appState.messages.first(where: { $0.id == "d1" })?.timestamp, "durable-ts",
+            "Existing durable presentation survives the promotion"
+        )
+        let cards = harness.appState.messages.filter { $0.role == .approval }
+        XCTAssertEqual(cards.count, 1, "Exactly one pending card")
+        XCTAssertEqual(cards.first?.approval?.sessionId, "stored-a", "The card routes to the durable session")
+        XCTAssertEqual(
+            cache.storedPendingDecisionKeys(profile: "default", sessionIDs: ["stored-a"]),
+            ["approval:stored-a"]
+        )
+        XCTAssertTrue(
+            cache.storedPendingDecisionKeys(profile: "default", sessionIDs: ["runtime-x"]).isEmpty,
+            "The runtime-x cache key is retired"
         )
     }
 

--- a/ConduitTests/ChatResumeCoordinatorTests.swift
+++ b/ConduitTests/ChatResumeCoordinatorTests.swift
@@ -341,6 +341,107 @@ final class ChatResumeCoordinatorTests: XCTestCase {
         XCTAssertEqual(harness.store.snapshot(for: wrongKey), .latest)
     }
 
+    func testDeletingStagedConversationBeforePublicationPreventsRestoration() {
+        // Automatic return stages B (pendingSessionKey, viewport frozen).
+        // Deleting B must invalidate the staged work: settling afterwards can
+        // publish nothing for B, the viewport is not stuck frozen, and B's
+        // persisted state is gone while unrelated state survives.
+        let harness = makeHarness()
+        let keyB = ChatScrollSessionKey(profile: "default", sessionID: "stored-b")
+        let keyOther = ChatScrollSessionKey(profile: "default", sessionID: "other")
+        let reading = ChatScrollSnapshot(anchorMessageID: "anchor-b", followsLatest: false)
+        harness.store.save(reading, for: keyB, at: Date())
+        harness.store.setLastSessionID("stored-b", for: "default")
+        harness.store.setLastSessionID("other", for: "work")
+
+        _ = harness.coordinator.selectTarget(
+            in: [session("stored-a"), session("stored-b")],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: "stored-b"
+        )
+        XCTAssertNil(harness.coordinator.pendingRestoration)
+        // The staged key freezes recording.
+        harness.coordinator.recordViewport(.latest, for: keyOther)
+        XCTAssertNil(harness.store.snapshot(for: keyOther))
+
+        harness.coordinator.removeSessions(profile: "default", sessionIDs: ["stored-b"])
+
+        XCTAssertNil(harness.store.snapshot(for: keyB))
+        XCTAssertNil(harness.store.lastSessionID(for: "default"))
+        XCTAssertEqual(
+            harness.store.lastSessionID(for: "work"),
+            "other",
+            "Deletion is scoped: another profile's pointer survives"
+        )
+        // Settling the (now-deleted) conversation can produce no restoration.
+        XCTAssertNil(harness.coordinator.reconciliationSettled(sessionKey: keyB))
+        // The viewport must not be left permanently frozen.
+        harness.coordinator.recordViewport(.latest, for: keyOther)
+        XCTAssertEqual(harness.store.snapshot(for: keyOther), .latest)
+    }
+
+    func testDeletingPublishedConversationInvalidatesItsRestorationRequest() throws {
+        // After a restoration request for B is published, deleting B must
+        // invalidate it: the stale generation is no longer current, and
+        // completion/abandon of that generation cannot resurrect it.
+        let harness = makeHarness()
+        let keyB = ChatScrollSessionKey(profile: "default", sessionID: "stored-b")
+        let reading = ChatScrollSnapshot(anchorMessageID: "anchor-b", followsLatest: false)
+        harness.store.save(reading, for: keyB, at: Date())
+        harness.store.setLastSessionID("stored-b", for: "default")
+
+        _ = harness.coordinator.selectTarget(
+            in: [session("stored-b")],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: "stored-b"
+        )
+        let request = try XCTUnwrap(harness.coordinator.reconciliationSettled(sessionKey: keyB))
+
+        harness.coordinator.removeSessions(profile: "default", sessionIDs: ["stored-b"])
+
+        XCTAssertFalse(
+            harness.coordinator.isCurrent(generation: request.generation),
+            "The deleted conversation's published restoration is no longer current"
+        )
+        harness.coordinator.completeRestoration(generation: request.generation)
+        harness.coordinator.abandonRestoration(generation: request.generation)
+        XCTAssertNil(
+            harness.coordinator.pendingRestoration,
+            "A stale generation cannot resurrect the deleted request"
+        )
+        // Viewport recording works again for the surviving conversation.
+        let keyOther = ChatScrollSessionKey(profile: "default", sessionID: "other")
+        harness.coordinator.recordViewport(.latest, for: keyOther)
+        XCTAssertEqual(harness.store.snapshot(for: keyOther), .latest)
+    }
+
+    func testDeletingUnrelatedConversationKeepsPendingRestoration() throws {
+        // Deleting A while restoration B is staged+published leaves B's
+        // pending work — and B's persisted state — fully intact.
+        let harness = makeHarness()
+        let keyA = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        let keyB = ChatScrollSessionKey(profile: "default", sessionID: "stored-b")
+        let readingB = ChatScrollSnapshot(anchorMessageID: "anchor-b", followsLatest: false)
+        harness.store.save(readingB, for: keyB, at: Date())
+        harness.store.setLastSessionID("stored-b", for: "default")
+
+        _ = harness.coordinator.selectTarget(
+            in: [session("stored-a"), session("stored-b")],
+            profile: "default",
+            purpose: .automaticReturn,
+            currentSessionID: "stored-b"
+        )
+        let request = try XCTUnwrap(harness.coordinator.reconciliationSettled(sessionKey: keyB))
+
+        harness.coordinator.removeSessions(profile: "default", sessionIDs: ["stored-a"])
+
+        XCTAssertTrue(harness.coordinator.isCurrent(generation: request.generation))
+        XCTAssertNotNil(harness.coordinator.pendingRestoration)
+        XCTAssertEqual(harness.store.snapshot(for: keyB), readingB)
+    }
+
     private func makeHarness() -> (
         coordinator: ChatResumeCoordinator,
         store: ChatResumeStore,

--- a/ConduitTests/ChatResumeStoreTests.swift
+++ b/ConduitTests/ChatResumeStoreTests.swift
@@ -106,6 +106,41 @@ final class ChatResumeStoreTests: XCTestCase {
         XCTAssertNil(store.snapshot(for: .init(profile: "default", sessionID: "stored-a")))
     }
 
+    func testRemoveSessionsDropsSnapshotsAndLastSelectionWithoutTouchingSiblings() throws {
+        let (defaults, suite) = try defaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = ChatResumeStore(defaults: defaults)
+        let deletedKey = ChatScrollSessionKey(profile: "default", sessionID: "stored-a")
+        let siblingKey = ChatScrollSessionKey(profile: "default", sessionID: "stored-b")
+        let otherProfileKey = ChatScrollSessionKey(profile: "work", sessionID: "stored-a")
+        store.save(
+            ChatScrollSnapshot(anchorMessageID: "deleted-anchor", followsLatest: false),
+            for: deletedKey,
+            at: Date()
+        )
+        store.save(
+            ChatScrollSnapshot(anchorMessageID: "sibling-anchor", followsLatest: false),
+            for: siblingKey,
+            at: Date()
+        )
+        store.save(
+            ChatScrollSnapshot(anchorMessageID: "other-profile-anchor", followsLatest: false),
+            for: otherProfileKey,
+            at: Date()
+        )
+        store.setLastSessionID("stored-a", for: "default")
+
+        store.removeSessions(profile: "default", sessionIDs: ["stored-a", "runtime-a"])
+
+        XCTAssertNil(store.snapshot(for: deletedKey))
+        XCTAssertNil(store.lastSessionID(for: "default"), "The deleted conversation cannot stay last-selected")
+        XCTAssertNotNil(store.snapshot(for: siblingKey))
+        XCTAssertNotNil(
+            store.snapshot(for: otherProfileKey),
+            "Deletion is profile-scoped; another profile's same-named session survives"
+        )
+    }
+
     func testSnapshotMigratesFromRuntimeToCanonicalKey() throws {
         let (defaults, suite) = try defaults()
         defer { defaults.removePersistentDomain(forName: suite) }

--- a/ConduitTests/ConversationIdentityIndexTests.swift
+++ b/ConduitTests/ConversationIdentityIndexTests.swift
@@ -103,6 +103,93 @@ final class ConversationIdentityIndexTests: XCTestCase {
         XCTAssertEqual(index.durableID(forRuntime: "runtime-x", profile: "default"), "stored-a")
     }
 
+    func testAuthoritativeRecordEstablishesNewMapping() {
+        let index = ConversationIdentityIndex()
+        XCTAssertNil(index.recordAuthoritative(
+            runtimeID: "runtime-x",
+            durableID: "stored-a",
+            profile: "default",
+            source: .activeList
+        ))
+        XCTAssertEqual(index.durableID(forRuntime: "runtime-x", profile: "default"), "stored-a")
+    }
+
+    func testAuthoritativeRecordRebindsStaleConfirmedMapping() {
+        // The exact split-brain case: the index holds a historical
+        // runtime-x → stored-B mapping, but the app just ADMITTED a resume
+        // proving runtime-x now routes to stored-A. Keeping the old mapping
+        // would leave the selected conversation and the index disagreeing,
+        // so the authoritative rebind wins and the displaced mapping is
+        // returned for diagnostics.
+        let index = ConversationIdentityIndex()
+        index.record(
+            runtimeID: "runtime-x",
+            durableID: "stored-b",
+            profile: "default",
+            source: .resume
+        )
+        let conflict = index.recordAuthoritative(
+            runtimeID: "runtime-x",
+            durableID: "stored-a",
+            profile: "default",
+            source: .resume
+        )
+        XCTAssertEqual(
+            conflict,
+            ConversationIdentityIndex.IdentityConflict(
+                runtimeID: "runtime-x",
+                confirmedDurableID: "stored-b",
+                incomingDurableID: "stored-a",
+                source: .resume
+            )
+        )
+        XCTAssertEqual(
+            index.durableID(forRuntime: "runtime-x", profile: "default"),
+            "stored-a",
+            "The app accepted the resume into conversation-owned state; the index must agree"
+        )
+    }
+
+    func testNotificationEvidenceCannotOverwriteAuthoritativeMapping() {
+        // A stale dual-ID push payload must not poison a fresher
+        // authoritative mapping: navigation may attempt the payload's claim,
+        // but the index keeps the live-registry truth.
+        let index = ConversationIdentityIndex()
+        index.recordAuthoritative(
+            runtimeID: "runtime-x",
+            durableID: "stored-b",
+            profile: "default",
+            source: .activeList
+        )
+        let conflict = index.record(
+            runtimeID: "runtime-x",
+            durableID: "stored-a",
+            profile: "default",
+            source: .notification
+        )
+        XCTAssertNotNil(conflict)
+        XCTAssertEqual(index.durableID(forRuntime: "runtime-x", profile: "default"), "stored-b")
+    }
+
+    func testActiveListRowsRebindLikeCatalogTruth() {
+        // session.active_list is the live registry: its re-attribution has
+        // the same authority as a catalog refresh.
+        let index = ConversationIdentityIndex()
+        index.record(
+            runtimeID: "runtime-x",
+            durableID: "stored-a",
+            profile: "default",
+            source: .resume
+        )
+        index.recordAuthoritative(
+            runtimeID: "runtime-x",
+            durableID: "stored-b",
+            profile: "default",
+            source: .activeList
+        )
+        XCTAssertEqual(index.durableID(forRuntime: "runtime-x", profile: "default"), "stored-b")
+    }
+
     func testCatalogReattributionOverwritesStaleConfirmedMapping() {
         // The live registry is the freshest authority on what a runtime id
         // routes to; the row's new stored id is a routing identity change.

--- a/ConduitTests/ConversationIdentityIndexTests.swift
+++ b/ConduitTests/ConversationIdentityIndexTests.swift
@@ -1,0 +1,237 @@
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class ConversationIdentityIndexTests: XCTestCase {
+    func testRecordAndLookupRoundTrip() {
+        let index = ConversationIdentityIndex()
+        index.record(
+            runtimeID: "runtime-a",
+            durableID: "stored-a",
+            profile: "default",
+            source: .resume
+        )
+        XCTAssertEqual(index.durableID(forRuntime: "runtime-a", profile: "default"), "stored-a")
+    }
+
+    func testSelfMappingCarriesNoInformation() {
+        let index = ConversationIdentityIndex()
+        index.record(
+            runtimeID: "same",
+            durableID: "same",
+            profile: "default",
+            source: .create
+        )
+        XCTAssertNil(
+            index.durableID(forRuntime: "same", profile: "default"),
+            "A runtime id equal to its durable id needs no index entry"
+        )
+    }
+
+    func testLookupNormalizesWhitespace() {
+        let index = ConversationIdentityIndex()
+        index.record(
+            runtimeID: "  runtime-a  ",
+            durableID: " stored-a ",
+            profile: " default ",
+            source: .resume
+        )
+        XCTAssertEqual(index.durableID(forRuntime: "runtime-a", profile: "default"), "stored-a")
+    }
+
+    func testMappingsAreProfileScoped() {
+        let index = ConversationIdentityIndex()
+        index.record(
+            runtimeID: "runtime-shared",
+            durableID: "stored-in-default",
+            profile: "default",
+            source: .resume
+        )
+        XCTAssertNil(
+            index.durableID(forRuntime: "runtime-shared", profile: "work"),
+            "A runtime id from one profile must never establish ownership in another"
+        )
+        XCTAssertEqual(index.durableID(forRuntime: "runtime-shared", profile: "default"), "stored-in-default")
+    }
+
+    func testConflictingEvidenceKeepsConfirmedMappingAndReportsConflict() {
+        let index = ConversationIdentityIndex()
+        index.record(
+            runtimeID: "runtime-x",
+            durableID: "stored-a",
+            profile: "default",
+            source: .resume
+        )
+        let conflict = index.record(
+            runtimeID: "runtime-x",
+            durableID: "stored-b",
+            profile: "default",
+            source: .notification
+        )
+
+        XCTAssertEqual(
+            conflict,
+            ConversationIdentityIndex.IdentityConflict(
+                runtimeID: "runtime-x",
+                confirmedDurableID: "stored-a",
+                incomingDurableID: "stored-b",
+                source: .notification
+            ),
+            "A disagreeing positive claim is surfaced, never silently unioned"
+        )
+        XCTAssertEqual(
+            index.durableID(forRuntime: "runtime-x", profile: "default"),
+            "stored-a",
+            "The confirmed mapping stands until the authoritative catalog changes it"
+        )
+    }
+
+    func testIdenticalEvidenceIsNotAConflict() {
+        let index = ConversationIdentityIndex()
+        index.record(
+            runtimeID: "runtime-x",
+            durableID: "stored-a",
+            profile: "default",
+            source: .resume
+        )
+        XCTAssertNil(index.record(
+            runtimeID: "runtime-x",
+            durableID: "stored-a",
+            profile: "default",
+            source: .catalog
+        ))
+        XCTAssertEqual(index.durableID(forRuntime: "runtime-x", profile: "default"), "stored-a")
+    }
+
+    func testCatalogReattributionOverwritesStaleConfirmedMapping() {
+        // The live registry is the freshest authority on what a runtime id
+        // routes to; the row's new stored id is a routing identity change.
+        let index = ConversationIdentityIndex()
+        index.record(
+            runtimeID: "runtime-x",
+            durableID: "stored-a",
+            profile: "default",
+            source: .resume
+        )
+        index.recordCatalogIdentity(
+            [makeSummary(id: "stored-b", stored: "stored-b", alternateIDs: ["runtime-x"])],
+            profile: "default"
+        )
+        XCTAssertEqual(
+            index.durableID(forRuntime: "runtime-x", profile: "default"),
+            "stored-b"
+        )
+    }
+
+    func testCatalogEvidenceRecordsEveryLabeledRowAlias() {
+        let index = ConversationIdentityIndex()
+        index.recordCatalogIdentity(
+            [
+                makeSummary(id: "runtime-1", stored: "stored-1", alternateIDs: ["runtime-1b"]),
+                makeSummary(id: "legacy-row", stored: nil, alternateIDs: ["legacy-alt"])
+            ],
+            profile: "default"
+        )
+        XCTAssertEqual(index.durableID(forRuntime: "runtime-1", profile: "default"), "stored-1")
+        XCTAssertEqual(index.durableID(forRuntime: "runtime-1b", profile: "default"), "stored-1")
+        XCTAssertNil(
+            index.durableID(forRuntime: "legacy-row", profile: "default"),
+            "An unlabeled row's primary id is already its durable identity; the self-mapping is information-free"
+        )
+        XCTAssertNil(index.durableID(forRuntime: "legacy-alt", profile: "default"))
+    }
+
+    func testRemoveSessionIDsDropsMappingsByRuntimeOrDurable() {
+        let index = ConversationIdentityIndex()
+        index.record(runtimeID: "runtime-a", durableID: "stored-a", profile: "default", source: .resume)
+        index.record(runtimeID: "runtime-a2", durableID: "stored-a", profile: "default", source: .resume)
+        index.record(runtimeID: "runtime-b", durableID: "stored-b", profile: "default", source: .resume)
+
+        index.removeSessionIDs(["stored-a"], profile: "default")
+        XCTAssertNil(index.durableID(forRuntime: "runtime-a", profile: "default"))
+        XCTAssertNil(index.durableID(forRuntime: "runtime-a2", profile: "default"))
+        XCTAssertEqual(index.durableID(forRuntime: "runtime-b", profile: "default"), "stored-b")
+
+        index.removeSessionIDs(["runtime-b"], profile: "default")
+        XCTAssertNil(index.durableID(forRuntime: "runtime-b", profile: "default"))
+    }
+
+    func testRemoveSessionIDsIsProfileScoped() {
+        let index = ConversationIdentityIndex()
+        index.record(runtimeID: "runtime-a", durableID: "stored-a", profile: "default", source: .resume)
+        index.record(runtimeID: "runtime-a", durableID: "stored-work", profile: "work", source: .resume)
+
+        index.removeSessionIDs(["stored-a"], profile: "default")
+        XCTAssertEqual(
+            index.durableID(forRuntime: "runtime-a", profile: "work"),
+            "stored-work",
+            "Deletion in one profile must not revoke another profile's identity"
+        )
+    }
+
+    func testRemoveAllDropsEveryProfile() {
+        let index = ConversationIdentityIndex()
+        index.record(runtimeID: "runtime-a", durableID: "stored-a", profile: "default", source: .resume)
+        index.record(runtimeID: "runtime-b", durableID: "stored-b", profile: "work", source: .catalog)
+
+        index.removeAll()
+        XCTAssertNil(index.durableID(forRuntime: "runtime-a", profile: "default"))
+        XCTAssertNil(index.durableID(forRuntime: "runtime-b", profile: "work"))
+    }
+
+    func testCatalogFirstRowWinsWithinOneSnapshotOverStaleMergedRow() {
+        // The committed catalog can contain cached rows merged after fresh
+        // ones, and routing reads the same order with `first(where:)` — so
+        // the index must not pin a later stale row's re-attribution.
+        let index = ConversationIdentityIndex()
+        index.recordCatalogIdentity(
+            [
+                makeSummary(id: "stored-fresh", stored: "stored-fresh", alternateIDs: ["runtime-x"]),
+                makeSummary(id: "stale-cache", stored: "stale-cache", alternateIDs: ["runtime-x"])
+            ],
+            profile: "default"
+        )
+        XCTAssertEqual(
+            index.durableID(forRuntime: "runtime-x", profile: "default"),
+            "stored-fresh",
+            "The first (freshest) row in one snapshot decides, mirroring the resolver"
+        )
+    }
+
+    func testCatalogSkipsRowsLabeledForAnotherProfile() {
+        let index = ConversationIdentityIndex()
+        index.recordCatalogIdentity(
+            [
+                makeSummary(id: "work-row", stored: "work-durable", alternateIDs: ["runtime-w"], profile: "work"),
+                makeSummary(id: "default-row", stored: "default-durable", alternateIDs: ["runtime-d"], profile: nil)
+            ],
+            profile: "default"
+        )
+        XCTAssertNil(
+            index.durableID(forRuntime: "runtime-w", profile: "default"),
+            "A foreign-profile row must not commit into this profile's scope"
+        )
+        XCTAssertEqual(index.durableID(forRuntime: "runtime-d", profile: "default"), "default-durable")
+    }
+
+    private func makeSummary(
+        id: String,
+        stored: String?,
+        alternateIDs: [String],
+        profile: String? = "default"
+    ) -> SessionSummary {
+        SessionSummary(
+            id: id,
+            storedSessionId: stored,
+            alternateIds: alternateIDs,
+            title: id,
+            model: "Hermes",
+            updatedLabel: "now",
+            profile: profile,
+            source: .chat,
+            isActive: false,
+            isArchived: false,
+            lineageRootId: nil
+        )
+    }
+}

--- a/ConduitTests/MessageNormalizerTests.swift
+++ b/ConduitTests/MessageNormalizerTests.swift
@@ -135,15 +135,34 @@ final class MessageNormalizerTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            NotificationSessionResolver.resumableSessionID(for: "runtime-123", in: [session]),
-            "stored-123"
+            NotificationSessionResolver.route(
+                target: ConduitNotificationTarget(profile: nil, sessionId: "runtime-123", type: nil),
+                catalog: [session],
+                identityIndex: ConversationIdentityIndex(),
+                profile: "default"
+            ),
+            NotificationSessionResolver.Route(
+                resumeTargetID: "stored-123",
+                durableSessionID: "stored-123",
+                basis: .catalogAlias
+            )
         )
     }
 
     func testNotificationResolverTrimsUnknownRuntimeID() {
         XCTAssertEqual(
-            NotificationSessionResolver.resumableSessionID(for: "  runtime-123  ", in: []),
-            "runtime-123"
+            NotificationSessionResolver.route(
+                target: ConduitNotificationTarget(profile: nil, sessionId: "  runtime-123  ", type: nil),
+                catalog: [],
+                identityIndex: ConversationIdentityIndex(),
+                profile: "default"
+            ),
+            NotificationSessionResolver.Route(
+                resumeTargetID: "runtime-123",
+                durableSessionID: nil,
+                basis: .legacyRuntime
+            ),
+            "An unknown runtime id flows through as itself — never reinterpreted as a durable id"
         )
     }
 

--- a/ConduitTests/SessionIdentityContractTests.swift
+++ b/ConduitTests/SessionIdentityContractTests.swift
@@ -520,4 +520,37 @@ final class SessionIdentityContractTests: XCTestCase {
             identity: identity
         ))
     }
+
+    // MARK: - Durable-owned presentation writes
+
+    func testPresentationWritesCollapseToDurableKeyOnceEstablished() {
+        // With no durable id (runtime-only conversation), the supplied
+        // runtime keys pass through: temporary runtime ownership is allowed.
+        XCTAssertEqual(
+            AppState.durableOwnedPresentationIDs(["runtime-x"], durableSessionID: nil),
+            ["runtime-x"]
+        )
+        // Once the durable id is established, it is the ONLY persisted key —
+        // whether or not the alias list already contained it. A write must
+        // never recreate a runtime-keyed copy that consolidation retired.
+        XCTAssertEqual(
+            AppState.durableOwnedPresentationIDs(
+                ["runtime-new", "stored-a"],
+                durableSessionID: "stored-a"
+            ),
+            ["stored-a"]
+        )
+        XCTAssertEqual(
+            AppState.durableOwnedPresentationIDs(
+                ["runtime-new"],
+                durableSessionID: "stored-a"
+            ),
+            ["stored-a"]
+        )
+        // Empty/whitespace ids collapse to the durable key alone.
+        XCTAssertEqual(
+            AppState.durableOwnedPresentationIDs(["", "  "], durableSessionID: "stored-a"),
+            ["stored-a"]
+        )
+    }
 }

--- a/ConduitTests/SessionIdentityContractTests.swift
+++ b/ConduitTests/SessionIdentityContractTests.swift
@@ -1,0 +1,523 @@
+import XCTest
+@testable import Conduit
+
+/// Architectural contract suite for conversation identity: the invariants
+/// that must hold ACROSS the shared identity components
+/// (`ConversationIdentity`, `ConversationIdentityGate`,
+/// `ConversationIdentityIndex`, `NotificationSessionResolver`) and the
+/// entry points that consume them.
+///
+/// Feature-specific behavior keeps its own suites (ChatResumePolicyTests,
+/// AppStateForegroundLifecycleTests, CompactResumeTranscriptTests, the
+/// AppStateChatResumeTests matrix). This suite pins the identity contract
+/// itself:
+///
+///     There is one consistent definition of conversation identity
+///     throughout Conduit.
+///
+/// - A runtime id is routing state; a durable id is conversation ownership.
+/// - Only positive evidence creates or resolves identity mappings.
+/// - Explicit navigation may switch; recovery may not.
+/// - Old suspended work never gains ownership through the index.
+@MainActor
+final class SessionIdentityContractTests: XCTestCase {
+    private let profile = "default"
+
+    private func makeIndex() -> ConversationIdentityIndex {
+        ConversationIdentityIndex()
+    }
+
+    private func target(
+        runtime: String,
+        durable: String? = nil,
+        notificationProfile: String? = nil
+    ) -> ConduitNotificationTarget {
+        ConduitNotificationTarget(
+            profile: notificationProfile,
+            sessionId: runtime,
+            durableSessionID: durable,
+            type: nil
+        )
+    }
+
+    private func summary(
+        _ id: String,
+        stored: String? = nil,
+        alternateIDs: [String] = [],
+        profile: String? = "default"
+    ) -> SessionSummary {
+        SessionSummary(
+            id: id,
+            storedSessionId: stored,
+            alternateIds: alternateIDs,
+            title: id,
+            model: "Hermes",
+            updatedLabel: "now",
+            profile: profile,
+            source: .chat,
+            isActive: false,
+            isArchived: false,
+            lineageRootId: nil
+        )
+    }
+
+    // MARK: - Notification routing contract
+
+    func testExplicitDualIdentityRoutesDurableWithoutCatalog() {
+        let route = NotificationSessionResolver.route(
+            target: target(runtime: "runtime-a", durable: "stored-a"),
+            catalog: [],
+            identityIndex: makeIndex(),
+            profile: profile
+        )
+        XCTAssertEqual(
+            route,
+            NotificationSessionResolver.Route(
+                resumeTargetID: "stored-a",
+                durableSessionID: "stored-a",
+                basis: .explicitDurable
+            )
+        )
+    }
+
+    func testRuntimeOnlyWithCatalogAliasRoutesToStoredID() {
+        let route = NotificationSessionResolver.route(
+            target: target(runtime: "runtime-a"),
+            catalog: [summary("stored-a", stored: "stored-a", alternateIDs: ["runtime-a"])],
+            identityIndex: makeIndex(),
+            profile: profile
+        )
+        XCTAssertEqual(route.basis, .catalogAlias)
+        XCTAssertEqual(route.resumeTargetID, "stored-a")
+    }
+
+    func testRuntimeOnlyWithConfirmedIndexAliasRoutesWithoutCatalog() {
+        let index = makeIndex()
+        index.record(
+            runtimeID: "runtime-a",
+            durableID: "stored-a",
+            profile: profile,
+            source: .resume
+        )
+        let route = NotificationSessionResolver.route(
+            target: target(runtime: "runtime-a"),
+            catalog: [],
+            identityIndex: index,
+            profile: profile
+        )
+        XCTAssertEqual(
+            route,
+            NotificationSessionResolver.Route(
+                resumeTargetID: "stored-a",
+                durableSessionID: "stored-a",
+                basis: .confirmedAlias
+            ),
+            "A confirmed mapping answers when the catalog temporarily omits the alias"
+        )
+    }
+
+    func testCatalogAliasOutranksIndexWhenTheyDisagree() {
+        // The live registry is fresher: if the catalog now attributes
+        // runtime-x to stored-b, routing follows the catalog, not the
+        // confirmed history.
+        let index = makeIndex()
+        index.record(
+            runtimeID: "runtime-x",
+            durableID: "stored-a",
+            profile: profile,
+            source: .resume
+        )
+        let route = NotificationSessionResolver.route(
+            target: target(runtime: "runtime-x"),
+            catalog: [summary("stored-b", stored: "stored-b", alternateIDs: ["runtime-x"])],
+            identityIndex: index,
+            profile: profile
+        )
+        XCTAssertEqual(route.resumeTargetID, "stored-b")
+        XCTAssertEqual(route.basis, .catalogAlias)
+    }
+
+    func testUnknownRuntimeRoutesToItselfNeverToAnotherConversation() {
+        let route = NotificationSessionResolver.route(
+            target: target(runtime: "runtime-unknown"),
+            catalog: [
+                summary("stored-newest", stored: "stored-newest"),
+                summary("stored-older", stored: "stored-older")
+            ],
+            identityIndex: makeIndex(),
+            profile: profile
+        )
+        XCTAssertEqual(
+            route,
+            NotificationSessionResolver.Route(
+                resumeTargetID: "runtime-unknown",
+                durableSessionID: nil,
+                basis: .legacyRuntime
+            ),
+            "No fallback may invent a durable conversation for an unknown runtime id"
+        )
+    }
+
+    func testNotificationRoutingIsProfileScoped() {
+        let index = makeIndex()
+        index.record(
+            runtimeID: "runtime-shared",
+            durableID: "stored-in-work",
+            profile: "work",
+            source: .resume
+        )
+        // Same profile name, same runtime string, different profile scope:
+        // the default-profile lookup must not see work's mapping.
+        let defaultRoute = NotificationSessionResolver.route(
+            target: target(runtime: "runtime-shared"),
+            catalog: [],
+            identityIndex: index,
+            profile: "default"
+        )
+        XCTAssertEqual(defaultRoute.basis, .legacyRuntime)
+        XCTAssertEqual(defaultRoute.resumeTargetID, "runtime-shared")
+
+        let workRoute = NotificationSessionResolver.route(
+            target: target(runtime: "runtime-shared", notificationProfile: "work"),
+            catalog: [],
+            identityIndex: index,
+            profile: "work"
+        )
+        XCTAssertEqual(workRoute.resumeTargetID, "stored-in-work")
+    }
+
+    // MARK: - Payload parsing contract
+
+    func testPayloadWithStoredSessionIDParsesDualIdentity() {
+        let service = PushNotificationService.shared
+        defer {
+            if let pendingTarget = service.pendingTarget {
+                service.clearPendingTarget(pendingTarget)
+            }
+        }
+        service.receiveNotificationPayload([
+            "body": [
+                "conduit": [
+                    "session_id": "runtime-a",
+                    "stored_session_id": "stored-a",
+                    "profile": "default",
+                    "type": "response.ready"
+                ]
+            ]
+        ])
+        XCTAssertEqual(
+            service.pendingTarget,
+            ConduitNotificationTarget(
+                profile: "default",
+                sessionId: "runtime-a",
+                durableSessionID: "stored-a",
+                type: "response.ready"
+            )
+        )
+    }
+
+    func testPayloadSessionKeySpellingParsesAsDurableIdentity() {
+        let service = PushNotificationService.shared
+        defer {
+            if let pendingTarget = service.pendingTarget {
+                service.clearPendingTarget(pendingTarget)
+            }
+        }
+        service.receiveNotificationPayload([
+            "conduit": [
+                "session_id": "runtime-a",
+                "session_key": "stored-a",
+                "type": "input.needed"
+            ]
+        ])
+        XCTAssertEqual(service.pendingTarget?.durableSessionID, "stored-a")
+    }
+
+    func testLegacyPayloadWithoutDurableFieldParsesRuntimeOnly() {
+        let service = PushNotificationService.shared
+        defer {
+            if let pendingTarget = service.pendingTarget {
+                service.clearPendingTarget(pendingTarget)
+            }
+        }
+        service.receiveNotificationPayload([
+            "conduit": [
+                "session_id": "runtime-a",
+                "type": "response.ready"
+            ]
+        ])
+        XCTAssertNil(
+            service.pendingTarget?.durableSessionID,
+            "Older payloads degrade to alias resolution, never to reinterpreting the runtime id"
+        )
+    }
+
+    func testApprovalDecisionSessionKeyIsNotPromotedToRoutingIdentity() {
+        // decision.session_key answers approval.respond; only a top-level
+        // routing field may claim durable routing identity.
+        let service = PushNotificationService.shared
+        defer {
+            if let pendingTarget = service.pendingTarget {
+                service.clearPendingTarget(pendingTarget)
+            }
+        }
+        service.receiveNotificationPayload([
+            "conduit": [
+                "session_id": "runtime-a",
+                "type": "approval.needed",
+                "decision": [
+                    "kind": "approval",
+                    "session_key": "approval-answer-key",
+                    "description": "Run it?",
+                    "choices": ["once", "deny"]
+                ]
+            ]
+        ])
+        XCTAssertEqual(service.pendingTarget?.sessionId, "runtime-a")
+        XCTAssertNil(service.pendingTarget?.durableSessionID)
+        guard case .approval(let sessionKey, _, _) = service.pendingTarget?.decision else {
+            return XCTFail("The approval card must still parse")
+        }
+        XCTAssertEqual(sessionKey, "approval-answer-key")
+    }
+
+    func testRoutingStoredSessionIDOutranksSessionKeySpelling() {
+        // Both top-level spellings present (a transitional relay): the
+        // canonical stored_session_id wins deterministically.
+        let service = PushNotificationService.shared
+        defer {
+            if let pendingTarget = service.pendingTarget {
+                service.clearPendingTarget(pendingTarget)
+            }
+        }
+        service.receiveNotificationPayload([
+            "conduit": [
+                "session_id": "runtime-a",
+                "stored_session_id": "stored-canonical",
+                "session_key": "stored-legacy",
+                "type": "response.ready"
+            ]
+        ])
+        XCTAssertEqual(service.pendingTarget?.durableSessionID, "stored-canonical")
+    }
+
+    func testCatalogRowLabeledForAnotherProfileDoesNotRouteThisProfile() {
+        let route = NotificationSessionResolver.route(
+            target: target(runtime: "runtime-shared"),
+            catalog: [
+                summary(
+                    "stored-foreign",
+                    stored: "stored-foreign",
+                    alternateIDs: ["runtime-shared"],
+                    profile: "work"
+                )
+            ],
+            identityIndex: makeIndex(),
+            profile: profile
+        )
+        XCTAssertEqual(
+            route.basis, .legacyRuntime,
+            "A foreign-profile catalog row must not route this profile's notification"
+        )
+        XCTAssertEqual(route.resumeTargetID, "runtime-shared")
+    }
+
+    // MARK: - Cross-component agreement
+
+    func testRuntimeRotationRetainsDurableOwnershipAcrossAllComponents() {
+        // stored-a, runtime-a → runtime-b (admitted rebind). The gate admits
+        // the rotation as a knownAlias/rebind; the index maps BOTH runtimes
+        // to stored-a; notification routing for either runtime reaches
+        // stored-a.
+        let selected = ConversationIdentity(
+            profile: profile,
+            durableSessionID: "stored-a",
+            runtimeSessionID: "runtime-a",
+            acceptedSessionIDs: ["stored-a", "runtime-a"]
+        )
+        let claim = ResumeIdentityClaim(runtimeSessionID: "runtime-b", durableSessionID: nil)
+        let catalog = [summary("stored-a", stored: "stored-a", alternateIDs: ["runtime-a"])]
+
+        let admission = ConversationIdentityGate.admit(
+            claim: claim,
+            selected: selected,
+            catalog: catalog
+        )
+        guard case .success = admission else {
+            return XCTFail("A rotation of the selected conversation must be admitted, got \(admission)")
+        }
+
+        let index = makeIndex()
+        for runtime in ["runtime-a", "runtime-b"] {
+            index.record(
+                runtimeID: runtime,
+                durableID: "stored-a",
+                profile: profile,
+                source: .resume
+            )
+        }
+        for runtime in ["runtime-a", "runtime-b"] {
+            XCTAssertEqual(
+                NotificationSessionResolver.route(
+                    target: target(runtime: runtime),
+                    catalog: [],
+                    identityIndex: index,
+                    profile: profile
+                ).resumeTargetID,
+                "stored-a",
+                "Runtime rotation must not detach notification routing from the durable conversation"
+            )
+        }
+    }
+
+    func testConflictingReattributionCannotHandOwnershipToSuspendedWork() {
+        // runtime-x was confirmed for stored-a; the catalog now says it
+        // routes to stored-b. The index moves (authoritative refresh), but a
+        // captured ConversationIdentity from the stored-a era is immutable:
+        // old suspended work holds its own accepted set and can never adopt
+        // stored-b through the index.
+        let index = makeIndex()
+        index.record(
+            runtimeID: "runtime-x",
+            durableID: "stored-a",
+            profile: profile,
+            source: .resume
+        )
+        let capturedDuringStoredAOwnership = ConversationIdentity(
+            profile: profile,
+            durableSessionID: "stored-a",
+            runtimeSessionID: "runtime-x",
+            acceptedSessionIDs: ["stored-a", "runtime-x"]
+        )
+
+        index.recordCatalogIdentity(
+            [summary("stored-b", stored: "stored-b", alternateIDs: ["runtime-x"])],
+            profile: profile
+        )
+
+        XCTAssertEqual(
+            index.durableID(forRuntime: "runtime-x", profile: profile),
+            "stored-b",
+            "The live registry decides current routing"
+        )
+        XCTAssertEqual(
+            capturedDuringStoredAOwnership.acceptedSessionIDs,
+            ["stored-a", "runtime-x"],
+            "The captured identity is capture-time evidence, not live state"
+        )
+        let staleClaim = ResumeIdentityClaim(runtimeSessionID: "runtime-x", durableSessionID: "stored-b")
+        guard case .failure(.durableContradiction) = ConversationIdentityGate.admit(
+            claim: staleClaim,
+            selected: capturedDuringStoredAOwnership,
+            catalog: [summary("stored-b", stored: "stored-b", alternateIDs: ["runtime-x"])]
+        ) else {
+            return XCTFail("Old stored-a work must not be able to adopt stored-b via the reused runtime")
+        }
+    }
+
+    func testCatalogOmissionIsNotNegativeIdentityEvidence() {
+        let index = makeIndex()
+        index.record(
+            runtimeID: "runtime-a",
+            durableID: "stored-a",
+            profile: profile,
+            source: .resume
+        )
+        // A catalog refresh that dropped the conversation entirely, then a
+        // labeled row comes back with the same identity: both lookups keep
+        // answering.
+        index.recordCatalogIdentity([], profile: profile)
+        XCTAssertEqual(index.durableID(forRuntime: "runtime-a", profile: profile), "stored-a")
+        index.recordCatalogIdentity(
+            [summary("stored-a", stored: "stored-a", alternateIDs: ["runtime-a"])],
+            profile: profile
+        )
+        XCTAssertEqual(index.durableID(forRuntime: "runtime-a", profile: profile), "stored-a")
+    }
+
+    func testResumeAdmissionAndIndexAgreeOnForeignRuntimeRejection() {
+        // runtime-b is positively owned by stored-b's catalog row; the gate
+        // rejects it for stored-a's conversation, and — independently — the
+        // index never recorded runtime-b→stored-a, so notification routing
+        // cannot route runtime-b to stored-a either.
+        let selected = ConversationIdentity(
+            profile: profile,
+            durableSessionID: "stored-a",
+            runtimeSessionID: "runtime-a",
+            acceptedSessionIDs: ["stored-a", "runtime-a"]
+        )
+        let catalog = [
+            summary("stored-a", stored: "stored-a", alternateIDs: ["runtime-a"]),
+            summary("stored-b", stored: "stored-b", alternateIDs: ["runtime-b"])
+        ]
+        let claim = ResumeIdentityClaim(runtimeSessionID: "runtime-b", durableSessionID: nil)
+        guard case .failure(.foreignRuntimeOwnership) = ConversationIdentityGate.admit(
+            claim: claim,
+            selected: selected,
+            catalog: catalog
+        ) else {
+            return XCTFail("Foreign runtime ownership must be rejected")
+        }
+
+        let index = makeIndex()
+        index.recordCatalogIdentity(catalog, profile: profile)
+        let route = NotificationSessionResolver.route(
+            target: target(runtime: "runtime-b"),
+            catalog: catalog,
+            identityIndex: index,
+            profile: profile
+        )
+        XCTAssertEqual(route.resumeTargetID, "stored-b")
+    }
+
+    // MARK: - Composer draft identity contract
+
+    func testComposerDraftEquivalenceSurvivesRotationButNotReattribution() {
+        // stored-a with confirmed aliases {stored-a, runtime-old,
+        // runtime-new}: the draft follows the conversation through the
+        // rotation.
+        let rotationIdentity = ChatScrollSessionIdentity(
+            profile: profile,
+            canonicalSessionID: "stored-a",
+            equivalentSessionIDs: ["stored-a", "runtime-old", "runtime-new"],
+            isReconciling: false,
+            settledRevision: 1
+        )
+        XCTAssertTrue(ComposerBar.draftKeysAreEquivalent(
+            ComposerBar.composerDraftKey(for: "runtime-new", profile: profile),
+            ComposerBar.composerDraftKey(for: "stored-a", profile: profile),
+            identity: rotationIdentity
+        ))
+
+        // The runtime string is later positively re-attributed to stored-b:
+        // the re-attributed identity no longer bridges runtime-x and
+        // stored-a, so stored-a's draft must not migrate into stored-b.
+        let reattributedIdentity = ChatScrollSessionIdentity(
+            profile: profile,
+            canonicalSessionID: "stored-b",
+            equivalentSessionIDs: ["stored-b", "runtime-x"],
+            isReconciling: false,
+            settledRevision: 2
+        )
+        XCTAssertFalse(ComposerBar.draftKeysAreEquivalent(
+            ComposerBar.composerDraftKey(for: "runtime-x", profile: profile),
+            ComposerBar.composerDraftKey(for: "stored-a", profile: profile),
+            identity: reattributedIdentity
+        ))
+    }
+
+    func testComposerDraftKeysAreProfileScoped() {
+        let identity = ChatScrollSessionIdentity(
+            profile: profile,
+            canonicalSessionID: "stored-a",
+            equivalentSessionIDs: ["stored-a"],
+            isReconciling: false,
+            settledRevision: 1
+        )
+        XCTAssertFalse(ComposerBar.draftKeysAreEquivalent(
+            ComposerBar.composerDraftKey(for: "stored-a", profile: "default"),
+            ComposerBar.composerDraftKey(for: "stored-a", profile: "work"),
+            identity: identity
+        ))
+    }
+}

--- a/ConduitTests/SessionPresentationCacheTests.swift
+++ b/ConduitTests/SessionPresentationCacheTests.swift
@@ -187,6 +187,44 @@ final class SessionPresentationCacheTests: XCTestCase {
         XCTAssertEqual(merged.count, 1)
     }
 
+    func testRemoveSessionsDropsEveryAliasRecordButLeavesSiblings() {
+        let (cache, _, _, _) = makeIsolatedCache()
+        let profile = "remove-test"
+        let deletedPrimary = "remove-deleted-primary"
+        let deletedAlias = "remove-deleted-alias"
+        let sibling = "remove-sibling"
+
+        let messages = [
+            ChatMessage(id: "msg-1", role: .user, content: "Remove me", timestamp: "2024-01-01"),
+        ]
+        cache.save(messages, profile: profile, sessionIDs: [deletedPrimary, deletedAlias])
+        cache.save(
+            [ChatMessage(id: "msg-2", role: .user, content: "Keep me", timestamp: "2024-01-02")],
+            profile: profile,
+            sessionIDs: [sibling]
+        )
+
+        cache.removeSessions(profile: profile, sessionIDs: [deletedPrimary, deletedAlias])
+
+        let probe = ChatMessage(id: "msg-1", role: .user, content: "Remove me", timestamp: "")
+        for alias in [deletedPrimary, deletedAlias] {
+            XCTAssertEqual(
+                cache.merge([probe], profile: profile, sessionIDs: [alias]).first?.timestamp,
+                "",
+                "A deleted conversation's cached presentation must not survive under any alias"
+            )
+        }
+        XCTAssertEqual(
+            cache.merge(
+                [ChatMessage(id: "msg-2", role: .user, content: "Keep me", timestamp: "")],
+                profile: profile,
+                sessionIDs: [sibling]
+            ).first?.timestamp,
+            "2024-01-02",
+            "Sibling conversations keep their cached presentation"
+        )
+    }
+
     // MARK: - Multiple session IDs
 
     func testSaveAndMergeAcrossLineageSessionIds() {

--- a/ConduitTests/SessionPresentationCacheTests.swift
+++ b/ConduitTests/SessionPresentationCacheTests.swift
@@ -384,6 +384,290 @@ final class SessionPresentationCacheTests: XCTestCase {
         )
     }
 
+    func testConsolidationPromotesNewPendingApprovalIntoExistingDurableRecord() throws {
+        // The notification-promotion case: the durable record already holds
+        // normal presentation when a fresh pending approval arrives under a
+        // runtime alias. Consolidation must promote the CARD (deduped,
+        // routing id rewritten to the durable session) while keeping the
+        // durable transcript authoritative — and retire the alias key.
+        let (cache, _, tickClock, _) = try makeIsolatedCache()
+        let profile = "promote"
+        cache.save(
+            [ChatMessage(id: "d1", role: .assistant, content: "Durable transcript", timestamp: "durable-ts")],
+            profile: profile,
+            sessionIDs: ["stored-a"]
+        )
+        tickClock()
+        let approval = ApprovalActivity(
+            sessionId: "runtime-x",
+            command: "",
+            description: "Fresh push approval",
+            choices: ["once", "deny"],
+            allowPermanent: false,
+            smartDenied: false,
+            status: .pending,
+            choice: nil,
+            error: nil
+        )
+        cache.save(
+            [
+                ChatMessage(
+                    id: "approval-runtime-x",
+                    role: .approval,
+                    content: "Fresh push approval",
+                    timestamp: "push-ts",
+                    approval: approval
+                )
+            ],
+            profile: profile,
+            sessionIDs: ["runtime-old"]
+        )
+
+        cache.consolidateUnderDurableKey(
+            profile: profile,
+            durableSessionID: "stored-a",
+            // Production unions every runtime the admitted resume knows: the
+            // push-named key (runtime-old) AND the card's own embedded
+            // session key (runtime-x) — both are retired by promotion.
+            runtimeAliases: ["runtime-old", "runtime-x"]
+        )
+
+        let probe = [
+            ChatMessage(id: "d1", role: .assistant, content: "Durable transcript", timestamp: ""),
+            ChatMessage(id: "approval-runtime-x", role: .approval, content: "Fresh push approval", timestamp: ""),
+        ]
+        let merged = cache.merge(
+            probe,
+            profile: profile,
+            sessionIDs: ["stored-a"],
+            includePendingApprovals: true
+        )
+        XCTAssertEqual(merged[0].timestamp, "durable-ts", "The durable transcript stays authoritative")
+        XCTAssertEqual(
+            merged[1].approval?.sessionId, "stored-a",
+            "The promoted card answers against the durable session"
+        )
+        XCTAssertEqual(merged[1].approval?.status, .pending)
+        // No duplicates, no runtime key: consolidating again must not add a
+        // second card, and the runtime-old copy is gone.
+        cache.consolidateUnderDurableKey(
+            profile: profile,
+            durableSessionID: "stored-a",
+            runtimeAliases: ["runtime-old", "runtime-x"]
+        )
+        let mergedAgain = cache.merge(
+            probe,
+            profile: profile,
+            sessionIDs: ["stored-a"],
+            includePendingApprovals: true
+        )
+        XCTAssertEqual(mergedAgain.filter { $0.role == .approval }.count, 1)
+        XCTAssertNil(
+            cache.merge([probe[1]], profile: profile, sessionIDs: ["runtime-old"], includePendingApprovals: true)
+                .first?.approval,
+            "The runtime alias key is retired — no card answers from it"
+        )
+    }
+
+    func testConsolidationPromotesPendingClarifyIntoExistingDurableRecordWithoutRewritingRequestId() throws {
+        // Clarify request ids are request identity (relay-minted), not
+        // session routing identity: promotion must preserve them verbatim,
+        // dedupe on a second pass, and retire the alias key.
+        let (cache, _, tickClock, _) = try makeIsolatedCache()
+        let profile = "promote-clarify"
+        cache.save(
+            [ChatMessage(id: "d1", role: .assistant, content: "Durable transcript", timestamp: "durable-ts")],
+            profile: profile,
+            sessionIDs: ["stored-a"]
+        )
+        tickClock()
+        cache.save(
+            [
+                ChatMessage(
+                    id: "clarify-conduit-push-q1",
+                    role: .clarify,
+                    content: "Which env?",
+                    timestamp: "push-ts",
+                    clarify: ClarifyActivity(
+                        requestId: "conduit-push-q1",
+                        question: "Which env?",
+                        choices: [ClarifyChoice(label: "staging", value: "staging")],
+                        status: .pending,
+                        answer: nil,
+                        error: nil
+                    )
+                )
+            ],
+            profile: profile,
+            sessionIDs: ["runtime-old"]
+        )
+
+        cache.consolidateUnderDurableKey(
+            profile: profile,
+            durableSessionID: "stored-a",
+            runtimeAliases: ["runtime-old"]
+        )
+
+        let probe = [ChatMessage(id: "p", role: .assistant, content: "probe", timestamp: "")]
+        let merged = cache.merge(probe, profile: profile, sessionIDs: ["stored-a"], includePendingClarifications: true)
+        let cards = merged.filter { $0.clarify?.requestId == "conduit-push-q1" }
+        XCTAssertEqual(cards.count, 1, "Exactly one promoted clarify card")
+        XCTAssertEqual(cards.first?.clarify?.requestId, "conduit-push-q1", "Request ids are never rewritten")
+        cache.consolidateUnderDurableKey(
+            profile: profile,
+            durableSessionID: "stored-a",
+            runtimeAliases: ["runtime-old"]
+        )
+        let mergedAgain = cache.merge(probe, profile: profile, sessionIDs: ["stored-a"], includePendingClarifications: true)
+        XCTAssertEqual(
+            mergedAgain.filter { $0.clarify?.requestId == "conduit-push-q1" }.count, 1,
+            "Promotion dedupes by decision key"
+        )
+        XCTAssertTrue(
+            cache.merge(probe, profile: profile, sessionIDs: ["runtime-old"], includePendingClarifications: true)
+                .filter { $0.clarify?.requestId == "conduit-push-q1" }.isEmpty,
+            "The runtime alias key is retired"
+        )
+    }
+
+    func testConsolidationRefreshesExpiredDurableMarkerSoPromotedCardStaysVisible() throws {
+        // A durable record whose unconfirmed marker has expired must not
+        // kill a freshly promoted card: promotion refreshes the marker from
+        // the contributing alias so the card renders after the promotion.
+        let (cache, cacheDefaults, tickClock, _) = try makeIsolatedCache()
+        let profile = "expired-marker"
+        let expiredApproval = ApprovalActivity(
+            sessionId: "stored-a",
+            command: "",
+            description: "Old durable card",
+            choices: ["once", "deny"],
+            allowPermanent: false,
+            smartDenied: false,
+            status: .pending,
+            choice: nil,
+            error: nil
+        )
+        cache.save(
+            [
+                ChatMessage(
+                    id: "approval-old",
+                    role: .approval,
+                    content: "Old durable card",
+                    timestamp: "old-ts",
+                    approval: expiredApproval
+                )
+            ],
+            profile: profile,
+            sessionIDs: ["stored-a"],
+            unconfirmedPendingDecisionKeys: ["approval:stored-a"]
+        )
+        // Age the durable record's marker past the 24h unconfirmed window.
+        for _ in 0..<8_700 { tickClock() }
+        let freshApproval = ApprovalActivity(
+            sessionId: "runtime-x",
+            command: "",
+            description: "Fresh push approval",
+            choices: ["once", "deny"],
+            allowPermanent: false,
+            smartDenied: false,
+            status: .pending,
+            choice: nil,
+            error: nil
+        )
+        cache.recordPendingDecision(
+            ChatMessage(
+                id: "approval-fresh",
+                role: .approval,
+                content: "Fresh push approval",
+                timestamp: "fresh-ts",
+                approval: freshApproval
+            ),
+            profile: profile,
+            sessionIDs: ["runtime-x"]
+        )
+        XCTAssertEqual(
+            cache.storedPendingDecisionKeys(profile: profile, sessionIDs: ["runtime-x"]),
+            ["approval:runtime-x"],
+            "Fixture check: the fresh card is staged under the runtime key"
+        )
+        XCTAssertTrue(
+            cache.unconfirmedPendingDecisionDate(profile: profile, sessionIDs: ["stored-a"]).map {
+                cache.isUnconfirmedPendingDecisionExpired(since: $0)
+            } ?? false,
+            "Fixture check: the durable marker is expired at consolidation time"
+        )
+
+        cache.consolidateUnderDurableKey(
+            profile: profile,
+            durableSessionID: "stored-a",
+            runtimeAliases: ["runtime-x"]
+        )
+
+        XCTAssertEqual(
+            cache.storedPendingDecisionKeys(profile: profile, sessionIDs: ["stored-a"]),
+            ["approval:stored-a"],
+            "Promotion must land the fresh card in the durable record"
+        )
+
+        let probe = [
+            ChatMessage(id: "approval-fresh", role: .approval, content: "Fresh push approval", timestamp: "")
+        ]
+        let merged = cache.merge(
+            probe,
+            profile: profile,
+            sessionIDs: ["stored-a"],
+            includePendingApprovals: true
+        )
+        XCTAssertEqual(
+            merged.first?.approval?.description, "Fresh push approval",
+            "The freshly promoted card must not be killed by the durable record's expired marker"
+        )
+        XCTAssertEqual(merged.first?.approval?.sessionId, "stored-a")
+    }
+
+    func testConsolidationStaleAliasNeverOverwritesDurableTranscript() throws {
+        // Inverse protection: a stale alias snapshot with NO new pending
+        // decision must not touch the durable transcript presentation at
+        // all — the alias key is simply retired.
+        let (cache, _, tickClock, _) = try makeIsolatedCache()
+        let profile = "stale-alias"
+        let durableMessages = [
+            ChatMessage(id: "d1", role: .assistant, content: "Fresh row", timestamp: "fresh-ts"),
+            ChatMessage(id: "d2", role: .user, content: "Second", timestamp: "fresh-ts-2"),
+        ]
+        cache.save(durableMessages, profile: profile, sessionIDs: ["stored-a"])
+        tickClock()
+        let staleMessages = [
+            ChatMessage(id: "s1", role: .assistant, content: "Stale row", timestamp: "stale-ts"),
+        ]
+        cache.save(staleMessages, profile: profile, sessionIDs: ["runtime-x"])
+
+        cache.consolidateUnderDurableKey(
+            profile: profile,
+            durableSessionID: "stored-a",
+            runtimeAliases: ["runtime-x"]
+        )
+
+        let probe = durableMessages.map { message in
+            ChatMessage(id: message.id, role: message.role, content: message.content, timestamp: "")
+        }
+        XCTAssertEqual(
+            cache.merge(probe, profile: profile, sessionIDs: ["stored-a"]).map(\.timestamp),
+            ["fresh-ts", "fresh-ts-2"],
+            "The durable transcript presentation is unchanged"
+        )
+        XCTAssertTrue(
+            cache.merge(
+                staleMessages.map { message in
+                    ChatMessage(id: message.id, role: message.role, content: message.content, timestamp: "")
+                },
+                profile: profile,
+                sessionIDs: ["runtime-x"]
+            ).allSatisfy { $0.timestamp.isEmpty },
+            "The stale alias key is retired"
+        )
+    }
+
     func testConsolidationPreservesPendingClarifyThroughEstablishment() throws {
         // A pending clarify recorded under a runtime-only identity survives
         // the runtime→durable establishment migration.

--- a/ConduitTests/SessionPresentationCacheTests.swift
+++ b/ConduitTests/SessionPresentationCacheTests.swift
@@ -187,8 +187,8 @@ final class SessionPresentationCacheTests: XCTestCase {
         XCTAssertEqual(merged.count, 1)
     }
 
-    func testRemoveSessionsDropsEveryAliasRecordButLeavesSiblings() {
-        let (cache, _, _, _) = makeIsolatedCache()
+    func testRemoveSessionsDropsEveryAliasRecordButLeavesSiblings() throws {
+        let (cache, _, _, _) = try makeIsolatedCache()
         let profile = "remove-test"
         let deletedPrimary = "remove-deleted-primary"
         let deletedAlias = "remove-deleted-alias"
@@ -225,6 +225,208 @@ final class SessionPresentationCacheTests: XCTestCase {
         )
     }
 
+    // MARK: - Durable-owned persistence (runtime alias retirement)
+
+    func testConsolidationMigratesRuntimeOnlyRecordToDurableKeyWithoutLoss() throws {
+        // Runtime-only establishment: presentation cached under runtime-x
+        // must MIGRATE to the durable key when stored-A is established —
+        // never be lost — and the mutable runtime key must be retired.
+        let (cache, _, tickClock, _) = try makeIsolatedCache()
+        let profile = "consolidate"
+        let messages = [
+            ChatMessage(id: "m1", role: .assistant, content: "Answer", timestamp: "ts-1"),
+            ChatMessage(
+                id: "m2",
+                role: .user,
+                content: "Question",
+                timestamp: "ts-2",
+                tool: ToolActivity(id: "t1", name: "shell", input: "", output: "files", status: .complete)
+            ),
+        ]
+        cache.save(messages, profile: profile, sessionIDs: ["runtime-x"])
+        tickClock()
+
+        cache.consolidateUnderDurableKey(
+            profile: profile,
+            durableSessionID: "stored-a",
+            runtimeAliases: ["runtime-x"]
+        )
+
+        let probe = messages.map { message -> ChatMessage in
+            var row = ChatMessage(id: message.id, role: message.role, content: message.content, timestamp: "")
+            // The merge only ENRICHES an existing tool row — mirror the
+            // gateway's compact shape (tool present, details omitted).
+            if let tool = message.tool {
+                row.tool = ToolActivity(id: tool.id, name: tool.name, input: "", output: nil, status: tool.status)
+            }
+            return row
+        }
+        let merged = cache.merge(probe, profile: profile, sessionIDs: ["stored-a"])
+        XCTAssertEqual(merged.map(\.timestamp), ["ts-1", "ts-2"], "Establishment migrates the record")
+        XCTAssertEqual(merged[1].tool?.input, "files", "Tool metadata migrates with the record")
+        XCTAssertEqual(
+            cache.merge(probe, profile: profile, sessionIDs: ["runtime-x"]).map(\.timestamp),
+            ["", ""],
+            "The runtime-keyed copy is retired"
+        )
+    }
+
+    func testReattributedRuntimeCannotLeakPresentationIntoAnotherConversation() throws {
+        // The reported bleed: A's presentation (pending approval card
+        // included) was cached under runtime-x; the gateway later
+        // re-attributes runtime-x to stored-B. After consolidation retired
+        // the runtime key, restoring B through runtime-x must find NOTHING
+        // of A's — while A's own presentation survives under its durable key.
+        let (cache, _, tickClock, _) = try makeIsolatedCache()
+        let profile = "bleed"
+        let approval = ApprovalActivity(
+            sessionId: "runtime-x",
+            command: "",
+            description: "A's pending approval",
+            choices: ["once", "deny"],
+            allowPermanent: false,
+            smartDenied: false,
+            status: .pending,
+            choice: nil,
+            error: nil
+        )
+        let aMessages = [
+            ChatMessage(
+                id: "a-approval",
+                role: .approval,
+                content: "A's pending approval",
+                timestamp: "a-ts",
+                approval: approval
+            ),
+        ]
+        cache.save(aMessages, profile: profile, sessionIDs: ["stored-a", "runtime-x"])
+        tickClock()
+
+        cache.consolidateUnderDurableKey(
+            profile: profile,
+            durableSessionID: "stored-a",
+            runtimeAliases: ["runtime-x"]
+        )
+
+        // Restore B using the re-attributed runtime id.
+        let bProbe = [
+            ChatMessage(id: "b-row", role: .assistant, content: "B's own reply", timestamp: "")
+        ]
+        let restoredForB = cache.merge(
+            bProbe,
+            profile: profile,
+            sessionIDs: ["runtime-x"],
+            includePendingApprovals: true
+        )
+        XCTAssertNil(restoredForB[0].approval, "A's pending approval must not cross into B")
+        XCTAssertEqual(restoredForB[0].timestamp, "", "A's timestamps must not cross into B")
+        XCTAssertFalse(restoredForB.contains { $0.role == .approval })
+
+        // Positive control: A still restores through its durable key, and the
+        // migrated card now answers against the DURABLE session — after a
+        // later rotation of runtime-x, an approve tap can never dispatch to
+        // whatever the old runtime id routes to.
+        let aProbe = [
+            ChatMessage(id: "a-approval", role: .approval, content: "A's pending approval", timestamp: "")
+        ]
+        let restoredForA = cache.merge(
+            aProbe,
+            profile: profile,
+            sessionIDs: ["stored-a"],
+            includePendingApprovals: true
+        )
+        XCTAssertEqual(restoredForA[0].approval?.description, "A's pending approval")
+        XCTAssertEqual(restoredForA[0].timestamp, "a-ts")
+        XCTAssertEqual(
+            restoredForA[0].approval?.sessionId, "stored-a",
+            "Consolidation rewrites the card's routing identity to the durable session"
+        )
+    }
+
+    func testConsolidationKeepsExistingDurableRecordOverAliasCopy() throws {
+        // When the durable key already holds the live write, consolidation
+        // must keep it (dropping stale alias copies), not overwrite it with
+        // an older alias snapshot.
+        let (cache, _, tickClock, _) = try makeIsolatedCache()
+        let profile = "keep-live"
+        cache.save(
+            [ChatMessage(id: "live", role: .assistant, content: "Live durable write", timestamp: "live-ts")],
+            profile: profile,
+            sessionIDs: ["stored-a"]
+        )
+        tickClock()
+        cache.save(
+            [ChatMessage(id: "stale", role: .assistant, content: "Stale alias copy", timestamp: "stale-ts")],
+            profile: profile,
+            sessionIDs: ["runtime-x"]
+        )
+
+        cache.consolidateUnderDurableKey(
+            profile: profile,
+            durableSessionID: "stored-a",
+            runtimeAliases: ["runtime-x"]
+        )
+
+        let probe = [ChatMessage(id: "live", role: .assistant, content: "Live durable write", timestamp: "")]
+        XCTAssertEqual(
+            cache.merge(probe, profile: profile, sessionIDs: ["stored-a"]).first?.timestamp,
+            "live-ts",
+            "The durable record is the live write and survives"
+        )
+        XCTAssertEqual(
+            cache.merge(
+                [ChatMessage(id: "stale", role: .assistant, content: "Stale alias copy", timestamp: "")],
+                profile: profile,
+                sessionIDs: ["runtime-x"]
+            ).map(\.timestamp),
+            [""],
+            "The alias copy is retired"
+        )
+    }
+
+    func testConsolidationPreservesPendingClarifyThroughEstablishment() throws {
+        // A pending clarify recorded under a runtime-only identity survives
+        // the runtime→durable establishment migration.
+        let (cache, _, tickClock, _) = try makeIsolatedCache()
+        let profile = "clarify-migrate"
+        let clarify = ClarifyActivity(
+            requestId: "conduit-push-xyz",
+            question: "Which env?",
+            choices: [ClarifyChoice(label: "staging", value: "staging")],
+            status: .pending,
+            answer: nil,
+            error: nil
+        )
+        cache.save(
+            [
+                ChatMessage(
+                    id: "clarify-conduit-push-xyz",
+                    role: .clarify,
+                    content: "Which env?",
+                    timestamp: "c-ts",
+                    clarify: clarify
+                )
+            ],
+            profile: profile,
+            sessionIDs: ["runtime-only"]
+        )
+        tickClock()
+
+        cache.consolidateUnderDurableKey(
+            profile: profile,
+            durableSessionID: "stored-a",
+            runtimeAliases: ["runtime-only"]
+        )
+
+        let probe = [ChatMessage(id: "probe", role: .assistant, content: "p", timestamp: "")]
+        let restored = cache.merge(probe, profile: profile, sessionIDs: ["stored-a"], includePendingClarifications: true)
+        XCTAssertTrue(
+            restored.contains { $0.clarify?.requestId == "conduit-push-xyz" && $0.clarify?.status == .pending },
+            "The pending clarify migrates with the record"
+        )
+    }
+
+
     // MARK: - Multiple session IDs
 
     func testSaveAndMergeAcrossLineageSessionIds() {
@@ -253,9 +455,12 @@ final class SessionPresentationCacheTests: XCTestCase {
 
     /// Isolated cache with a manually advanced clock so alias-write order
     /// (and therefore CachedSession.updatedAt comparisons) is deterministic.
-    private func makeIsolatedCache() -> (cache: SessionPresentationCache, defaults: UserDefaults, tickClock: () -> Void, suiteName: String) {
+    private func makeIsolatedCache() throws -> (cache: SessionPresentationCache, defaults: UserDefaults, tickClock: () -> Void, suiteName: String) {
         let suiteName = "SessionPresentationCacheTests.dedup." + UUID().uuidString
-        let defaults = UserDefaults(suiteName: suiteName)!
+        let defaults = try XCTUnwrap(
+            UserDefaults(suiteName: suiteName),
+            "Could not create isolated UserDefaults suite"
+        )
         let clock = DeterministicClock()
         let cache = SessionPresentationCache(defaults: defaults, now: { clock.currentValue() })
         addTeardownBlock {
@@ -270,8 +475,8 @@ final class SessionPresentationCacheTests: XCTestCase {
     /// Merging through both aliases must yield the freshest snapshot's
     /// metadata exactly once per row. The old duplicated-candidate pool
     /// flattened both generations and could attach stale metadata.
-    func testDualAliasMergeYieldsFreshestSnapshotOncePerRow() {
-        let (cache, _, tickClock, _) = makeIsolatedCache()
+    func testDualAliasMergeYieldsFreshestSnapshotOncePerRow() throws {
+        let (cache, _, tickClock, _) = try makeIsolatedCache()
         let primaryId = "alias-primary-" + UUID().uuidString
         let resolvedId = "alias-resolved-" + UUID().uuidString
         let profile = "test"
@@ -308,8 +513,8 @@ final class SessionPresentationCacheTests: XCTestCase {
     /// Tool-call flavor of the same drift: same tool name, fresher input
     /// preview. Duplicated candidates must not cross-wire row one's input
     /// with row two's.
-    func testRepeatedToolCallsKeepDistinctFreshMetadataAcrossAliases() {
-        let (cache, _, tickClock, _) = makeIsolatedCache()
+    func testRepeatedToolCallsKeepDistinctFreshMetadataAcrossAliases() throws {
+        let (cache, _, tickClock, _) = try makeIsolatedCache()
         let primaryId = "tool-primary-" + UUID().uuidString
         let resolvedId = "tool-resolved-" + UUID().uuidString
         let profile = "test"
@@ -355,8 +560,8 @@ final class SessionPresentationCacheTests: XCTestCase {
 
     /// Duplicate STRINGS inside sessionIDs behave like any other
     /// multi-alias lookup rather than a doubled pool.
-    func testDuplicateStringsInsideSessionIDsDoNotDuplicateCandidates() {
-        let (cache, _, _, _) = makeIsolatedCache()
+    func testDuplicateStringsInsideSessionIDsDoNotDuplicateCandidates() throws {
+        let (cache, _, _, _) = try makeIsolatedCache()
         let sessionId = "dup-string-" + UUID().uuidString
         let profile = "test"
 
@@ -378,8 +583,8 @@ final class SessionPresentationCacheTests: XCTestCase {
     }
 
     /// Single-alias lookup keeps working exactly as before.
-    func testSingleAliasMergeUnchangedByDeduplication() {
-        let (cache, _, _, _) = makeIsolatedCache()
+    func testSingleAliasMergeUnchangedByDeduplication() throws {
+        let (cache, _, _, _) = try makeIsolatedCache()
         let sessionId = "single-" + UUID().uuidString
         let profile = "test"
 
@@ -400,8 +605,8 @@ final class SessionPresentationCacheTests: XCTestCase {
     /// Two supplied IDs that hold genuinely DIFFERENT snapshots must both
     /// stay available to the matcher: dedup keys on whole-record logical
     /// identity, never on surface similarity of individual rows.
-    func testDifferentSnapshotsRemainAvailableToMatcher() {
-        let (cache, _, _, _) = makeIsolatedCache()
+    func testDifferentSnapshotsRemainAvailableToMatcher() throws {
+        let (cache, _, _, _) = try makeIsolatedCache()
         let primaryId = "distinct-primary-" + UUID().uuidString
         let resolvedId = "distinct-resolved-" + UUID().uuidString
         let profile = "test"
@@ -438,8 +643,8 @@ final class SessionPresentationCacheTests: XCTestCase {
     /// call's argument order (production passes [resolved, requested] so
     /// the live write leads). Here the newer-written alias is listed
     /// second; precedence still follows argument order by design.
-    func testDivergentSnapshotTieResolvesByAliasArgumentOrder() {
-        let (cache, _, tickClock, _) = makeIsolatedCache()
+    func testDivergentSnapshotTieResolvesByAliasArgumentOrder() throws {
+        let (cache, _, tickClock, _) = try makeIsolatedCache()
         let requestedId = "tie-requested-" + UUID().uuidString
         let resolvedId = "tie-resolved-" + UUID().uuidString
         let profile = "test"

--- a/ConduitTests/SessionRenameTests.swift
+++ b/ConduitTests/SessionRenameTests.swift
@@ -70,6 +70,30 @@ final class SessionRenameTests: XCTestCase {
         XCTAssertEqual(storedRequest?.1, "Renamed")
     }
 
+    func testRotatedActiveRuntimeOutsideRowIDsRenamesDurableTarget() async throws {
+        // A runtime rotation the row has not caught up with (activeSessionID
+        // is the confirmed new runtime, the stale row still lists only the
+        // old one) must not fire the runtime RPC at an unverified id: the
+        // rename targets the row's durable id instead.
+        let session = makeSession()
+        var runtimeRequest: (String, String)?
+        var storedRequest: (String, String)?
+
+        _ = try await SessionRenameOperation.perform(
+            session: session,
+            activeSessionID: "runtime-new",
+            title: "Renamed",
+            operations: .init(
+                renameRuntime: { runtimeRequest = ($0, $1) },
+                renameStored: { storedRequest = ($0, $1) }
+            )
+        )
+
+        XCTAssertNil(runtimeRequest, "runtime-new is not positively tied to this row")
+        XCTAssertEqual(storedRequest?.0, "stored-id", "The durable id is the safe rename target")
+        XCTAssertEqual(storedRequest?.1, "Renamed")
+    }
+
     func testFailedRuntimeRPCFallsBackToStoredSessionPATCH() async throws {
         let session = makeSession()
         var storedRequest: (String, String)?

--- a/ConduitTests/SessionYoloStoreTests.swift
+++ b/ConduitTests/SessionYoloStoreTests.swift
@@ -95,6 +95,24 @@ final class SessionYoloStoreTests: XCTestCase {
         XCTAssertEqual(diagnostics, [.unsupportedVersion(99)])
     }
 
+    func testClearAllOverridesDropsEveryProfileAndSurvivesRecreation() {
+        let (suite, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let key = "test.session-yolo"
+        let store = SessionYoloStore(defaults: defaults, storageKey: key)
+
+        store.setOverride(true, for: "default", sessionID: "session-a")
+        store.setOverride(false, for: "work", sessionID: "session-b")
+        store.clearAllOverrides()
+
+        XCTAssertNil(store.storedOverride(for: "default", sessionID: "session-a"))
+        XCTAssertNil(store.storedOverride(for: "work", sessionID: "session-b"))
+
+        let recreated = SessionYoloStore(defaults: defaults, storageKey: key)
+        XCTAssertNil(recreated.storedOverride(for: "default", sessionID: "session-a"))
+        XCTAssertNil(recreated.storedOverride(for: "work", sessionID: "session-b"))
+    }
+
     private func makeDefaults() -> (String, UserDefaults) {
         let suite = "SessionYoloStoreTests.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suite) else {

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -382,6 +382,105 @@ final class VoiceConversationControllerTests: XCTestCase {
         XCTAssertEqual(gateway.stream?.appended, ["Second."])
     }
 
+    func testAdmittedRuntimeRebindKeepsAssistantVoiceFlowing() async {
+        // Hermes events carry runtime routing ids. When a resume rebinds the
+        // conversation's runtime mid-turn, the new id is a confirmed alias —
+        // the assistant's voice must keep flowing instead of being dropped
+        // by raw equality with the captured id.
+        let gateway = MockGateway()
+        let controller = VoiceConversationController(
+            capture: MockCapture(permissionGranted: true),
+            playback: MockPlayback(),
+            gateway: gateway,
+            submit: { _ in true },
+            interrupt: {}
+        )
+        controller.beginVoiceTurn(sessionID: "voice-session")
+        await controller.startListening()
+        let start = Date()
+        controller.ingestAudioLevel(0.1, at: start)
+        controller.ingestAudioLevel(0, at: start.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        controller.receiveAssistantEvent(.delta(sessionID: "voice-session", text: "Hello "))
+        // The admitted rebind: the reconciled conversation positively
+        // contains the turn's captured id.
+        controller.extendAssistantSessionIDs(
+            ["runtime-rebound"],
+            ofConversationContaining: ["stored-a", "voice-session"]
+        )
+        controller.receiveAssistantEvent(.delta(sessionID: "runtime-rebound", text: "world."))
+        controller.receiveAssistantEvent(.delta(sessionID: "unrelated", text: " no"))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(gateway.stream?.appended, ["Hello ", "world."])
+    }
+
+    func testVoiceAliasExtensionIgnoresADifferentConversation() async {
+        // A reconcile belonging to conversation B while the voice turn is
+        // live on conversation A must never inject B's runtime into A's
+        // ownership: without the positive overlap guard, B's assistant
+        // stream would be spoken into A's turn.
+        let gateway = MockGateway()
+        let controller = VoiceConversationController(
+            capture: MockCapture(permissionGranted: true),
+            playback: MockPlayback(),
+            gateway: gateway,
+            submit: { _ in true },
+            interrupt: {}
+        )
+        controller.beginVoiceTurn(sessionID: "voice-session")
+        await controller.startListening()
+        let start = Date()
+        controller.ingestAudioLevel(0.1, at: start)
+        controller.ingestAudioLevel(0, at: start.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        // The reconciled conversation's accepted set is disjoint from the
+        // turn's captured id — the extension must be refused.
+        controller.extendAssistantSessionIDs(
+            ["runtime-of-b"],
+            ofConversationContaining: ["stored-b", "runtime-of-b"]
+        )
+        controller.receiveAssistantEvent(.delta(sessionID: "runtime-of-b", text: " no"))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertTrue(
+            gateway.stream?.appended.isEmpty ?? true,
+            "Another conversation's runtime must never gain this turn's speech"
+        )
+    }
+
+    func testVoiceAliasExtensionWithoutActiveTurnDoesNotLeakIntoNextTurn() async {
+        let gateway = MockGateway()
+        let controller = VoiceConversationController(
+            capture: MockCapture(permissionGranted: true),
+            playback: MockPlayback(),
+            gateway: gateway,
+            submit: { _ in true },
+            interrupt: {}
+        )
+        // No beginVoiceTurn: the extension is a no-op and a later turn
+        // captures only its own id.
+        controller.extendAssistantSessionIDs(
+            ["runtime-rebound"],
+            ofConversationContaining: ["runtime-rebound"]
+        )
+        controller.beginVoiceTurn(sessionID: "voice-session")
+        await controller.startListening()
+        let start = Date()
+        controller.ingestAudioLevel(0.1, at: start)
+        controller.ingestAudioLevel(0, at: start.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        controller.receiveAssistantEvent(.delta(sessionID: "runtime-rebound", text: " no"))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertTrue(
+            gateway.stream?.appended.isEmpty ?? true,
+            "A stale alias extension must not give the next turn's events speech"
+        )
+    }
+
     func testAudioInterruptionDuringTranscriptionCannotGhostSubmit() async {
         let capture = MockCapture(permissionGranted: true)
         let gateway = MockGateway(transcript: "late", transcriptionDelayNanoseconds: 150_000_000)


### PR DESCRIPTION
# Harden conversation identity across session boundaries

Follow-up to #137 (merged as b3fa7c3). #137 established the conversation identity model — durable identity, runtime identity, confirmed aliases, profile — and the resume admission gate. This pass closes the remaining places that interpreted raw session-ID strings independently, so there is **one consistent definition of conversation identity throughout Conduit**: future features should not need to know whether a string is a stored ID, runtime ID, alias, or current routing ID.

This is **not** a redesign of #137; `ConversationIdentity`, the admission gate, and its tests are preserved intact.

## 0. Round 2: split-brain, delete-of-pending-restoration, durable-owned presentation

Round 2 closes the correctness gaps found in review, without touching the architecture:

- **No split-brain.** `recordAuthoritative(...)` is the explicit fresh-evidence API: an admitted resume, an `active_list` row, or a verified create/branch REBINDS a conflicting historical mapping, because the app has already accepted that routing into conversation-owned state. When nothing else established the durable, the resume TARGET itself is the durable candidate (a stored-addressed resume positively names it; runtime-addressed resumes degenerate to self-mappings the index skips). After every admitted resume: index, selected conversation, and reconciliation agree. `record(...)` remains the low-authority path (historical aliases, notification payloads) and never overwrites.
- **Deletion invalidates pending in-memory restoration.** `ChatResumeCoordinator.removeSessions` now clears `pendingSessionKey` (+ fallback-selection state) and published `pendingRestoration` belonging to the deleted identities — the stale generation stops being current, so completion/abandon cannot resurrect it — unfreezes the viewport, and bumps the automatic-work epoch. Strictly scoped: pending work for other conversations is untouched.
- **Durable-owned presentation persistence.** Once the durable id is established, the durable key is the ONLY persistent presentation key: `consolidateUnderDurableKey` migrates runtime-keyed records into it at admission (freshest wins; nothing lost) and retires the alias keys, while `durableOwnedPresentationIDs` collapses all write id-lists to the durable key so flushes can never recreate alias copies. A runtime id the gateway later re-attributes elsewhere therefore carries no trace of the previous conversation — timestamps, attachments, tool metadata, or pending decision cards. Migrated approval cards have their embedded session id rewritten to the durable id, so an approve tap dispatches to the durable session even after later rotations. Merge lookups remain tolerant supersets.
- **`session.active_list` feeds the index.** All three registry probe sites record rows (runtime → stored, authoritative) with the profile captured before the await and a currency fence (profile + live client identity) so superseded connections cannot write. Strictly observational: rows never mutate the selected conversation, and healthy-foreground observe-don't-resume is untouched.
- **Notification conflict semantics pinned.** A stale dual-ID push against fresher live truth is rejected by admission and poisons nothing; decision cards persist only under the push-named id until the open succeeds.

## 1. Shared confirmed identity index (`ConversationIdentityIndex`)

New profile-scoped component answering: *what durable conversation is runtime-a positively known to belong to?* It is not a second session state machine — `ConversationIdentity` remains the ownership value.

**Accepted evidence only** (each tagged with a source for diagnostics: `catalog`, `resume`, `active_list`-class registries, `create`, `branch`, `notification`):
- admitted resume results (the rebind/establishment point in the reconcile);
- explicitly labeled catalog rows (`storedSessionId` + id set), committed at both catalog publish points;
- verified create/branch responses (the summary built from the same response);
- notification payloads that explicitly carry both identities.

**Never evidence:** catalog ordering, newest activity, timestamps, title equality, string resemblance, profile co-membership.

**Conflict behavior — explicit authority table.** Callers pick the API by authority, never by convenience:

| Evidence | API | May establish? | May rebind? |
|---|---|---|---|
| historical confirmed alias | `record` | yes | no |
| dual-ID notification payload | `record` | yes | no |
| admitted `session.resume` | `recordAuthoritative` | yes | **yes** |
| authoritative catalog snapshot | `recordCatalogIdentity` | yes | yes (first claim per snapshot) |
| `session.active_list` row | `recordAuthoritative` | yes | **yes** |
| verified create result | `recordAuthoritative` | yes | yes (created conversation) |
| verified branch result | `recordAuthoritative` | yes | yes (branched conversation) |

The rule behind the table: when the app has already ACCEPTED fresh routing evidence into conversation-owned state, the index must not disagree — a rebind wins and the displaced mapping is logged; historical observations and unverified payload claims never overwrite a fresher confirmed mapping, they surface a conflict. Suspended operations are unaffected either way because they hold capture-time `acceptedSessionIDs` and can never gain ownership through the index.

**Scope & lifecycle:** mappings are keyed by normalized profile — one profile's runtime IDs can never establish ownership in another. `removeAll()` at the `prepareChatResumeForConnection(to:)` server-change boundary; `removeSessionIDs` on explicit delete. Catalog omission never clears mappings. Logout/re-login on the same server keeps mappings (same server identity).

## 2. Notification routing

`ConduitNotificationTarget` now separates `sessionId` (runtime) from `durableSessionID` (parsed from a new `stored_session_id` / `session_key` **top-level routing field** in the conduit payload; **backward compatible** — older payloads parse exactly as before). `NotificationSessionResolver.resumableSessionID` is replaced by `route(target:catalog:identityIndex:profile:)` with an explicit evidence hierarchy:

1. **explicitDurable** — payload carries the durable id → route there, no catalog needed;
2. **catalogAlias** — live catalog row positively contains the runtime id;
3. **confirmedAlias** — the shared index fills a stale/omitted catalog;
4. **legacyRuntime** — no positive durable evidence: the notification's own runtime id is resumed directly (historical behavior), and nothing else. **An unknown runtime ID is never reinterpreted as a durable conversation — there is no newest-chat/ordering/similarity fallback.**

Decision cards remain functional and are recorded under all routed identities (durable + runtime). `decision.session_key` stays the `approval.respond` answer key and is deliberately **not** promoted to routing identity (a `stored_session_id`/`session_key` precedence test pins the top-level parsing). The payload's dual identity is committed to the index **only after the open succeeds** — a failed resume (e.g. the durable conversation was deleted server-side) leaves no dead mapping — and a disagreement with the confirmed mapping is logged by id at the call site.

*Notifier note:* the relay/gateway today sends only `session_id`; the iOS side is forward-compatible. When the notifier adds `stored_session_id` to the routing payload, routing upgrades automatically without an app release on the parser side (both spellings accepted).

## 3. Server-change contract (cross-server leak fix)

`prepareChatResumeForConnection(to:)` now also clears `SessionYoloStore` overrides and the identity index — previously YOLO overrides were keyed only by (profile, session id), so Server A `default`/`abc` could leak its override into Server B `default`/`abc`. Resume store, presentation cache, titles, pins, and review cache were already cleared there (verified; unchanged).

## 4. Delete revocation

Explicit deletion now revokes the conversation's identity: index mappings, resume/scroll snapshots (plus the profile's last-selected pointer when it names the deleted conversation), and cached presentation — including pending decision cards — under **every** alias. Archive keeps identity (the conversation still exists; product semantics unchanged). Branch responses index the branch's own ids only; source and branch never alias.

## 5. Voice event identity

Voice assistant events carry runtime routing ids. Matching now uses a confirmed alias set (`beginVoiceTurn` capture + `extendAssistantSessionIDs(_:ofConversationContaining:)` on admitted rebinds) instead of raw equality with the turn's captured id, so a mid-voice-turn runtime rotation no longer silently drops the assistant's speech. Two guards keep ownership tight: the extension applies only when the reconciled conversation's accepted ids POSITIVELY overlap the turn's captured ids (a reconcile belonging to a different conversation can never inject its runtime — a vector all three review models flagged), and extensions are ignored when no turn is active, so nothing leaks into the next turn.

## 6. Audits that found no defect (pinned instead)

- **Rename** (`SessionRenameOperation`): existing guards are correct under the durable/runtime model — active-runtime RPC only when `activeSessionID` positively matches the row, durable PATCH fallback otherwise, `ContextChanged` on client swap, profile fences on application. Added a rotation pin: a confirmed new runtime that the stale row doesn't list must rename via the durable id, never the unverified runtime string.
- **Stream-event acceptance**: `reconciliation.accepts` + `eventBelongsToActiveSession` already implement the alias contract (#137); untouched, covered.
- **Composer drafts**: in-memory, equivalence-driven migration verified via new contract tests — a draft follows `runtime-old → runtime-new` rotation, does **not** follow a re-attributed runtime string into another conversation, and is profile-scoped.
- **Compact resume (#106)** and **observational foreground (#17)**: untouched; existing suites (`CompactResumeTranscriptTests`, `AppStateForegroundLifecycleTests`) cover them.

## Test plan

- New `SessionIdentityContractTests`: cross-component identity matrix (routing hierarchy, profile scoping, rotation ownership retention, re-attribution rejection, catalog omission, payload parsing, draft equivalence).
- New `ConversationIdentityIndexTests`: evidence, conflict, authoritative catalog overwrite, scoping, revocation.
- Extended: `AppStateChatResumeTests` (dual-identity notification opens, runtime-only + confirmed alias, unknown-runtime safety pin, index commit through the notification path, server-change isolation, delete revocation), `MessageNormalizerTests` (resolver route API), `VoiceConversationControllerTests` (rebind alias, no-leak), `SessionYoloStoreTests`, `ChatResumeStoreTests`, `SessionPresentationCacheTests`, `SessionRenameTests`.
- Focused suites green locally on the Mac build box; full unit suite + planner validation (`plan-tests.py validate`) + script tests green. Hosted CI green on this branch.

## Review gate

Round 1 — three independent reviewer models (2× APPROVE-WITH-NITS, 1× REQUEST-CHANGES). All flagged defects fixed before push:

- **Voice extension conversation-blindness** (3/3 flagged): adopted the positive-overlap guard + a dedicated cross-conversation non-leak test.
- **Catalog commit ordering** (1/3): `recordCatalogIdentity` is now first-claim-wins within one snapshot (the committed catalog can contain stale cached rows merged after fresh ones, and routing reads that same order), so the index can never pin a re-attribution the resolver would not route to.
- **Notification evidence timing** (2/3): explicit-durable payload evidence is committed only after the open succeeds, with conflict logging at the call site.
- **Resolver hardening** (1/3): catalog alias lookup skips foreign-profile rows and returns trimmed ids.
- **Rejected finding** (documented): one reviewer proposed that `legacyRuntimeRebind` admissions must not record index evidence. Rejected with evidence — the admission gate's `.success` IS the positive adoption (`context?.acceptedSessionIDs.insert` runs for the same result), and the legacy rebind path is precisely how runtime rotation manifests on gateways that do not echo stored ids; excluding it would break rotation routing. The third reviewer independently verified this hook cannot record a contradicted mapping (all rejections return early).

Round 2 (the split-brain / delete / durable-owned-presentation commit) — two focused reviewers, both REQUEST-CHANGES; every Major fixed before push:

- **Write collapse was not durable-only**: `durableOwnedPresentationIDs` returned `aliases + [durable]` when the durable id wasn't already in the list, letting flushes recreate retired runtime keys. A write now lands on the durable key alone once established (the contract test pins the stricter rule).
- **Stale push decision bled into the claimed durable**: decision cards were persisted before the open proved the route. Cards now persist only under the push-named identity before the open; a successful open's consolidation migrates them to the durable key.
- **`active_list` had no currency fence**: in-flight rows from a superseded connection could repopulate the index scope a server change just cleared. All three probe sites fence on the committed server identity (the exact `prepareChatResumeForConnection` boundary) plus profile. A client-identity fence was deliberately rejected — the foreground suite pins that a client replacement (even re-addressed) must still be accepted.
- **Migrated approval cards kept a stale routing id**: consolidation rewrites an approval's embedded session id from a retired runtime alias to the durable id, so an approve tap dispatches to the durable session even after later rotations (the first implementation mutated a local copy without writing it back — the new regression test caught it).

## Not done deliberately

- No persistence schema for the index (in-memory by design; the notification path refreshes the catalog first, and the index exists to bridge within-run catalog churn — persisted mappings would need cross-launch invalidation semantics this pass deliberately avoids).
- Notifier-side payload emission of `stored_session_id` lives in the notifier repo; this PR ships the forward-compatible contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved notification routing to open the correct conversation using durable or confirmed session identities.
  - Preserved pending approvals and conversation presentation when session identifiers change.
  - Voice conversations now continue safely across confirmed session-identifier rotations.

- **Bug Fixes**
  - Prevented stale or rejected notifications from appearing in the wrong conversation.
  - Deleting a conversation now clears its saved state and cancels pending restoration.
  - Server changes now clear outdated session overrides and identity mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->