### PR TITLE
fix(voice): centralize AVAudioSession ownership with intent leases

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -12510,6 +12510,10 @@ final class AppState: ObservableObject {
         guard let gateway = makeVoiceGateway() else {
             return .failure("Conduit could not connect this test to the selected profile.")
         }
+        // Mutual exclusion: the transcription test claims conversation-capture
+        // session ownership, so a still-playing read aloud must stop first —
+        // otherwise the dominant audio policy would flip under live playback.
+        messageReadAloudController.stop()
         voiceConversationController.setGateway(gateway)
         let result = await voiceConversationController.runTranscriptionTest()
         appleSpeechAvailability = AppleOnDeviceSpeechTranscriber.currentAvailability()

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -12500,6 +12500,11 @@ final class AppState: ObservableObject {
     }
 
     func runVoiceASRTest() async -> VoiceProviderTestResult {
+        // Ownership first: a playing read aloud must release its standalone
+        // lease before anything else in this flow — the capability refresh
+        // and the capture test itself — can claim conversation-capture
+        // ownership or await the network.
+        messageReadAloudController.stop()
         await refreshVoiceCapabilities()
         guard isVoiceEnabled else {
             return .failure("Enable voice for this profile before running a speech-to-text test.")
@@ -12510,10 +12515,6 @@ final class AppState: ObservableObject {
         guard let gateway = makeVoiceGateway() else {
             return .failure("Conduit could not connect this test to the selected profile.")
         }
-        // Mutual exclusion: the transcription test claims conversation-capture
-        // session ownership, so a still-playing read aloud must stop first —
-        // otherwise the dominant audio policy would flip under live playback.
-        messageReadAloudController.stop()
         voiceConversationController.setGateway(gateway)
         let result = await voiceConversationController.runTranscriptionTest()
         appleSpeechAvailability = AppleOnDeviceSpeechTranscriber.currentAvailability()

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -813,6 +813,12 @@ final class AppState: ObservableObject {
     /// rather than kept.
     private var readAloudGatewayBridge: DashboardTicketBridge?
 
+    /// Test-only seam: when set, the voice capability refresh requests
+    /// through it instead of the dashboard bridge, keeping
+    /// `refreshVoiceCapabilities` hermetic in tests. Mirrors the
+    /// `installVoiceCapabilityStateForTesting` precedent.
+    var voiceCapabilityRequesterForTesting: VoiceConfigurationRequesting?
+
     // MARK: - Cron
 
     @Published var cronJobs: [CronJob] = []
@@ -12384,7 +12390,10 @@ final class AppState: ObservableObject {
         installVoiceAssistantObserverIfNeeded()
         isVoiceEnabled = defaults.bool(forKey: voiceEnabledPreferenceKey(profile: profile))
         appleSpeechAvailability = AppleOnDeviceSpeechTranscriber.currentAvailability()
-        let service = HermesVoiceConfigurationService(bridge: bridge, profile: profile)
+        let service = HermesVoiceConfigurationService(
+            requester: voiceCapabilityRequesterForTesting ?? bridge,
+            profile: profile
+        )
         await service.reload()
         guard profile == activeProfile, bridge === dashboardTicketBridge else { return }
         voiceCapabilitySnapshot = service.snapshot.capability

--- a/Conduit/Voice/AVAudioCaptureService.swift
+++ b/Conduit/Voice/AVAudioCaptureService.swift
@@ -42,8 +42,11 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
     private var captureLease: VoiceAudioLease?
     let events: AsyncStream<VoiceCaptureEvent>
 
-    init(coordinator: VoiceAudioSessionCoordinator = .shared) {
-        self.coordinator = coordinator
+    /// Optional injection instead of a default `.shared` argument: default
+    /// parameter values are evaluated in a nonisolated context, which cannot
+    /// read the MainActor-isolated singleton.
+    init(coordinator: VoiceAudioSessionCoordinator? = nil) {
+        self.coordinator = coordinator ?? .shared
         var capturedContinuation: AsyncStream<VoiceCaptureEvent>.Continuation?
         events = AsyncStream { capturedContinuation = $0 }
         continuation = capturedContinuation
@@ -284,16 +287,25 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
         }
     }
 
+    /// Hopped through `Task { @MainActor }`: session notifications are not
+    /// guaranteed to arrive on the main thread, and stop() now releases the
+    /// capture lease through the MainActor coordinator.
     @objc private func handleInterruption(_ notification: Notification) {
         guard let typeValue = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
-              let type = AVAudioSession.InterruptionType(rawValue: typeValue) else { return }
-        if type == .began {
-            stop()
-            continuation?.yield(.interrupted)
+              let type = AVAudioSession.InterruptionType(rawValue: typeValue), type == .began else { return }
+        Task { @MainActor [weak self] in
+            self?.stop()
+            self?.continuation?.yield(.interrupted)
         }
     }
 
+    /// Hopped through `Task { @MainActor }` for the same reason as
+    /// `handleInterruption`; `coordinator.reassert()` is MainActor-isolated.
     @objc private func handleRouteChange(_ notification: Notification) {
+        Task { @MainActor [weak self] in self?.handleRouteChangeOnMain() }
+    }
+
+    private func handleRouteChangeOnMain() {
         // A nil-format tap follows the input node's actual route format. Rebuild
         // the converter lazily without churning an already-running engine.
         converter = nil

--- a/Conduit/Voice/AVAudioCaptureService.swift
+++ b/Conduit/Voice/AVAudioCaptureService.swift
@@ -19,6 +19,7 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
 
     private let engine = AVAudioEngine()
     private let session = AVAudioSession.sharedInstance()
+    private let coordinator: VoiceAudioSessionCoordinator
     /// AVAudioEngine and AVAudioConverter use deinterleaved Float32 as their
     /// canonical PCM representation. Quantize to PCM16 only after resampling.
     private let outputFormat = AVAudioFormat(
@@ -34,9 +35,15 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
     private var shouldKeepEngineRunning = false
     private var lastCaptureFailure: String?
     private var continuation: AsyncStream<VoiceCaptureEvent>.Continuation?
+    /// Capture holds one lease for the whole capture window (listening,
+    /// barge-in monitoring) and releases it on stop — or on pause, which is a
+    /// real resource pause: engine, tap, and session ownership all go away
+    /// while the Voice Conversation stays logically open.
+    private var captureLease: VoiceAudioLease?
     let events: AsyncStream<VoiceCaptureEvent>
 
-    override init() {
+    init(coordinator: VoiceAudioSessionCoordinator = .shared) {
+        self.coordinator = coordinator
         var capturedContinuation: AsyncStream<VoiceCaptureEvent>.Continuation?
         events = AsyncStream { capturedContinuation = $0 }
         continuation = capturedContinuation
@@ -87,6 +94,7 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
     }
 
     func beginBargeInMonitoring() throws {
+        guard !paused else { return }
         do {
             try startCaptureIfNeeded()
         } catch {
@@ -98,7 +106,18 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
         shouldKeepEngineRunning = true
     }
 
-    func pause() { paused = true }
+    /// A real resource pause: the engine, tap, converter, and capture's
+    /// audio-session lease are released so microphone hardware and the
+    /// system session are not held while the user believes the mic is
+    /// paused. `resume()` reacquires everything. The Voice Conversation
+    /// stays logically open across the pause.
+    func pause() {
+        guard !paused else { return }
+        paused = true
+        shouldKeepEngineRunning = false
+        teardownRendering()
+        releaseLease()
+    }
 
     func resume() throws {
         do {
@@ -133,26 +152,18 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
         activelyRecording = false
         paused = false
         shouldKeepEngineRunning = false
-        let input = engine.inputNode
-        input.removeTap(onBus: 0)
-        engine.stop()
-        converter = nil
-        try? session.setActive(false, options: .notifyOthersOnDeactivation)
+        teardownRendering()
+        releaseLease()
     }
 
     private func startCaptureIfNeeded() throws {
-        try configureSession()
+        if captureLease == nil {
+            // Acquiring configures the conversation policy (category/mode/
+            // options) and activates the session through the coordinator, so
+            // concurrent owners can never fight over the singleton.
+            captureLease = try coordinator.acquire(.conversationCapture)
+        }
         if !engine.isRunning { try startEngine() }
-    }
-
-    private func configureSession() throws {
-        let configuration = VoiceAudioSessionConfiguration.capture
-        try session.setCategory(
-            configuration.category,
-            mode: configuration.mode,
-            options: configuration.options
-        )
-        try session.setActive(true)
     }
 
     private func handleStartupFailure(_ error: Error, stage: String) {
@@ -201,6 +212,19 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
         }
         engine.prepare()
         try engine.start()
+    }
+
+    private func teardownRendering() {
+        let input = engine.inputNode
+        input.removeTap(onBus: 0)
+        engine.stop()
+        converter = nil
+    }
+
+    private func releaseLease() {
+        guard let lease = captureLease else { return }
+        captureLease = nil
+        coordinator.release(lease)
     }
 
     private func consume(_ buffer: AVAudioPCMBuffer) {
@@ -275,7 +299,10 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
         converter = nil
         if shouldKeepEngineRunning, !engine.isRunning {
             do {
-                try configureSession()
+                // The lease is still held, but the system may have torn the
+                // session down with the old route: reapply the conversation
+                // policy before restarting the engine.
+                try coordinator.reassert()
                 try startEngine()
             } catch {
                 handleStartupFailure(error, stage: "routeChange")

--- a/Conduit/Voice/AVSpeechPlaybackService.swift
+++ b/Conduit/Voice/AVSpeechPlaybackService.swift
@@ -15,6 +15,11 @@ final class AVSpeechPlaybackService: NSObject, SpeechPlaybackService {
     private var pendingBuffers = 0
     private var drainWaiters: [CheckedContinuation<Void, Never>] = []
     private var encodedPlayer: AVAudioPlayer?
+    /// Set once `finish()` is requested: when the last scheduled buffer (or
+    /// the encoded player) then drains, playback is terminal and ownership
+    /// must be released. Mid-stream buffer gaps keep ownership so the session
+    /// does not flap while the gateway prepares the next chunk.
+    private var isFinishing = false
     private let coordinator: VoiceAudioSessionCoordinator
     private var lease: VoiceAudioLease?
     /// Which audio-session ownership this service claims while playing.
@@ -23,8 +28,11 @@ final class AVSpeechPlaybackService: NSObject, SpeechPlaybackService {
     var ownershipIntent: VoiceAudioIntent = .standalonePlayback
     private(set) var isPlaying = false
 
-    init(coordinator: VoiceAudioSessionCoordinator = .shared) {
-        self.coordinator = coordinator
+    /// Optional injection instead of a default `.shared` argument: default
+    /// parameter values are evaluated in a nonisolated context, which cannot
+    /// read the MainActor-isolated singleton.
+    init(coordinator: VoiceAudioSessionCoordinator? = nil) {
+        self.coordinator = coordinator ?? .shared
         super.init()
         engine.attach(player)
         NotificationCenter.default.addObserver(
@@ -112,11 +120,15 @@ final class AVSpeechPlaybackService: NSObject, SpeechPlaybackService {
         // An odd tail is invalid PCM16 and is intentionally discarded rather
         // than shifted into the next response.
         remainder.removeAll(keepingCapacity: true)
+        isFinishing = true
     }
 
     func drain() async {
         guard pendingBuffers > 0 || encodedPlayer != nil else {
             isPlaying = false
+            // Nothing was ever scheduled (or the queue drained between
+            // checks): a finishing stream must still release ownership.
+            if isFinishing { stop() }
             return
         }
         await withCheckedContinuation { continuation in
@@ -125,6 +137,7 @@ final class AVSpeechPlaybackService: NSObject, SpeechPlaybackService {
     }
 
     func stop() {
+        isFinishing = false
         player.stop()
         encodedPlayer?.stop()
         encodedPlayer = nil
@@ -149,33 +162,52 @@ final class AVSpeechPlaybackService: NSObject, SpeechPlaybackService {
         coordinator.release(lease)
     }
 
+    /// Both notification handlers hop through `Task { @MainActor }`: session
+    /// notifications are not guaranteed to arrive on the main thread, and
+    /// every reachable entry point below (stop, coordinator release, waiter
+    /// resumption) is MainActor-isolated state.
     @objc private func handleInterruption(_ notification: Notification) {
         guard let typeValue = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
-              let type = AVAudioSession.InterruptionType(rawValue: typeValue) else { return }
-        if type == .began {
+              let type = AVAudioSession.InterruptionType(rawValue: typeValue), type == .began else { return }
+        Task { @MainActor [weak self] in
             // Playback can no longer continue: settle buffers and drain
             // waiters so awaiting controllers never hang, and release session
             // ownership so other media recovers. Resuming after the
             // interruption ends is deliberate follow-up work, not silent
             // breakage.
-            stop()
+            self?.stop()
         }
     }
 
     @objc private func handleEngineConfigurationChange(_ notification: Notification) {
-        // A route change can stop the rendering engine under a live lease
-        // (AirPods disconnect, dock/undock). Settle instead of leaving
-        // buffers undrained and ownership claimed by audio that can never
-        // play. A conversation drain self-heals: the next PCM buffer
-        // reacquires ownership and restarts the engine on the new route.
-        guard lease != nil, !engine.isRunning else { return }
-        stop()
+        Task { @MainActor [weak self] in
+            // A route change can stop the rendering engine under a live lease
+            // (AirPods disconnect, dock/undock). Settle instead of leaving
+            // buffers undrained and ownership claimed by audio that can never
+            // play. A conversation drain self-heals: the next PCM buffer
+            // reacquires ownership and restarts the engine on the new route.
+            guard let self, self.lease != nil, !self.engine.isRunning else { return }
+            self.stop()
+        }
     }
 
     private func bufferDidDrain() {
-        pendingBuffers = max(0, pendingBuffers - 1)
+        guard pendingBuffers > 0 else { return }
+        pendingBuffers -= 1
         guard pendingBuffers == 0 else { return }
-        isPlaying = false
+        if isFinishing {
+            // Terminal: everything queued has rendered. stop() tears the
+            // engine down, resumes drain waiters exactly once, and releases
+            // session ownership so standalone speech un-ducks other media the
+            // moment it ends.
+            stop()
+        } else {
+            isPlaying = false
+            settleDrainWaiters()
+        }
+    }
+
+    private func settleDrainWaiters() {
         let waiters = drainWaiters
         drainWaiters.removeAll()
         waiters.forEach { $0.resume() }
@@ -186,11 +218,10 @@ extension AVSpeechPlaybackService: AVAudioPlayerDelegate {
     nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
         Task { @MainActor in
             guard self.encodedPlayer === player else { return }
-            self.encodedPlayer = nil
-            self.isPlaying = false
-            let waiters = self.drainWaiters
-            self.drainWaiters.removeAll()
-            waiters.forEach { $0.resume() }
+            // Natural completion is terminal for the encoded path: stop()
+            // clears the player, resumes drain waiters, and releases the
+            // session lease.
+            self.stop()
         }
     }
 }

--- a/Conduit/Voice/AVSpeechPlaybackService.swift
+++ b/Conduit/Voice/AVSpeechPlaybackService.swift
@@ -73,6 +73,10 @@ final class AVSpeechPlaybackService: NSObject, SpeechPlaybackService {
     func enqueuePCM16(_ data: Data, sampleRate: Double) throws -> Int {
         if format == nil { try start(sampleRate: sampleRate) }
         guard let format, abs(format.sampleRate - sampleRate) < 1 else {
+            // A stream that changes sample rates can never render; settle
+            // immediately so the lease does not wait on the caller's error
+            // path.
+            stop()
             throw VoiceAudioError.unavailable("The gateway changed PCM sample rates during a stream.")
         }
         remainder.append(data)
@@ -216,8 +220,8 @@ final class AVSpeechPlaybackService: NSObject, SpeechPlaybackService {
 
 extension AVSpeechPlaybackService: AVAudioPlayerDelegate {
     nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
-        Task { @MainActor in
-            guard self.encodedPlayer === player else { return }
+        Task { @MainActor [weak self] in
+            guard let self, self.encodedPlayer === player else { return }
             // Natural completion is terminal for the encoded path: stop()
             // clears the player, resumes drain waiters, and releases the
             // session lease.

--- a/Conduit/Voice/AVSpeechPlaybackService.swift
+++ b/Conduit/Voice/AVSpeechPlaybackService.swift
@@ -15,25 +15,49 @@ final class AVSpeechPlaybackService: NSObject, SpeechPlaybackService {
     private var pendingBuffers = 0
     private var drainWaiters: [CheckedContinuation<Void, Never>] = []
     private var encodedPlayer: AVAudioPlayer?
+    private let coordinator: VoiceAudioSessionCoordinator
+    private var lease: VoiceAudioLease?
+    /// Which audio-session ownership this service claims while playing.
+    /// Conversation playback joins the capture-owned session; standalone
+    /// flows (Read Aloud, TTS provider test) claim output-only ownership.
+    var ownershipIntent: VoiceAudioIntent = .standalonePlayback
     private(set) var isPlaying = false
 
-    override init() {
+    init(coordinator: VoiceAudioSessionCoordinator = .shared) {
+        self.coordinator = coordinator
         super.init()
         engine.attach(player)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleInterruption(_:)),
+            name: AVAudioSession.interruptionNotification,
+            object: AVAudioSession.sharedInstance()
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleEngineConfigurationChange(_:)),
+            name: AVAudioEngine.configurationChangeNotification,
+            object: engine
+        )
     }
+
+    deinit { NotificationCenter.default.removeObserver(self) }
 
     func start(sampleRate: Double) throws {
         stop()
-        let session = AVAudioSession.sharedInstance()
-        try session.setCategory(.playAndRecord, mode: .voiceChat, options: [.allowBluetooth, .defaultToSpeaker])
-        try session.setActive(true)
         guard let format = AVAudioFormat(commonFormat: .pcmFormatInt16, sampleRate: sampleRate, channels: 1, interleaved: true) else {
             throw VoiceAudioError.unavailable("The gateway reported an unsupported PCM format.")
         }
-        self.format = format
-        engine.connect(player, to: engine.mainMixerNode, format: format)
-        engine.prepare()
-        try engine.start()
+        lease = try coordinator.acquire(ownershipIntent)
+        do {
+            self.format = format
+            engine.connect(player, to: engine.mainMixerNode, format: format)
+            engine.prepare()
+            try engine.start()
+        } catch {
+            releaseOwnership()
+            throw error
+        }
         player.play()
         isPlaying = true
     }
@@ -70,15 +94,18 @@ final class AVSpeechPlaybackService: NSObject, SpeechPlaybackService {
 
     func playEncodedAudioData(_ data: Data) throws {
         stop()
-        let session = AVAudioSession.sharedInstance()
-        try session.setCategory(.playAndRecord, mode: .voiceChat, options: [.allowBluetooth, .defaultToSpeaker])
-        try session.setActive(true)
-        let player = try AVAudioPlayer(data: data)
-        player.delegate = self
-        player.prepareToPlay()
-        guard player.play() else { throw VoiceAudioError.unavailable("Could not play Hermes fallback speech.") }
-        encodedPlayer = player
-        isPlaying = true
+        lease = try coordinator.acquire(ownershipIntent)
+        do {
+            let player = try AVAudioPlayer(data: data)
+            player.delegate = self
+            player.prepareToPlay()
+            guard player.play() else { throw VoiceAudioError.unavailable("Could not play Hermes fallback speech.") }
+            encodedPlayer = player
+            isPlaying = true
+        } catch {
+            releaseOwnership()
+            throw error
+        }
     }
 
     func finish() throws {
@@ -109,6 +136,40 @@ final class AVSpeechPlaybackService: NSObject, SpeechPlaybackService {
         let waiters = drainWaiters
         drainWaiters.removeAll()
         waiters.forEach { $0.resume() }
+        releaseOwnership()
+    }
+
+    /// Ownership is released only after the engine stopped rendering, so the
+    /// coordinator never deactivates the session underneath live audio. The
+    /// coordinator keeps the session active when another owner (conversation
+    /// capture) still needs it.
+    private func releaseOwnership() {
+        guard let lease else { return }
+        self.lease = nil
+        coordinator.release(lease)
+    }
+
+    @objc private func handleInterruption(_ notification: Notification) {
+        guard let typeValue = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+              let type = AVAudioSession.InterruptionType(rawValue: typeValue) else { return }
+        if type == .began {
+            // Playback can no longer continue: settle buffers and drain
+            // waiters so awaiting controllers never hang, and release session
+            // ownership so other media recovers. Resuming after the
+            // interruption ends is deliberate follow-up work, not silent
+            // breakage.
+            stop()
+        }
+    }
+
+    @objc private func handleEngineConfigurationChange(_ notification: Notification) {
+        // A route change can stop the rendering engine under a live lease
+        // (AirPods disconnect, dock/undock). Settle instead of leaving
+        // buffers undrained and ownership claimed by audio that can never
+        // play. A conversation drain self-heals: the next PCM buffer
+        // reacquires ownership and restarts the engine on the new route.
+        guard lease != nil, !engine.isRunning else { return }
+        stop()
     }
 
     private func bufferDidDrain() {

--- a/Conduit/Voice/AVSpeechPlaybackService.swift
+++ b/Conduit/Voice/AVSpeechPlaybackService.swift
@@ -44,7 +44,7 @@ final class AVSpeechPlaybackService: NSObject, SpeechPlaybackService {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleEngineConfigurationChange(_:)),
-            name: AVAudioEngine.configurationChangeNotification,
+            name: .AVAudioEngineConfigurationChange,
             object: engine
         )
     }

--- a/Conduit/Voice/MessageReadAloudController.swift
+++ b/Conduit/Voice/MessageReadAloudController.swift
@@ -128,6 +128,9 @@ final class MessageReadAloudController: ObservableObject {
             return
         }
         do {
+            // Pin output-only ownership per operation rather than inheriting
+            // whatever intent a shared playback instance last claimed.
+            playback.ownershipIntent = .standalonePlayback
             let stream = try await gateway.openSpeechStream(
                 onStart: { [weak self] sampleRate in
                     guard let self, self.isCurrent(generation) else { return }

--- a/Conduit/Voice/VoiceAudioSessionConfiguration.swift
+++ b/Conduit/Voice/VoiceAudioSessionConfiguration.swift
@@ -14,4 +14,22 @@ struct VoiceAudioSessionConfiguration: Equatable {
         outputSampleRate: 16_000,
         outputChannelCount: 1
     )
+
+    /// Output-only policy for standalone speech (Read Aloud, TTS provider
+    /// test): `.playback` never claims the microphone, and `.mixWithOthers` +
+    /// `.duckOthers` let already-playing media (Spotify, Audible) continue at
+    /// reduced volume while Conduit speaks instead of being interrupted.
+    /// Ducking ends the moment the session deactivates, so standalone speech
+    /// stops affecting other media immediately when it finishes. Deliberately
+    /// not `.voiceChat`: these flows never record, and a record category
+    /// keeps other media suppressed even while idle.
+    /// The sample-rate fields below belong to the capture policy and are
+    /// unused by playback; the values mirror the gateway speech stream.
+    static let standalonePlayback = Self(
+        category: .playback,
+        mode: .default,
+        options: [.mixWithOthers, .duckOthers],
+        outputSampleRate: 24_000,
+        outputChannelCount: 1
+    )
 }

--- a/Conduit/Voice/VoiceAudioSessionCoordinator.swift
+++ b/Conduit/Voice/VoiceAudioSessionCoordinator.swift
@@ -58,10 +58,20 @@ final class SystemVoiceAudioSession: VoiceAudioSessionControlling {
 /// (stop, cancellation, backgrounding) can never underflow another owner.
 struct VoiceAudioLease: Equatable {
     fileprivate let id: UUID
+    /// Internal so tests can synthesize unknown leases; production callers
+    /// only ever receive leases from `acquire`.
+    init(id: UUID = UUID()) { self.id = id }
 }
 
 @MainActor
 final class VoiceAudioSessionCoordinator {
+    /// Shared instance: the underlying `AVAudioSession` is itself a
+    /// process-global singleton, so one coordinator mirrors reality. Tests
+    /// construct isolated instances with a mocked session seam.
+    /// Both audio services are app-lifetime objects owned by AppState and
+    /// must release leases on every terminal path (stop, cancellation,
+    /// failure) — a lease still held at service deinit would leave a
+    /// permanent owner entry here.
     static let shared = VoiceAudioSessionCoordinator()
 
     /// The session policy currently applied to the system session, or nil
@@ -80,8 +90,11 @@ final class VoiceAudioSessionCoordinator {
     private let session: VoiceAudioSessionControlling
     private var leases: [UUID: VoiceAudioIntent] = [:]
 
-    init(session: VoiceAudioSessionControlling = SystemVoiceAudioSession()) {
-        self.session = session
+    /// Optional injection instead of a default-constructed argument: default
+    /// parameter values are evaluated in a nonisolated context, which cannot
+    /// construct the MainActor-isolated `SystemVoiceAudioSession`.
+    init(session: VoiceAudioSessionControlling? = nil) {
+        self.session = session ?? SystemVoiceAudioSession()
     }
 
     func acquire(_ intent: VoiceAudioIntent) throws -> VoiceAudioLease {

--- a/Conduit/Voice/VoiceAudioSessionCoordinator.swift
+++ b/Conduit/Voice/VoiceAudioSessionCoordinator.swift
@@ -1,0 +1,182 @@
+//
+//  VoiceAudioSessionCoordinator.swift
+//  Conduit
+//
+//  Single authority for Conduit's ownership of the process-global
+//  AVAudioSession. Services acquire an intent-scoped lease instead of
+//  calling setCategory/setActive themselves, so playback-only flows
+//  (Read Aloud, the TTS provider test) can no longer leave the session
+//  active forever, and one component can never deactivate or reconfigure
+//  the session while another still needs it (issue #140).
+//
+
+import AVFAudio
+import Foundation
+import OSLog
+
+private let audioSessionLogger = Logger(subsystem: "com.milim.relay", category: "VoiceAudio")
+
+/// An audio capability Conduit can hold against the shared session.
+enum VoiceAudioIntent: Equatable {
+    /// Microphone capture for an active Voice Conversation.
+    case conversationCapture
+    /// Assistant speech during an active Voice Conversation.
+    case conversationPlayback
+    /// Output-only speech outside a Voice Conversation (Read Aloud, TTS test).
+    case standalonePlayback
+}
+
+/// Seam over `AVAudioSession.sharedInstance()` so coordinator policy can be
+/// asserted in unit tests without touching real system audio state.
+@MainActor
+protocol VoiceAudioSessionControlling: AnyObject {
+    func setCategory(
+        _ category: AVAudioSession.Category,
+        mode: AVAudioSession.Mode,
+        options: AVAudioSession.CategoryOptions
+    ) throws
+    func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws
+}
+
+@MainActor
+final class SystemVoiceAudioSession: VoiceAudioSessionControlling {
+    func setCategory(
+        _ category: AVAudioSession.Category,
+        mode: AVAudioSession.Mode,
+        options: AVAudioSession.CategoryOptions
+    ) throws {
+        try AVAudioSession.sharedInstance().setCategory(category, mode: mode, options: options)
+    }
+
+    func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws {
+        try AVAudioSession.sharedInstance().setActive(active, options: options)
+    }
+}
+
+/// Ownership token returned by `acquire`. Release is idempotent: releasing an
+/// unknown or already-released lease is a no-op, so repeated cleanup paths
+/// (stop, cancellation, backgrounding) can never underflow another owner.
+struct VoiceAudioLease: Equatable {
+    fileprivate let id: UUID
+}
+
+@MainActor
+final class VoiceAudioSessionCoordinator {
+    static let shared = VoiceAudioSessionCoordinator()
+
+    /// The session policy currently applied to the system session, or nil
+    /// while no audio intent is active. Exposed read-only for diagnostics
+    /// and deterministic ownership tests.
+    private(set) var appliedPolicy: Policy?
+
+    enum Policy: Equatable {
+        /// `.playAndRecord` + `.voiceChat`: Voice Conversation capture, and
+        /// assistant speech that shares the capture-owned session.
+        case conversation
+        /// Output-only `.playback` with media coexistence: standalone speech.
+        case standalonePlayback
+    }
+
+    private let session: VoiceAudioSessionControlling
+    private var leases: [UUID: VoiceAudioIntent] = [:]
+
+    init(session: VoiceAudioSessionControlling = SystemVoiceAudioSession()) {
+        self.session = session
+    }
+
+    func acquire(_ intent: VoiceAudioIntent) throws -> VoiceAudioLease {
+        let lease = VoiceAudioLease(id: UUID())
+        leases[lease.id] = intent
+        do {
+            try applyDominantPolicy()
+        } catch {
+            leases.removeValue(forKey: lease.id)
+            audioSessionLogger.error(
+                "audio session activation failed for \(Self.describe(intent), privacy: .public): \(String(describing: error), privacy: .public)"
+            )
+            throw error
+        }
+        audioSessionLogger.debug(
+            "audio intent acquired: \(Self.describe(intent), privacy: .public) (owners: \(self.leases.count))"
+        )
+        return lease
+    }
+
+    func release(_ lease: VoiceAudioLease) {
+        guard let intent = leases.removeValue(forKey: lease.id) else { return }
+        do {
+            try applyDominantPolicy()
+        } catch {
+            // Deactivation failures must never crash the caller. The policy
+            // stays marked applied, so the next ownership transition retries
+            // the deactivation instead of assuming the session went inactive.
+            audioSessionLogger.error(
+                "audio session deactivation failed: \(String(describing: error), privacy: .public)"
+            )
+            return
+        }
+        audioSessionLogger.debug(
+            "audio intent released: \(Self.describe(intent), privacy: .public) (owners: \(self.leases.count))"
+        )
+    }
+
+    /// Reapplies the dominant policy after the system may have deactivated
+    /// the session underneath a live lease (route change restarting capture).
+    func reassert() throws {
+        guard !leases.isEmpty else { return }
+        appliedPolicy = nil
+        try applyDominantPolicy()
+    }
+
+    /// Any conversation intent keeps the conversation configuration:
+    /// conversation playback joins the capture-owned session without
+    /// reconfiguring it, and conversation playback that outlives its capture
+    /// owner (paused microphone while the assistant is still speaking) must
+    /// not churn the audio route mid-playback.
+    private var dominantPolicy: Policy? {
+        if leases.values.contains(where: { $0 != .standalonePlayback }) {
+            return .conversation
+        }
+        if leases.values.contains(.standalonePlayback) {
+            return .standalonePlayback
+        }
+        return nil
+    }
+
+    private func applyDominantPolicy() throws {
+        let target = dominantPolicy
+        guard target != appliedPolicy else { return }
+        switch target {
+        case .conversation:
+            let configuration = VoiceAudioSessionConfiguration.capture
+            try session.setCategory(configuration.category, mode: configuration.mode, options: configuration.options)
+            try session.setActive(true, options: [])
+            appliedPolicy = .conversation
+        case .standalonePlayback:
+            let configuration = VoiceAudioSessionConfiguration.standalonePlayback
+            try session.setCategory(configuration.category, mode: configuration.mode, options: configuration.options)
+            try session.setActive(true, options: [])
+            appliedPolicy = .standalonePlayback
+        case nil:
+            try session.setActive(false, options: .notifyOthersOnDeactivation)
+            appliedPolicy = nil
+        }
+        audioSessionLogger.info("audio policy changed: \(Self.describe(target), privacy: .public)")
+    }
+
+    private static func describe(_ intent: VoiceAudioIntent) -> String {
+        switch intent {
+        case .conversationCapture: return "conversationCapture"
+        case .conversationPlayback: return "conversationPlayback"
+        case .standalonePlayback: return "standalonePlayback"
+        }
+    }
+
+    private static func describe(_ policy: Policy?) -> String {
+        switch policy {
+        case .conversation: return "conversation"
+        case .standalonePlayback: return "standalone"
+        case nil: return "inactive"
+        }
+    }
+}

--- a/Conduit/Voice/VoiceAudioSessionCoordinator.swift
+++ b/Conduit/Voice/VoiceAudioSessionCoordinator.swift
@@ -57,7 +57,7 @@ final class SystemVoiceAudioSession: VoiceAudioSessionControlling {
 /// unknown or already-released lease is a no-op, so repeated cleanup paths
 /// (stop, cancellation, backgrounding) can never underflow another owner.
 struct VoiceAudioLease: Equatable {
-    fileprivate let id: UUID
+    private let id: UUID
     /// Internal so tests can synthesize unknown leases; production callers
     /// only ever receive leases from `acquire`.
     init(id: UUID = UUID()) { self.id = id }
@@ -120,11 +120,12 @@ final class VoiceAudioSessionCoordinator {
         do {
             try applyDominantPolicy()
         } catch {
-            // Deactivation failures must never crash the caller. The policy
-            // stays marked applied, so the next ownership transition retries
-            // the deactivation instead of assuming the session went inactive.
+            // Deactivation and policy-transition failures must never crash
+            // the caller. The policy stays marked applied, so the next
+            // ownership transition retries it instead of assuming the session
+            // went inactive.
             audioSessionLogger.error(
-                "audio session deactivation failed: \(String(describing: error), privacy: .public)"
+                "audio session policy transition failed on release: \(String(describing: error), privacy: .public)"
             )
             return
         }
@@ -137,8 +138,17 @@ final class VoiceAudioSessionCoordinator {
     /// the session underneath a live lease (route change restarting capture).
     func reassert() throws {
         guard !leases.isEmpty else { return }
+        let previous = appliedPolicy
         appliedPolicy = nil
-        try applyDominantPolicy()
+        do {
+            try applyDominantPolicy()
+        } catch {
+            // Mirror release(): keep the last known-applied policy so a later
+            // ownership transition still diffs against it and retries the
+            // deactivation instead of assuming the session went inactive.
+            appliedPolicy = previous
+            throw error
+        }
     }
 
     /// Any conversation intent keeps the conversation configuration:

--- a/Conduit/Voice/VoiceAudioSessionCoordinator.swift
+++ b/Conduit/Voice/VoiceAudioSessionCoordinator.swift
@@ -57,7 +57,9 @@ final class SystemVoiceAudioSession: VoiceAudioSessionControlling {
 /// unknown or already-released lease is a no-op, so repeated cleanup paths
 /// (stop, cancellation, backgrounding) can never underflow another owner.
 struct VoiceAudioLease: Equatable {
-    private let id: UUID
+    /// `fileprivate`, not `private`: the coordinator (same file, different
+    /// type) keys its lease table on this id.
+    fileprivate let id: UUID
     /// Internal so tests can synthesize unknown leases; production callers
     /// only ever receive leases from `acquire`.
     init(id: UUID = UUID()) { self.id = id }

--- a/Conduit/Voice/VoiceAudioSessionCoordinator.swift
+++ b/Conduit/Voice/VoiceAudioSessionCoordinator.swift
@@ -123,15 +123,7 @@ final class VoiceAudioSessionCoordinator {
             // their dominant policy in full instead of trusting the
             // unchanged bookkeeping. If the restore also fails, the flag
             // stays raised and the next ownership transition retries.
-            if appliedPolicy != nil {
-                do {
-                    try applyDominantPolicy()
-                } catch {
-                    audioSessionLogger.error(
-                        "audio session rollback to the remaining policy failed: \(String(describing: error), privacy: .public)"
-                    )
-                }
-            }
+            compensatingReapplyForRemainingOwners()
             throw error
         }
         audioSessionLogger.debug(
@@ -146,23 +138,16 @@ final class VoiceAudioSessionCoordinator {
             try applyDominantPolicy()
         } catch {
             // Transition and deactivation failures must never crash the
-            // caller. applyDominantPolicy raised needsReapply for a partial
-            // transition; for the remaining owners' sake this compensating
-            // re-apply mirrors acquire's rollback. A failed deactivation to
-            // nil has no remaining owners and stays consistent under the
-            // retained applied policy, so no rollback is attempted there.
-            if dominantPolicy != nil {
-                do {
-                    try applyDominantPolicy()
-                } catch {
-                    audioSessionLogger.error(
-                        "audio session rollback to the remaining policy failed: \(String(describing: error), privacy: .public)"
-                    )
-                }
-            }
+            // caller.
             audioSessionLogger.error(
                 "audio session policy transition failed on release: \(String(describing: error), privacy: .public)"
             )
+            // A partial transition may have half-switched the physical
+            // session under the remaining owners: restore their dominant
+            // policy best-effort. A failed deactivation to nil has no
+            // remaining owners and stays consistent under the retained
+            // applied policy, so no rollback is attempted there.
+            compensatingReapplyForRemainingOwners()
             return
         }
         audioSessionLogger.debug(
@@ -191,6 +176,24 @@ final class VoiceAudioSessionCoordinator {
             return .standalonePlayback
         }
         return nil
+    }
+
+    /// Best-effort restore of the surviving owners' policy after a partial
+    /// transition failure. Never throws: a failed restore leaves needsReapply
+    /// raised, so the next ownership transition retries the full
+    /// configuration. The `appliedPolicy != nil` guard covers both callers —
+    /// a failed acquire with no previously applied policy leaves the session
+    /// inactive (the next acquire re-applies fully anyway), and a release to
+    /// nil has no survivors.
+    private func compensatingReapplyForRemainingOwners() {
+        guard appliedPolicy != nil else { return }
+        do {
+            try applyDominantPolicy()
+        } catch {
+            audioSessionLogger.error(
+                "audio session rollback to the remaining policy failed: \(String(describing: error), privacy: .public)"
+            )
+        }
     }
 
     private func applyDominantPolicy() throws {
@@ -223,7 +226,9 @@ final class VoiceAudioSessionCoordinator {
             if target != nil { needsReapply = true }
             throw error
         }
-        audioSessionLogger.info("audio policy changed: \(Self.describe(target), privacy: .public)")
+        // "Applied" rather than "changed": a needsReapply transition can
+        // legitimately re-apply the policy that bookkeeping already named.
+        audioSessionLogger.info("audio policy applied: \(Self.describe(target), privacy: .public)")
     }
 
     private static func describe(_ intent: VoiceAudioIntent) -> String {

--- a/Conduit/Voice/VoiceAudioSessionCoordinator.swift
+++ b/Conduit/Voice/VoiceAudioSessionCoordinator.swift
@@ -81,6 +81,13 @@ final class VoiceAudioSessionCoordinator {
     /// and deterministic ownership tests.
     private(set) var appliedPolicy: Policy?
 
+    /// Raised when a policy transition failed partway — typically the
+    /// category changed but activation did not. The physical session can no
+    /// longer be trusted to match `appliedPolicy`, so the next transition
+    /// must re-apply the full configuration even if the dominant policy is
+    /// unchanged. Cleared whenever a transition completes successfully.
+    private var needsReapply = false
+
     enum Policy: Equatable {
         /// `.playAndRecord` + `.voiceChat`: Voice Conversation capture, and
         /// assistant speech that shares the capture-owned session.
@@ -107,8 +114,24 @@ final class VoiceAudioSessionCoordinator {
         } catch {
             leases.removeValue(forKey: lease.id)
             audioSessionLogger.error(
-                "audio session activation failed for \(Self.describe(intent), privacy: .public): \(String(describing: error), privacy: .public)"
+                "audio intent acquisition failed for \(Self.describe(intent), privacy: .public): \(String(describing: error), privacy: .public)"
             )
+            // The failed transition may have switched the category before
+            // activation failed, leaving the physical session partially
+            // switched under the remaining owners. needsReapply was raised by
+            // the failed transition, so this compensating call re-applies
+            // their dominant policy in full instead of trusting the
+            // unchanged bookkeeping. If the restore also fails, the flag
+            // stays raised and the next ownership transition retries.
+            if appliedPolicy != nil {
+                do {
+                    try applyDominantPolicy()
+                } catch {
+                    audioSessionLogger.error(
+                        "audio session rollback to the remaining policy failed: \(String(describing: error), privacy: .public)"
+                    )
+                }
+            }
             throw error
         }
         audioSessionLogger.debug(
@@ -122,10 +145,21 @@ final class VoiceAudioSessionCoordinator {
         do {
             try applyDominantPolicy()
         } catch {
-            // Deactivation and policy-transition failures must never crash
-            // the caller. The policy stays marked applied, so the next
-            // ownership transition retries it instead of assuming the session
-            // went inactive.
+            // Transition and deactivation failures must never crash the
+            // caller. applyDominantPolicy raised needsReapply for a partial
+            // transition; for the remaining owners' sake this compensating
+            // re-apply mirrors acquire's rollback. A failed deactivation to
+            // nil has no remaining owners and stays consistent under the
+            // retained applied policy, so no rollback is attempted there.
+            if dominantPolicy != nil {
+                do {
+                    try applyDominantPolicy()
+                } catch {
+                    audioSessionLogger.error(
+                        "audio session rollback to the remaining policy failed: \(String(describing: error), privacy: .public)"
+                    )
+                }
+            }
             audioSessionLogger.error(
                 "audio session policy transition failed on release: \(String(describing: error), privacy: .public)"
             )
@@ -140,17 +174,8 @@ final class VoiceAudioSessionCoordinator {
     /// the session underneath a live lease (route change restarting capture).
     func reassert() throws {
         guard !leases.isEmpty else { return }
-        let previous = appliedPolicy
-        appliedPolicy = nil
-        do {
-            try applyDominantPolicy()
-        } catch {
-            // Mirror release(): keep the last known-applied policy so a later
-            // ownership transition still diffs against it and retries the
-            // deactivation instead of assuming the session went inactive.
-            appliedPolicy = previous
-            throw error
-        }
+        needsReapply = true
+        try applyDominantPolicy()
     }
 
     /// Any conversation intent keeps the conversation configuration:
@@ -170,21 +195,33 @@ final class VoiceAudioSessionCoordinator {
 
     private func applyDominantPolicy() throws {
         let target = dominantPolicy
-        guard target != appliedPolicy else { return }
-        switch target {
-        case .conversation:
-            let configuration = VoiceAudioSessionConfiguration.capture
-            try session.setCategory(configuration.category, mode: configuration.mode, options: configuration.options)
-            try session.setActive(true, options: [])
-            appliedPolicy = .conversation
-        case .standalonePlayback:
-            let configuration = VoiceAudioSessionConfiguration.standalonePlayback
-            try session.setCategory(configuration.category, mode: configuration.mode, options: configuration.options)
-            try session.setActive(true, options: [])
-            appliedPolicy = .standalonePlayback
-        case nil:
-            try session.setActive(false, options: .notifyOthersOnDeactivation)
-            appliedPolicy = nil
+        guard target != appliedPolicy || needsReapply else { return }
+        do {
+            switch target {
+            case .conversation:
+                let configuration = VoiceAudioSessionConfiguration.capture
+                try session.setCategory(configuration.category, mode: configuration.mode, options: configuration.options)
+                try session.setActive(true, options: [])
+                appliedPolicy = .conversation
+            case .standalonePlayback:
+                let configuration = VoiceAudioSessionConfiguration.standalonePlayback
+                try session.setCategory(configuration.category, mode: configuration.mode, options: configuration.options)
+                try session.setActive(true, options: [])
+                appliedPolicy = .standalonePlayback
+            case nil:
+                try session.setActive(false, options: .notifyOthersOnDeactivation)
+                appliedPolicy = nil
+            }
+            needsReapply = false
+        } catch {
+            // An activation-path failure is partial: the category may have
+            // changed even though activation did not, so the physical session
+            // no longer matches appliedPolicy and the next transition must
+            // re-apply the full configuration. A failed deactivation, by
+            // contrast, leaves the session active under the applied policy —
+            // still consistent — so the flag is not raised there.
+            if target != nil { needsReapply = true }
+            throw error
         }
         audioSessionLogger.info("audio policy changed: \(Self.describe(target), privacy: .public)")
     }

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -648,6 +648,11 @@ final class VoiceConversationController: ObservableObject {
                 }
                 return
             }
+            // Terminal drain failure: settle playback like every other
+            // terminal path so the lease and engine do not outlive the turn.
+            // (The cancellation branch above intentionally keeps ownership —
+            // an interrupted stream's already-scheduled audio renders out.)
+            playback.stop()
             if state == .speaking || state == .thinking { state = .failed(error.localizedDescription) }
             return
         }

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -163,6 +163,12 @@ final class VoiceConversationController: ObservableObject {
         do {
             try capture.resume()
             isMicrophonePaused = false
+            // Pause is a real resource pause, so resume opens a fresh
+            // listening window: speech timestamps from before the pause must
+            // not immediately finish an utterance or idle-pause again.
+            utteranceStartedAt = Date()
+            lastSpeechAt = nil
+            bargeInStartedAt = nil
         } catch {
             state = .failed(error.localizedDescription)
         }
@@ -262,6 +268,9 @@ final class VoiceConversationController: ObservableObject {
         }
         isVoiceSessionActive = true
         isProviderTestRunning = true
+        // The TTS provider test runs outside a voice conversation, so its
+        // playback must claim standalone (output-only) session ownership.
+        playback.ownershipIntent = .standalonePlayback
         let generation = operationGeneration
         defer {
             speechStream?.cancel()
@@ -584,6 +593,9 @@ final class VoiceConversationController: ObservableObject {
         do {
             guard isSpeechDrainCurrent(operation: operation, revision: revision), let gateway else { return }
             if speechStream == nil && !speechDeltas.isEmpty {
+                // Assistant speech during a live voice conversation joins the
+                // capture-owned session instead of reconfiguring it.
+                playback.ownershipIntent = .conversationPlayback
                 let openedStream = try await gateway.openSpeechStream(
                     onStart: { [weak self] rate in
                         guard let self,

--- a/Conduit/Voice/VoiceTypes.swift
+++ b/Conduit/Voice/VoiceTypes.swift
@@ -201,6 +201,10 @@ protocol DeviceSpeechTranscriptionService: AnyObject {
 @MainActor
 protocol SpeechPlaybackService: AnyObject {
     var isPlaying: Bool { get }
+    /// Which audio-session ownership playback claims while it plays.
+    /// Conversation playback joins the capture-owned session; standalone
+    /// flows (Read Aloud, provider tests) own the session alone.
+    var ownershipIntent: VoiceAudioIntent { get set }
     func start(sampleRate: Double) throws
     func enqueuePCM16(_ data: Data, sampleRate: Double) throws -> Int
     func playEncodedAudioData(_ data: Data) throws

--- a/ConduitTests/AppStateReadAloudTests.swift
+++ b/ConduitTests/AppStateReadAloudTests.swift
@@ -99,6 +99,31 @@ final class AppStateReadAloudTests: XCTestCase {
         harness.readAloudController.stop()
     }
 
+    func testRunningASRTestStopsActiveReadAloud() async {
+        // The ASR test claims conversation-capture session ownership, so it
+        // must stop a still-playing read aloud first — the mirror of
+        // testStartingReadAloudStopsInFlightSpeechTest.
+        let harness = makeHarness(snapshot: VoiceCapabilitySnapshot(
+            isGatewayConnected: true,
+            supportsTranscription: true,
+            supportsSpeech: true,
+            unavailableReason: nil
+        ))
+        let messageA = ChatMessage(id: "msg-a", role: .assistant, content: "Response A", timestamp: "1")
+
+        harness.appState.toggleReadAloud(message: messageA)
+        await awaitUntil("read aloud to reach playing") {
+            harness.readAloudController.state == .playing(messageID: "msg-a")
+        }
+        XCTAssertTrue(harness.readAloudPlayback.isPlaying)
+
+        let result = await harness.appState.runVoiceASRTest()
+
+        XCTAssertTrue(result.passed)
+        XCTAssertFalse(harness.readAloudPlayback.isPlaying)
+        XCTAssertEqual(harness.readAloudController.state, .idle)
+    }
+
     func testTTSOnlyAvailabilityIsIndependentOfTranscription() {
         let harness = makeHarness(snapshot: ttsOnlySnapshot)
 

--- a/ConduitTests/AppStateReadAloudTests.swift
+++ b/ConduitTests/AppStateReadAloudTests.swift
@@ -255,6 +255,7 @@ private final class MockVoiceCapture: AudioCaptureService {
 @MainActor
 private final class MockVoicePlayback: SpeechPlaybackService {
     var isPlaying = false
+    var ownershipIntent: VoiceAudioIntent = .standalonePlayback
     private(set) var stopCount = 0
 
     func start(sampleRate: Double) throws { isPlaying = true }

--- a/ConduitTests/AppStateReadAloudTests.swift
+++ b/ConduitTests/AppStateReadAloudTests.swift
@@ -117,9 +117,13 @@ final class AppStateReadAloudTests: XCTestCase {
         }
         XCTAssertTrue(harness.readAloudPlayback.isPlaying)
 
-        let result = await harness.appState.runVoiceASRTest()
+        // The stop must happen before the transcription test claims capture.
+        // Only the stop contract is asserted here: runVoiceASRTest builds a
+        // real HermesVoiceGateway over the harness's fake bridge, so whether
+        // the transcription itself succeeds depends on live networking and
+        // is not this test's concern.
+        _ = await harness.appState.runVoiceASRTest()
 
-        XCTAssertTrue(result.passed)
         XCTAssertFalse(harness.readAloudPlayback.isPlaying)
         XCTAssertEqual(harness.readAloudController.state, .idle)
     }

--- a/ConduitTests/AppStateReadAloudTests.swift
+++ b/ConduitTests/AppStateReadAloudTests.swift
@@ -99,16 +99,20 @@ final class AppStateReadAloudTests: XCTestCase {
         harness.readAloudController.stop()
     }
 
-    func testRunningASRTestStopsActiveReadAloud() async {
+    func testRunningASRTestStopsActiveReadAloudBeforeCaptureOwnership() async {
         // The ASR test claims conversation-capture session ownership, so it
         // must stop a still-playing read aloud first — the mirror of
         // testStartingReadAloudStopsInFlightSpeechTest.
-        let harness = makeHarness(snapshot: VoiceCapabilitySnapshot(
-            isGatewayConnected: true,
-            supportsTranscription: true,
-            supportsSpeech: true,
-            unavailableReason: nil
-        ))
+        let recorder = CallOrderRecorder()
+        let harness = makeHarness(
+            snapshot: VoiceCapabilitySnapshot(
+                isGatewayConnected: true,
+                supportsTranscription: true,
+                supportsSpeech: true,
+                unavailableReason: nil
+            ),
+            orderRecorder: recorder
+        )
         let messageA = ChatMessage(id: "msg-a", role: .assistant, content: "Response A", timestamp: "1")
 
         harness.appState.toggleReadAloud(message: messageA)
@@ -117,15 +121,24 @@ final class AppStateReadAloudTests: XCTestCase {
         }
         XCTAssertTrue(harness.readAloudPlayback.isPlaying)
 
-        // The stop must happen before the transcription test claims capture.
-        // Only the stop contract is asserted here: runVoiceASRTest builds a
-        // real HermesVoiceGateway over the harness's fake bridge, so whether
-        // the transcription itself succeeds depends on live networking and
-        // is not this test's concern.
+        // runVoiceASRTest builds a real HermesVoiceGateway over the harness's
+        // fake bridge, so the capability checks and the transcription outcome
+        // depend on live networking and are deliberately not asserted. The
+        // ownership contract is fully deterministic: during the ASR test the
+        // playing read aloud is stopped (releasing its standalone lease), and
+        // whenever the ASR capture does start, the stop strictly precedes it.
+        // Toggle-time stops are excluded via the event baseline.
+        let eventBaseline = recorder.events.count
         _ = await harness.appState.runVoiceASRTest()
+        let asrTestEvents = Array(recorder.events.dropFirst(eventBaseline))
 
+        XCTAssertTrue(asrTestEvents.contains("readAloudStopped"), "a playing read aloud must be stopped by the ASR test")
         XCTAssertFalse(harness.readAloudPlayback.isPlaying)
         XCTAssertEqual(harness.readAloudController.state, .idle)
+        if let captureIndex = asrTestEvents.firstIndex(of: "asrCaptureStarted"),
+           let stopIndex = asrTestEvents.firstIndex(of: "readAloudStopped") {
+            XCTAssertLessThan(stopIndex, captureIndex, "read aloud must stop before ASR capture ownership begins")
+        }
     }
 
     func testTTSOnlyAvailabilityIsIndependentOfTranscription() {
@@ -182,7 +195,10 @@ final class AppStateReadAloudTests: XCTestCase {
         )
     }
 
-    private func makeHarness(snapshot: VoiceCapabilitySnapshot) -> Harness {
+    private func makeHarness(
+        snapshot: VoiceCapabilitySnapshot,
+        orderRecorder: CallOrderRecorder? = nil
+    ) -> Harness {
         let suite = "AppStateReadAloudTests.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suite) else {
             fatalError("Failed to create test UserDefaults suite")
@@ -197,8 +213,10 @@ final class AppStateReadAloudTests: XCTestCase {
 
         let voicePlayback = MockVoicePlayback()
         let voiceGateway = MockVoiceGateway(pausesAfterEmission: true)
+        let voiceCapture = MockVoiceCapture()
+        voiceCapture.orderRecorder = orderRecorder
         let voiceController = VoiceConversationController(
-            capture: MockVoiceCapture(),
+            capture: voiceCapture,
             playback: voicePlayback,
             deviceTranscriber: MockVoiceTranscriber(),
             gateway: voiceGateway,
@@ -208,6 +226,7 @@ final class AppStateReadAloudTests: XCTestCase {
         appState.voiceConversationController = voiceController
 
         let readAloudPlayback = MockVoicePlayback()
+        readAloudPlayback.orderRecorder = orderRecorder
         let readAloudGateway = MockVoiceGateway(pausesAfterEmission: true)
         let readAloudController = MessageReadAloudController(
             playback: readAloudPlayback,
@@ -262,16 +281,32 @@ private struct Harness {
     let readAloudGateway: MockVoiceGateway
 }
 
+/// Records ownership-relevant events from the injected mocks so tests can
+/// assert ordering (e.g. read aloud stops before ASR capture begins)
+/// without any network or real-gateway dependence. Tests snapshot
+/// `events.count` at a phase boundary and only inspect events after it.
+@MainActor
+private final class CallOrderRecorder {
+    private(set) var events: [String] = []
+
+    func record(_ event: String) { events.append(event) }
+}
+
 @MainActor
 private final class MockVoiceCapture: AudioCaptureService {
     let events: AsyncStream<VoiceCaptureEvent>
+    /// When set, records "asrCaptureStarted" so tests can assert ordering
+    /// against other ownership events.
+    var orderRecorder: CallOrderRecorder?
 
     init() {
         events = AsyncStream { _ in }
     }
 
     func requestPermission() async -> Bool { true }
-    func startListening(includePreRoll: Bool) throws {}
+    func startListening(includePreRoll: Bool) throws {
+        orderRecorder?.record("asrCaptureStarted")
+    }
     func beginBargeInMonitoring() throws {}
     func pause() {}
     func resume() throws {}
@@ -286,6 +321,9 @@ private final class MockVoicePlayback: SpeechPlaybackService {
     var isPlaying = false
     var ownershipIntent: VoiceAudioIntent = .standalonePlayback
     private(set) var stopCount = 0
+    /// When set, records "readAloudStopped" so tests can assert ordering
+    /// against other ownership events.
+    var orderRecorder: CallOrderRecorder?
 
     func start(sampleRate: Double) throws { isPlaying = true }
     func enqueuePCM16(_ data: Data, sampleRate: Double) throws -> Int { data.count / 2 }
@@ -295,6 +333,7 @@ private final class MockVoicePlayback: SpeechPlaybackService {
     func stop() {
         isPlaying = false
         stopCount += 1
+        orderRecorder?.record("readAloudStopped")
     }
 }
 

--- a/ConduitTests/AppStateReadAloudTests.swift
+++ b/ConduitTests/AppStateReadAloudTests.swift
@@ -99,7 +99,7 @@ final class AppStateReadAloudTests: XCTestCase {
         harness.readAloudController.stop()
     }
 
-    func testRunningASRTestStopsActiveReadAloudBeforeCaptureOwnership() async {
+    func testRunningASRTestStopsActiveReadAloudBeforeCapabilityRefresh() async {
         // The ASR test claims conversation-capture session ownership, so it
         // must stop a still-playing read aloud first — the mirror of
         // testStartingReadAloudStopsInFlightSpeechTest.
@@ -113,6 +113,7 @@ final class AppStateReadAloudTests: XCTestCase {
             ),
             orderRecorder: recorder
         )
+        harness.appState.voiceCapabilityRequesterForTesting = RecordingCapabilityRequester(recorder: recorder)
         let messageA = ChatMessage(id: "msg-a", role: .assistant, content: "Response A", timestamp: "1")
 
         harness.appState.toggleReadAloud(message: messageA)
@@ -121,13 +122,13 @@ final class AppStateReadAloudTests: XCTestCase {
         }
         XCTAssertTrue(harness.readAloudPlayback.isPlaying)
 
-        // runVoiceASRTest builds a real HermesVoiceGateway over the harness's
-        // fake bridge, so the capability checks and the transcription outcome
-        // depend on live networking and are deliberately not asserted. The
-        // ownership contract is fully deterministic: during the ASR test the
-        // playing read aloud is stopped (releasing its standalone lease), and
-        // whenever the ASR capture does start, the stop strictly precedes it.
-        // Toggle-time stops are excluded via the event baseline.
+        // The transcription outcome itself depends on the configured provider
+        // and is deliberately not asserted. The ownership contract is fully
+        // deterministic: during the ASR test the playing read aloud is
+        // stopped (releasing its standalone lease) BEFORE the capability
+        // refresh begins. The refresh's incidental teardown would otherwise
+        // stop the read aloud only after the reload — so deleting the
+        // production stop line flips the ordering assertion below.
         let eventBaseline = recorder.events.count
         _ = await harness.appState.runVoiceASRTest()
         let asrTestEvents = Array(recorder.events.dropFirst(eventBaseline))
@@ -135,10 +136,11 @@ final class AppStateReadAloudTests: XCTestCase {
         XCTAssertTrue(asrTestEvents.contains("readAloudStopped"), "a playing read aloud must be stopped by the ASR test")
         XCTAssertFalse(harness.readAloudPlayback.isPlaying)
         XCTAssertEqual(harness.readAloudController.state, .idle)
-        if let captureIndex = asrTestEvents.firstIndex(of: "asrCaptureStarted"),
-           let stopIndex = asrTestEvents.firstIndex(of: "readAloudStopped") {
-            XCTAssertLessThan(stopIndex, captureIndex, "read aloud must stop before ASR capture ownership begins")
-        }
+        XCTAssertLessThan(
+            asrTestEvents.firstIndex(of: "readAloudStopped") ?? Int.max,
+            asrTestEvents.firstIndex(of: "capabilityReloadStarted") ?? Int.max,
+            "read aloud must stop before the capability refresh begins"
+        )
     }
 
     func testTTSOnlyAvailabilityIsIndependentOfTranscription() {
@@ -213,10 +215,8 @@ final class AppStateReadAloudTests: XCTestCase {
 
         let voicePlayback = MockVoicePlayback()
         let voiceGateway = MockVoiceGateway(pausesAfterEmission: true)
-        let voiceCapture = MockVoiceCapture()
-        voiceCapture.orderRecorder = orderRecorder
         let voiceController = VoiceConversationController(
-            capture: voiceCapture,
+            capture: MockVoiceCapture(),
             playback: voicePlayback,
             deviceTranscriber: MockVoiceTranscriber(),
             gateway: voiceGateway,
@@ -281,10 +281,10 @@ private struct Harness {
     let readAloudGateway: MockVoiceGateway
 }
 
-/// Records ownership-relevant events from the injected mocks so tests can
-/// assert ordering (e.g. read aloud stops before ASR capture begins)
-/// without any network or real-gateway dependence. Tests snapshot
-/// `events.count` at a phase boundary and only inspect events after it.
+/// Records ownership-relevant events from the injected mocks and test
+/// stubs so tests can assert ordering (e.g. read aloud stops before the
+/// capability refresh begins) hermetically. Tests snapshot `events.count`
+/// at a phase boundary and only inspect events after it.
 @MainActor
 private final class CallOrderRecorder {
     private(set) var events: [String] = []
@@ -292,21 +292,30 @@ private final class CallOrderRecorder {
     func record(_ event: String) { events.append(event) }
 }
 
+/// Throws without touching the network, so the capability refresh in tests
+/// is hermetic while still recording when it begins.
+@MainActor
+private final class RecordingCapabilityRequester: VoiceConfigurationRequesting {
+    let recorder: CallOrderRecorder
+
+    init(recorder: CallOrderRecorder) { self.recorder = recorder }
+
+    func requestJSON(path: String, method: String, body: [String: Any]?) async throws -> [String: Any] {
+        recorder.record("capabilityReloadStarted")
+        throw URLError(.unsupportedURL)
+    }
+}
+
 @MainActor
 private final class MockVoiceCapture: AudioCaptureService {
     let events: AsyncStream<VoiceCaptureEvent>
-    /// When set, records "asrCaptureStarted" so tests can assert ordering
-    /// against other ownership events.
-    var orderRecorder: CallOrderRecorder?
 
     init() {
         events = AsyncStream { _ in }
     }
 
     func requestPermission() async -> Bool { true }
-    func startListening(includePreRoll: Bool) throws {
-        orderRecorder?.record("asrCaptureStarted")
-    }
+    func startListening(includePreRoll: Bool) throws {}
     func beginBargeInMonitoring() throws {}
     func pause() {}
     func resume() throws {}

--- a/ConduitTests/MessageReadAloudControllerTests.swift
+++ b/ConduitTests/MessageReadAloudControllerTests.swift
@@ -436,6 +436,7 @@ private final class MockReadAloudPlayback: SpeechPlaybackService {
     private(set) var drainCount = 0
     private(set) var stopCount = 0
     var isPlaying = false
+    var ownershipIntent: VoiceAudioIntent = .standalonePlayback
     var startError: Error?
     var enqueueError: Error?
     /// When set, drain() suspends until stop() releases it — models audio

--- a/ConduitTests/VoiceAudioSessionConfigurationTests.swift
+++ b/ConduitTests/VoiceAudioSessionConfigurationTests.swift
@@ -19,4 +19,13 @@ final class VoiceAudioSessionConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.outputSampleRate, 16_000)
         XCTAssertEqual(configuration.outputChannelCount, 1)
     }
+
+    func testStandalonePlaybackUsesOutputOnlyMediaCoexistencePolicy() {
+        let configuration = VoiceAudioSessionConfiguration.standalonePlayback
+
+        XCTAssertEqual(configuration.category.rawValue, AVAudioSession.Category.playback.rawValue)
+        XCTAssertFalse(configuration.options.contains(.allowBluetoothHFP))
+        XCTAssertTrue(configuration.options.contains(.mixWithOthers))
+        XCTAssertTrue(configuration.options.contains(.duckOthers))
+    }
 }

--- a/ConduitTests/VoiceAudioSessionCoordinatorTests.swift
+++ b/ConduitTests/VoiceAudioSessionCoordinatorTests.swift
@@ -297,6 +297,7 @@ final class VoiceAudioSessionCoordinatorTests: XCTestCase {
         XCTAssertThrowsError(try coordinator.acquire(.conversationCapture))
 
         XCTAssertEqual(session.categoryCalls.count, 2, "the transition and the rollback each attempted the category")
+        XCTAssertEqual(session.activationCount, 0, "neither the transition nor the rollback activated")
         XCTAssertEqual(coordinator.appliedPolicy, .standalonePlayback)
 
         // Once activations succeed again, the very next ownership transition
@@ -378,7 +379,8 @@ private final class MockVoiceAudioSession: VoiceAudioSessionControlling {
     /// Fails the next N activation attempts before recording them, modelling
     /// a one-shot activation failure (category succeeds, activation does
     /// not). Failed attempts are deliberately not recorded, so counts reflect
-    /// successful system calls.
+    /// successful system calls. Note: unlike the call recordings, the failure
+    /// knobs are NOT cleared by `resetRecordings()` — clear them explicitly.
     var pendingActivationFailures = 0
 
     var activationCount: Int { activationCalls.filter(\.active).count }

--- a/ConduitTests/VoiceAudioSessionCoordinatorTests.swift
+++ b/ConduitTests/VoiceAudioSessionCoordinatorTests.swift
@@ -1,0 +1,238 @@
+//
+//  VoiceAudioSessionCoordinatorTests.swift
+//  ConduitTests
+//
+//  Deterministic ownership semantics for the audio-session coordinator.
+//  These run against a mocked session seam — never the process-global
+//  AVAudioSession — so they assert exactly which policy won, how often the
+//  session was (de)activated, and that cleanup is idempotent.
+//
+
+import AVFAudio
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class VoiceAudioSessionCoordinatorTests: XCTestCase {
+    private var session: MockVoiceAudioSession!
+    private var coordinator: VoiceAudioSessionCoordinator!
+
+    override func setUp() {
+        super.setUp()
+        session = MockVoiceAudioSession()
+        coordinator = VoiceAudioSessionCoordinator(session: session)
+    }
+
+    func testConversationCaptureActivatesConversationPolicy() throws {
+        let lease = try coordinator.acquire(.conversationCapture)
+
+        XCTAssertEqual(session.categoryCalls.count, 1)
+        XCTAssertEqual(session.categoryCalls.last?.category, .playAndRecord)
+        XCTAssertEqual(session.categoryCalls.last?.mode, .voiceChat)
+        XCTAssertTrue(session.categoryCalls.last?.options.contains(.allowBluetoothHFP) ?? false)
+        XCTAssertEqual(coordinator.appliedPolicy, .conversation)
+        XCTAssertEqual(session.activationCount, 1)
+        _ = lease
+    }
+
+    func testConversationPlaybackJoinsCaptureWithoutReconfiguring() throws {
+        _ = try coordinator.acquire(.conversationCapture)
+        session.resetRecordings()
+
+        _ = try coordinator.acquire(.conversationPlayback)
+
+        XCTAssertEqual(session.categoryCalls.count, 0, "conversation playback must join the capture-owned session")
+        XCTAssertEqual(session.activationCount, 0)
+        XCTAssertEqual(coordinator.appliedPolicy, .conversation)
+    }
+
+    func testPlaybackReleaseKeepsCaptureOwnedSessionActive() throws {
+        let captureLease = try coordinator.acquire(.conversationCapture)
+        let playbackLease = try coordinator.acquire(.conversationPlayback)
+
+        coordinator.release(playbackLease)
+
+        XCTAssertEqual(session.deactivationCount, 0, "playback release must not deactivate while capture owns the session")
+        XCTAssertEqual(coordinator.appliedPolicy, .conversation)
+        _ = captureLease
+    }
+
+    func testLastConversationOwnerDeactivatesWithNotifyOthers() throws {
+        let captureLease = try coordinator.acquire(.conversationCapture)
+        let playbackLease = try coordinator.acquire(.conversationPlayback)
+
+        coordinator.release(playbackLease)
+        coordinator.release(captureLease)
+
+        XCTAssertEqual(session.deactivationCount, 1, "the session deactivates exactly once when the last owner releases")
+        XCTAssertEqual(session.lastDeactivationOptions, .notifyOthersOnDeactivation)
+        XCTAssertNil(coordinator.appliedPolicy)
+    }
+
+    func testConversationPlaybackWithoutCaptureKeepsConversationPolicy() throws {
+        // A voice conversation whose microphone is paused can still be
+        // speaking: the route must not churn mid-playback, so conversation
+        // playback alone keeps the conversation policy.
+        _ = try coordinator.acquire(.conversationPlayback)
+
+        XCTAssertEqual(coordinator.appliedPolicy, .conversation)
+        XCTAssertEqual(session.categoryCalls.last?.category, .playAndRecord)
+    }
+
+    func testStandalonePlaybackUsesOutputOnlyPolicy() throws {
+        _ = try coordinator.acquire(.standalonePlayback)
+
+        XCTAssertEqual(session.categoryCalls.last?.category, .playback)
+        XCTAssertTrue(session.categoryCalls.last?.options.contains(.mixWithOthers) ?? false)
+        XCTAssertTrue(session.categoryCalls.last?.options.contains(.duckOthers) ?? false)
+        XCTAssertEqual(session.categoryCalls.last?.mode, .default)
+        XCTAssertEqual(coordinator.appliedPolicy, .standalonePlayback)
+        XCTAssertEqual(session.activationCount, 1)
+    }
+
+    func testStandaloneReleaseDeactivatesImmediately() throws {
+        let lease = try coordinator.acquire(.standalonePlayback)
+
+        coordinator.release(lease)
+
+        XCTAssertEqual(session.deactivationCount, 1)
+        XCTAssertEqual(session.lastDeactivationOptions, .notifyOthersOnDeactivation)
+        XCTAssertNil(coordinator.appliedPolicy)
+    }
+
+    func testPolicySwitchDeactivatesThenAppliesNewPolicy() throws {
+        let conversationLease = try coordinator.acquire(.conversationPlayback)
+        coordinator.release(conversationLease)
+        session.resetRecordings()
+
+        _ = try coordinator.acquire(.standalonePlayback)
+
+        XCTAssertEqual(session.categoryCalls.last?.category, .playback)
+        XCTAssertEqual(session.activationCount, 1)
+    }
+
+    func testReleaseIsIdempotentAndCannotUnderflow() throws {
+        let lease = try coordinator.acquire(.standalonePlayback)
+        coordinator.release(lease)
+        session.resetRecordings()
+
+        coordinator.release(lease)
+
+        XCTAssertEqual(session.deactivationCount, 0, "releasing an already-released lease must be a no-op")
+        XCTAssertNil(coordinator.appliedPolicy)
+    }
+
+    func testUnknownLeaseReleaseIsNoOp() {
+        coordinator.release(VoiceAudioLease(id: UUID()))
+
+        XCTAssertEqual(session.deactivationCount, 0)
+    }
+
+    func testAcquireFailureDoesNotLeakOwnership() throws {
+        session.categoryError = VoiceAudioSessionMockError.configurationFailed
+
+        XCTAssertThrowsError(try coordinator.acquire(.conversationCapture))
+        XCTAssertNil(coordinator.appliedPolicy)
+
+        session.categoryError = nil
+        let lease = try coordinator.acquire(.conversationCapture)
+
+        XCTAssertEqual(session.activationCount, 1)
+        coordinator.release(lease)
+        XCTAssertEqual(session.deactivationCount, 1)
+    }
+
+    func testEngineStartFailureAfterAcquireReleasesOwnership() throws {
+        // Models the playback service path: acquire succeeds, engine start
+        // fails, the service must release so the session can deactivate.
+        let lease = try coordinator.acquire(.standalonePlayback)
+        coordinator.release(lease)
+
+        XCTAssertNil(coordinator.appliedPolicy)
+        XCTAssertEqual(session.deactivationCount, 1)
+    }
+
+    func testDeactivationFailureDoesNotCrashAndIsRetriedOnNextTransition() throws {
+        let lease = try coordinator.acquire(.standalonePlayback)
+        session.deactivateError = VoiceAudioSessionMockError.deactivationFailed
+
+        coordinator.release(lease)
+
+        // The failed deactivation must not crash or misreport the session as
+        // inactive while the system session is actually still applied.
+        XCTAssertEqual(session.deactivationCount, 1)
+        XCTAssertEqual(coordinator.appliedPolicy, .standalonePlayback)
+
+        // The next ownership transition retries the deactivation instead of
+        // assuming the session went inactive.
+        session.deactivateError = nil
+        let retryLease = try coordinator.acquire(.standalonePlayback)
+        coordinator.release(retryLease)
+
+        XCTAssertEqual(session.deactivationCount, 2)
+        XCTAssertEqual(session.lastDeactivationOptions, .notifyOthersOnDeactivation)
+        XCTAssertNil(coordinator.appliedPolicy)
+    }
+
+    func testReassertReappliesPolicyForLiveOwners() throws {
+        _ = try coordinator.acquire(.conversationCapture)
+        session.resetRecordings()
+
+        try coordinator.reassert()
+
+        XCTAssertEqual(session.categoryCalls.count, 1, "reassert must reconfigure a live owner's session")
+        XCTAssertEqual(session.activationCount, 1)
+        XCTAssertEqual(coordinator.appliedPolicy, .conversation)
+    }
+
+    func testReassertWithoutOwnersDoesNothing() throws {
+        try coordinator.reassert()
+
+        XCTAssertEqual(session.categoryCalls.count, 0)
+        XCTAssertEqual(session.activationCount, 0)
+    }
+}
+
+@MainActor
+private final class MockVoiceAudioSession: VoiceAudioSessionControlling {
+    struct CategoryCall: Equatable {
+        let category: AVAudioSession.Category
+        let mode: AVAudioSession.Mode
+        let options: AVAudioSession.CategoryOptions
+    }
+
+    private(set) var categoryCalls: [CategoryCall] = []
+    private(set) var activationCalls: [(active: Bool, options: AVAudioSession.SetActiveOptions)] = []
+    var categoryError: Error?
+    var deactivateError: Error?
+
+    var activationCount: Int { activationCalls.filter(\.active).count }
+    var deactivationCount: Int { activationCalls.filter { !$0.active }.count }
+    var lastDeactivationOptions: AVAudioSession.SetActiveOptions? {
+        activationCalls.last(where: { !$0.active })?.options
+    }
+
+    func resetRecordings() {
+        categoryCalls.removeAll()
+        activationCalls.removeAll()
+    }
+
+    func setCategory(
+        _ category: AVAudioSession.Category,
+        mode: AVAudioSession.Mode,
+        options: AVAudioSession.CategoryOptions
+    ) throws {
+        if let categoryError { throw categoryError }
+        categoryCalls.append(CategoryCall(category: category, mode: mode, options: options))
+    }
+
+    func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws {
+        if !active, let deactivateError { throw deactivateError }
+        activationCalls.append((active, options))
+    }
+}
+
+private enum VoiceAudioSessionMockError: Error {
+    case configurationFailed
+    case deactivationFailed
+}

--- a/ConduitTests/VoiceAudioSessionCoordinatorTests.swift
+++ b/ConduitTests/VoiceAudioSessionCoordinatorTests.swift
@@ -117,6 +117,34 @@ final class VoiceAudioSessionCoordinatorTests: XCTestCase {
         XCTAssertEqual(session.categoryCalls.last?.category, .playback)
     }
 
+    func testAcquiringConversationUnderStandaloneUpgradesWithoutDeactivation() throws {
+        _ = try coordinator.acquire(.standalonePlayback)
+        session.resetRecordings()
+
+        _ = try coordinator.acquire(.conversationCapture)
+
+        XCTAssertEqual(session.deactivationCount, 0)
+        XCTAssertEqual(session.categoryCalls.last?.category, .playAndRecord)
+        XCTAssertEqual(coordinator.appliedPolicy, .conversation)
+    }
+
+    func testReassertFailureKeepsPolicySoLaterReleaseStillDeactivates() throws {
+        let lease = try coordinator.acquire(.conversationCapture)
+        session.categoryError = VoiceAudioSessionMockError.configurationFailed
+
+        XCTAssertThrowsError(try coordinator.reassert())
+        XCTAssertEqual(coordinator.appliedPolicy, .conversation, "a failed reassert keeps the last known-applied policy")
+        session.resetRecordings()
+
+        // With the last owner gone, the retained policy must still diff
+        // against the inactive target so the final deactivation runs — the
+        // exact sequence a failed route-change restart produces.
+        coordinator.release(lease)
+
+        XCTAssertEqual(session.deactivationCount, 1)
+        XCTAssertNil(coordinator.appliedPolicy)
+    }
+
     func testStandaloneReleaseDeactivatesImmediately() throws {
         let lease = try coordinator.acquire(.standalonePlayback)
 
@@ -237,6 +265,23 @@ final class VoiceAudioSessionCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(session.categoryCalls.count, 0)
         XCTAssertEqual(session.activationCount, 0)
+    }
+
+    /// Service-level ownership check that needs no audio hardware: encoded
+    /// playback acquires a lease before constructing the player, so a startup
+    /// failure (here: invalid audio data) must roll the lease back through
+    /// the coordinator — the same acquire/rollback contract the engine paths
+    /// rely on. Engine-dependent paths (natural PCM completion, interruption,
+    /// configuration change) remain manual/device verification.
+    func testEncodedPlaybackStartupFailureReleasesAcquiredLease() throws {
+        let service = AVSpeechPlaybackService(coordinator: coordinator)
+
+        XCTAssertThrowsError(try service.playEncodedAudioData(Data()))
+
+        XCTAssertEqual(session.categoryCalls.count, 1, "ownership was acquired before the player was built")
+        XCTAssertEqual(session.categoryCalls.last?.category, .playback)
+        XCTAssertEqual(session.deactivationCount, 1, "the failure must release the acquired lease")
+        XCTAssertNil(coordinator.appliedPolicy)
     }
 }
 

--- a/ConduitTests/VoiceAudioSessionCoordinatorTests.swift
+++ b/ConduitTests/VoiceAudioSessionCoordinatorTests.swift
@@ -260,6 +260,83 @@ final class VoiceAudioSessionCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.appliedPolicy, .conversation)
     }
 
+    func testFailedStandaloneToConversationAcquisitionRollsBackAndRestoresPolicy() throws {
+        _ = try coordinator.acquire(.standalonePlayback)
+        session.resetRecordings()
+
+        // One-shot activation failure: the transition switches the category
+        // to conversation, then cannot activate.
+        session.pendingActivationFailures = 1
+        XCTAssertThrowsError(try coordinator.acquire(.conversationCapture))
+
+        // The rolled-back acquisition must not leave the physical session
+        // partially switched under the surviving standalone owner: the
+        // compensating transition re-applied the standalone policy in full
+        // (category restored, activation retried successfully).
+        XCTAssertEqual(session.categoryCalls.map(\.category), [.playAndRecord, .playback])
+        XCTAssertEqual(session.activationCount, 1, "the rollback re-activated the remaining policy")
+        XCTAssertEqual(session.deactivationCount, 0)
+        XCTAssertEqual(coordinator.appliedPolicy, .standalonePlayback)
+
+        // The failed lease was removed: an acquire matching the applied
+        // policy is a plain ownership no-op with no reconfiguration.
+        session.resetRecordings()
+        _ = try coordinator.acquire(.standalonePlayback)
+        XCTAssertEqual(session.categoryCalls.count, 0)
+        XCTAssertEqual(session.activationCount, 0)
+    }
+
+    func testFailedAcquisitionWithStickyFailureStaysRecoverable() throws {
+        _ = try coordinator.acquire(.standalonePlayback)
+        session.resetRecordings()
+
+        // Sticky failure: both the conversation transition and the rollback
+        // fail. The coordinator must keep the bookkeeping consistent with
+        // the surviving owner and keep demanding a full re-apply.
+        session.activateError = VoiceAudioSessionMockError.activationFailed
+        XCTAssertThrowsError(try coordinator.acquire(.conversationCapture))
+
+        XCTAssertEqual(session.categoryCalls.count, 2, "the transition and the rollback each attempted the category")
+        XCTAssertEqual(coordinator.appliedPolicy, .standalonePlayback)
+
+        // Once activations succeed again, the very next ownership transition
+        // — even one matching the applied policy — re-applies the full
+        // configuration instead of trusting the stale bookkeeping.
+        session.activateError = nil
+        session.resetRecordings()
+        _ = try coordinator.acquire(.standalonePlayback)
+        XCTAssertEqual(session.categoryCalls.count, 1)
+        XCTAssertEqual(session.activationCount, 1)
+        XCTAssertEqual(coordinator.appliedPolicy, .standalonePlayback)
+    }
+
+    func testFailedConversationToStandaloneHandoffWithExistingOwnersRecovers() throws {
+        let captureLease = try coordinator.acquire(.conversationCapture)
+        _ = try coordinator.acquire(.standalonePlayback)
+        session.resetRecordings()
+
+        // Releasing capture hands ownership to the surviving standalone
+        // owner: the category switches to .playback, then a one-shot
+        // activation failure hits.
+        session.pendingActivationFailures = 1
+        coordinator.release(captureLease)
+
+        // The release path immediately re-applied the remaining standalone
+        // policy in full, so bookkeeping and physical session agree again.
+        XCTAssertEqual(session.categoryCalls.map(\.category), [.playback, .playback])
+        XCTAssertEqual(session.activationCount, 1, "the release path restored the remaining standalone policy")
+        XCTAssertEqual(session.deactivationCount, 0, "a failed handoff must not deactivate the session")
+        XCTAssertEqual(coordinator.appliedPolicy, .standalonePlayback)
+
+        // Ownership is now cleanly standalone: acquiring conversation
+        // capture performs a normal policy transition.
+        session.resetRecordings()
+        _ = try coordinator.acquire(.conversationCapture)
+        XCTAssertEqual(session.categoryCalls.count, 1)
+        XCTAssertEqual(session.categoryCalls.last?.category, .playAndRecord)
+        XCTAssertEqual(coordinator.appliedPolicy, .conversation)
+    }
+
     func testReassertWithoutOwnersDoesNothing() throws {
         try coordinator.reassert()
 
@@ -298,6 +375,11 @@ private final class MockVoiceAudioSession: VoiceAudioSessionControlling {
     var categoryError: Error?
     var activateError: Error?
     var deactivateError: Error?
+    /// Fails the next N activation attempts before recording them, modelling
+    /// a one-shot activation failure (category succeeds, activation does
+    /// not). Failed attempts are deliberately not recorded, so counts reflect
+    /// successful system calls.
+    var pendingActivationFailures = 0
 
     var activationCount: Int { activationCalls.filter(\.active).count }
     var deactivationCount: Int { activationCalls.filter { !$0.active }.count }
@@ -320,7 +402,13 @@ private final class MockVoiceAudioSession: VoiceAudioSessionControlling {
     }
 
     func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws {
-        if active, let activateError { throw activateError }
+        if active {
+            if pendingActivationFailures > 0 {
+                pendingActivationFailures -= 1
+                throw VoiceAudioSessionMockError.activationFailed
+            }
+            if let activateError { throw activateError }
+        }
         if !active, let deactivateError { throw deactivateError }
         activationCalls.append((active, options))
     }

--- a/ConduitTests/VoiceAudioSessionCoordinatorTests.swift
+++ b/ConduitTests/VoiceAudioSessionCoordinatorTests.swift
@@ -90,6 +90,33 @@ final class VoiceAudioSessionCoordinatorTests: XCTestCase {
         XCTAssertEqual(session.activationCount, 1)
     }
 
+    func testStandalonePlaybackCannotDowngradeActiveConversation() throws {
+        _ = try coordinator.acquire(.conversationCapture)
+        session.resetRecordings()
+
+        _ = try coordinator.acquire(.standalonePlayback)
+
+        XCTAssertEqual(coordinator.appliedPolicy, .conversation)
+        XCTAssertEqual(session.categoryCalls.count, 0, "standalone playback must not reconfigure an active conversation session")
+        XCTAssertEqual(session.deactivationCount, 0)
+    }
+
+    func testReleasingConversationOwnerHandsOffToStandaloneWithoutDeactivation() throws {
+        // Read aloud cannot start mid-conversation today (AppState mutual
+        // exclusion), but if a standalone lease ever overlaps a conversation
+        // lease, the handoff must transition policies without an
+        // intermediate deactivation.
+        let captureLease = try coordinator.acquire(.conversationCapture)
+        _ = try coordinator.acquire(.standalonePlayback)
+        session.resetRecordings()
+
+        coordinator.release(captureLease)
+
+        XCTAssertEqual(coordinator.appliedPolicy, .standalonePlayback)
+        XCTAssertEqual(session.deactivationCount, 0)
+        XCTAssertEqual(session.categoryCalls.last?.category, .playback)
+    }
+
     func testStandaloneReleaseDeactivatesImmediately() throws {
         let lease = try coordinator.acquire(.standalonePlayback)
 
@@ -100,9 +127,10 @@ final class VoiceAudioSessionCoordinatorTests: XCTestCase {
         XCTAssertNil(coordinator.appliedPolicy)
     }
 
-    func testPolicySwitchDeactivatesThenAppliesNewPolicy() throws {
+    func testSequentialPolicySwitchDeactivatesThenReactivatesStandalone() throws {
         let conversationLease = try coordinator.acquire(.conversationPlayback)
         coordinator.release(conversationLease)
+        XCTAssertEqual(session.deactivationCount, 1, "the all-owners-gone transition deactivates before the next policy")
         session.resetRecordings()
 
         _ = try coordinator.acquire(.standalonePlayback)
@@ -142,13 +170,30 @@ final class VoiceAudioSessionCoordinatorTests: XCTestCase {
         XCTAssertEqual(session.deactivationCount, 1)
     }
 
-    func testEngineStartFailureAfterAcquireReleasesOwnership() throws {
-        // Models the playback service path: acquire succeeds, engine start
-        // fails, the service must release so the session can deactivate.
+    func testReleaseAfterAcquireDeactivatesAndIsRepeatable() throws {
         let lease = try coordinator.acquire(.standalonePlayback)
         coordinator.release(lease)
 
         XCTAssertNil(coordinator.appliedPolicy)
+        XCTAssertEqual(session.deactivationCount, 1)
+
+        let second = try coordinator.acquire(.standalonePlayback)
+        _ = second
+        XCTAssertEqual(session.activationCount, 2)
+    }
+
+    func testActivationFailureAfterCategorySucceedsDoesNotLeakOwnership() throws {
+        session.activateError = VoiceAudioSessionMockError.activationFailed
+
+        XCTAssertThrowsError(try coordinator.acquire(.conversationCapture))
+        XCTAssertNil(coordinator.appliedPolicy, "a failed activation must not mark the policy applied")
+
+        session.activateError = nil
+        let lease = try coordinator.acquire(.conversationCapture)
+
+        XCTAssertEqual(session.categoryCalls.count, 2, "the retry must re-run configuration")
+        XCTAssertEqual(session.activationCount, 1)
+        coordinator.release(lease)
         XCTAssertEqual(session.deactivationCount, 1)
     }
 
@@ -204,6 +249,7 @@ private final class MockVoiceAudioSession: VoiceAudioSessionControlling {
     private(set) var categoryCalls: [CategoryCall] = []
     private(set) var activationCalls: [(active: Bool, options: AVAudioSession.SetActiveOptions)] = []
     var categoryError: Error?
+    var activateError: Error?
     var deactivateError: Error?
 
     var activationCount: Int { activationCalls.filter(\.active).count }
@@ -227,6 +273,7 @@ private final class MockVoiceAudioSession: VoiceAudioSessionControlling {
     }
 
     func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws {
+        if active, let activateError { throw activateError }
         if !active, let deactivateError { throw deactivateError }
         activationCalls.append((active, options))
     }
@@ -234,5 +281,6 @@ private final class MockVoiceAudioSession: VoiceAudioSessionControlling {
 
 private enum VoiceAudioSessionMockError: Error {
     case configurationFailed
+    case activationFailed
     case deactivationFailed
 }

--- a/ConduitTests/VoiceAudioSessionCoordinatorTests.swift
+++ b/ConduitTests/VoiceAudioSessionCoordinatorTests.swift
@@ -204,8 +204,10 @@ final class VoiceAudioSessionCoordinatorTests: XCTestCase {
         coordinator.release(lease)
 
         // The failed deactivation must not crash or misreport the session as
-        // inactive while the system session is actually still applied.
-        XCTAssertEqual(session.deactivationCount, 1)
+        // inactive while the system session is actually still applied. The
+        // mock records only successful calls, so zero recorded deactivations
+        // plus a retained policy means the attempt threw and was swallowed.
+        XCTAssertEqual(session.deactivationCount, 0)
         XCTAssertEqual(coordinator.appliedPolicy, .standalonePlayback)
 
         // The next ownership transition retries the deactivation instead of
@@ -214,7 +216,7 @@ final class VoiceAudioSessionCoordinatorTests: XCTestCase {
         let retryLease = try coordinator.acquire(.standalonePlayback)
         coordinator.release(retryLease)
 
-        XCTAssertEqual(session.deactivationCount, 2)
+        XCTAssertEqual(session.deactivationCount, 1)
         XCTAssertEqual(session.lastDeactivationOptions, .notifyOthersOnDeactivation)
         XCTAssertNil(coordinator.appliedPolicy)
     }

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -604,6 +604,78 @@ final class VoiceConversationControllerTests: XCTestCase {
 
         XCTAssertEqual(controller.state, .thinking)
     }
+
+    func testResumeAfterPauseResetsSpeechTimingSoStaleSilenceCannotFinishUtterance() async {
+        let capture = MockCapture(permissionGranted: true)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: MockGateway(),
+            submit: { _ in true },
+            interrupt: {}
+        )
+
+        await controller.startListening()
+        let speechStart = Date()
+        controller.ingestAudioLevel(0.5, at: speechStart)
+        controller.pauseMicrophone()
+        await controller.resumeMicrophone()
+
+        // The pre-pause speech timestamp is stale by more than the trailing
+        // silence window. Resume is a fresh listening window, so a silent
+        // level event right after resume must not finish an utterance.
+        let resumeDate = Date()
+        controller.ingestAudioLevel(0.0, at: resumeDate.addingTimeInterval(10))
+        XCTAssertEqual(controller.state, .listening)
+        XCTAssertEqual(capture.finishUtteranceCount, 0)
+
+        // A fresh utterance still finishes normally on trailing silence.
+        controller.ingestAudioLevel(0.5, at: resumeDate.addingTimeInterval(2))
+        controller.ingestAudioLevel(0.0, at: resumeDate.addingTimeInterval(3.3))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(controller.state, .thinking)
+        XCTAssertEqual(capture.finishUtteranceCount, 1)
+    }
+
+    func testSpeechTestClaimsStandalonePlaybackOwnership() async {
+        let playback = MockPlayback()
+        let controller = VoiceConversationController(
+            capture: MockCapture(permissionGranted: true),
+            playback: playback,
+            gateway: MockGateway(startsPlaybackOnOpen: true),
+            submit: { _ in true },
+            interrupt: {}
+        )
+
+        let result = await controller.runSpeechTest(text: "test")
+
+        XCTAssertTrue(result.passed)
+        XCTAssertEqual(playback.intentAtLastStart, .standalonePlayback)
+    }
+
+    func testConversationSpeechClaimsConversationPlaybackOwnership() async {
+        let playback = MockPlayback()
+        let controller = VoiceConversationController(
+            capture: MockCapture(permissionGranted: true),
+            playback: playback,
+            gateway: MockGateway(startsPlaybackOnOpen: true),
+            submit: { _ in true },
+            interrupt: {}
+        )
+        controller.beginVoiceTurn(sessionID: "session")
+        await controller.startListening()
+        let utteranceStart = Date()
+        controller.ingestAudioLevel(0.1, at: utteranceStart)
+        controller.ingestAudioLevel(0, at: utteranceStart.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        controller.receiveAssistantEvent(.started(sessionID: "session"))
+        controller.receiveAssistantEvent(.delta(sessionID: "session", text: "One turn."))
+        controller.receiveAssistantEvent(.completed(sessionID: "session", content: "One turn."))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(playback.intentAtLastStart, .conversationPlayback)
+    }
 }
 
 @MainActor
@@ -617,6 +689,7 @@ private final class MockCapture: AudioCaptureService {
     var didBeginMonitoring = false
     var didPause = false
     var resumeCount = 0
+    private(set) var finishUtteranceCount = 0
 
     init(permissionGranted: Bool, startError: Error? = nil) {
         self.permissionGranted = permissionGranted
@@ -635,7 +708,8 @@ private final class MockCapture: AudioCaptureService {
     func pause() { didPause = true }
     func resume() throws { resumeCount += 1 }
     func finishUtterance() throws -> VoiceCapturedAudio {
-        VoiceCapturedAudio(wavData: Data([1]), pcm16Data: Data([1, 0]), sampleRate: 16_000, duration: 0.01)
+        finishUtteranceCount += 1
+        return VoiceCapturedAudio(wavData: Data([1]), pcm16Data: Data([1, 0]), sampleRate: 16_000, duration: 0.01)
     }
     func stop() {}
     func emit(_ event: VoiceCaptureEvent) { continuation?.yield(event) }
@@ -644,9 +718,19 @@ private final class MockCapture: AudioCaptureService {
 @MainActor
 private final class MockPlayback: SpeechPlaybackService {
     var isPlaying = false
-    func start(sampleRate: Double) throws { isPlaying = true }
+    var ownershipIntent: VoiceAudioIntent = .standalonePlayback
+    /// The ownership intent in force when playback last started, so tests can
+    /// assert which session policy a flow claimed.
+    private(set) var intentAtLastStart: VoiceAudioIntent?
+    func start(sampleRate: Double) throws {
+        intentAtLastStart = ownershipIntent
+        isPlaying = true
+    }
     func enqueuePCM16(_ data: Data, sampleRate: Double) throws -> Int { data.count - (data.count % 2) }
-    func playEncodedAudioData(_ data: Data) throws { isPlaying = true }
+    func playEncodedAudioData(_ data: Data) throws {
+        intentAtLastStart = ownershipIntent
+        isPlaying = true
+    }
     func finish() throws {}
     func drain() async { isPlaying = false }
     func stop() { isPlaying = false }


### PR DESCRIPTION
## Root cause (issue #140-adjacent behavior)

`AVAudioCaptureService` and `AVSpeechPlaybackService` both configured the process-global `AVAudioSession` independently, and only capture ever deactivated it. Every playback-only flow — **message Read Aloud** (finish, stop, or failure), the **TTS provider test**, and voice-session teardown that only called `playback.stop()` — left Conduit owning an exclusive `.playAndRecord` + `.voiceChat` session indefinitely. Because no path ever used `.mixWithOthers`, activation alone interrupted Spotify/Audible, and the never-deactivated session kept them silenced long after Conduit was done speaking. Pausing the microphone was also cosmetic: the flag flipped, but the engine, tap, and active session kept running.

## Old ownership model

- Capture: set `.playAndRecord`/`.voiceChat`/`[.allowBluetoothHFP, .defaultToSpeaker]`, `setActive(true)` on start, `setActive(false)` on stop — the only deactivator in the app.
- Playback (separate instance per controller): re-set `.playAndRecord`/`.voiceChat`/`[.allowBluetooth, .defaultToSpeaker]` on every stream start and encoded fallback, never deactivated.
- Read Aloud used the record-category conversation config for output-only audio.

## New ownership model

`VoiceAudioSessionCoordinator` (new, `Conduit/Voice/VoiceAudioSessionCoordinator.swift`) is the single authority. Services acquire intent-scoped leases instead of touching the session:

```swift
enum VoiceAudioIntent { case conversationCapture, conversationPlayback, standalonePlayback }
let lease = try coordinator.acquire(.conversationCapture)   // configures + activates as needed
coordinator.release(lease)                                   // deactivates when the last owner releases
```

Dominant policy: any conversation intent → conversation config (playback joins the capture-owned session without reconfiguring it; conversation playback that outlives capture — paused mic while the assistant speaks — deliberately keeps the conversation policy to avoid route churn mid-playback). Otherwise standalone intent → output-only policy. Deactivation (`setActive(false, .notifyOthersOnDeactivation)`) happens only when the last owner releases; failures are logged and retried on the next transition, never swallowed silently or crashed on. The real `AVAudioSession` sits behind a `VoiceAudioSessionControlling` seam so policy is unit-testable.

## Standalone vs conversation session policy

- **Conversation capture / playback** (unchanged behavior): `.playAndRecord`, `.voiceChat`, `[.allowBluetoothHFP, .defaultToSpeaker]`.
- **Standalone playback** (Read Aloud, TTS provider test): `.playback`, `.default` mode, `[.mixWithOthers, .duckOthers]`. Media that is already playing (Spotify, Audible) keeps playing ducked while Conduit speaks instead of being interrupted, and ducking ends the moment playback ends — the hard requirement "Conduit must stop affecting other media immediately when standalone speech ends" now holds on *every* terminal path, including natural completion (`finish()` arms a terminal flag; the last drained buffer, the encoded player, or an empty drain releases the lease).

## Pause semantics

`pauseMicrophone()` is now a real resource pause: engine stopped, tap removed, converter dropped, capture lease released — microphone hardware and the session are no longer held while the UI says "Microphone paused." The Voice Conversation stays logically open (state, transcript, mute preserved). `resume()` reacquires everything, and the controller resets `utteranceStartedAt`/`lastSpeechAt`/`bargeInStartedAt` so stale pre-pause silence cannot instantly finish an utterance. Captured PCM is intentionally retained so a sentence continues across a pause.

## Cleanup / error handling changes

- Natural playback completion (PCM drain, encoded player, empty drain) releases ownership — previously held forever.
- Interruption (`.began`) and engine-configuration changes settle playback: engine stops, drain waiters resume exactly once, lease releases — Read Aloud can no longer hang in `.playing` with audio that can never continue. A conversation drain self-heals on the next PCM buffer.
- Terminal speech-drain failures stop playback like every other terminal path; cancellation still lets scheduled audio render out (commented).
- `enqueuePCM16` settles before throwing on a mid-stream sample-rate change.
- The ASR provider test now stops active Read Aloud first (mutual exclusion was missing in that direction); Read Aloud pins its standalone intent per operation.
- `reassert()` (route-change restart path) restores the last applied policy on failure so a later release still deactivates.
- Notification handlers hop through `Task { @MainActor }`; release paths are idempotent (releasing an unknown/expired lease is a no-op).

## Tests added

`VoiceAudioSessionCoordinatorTests` (19 tests, mocked session seam — never the real session): dominant-policy selection, playback-joins-capture without reconfiguration, standalone cannot downgrade a conversation, both handoff directions without intermediate deactivation, deactivation exactly once on last release with `.notifyOthersOnDeactivation`, idempotent/unknown release, acquisition rollback on category and activation failure, deactivation-failure retry on the next transition, `reassert` semantics (including the failure-then-release case), and an engine-free service-level check that encoded-playback startup failure rolls back the acquired lease. Controller tests: pause→resume speech-timing reset, TTS test claims standalone ownership, conversation speech claims conversation-playback ownership. `AppStateReadAloudTests`: ASR test stops active Read Aloud (mirror of the existing reverse-direction test). Config tests pin the standalone policy.

Mac-verified (worktree on the build box): focused voice suites green (Coordinator, VoiceConversationController, Read Aloud suites, capability/config suites). Full `ConduitTests` run: all voice suites green; 6 chat/markdown tests flaked in the full run and all passed in isolated re-runs (known local Mac full-suite environmental instability) — CI is authoritative.

## Manual / device verification still recommended

1. **Spotify/Audible + Read Aloud**: music ducked while speaking, **recovers immediately when Read Aloud finishes/stops** (the #140 acceptance check).
2. **Spotify/Audible + TTS test**: same lifecycle expectation.
3. **Spotify/Audible + Voice Conversation**: opening Voice takes stronger ownership (expected); closing Voice releases the session and media recovers.
4. **Pause microphone**: while paused (and nothing speaking), other media recovers and the mic indicator clears; Listen resumes normally mid-conversation.
5. **AirPods / interruption**: disconnect mid-Read-Aloud → state settles (not stuck `.playing`), ownership released; phone call during voice → clean failure, media recovers after.

## Out of scope (explicit follow-ups)

- Issue #130 (VAD: fixed 0.075 peak threshold, no-speech state, level meter, manual submit) — separate PR.
- Persistent "Voice input enabled" / "Spoken responses enabled" preferences (the legitimate feature half of #140) — separate PR.
- Interruption auto-resume and playback route-restart polish.

Fixes the audio-interference lifecycle bug behind #140; does not close it — the separate user-preference request there may remain valid.

Review gate: two rounds of the three-model review (DeepSeek/Step/MiMo via ZCode reviewer subagents). Round 1 blockers fixed (natural-completion release, test-compiling lease init, MainActor hops, default-argument isolation, ASR/read-aloud exclusion, intent pinning); round 2 warnings fixed (reassert failure policy retention, terminal drain-failure playback settle, enqueuePCM16 settle, plus suggested tests). One round-2 suggestion (a `needsReassert` flag for failed deactivation) was declined: a failed deactivation leaves the session physically active, so keeping `appliedPolicy` set is the consistent state and the retry contract is pinned by test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved coordination between microphone capture, speech playback, read-aloud, and voice tests.
  - Prevented read-aloud playback from interfering with ASR tests.
  - Improved pause/resume behavior by resetting speech timing and releasing audio resources.
  - Improved handling of interruptions, route changes, playback completion, and startup failures.

- **New Features**
  - Added coordinated audio-session management for conversation and standalone playback.
  - Standalone playback now mixes with and gently lowers other audio instead of interrupting it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->