### PR TITLE
feat(setup): open Connection Setup from Settings for the current connection

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2227,7 +2227,29 @@ final class AppState: ObservableObject {
 
     // MARK: - Connection management
 
+#if DEBUG
+    /// UI-test-only connected state: a snapshot connection with no client and
+    /// no transport. Reconnect paths refuse to run while it is active (see
+    /// `reconnectForRetry`), so the stubbed session is inert by construction
+    /// and Settings-UI tests never touch a network or a real dashboard.
+    private static func uiTestConnectedStub() -> HermesConnection? {
+        let arguments = ProcessInfo.processInfo.arguments
+        guard let index = arguments.firstIndex(of: "-CONDUIT_UI_TEST_CONNECTED_DASHBOARD"),
+              index + 1 < arguments.count else { return nil }
+        return HermesConnection(baseUrl: arguments[index + 1], ticket: "ui-test-stub")
+    }
+#endif
+
     func loadSavedConnection() {
+        #if DEBUG
+        if let stub = Self.uiTestConnectedStub() {
+            connection = stub
+            isConnected = true
+            isConnecting = false
+            showLogin = false
+            return
+        }
+        #endif
         if let credentials = KeychainHelper.loadCredentials() {
             Task { await restoreSavedCredentials(credentials) }
         } else if let saved = KeychainHelper.loadConnection() {
@@ -4539,6 +4561,11 @@ final class AppState: ObservableObject {
     }
 
     func reconnectForRetry(purpose requestedPurpose: ChatResumeSyncPurpose) async {
+        #if DEBUG
+        // The UI-test stubbed session has no transport to restore; every
+        // automatic or explicit reconnect is a deterministic no-op for it.
+        guard Self.uiTestConnectedStub() == nil else { return }
+        #endif
         guard let savedConnection = connection else { return }
         let purpose = beginChatResumeRecovery(purpose: requestedPurpose)
         let automaticWorkToken = purpose == .automaticReturn

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2243,6 +2243,7 @@ final class AppState: ObservableObject {
     func loadSavedConnection() {
         #if DEBUG
         if let stub = Self.uiTestConnectedStub() {
+            lifecycleLog.notice("UI-test connected stub active: no transport will be created and reconnects are inert")
             connection = stub
             isConnected = true
             isConnecting = false

--- a/Conduit/Services/ConnectionFailure.swift
+++ b/Conduit/Services/ConnectionFailure.swift
@@ -194,6 +194,10 @@ enum ConnectionHelpDestination: Equatable, Hashable, Identifiable, CaseIterable 
     case network
     case tls
     case cloudflare
+    /// Round 5: the Settings entry for an already-connected user. Skips the
+    /// first-run readiness questions and seeds the wizard from the current
+    /// configuration instead.
+    case currentConnection
 
     var id: Self { self }
 }

--- a/Conduit/Services/ConnectionSetupApplication.swift
+++ b/Conduit/Services/ConnectionSetupApplication.swift
@@ -29,7 +29,12 @@ struct ConnectionSetupApplication: Equatable, CustomStringConvertible, CustomDeb
     /// credentials DO exist, and the tested URL moved: the applied
     /// configuration cannot use them, and keeping them would send a stale
     /// password to the next reconnect against the new address. The live
-    /// session is untouched either way.
+    /// session is untouched either way. A credential-less apply to the SAME
+    /// URL deliberately keeps the saved record: that shape is the interactive
+    /// sign-in outcome for the current dashboard, which is not a verified
+    /// replacement for the working native credentials — deleting them here
+    /// would strand the still-connected configuration (Round-5 acceptance:
+    /// a failed or inconclusive experiment must be harmless).
     let clearsSavedCredentials: Bool
     /// Same-origin rewrite of the inherited Cloudflare Access token to the
     /// new normalized URL string (path-only moves). A cross-origin apply
@@ -99,8 +104,9 @@ extension ConnectionSetupApplication {
         var rewrite: CloudflareAccessRewrite?
         if let access = savedCloudflareAccess, access.isConfigured,
            LoginCloudflareHandoff.sameOrigin(currentURL, newURL) {
+            let currentOrigin = (try? ConnectionURLPolicy.normalizedBaseURL(currentURL)) ?? currentURL
             let newOrigin = (try? ConnectionURLPolicy.normalizedBaseURL(newURL)) ?? newURL
-            if newOrigin != currentURL {
+            if newOrigin != currentOrigin {
                 rewrite = CloudflareAccessRewrite(access: access, origin: newOrigin)
             }
         }
@@ -140,10 +146,14 @@ enum ConnectionSetupSeeding {
         for dashboardURL: String,
         saved: DashboardCredentials?
     ) -> (username: String, password: String)? {
-        guard let saved,
-              saved.baseURL == dashboardURL.trimmingCharacters(in: .whitespacesAndNewlines) else {
-            return nil
-        }
+        guard let saved else { return nil }
+        // Both sides compare policy-normalized, so a trailing-slash or
+        // default-port spelling of the same address still seeds. Anything
+        // that fails normalization compares trimmed-raw (fail closed).
+        let wanted = (try? ConnectionURLPolicy.normalizedBaseURL(dashboardURL))
+            ?? dashboardURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let stored = (try? ConnectionURLPolicy.normalizedBaseURL(saved.baseURL)) ?? saved.baseURL
+        guard stored == wanted else { return nil }
         return (saved.username, saved.requiresFaceID ? "" : saved.password)
     }
 }

--- a/Conduit/Services/ConnectionSetupApplication.swift
+++ b/Conduit/Services/ConnectionSetupApplication.swift
@@ -74,11 +74,12 @@ extension ConnectionSetupApplication {
         savedCredentials: DashboardCredentials?,
         savedCloudflareAccess: CloudflareAccessCredentials?
     ) -> ConnectionSetupApplication {
-        let newURL = result.serverURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        let currentURL = currentDashboardURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        // Both addresses are policy-normalized upstream (the wizard's result
-        // by ConnectionSetupAddressBuilder, the current one at save time), so
-        // string equality is exact equality of scheme, host, port, and path.
+        // Normalize both sides before comparing so a non-canonical spelling
+        // of an unchanged address can never plan a spurious rewrite.
+        let newURL = (try? ConnectionURLPolicy.normalizedBaseURL(result.serverURL))
+            ?? result.serverURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let currentURL = (try? ConnectionURLPolicy.normalizedBaseURL(currentDashboardURL))
+            ?? currentDashboardURL.trimmingCharacters(in: .whitespacesAndNewlines)
         let urlChanged = newURL != currentURL
 
         let hasResultCredentials =
@@ -152,7 +153,8 @@ enum ConnectionSetupSeeding {
         // that fails normalization compares trimmed-raw (fail closed).
         let wanted = (try? ConnectionURLPolicy.normalizedBaseURL(dashboardURL))
             ?? dashboardURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        let stored = (try? ConnectionURLPolicy.normalizedBaseURL(saved.baseURL)) ?? saved.baseURL
+        let stored = (try? ConnectionURLPolicy.normalizedBaseURL(saved.baseURL))
+            ?? saved.baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
         guard stored == wanted else { return nil }
         return (saved.username, saved.requiresFaceID ? "" : saved.password)
     }

--- a/Conduit/Services/ConnectionSetupApplication.swift
+++ b/Conduit/Services/ConnectionSetupApplication.swift
@@ -1,0 +1,149 @@
+//
+//  ConnectionSetupApplication.swift
+//  Conduit
+//
+//  Round 5: the persisted-configuration effect of applying a tested
+//  ConnectionSetupResult from the Settings current-connection entry.
+//  Deliberately a pure plan: the policy — update the saved/login
+//  configuration WITHOUT touching the active connection, never create
+//  credentials that were never saved, never copy a Cloudflare service
+//  token across origins — is unit-testable without Keychain, AppState, or
+//  a live session. The Settings view performs the writes via perform(_:);
+//  the plan itself has no side effects, so a failed experiment in the
+//  wizard can never mutate anything (nothing is planned until Review
+//  hands off a tested result).
+//
+
+import Foundation
+
+struct ConnectionSetupApplication: Equatable, CustomStringConvertible, CustomDebugStringConvertible {
+    /// The dashboard URL to hand to `AppState.rememberDashboardURL`. Nil when
+    /// the tested URL already equals the current one.
+    let dashboardURLToRemember: String?
+    /// Replacement saved credentials. Non-nil only when credentials were
+    /// already saved for the current connection AND the tested values differ:
+    /// an explicit apply updates an existing saved configuration, it never
+    /// starts persisting credentials the user chose not to save.
+    let credentialsToSave: DashboardCredentials?
+    /// Set only when the applied result carries no credentials, saved
+    /// credentials DO exist, and the tested URL moved: the applied
+    /// configuration cannot use them, and keeping them would send a stale
+    /// password to the next reconnect against the new address. The live
+    /// session is untouched either way.
+    let clearsSavedCredentials: Bool
+    /// Same-origin rewrite of the inherited Cloudflare Access token to the
+    /// new normalized URL string (path-only moves). A cross-origin apply
+    /// never appears here: the token is neither copied to the new origin nor
+    /// deleted from the old one.
+    let cloudflareTokenRewrite: CloudflareAccessRewrite?
+
+    struct CloudflareAccessRewrite: Equatable {
+        let access: CloudflareAccessCredentials
+        let origin: String
+    }
+
+    /// True when applying changes nothing — a successfully tested but
+    /// unchanged configuration needs no writes and no confirmation.
+    var isEmpty: Bool {
+        dashboardURLToRemember == nil
+            && credentialsToSave == nil
+            && !clearsSavedCredentials
+            && cloudflareTokenRewrite == nil
+    }
+
+    // Never let ordinary diagnostic interpolation disclose credentials or an
+    // unvalidated URL.
+    var description: String { "ConnectionSetupApplication(redacted)" }
+    var debugDescription: String { description }
+}
+
+extension ConnectionSetupApplication {
+    /// Plans the persisted-configuration effect of an applied wizard result.
+    /// `currentDashboardURL` is the ACTIVE connection's base URL (or the last
+    /// configured one when signed out); `savedCredentials` is the Keychain
+    /// record for that address, and `savedCloudflareAccess` is the origin-
+    /// matched token for it (both as loaded by `KeychainHelper`).
+    static func plan(
+        result: ConnectionSetupResult,
+        currentDashboardURL: String,
+        savedCredentials: DashboardCredentials?,
+        savedCloudflareAccess: CloudflareAccessCredentials?
+    ) -> ConnectionSetupApplication {
+        let newURL = result.serverURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let currentURL = currentDashboardURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Both addresses are policy-normalized upstream (the wizard's result
+        // by ConnectionSetupAddressBuilder, the current one at save time), so
+        // string equality is exact equality of scheme, host, port, and path.
+        let urlChanged = newURL != currentURL
+
+        let hasResultCredentials =
+            !result.username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !result.password.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+
+        var credentialsToSave: DashboardCredentials?
+        var clearsSavedCredentials = false
+        if let saved = savedCredentials {
+            if hasResultCredentials {
+                let replacement = DashboardCredentials(
+                    baseURL: newURL,
+                    username: result.username,
+                    password: result.password,
+                    requiresFaceID: saved.requiresFaceID
+                )
+                credentialsToSave = replacement != saved ? replacement : nil
+            } else if urlChanged {
+                clearsSavedCredentials = true
+            }
+        }
+
+        var rewrite: CloudflareAccessRewrite?
+        if let access = savedCloudflareAccess, access.isConfigured,
+           LoginCloudflareHandoff.sameOrigin(currentURL, newURL) {
+            let newOrigin = (try? ConnectionURLPolicy.normalizedBaseURL(newURL)) ?? newURL
+            if newOrigin != currentURL {
+                rewrite = CloudflareAccessRewrite(access: access, origin: newOrigin)
+            }
+        }
+
+        return ConnectionSetupApplication(
+            dashboardURLToRemember: urlChanged ? newURL : nil,
+            credentialsToSave: credentialsToSave,
+            clearsSavedCredentials: clearsSavedCredentials,
+            cloudflareTokenRewrite: rewrite
+        )
+    }
+
+    /// Performs the plan's writes. The live connection — AppState's
+    /// `connection`, `client`, session, and chat state — is never touched:
+    /// only the saved/login configuration moves, so the current session keeps
+    /// running and the new settings take effect on the next explicit
+    /// reconnect (an app relaunch, or signing in again).
+    @MainActor
+    func perform(appState: AppState) {
+        if let url = dashboardURLToRemember { appState.rememberDashboardURL(url) }
+        if let credentials = credentialsToSave { KeychainHelper.saveCredentials(credentials) }
+        if clearsSavedCredentials { KeychainHelper.clearCredentials() }
+        if let rewrite = cloudflareTokenRewrite {
+            KeychainHelper.saveCloudflareAccess(rewrite.access, origin: rewrite.origin)
+        }
+    }
+}
+
+/// Picks the saved credentials that may seed the Settings wizard for a
+/// dashboard address. Only a record saved for exactly this normalized URL
+/// qualifies — credentials for another server never leak into the draft — and
+/// a Face ID-protected record surrenders its username only: reusing the saved
+/// password must never bypass the biometric gate that saved it, so the wizard
+/// asks for that password again.
+enum ConnectionSetupSeeding {
+    static func wizardCredentials(
+        for dashboardURL: String,
+        saved: DashboardCredentials?
+    ) -> (username: String, password: String)? {
+        guard let saved,
+              saved.baseURL == dashboardURL.trimmingCharacters(in: .whitespacesAndNewlines) else {
+            return nil
+        }
+        return (saved.username, saved.requiresFaceID ? "" : saved.password)
+    }
+}

--- a/Conduit/Services/ConnectionSetupDraft.swift
+++ b/Conduit/Services/ConnectionSetupDraft.swift
@@ -50,6 +50,19 @@ struct ConnectionSetupDraft: Equatable, CustomStringConvertible, CustomDebugStri
                                      password: password)
     }
 
+    /// The staged connection test's target: the built address plus whatever
+    /// credentials are present, without requiring them. Provider discovery —
+    /// not form presence — decides whether a password applies, and an
+    /// interactive-auth dashboard legitimately has none to type. Review
+    /// acceptance is still strict: a credential-less draft can only complete
+    /// through the interactive-auth outcome (`ConnectionSetupFlow.acceptedResult`).
+    func testConfiguration() throws -> ConnectionSetupResult {
+        let address = try ConnectionSetupAddressBuilder.build(self)
+        return ConnectionSetupResult(serverURL: address,
+                                     username: username,
+                                     password: password)
+    }
+
     // Do not let ordinary diagnostic interpolation disclose credentials or
     // an unvalidated pasted URL (which could itself contain credentials).
     var description: String { "ConnectionSetupDraft(redacted)" }

--- a/Conduit/Services/ConnectionSetupDraft.swift
+++ b/Conduit/Services/ConnectionSetupDraft.swift
@@ -41,13 +41,13 @@ struct ConnectionSetupDraft: Equatable, CustomStringConvertible, CustomDebugStri
 
     func result() throws -> ConnectionSetupResult {
         let address = try ConnectionSetupAddressBuilder.build(self)
-        guard !username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-              !password.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        let result = ConnectionSetupResult(serverURL: address,
+                                           username: username,
+                                           password: password)
+        guard result.hasUsableCredentials else {
             throw ConnectionSetupValidationError.credentialsRequired
         }
-        return ConnectionSetupResult(serverURL: address,
-                                     username: username,
-                                     password: password)
+        return result
     }
 
     /// The staged connection test's target: the built address plus whatever
@@ -73,6 +73,17 @@ struct ConnectionSetupResult: Equatable, CustomStringConvertible, CustomDebugStr
     let serverURL: String
     let username: String
     let password: String
+
+    /// Presence-only credential check with the SAME semantic requirement as
+    /// `ConnectionSetupDraft.result()`: a native password login needs both a
+    /// non-empty username and a non-empty password. Presence only — the
+    /// values themselves are never trimmed or rewritten. Used by the staged
+    /// probe to stop at the credentials-required outcome instead of sending
+    /// an empty-credential login attempt.
+    var hasUsableCredentials: Bool {
+        !username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !password.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
 
     var description: String { "ConnectionSetupResult(redacted)" }
     var debugDescription: String { description }

--- a/Conduit/Services/ConnectionSetupFlow.swift
+++ b/Conduit/Services/ConnectionSetupFlow.swift
@@ -206,16 +206,21 @@ struct ConnectionSetupFlow: Equatable {
     /// entry skips the first-run readiness questions entirely; its shape
     /// depends on the seed:
     ///
-    /// * Both credential fields empty is the interactive-auth signature — no
-    ///   password exists to type — so the wizard opens straight on the
-    ///   staged test, with the details screen kept underneath so Back
-    ///   reaches an editable address ("change your connection" must not
-    ///   require a failure first).
+    /// * Both credential fields empty means credentials are simply
+    ///   UNAVAILABLE to the wizard (nothing saved, or a browser-auth
+    ///   connection) — it is never an authentication mode. Provider
+    ///   discovery runs fine without credentials and decides the auth mode,
+    ///   so the wizard opens straight on the staged test, with the details
+    ///   screen kept underneath so Back reaches an editable address
+    ///   ("change your connection" must not require a failure first). A
+    ///   password-capable dashboard stops at the credentials-required
+    ///   partial outcome; an interactive one at browser sign-in required.
     /// * A username with an empty password is a native deployment whose
     ///   password was withheld (Face ID-protected record) or forgotten: it
     ///   lands on the prefilled details/credentials screens so the user is
-    ///   asked for the password instead of spending an empty-credential
-    ///   login attempt on their own server.
+    ///   asked for the password instead of testing without one. The
+    ///   invariant either way: no password login happens until BOTH
+    ///   credentials are present.
     /// * An address that cannot even be built falls back to the details
     ///   screen, which surfaces the validation.
     static func initialPath(for destination: ConnectionHelpDestination, draft: ConnectionSetupDraft) -> [ConnectionSetupStep] {
@@ -460,7 +465,11 @@ struct ConnectionSetupFlow: Equatable {
     /// cancellation, a newer run, or a draft reset — are ignored, so a late
     /// completion can never overwrite newer state. A terminal event (full
     /// native success, or the interactive sign-in outcome) seals the result
-    /// at the current draft revision and advances to Review.
+    /// at the current draft revision and advances to Review. The
+    /// credentials-required partial outcome also terminates the RUN but
+    /// deliberately seals nothing and navigates nowhere: it authorizes
+    /// nothing (`canUseSettings` stays false) and stays on the test screen
+    /// with its Enter Credentials recovery.
     @discardableResult
     mutating func applyTestEvent(_ event: ConnectionSetupTestEvent, generation: Int) -> Bool {
         guard generation == testGeneration, step == .connectionTest else { return false }

--- a/Conduit/Services/ConnectionSetupFlow.swift
+++ b/Conduit/Services/ConnectionSetupFlow.swift
@@ -185,7 +185,7 @@ struct ConnectionSetupFlow: Equatable {
         self.draft = draft
         self.inheritedCloudflareAccess = inheritedCloudflareAccess
         self.inheritedCloudflareOriginURL = inheritedCloudflareOriginURL
-        path = [Self.initialStep(for: entry, draft: draft)]
+        path = Self.initialPath(for: entry, draft: draft)
     }
 
     /// Failure-driven Round-1 destinations land at sensible parts of the
@@ -202,18 +202,33 @@ struct ConnectionSetupFlow: Equatable {
         }
     }
 
-    /// The step a fresh wizard lands on. The Settings current-connection
-    /// entry skips the first-run readiness questions entirely: with a usable
-    /// password seed it opens on the (prefilled) connection-details screen;
-    /// without one — an interactive-auth deployment legitimately has no
-    /// stored password — it opens straight on the staged test rather than
-    /// parking the user on a meaningless password field.
-    static func initialStep(for destination: ConnectionHelpDestination, draft: ConnectionSetupDraft) -> ConnectionSetupStep {
-        guard destination == .currentConnection,
-              draft.password.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return entryStep(for: destination)
+    /// The path a fresh wizard starts on. The Settings current-connection
+    /// entry skips the first-run readiness questions entirely; its shape
+    /// depends on the seed:
+    ///
+    /// * Both credential fields empty is the interactive-auth signature — no
+    ///   password exists to type — so the wizard opens straight on the
+    ///   staged test, with the details screen kept underneath so Back
+    ///   reaches an editable address ("change your connection" must not
+    ///   require a failure first).
+    /// * A username with an empty password is a native deployment whose
+    ///   password was withheld (Face ID-protected record) or forgotten: it
+    ///   lands on the prefilled details/credentials screens so the user is
+    ///   asked for the password instead of spending an empty-credential
+    ///   login attempt on their own server.
+    /// * An address that cannot even be built falls back to the details
+    ///   screen, which surfaces the validation.
+    static func initialPath(for destination: ConnectionHelpDestination, draft: ConnectionSetupDraft) -> [ConnectionSetupStep] {
+        guard destination == .currentConnection else {
+            return [entryStep(for: destination)]
         }
-        return .connectionTest
+        let credentialsEmpty =
+            draft.username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && draft.password.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        guard credentialsEmpty, (try? draft.testConfiguration()) != nil else {
+            return [entryStep(for: destination)]
+        }
+        return [.connectionDetails, .connectionTest]
     }
 
     /// True only for the Settings current-connection entry, so the few copy
@@ -294,8 +309,21 @@ struct ConnectionSetupFlow: Equatable {
 
     mutating func submitCredentials() {
         guard step == .loginCredentials else { return }
+        // The Settings current-connection entry may proceed with no
+        // credentials at all: an interactive-auth dashboard signs in through
+        // the browser, so empty fields are its normal shape — including when
+        // returning here after editing a failed test's address. LoginView
+        // entries keep the strict requirement; a first-run user must not
+        // spend a real server's login attempt on empty credentials.
+        let credentialsOptional = enteredFromCurrentConnection
+            && draft.username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && draft.password.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         do {
-            _ = try draft.result()
+            if credentialsOptional {
+                _ = try draft.testConfiguration()
+            } else {
+                _ = try draft.result()
+            }
             advance(to: .connectionTest)
             // A test result validated against an OLDER draft must never
             // authorize this fresh entry: edits bump the revision, so any
@@ -393,13 +421,15 @@ struct ConnectionSetupFlow: Equatable {
         hasCurrentSuccessfulTest || hasCurrentInteractiveAuthOutcome
     }
 
-    /// Round 5 (Settings current-connection entry): the CURRENT staged test
-    /// validated a configuration byte-identical to the one the wizard was
-    /// seeded with, so Review can offer plain Done — there is nothing to
-    /// apply. Any draft edit (address, credentials, route) breaks equality
+    /// Round 5: the CURRENT staged test validated a configuration
+    /// byte-identical to the one the wizard was seeded with, so Review can
+    /// offer plain Done — there is nothing to apply. Gated to the Settings
+    /// current-connection entry: the LoginView wizard must always offer its
+    /// normal "Use these settings" handoff, even when the user edited
+    /// nothing. Any draft edit (address, credentials, route) breaks equality
     /// exactly like it breaks the staged test's revision match.
     var testedSettingsUnchanged: Bool {
-        canUseSettings && draft == seededDraft
+        enteredFromCurrentConnection && canUseSettings && draft == seededDraft
     }
 
     /// The inherited Cloudflare token, ONLY when it is same-origin with the

--- a/Conduit/Services/ConnectionSetupFlow.swift
+++ b/Conduit/Services/ConnectionSetupFlow.swift
@@ -149,6 +149,10 @@ struct ConnectionSetupFlow: Equatable {
     private(set) var inheritedCloudflareOriginURL: String
     private(set) var validationError: ConnectionSetupValidationError?
     private let entry: ConnectionHelpDestination
+    /// The draft exactly as the wizard was seeded. The Settings
+    /// current-connection entry compares against it so a tested-but-unchanged
+    /// configuration can offer plain Done instead of an apply.
+    private let seededDraft: ConnectionSetupDraft
 
     var accessMethod: ConnectionAccessMethod? { draft.accessMethod }
 
@@ -177,10 +181,11 @@ struct ConnectionSetupFlow: Equatable {
         inheritedCloudflareOriginURL: String = ""
     ) {
         self.entry = entry
+        self.seededDraft = draft
         self.draft = draft
         self.inheritedCloudflareAccess = inheritedCloudflareAccess
         self.inheritedCloudflareOriginURL = inheritedCloudflareOriginURL
-        path = [Self.entryStep(for: entry)]
+        path = [Self.initialStep(for: entry, draft: draft)]
     }
 
     /// Failure-driven Round-1 destinations land at sensible parts of the
@@ -193,8 +198,28 @@ struct ConnectionSetupFlow: Equatable {
         case .network: return .accessMethod
         case .tls: return .tlsTroubleshooting
         case .cloudflare: return .cloudflareTroubleshooting
+        case .currentConnection: return .connectionDetails
         }
     }
+
+    /// The step a fresh wizard lands on. The Settings current-connection
+    /// entry skips the first-run readiness questions entirely: with a usable
+    /// password seed it opens on the (prefilled) connection-details screen;
+    /// without one — an interactive-auth deployment legitimately has no
+    /// stored password — it opens straight on the staged test rather than
+    /// parking the user on a meaningless password field.
+    static func initialStep(for destination: ConnectionHelpDestination, draft: ConnectionSetupDraft) -> ConnectionSetupStep {
+        guard destination == .currentConnection,
+              draft.password.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return entryStep(for: destination)
+        }
+        return .connectionTest
+    }
+
+    /// True only for the Settings current-connection entry, so the few copy
+    /// distinctions that would otherwise sound wrong to an already-connected
+    /// user can be made without forking the wizard's wording.
+    var enteredFromCurrentConnection: Bool { entry == .currentConnection }
 
     mutating func back() {
         guard canGoBack else { return }
@@ -295,8 +320,28 @@ struct ConnectionSetupFlow: Equatable {
     /// untested configuration is never handed off.
     mutating func complete() -> ConnectionSetupResult? {
         guard step == .review, canUseSettings else { return nil }
-        do { return try draft.result() }
-        catch { record(error); return nil }
+        switch acceptedResult() {
+        case .success(let result): return result
+        case .failure(let error): record(error); return nil
+        }
+    }
+
+    /// The result Review can hand off: the fully-validated draft, or — only
+    /// when the CURRENT staged outcome is the interactive-auth terminal — the
+    /// address-only configuration. Discovery, not form presence, proved how
+    /// that dashboard authenticates, so there is no password to require.
+    /// Every other validation failure stays a failure.
+    func acceptedResult() -> Result<ConnectionSetupResult, ConnectionSetupValidationError> {
+        do { return .success(try draft.result()) }
+        catch {
+            if (error as? ConnectionSetupValidationError) == .credentialsRequired,
+               hasCurrentInteractiveAuthOutcome,
+               let addressOnly = try? draft.testConfiguration() {
+                return .success(addressOnly)
+            }
+            let validationError = error as? ConnectionSetupValidationError ?? .policy(.invalidURL)
+            return .failure(validationError)
+        }
     }
 
     /// Pure revalidation for rendering the Review card: the validated result
@@ -305,11 +350,7 @@ struct ConnectionSetupFlow: Equatable {
     /// failure can never silently blank the Review content — the view renders
     /// the failure branch instead.
     func reviewState() -> Result<ConnectionSetupResult, ConnectionSetupValidationError> {
-        do { return .success(try draft.result()) }
-        catch {
-            let validationError = error as? ConnectionSetupValidationError ?? .policy(.invalidURL)
-            return .failure(validationError)
-        }
+        acceptedResult()
     }
 
     private mutating func record(_ error: Error) {
@@ -352,6 +393,15 @@ struct ConnectionSetupFlow: Equatable {
         hasCurrentSuccessfulTest || hasCurrentInteractiveAuthOutcome
     }
 
+    /// Round 5 (Settings current-connection entry): the CURRENT staged test
+    /// validated a configuration byte-identical to the one the wizard was
+    /// seeded with, so Review can offer plain Done — there is nothing to
+    /// apply. Any draft edit (address, credentials, route) breaks equality
+    /// exactly like it breaks the staged test's revision match.
+    var testedSettingsUnchanged: Bool {
+        canUseSettings && draft == seededDraft
+    }
+
     /// The inherited Cloudflare token, ONLY when it is same-origin with the
     /// draft's current address. A service token entered for one dashboard is
     /// never sent to a different origin during the test (Round-3 origin
@@ -359,7 +409,7 @@ struct ConnectionSetupFlow: Equatable {
     func cloudflareAccessForDraft() -> CloudflareAccessCredentials? {
         guard let access = inheritedCloudflareAccess, access.isConfigured else { return nil }
         let origin = inheritedCloudflareOriginURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !origin.isEmpty, let result = try? draft.result() else { return nil }
+        guard !origin.isEmpty, let result = try? draft.testConfiguration() else { return nil }
         return LoginCloudflareHandoff.sameOrigin(result.serverURL, origin) ? access : nil
     }
 

--- a/Conduit/Services/ConnectionSetupTest.swift
+++ b/Conduit/Services/ConnectionSetupTest.swift
@@ -303,10 +303,11 @@ protocol ConnectionSetupTesting {
 /// The production probe. Reuses `NativeAuthClient` unchanged for every
 /// request — including its redirect policy, Cloudflare header application,
 /// transport policy, and status classification via
-/// `ConnectionFailureClassifier`. A password-capable dashboard sees exactly
-/// one discovery request, one password-login attempt, and one ticket mint;
-/// an interactive-auth dashboard sees exactly one discovery request and
-/// nothing else.
+/// `ConnectionFailureClassifier`. A password-capable dashboard with present
+/// credentials sees exactly one discovery request, one password-login
+/// attempt, and one ticket mint. A password-capable dashboard without
+/// present credentials — and an interactive-auth dashboard — sees exactly
+/// one discovery request and nothing else.
 struct ConnectionSetupProbe: ConnectionSetupTesting {
     private static let logger = Logger(subsystem: "com.milim.relay", category: "connection-setup-test")
 

--- a/Conduit/Services/ConnectionSetupTest.swift
+++ b/Conduit/Services/ConnectionSetupTest.swift
@@ -12,16 +12,16 @@
 //  status classification. Stage 1 (transport) and stage 2 (Hermes dashboard
 //  confirmation) ride on the same provider-discovery request the normal
 //  login flow performs first; stage 3 is the full native connect (password
-//  login + ws-ticket mint) for password-capable dashboards. A dashboard that
-//  answers discovery with an unauthenticated redirect to a sign-in page has
-//  proven everything the probe can test and ends the run in the supported
-//  `requiresInteractiveSignIn` outcome: no native login, no ticket, no
-//  WebView — the actual sign-in happens in LoginView after the handoff.
-//  The milestone for "Login successful" is exactly the milestone normal
-//  login reaches before it would commit anything — and the probe commits
-//  nothing: no cookie store write, no Keychain, no AppState mutation, no
-//  websocket, no screen changes. The resulting ticket and transaction
-//  cookies are discarded here.
+//  login + ws-ticket mint) for password-capable dashboards WITH present
+//  credentials. Two dashboards legitimately stop before stage 3's login: one
+//  that answers discovery with an unauthenticated redirect to a sign-in page
+//  ends in the supported `requiresInteractiveSignIn` outcome, and a
+//  password-capable dashboard whose tested configuration carries no usable
+//  credentials ends in the supported `requiresCredentials` partial outcome —
+//  credential absence is not an authentication mode, and an empty-credential
+//  login is never sent. The probe commits nothing: no cookie store write, no
+//  Keychain, no AppState mutation, no websocket, no screen changes. The
+//  resulting ticket and transaction cookies are discarded here.
 //
 
 import Foundation
@@ -85,6 +85,14 @@ enum ConnectionSetupStageState: Equatable {
     /// outcome — explicitly NOT a success (the user has not authenticated)
     /// and NOT a failure (nothing went wrong).
     case requiresInteractiveSignIn
+    /// The dashboard is a native password dashboard, but the test
+    /// configuration carries no usable credentials to test it with. A
+    /// supported partial outcome: transport and dashboard identity are
+    /// proven, no login attempt was made, and the user can enter
+    /// credentials to finish the test. Explicitly NOT a success, NOT a
+    /// failure, and NOT an authentication mode — credential availability is
+    /// a property of the seed, never of the dashboard.
+    case requiresCredentials
     case failed(ConnectionFailure)
 
     /// VoiceOver state word, so success/failure is never communicated by
@@ -95,6 +103,7 @@ enum ConnectionSetupStageState: Equatable {
         case .running: return "checking"
         case .succeeded: return "passed"
         case .requiresInteractiveSignIn: return "browser sign-in required"
+        case .requiresCredentials: return "credentials required"
         case .failed: return "failed"
         }
     }
@@ -111,6 +120,12 @@ enum ConnectionSetupTestEvent: Equatable {
     /// server and dashboard have succeeded. No password login, ticket mint,
     /// or WebView follows inside the probe.
     case requiresInteractiveSignIn(ConnectionSetupTestStage)
+    /// Terminal partial outcome: the dashboard is a native password
+    /// dashboard but the tested configuration carries no usable credentials.
+    /// Emitted once, at the authentication stage, after server and dashboard
+    /// have succeeded — INSTEAD of any login attempt. No password login and
+    /// no ticket mint follow; an empty-credential login is never sent.
+    case requiresCredentials(ConnectionSetupTestStage)
     case failed(ConnectionSetupTestStage, ConnectionFailure)
 }
 
@@ -132,6 +147,14 @@ struct ConnectionSetupTestState: Equatable {
     /// successful".
     static let interactiveReadyMessage = "This dashboard uses browser-based sign-in. "
         + "Conduit will open the sign-in page after you return to the login screen."
+
+    /// The credentials-required partial outcome's copy: server and dashboard
+    /// passed, but testing native login needs the user's credentials first.
+    /// Names the dashboard's auth mode (learned from provider discovery) and
+    /// asks for the missing secret — never a success, failure, or
+    /// "connection ready" claim.
+    static let credentialsRequiredMessage = "This dashboard uses username and password sign-in. "
+        + "Enter your credentials to finish testing the connection."
 
     subscript(stage: ConnectionSetupTestStage) -> ConnectionSetupStageState {
         get {
@@ -165,6 +188,9 @@ struct ConnectionSetupTestState: Equatable {
         case .requiresInteractiveSignIn(let stage):
             guard self[stage] == .pending || self[stage] == .running else { return }
             self[stage] = .requiresInteractiveSignIn
+        case .requiresCredentials(let stage):
+            guard self[stage] == .pending || self[stage] == .running else { return }
+            self[stage] = .requiresCredentials
         case .failed(let stage, let failure):
             guard self[stage] == .pending || self[stage] == .running else { return }
             self[stage] = .failed(failure)
@@ -188,6 +214,17 @@ struct ConnectionSetupTestState: Equatable {
             && authentication == .requiresInteractiveSignIn
     }
 
+    /// The staged test ended in the supported credentials-required partial
+    /// outcome: server and dashboard succeeded, and authentication stopped
+    /// before any login attempt because the tested configuration carries no
+    /// usable credentials. Never a success, never a failure, and never an
+    /// authentication mode — discovery decides that, not credential absence.
+    var requiresCredentials: Bool {
+        server == .succeeded
+            && dashboard == .succeeded
+            && authentication == .requiresCredentials
+    }
+
     /// The first failed stage in run order, if any.
     var failedStage: ConnectionSetupTestStage? {
         ConnectionSetupTestStage.allCases.first { stage in
@@ -208,6 +245,7 @@ struct ConnectionSetupTestState: Equatable {
         case .running: return stage.runningLabel
         case .succeeded: return stage.successLabel
         case .requiresInteractiveSignIn: return "Browser sign-in required"
+        case .requiresCredentials: return "Credentials required"
         case .pending, .failed: return stage.objectiveLabel
         }
     }
@@ -350,7 +388,18 @@ struct ConnectionSetupProbe: ConnectionSetupTesting {
         // commit cookies. The transaction (ticket + transaction cookies) is
         // deliberately discarded: the test persists nothing and connects
         // nothing.
+        //
+        // A password-capable dashboard WITHOUT present credentials stops
+        // here at the supported credentials-required outcome. Credential
+        // absence is not an authentication mode — it only means the Settings
+        // seed could not supply the secret — and an empty-credential login
+        // would be a real, rate-limited authentication attempt against a
+        // connection that may already be known to work.
         onEvent(.started(.authentication))
+        guard result.hasUsableCredentials else {
+            onEvent(.requiresCredentials(.authentication))
+            return
+        }
         do {
             // Deliberately discarded: commitCookies() is never called, so
             // the transaction never reaches the shared cookie store.
@@ -389,6 +438,7 @@ struct ConnectionSetupTestProbeStub: ConnectionSetupTesting {
     enum Script: String {
         case success
         case interactiveSignInRequired = "auth:interactiveSignInRequired"
+        case credentialsRequired = "auth:credentialsRequired"
         case serverHostNotFound = "server:hostNotFound"
         case dashboardUnexpected = "dashboard:unexpectedServerResponse"
         case authRejected = "auth:authenticationRejected"
@@ -410,6 +460,13 @@ struct ConnectionSetupTestProbeStub: ConnectionSetupTesting {
                 onEvent(.succeeded(.dashboard))
                 onEvent(.started(.authentication))
                 onEvent(.requiresInteractiveSignIn(.authentication))
+            case .credentialsRequired:
+                onEvent(.started(.server))
+                onEvent(.succeeded(.server))
+                onEvent(.started(.dashboard))
+                onEvent(.succeeded(.dashboard))
+                onEvent(.started(.authentication))
+                onEvent(.requiresCredentials(.authentication))
             case .serverHostNotFound:
                 onEvent(.started(.server))
                 onEvent(.failed(.server, .hostNotFound))

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -625,7 +625,7 @@ private struct SettingsHome: View {
                         settingsLink(.capabilities, icon: "puzzlepiece.extension", title: "Capabilities", detail: "Skills, toolsets, and categories")
                     }
                     homeSection("Connection", tint: .conduitAura) {
-                        settingsLink(.gateway, icon: "radio", title: "Gateway", detail: snapshot.server ?? "Not connected")
+                        settingsLink(.gateway, icon: "radio", title: "Gateway", detail: snapshot.server ?? "Not connected", identifier: "settings.gateway")
                         settingsActionRow(
                             icon: "checkmark.circle",
                             title: "Connection Setup",
@@ -710,7 +710,7 @@ private struct SettingsHome: View {
         ConduitSettingsSection(title: title, symbol: title == "Profile" ? "person.crop.circle" : "gearshape.2", tint: tint, content: content)
     }
 
-    private func settingsLink(_ destination: SettingsDestination, icon: String, title: String, detail: String) -> some View {
+    private func settingsLink(_ destination: SettingsDestination, icon: String, title: String, detail: String, identifier: String = "") -> some View {
         Button {
             Haptics.selection()
             path.append(destination)
@@ -719,6 +719,7 @@ private struct SettingsHome: View {
         }
         .buttonStyle(.plain)
         .accessibilityHint(detail)
+        .accessibilityIdentifier(identifier)
     }
 
     private func settingsActionRow(icon: String, title: String, detail: String, identifier: String, action: @escaping () -> Void) -> some View {

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -589,6 +589,14 @@ private struct SettingsHome: View {
     let snapshot: SettingsSnapshot
     @Binding var path: [SettingsDestination]
     @EnvironmentObject private var appState: AppState
+    /// Round 5: the Settings entry into the existing Connection Setup
+    /// assistant, seeded from the current configuration.
+    @State private var showsConnectionSetup = false
+    /// Set by the wizard's completion when the applied plan changes the
+    /// saved configuration; surfaced as an alert only after the wizard sheet
+    /// has dismissed (one presentation context at a time).
+    @State private var pendingAppliedNotice = false
+    @State private var appliedConnectionNotice = false
 
     var body: some View {
         ZStack {
@@ -608,6 +616,14 @@ private struct SettingsHome: View {
                     }
                     homeSection("Connection", tint: .conduitAura) {
                         settingsLink(.gateway, icon: "radio", title: "Gateway", detail: snapshot.server ?? "Not connected")
+                        settingsActionRow(
+                            icon: "checkmark.circle",
+                            title: "Connection Setup",
+                            detail: "Test, troubleshoot, or change your connection",
+                            identifier: "settings.connection-setup"
+                        ) {
+                            showsConnectionSetup = true
+                        }
                     }
                     homeSection("On this device", tint: .conduitAccent) {
                         settingsLink(.appearance, icon: "circle.lefthalf.filled", title: "Appearance", detail: "Theme and interface preferences")
@@ -622,6 +638,54 @@ private struct SettingsHome: View {
                 }
                 .padding(16)
             }
+        }
+        .sheet(isPresented: $showsConnectionSetup, onDismiss: {
+            guard pendingAppliedNotice else { return }
+            pendingAppliedNotice = false
+            appliedConnectionNotice = true
+        }) {
+            connectionSetupSheet
+        }
+        .alert("Settings applied", isPresented: $appliedConnectionNotice) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Saved for your next reconnect. Your current session stays connected.")
+        }
+    }
+
+    /// The active connection's address — the live connection when one exists,
+    /// else the last configured dashboard. Seeding reads it; applying a
+    /// tested result never writes to the live session itself.
+    private var currentDashboardURL: String {
+        appState.connection?.baseUrl ?? appState.lastDashboardURL
+    }
+
+    @ViewBuilder
+    private var connectionSetupSheet: some View {
+        let seedURL = currentDashboardURL
+        let saved = KeychainHelper.loadCredentials()
+        let seeded = ConnectionSetupSeeding.wizardCredentials(for: seedURL, saved: saved)
+        ConnectionSetupView(
+            initialDestination: .currentConnection,
+            initialDraft: ConnectionSetupDraft(
+                existingServerURL: seedURL,
+                username: seeded?.username ?? "",
+                password: seeded?.password ?? ""
+            ),
+            // The probe may reuse this same-origin service token; the wizard
+            // re-verifies the origin itself before sending it and never
+            // displays, edits, or persists it.
+            initialCloudflareAccess: KeychainHelper.loadCloudflareAccess(for: seedURL),
+            initialCloudflareOriginURL: seedURL
+        ) { result in
+            let plan = ConnectionSetupApplication.plan(
+                result: result,
+                currentDashboardURL: seedURL,
+                savedCredentials: saved,
+                savedCloudflareAccess: KeychainHelper.loadCloudflareAccess(for: seedURL)
+            )
+            plan.perform(appState: appState)
+            pendingAppliedNotice = !plan.isEmpty
         }
     }
 
@@ -638,21 +702,37 @@ private struct SettingsHome: View {
             Haptics.selection()
             path.append(destination)
         } label: {
-            HStack(spacing: 12) {
-                Image(systemName: icon).font(.subheadline.weight(.semibold)).foregroundStyle(.conduitAccent).frame(width: 25)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(title).font(.subheadline.weight(.semibold))
-                    Text(detail).font(.caption).foregroundStyle(.secondary).lineLimit(2)
-                }
-                Spacer(minLength: 8)
-                Image(systemName: "chevron.right").font(.caption.weight(.semibold)).foregroundStyle(.tertiary)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.vertical, 5)
-            .contentShape(Rectangle())
+            settingsRowLabel(icon: icon, title: title, detail: detail)
         }
         .buttonStyle(.plain)
         .accessibilityHint(detail)
+    }
+
+    private func settingsActionRow(icon: String, title: String, detail: String, identifier: String, action: @escaping () -> Void) -> some View {
+        Button {
+            Haptics.selection()
+            action()
+        } label: {
+            settingsRowLabel(icon: icon, title: title, detail: detail)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(identifier)
+        .accessibilityHint(detail)
+    }
+
+    private func settingsRowLabel(icon: String, title: String, detail: String) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon).font(.subheadline.weight(.semibold)).foregroundStyle(.conduitAccent).frame(width: 25)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title).font(.subheadline.weight(.semibold))
+                Text(detail).font(.caption).foregroundStyle(.secondary).lineLimit(2)
+            }
+            Spacer(minLength: 8)
+            Image(systemName: "chevron.right").font(.caption.weight(.semibold)).foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 5)
+        .contentShape(Rectangle())
     }
 }
 

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -591,12 +591,22 @@ private struct SettingsHome: View {
     @EnvironmentObject private var appState: AppState
     /// Round 5: the Settings entry into the existing Connection Setup
     /// assistant, seeded from the current configuration.
-    @State private var showsConnectionSetup = false
+    @State private var connectionSetupSeed: ConnectionSetupSeed?
     /// Set by the wizard's completion when the applied plan changes the
     /// saved configuration; surfaced as an alert only after the wizard sheet
     /// has dismissed (one presentation context at a time).
     @State private var pendingAppliedNotice = false
     @State private var appliedConnectionNotice = false
+
+    /// Per-presentation seed for the wizard, built once when the row is
+    /// tapped so the Keychain reads stay off the render path.
+    private struct ConnectionSetupSeed: Identifiable {
+        let url: String
+        let username: String
+        let password: String
+        let cloudflareAccess: CloudflareAccessCredentials?
+        var id: String { url }
+    }
 
     var body: some View {
         ZStack {
@@ -622,7 +632,15 @@ private struct SettingsHome: View {
                             detail: "Test, troubleshoot, or change your connection",
                             identifier: "settings.connection-setup"
                         ) {
-                            showsConnectionSetup = true
+                            let seedURL = currentDashboardURL
+                            let saved = KeychainHelper.loadCredentials()
+                            let seeded = ConnectionSetupSeeding.wizardCredentials(for: seedURL, saved: saved)
+                            connectionSetupSeed = ConnectionSetupSeed(
+                                url: seedURL,
+                                username: seeded?.username ?? "",
+                                password: seeded?.password ?? "",
+                                cloudflareAccess: KeychainHelper.loadCloudflareAccess(for: seedURL)
+                            )
                         }
                     }
                     homeSection("On this device", tint: .conduitAccent) {
@@ -639,12 +657,36 @@ private struct SettingsHome: View {
                 .padding(16)
             }
         }
-        .sheet(isPresented: $showsConnectionSetup, onDismiss: {
+        .sheet(item: $connectionSetupSeed, onDismiss: {
             guard pendingAppliedNotice else { return }
             pendingAppliedNotice = false
             appliedConnectionNotice = true
-        }) {
-            connectionSetupSheet
+        }) { seed in
+            ConnectionSetupView(
+                initialDestination: .currentConnection,
+                initialDraft: ConnectionSetupDraft(
+                    existingServerURL: seed.url,
+                    username: seed.username,
+                    password: seed.password
+                ),
+                // The probe may reuse this same-origin service token; the
+                // wizard re-verifies the origin itself before sending it and
+                // never displays, edits, or persists it.
+                initialCloudflareAccess: seed.cloudflareAccess,
+                initialCloudflareOriginURL: seed.url
+            ) { result in
+                // Reload the saved state at apply time: the plan must decide
+                // against what exists NOW, not what existed when the sheet
+                // was seeded.
+                let plan = ConnectionSetupApplication.plan(
+                    result: result,
+                    currentDashboardURL: seed.url,
+                    savedCredentials: KeychainHelper.loadCredentials(),
+                    savedCloudflareAccess: KeychainHelper.loadCloudflareAccess(for: seed.url)
+                )
+                plan.perform(appState: appState)
+                pendingAppliedNotice = !plan.isEmpty
+            }
         }
         .alert("Settings applied", isPresented: $appliedConnectionNotice) {
             Button("OK", role: .cancel) {}
@@ -658,35 +700,6 @@ private struct SettingsHome: View {
     /// tested result never writes to the live session itself.
     private var currentDashboardURL: String {
         appState.connection?.baseUrl ?? appState.lastDashboardURL
-    }
-
-    @ViewBuilder
-    private var connectionSetupSheet: some View {
-        let seedURL = currentDashboardURL
-        let saved = KeychainHelper.loadCredentials()
-        let seeded = ConnectionSetupSeeding.wizardCredentials(for: seedURL, saved: saved)
-        ConnectionSetupView(
-            initialDestination: .currentConnection,
-            initialDraft: ConnectionSetupDraft(
-                existingServerURL: seedURL,
-                username: seeded?.username ?? "",
-                password: seeded?.password ?? ""
-            ),
-            // The probe may reuse this same-origin service token; the wizard
-            // re-verifies the origin itself before sending it and never
-            // displays, edits, or persists it.
-            initialCloudflareAccess: KeychainHelper.loadCloudflareAccess(for: seedURL),
-            initialCloudflareOriginURL: seedURL
-        ) { result in
-            let plan = ConnectionSetupApplication.plan(
-                result: result,
-                currentDashboardURL: seedURL,
-                savedCredentials: saved,
-                savedCloudflareAccess: KeychainHelper.loadCloudflareAccess(for: seedURL)
-            )
-            plan.perform(appState: appState)
-            pendingAppliedNotice = !plan.isEmpty
-        }
     }
 
     private var profileDisplayName: String {

--- a/Conduit/Views/ConnectionSetupForm.swift
+++ b/Conduit/Views/ConnectionSetupForm.swift
@@ -146,6 +146,13 @@ struct ConnectionSetupForm: View {
     private var connectionTest: some View {
         VStack(alignment: .leading, spacing: 18) {
             Text("Test connection").font(.title2.weight(.semibold))
+            // Entries that skipped the details form (the Settings
+            // current-connection entry) still show what is being tested.
+            if flow.enteredFromCurrentConnection,
+               let address = try? ConnectionSetupAddressBuilder.build(flow.draft) {
+                Text(address).font(.subheadline).textSelection(.enabled)
+                    .accessibilityIdentifier("setup.address-preview")
+            }
             Text("Conduit will check the dashboard address and try your credentials now. Nothing is saved, and Conduit won’t connect yet — you’ll confirm everything on the Review screen.")
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -225,10 +232,14 @@ struct ConnectionSetupForm: View {
             // Revalidate for rendering only: a draft that stopped validating
             // after reaching Review must never silently blank the card.
             reviewContent
-            Text("These settings will fill the login form. You’ll tap Connect there when you’re ready.")
+            Text(flow.enteredFromCurrentConnection
+                 ? "Applying saves these settings for your next reconnect. Your current session stays connected."
+                 : "These settings will fill the login form. You’ll tap Connect there when you’re ready.")
                 .foregroundStyle(.secondary)
             validationNotice
-            Button("Use these settings") {
+            // From Settings with unchanged, successfully tested settings
+            // there is nothing to apply — Done simply closes the wizard.
+            Button(flow.testedSettingsUnchanged ? "Done" : "Use these settings") {
                 if let result = flow.complete() { onComplete(result) }
             }
             .buttonStyle(.borderedProminent)
@@ -242,8 +253,17 @@ struct ConnectionSetupForm: View {
         case .success(let result):
             reviewValue("Connection method", flow.draft.methodTitle)
             reviewValue("Dashboard address", result.serverURL)
-            reviewValue("Username", result.username)
-            reviewValue("Password", "Entered")
+            if !result.username.isEmpty {
+                reviewValue("Username", result.username)
+            }
+            if result.password.isEmpty {
+                // Only reachable through the interactive-auth acceptance:
+                // discovery proved this dashboard signs in via the browser,
+                // so the absent password is expected, not an omission.
+                reviewValue("Password", "None — browser sign-in")
+            } else {
+                reviewValue("Password", "Entered")
+            }
         case .failure(let error):
             VStack(alignment: .leading, spacing: 8) {
                 Text("These settings can’t be used yet. Go Back to edit them, then return here.")

--- a/Conduit/Views/ConnectionSetupForm.swift
+++ b/Conduit/Views/ConnectionSetupForm.swift
@@ -414,17 +414,11 @@ struct ConnectionSetupStageRow: View {
                 .font(.footnote)
                 .foregroundStyle(.green)
                 .padding(.top, 2)
-        case .requiresInteractiveSignIn:
+        case .requiresInteractiveSignIn, .requiresCredentials:
             // An open circle in the accent color: deliberately not a
             // checkmark (the user has not authenticated) and not an error
-            // mark (nothing failed). Text and VoiceOver carry the meaning.
-            Image(systemName: "circle")
-                .font(.footnote)
-                .foregroundStyle(.conduitAccent)
-                .padding(.top, 2)
-        case .requiresCredentials:
-            // Same open-circle shape as the interactive outcome: a partial
-            // result, not an error and not a success.
+            // mark (nothing failed). Both are partial outcomes — text and
+            // VoiceOver carry which one it is.
             Image(systemName: "circle")
                 .font(.footnote)
                 .foregroundStyle(.conduitAccent)

--- a/Conduit/Views/ConnectionSetupForm.swift
+++ b/Conduit/Views/ConnectionSetupForm.swift
@@ -162,6 +162,11 @@ struct ConnectionSetupForm: View {
             if let failure = flow.testState.failedFailure,
                let stage = flow.testState.failedStage {
                 failedTestRecovery(stage: stage, failure: failure)
+            } else if flow.testState.requiresCredentials {
+                // Partial outcome, not a failure: server and dashboard
+                // passed, no login was attempted, and the missing secret is
+                // the only thing between the user and a full test.
+                credentialsRequiredRecovery
             } else if flow.canUseSettings {
                 // Reachable after returning Back from Review: a passing or
                 // interactive outcome is still current, so continue without
@@ -177,6 +182,29 @@ struct ConnectionSetupForm: View {
                     .frame(maxWidth: .infinity)
                     .accessibilityIdentifier("setup.test.run")
             }
+        }
+    }
+
+    /// The credentials-required partial outcome's recovery: Enter
+    /// Credentials is the primary action and routes to the existing
+    /// credentials step (leaving the test step invalidates the partial
+    /// result, so returning runs a fresh full test). Retry is deliberately
+    /// absent — retrying with the same missing credentials would be
+    /// pointless, and no login attempt occurred, so there is no
+    /// rate-limit concern.
+    @ViewBuilder
+    private var credentialsRequiredRecovery: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(ConnectionSetupTestState.credentialsRequiredMessage)
+                .font(.subheadline)
+                .fixedSize(horizontal: false, vertical: true)
+                .accessibilityIdentifier("setup.test.credentials-required")
+            Button("Enter Credentials") {
+                flow.editAfterFailedTest(.loginCredentials)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.conduitAccent)
+            .accessibilityIdentifier("setup.test.enter-credentials")
         }
     }
 
@@ -390,6 +418,13 @@ struct ConnectionSetupStageRow: View {
             // An open circle in the accent color: deliberately not a
             // checkmark (the user has not authenticated) and not an error
             // mark (nothing failed). Text and VoiceOver carry the meaning.
+            Image(systemName: "circle")
+                .font(.footnote)
+                .foregroundStyle(.conduitAccent)
+                .padding(.top, 2)
+        case .requiresCredentials:
+            // Same open-circle shape as the interactive outcome: a partial
+            // result, not an error and not a success.
             Image(systemName: "circle")
                 .font(.footnote)
                 .foregroundStyle(.conduitAccent)

--- a/Conduit/Views/ConnectionSetupView.swift
+++ b/Conduit/Views/ConnectionSetupView.swift
@@ -101,7 +101,10 @@ struct ConnectionSetupView: View {
     // MARK: - Staged connection test
 
     private func startTestRun() {
-        guard let run = try? flow.draft.result(),
+        // Credentials are optional here: provider discovery decides whether a
+        // password applies, so an interactive-auth dashboard is testable
+        // without typing one first.
+        guard let run = try? flow.draft.testConfiguration(),
               let generation = flow.beginTest() else { return }
         let access = flow.cloudflareAccessForDraft()
         let prober = prober
@@ -605,6 +608,7 @@ extension ConnectionHelpDestination {
         case .network: return "Network & reachability"
         case .tls: return "HTTPS & certificates"
         case .cloudflare: return "Cloudflare Access"
+        case .currentConnection: return "Current connection"
         }
     }
 
@@ -628,7 +632,7 @@ extension ConnectionHelpDestination {
                 "Make sure a Service Auth policy allows that token to reach this Access application.",
                 "Or turn off \"Use Cloudflare Access service token\" to sign in interactively through the in-app browser."
             ]
-        case .start, .dashboard, .credentials, .network:
+        case .start, .dashboard, .credentials, .network, .currentConnection:
             return []
         }
     }

--- a/Conduit/Views/ConnectionSetupView.swift
+++ b/Conduit/Views/ConnectionSetupView.swift
@@ -128,6 +128,11 @@ struct ConnectionSetupView: View {
                         notification: .announcement,
                         argument: ConnectionSetupTestState.interactiveReadyMessage
                     )
+                case .requiresCredentials(.authentication):
+                    UIAccessibility.post(
+                        notification: .announcement,
+                        argument: ConnectionSetupTestState.credentialsRequiredMessage
+                    )
                 case .failed(_, let failure):
                     UIAccessibility.post(notification: .announcement, argument: failure.userTitle)
                 default:

--- a/ConduitTests/ConnectionSetupFlowTests.swift
+++ b/ConduitTests/ConnectionSetupFlowTests.swift
@@ -135,6 +135,7 @@ final class ConnectionSetupFlowTests: XCTestCase {
         XCTAssertEqual(ConnectionSetupFlow.entryStep(for: .network), .accessMethod)
         XCTAssertEqual(ConnectionSetupFlow.entryStep(for: .tls), .tlsTroubleshooting)
         XCTAssertEqual(ConnectionSetupFlow.entryStep(for: .cloudflare), .cloudflareTroubleshooting)
+        XCTAssertEqual(ConnectionSetupFlow.entryStep(for: .currentConnection), .connectionDetails)
     }
 
     func testTLSAndCloudflareEntriesOpenTroubleshootingDirectly() {

--- a/ConduitTests/ConnectionSetupSettingsTests.swift
+++ b/ConduitTests/ConnectionSetupSettingsTests.swift
@@ -1,0 +1,315 @@
+//
+//  ConnectionSetupSettingsTests.swift
+//  Conduit
+//
+//  Round 5: the Settings current-connection entry into the Connection Setup
+//  wizard. Covers the semantic entry destination (question-free, seeded from
+//  the current configuration), the interactive-auth path that must never be
+//  blocked by meaningless password fields, the unchanged-settings Done offer,
+//  cancel safety, and the pure apply plan whose writes never touch the live
+//  connection.
+//
+
+import XCTest
+@testable import Conduit
+
+final class ConnectionSetupSettingsTests: XCTestCase {
+    private let currentURL = "https://hermes.example:9443/hermes"
+
+    private func seededFlow(password: String) -> ConnectionSetupFlow {
+        ConnectionSetupFlow(
+            entry: .currentConnection,
+            draft: ConnectionSetupDraft(
+                existingServerURL: currentURL,
+                username: password.isEmpty ? "" : "eric",
+                password: password
+            )
+        )
+    }
+
+    // MARK: - Entry destinations
+
+    func testEntryStepMappingForCurrentConnection() {
+        XCTAssertEqual(ConnectionSetupFlow.entryStep(for: .currentConnection), .connectionDetails)
+        XCTAssertEqual(
+            ConnectionSetupFlow(entry: .currentConnection, draft: ConnectionSetupDraft(
+                existingServerURL: currentURL, username: "eric", password: "fixture"
+            )).step,
+            .connectionDetails
+        )
+    }
+
+    func testPasswordlessCurrentConnectionEntryOpensTheStagedTestDirectly() {
+        // An interactive-auth deployment legitimately has no stored password.
+        // Never park the user on a meaningless password field, and never make
+        // an already-connected user answer the first-run readiness questions.
+        let flow = ConnectionSetupFlow(
+            entry: .currentConnection,
+            draft: ConnectionSetupDraft(existingServerURL: currentURL)
+        )
+        XCTAssertEqual(flow.step, .connectionTest)
+        XCTAssertTrue(flow.enteredFromCurrentConnection)
+        XCTAssertNil(flow.progressLabel, "The Settings entry sits outside the numbered first-run sequence")
+    }
+
+    // MARK: - Existing native-auth connection
+
+    func testSeededNativeConnectionReachesTheTestWithoutRetypingAndPreservesTheExactAddress() throws {
+        var flow = seededFlow(password: "fixture")
+        XCTAssertEqual(flow.step, .connectionDetails)
+
+        // Both screens are prefilled from the seeded configuration; no
+        // first-run question ever appears.
+        flow.submitDetails()
+        XCTAssertEqual(flow.step, .loginCredentials)
+        XCTAssertEqual(flow.draft.username, "eric")
+        XCTAssertEqual(flow.draft.password, "fixture")
+        flow.submitCredentials()
+        XCTAssertEqual(flow.step, .connectionTest)
+
+        StagedTestDriver.runSuccessfulTest(on: &flow)
+        XCTAssertEqual(flow.step, .review)
+        XCTAssertTrue(flow.testedSettingsUnchanged, "An untouched seeded configuration is unchanged")
+
+        let result = try XCTUnwrap(flow.complete())
+        XCTAssertEqual(
+            result.serverURL, currentURL,
+            "Scheme, host, port, and path prefix must all survive the round trip"
+        )
+    }
+
+    func testEditedAddressIsNeverTreatedAsUnchanged() throws {
+        var flow = seededFlow(password: "fixture")
+        flow.draft.existingServerURL = "https://new.example/hermes"
+        flow.submitDetails()
+        flow.submitCredentials()
+        XCTAssertEqual(flow.step, .connectionTest)
+        StagedTestDriver.runSuccessfulTest(on: &flow)
+        XCTAssertEqual(flow.step, .review)
+
+        XCTAssertFalse(flow.testedSettingsUnchanged, "A deliberate edit must be applied, not dismissed as Done")
+        let result = try XCTUnwrap(flow.complete())
+        XCTAssertEqual(result.serverURL, "https://new.example/hermes")
+    }
+
+    // MARK: - Cancel safety
+
+    func testBackingOutBeforeReviewCanNeverProduceAConfigurationToApply() {
+        var flow = seededFlow(password: "fixture")
+        flow.draft.existingServerURL = "https://new.example/hermes"
+        flow.submitDetails()
+
+        // The user dismisses the wizard here. Only Review can hand off a
+        // configuration, so a cancelled edit can never persist anything.
+        XCTAssertNil(flow.complete())
+        XCTAssertNil(flow.validationError, "An abandoned edit leaves no error behind")
+    }
+
+    func testUnchangedDetectionRequiresACurrentTest() {
+        var flow = seededFlow(password: "fixture")
+        XCTAssertFalse(flow.testedSettingsUnchanged, "Untested settings are never Done-eligible")
+        flow.draft.accessMethod = .reverseProxy
+        XCTAssertFalse(flow.testedSettingsUnchanged)
+    }
+
+    // MARK: - Interactive auth from Settings
+
+    func testInteractiveAuthDeploymentTestsAndCompletesWithoutAnyPassword() throws {
+        var flow = ConnectionSetupFlow(
+            entry: .currentConnection,
+            draft: ConnectionSetupDraft(existingServerURL: currentURL)
+        )
+        XCTAssertEqual(flow.step, .connectionTest)
+
+        let generation = try XCTUnwrap(flow.beginTest())
+        for event in StagedTestDriver.successEvents.dropLast(2) {
+            XCTAssertTrue(flow.applyTestEvent(event, generation: generation))
+        }
+        XCTAssertTrue(flow.applyTestEvent(.started(.authentication), generation: generation))
+        XCTAssertTrue(flow.applyTestEvent(.requiresInteractiveSignIn(.authentication), generation: generation))
+        XCTAssertEqual(flow.step, .review)
+
+        XCTAssertTrue(flow.testedSettingsUnchanged, "The untouched interactive deployment is Done-eligible")
+        let result = try XCTUnwrap(flow.complete())
+        XCTAssertEqual(result.serverURL, currentURL, "The address-only configuration completes the handoff")
+        XCTAssertTrue(result.username.isEmpty)
+        XCTAssertTrue(result.password.isEmpty)
+    }
+
+    func testInteractiveOutcomeDoesNotRelaxAcceptanceForNativeSuccess() throws {
+        // The credentialsRequired relaxation is bound to the interactive
+        // outcome: a full native success with empty credentials is
+        // impossible, and any other validation failure stays a failure.
+        var flow = ConnectionSetupFlow(
+            entry: .currentConnection,
+            draft: ConnectionSetupDraft(existingServerURL: currentURL)
+        )
+        flow.draft.existingServerURL = "not a url"
+        flow.draft.username = ""
+        XCTAssertEqual(flow.step, .connectionTest)
+        StagedTestDriver.runSuccessfulTest(on: &flow)
+        XCTAssertEqual(flow.step, .review, "The staged test advanced before the address was corrupted")
+        XCTAssertEqual(
+            flow.reviewState(), .failure(.policy(.invalidURL)),
+            "A broken address is never accepted, interactively or otherwise"
+        )
+        XCTAssertNil(flow.complete())
+    }
+
+    func testInheritedCloudflareTokenAppliesDuringInteractiveDiscovery() throws {
+        let access = try XCTUnwrap(CloudflareAccessCredentials.from(clientID: "id", clientSecret: "secret"))
+        let flow = ConnectionSetupFlow(
+            entry: .currentConnection,
+            draft: ConnectionSetupDraft(existingServerURL: currentURL),
+            inheritedCloudflareAccess: access,
+            inheritedCloudflareOriginURL: currentURL
+        )
+        XCTAssertEqual(try XCTUnwrap(flow.cloudflareAccessForDraft()), access,
+                       "The same-origin token must reach discovery even with no credentials in the draft")
+    }
+
+    func testTestConfigurationPreservesTheAddressWithoutRequiringCredentials() throws {
+        let draft = ConnectionSetupDraft(existingServerURL: currentURL, username: "", password: "")
+        let configuration = try draft.testConfiguration()
+        XCTAssertEqual(configuration.serverURL, currentURL)
+        XCTAssertTrue(configuration.username.isEmpty)
+        XCTAssertTrue(configuration.password.isEmpty)
+        XCTAssertThrowsError(try draft.result(), "Full acceptance stays strict for empty credentials")
+    }
+
+    // MARK: - Seeding
+
+    func testWizardCredentialsSeedOnlyMatchingUnprotectedRecords() {
+        let matching = DashboardCredentials(
+            baseURL: currentURL, username: "eric", password: "fixture", requiresFaceID: false
+        )
+        let seeded = ConnectionSetupSeeding.wizardCredentials(for: currentURL, saved: matching)
+        XCTAssertEqual(seeded?.username, "eric")
+        XCTAssertEqual(seeded?.password, "fixture")
+
+        let faceID = DashboardCredentials(
+            baseURL: currentURL, username: "eric", password: "fixture", requiresFaceID: true
+        )
+        let protected = ConnectionSetupSeeding.wizardCredentials(for: currentURL, saved: faceID)
+        XCTAssertEqual(protected?.username, "eric")
+        XCTAssertEqual(protected?.password, "", "A Face ID-protected record keeps its password back")
+
+        let foreign = DashboardCredentials(
+            baseURL: "https://other.example", username: "eric", password: "fixture", requiresFaceID: false
+        )
+        XCTAssertNil(ConnectionSetupSeeding.wizardCredentials(for: currentURL, saved: foreign))
+        XCTAssertNil(ConnectionSetupSeeding.wizardCredentials(for: currentURL, saved: nil))
+    }
+
+    // MARK: - Apply plan (pure policy)
+
+    private let savedCredentials = DashboardCredentials(
+        baseURL: "https://hermes.example:9443/hermes",
+        username: "eric",
+        password: "fixture",
+        requiresFaceID: true
+    )
+
+    func testUnchangedResultProducesAnEmptyPlan() {
+        let plan = ConnectionSetupApplication.plan(
+            result: ConnectionSetupResult(serverURL: currentURL, username: "eric", password: "fixture"),
+            currentDashboardURL: currentURL,
+            savedCredentials: savedCredentials,
+            savedCloudflareAccess: nil
+        )
+        XCTAssertTrue(plan.isEmpty)
+        XCTAssertFalse(plan.clearsSavedCredentials)
+    }
+
+    func testChangedURLRemembersTheAddressAndReplacesExistingSavedCredentials() {
+        let plan = ConnectionSetupApplication.plan(
+            result: ConnectionSetupResult(serverURL: "https://new.example/hermes", username: "eric", password: "next"),
+            currentDashboardURL: currentURL,
+            savedCredentials: savedCredentials,
+            savedCloudflareAccess: nil
+        )
+        XCTAssertEqual(plan.dashboardURLToRemember, "https://new.example/hermes")
+        XCTAssertEqual(
+            plan.credentialsToSave,
+            DashboardCredentials(
+                baseURL: "https://new.example/hermes",
+                username: "eric",
+                password: "next",
+                requiresFaceID: true
+            ),
+            "The replacement preserves the saved Face ID preference"
+        )
+        XCTAssertFalse(plan.clearsSavedCredentials)
+    }
+
+    func testPlanNeverCreatesCredentialsWhenNoneWereSaved() {
+        let plan = ConnectionSetupApplication.plan(
+            result: ConnectionSetupResult(serverURL: "https://new.example", username: "eric", password: "next"),
+            currentDashboardURL: currentURL,
+            savedCredentials: nil,
+            savedCloudflareAccess: nil
+        )
+        XCTAssertEqual(plan.dashboardURLToRemember, "https://new.example")
+        XCTAssertNil(plan.credentialsToSave, "An explicit apply never starts persisting credentials the user never saved")
+        XCTAssertFalse(plan.clearsSavedCredentials)
+    }
+
+    func testCredentiallessApplyToANewURLClearsStaleSavedCredentials() {
+        let plan = ConnectionSetupApplication.plan(
+            result: ConnectionSetupResult(serverURL: "https://new.example", username: "", password: ""),
+            currentDashboardURL: currentURL,
+            savedCredentials: savedCredentials,
+            savedCloudflareAccess: nil
+        )
+        XCTAssertTrue(plan.clearsSavedCredentials, "The applied configuration cannot use the old password; keeping it would send it to the new address")
+        XCTAssertNil(plan.credentialsToSave)
+    }
+
+    func testCredentiallessApplyToTheSameURLKeepsSavedCredentials() {
+        let plan = ConnectionSetupApplication.plan(
+            result: ConnectionSetupResult(serverURL: currentURL, username: "", password: ""),
+            currentDashboardURL: currentURL,
+            savedCredentials: savedCredentials,
+            savedCloudflareAccess: nil
+        )
+        XCTAssertTrue(plan.isEmpty, "Testing the current address interactively changes nothing")
+        XCTAssertFalse(plan.clearsSavedCredentials)
+    }
+
+    func testSameOriginPathMoveRewritesTheCloudflareTokenWithoutCopyingAcrossOrigins() throws {
+        let access = try XCTUnwrap(CloudflareAccessCredentials.from(clientID: "id", clientSecret: "secret"))
+        let plan = ConnectionSetupApplication.plan(
+            result: ConnectionSetupResult(serverURL: "https://hermes.example:9443/team", username: "eric", password: "fixture"),
+            currentDashboardURL: currentURL,
+            savedCredentials: nil,
+            savedCloudflareAccess: access
+        )
+        XCTAssertEqual(
+            plan.cloudflareTokenRewrite,
+            ConnectionSetupApplication.CloudflareAccessRewrite(access: access, origin: "https://hermes.example:9443/team"),
+            "A path-only move is same-origin: the token is re-bound to the new normalized URL"
+        )
+    }
+
+    func testCrossOriginApplyLeavesTheCloudflareTokenUntouched() throws {
+        let access = try XCTUnwrap(CloudflareAccessCredentials.from(clientID: "id", clientSecret: "secret"))
+        let plan = ConnectionSetupApplication.plan(
+            result: ConnectionSetupResult(serverURL: "https://new.example", username: "eric", password: "fixture"),
+            currentDashboardURL: currentURL,
+            savedCredentials: nil,
+            savedCloudflareAccess: access
+        )
+        XCTAssertNil(plan.cloudflareTokenRewrite, "A service token is never copied to another origin nor deleted from its own")
+    }
+
+    func testApplicationDescriptionIsRedacted() {
+        let plan = ConnectionSetupApplication.plan(
+            result: ConnectionSetupResult(serverURL: "https://new.example", username: "eric", password: "super-secret"),
+            currentDashboardURL: currentURL,
+            savedCredentials: savedCredentials,
+            savedCloudflareAccess: nil
+        )
+        XCTAssertFalse(String(describing: plan).contains("super-secret"))
+        XCTAssertFalse(String(reflecting: plan).contains("super-secret"))
+    }
+}

--- a/ConduitTests/ConnectionSetupSettingsTests.swift
+++ b/ConduitTests/ConnectionSetupSettingsTests.swift
@@ -39,10 +39,13 @@ final class ConnectionSetupSettingsTests: XCTestCase {
         )
     }
 
-    func testPasswordlessCurrentConnectionEntryOpensTheStagedTestDirectly() {
-        // An interactive-auth deployment legitimately has no stored password.
-        // Never park the user on a meaningless password field, and never make
-        // an already-connected user answer the first-run readiness questions.
+    func testCredentialsUnavailableEntryOpensTheStagedTestDirectly() {
+        // Both credential fields empty means credentials are simply
+        // UNAVAILABLE to the wizard — never an authentication mode. Provider
+        // discovery runs without credentials and decides the auth mode, so
+        // the wizard opens straight on the staged test. Never park the user
+        // on a meaningless password field, and never make an
+        // already-connected user answer the first-run readiness questions.
         let flow = ConnectionSetupFlow(
             entry: .currentConnection,
             draft: ConnectionSetupDraft(existingServerURL: currentURL)
@@ -54,6 +57,72 @@ final class ConnectionSetupSettingsTests: XCTestCase {
         var editable = flow
         editable.back()
         XCTAssertEqual(editable.step, .connectionDetails)
+    }
+
+    func testNativeDashboardWithoutSavedCredentialsStopsAtCredentialsRequiredAndNeverLogsIn() throws {
+        // THE Round-5.1 regression: an actively-connected native-password
+        // user who chose not to save credentials seeds an empty draft.
+        // Discovery proves a password dashboard; the staged test must stop
+        // at the credentials-required partial outcome — no empty-credential
+        // login attempt, no review authorization, live connection untouched.
+        var flow = ConnectionSetupFlow(
+            entry: .currentConnection,
+            draft: ConnectionSetupDraft(existingServerURL: currentURL)
+        )
+        XCTAssertEqual(flow.step, .connectionTest)
+        let generation = try XCTUnwrap(flow.beginTest())
+        for event in StagedTestDriver.successEvents.prefix(5) {
+            XCTAssertTrue(flow.applyTestEvent(event, generation: generation))
+        }
+        XCTAssertTrue(flow.applyTestEvent(.requiresCredentials(.authentication), generation: generation))
+
+        XCTAssertEqual(flow.testState.server, .succeeded)
+        XCTAssertEqual(flow.testState.dashboard, .succeeded)
+        XCTAssertEqual(flow.testState.authentication, .requiresCredentials)
+        XCTAssertTrue(flow.testState.requiresCredentials)
+        XCTAssertFalse(flow.testState.allSucceeded)
+        XCTAssertFalse(flow.testState.requiresInteractiveSignIn)
+        XCTAssertFalse(flow.canUseSettings, "A partial test never authorizes the settings handoff")
+        XCTAssertEqual(flow.step, .connectionTest, "The partial outcome stays on the test screen")
+        XCTAssertNil(flow.complete())
+
+        // Enter Credentials routes to the existing credentials step, leaving
+        // the test step, which resets the partial display for a fresh run.
+        flow.editAfterFailedTest(.loginCredentials)
+        XCTAssertEqual(flow.step, .loginCredentials)
+        XCTAssertEqual(flow.testState, ConnectionSetupTestState(), "The partial result never outlives the test step")
+        XCTAssertTrue(flow.draft.usesExistingAddress, "The current URL is preserved for the retry")
+    }
+
+    func testStaleCredentialsRequiredOutcomeCannotOutliveANewerRun() throws {
+        var flow = ConnectionSetupFlow(
+            entry: .currentConnection,
+            draft: ConnectionSetupDraft(existingServerURL: currentURL)
+        )
+        let staleGeneration = try XCTUnwrap(flow.beginTest())
+        for event in StagedTestDriver.successEvents.prefix(5) {
+            flow.applyTestEvent(event, generation: staleGeneration)
+        }
+        flow.applyTestEvent(.requiresCredentials(.authentication), generation: staleGeneration)
+        XCTAssertTrue(flow.testState.requiresCredentials)
+
+        // A fresh run resets the partial outcome and rotates the generation;
+        // the stale run's late terminal event must be dropped entirely.
+        let freshGeneration = try XCTUnwrap(flow.beginTest())
+        XCTAssertNotEqual(staleGeneration, freshGeneration)
+        XCTAssertEqual(flow.testState, ConnectionSetupTestState())
+        XCTAssertFalse(
+            flow.applyTestEvent(.requiresCredentials(.authentication), generation: staleGeneration),
+            "A stale credentials-required event is ignored, not applied"
+        )
+        XCTAssertEqual(flow.testState.authentication, .pending)
+
+        // The fresh run succeeds normally.
+        for event in StagedTestDriver.successEvents {
+            flow.applyTestEvent(event, generation: freshGeneration)
+        }
+        XCTAssertEqual(flow.step, .review)
+        XCTAssertTrue(flow.canUseSettings)
     }
 
     func testFaceIDWithheldSeedLandsOnDetailsInsteadOfAnEmptyPasswordProbe() {
@@ -187,6 +256,11 @@ final class ConnectionSetupSettingsTests: XCTestCase {
     // MARK: - Interactive auth from Settings
 
     func testInteractiveAuthDeploymentTestsAndCompletesWithoutAnyPassword() throws {
+        // Credential absence does NOT decide the auth mode — the discovery
+        // result does. A dashboard whose discovery reports interactive
+        // sign-in ends in the supported terminal outcome with no login, no
+        // ticket, and an address-only completion; the unchanged Settings
+        // entry may offer plain Done.
         var flow = ConnectionSetupFlow(
             entry: .currentConnection,
             draft: ConnectionSetupDraft(existingServerURL: currentURL)
@@ -258,7 +332,17 @@ final class ConnectionSetupSettingsTests: XCTestCase {
         XCTAssertEqual(configuration.serverURL, currentURL)
         XCTAssertTrue(configuration.username.isEmpty)
         XCTAssertTrue(configuration.password.isEmpty)
+        XCTAssertFalse(configuration.hasUsableCredentials)
         XCTAssertThrowsError(try draft.result(), "Full acceptance stays strict for empty credentials")
+
+        // Presence-only: whitespace-only fields are as unusable as empty
+        // ones, and the values themselves are never trimmed or rewritten.
+        let padded = ConnectionSetupResult(serverURL: currentURL, username: "  ", password: "\n")
+        XCTAssertFalse(padded.hasUsableCredentials)
+        let present = ConnectionSetupResult(serverURL: currentURL, username: " eric ", password: " secret ")
+        XCTAssertTrue(present.hasUsableCredentials)
+        XCTAssertEqual(present.username, " eric ")
+        XCTAssertEqual(present.password, " secret ")
     }
 
     // MARK: - Seeding

--- a/ConduitTests/ConnectionSetupSettingsTests.swift
+++ b/ConduitTests/ConnectionSetupSettingsTests.swift
@@ -50,6 +50,30 @@ final class ConnectionSetupSettingsTests: XCTestCase {
         XCTAssertEqual(flow.step, .connectionTest)
         XCTAssertTrue(flow.enteredFromCurrentConnection)
         XCTAssertNil(flow.progressLabel, "The Settings entry sits outside the numbered first-run sequence")
+        XCTAssertTrue(flow.canGoBack, "Back from the test must reach an editable address")
+        var editable = flow
+        editable.back()
+        XCTAssertEqual(editable.step, .connectionDetails)
+    }
+
+    func testFaceIDWithheldSeedLandsOnDetailsInsteadOfAnEmptyPasswordProbe() {
+        // A username with a withheld (Face ID-protected) password is a NATIVE
+        // deployment: the wizard must ask for the password, never open
+        // straight onto a staged test that would spend an empty-credential
+        // login attempt on the user's own server.
+        let flow = ConnectionSetupFlow(
+            entry: .currentConnection,
+            draft: ConnectionSetupDraft(existingServerURL: currentURL, username: "eric", password: "")
+        )
+        XCTAssertEqual(flow.step, .connectionDetails)
+    }
+
+    func testUnbuildableSeedAddressFallsBackToTheDetailsEntry() {
+        let flow = ConnectionSetupFlow(
+            entry: .currentConnection,
+            draft: ConnectionSetupDraft(existingServerURL: "not a url")
+        )
+        XCTAssertEqual(flow.step, .connectionDetails, "A broken address belongs on the details screen, which surfaces the validation")
     }
 
     // MARK: - Existing native-auth connection
@@ -112,6 +136,54 @@ final class ConnectionSetupSettingsTests: XCTestCase {
         XCTAssertFalse(flow.testedSettingsUnchanged)
     }
 
+    func testLoginEntryAlwaysOffersTheSettingsHandoffEvenWhenUnchanged() throws {
+        // The "Done" offer belongs to the Settings entry alone: the
+        // LoginView-driven wizard keeps its normal "Use these settings"
+        // handoff even when the user edited nothing.
+        var flow = ConnectionSetupFlow(entry: .credentials, draft: ConnectionSetupDraft(
+            existingServerURL: currentURL, username: "eric", password: "fixture"
+        ))
+        flow.answerCredentials(.yes)
+        XCTAssertEqual(flow.step, .loginCredentials)
+        flow.submitCredentials()
+        StagedTestDriver.runSuccessfulTest(on: &flow)
+        XCTAssertEqual(flow.step, .review)
+        XCTAssertFalse(flow.testedSettingsUnchanged, "The login entry must never collapse the handoff into Done")
+    }
+
+    func testInteractiveEntryCanContinueWithEmptyCredentialsAfterEditingTheAddress() throws {
+        // Edit-after-failure must not dead-end at a meaningless password
+        // screen for an interactive-auth deployment: with both fields empty
+        // and a buildable address, the Settings entry continues to the test.
+        var flow = ConnectionSetupFlow(
+            entry: .currentConnection,
+            draft: ConnectionSetupDraft(existingServerURL: currentURL)
+        )
+        XCTAssertEqual(flow.step, .connectionTest)
+        flow.back()
+        XCTAssertEqual(flow.step, .connectionDetails)
+        flow.draft.existingServerURL = "https://fixed.example/hermes"
+        flow.submitDetails()
+        XCTAssertEqual(flow.step, .loginCredentials)
+        XCTAssertTrue(flow.draft.username.isEmpty)
+        XCTAssertTrue(flow.draft.password.isEmpty)
+        flow.submitCredentials()
+        XCTAssertEqual(flow.step, .connectionTest, "Empty credentials must not block the Settings interactive path")
+        XCTAssertNil(flow.validationError)
+    }
+
+    func testLoginEntryStillRequiresCredentialsBeforeTheTest() {
+        // The empty-credential relaxation is scoped to the Settings entry;
+        // the LoginView wizard keeps its strict requirement.
+        var flow = ConnectionSetupFlow(entry: .credentials, draft: ConnectionSetupDraft(
+            existingServerURL: currentURL
+        ))
+        flow.answerCredentials(.yes)
+        flow.submitCredentials()
+        XCTAssertEqual(flow.step, .loginCredentials)
+        XCTAssertEqual(flow.validationError, .credentialsRequired)
+    }
+
     // MARK: - Interactive auth from Settings
 
     func testInteractiveAuthDeploymentTestsAndCompletesWithoutAnyPassword() throws {
@@ -168,6 +240,18 @@ final class ConnectionSetupSettingsTests: XCTestCase {
                        "The same-origin token must reach discovery even with no credentials in the draft")
     }
 
+    func testInheritedCloudflareTokenNeverAppliesCrossOriginWithoutCredentials() throws {
+        let access = try XCTUnwrap(CloudflareAccessCredentials.from(clientID: "id", clientSecret: "secret"))
+        let flow = ConnectionSetupFlow(
+            entry: .currentConnection,
+            draft: ConnectionSetupDraft(existingServerURL: currentURL),
+            inheritedCloudflareAccess: access,
+            inheritedCloudflareOriginURL: "https://other.example:9443"
+        )
+        XCTAssertNil(flow.cloudflareAccessForDraft(),
+                     "Origin safety does not depend on credentials being present in the draft")
+    }
+
     func testTestConfigurationPreservesTheAddressWithoutRequiringCredentials() throws {
         let draft = ConnectionSetupDraft(existingServerURL: currentURL, username: "", password: "")
         let configuration = try draft.testConfiguration()
@@ -186,6 +270,13 @@ final class ConnectionSetupSettingsTests: XCTestCase {
         let seeded = ConnectionSetupSeeding.wizardCredentials(for: currentURL, saved: matching)
         XCTAssertEqual(seeded?.username, "eric")
         XCTAssertEqual(seeded?.password, "fixture")
+
+        // The same address spelled with a trailing slash still seeds: both
+        // sides are compared policy-normalized.
+        let trailingSlash = ConnectionSetupSeeding.wizardCredentials(
+            for: currentURL + "/", saved: matching
+        )
+        XCTAssertEqual(trailingSlash?.username, "eric")
 
         let faceID = DashboardCredentials(
             baseURL: currentURL, username: "eric", password: "fixture", requiresFaceID: true
@@ -274,6 +365,18 @@ final class ConnectionSetupSettingsTests: XCTestCase {
         )
         XCTAssertTrue(plan.isEmpty, "Testing the current address interactively changes nothing")
         XCTAssertFalse(plan.clearsSavedCredentials)
+    }
+
+    func testCredentiallessResultWithNoSavedCredentialsNeverTouchesCredentials() {
+        let plan = ConnectionSetupApplication.plan(
+            result: ConnectionSetupResult(serverURL: "https://new.example", username: "", password: ""),
+            currentDashboardURL: currentURL,
+            savedCredentials: nil,
+            savedCloudflareAccess: nil
+        )
+        XCTAssertEqual(plan.dashboardURLToRemember, "https://new.example")
+        XCTAssertNil(plan.credentialsToSave)
+        XCTAssertFalse(plan.clearsSavedCredentials, "There is nothing to clear when nothing was ever saved")
     }
 
     func testSameOriginPathMoveRewritesTheCloudflareTokenWithoutCopyingAcrossOrigins() throws {

--- a/ConduitTests/ConnectionSetupTestTests.swift
+++ b/ConduitTests/ConnectionSetupTestTests.swift
@@ -567,7 +567,7 @@ final class ConnectionSetupTestTests: XCTestCase {
         XCTAssertEqual(state.rowLabel(for: .authentication), "Login successful")
     }
 
-    // MARK: - Credentials-required partial outcome (Round 5.1)
+    // MARK: - Credentials-required partial outcome, flow model (Round 5.1)
 
     /// The staged credentials-required run: server and dashboard succeed and
     /// authentication stops BEFORE any login attempt because the tested
@@ -649,7 +649,26 @@ final class ConnectionSetupTestTests: XCTestCase {
         XCTAssertNotEqual(state.rowLabel(for: .authentication), ConnectionSetupTestStage.authentication.successLabel)
     }
 
+    func testCredentialsRequiredOutcomeIsMonotonicWithinARun() {
+        // A terminal stage never reverts, whatever arrives later in the same
+        // run: the partial outcome can be superseded only by a new run, not
+        // by late events.
+        var state = ConnectionSetupTestState()
+        state.apply(Self.credentialsRequiredEvents[4]) // started(.authentication)
+        state.apply(.requiresCredentials(.authentication))
+        state.apply(.succeeded(.authentication))
+        XCTAssertEqual(state.authentication, .requiresCredentials)
+        state.apply(.failed(.authentication, .authenticationRejected))
+        XCTAssertEqual(state.authentication, .requiresCredentials)
+    }
+
     func testTestCopyContainsNoExposureOrCredentialLanguage() {
+        // `ConnectionSetupTestState.credentialsRequiredMessage` is
+        // deliberately absent from this scan: as the recovery notice for a
+        // proven password dashboard it must name the username-and-password
+        // auth mode, so the "password" forbidden word below — which guards
+        // row labels and ready claims, not recovery notices — does not
+        // apply to it.
         var allStrings = [
             ConnectionSetupTestState.readyMessage,
             ConnectionSetupTestState.interactiveReadyMessage,
@@ -825,7 +844,7 @@ final class ConnectionSetupTestTests: XCTestCase {
         XCTAssertEqual(events, [.started(.server)], "Cancellation must emit no failure events")
     }
 
-    // MARK: - Credentials-required partial outcome (Round 5.1)
+    // MARK: - Credentials-required partial outcome, probe (Round 5.1)
 
     @MainActor
     private func runProbeWithCredentials(
@@ -877,7 +896,9 @@ final class ConnectionSetupTestTests: XCTestCase {
         XCTAssertEqual(events, Array(StagedTestDriver.successEvents.prefix(5)) + [
             .requiresCredentials(.authentication)
         ])
+        XCTAssertEqual(SetupProbeURLProtocol.requestCount(forPath: "/api/auth/providers", host: host), 1)
         XCTAssertEqual(SetupProbeURLProtocol.requestCount(forPath: "/auth/password-login", host: host), 0)
+        XCTAssertEqual(SetupProbeURLProtocol.requestCount(forPath: "/api/auth/ws-ticket", host: host), 0)
     }
 
     // MARK: - Interactive sign-in outcome

--- a/ConduitTests/ConnectionSetupTestTests.swift
+++ b/ConduitTests/ConnectionSetupTestTests.swift
@@ -69,6 +69,17 @@ final class ConnectionSetupTestTests: XCTestCase {
         return flow
     }
 
+    /// A flow at `.connectionTest` via the Settings current-connection entry
+    /// with an empty credential seed (credentials unavailable — the exact
+    /// shape of an actively-connected user who never saved credentials).
+    private func makeCredentialsLessSettingsFlowAtTestStep() -> ConnectionSetupFlow {
+        let flow = ConnectionSetupFlow(entry: .currentConnection, draft: ConnectionSetupDraft(
+            existingServerURL: "https://hermes.example:9443/hermes"
+        ))
+        XCTAssertEqual(flow.step, .connectionTest, "The credentials-unavailable Settings entry lands on the staged test")
+        return flow
+    }
+
     // MARK: - State machine (spec 19)
 
     func testFullSuccessSequenceReachesAcceptableState() {
@@ -556,11 +567,94 @@ final class ConnectionSetupTestTests: XCTestCase {
         XCTAssertEqual(state.rowLabel(for: .authentication), "Login successful")
     }
 
+    // MARK: - Credentials-required partial outcome (Round 5.1)
+
+    /// The staged credentials-required run: server and dashboard succeed and
+    /// authentication stops BEFORE any login attempt because the tested
+    /// configuration carries no usable credentials.
+    static let credentialsRequiredEvents: [ConnectionSetupTestEvent] = [
+        .started(.server), .succeeded(.server),
+        .started(.dashboard), .succeeded(.dashboard),
+        .started(.authentication),
+        .requiresCredentials(.authentication)
+    ]
+
+    func testCredentialsRequiredOutcomeIsNeitherSuccessNorFailureNorInteractive() throws {
+        var flow = makeCredentialsLessSettingsFlowAtTestStep()
+        let generation = try XCTUnwrap(flow.beginTest())
+        for event in Self.credentialsRequiredEvents {
+            XCTAssertTrue(flow.applyTestEvent(event, generation: generation))
+        }
+
+        XCTAssertEqual(flow.testState.server, .succeeded)
+        XCTAssertEqual(flow.testState.dashboard, .succeeded)
+        XCTAssertEqual(flow.testState.authentication, .requiresCredentials)
+        XCTAssertTrue(flow.testState.requiresCredentials)
+        XCTAssertFalse(flow.testState.allSucceeded, "A partial test is never a success")
+        XCTAssertFalse(flow.testState.requiresInteractiveSignIn, "Credential absence is never an authentication mode")
+        XCTAssertFalse(flow.canUseSettings, "A partial test never authorizes the settings handoff")
+        XCTAssertEqual(flow.step, .connectionTest, "The partial outcome does not advance to Review")
+        XCTAssertNil(flow.complete())
+        XCTAssertNil(flow.testSucceededAtRevision, "Nothing was sealed: the outcome authorizes nothing")
+    }
+
+    func testCredentialsRequiredOutcomeRoutesToCredentialsEntryAndResets() throws {
+        var flow = makeCredentialsLessSettingsFlowAtTestStep()
+        let generation = try XCTUnwrap(flow.beginTest())
+        for event in Self.credentialsRequiredEvents {
+            flow.applyTestEvent(event, generation: generation)
+        }
+        XCTAssertTrue(flow.testState.requiresCredentials)
+
+        flow.editAfterFailedTest(.loginCredentials)
+        XCTAssertEqual(flow.step, .loginCredentials)
+        XCTAssertEqual(flow.testState, ConnectionSetupTestState(), "Leaving the test step invalidates the partial result")
+
+        // With both credentials entered, the rerun takes the normal path.
+        flow.draft.username = "probe-user"
+        flow.draft.password = "in-memory-fixture"
+        flow.submitCredentials()
+        XCTAssertEqual(flow.step, .connectionTest)
+        let rerun = try XCTUnwrap(flow.beginTest())
+        for event in StagedTestDriver.successEvents {
+            flow.applyTestEvent(event, generation: rerun)
+        }
+        XCTAssertEqual(flow.step, .review, "A full rerun with present credentials succeeds normally")
+    }
+
+    func testStaleCredentialsRequiredEventFromAnOlderRunIsDropped() throws {
+        var flow = makeCredentialsLessSettingsFlowAtTestStep()
+        let staleGeneration = try XCTUnwrap(flow.beginTest())
+        for event in Self.credentialsRequiredEvents {
+            flow.applyTestEvent(event, generation: staleGeneration)
+        }
+
+        // A newer run rotates the generation and resets the state.
+        let freshGeneration = try XCTUnwrap(flow.beginTest())
+        flow.applyTestEvent(.started(.server), generation: freshGeneration)
+        XCTAssertEqual(flow.testState.server, .running)
+
+        // The old run's late partial outcome cannot corrupt the newer run.
+        flow.applyTestEvent(.requiresCredentials(.authentication), generation: staleGeneration)
+        XCTAssertEqual(flow.testState.authentication, .pending, "The stale partial outcome is ignored")
+        XCTAssertFalse(flow.testState.requiresCredentials)
+    }
+
+    func testCredentialsRequiredRowCarriesDistinctMeaningAndSafeCopy() {
+        var state = ConnectionSetupTestState()
+        state.apply(Self.credentialsRequiredEvents[4]) // started(.authentication)
+        state.apply(.requiresCredentials(.authentication))
+        XCTAssertEqual(state.rowLabel(for: .authentication), "Credentials required")
+        XCTAssertEqual(state.accessibilityLabel(for: .authentication), "Authentication, credentials required")
+        XCTAssertNotEqual(state.rowLabel(for: .authentication), ConnectionSetupTestStage.authentication.successLabel)
+    }
+
     func testTestCopyContainsNoExposureOrCredentialLanguage() {
         var allStrings = [
             ConnectionSetupTestState.readyMessage,
             ConnectionSetupTestState.interactiveReadyMessage,
-            "Browser sign-in required"
+            "Browser sign-in required",
+            "Credentials required"
         ]
         for stage in ConnectionSetupTestStage.allCases {
             allStrings.append(contentsOf: [stage.objectiveLabel, stage.runningLabel, stage.successLabel])
@@ -729,6 +823,61 @@ final class ConnectionSetupTestTests: XCTestCase {
         task.cancel()
         await task.value
         XCTAssertEqual(events, [.started(.server)], "Cancellation must emit no failure events")
+    }
+
+    // MARK: - Credentials-required partial outcome (Round 5.1)
+
+    @MainActor
+    private func runProbeWithCredentials(
+        _ baseURL: String,
+        username: String,
+        password: String
+    ) async -> [ConnectionSetupTestEvent] {
+        let probe = ConnectionSetupProbe(sessionConfiguration: Self.makeProbeConfiguration())
+        var events: [ConnectionSetupTestEvent] = []
+        await probe.runTest(
+            result: ConnectionSetupResult(
+                serverURL: baseURL,
+                username: username,
+                password: password
+            ),
+            cloudflareAccess: nil,
+            onEvent: { events.append($0) }
+        )
+        return events
+    }
+
+    func testProbePasswordCapableDashboardWithoutCredentialsNeverAttemptsLogin() async {
+        // THE Round-5.1 invariant: a password-capable dashboard plus missing
+        // credentials performs EXACTLY ONE provider-discovery request and
+        // ZERO password-login and ws-ticket requests. An empty-credential
+        // login would be a real, rate-limited authentication attempt against
+        // a connection that may already be known to work.
+        let host = "probe-success.example"
+        let events = await runProbeWithCredentials("https://\(host)", username: "", password: "")
+        XCTAssertEqual(events, Array(StagedTestDriver.successEvents.prefix(5)) + [
+            .requiresCredentials(.authentication)
+        ])
+        XCTAssertEqual(SetupProbeURLProtocol.requestCount(forPath: "/api/auth/providers", host: host), 1)
+        XCTAssertEqual(
+            SetupProbeURLProtocol.requestCount(forPath: "/auth/password-login", host: host), 0,
+            "No password-login request may occur without present credentials"
+        )
+        XCTAssertEqual(
+            SetupProbeURLProtocol.requestCount(forPath: "/api/auth/ws-ticket", host: host), 0,
+            "No ticket mint may occur without present credentials"
+        )
+    }
+
+    func testProbeWhitespaceOnlyCredentialsAlsoStopAtCredentialsRequired() async {
+        // Presence, not content: whitespace-only credentials are as unusable
+        // as empty ones, and neither is ever sent.
+        let host = "probe-success.example"
+        let events = await runProbeWithCredentials("https://\(host)", username: " ", password: " ")
+        XCTAssertEqual(events, Array(StagedTestDriver.successEvents.prefix(5)) + [
+            .requiresCredentials(.authentication)
+        ])
+        XCTAssertEqual(SetupProbeURLProtocol.requestCount(forPath: "/auth/password-login", host: host), 0)
     }
 
     // MARK: - Interactive sign-in outcome

--- a/ConduitUITests/ConnectionSetupSettingsUITests.swift
+++ b/ConduitUITests/ConnectionSetupSettingsUITests.swift
@@ -40,8 +40,7 @@ final class ConnectionSetupSettingsUITests: XCTestCase {
 
         // The Connection section carries the current dashboard (the Gateway
         // row) and the new Connection Setup entry.
-        XCTAssertTrue(app.buttons[Identity.settingsRow].waitForExistence(timeout: 5))
-        app.buttons[Identity.settingsRow].tap()
+        tapVisible(app.buttons[Identity.settingsRow], in: app)
 
         // The passwordless seed opens straight on the staged test with the
         // current URL preserved exactly — no first-run readiness questions,
@@ -107,8 +106,7 @@ final class ConnectionSetupSettingsUITests: XCTestCase {
         app.launch()
 
         openSettings(app)
-        XCTAssertTrue(app.buttons[Identity.settingsRow].waitForExistence(timeout: 5))
-        app.buttons[Identity.settingsRow].tap()
+        tapVisible(app.buttons[Identity.settingsRow], in: app)
 
         let preview = row(app, Identity.addressPreview)
         XCTAssertTrue(preview.waitForExistence(timeout: 5), "Wizard did not open on the staged test. Tree:\n\(app.debugDescription)")
@@ -131,6 +129,50 @@ final class ConnectionSetupSettingsUITests: XCTestCase {
         XCTAssertTrue(app.buttons[Identity.settingsRow].waitForExistence(timeout: 5), "Done did not return to Settings. Tree:\n\(app.debugDescription)")
         XCTAssertFalse(app.alerts.firstMatch.exists, "Done on unchanged settings applies nothing and needs no confirmation")
         XCTAssertFalse(app.textFields["login.server-url"].exists, "The live session must never be disrupted by the wizard")
+    }
+
+    func testNativeDashboardWithoutSavedCredentialsStopsAtCredentialsRequired() {
+        // The real no-saved-credentials native scenario: credential absence
+        // is NOT interactive auth. Discovery proves a password dashboard,
+        // the staged test stops at Credentials required — no empty-credential
+        // login request is ever sent — and Enter Credentials routes to the
+        // existing credentials step with the URL preserved.
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-CONDUIT_UI_TEST_CONNECTED_DASHBOARD", Identity.stubDashboardURL,
+            "-CONNECTION_SETUP_TEST_RESULT", "auth:credentialsRequired"
+        ]
+        app.launch()
+
+        openSettings(app)
+        tapVisible(app.buttons[Identity.settingsRow], in: app)
+
+        let preview = row(app, Identity.addressPreview)
+        XCTAssertTrue(preview.waitForExistence(timeout: 5), "Wizard did not open on the staged test. Tree:\n\(app.debugDescription)")
+        XCTAssertEqual(preview.label, Identity.stubDashboardURL)
+
+        tapVisible(app.buttons[Identity.testRun], in: app)
+
+        // The partial outcome: two passed stages, then Credentials required
+        // — never Login successful, never Browser sign-in required, and no
+        // ready claim.
+        let notice = app.staticTexts["setup.test.credentials-required"]
+        XCTAssertTrue(notice.waitForExistence(timeout: 5))
+        let authRow = row(app, "setup.test.stage.authentication")
+        XCTAssertTrue(authRow.exists)
+        XCTAssertTrue(authRow.label.lowercased().contains("credentials required"), "Got: \(authRow.label)")
+        XCTAssertFalse(app.staticTexts["setup.test.ready"].exists)
+        XCTAssertFalse(app.staticTexts["setup.test.interactive-ready"].exists)
+        XCTAssertFalse(app.buttons[Identity.useSettings].exists, "A partial test must not authorize the settings handoff")
+
+        // Enter Credentials routes to the existing credentials step with the
+        // current URL intact.
+        tapVisible(app.buttons["setup.test.enter-credentials"], in: app)
+        let username = app.textFields[Identity.username]
+        XCTAssertTrue(username.waitForExistence(timeout: 5), "Credentials step did not appear. Tree:\n\(app.debugDescription)")
+        let urlField = app.textFields[Identity.urlField]
+        XCTAssertFalse(urlField.exists, "The URL is owned by the details step; credentials step only asks for credentials")
+        XCTAssertTrue(app.buttons[Identity.back].exists, "Back returns toward the tested connection")
     }
 
     // MARK: - Walk helpers

--- a/ConduitUITests/ConnectionSetupSettingsUITests.swift
+++ b/ConduitUITests/ConnectionSetupSettingsUITests.swift
@@ -5,14 +5,21 @@ import XCTest
 /// (`-CONDUIT_UI_TEST_CONNECTED_DASHBOARD`: a snapshot connection with no
 /// transport), and the staged test runs against the deterministic
 /// `-CONNECTION_SETUP_TEST_RESULT` stub — no test touches a real server.
+///
+/// The simulator has no saved credentials, so the seed is the passwordless
+/// interactive-auth shape: the wizard opens directly on the staged test with
+/// the current URL preserved, and Back reaches the editable details screens.
 final class ConnectionSetupSettingsUITests: XCTestCase {
     private enum Identity {
         static let stubDashboardURL = "https://conduit-uitest.example"
         static let settingsRow = "settings.connection-setup"
+        static let gatewayRow = "settings.gateway"
         static let urlField = "setup.url"
+        static let addressPreview = "setup.address-preview"
         static let next = "setup.next"
         static let username = "setup.username"
         static let password = "setup.password"
+        static let back = "setup.back"
         static let testRun = "setup.test.run"
         static let useSettings = "setup.use-settings"
     }
@@ -21,7 +28,7 @@ final class ConnectionSetupSettingsUITests: XCTestCase {
         continueAfterFailure = false
     }
 
-    func testSettingsConnectionSetupTestsCurrentConnectionAndLeavesItUntouched() {
+    func testSettingsConnectionSetupEditsTestsAndAppliesWithoutTouchingTheSession() {
         let app = XCUIApplication()
         app.launchArguments += [
             "-CONDUIT_UI_TEST_CONNECTED_DASHBOARD", Identity.stubDashboardURL,
@@ -36,11 +43,18 @@ final class ConnectionSetupSettingsUITests: XCTestCase {
         XCTAssertTrue(app.buttons[Identity.settingsRow].waitForExistence(timeout: 5))
         app.buttons[Identity.settingsRow].tap()
 
-        // The wizard opens on the prefilled connection-details screen — no
-        // first-run readiness questions — with the current URL preserved
-        // exactly.
+        // The passwordless seed opens straight on the staged test with the
+        // current URL preserved exactly — no first-run readiness questions,
+        // no meaningless password field.
+        let preview = row(app, Identity.addressPreview)
+        XCTAssertTrue(preview.waitForExistence(timeout: 5), "Wizard did not open on the staged test. Tree:\n\(app.debugDescription)")
+        XCTAssertEqual(preview.label, Identity.stubDashboardURL)
+
+        // Back reaches the editable details screen, also prefilled with the
+        // exact current address.
+        tapVisible(app.buttons[Identity.back], in: app)
         let urlField = app.textFields[Identity.urlField]
-        XCTAssertTrue(urlField.waitForExistence(timeout: 5), "Wizard did not open on connection details. Tree:\n\(app.debugDescription)")
+        XCTAssertTrue(urlField.waitForExistence(timeout: 5), "Details screen did not appear. Tree:\n\(app.debugDescription)")
         XCTAssertEqual(urlField.value as? String, Identity.stubDashboardURL)
 
         tapVisible(app.buttons[Identity.next], in: app)
@@ -72,12 +86,51 @@ final class ConnectionSetupSettingsUITests: XCTestCase {
         // The active connection is intact: still inside Settings, still the
         // stubbed connected session, never bounced to the login card.
         XCTAssertFalse(app.textFields["login.server-url"].exists, "The live session must never be disrupted by the wizard")
-        let gatewayRow = app.buttons["settings.gateway"]
+        let gatewayRow = app.buttons[Identity.gatewayRow]
         XCTAssertTrue(gatewayRow.waitForExistence(timeout: 5))
         XCTAssertTrue(
             gatewayRow.label.contains(Identity.stubDashboardURL),
             "The Gateway row still shows the current dashboard, got: \(gatewayRow.label)"
         )
+    }
+
+    func testInteractiveSignInOutcomeFromSettingsOffersDoneAndDismissesSafely() {
+        // A browser-sign-in deployment with no stored password: the staged
+        // test ends in the supported interactive outcome, Review offers plain
+        // Done (unchanged settings), and dismissing leaves the active
+        // session untouched.
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-CONDUIT_UI_TEST_CONNECTED_DASHBOARD", Identity.stubDashboardURL,
+            "-CONNECTION_SETUP_TEST_RESULT", "auth:interactiveSignInRequired"
+        ]
+        app.launch()
+
+        openSettings(app)
+        XCTAssertTrue(app.buttons[Identity.settingsRow].waitForExistence(timeout: 5))
+        app.buttons[Identity.settingsRow].tap()
+
+        let preview = row(app, Identity.addressPreview)
+        XCTAssertTrue(preview.waitForExistence(timeout: 5), "Wizard did not open on the staged test. Tree:\n\(app.debugDescription)")
+        XCTAssertEqual(preview.label, Identity.stubDashboardURL)
+
+        tapVisible(app.buttons[Identity.testRun], in: app)
+
+        // Review, reached by auto-advance: browser sign-in is explained,
+        // "Login successful" is never claimed, and unchanged settings offer
+        // Done instead of Use These Settings.
+        let interactiveReady = app.staticTexts["setup.test.interactive-ready"]
+        XCTAssertTrue(interactiveReady.waitForExistence(timeout: 5))
+        XCTAssertTrue(interactiveReady.label.contains("browser-based sign-in"), "Got: \(interactiveReady.label)")
+        XCTAssertFalse(app.staticTexts["setup.test.ready"].exists, "Interactive auth must never claim the connection is ready to use")
+        let authRow = row(app, "setup.test.stage.authentication")
+        XCTAssertTrue(authRow.exists)
+        XCTAssertTrue(authRow.label.lowercased().contains("browser sign-in required"), "Got: \(authRow.label)")
+
+        tapVisible(app.buttons[Identity.useSettings], in: app)
+        XCTAssertTrue(app.buttons[Identity.settingsRow].waitForExistence(timeout: 5), "Done did not return to Settings. Tree:\n\(app.debugDescription)")
+        XCTAssertFalse(app.alerts.firstMatch.exists, "Done on unchanged settings applies nothing and needs no confirmation")
+        XCTAssertFalse(app.textFields["login.server-url"].exists, "The live session must never be disrupted by the wizard")
     }
 
     // MARK: - Walk helpers
@@ -90,6 +143,12 @@ final class ConnectionSetupSettingsUITests: XCTestCase {
         let settings = app.buttons["Settings"]
         XCTAssertTrue(settings.waitForExistence(timeout: 5), "Sidebar did not appear. Tree:\n\(app.debugDescription)")
         settings.tap()
+    }
+
+    /// Stage rows and the address preview are single combined accessibility
+    /// elements, so query by identifier across element types.
+    private func row(_ app: XCUIApplication, _ identifier: String) -> XCUIElement {
+        app.descendants(matching: .any).matching(identifier: identifier).firstMatch
     }
 
     private func tapVisible(_ element: XCUIElement, in app: XCUIApplication) {

--- a/ConduitUITests/ConnectionSetupSettingsUITests.swift
+++ b/ConduitUITests/ConnectionSetupSettingsUITests.swift
@@ -72,7 +72,12 @@ final class ConnectionSetupSettingsUITests: XCTestCase {
         // The active connection is intact: still inside Settings, still the
         // stubbed connected session, never bounced to the login card.
         XCTAssertFalse(app.textFields["login.server-url"].exists, "The live session must never be disrupted by the wizard")
-        XCTAssertTrue(app.staticTexts[Identity.stubDashboardURL].firstMatch.exists, "The Gateway row still shows the current dashboard")
+        let gatewayRow = app.buttons["settings.gateway"]
+        XCTAssertTrue(gatewayRow.waitForExistence(timeout: 5))
+        XCTAssertTrue(
+            gatewayRow.label.contains(Identity.stubDashboardURL),
+            "The Gateway row still shows the current dashboard, got: \(gatewayRow.label)"
+        )
     }
 
     // MARK: - Walk helpers

--- a/ConduitUITests/ConnectionSetupSettingsUITests.swift
+++ b/ConduitUITests/ConnectionSetupSettingsUITests.swift
@@ -1,0 +1,105 @@
+import XCTest
+
+/// Round-5 Connection Setup UI coverage: the Settings entry for an
+/// already-connected user. The app starts in the inert DEBUG connected stub
+/// (`-CONDUIT_UI_TEST_CONNECTED_DASHBOARD`: a snapshot connection with no
+/// transport), and the staged test runs against the deterministic
+/// `-CONNECTION_SETUP_TEST_RESULT` stub — no test touches a real server.
+final class ConnectionSetupSettingsUITests: XCTestCase {
+    private enum Identity {
+        static let stubDashboardURL = "https://conduit-uitest.example"
+        static let settingsRow = "settings.connection-setup"
+        static let urlField = "setup.url"
+        static let next = "setup.next"
+        static let username = "setup.username"
+        static let password = "setup.password"
+        static let testRun = "setup.test.run"
+        static let useSettings = "setup.use-settings"
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testSettingsConnectionSetupTestsCurrentConnectionAndLeavesItUntouched() {
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-CONDUIT_UI_TEST_CONNECTED_DASHBOARD", Identity.stubDashboardURL,
+            "-CONNECTION_SETUP_TEST_RESULT", "success"
+        ]
+        app.launch()
+
+        openSettings(app)
+
+        // The Connection section carries the current dashboard (the Gateway
+        // row) and the new Connection Setup entry.
+        XCTAssertTrue(app.buttons[Identity.settingsRow].waitForExistence(timeout: 5))
+        app.buttons[Identity.settingsRow].tap()
+
+        // The wizard opens on the prefilled connection-details screen — no
+        // first-run readiness questions — with the current URL preserved
+        // exactly.
+        let urlField = app.textFields[Identity.urlField]
+        XCTAssertTrue(urlField.waitForExistence(timeout: 5), "Wizard did not open on connection details. Tree:\n\(app.debugDescription)")
+        XCTAssertEqual(urlField.value as? String, Identity.stubDashboardURL)
+
+        tapVisible(app.buttons[Identity.next], in: app)
+        let username = app.textFields[Identity.username]
+        XCTAssertTrue(username.waitForExistence(timeout: 5))
+        tapVisible(username, in: app)
+        username.typeText("uitest-user")
+        let password = app.secureTextFields[Identity.password]
+        tapVisible(password, in: app)
+        password.typeText("uitest-fixture")
+        dismissKeyboard(app)
+        tapVisible(app.buttons[Identity.next], in: app)
+
+        // The real Round-4 staged test screen, driven by the stub.
+        XCTAssertTrue(app.buttons[Identity.testRun].waitForExistence(timeout: 5), "Test screen did not appear. Tree:\n\(app.debugDescription)")
+        tapVisible(app.buttons[Identity.testRun], in: app)
+        XCTAssertTrue(app.staticTexts["setup.test.ready"].waitForExistence(timeout: 5))
+
+        // Applying the changed configuration (a typed password) closes the
+        // wizard and lands back on Settings. Nothing connects, no reconnect
+        // fires, and the session stub is untouched.
+        tapVisible(app.buttons[Identity.useSettings], in: app)
+        XCTAssertTrue(app.buttons[Identity.settingsRow].waitForExistence(timeout: 5), "Wizard did not return to Settings. Tree:\n\(app.debugDescription)")
+
+        // Unchanged URL and no previously saved credentials: applying is a
+        // no-op, so no confirmation alert appears.
+        XCTAssertFalse(app.alerts.firstMatch.exists, "A no-op apply must not claim to have changed settings")
+
+        // The active connection is intact: still inside Settings, still the
+        // stubbed connected session, never bounced to the login card.
+        XCTAssertFalse(app.textFields["login.server-url"].exists, "The live session must never be disrupted by the wizard")
+        XCTAssertTrue(app.staticTexts[Identity.stubDashboardURL].firstMatch.exists, "The Gateway row still shows the current dashboard")
+    }
+
+    // MARK: - Walk helpers
+
+    private func openSettings(_ app: XCUIApplication) {
+        let sessions = app.buttons["Open sessions"]
+        XCTAssertTrue(sessions.waitForExistence(timeout: 10), "Main app shell did not appear. Tree:\n\(app.debugDescription)")
+        sessions.tap()
+
+        let settings = app.buttons["Settings"]
+        XCTAssertTrue(settings.waitForExistence(timeout: 5), "Sidebar did not appear. Tree:\n\(app.debugDescription)")
+        settings.tap()
+    }
+
+    private func tapVisible(_ element: XCUIElement, in app: XCUIApplication) {
+        XCTAssertTrue(element.waitForExistence(timeout: 5))
+        for _ in 0..<6 {
+            if element.isHittable { break }
+            app.swipeUp()
+        }
+        XCTAssertTrue(element.isHittable)
+        element.tap()
+    }
+
+    private func dismissKeyboard(_ app: XCUIApplication) {
+        let done = app.buttons["setup.keyboard-done"]
+        guard done.waitForExistence(timeout: 2) else { return }
+        done.tap()
+    }
+}


### PR DESCRIPTION
## Round 5: Connection Setup from Settings

Follow-up to #131 → #136 → #138 (rounds 1–4). **Not a setup-system redesign**: this makes the completed Connection Setup Assistant available from Settings for an already-connected user, seeded from the current configuration, running the unchanged Round-4 staged test.

> An already-connected user can open Settings, launch Connection Setup prefilled from their current Hermes configuration, run the staged connection test, inspect diagnostics, optionally edit/test replacement settings, and leave without disrupting the active session unless they explicitly choose to apply a change.

### Settings files changed

| File | Change |
|---|---|
| `Conduit/Views/AuxiliaryViews.swift` | Settings → Connection section gains **Connection Setup** ("Test, troubleshoot, or change your connection") next to the existing Gateway row. Presents the real `ConnectionSetupView` as a sheet via a per-tap seed (`sheet(item:)`, so Keychain reads stay off the render path). Post-apply confirmation alert shown only when the apply plan actually changed something. |
| `Conduit/Services/ConnectionSetupApplication.swift` (new) | Pure apply-plan policy + seeding policy (below). |
| `Conduit/Services/ConnectionFailure.swift` | `ConnectionHelpDestination.currentConnection` — the semantic Settings entry destination. |
| `Conduit/Services/ConnectionSetupFlow.swift` | Entry mapping, `initialPath`, empty-credential continuation (Settings entry only), interactive-aware acceptance (`acceptedResult`), `testedSettingsUnchanged`. |
| `Conduit/Services/ConnectionSetupDraft.swift` | `testConfiguration()` — address + optional credentials. |
| `Conduit/Views/ConnectionSetupView.swift` / `ConnectionSetupForm.swift` | Probe target uses `testConfiguration()`; entry-aware Review copy and Done/Use-these-settings label; address preview on the test screen for the current-connection entry; username/password rows render honestly for credential-less interactive acceptance. |
| `Conduit/Services/AppState.swift` | Inert DEBUG UI-test connected stub (`-CONDUIT_UI_TEST_CONNECTED_DASHBOARD`) + reconnect suppression while it is active (`#if DEBUG` only). |

### Source of current connection data

- **URL**: `appState.connection?.baseUrl` (the **active** connection) falling back to `appState.lastDashboardURL` (last configured). The two concepts stay distinct; applying never writes to the live connection.
- **Credentials**: `KeychainHelper.loadCredentials()`, used only when the record's base URL matches the current address (policy-normalized on both sides).
- **Cloudflare Access**: `KeychainHelper.loadCloudflareAccess(for: currentURL)` — the existing origin-matched Keychain record. No new store, no new persistence.

### Exact Settings navigation

```
Settings (sheet)
└── Connection
    ├── Gateway          (existing; shows current dashboard + status)
    └── Connection Setup → sheet: existing ConnectionSetupView
        → staged test (or prefilled details → credentials → test)
        → Review → Done (unchanged) / Use These Settings (changed)
```

### How current values are seeded

`ConnectionSetupSeeding.wizardCredentials(for:saved:)` returns the saved username/password only for a record saved for **exactly this URL** (policy-normalized comparison). A **Face ID-protected** record surrenders its username only — the wizard asks for the password again rather than bypassing the biometric gate. The Cloudflare token is passed as the same-origin inherited probe token (Round-3 origin rechecks still apply; never displayed or persisted by the wizard).

### Credential handling

- Nothing is persisted by opening, editing, testing, cancelling, or dismissing. The **only** write path is an explicit **Use These Settings** on Review, through the pure `ConnectionSetupApplication.plan`:
  - remembers the dashboard URL when it changed;
  - **replaces** saved credentials only when a record already existed (preserving its Face ID preference) and values differ — it **never creates** credential persistence the user never opted into;
  - clears saved credentials only when the applied URL moved and the applied config has no credentials (a stale password would otherwise be sent to the new address);
  - rewrites the Cloudflare token **only same-origin** (path-only moves); never copies it cross-origin, never deletes the working origin's token.
- Applying to the **same URL** with a credential-less result (the interactive outcome) is a deliberate no-op — that outcome is not a verified replacement for the working credentials.

### Interactive-auth behavior

Both-credential-fields-empty is the interactive-auth signature: the wizard opens **directly on the staged test** (details screen underneath, so Back reaches an editable address), and `draft.testConfiguration()` lets provider discovery run without credentials. Review acceptance stays strict: the address-only handoff is authorized **only** by the current `requiresInteractiveSignIn` outcome; full native success still requires real credentials; every other validation failure stays a failure. From Settings, a browser-sign-in deployment tests to "Browser sign-in required" and offers plain **Done** — no username/password login request, no ticket mint.

### Active-session safety

The wizard still has no `AppState` mutation capability (architectural guarantee — the probe commits nothing, and `perform(appState:)` only writes the saved/login configuration: defaults URL + Keychain). Opening/editing/testing/failing/cancelling/dismissing cannot disconnect the client, replace the connection, change the session, trigger reconnect, or reset chat state. A failed experiment plans nothing. LoginView's entry behavior is unchanged (strict credential gate, normal Use-these-settings handoff, same handoff semantics).

### Changed settings

`test → apply → live session stays intact → new settings take effect on the next explicit reconnect` (app relaunch / next sign-in). No automatic disconnect or reconnect; after a changed apply a single confirmation says exactly that.

### Tests & results

New: `ConnectionSetupSettingsTests` (20 tests: entry shapes, Face ID withheld seed, unbuildable address fallback, exact-URL preservation, unchanged-Done gating to the Settings entry, cancel safety, interactive completion without credentials, credential-less continuation after editing, seeding normalization, apply-plan policy incl. cross-origin token and no-create rules, redaction). New: `ConnectionSetupSettingsUITests` (2 deterministic UI paths on the inert DEBUG connected stub — no real server). Updated: destination mapping pin.

Mac-verified (worktree at this exact HEAD):

- focused: ConnectionSetupSettings/Flow/Test/Draft + LoginCloudflareHandoff + NativeAuthClient — **161/161** ✓
- full `ConduitTests` — **1927/1927, 0 failures** ✓ (baseline 1907 → +20)
- new UI tests locally — **2/2** ✓ (hosted CI UI lanes exercise them again)

### Hosted CI

**Green** — [CI run 34078500111](https://github.com/kaishi00/hermes-conduit/actions/runs/34078500111): Plan & validate, Build test products, unit-1..unit-4, UI tests (incl. the 2 new Settings paths), CodeRabbit, and opencode-review all pass. Test-planner tooling untouched (`scripts/plan-tests.py validate` / `scripts/tests` unaffected — no lane or planner changes).

### Intentionally deferred

- An explicit "Reconnect Now" button (no existing safe connect-with-new-credentials operation outside LoginView; the safer Round-5 contract is apply-now / connect-on-next-reconnect, per spec).
- Any lighter Settings-only test path (exercising the real Round-4 probe is the point).
- The spec's out-of-scope list: no Bonjour/QR/Tailscale-API/multi-server/credential-vault/etc.


## Round 5.1 pre-merge compatibility fix

**The bug:** an actively-connected native-password user who chose NOT to save credentials seeds an empty draft. Round 5 treated "both credential fields empty" as an interactive-auth signature and opened the staged test directly — where provider discovery correctly found a password-capable dashboard, and the probe then called `client.connect(username: "", password: "")`: a real, rate-limited login attempt with empty credentials against a connection that may already be known to work.

**The semantic model:** credentials are **available** or **unavailable** — `ConnectionSetupResult.hasUsableCredentials` (presence-only, non-empty after trimming; values are never trimmed or rewritten, and `ConnectionSetupDraft.result()` now reuses the same check). Credential absence is NOT an authentication mode; provider discovery remains the sole authority.

**Staged-state changes:** new typed `ConnectionSetupStageState.requiresCredentials` + `ConnectionSetupTestEvent.requiresCredentials(_)` emitted at the authentication stage after server and dashboard succeed. It is not a success, not a failure, not `.authenticationRejected`, not rate-limited, and not the interactive outcome; it seals no revision, never advances to Review, and leaves `canUseSettings == false` — no Done/ready/"Login successful" claims.

**Request counts for password-capable + missing credentials (pinned by tests):** exactly **1 provider-discovery request, 0 password-login requests, 0 ws-ticket requests**. Whitespace-only credentials behave identically. The interactive path is discovery-only as before, and the full native path remains 1/1/1.

**Recovery UX:** the test screen shows ✓ Dashboard reachable, ✓ Hermes dashboard found, ○ Credentials required with the explanatory notice and **Enter Credentials** as the primary action (no retry, no failure presentation, no rate-limit warning — no login attempt occurred). It routes to the existing credentials step with the URL preserved; leaving the test step invalidates the partial result, so Continue runs a clean full staged test.

**Face ID:** unchanged — a protected record still seeds username only and lands on the credential entry screen; no biometric weakening, and no native login can occur before both credentials are present.

**Active-session safety:** unchanged — the probe still commits nothing; no Keychain/defaults writes outside the explicit Apply path.

**UI-test Minor (CodeRabbit):** both settings-row taps now use the scroll-aware `tapVisible` helper; a third deterministic UI test drives the credentials-required path via the new DEBUG-only `auth:credentialsRequired` stub.

**Verification (Mac, worktree at pushed HEAD):** focused ConnectionSetupSettings/Test/Flow/Draft + NativeAuthClient + LoginCloudflareHandoff — 160/160; full `ConduitTests` on the main-merged branch — 2001/2001, 0 failures; all 11 Connection Setup UI tests pass locally; `git diff --check` clean. Review gate on the fix: **APPROVE + 2× APPROVE_WITH_NITS, zero BLOCKER/WARNING findings** (hygiene nits applied: full count pins on the whitespace path, reducer monotonicity test, copy-scan exemption comment, probe doc, marker/MARK tidy-up). Branch merged with latest main (#139) — merge was conflict-free.

### Review gate

3-reviewer cycle (2× REQUEST_CHANGES + 1× approve-with-nits) → every finding fixed or declined with rationale (declines: same-URL credential keeping — no-strand invariant; Cloudflare old-token cleanup — single-record Keychain update in place; unverified typed creds under the interactive outcome — LoginView handoff parity). Follow-up re-review of the fix commits: **APPROVE_WITH_NITS**, both nits applied. No open BLOCKERs or WARNINGs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Connection Setup option in Settings for updating an existing connection without interrupting the active session.
  * Existing connection details and eligible credentials are prefilled in the setup flow.
  * Added support for browser-based sign-in when credentials are not required.
  * Added clearer handling and recovery when credentials are required.
  * Shows whether settings changed and confirms when updates are applied.

* **Bug Fixes**
  * Improved validation and credential handling during connection testing and setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->