### PR TITLE
fix(haptics): decouple response haptics from the shared voice audio session

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -12591,13 +12591,23 @@ final class AppState: ObservableObject {
         responseHaptics.invalidateConclusion()
     }
 
+    /// While a voice session may hold the audio session — Voice Conversation
+    /// (listening, thinking, speaking, muted, transcribing, including a
+    /// paused mic) or a provider test — the custom Core Haptics response
+    /// pattern is suppressed: Core Haptics must never contend with voice
+    /// capture or reactivate the coordinator-owned session (issue #140).
+    /// Response feedback falls back to the UIKit pattern in that state.
+    var responseHapticsMayUseCoreHaptics: Bool {
+        voiceConversationController.state == .idle
+    }
+
     private func performResponseHapticEffects(
         _ effects: [ResponseHapticState.Effect]
     ) {
         for effect in effects {
             switch effect {
             case .responseStarted:
-                Haptics.responseStarted()
+                Haptics.responseStarted(coreHapticsAllowed: responseHapticsMayUseCoreHaptics)
             case .toolStarted:
                 Haptics.toolStarted()
             case .responseConcluded:

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -12593,15 +12593,19 @@ final class AppState: ObservableObject {
 
     /// While a voice session may hold the audio session — Voice Conversation
     /// (listening, thinking, speaking, muted, transcribing, including a
-    /// paused mic) or a provider test — the custom Core Haptics response
-    /// pattern is suppressed: Core Haptics must never contend with voice
-    /// capture or reactivate the coordinator-owned session (issue #140).
-    /// Response feedback falls back to the UIKit pattern in that state.
+    /// paused mic and the arming window) or a provider test — the custom
+    /// Core Haptics response pattern is suppressed: Core Haptics must never
+    /// contend with voice capture or reactivate the coordinator-owned
+    /// session (issue #140). Response feedback falls back to the UIKit
+    /// pattern in that state.
     var responseHapticsMayUseCoreHaptics: Bool {
-        voiceConversationController.state == .idle
+        !voiceConversationController.hasLiveVoiceSession
     }
 
-    private func performResponseHapticEffects(
+    /// Internal for testing: the response-haptic forwarding seam is the
+    /// exact line that must degrade Core Haptics while a voice session is
+    /// live, so tests drive it end to end.
+    func performResponseHapticEffects(
         _ effects: [ResponseHapticState.Effect]
     ) {
         for effect in effects {

--- a/Conduit/Services/Haptics.swift
+++ b/Conduit/Services/Haptics.swift
@@ -15,8 +15,23 @@ struct HapticsEnginePolicy: Equatable {
     let usesSharedAudioSession: Bool
     let playsHapticsOnly: Bool
 
+    /// Ordinary response haptics deliberately do NOT bind
+    /// `AVAudioSession.sharedInstance()`. A shared-session-bound
+    /// CHHapticEngine activates the app session when it starts, so a plain
+    /// text-chat response interrupted Spotify/Audible around every response
+    /// lifecycle (issue #140). An unbound, haptics-only engine neither
+    /// claims the voice session nor holds an audio route.
+    ///
+    /// History: #48 bound this engine to the shared session because the
+    /// *unconfigured* engine (no `playsHapticsOnly`) created its own audio
+    /// session whose contention broke voice-capture startup (-10868) after
+    /// haptic activity. The haptics-only flag addresses the routing half of
+    /// that failure, and `responseStarted(coreHapticsAllowed:)` keeps the
+    /// custom engine entirely out of the picture while a voice session may
+    /// hold the session — so the #48 coexistence guarantee is now enforced
+    /// by suppression instead of by shared ownership.
     static let response = Self(
-        usesSharedAudioSession: true,
+        usesSharedAudioSession: false,
         playsHapticsOnly: true
     )
 }
@@ -182,6 +197,9 @@ enum Haptics {
 #if DEBUG
     static var testEmissionHandler: ((Event) -> Void)?
     static var testSuppressesHardware = false
+    /// Test seam: counts makeCoreHapticsEngine() attempts so tests can pin
+    /// that suppressed/disabled response haptics never create an engine.
+    static var coreHapticsEngineCreationCount = 0
 #endif
 
     static let preferenceKey = "conduit.haptics"
@@ -265,9 +283,18 @@ enum Haptics {
         softGenerator.prepare()
     }
 
-    static func responseStarted() {
+    /// The custom multi-hit response-start pattern. When `coreHapticsAllowed`
+    /// is false — a voice session may hold the audio session — the pattern
+    /// degrades to the UIKit fallback so Core Haptics never starts an engine
+    /// (and never touches any audio session) while voice capture or playback
+    /// is live.
+    static func responseStarted(coreHapticsAllowed: Bool = true) {
         guard emit(.responseStarted) else { return }
         let token = beginLifecyclePattern(duration: 0.18)
+        guard coreHapticsAllowed else {
+            playResponseStartFallback(token: token)
+            return
+        }
         do {
             let engine: CHHapticEngine
             if let coreHapticsEngine {
@@ -366,6 +393,9 @@ enum Haptics {
         ]
     }
     private static func makeCoreHapticsEngine() throws -> CHHapticEngine {
+#if DEBUG
+        coreHapticsEngineCreationCount += 1
+#endif
         let engine: CHHapticEngine
         if enginePolicy.usesSharedAudioSession {
             engine = try CHHapticEngine(audioSession: AVAudioSession.sharedInstance())

--- a/Conduit/Services/Haptics.swift
+++ b/Conduit/Services/Haptics.swift
@@ -6,34 +6,22 @@
 //  calibrated response lifecycle patterns and subordinate tool activity.
 //
 
-import AVFAudio
 import CoreHaptics
 import SwiftUI
 import UIKit
 
+/// The response lifecycle's Core Haptics engine is haptics-only and
+/// deliberately unbound: it neither creates a binding to nor activates
+/// Conduit's shared voice `AVAudioSession` (issue #140 — a shared-session
+/// engine activates the app session on start, interrupting external media
+/// on every text-chat response). While a voice session may hold the session,
+/// the custom pattern is suppressed entirely (see
+/// `responseStarted(coreHapticsAllowed:)`) — the #48 coexistence guarantee
+/// is enforced by suppression, not by shared ownership.
 struct HapticsEnginePolicy: Equatable {
-    let usesSharedAudioSession: Bool
     let playsHapticsOnly: Bool
 
-    /// Ordinary response haptics deliberately do NOT bind
-    /// `AVAudioSession.sharedInstance()`. A shared-session-bound
-    /// CHHapticEngine activates the app session when it starts, so a plain
-    /// text-chat response interrupted Spotify/Audible around every response
-    /// lifecycle (issue #140). An unbound, haptics-only engine neither
-    /// claims the voice session nor holds an audio route.
-    ///
-    /// History: #48 bound this engine to the shared session because the
-    /// *unconfigured* engine (no `playsHapticsOnly`) created its own audio
-    /// session whose contention broke voice-capture startup (-10868) after
-    /// haptic activity. The haptics-only flag addresses the routing half of
-    /// that failure, and `responseStarted(coreHapticsAllowed:)` keeps the
-    /// custom engine entirely out of the picture while a voice session may
-    /// hold the session — so the #48 coexistence guarantee is now enforced
-    /// by suppression instead of by shared ownership.
-    static let response = Self(
-        usesSharedAudioSession: false,
-        playsHapticsOnly: true
-    )
+    static let response = Self(playsHapticsOnly: true)
 }
 
 enum HapticsEngineStopPolicy {
@@ -405,12 +393,12 @@ enum Haptics {
 #if DEBUG
         coreHapticsEngineCreationCount += 1
 #endif
-        let engine: CHHapticEngine
-        if enginePolicy.usesSharedAudioSession {
-            engine = try CHHapticEngine(audioSession: AVAudioSession.sharedInstance())
-        } else {
-            engine = try CHHapticEngine()
-        }
+        // Deliberately the session-free initializer: binding this engine to
+        // AVAudioSession.sharedInstance() re-introduces the issue #140
+        // media interruption (the engine activates the shared session on
+        // start). Coexistence with voice capture is enforced by suppression
+        // in responseStarted(coreHapticsAllowed:), not by session sharing.
+        let engine = try CHHapticEngine()
         engine.playsHapticsOnly = enginePolicy.playsHapticsOnly
         engine.isAutoShutdownEnabled = true
         engine.resetHandler = { [weak engine] in

--- a/Conduit/Services/Haptics.swift
+++ b/Conduit/Services/Haptics.swift
@@ -200,6 +200,14 @@ enum Haptics {
     /// Test seam: counts makeCoreHapticsEngine() attempts so tests can pin
     /// that suppressed/disabled response haptics never create an engine.
     static var coreHapticsEngineCreationCount = 0
+    /// Clears cached engine and pattern state so the creation counter and
+    /// engine reuse are deterministic regardless of test order.
+    static func resetCoreHapticsStateForTesting() {
+        cancelLifecyclePattern()
+        clearLifecyclePatternState()
+        coreHapticsEngine = nil
+        coreHapticsEngineCreationCount = 0
+    }
 #endif
 
     static let preferenceKey = "conduit.haptics"
@@ -287,8 +295,9 @@ enum Haptics {
     /// is false — a voice session may hold the audio session — the pattern
     /// degrades to the UIKit fallback so Core Haptics never starts an engine
     /// (and never touches any audio session) while voice capture or playback
-    /// is live.
-    static func responseStarted(coreHapticsAllowed: Bool = true) {
+    /// is live. The parameter is deliberately required: every call site must
+    /// decide, so the audio-activating path cannot be reached by omission.
+    static func responseStarted(coreHapticsAllowed: Bool) {
         guard emit(.responseStarted) else { return }
         let token = beginLifecyclePattern(duration: 0.18)
         guard coreHapticsAllowed else {

--- a/Conduit/Services/Haptics.swift
+++ b/Conduit/Services/Haptics.swift
@@ -188,13 +188,20 @@ enum Haptics {
     /// Test seam: counts makeCoreHapticsEngine() attempts so tests can pin
     /// that suppressed/disabled response haptics never create an engine.
     static var coreHapticsEngineCreationCount = 0
-    /// Clears cached engine and pattern state so the creation counter and
-    /// engine reuse are deterministic regardless of test order.
+    /// Test seam: when set, replaces real CHHapticEngine construction so
+    /// tests can verify that the allowed path requests the custom engine
+    /// without touching haptic hardware. Throwing from the factory
+    /// simulates construction failure; returning an engine still runs the
+    /// response-engine configuration.
+    static var coreHapticsEngineFactoryForTesting: (() throws -> CHHapticEngine)?
+    /// Clears cached engine, pattern state, factory, and counter so engine
+    /// requests are deterministic regardless of test order.
     static func resetCoreHapticsStateForTesting() {
         cancelLifecyclePattern()
         clearLifecyclePatternState()
         coreHapticsEngine = nil
         coreHapticsEngineCreationCount = 0
+        coreHapticsEngineFactoryForTesting = nil
     }
 #endif
 
@@ -392,6 +399,11 @@ enum Haptics {
     private static func makeCoreHapticsEngine() throws -> CHHapticEngine {
 #if DEBUG
         coreHapticsEngineCreationCount += 1
+        if let factory = coreHapticsEngineFactoryForTesting {
+            let engine = try factory()
+            configureResponseHapticEngine(engine)
+            return engine
+        }
 #endif
         // Deliberately the session-free initializer: binding this engine to
         // AVAudioSession.sharedInstance() re-introduces the issue #140
@@ -399,6 +411,11 @@ enum Haptics {
         // start). Coexistence with voice capture is enforced by suppression
         // in responseStarted(coreHapticsAllowed:), not by session sharing.
         let engine = try CHHapticEngine()
+        configureResponseHapticEngine(engine)
+        return engine
+    }
+
+    private static func configureResponseHapticEngine(_ engine: CHHapticEngine) {
         engine.playsHapticsOnly = enginePolicy.playsHapticsOnly
         engine.isAutoShutdownEnabled = true
         engine.resetHandler = { [weak engine] in
@@ -417,7 +434,6 @@ enum Haptics {
                 }
             }
         }
-        return engine
     }
 
     private static func clearLifecyclePatternState() {

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -123,6 +123,14 @@ final class VoiceConversationController: ObservableObject {
         isOutputMuted = preferences.outputMuted
     }
 
+    /// True from the moment a voice session is armed (including the
+    /// permission-await and provider-test windows where `state` is still
+    /// `.idle`) until it is terminally stopped. Audio-adjacent side features
+    /// — response haptics — must stand down while this is true.
+    var hasLiveVoiceSession: Bool {
+        isVoiceSessionActive || isProviderTestRunning || state != .idle
+    }
+
     func setForegroundActive(_ active: Bool) {
         isForegroundActive = active
         guard !active else { return }
@@ -534,6 +542,10 @@ final class VoiceConversationController: ObservableObject {
         isMicrophonePaused = false
         isAwaitingVoiceAssistant = false
         awaitedAssistantResponseStarted = false
+        // Terminal path: release session-ownership bookkeeping so audio-
+        // adjacent side features (response haptics) do not stand down
+        // forever after an interruption.
+        isVoiceSessionActive = false
         state = .failed("Audio was interrupted.")
     }
 

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -123,12 +123,22 @@ final class VoiceConversationController: ObservableObject {
         isOutputMuted = preferences.outputMuted
     }
 
-    /// True from the moment a voice session is armed (including the
-    /// permission-await and provider-test windows where `state` is still
-    /// `.idle`) until it is terminally stopped. Audio-adjacent side features
-    /// — response haptics — must stand down while this is true.
+    /// True while a voice session or provider test is armed or live — i.e.
+    /// while voice audio ownership may exist or is being acquired — so
+    /// audio-adjacent side features (response haptics) stand down.
+    ///
+    /// Deliberately does NOT key off `state != .idle`: a terminal
+    /// `.failed("Audio was interrupted.")` has no live operation and must
+    /// not suppress Core Haptics indefinitely. The explicit ownership flags
+    /// cover every real ownership window: `startListening` raises
+    /// `isVoiceSessionActive` before its permission await (arming window),
+    /// all listening/thinking/speaking/muted/transcribing states occur with
+    /// it raised, and provider tests raise `isProviderTestRunning`. A failed
+    /// arming attempt keeps the flag until the session is stopped or
+    /// re-armed — bounded by the voice sheet's lifetime and conservative in
+    /// the safe direction.
     var hasLiveVoiceSession: Bool {
-        isVoiceSessionActive || isProviderTestRunning || state != .idle
+        isVoiceSessionActive || isProviderTestRunning
     }
 
     func setForegroundActive(_ active: Bool) {

--- a/ConduitTests/HapticsTests.swift
+++ b/ConduitTests/HapticsTests.swift
@@ -14,13 +14,10 @@ final class HapticsTests: XCTestCase {
         super.tearDown()
     }
 
-    func testResponseEngineDoesNotBindSharedAudioSession() {
-        // Ordinary response haptics must not bind AVAudioSession
-        // sharedInstance(): a shared-session-bound CHHapticEngine activates
-        // the app session when it starts, which interrupts external media
-        // (Spotify/Audible) around every text-chat response lifecycle
-        // (issue #140). The engine stays haptics-only.
-        XCTAssertFalse(Haptics.enginePolicy.usesSharedAudioSession)
+    func testResponseEngineIsHapticsOnly() {
+        // The response lifecycle's Core Haptics engine is haptics-only and
+        // session-free: it must never bind or activate the shared voice
+        // AVAudioSession (issue #140).
         XCTAssertTrue(Haptics.enginePolicy.playsHapticsOnly)
     }
 

--- a/ConduitTests/HapticsTests.swift
+++ b/ConduitTests/HapticsTests.swift
@@ -4,9 +4,85 @@ import XCTest
 
 @MainActor
 final class HapticsTests: XCTestCase {
-    func testResponseEngineUsesSharedHapticsOnlyPolicy() {
-        XCTAssertTrue(Haptics.enginePolicy.usesSharedAudioSession)
+    func testResponseEngineDoesNotBindSharedAudioSession() {
+        // Ordinary response haptics must not bind AVAudioSession
+        // sharedInstance(): a shared-session-bound CHHapticEngine activates
+        // the app session when it starts, which interrupts external media
+        // (Spotify/Audible) around every text-chat response lifecycle
+        // (issue #140). The engine stays haptics-only.
+        XCTAssertFalse(Haptics.enginePolicy.usesSharedAudioSession)
         XCTAssertTrue(Haptics.enginePolicy.playsHapticsOnly)
+    }
+
+    func testUIKitFallbackResponseStartedDoesNotCreateEngine() {
+        let previousHandler = Haptics.testEmissionHandler
+        let previousSuppressesHardware = Haptics.testSuppressesHardware
+        var events: [Haptics.Event] = []
+        defer {
+            Haptics.testEmissionHandler = previousHandler
+            Haptics.testSuppressesHardware = previousSuppressesHardware
+        }
+
+        Haptics.testEmissionHandler = { events.append($0) }
+        Haptics.testSuppressesHardware = false
+        Haptics.coreHapticsEngineCreationCount = 0
+
+        // While a voice session may hold the audio session, response haptics
+        // degrade to the UIKit fallback pattern and must not create — or
+        // start — a Core Haptics engine at all.
+        Haptics.responseStarted(coreHapticsAllowed: false)
+
+        XCTAssertEqual(events, [.responseStarted])
+        XCTAssertEqual(
+            Haptics.coreHapticsEngineCreationCount, 0,
+            "degraded response haptics must not create a Core Haptics engine"
+        )
+    }
+
+    func testUnsuppressedResponseStartedAttemptsCoreHapticsEngine() {
+        let previousHandler = Haptics.testEmissionHandler
+        let previousSuppressesHardware = Haptics.testSuppressesHardware
+        var events: [Haptics.Event] = []
+        defer {
+            Haptics.testEmissionHandler = previousHandler
+            Haptics.testSuppressesHardware = previousSuppressesHardware
+        }
+
+        Haptics.testEmissionHandler = { events.append($0) }
+        Haptics.testSuppressesHardware = false
+        Haptics.coreHapticsEngineCreationCount = 0
+
+        Haptics.responseStarted(coreHapticsAllowed: true)
+
+        XCTAssertEqual(events, [.responseStarted])
+        XCTAssertEqual(
+            Haptics.coreHapticsEngineCreationCount, 1,
+            "unsuppressed response haptics attempt the custom Core Haptics pattern"
+        )
+    }
+
+    func testHapticsDisabledPreventsEngineCreation() {
+        let defaults = UserDefaults.standard
+        let previousValue = defaults.object(forKey: Haptics.preferenceKey)
+        defer {
+            if let previousValue {
+                defaults.set(previousValue, forKey: Haptics.preferenceKey)
+            } else {
+                defaults.removeObject(forKey: Haptics.preferenceKey)
+            }
+        }
+
+        Haptics.enabled = false
+        Haptics.coreHapticsEngineCreationCount = 0
+
+        Haptics.responseStarted(coreHapticsAllowed: true)
+        Haptics.toolStarted()
+        Haptics.responseConcluded()
+
+        XCTAssertEqual(
+            Haptics.coreHapticsEngineCreationCount, 0,
+            "a disabled haptics preference must never create Core Haptics resources"
+        )
     }
 
     func testEngineStopPolicyDiscardsOnlyRecoveryCriticalStops() {

--- a/ConduitTests/HapticsTests.swift
+++ b/ConduitTests/HapticsTests.swift
@@ -4,6 +4,16 @@ import XCTest
 
 @MainActor
 final class HapticsTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        Haptics.resetCoreHapticsStateForTesting()
+    }
+
+    override func tearDown() {
+        Haptics.resetCoreHapticsStateForTesting()
+        super.tearDown()
+    }
+
     func testResponseEngineDoesNotBindSharedAudioSession() {
         // Ordinary response haptics must not bind AVAudioSession
         // sharedInstance(): a shared-session-bound CHHapticEngine activates
@@ -73,11 +83,8 @@ final class HapticsTests: XCTestCase {
         }
 
         Haptics.enabled = false
-        Haptics.coreHapticsEngineCreationCount = 0
 
         Haptics.responseStarted(coreHapticsAllowed: true)
-        Haptics.toolStarted()
-        Haptics.responseConcluded()
 
         XCTAssertEqual(
             Haptics.coreHapticsEngineCreationCount, 0,

--- a/ConduitTests/HapticsTests.swift
+++ b/ConduitTests/HapticsTests.swift
@@ -32,7 +32,6 @@ final class HapticsTests: XCTestCase {
 
         Haptics.testEmissionHandler = { events.append($0) }
         Haptics.testSuppressesHardware = false
-        Haptics.coreHapticsEngineCreationCount = 0
 
         // While a voice session may hold the audio session, response haptics
         // degrade to the UIKit fallback pattern and must not create — or
@@ -46,10 +45,11 @@ final class HapticsTests: XCTestCase {
         )
     }
 
-    func testUnsuppressedResponseStartedAttemptsCoreHapticsEngine() {
+    func testUnsuppressedResponseStartedRequestsCustomEngineWithoutHardware() {
         let previousHandler = Haptics.testEmissionHandler
         let previousSuppressesHardware = Haptics.testSuppressesHardware
         var events: [Haptics.Event] = []
+        var factoryCalls = 0
         defer {
             Haptics.testEmissionHandler = previousHandler
             Haptics.testSuppressesHardware = previousSuppressesHardware
@@ -57,20 +57,24 @@ final class HapticsTests: XCTestCase {
 
         Haptics.testEmissionHandler = { events.append($0) }
         Haptics.testSuppressesHardware = false
-        Haptics.coreHapticsEngineCreationCount = 0
+        // A throwing factory proves the allowed path REQUESTS the custom
+        // engine without constructing or starting real haptic hardware.
+        Haptics.coreHapticsEngineFactoryForTesting = {
+            factoryCalls += 1
+            throw VoiceAudioError.unavailable("No haptic hardware in unit tests.")
+        }
 
         Haptics.responseStarted(coreHapticsAllowed: true)
 
         XCTAssertEqual(events, [.responseStarted])
-        XCTAssertEqual(
-            Haptics.coreHapticsEngineCreationCount, 1,
-            "unsuppressed response haptics attempt the custom Core Haptics pattern"
-        )
+        XCTAssertEqual(factoryCalls, 1, "the allowed path requests the custom engine")
+        XCTAssertEqual(Haptics.coreHapticsEngineCreationCount, 1)
     }
 
     func testHapticsDisabledPreventsEngineCreation() {
         let defaults = UserDefaults.standard
         let previousValue = defaults.object(forKey: Haptics.preferenceKey)
+        var factoryCalls = 0
         defer {
             if let previousValue {
                 defaults.set(previousValue, forKey: Haptics.preferenceKey)
@@ -80,13 +84,18 @@ final class HapticsTests: XCTestCase {
         }
 
         Haptics.enabled = false
+        Haptics.coreHapticsEngineFactoryForTesting = {
+            factoryCalls += 1
+            throw VoiceAudioError.unavailable("No haptic hardware in unit tests.")
+        }
 
         Haptics.responseStarted(coreHapticsAllowed: true)
 
         XCTAssertEqual(
-            Haptics.coreHapticsEngineCreationCount, 0,
-            "a disabled haptics preference must never create Core Haptics resources"
+            factoryCalls, 0,
+            "a disabled haptics preference must never request Core Haptics resources"
         )
+        XCTAssertEqual(Haptics.coreHapticsEngineCreationCount, 0)
     }
 
     func testEngineStopPolicyDiscardsOnlyRecoveryCriticalStops() {

--- a/ConduitTests/HapticsVoiceIsolationTests.swift
+++ b/ConduitTests/HapticsVoiceIsolationTests.swift
@@ -29,6 +29,12 @@ final class HapticsVoiceIsolationTests: XCTestCase {
         super.tearDown()
     }
 
+    /// The degraded (voice-safe) response-start path exercises the full
+    /// lifecycle — emission, fallback pattern, cancellation — while
+    /// asserting zero Core Haptics engine creation and zero interaction
+    /// with any voice audio session. Deliberately no test here starts the
+    /// real Core Haptics engine: hardware-dependent behavior belongs to the
+    /// PR's device checklist, and this suite must stay deterministic.
     func testResponseHapticLifecycleLeavesVoiceAudioSessionUntouched() {
         let previousHandler = Haptics.testEmissionHandler
         let previousSuppressesHardware = Haptics.testSuppressesHardware
@@ -39,11 +45,12 @@ final class HapticsVoiceIsolationTests: XCTestCase {
         Haptics.testEmissionHandler = { _ in }
         Haptics.testSuppressesHardware = false
 
-        Haptics.responseStarted(coreHapticsAllowed: true)
+        Haptics.responseStarted(coreHapticsAllowed: false)
         Haptics.toolStarted()
         Haptics.responseConcluded()
         Haptics.cancelLifecyclePattern()
 
+        XCTAssertEqual(Haptics.coreHapticsEngineCreationCount, 0)
         XCTAssertEqual(session.categoryCalls.count, 0)
         XCTAssertEqual(session.activationCalls.count, 0)
         XCTAssertNil(coordinator.appliedPolicy)

--- a/ConduitTests/HapticsVoiceIsolationTests.swift
+++ b/ConduitTests/HapticsVoiceIsolationTests.swift
@@ -147,6 +147,81 @@ final class HapticsVoiceIsolationTests: XCTestCase {
             "response-start haptics outside a voice session may use the custom pattern"
         )
     }
+
+    func testAudioInterruptionReleasesHapticSuppression() async {
+        // Regression: after a terminal audio interruption the controller sits
+        // in .failed with no live voice operation, so haptic suppression must
+        // clear even though the failed UI state is not .idle.
+        let suiteName = "HapticsVoiceIsolation.Interruption.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create test UserDefaults suite")
+            return
+        }
+        addTeardownBlock { defaults.removePersistentDomain(forName: suiteName) }
+
+        let appState = AppState(defaults: defaults, loadSavedConnection: false)
+        let capture = StubPermissionCapture()
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: StubPlayback(),
+            gateway: StubVoiceGateway(),
+            submit: { _ in true },
+            interrupt: {}
+        )
+        appState.voiceConversationController = controller
+
+        await controller.startListening()
+        XCTAssertFalse(appState.responseHapticsMayUseCoreHaptics, "a live voice session suppresses Core Haptics")
+
+        capture.emit(.interrupted)
+        await waitUntil { controller.state == .failed("Audio was interrupted.") }
+
+        XCTAssertFalse(controller.hasLiveVoiceSession, "an interrupted session is terminal: no voice operation is live")
+        XCTAssertTrue(
+            appState.responseHapticsMayUseCoreHaptics,
+            "a failed UI state by itself must not imply live audio ownership"
+        )
+    }
+
+    func testProviderTestInterruptionReleasesHapticSuppression() async {
+        // Regression: a provider test interrupted mid-capture must terminate,
+        // clear its ownership flags, and release haptic suppression —
+        // regardless of whether the UI ends up back on .idle or .failed.
+        let capture = StubPermissionCapture()
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: StubPlayback(),
+            gateway: StubVoiceGateway(),
+            submit: { _ in true },
+            interrupt: {}
+        )
+
+        let testTask = Task { await controller.runTranscriptionTest(duration: 1) }
+        await waitUntil { controller.state == .listening }
+
+        capture.emit(.interrupted)
+        let result = await testTask.value
+
+        XCTAssertFalse(result.passed, "an interrupted provider test must not report success")
+        XCTAssertFalse(
+            controller.hasLiveVoiceSession,
+            "the interrupted provider test must release its ownership flags after terminating"
+        )
+    }
+
+    private func waitUntil(
+        _ condition: @MainActor () -> Bool,
+        timeout: TimeInterval = 2
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition() {
+            if Date() >= deadline {
+                XCTFail("Timed out waiting for condition")
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
 }
 
 @MainActor
@@ -183,9 +258,18 @@ private final class RecordingVoiceAudioSession: VoiceAudioSessionControlling {
 @MainActor
 private final class StubPermissionCapture: AudioCaptureService {
     let events: AsyncStream<VoiceCaptureEvent>
+    private var continuation: AsyncStream<VoiceCaptureEvent>.Continuation?
 
     init() {
-        events = AsyncStream { _ in }
+        var captured: AsyncStream<VoiceCaptureEvent>.Continuation?
+        events = AsyncStream { captured = $0 }
+        continuation = captured
+    }
+
+    /// Delivers a capture event through the same stream the real service
+    /// uses, so tests can drive interruption handling end to end.
+    func emit(_ event: VoiceCaptureEvent) {
+        continuation?.yield(event)
     }
 
     func requestPermission() async -> Bool { true }

--- a/ConduitTests/HapticsVoiceIsolationTests.swift
+++ b/ConduitTests/HapticsVoiceIsolationTests.swift
@@ -1,0 +1,179 @@
+//
+//  HapticsVoiceIsolationTests.swift
+//  ConduitTests
+//
+//  Pins that ordinary response haptics never interact with the voice audio
+//  session: no acquisition, no policy change, no activation or deactivation.
+//  VoiceAudioSessionCoordinator stays the sole authority over the shared
+//  session (PR #141); response haptics must not couple to it (issue #140).
+//
+
+import AVFAudio
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class HapticsVoiceIsolationTests: XCTestCase {
+    private var session: RecordingVoiceAudioSession!
+    private var coordinator: VoiceAudioSessionCoordinator!
+
+    override func setUp() {
+        super.setUp()
+        session = RecordingVoiceAudioSession()
+        coordinator = VoiceAudioSessionCoordinator(session: session)
+    }
+
+    func testResponseHapticLifecycleLeavesVoiceAudioSessionUntouched() {
+        let previousHandler = Haptics.testEmissionHandler
+        let previousSuppressesHardware = Haptics.testSuppressesHardware
+        defer {
+            Haptics.testEmissionHandler = previousHandler
+            Haptics.testSuppressesHardware = previousSuppressesHardware
+        }
+        Haptics.testEmissionHandler = { _ in }
+        Haptics.testSuppressesHardware = false
+
+        Haptics.responseStarted(coreHapticsAllowed: true)
+        Haptics.toolStarted()
+        Haptics.responseConcluded()
+        Haptics.cancelLifecyclePattern()
+
+        XCTAssertEqual(session.categoryCalls.count, 0)
+        XCTAssertEqual(session.activationCalls.count, 0)
+        XCTAssertNil(coordinator.appliedPolicy)
+    }
+
+    func testResponseHapticsLeaveActiveVoiceOwnershipIntact() throws {
+        let previousHandler = Haptics.testEmissionHandler
+        let previousSuppressesHardware = Haptics.testSuppressesHardware
+        defer {
+            Haptics.testEmissionHandler = previousHandler
+            Haptics.testSuppressesHardware = previousSuppressesHardware
+        }
+        Haptics.testEmissionHandler = { _ in }
+        Haptics.testSuppressesHardware = false
+
+        let lease = try coordinator.acquire(.conversationCapture)
+        session.resetRecordings()
+
+        Haptics.responseStarted(coreHapticsAllowed: false)
+        Haptics.cancelLifecyclePattern()
+
+        XCTAssertEqual(session.categoryCalls.count, 0)
+        XCTAssertEqual(session.activationCalls.count, 0)
+        XCTAssertEqual(session.deactivationCount, 0)
+        XCTAssertEqual(coordinator.appliedPolicy, .conversation)
+
+        coordinator.release(lease)
+        XCTAssertEqual(session.deactivationCount, 1, "only the explicit owner release may deactivate the session")
+    }
+
+    func testAppStateSuppressesCoreHapticsWhileVoiceSessionIsActive() async {
+        let suiteName = "HapticsVoiceIsolation.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create test UserDefaults suite")
+            return
+        }
+        addTeardownBlock { defaults.removePersistentDomain(forName: suiteName) }
+
+        let appState = AppState(defaults: defaults, loadSavedConnection: false)
+        let controller = VoiceConversationController(
+            capture: StubPermissionCapture(),
+            playback: StubPlayback(),
+            gateway: StubVoiceGateway(),
+            submit: { _ in true },
+            interrupt: {}
+        )
+        appState.voiceConversationController = controller
+
+        // No voice session: ordinary response haptics may use Core Haptics.
+        XCTAssertTrue(appState.responseHapticsMayUseCoreHaptics)
+
+        // A live voice conversation means capture or playback ownership may
+        // be held, so the custom Core Haptics pattern is suppressed in
+        // favour of the UIKit fallback.
+        await controller.startListening()
+        XCTAssertFalse(appState.responseHapticsMayUseCoreHaptics)
+
+        controller.stop()
+        XCTAssertTrue(appState.responseHapticsMayUseCoreHaptics)
+    }
+}
+
+@MainActor
+private final class RecordingVoiceAudioSession: VoiceAudioSessionControlling {
+    struct CategoryCall: Equatable {
+        let category: AVAudioSession.Category
+        let mode: AVAudioSession.Mode
+        let options: AVAudioSession.CategoryOptions
+    }
+
+    private(set) var categoryCalls: [CategoryCall] = []
+    private(set) var activationCalls: [(active: Bool, options: AVAudioSession.SetActiveOptions)] = []
+
+    var deactivationCount: Int { activationCalls.filter { !$0.active }.count }
+
+    func resetRecordings() {
+        categoryCalls.removeAll()
+        activationCalls.removeAll()
+    }
+
+    func setCategory(
+        _ category: AVAudioSession.Category,
+        mode: AVAudioSession.Mode,
+        options: AVAudioSession.CategoryOptions
+    ) throws {
+        categoryCalls.append(CategoryCall(category: category, mode: mode, options: options))
+    }
+
+    func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws {
+        activationCalls.append((active, options))
+    }
+}
+
+@MainActor
+private final class StubPermissionCapture: AudioCaptureService {
+    let events: AsyncStream<VoiceCaptureEvent>
+
+    init() {
+        events = AsyncStream { _ in }
+    }
+
+    func requestPermission() async -> Bool { true }
+    func startListening(includePreRoll: Bool) throws {}
+    func beginBargeInMonitoring() throws {}
+    func pause() {}
+    func resume() throws {}
+    func finishUtterance() throws -> VoiceCapturedAudio {
+        VoiceCapturedAudio(wavData: Data([1]), pcm16Data: Data([1, 0]), sampleRate: 16_000, duration: 0.01)
+    }
+    func stop() {}
+}
+
+@MainActor
+private final class StubPlayback: SpeechPlaybackService {
+    var isPlaying = false
+    var ownershipIntent: VoiceAudioIntent = .standalonePlayback
+
+    func start(sampleRate: Double) throws { isPlaying = true }
+    func enqueuePCM16(_ data: Data, sampleRate: Double) throws -> Int { data.count / 2 }
+    func playEncodedAudioData(_ data: Data) throws { isPlaying = true }
+    func finish() throws {}
+    func drain() async { isPlaying = false }
+    func stop() { isPlaying = false }
+}
+
+@MainActor
+private final class StubVoiceGateway: VoiceGatewayService {
+    let profile = "default"
+
+    func transcribe(_ audio: VoiceCapturedAudio) async throws -> String { "" }
+
+    func openSpeechStream(
+        onStart: @escaping @MainActor (Double) throws -> Void,
+        onPCM16: @escaping @MainActor (Data, Double) throws -> Void,
+        onEncodedAudio: @escaping @MainActor (Data) throws -> Void
+    ) async throws -> VoiceSpeechStream {
+        throw VoiceAudioError.unavailable("Unused in haptics isolation tests.")
+    }
+}

--- a/ConduitTests/HapticsVoiceIsolationTests.swift
+++ b/ConduitTests/HapticsVoiceIsolationTests.swift
@@ -19,8 +19,14 @@ final class HapticsVoiceIsolationTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        Haptics.resetCoreHapticsStateForTesting()
         session = RecordingVoiceAudioSession()
         coordinator = VoiceAudioSessionCoordinator(session: session)
+    }
+
+    override func tearDown() {
+        Haptics.resetCoreHapticsStateForTesting()
+        super.tearDown()
     }
 
     func testResponseHapticLifecycleLeavesVoiceAudioSessionUntouched() {
@@ -95,8 +101,51 @@ final class HapticsVoiceIsolationTests: XCTestCase {
         await controller.startListening()
         XCTAssertFalse(appState.responseHapticsMayUseCoreHaptics)
 
+        // A paused mic keeps the voice session logically open (and the
+        // conversation state non-idle), so suppression holds.
+        controller.pauseMicrophone()
+        XCTAssertFalse(appState.responseHapticsMayUseCoreHaptics)
+
         controller.stop()
         XCTAssertTrue(appState.responseHapticsMayUseCoreHaptics)
+    }
+
+    func testAppStateForwardingSuppressesEngineCreationWhileVoiceSessionIsLive() async {
+        // End-to-end pin of the forwarding seam: while a voice session is
+        // live, performResponseHapticEffects must degrade response-start to
+        // the UIKit fallback (no engine creation); once the session ends, the
+        // custom pattern is allowed again. Reverting the forwarding line to
+        // an unconditionally-allowed call fails this test.
+        let suiteName = "HapticsVoiceIsolation.Forwarding.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create test UserDefaults suite")
+            return
+        }
+        addTeardownBlock { defaults.removePersistentDomain(forName: suiteName) }
+
+        let appState = AppState(defaults: defaults, loadSavedConnection: false)
+        let controller = VoiceConversationController(
+            capture: StubPermissionCapture(),
+            playback: StubPlayback(),
+            gateway: StubVoiceGateway(),
+            submit: { _ in true },
+            interrupt: {}
+        )
+        appState.voiceConversationController = controller
+
+        await controller.startListening()
+        appState.performResponseHapticEffects([.responseStarted])
+        XCTAssertEqual(
+            Haptics.coreHapticsEngineCreationCount, 0,
+            "response-start haptics during a live voice session must not create a Core Haptics engine"
+        )
+
+        controller.stop()
+        appState.performResponseHapticEffects([.responseStarted])
+        XCTAssertEqual(
+            Haptics.coreHapticsEngineCreationCount, 1,
+            "response-start haptics outside a voice session may use the custom pattern"
+        )
     }
 }
 

--- a/ConduitTests/ResponseHapticStateTests.swift
+++ b/ConduitTests/ResponseHapticStateTests.swift
@@ -211,7 +211,7 @@ final class HapticsEmissionTests: XCTestCase {
         Haptics.warning()
         Haptics.selection()
         Haptics.toolStarted()
-        Haptics.responseStarted()
+        Haptics.responseStarted(coreHapticsAllowed: true)
         Haptics.responseConcluded()
     }
 }

--- a/docs/superpowers/plans/2026-08-12-voice-capture-session-recovery.md
+++ b/docs/superpowers/plans/2026-08-12-voice-capture-session-recovery.md
@@ -11,8 +11,6 @@
 > `VoiceConversationController.hasLiveVoiceSession`). Do not restore the
 > shared-session binding; the route-native capture hardening below remains
 > in force.
-
-
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Make the shared iOS microphone capture path start reliably after Core Haptics activity or route changes while preserving the existing 16 kHz mono PCM16 transcription contract.

--- a/docs/superpowers/plans/2026-08-12-voice-capture-session-recovery.md
+++ b/docs/superpowers/plans/2026-08-12-voice-capture-session-recovery.md
@@ -1,5 +1,18 @@
 # Voice Capture Session Recovery Implementation Plan
 
+> **SUPERSEDED (2026-09-07, PR #143):** This plan's shared-session haptic
+> binding ("Core Haptics as a haptics-only engine bound to the shared
+> AVAudioSession") has been intentionally superseded. A shared-session-bound
+> engine activates the app session when it starts, so ordinary text-chat
+> response haptics interrupted external media (issue #140). The current
+> strategy is an **unbound, haptics-only** engine plus **suppressing the
+> custom Core Haptics pattern entirely while a voice session is live**
+> (`responseStarted(coreHapticsAllowed:)`, gated by
+> `VoiceConversationController.hasLiveVoiceSession`). Do not restore the
+> shared-session binding; the route-native capture hardening below remains
+> in force.
+
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Make the shared iOS microphone capture path start reliably after Core Haptics activity or route changes while preserving the existing 16 kHz mono PCM16 transcription contract.

--- a/docs/superpowers/specs/2026-08-12-voice-capture-session-design.md
+++ b/docs/superpowers/specs/2026-08-12-voice-capture-session-design.md
@@ -1,5 +1,16 @@
 # Voice Capture Session Recovery Design
 
+> **SUPERSEDED (2026-09-07, PR #143):** The "Shared haptic audio-session
+> ownership" section below has been intentionally superseded. Binding the
+> response haptic engine to the shared `AVAudioSession` made every
+> text-chat response activate the app session, interrupting external media
+> (issue #140). The current strategy is an **unbound, haptics-only**
+> engine plus **suppressing the custom Core Haptics pattern while a voice
+> session is live** — the #48 contention concern is addressed by keeping
+> Core Haptics inactive during voice ownership, not by sharing the
+> session.
+
+
 ## Context
 
 On an iPhone 16 Pro Max running iOS 27, the Voice settings action **Record ASR** fails before transcription with:


### PR DESCRIPTION
## Summary

Ordinary text-chat **response haptics** — not voice — were interrupting Spotify/Audible (issue #140's real-world reproduction): start external audio, send a typed message, and the media cuts out around the response lifecycle. This PR removes the last un-coordinated touch of the shared `AVAudioSession` — the response-haptic Core Haptics engine — and adds a deliberate stand-down while voice sessions are live. VoiceAudioSessionCoordinator (PR #141) remains the only authority over the shared session; ordinary haptics gain no lease or intent.

Follow-up to #141; does not reopen its architecture. Out of scope: #130 VAD work, persistent STT/TTS preferences, interruption auto-resume, haptic UX redesign.

## Root cause

`HapticsEnginePolicy.response` originally set `usesSharedAudioSession == true`, so `makeCoreHapticsEngine()` created `CHHapticEngine(audioSession: AVAudioSession.sharedInstance())`. The only Core Haptics usage is `responseStarted()` — fired on the first message delta of a response — which calls `engine.start()`. A shared-session-bound engine **activates the app's session when it starts**: with no voice session active, that activates an exclusive session (default/last category) and interrupts external media, exactly matching the reporter's steps. This also explains why #141 didn't fully resolve #140: the haptic engine was never under coordinator ownership.

## Why the shared binding existed (#48), and why this is safe

#48's design doc records the original failure: on iOS 27 the **Record ASR** capture failed with `-10868` after haptic activity. The then-current engine was an unconfigured `CHHapticEngine()` — **without** `playsHapticsOnly` — which Apple documents as creating its own audio session; that independent session contended with voice-capture activation. #48's fix was to bind haptics to the shared session so both features shared one audio-session boundary (the doc itself hedges that the route-native capture hardening shipped in the same PR may have been the primary fix).

This PR does not restore that failure mode:

1. The response engine is now **structurally session-free**: `CHHapticEngine()` with `playsHapticsOnly = true` — no configuration branch exists that can bind it to the shared session, and `Haptics.swift` no longer imports `AVFAudio`.
2. The #48 guarantee is enforced **by suppression instead of shared ownership**: while a voice session may hold the session, the custom Core Haptics pattern is skipped entirely and response feedback uses the existing UIKit fallback. Core Haptics is never created *or started* while capture/playback may be live, so nothing can contend with `AVAudioEngine` startup or reactivate the coordinator-owned session.
3. `VoiceAudioSessionCoordinator` is untouched — no new lease, no new intent, no calls into it from Haptics.

## Changes

- `Haptics.swift`
  - `HapticsEnginePolicy.response` reduced to `playsHapticsOnly = true`; the engine is constructed with the session-free initializer only (`CHHapticEngine()`), and the `AVFAudio` import is gone — no production haptic path can bind the shared session.
  - `responseStarted(coreHapticsAllowed:)` — the parameter is required (no default), so every call site must decide. When disallowed, the existing UIKit fallback pattern plays and Core Haptics is never created or started.
  - DEBUG seams: `coreHapticsEngineCreationCount`, an injectable `coreHapticsEngineFactoryForTesting` (so tests prove the allowed path *requests* the custom engine without touching haptic hardware), and `resetCoreHapticsStateForTesting()` for deterministic ordering.
- `VoiceConversationController`
  - New `hasLiveVoiceSession` — the suppression gate — based on **explicit live-operation flags only**: `isVoiceSessionActive || isProviderTestRunning`.
    - The arming window is covered: `startListening` raises `isVoiceSessionActive` **before** its permission awaits, while `state` is still `.idle`.
    - All live conversation states (listening/thinking/speaking/muted/transcribing, including a paused mic) occur with `isVoiceSessionActive` raised; provider tests raise `isProviderTestRunning`.
    - `.failed` UI state alone does **not** imply audio ownership: a terminal audio interruption clears `isVoiceSessionActive`, so after `failForAudioInterruption()` (which ends in `.failed`) haptic suppression releases. A failed *arming* attempt conservatively keeps the flag until the session is stopped or re-armed (bounded by the voice sheet's lifetime).
  - `failForAudioInterruption()` now clears `isVoiceSessionActive` — a terminal path must release session-ownership bookkeeping.
- `AppState`
  - `responseHapticsMayUseCoreHaptics` gates the custom engine; `performResponseHapticEffects` (internal, pinned by tests) forwards it. Everything else about the haptic UX (preferences, patterns, cancellation, foreground suppression, UIKit fallbacks) is unchanged.
- `docs/superpowers/2026-08-12-voice-capture-session-*`
  - The #48 plan/spec now carry SUPERSEDED banners: the shared-session haptic binding is intentionally replaced by the unbound haptics-only engine + voice-liveness suppression strategy.

## TDD

Tests were committed first (red stage) and verified on the Mac build box: the policy assertion failed at runtime against the old policy, the suppression/counter tests failed to compile on the missing seam, and the interruption regressions failed with `hasLiveVoiceSession` stuck true. Green stage: 121 focused tests pass — Haptics (8), HapticsVoiceIsolation (6), ResponseHapticState (7), InteractionHaptics (5), plus the #141 coordinator/config/read-aloud/conversation suites unchanged (90).

Coverage pins:
1. **No shared-session binding, structurally**: the engine is constructed session-free only; the policy pins `playsHapticsOnly == true`; `Haptics.swift` has no `AVAudioSession`/`AVFAudio` references outside comments.
2. **Lifecycle functionality**: response start/tool/conclude effects still emitted with no voice-audio lease.
3. **Haptics disabled**: no emission and zero engine-creation requests.
4. **Degradation**: suppressed response start emits, falls back to UIKit, and makes zero engine-creation requests; an allowed response start requests the custom engine through the injected factory without touching hardware; a live voice session (including paused mic) suppresses; the `performResponseHapticEffects` forwarding seam is pinned end to end so reverting the production forwarding line fails the suite.
5. **Interruption regressions**: a terminal audio interruption during a normal conversation *or* a provider test terminates the operation, clears ownership flags, and releases haptic suppression even though the UI state remains `.failed`.
6. **Voice isolation**: response haptics leave the coordinator session mock untouched (zero category/activation calls, policy unchanged) with and without a live voice owner.

## Verification

- Mac build box: 121/121 focused tests above; #141 coordinator suites pass unchanged.
- Hosted CI: full matrix.

### Device verification checklist (physical media routing — not simulator-provable)

- **A. Typed chat + Spotify/Audible**: external audio playing → typed message → response streams (haptic fires) → tools → completion. Expected: media never stops or glitches.
- **B. Haptics disabled**: same flow with the preference off. Expected: no disturbance.
- **C. Voice Conversation**: run a voice turn; expected: capture, playback, and state remain healthy (custom haptics degrade to UIKit during the session).
- **D. Bluetooth/AirPods**: repeat voice capture on HFP; expected: no route changes or capture failures from haptic activity.
- **E. Read Aloud**: with external media playing, Read Aloud ducks/mixes per #141 and media recovers on finish; response haptics do not interfere with the coordinator-owned session.
- **#48 regression check**: Record ASR (Settings → Voice) immediately after a text response with haptics; expected: capture starts cleanly (no `-10868`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented response haptics from interfering with active voice conversations or provider tests.
  * Preserved UIKit haptic feedback when custom Core Haptics are unavailable or suppressed.
  * Prevented response haptics from activating or modifying the shared audio session.
  * Corrected voice-session cleanup after audio interruptions, allowing related features to resume normally.

* **Documentation**
  * Marked the previous shared audio-session haptics approach as superseded and documented the updated behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->