### PR TITLE
feat(setup): Repair Connection with explicit tested reconnect

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -769,6 +769,12 @@ final class AppState: ObservableObject {
     /// once by LoginView; never read by the connected composer banner, so a
     /// sign-in failure cannot resurface stale over a healthy session.
     @Published var pendingLoginFailure: ConnectionFailurePresentation?
+    /// Round 6: the classified failure of the most recent failed connection
+    /// attempt (saved-credential reconnect, repair activation, or a failed
+    /// explicit connect). Typed — never recovered from user-facing strings —
+    /// so Repair Connection can seed its routing from the actual problem.
+    /// Cleared by any successful connection and by explicit disconnect.
+    @Published private(set) var lastConnectionFailure: ConnectionFailure?
     @Published var showLogin = true
     @Published private(set) var composerPrefillText = ""
     @Published private(set) var composerPrefillToken = UUID()
@@ -2275,10 +2281,42 @@ final class AppState: ObservableObject {
               index + 1 < arguments.count else { return nil }
         return HermesConnection(baseUrl: arguments[index + 1], ticket: "ui-test-stub")
     }
+
+    /// UI-test-only FAILED-connection state (Round 6): a snapshot connection
+    /// with a surfaced, classified stable failure so the Repair Connection
+    /// entry is visible. Inert by construction under the same reconnect
+    /// suppression as the connected stub. `-CONDUIT_UI_TEST_FAILURE_KIND
+    /// none` retains no failure, so the repair entry opens straight on the
+    /// staged test.
+    private static func uiTestFailedConnectionStub() -> HermesConnection? {
+        let arguments = ProcessInfo.processInfo.arguments
+        guard let index = arguments.firstIndex(of: "-CONDUIT_UI_TEST_FAILED_CONNECTION"),
+              index + 1 < arguments.count else { return nil }
+        return HermesConnection(baseUrl: arguments[index + 1], ticket: "ui-test-stub")
+    }
+
+    private static func uiTestFailureKind() -> ConnectionFailure? {
+        let arguments = ProcessInfo.processInfo.arguments
+        guard let index = arguments.firstIndex(of: "-CONDUIT_UI_TEST_FAILURE_KIND"),
+              index + 1 < arguments.count else { return .hostNotFound }
+        return arguments[index + 1] == "none" ? nil : .hostNotFound
+    }
 #endif
 
     func loadSavedConnection() {
         #if DEBUG
+        if let stub = Self.uiTestFailedConnectionStub() {
+            let failureKind = Self.uiTestFailureKind()
+            lifecycleLog.notice("UI-test failed-connection stub active: repair surface visible, transport inert")
+            connection = stub
+            isConnected = false
+            isConnecting = false
+            turnState = .reconnecting
+            lastConnectionFailure = failureKind
+            errorMessage = "The connection to Hermes was lost. (UI test stub)"
+            showLogin = false
+            return
+        }
         if let stub = Self.uiTestConnectedStub() {
             lifecycleLog.notice("UI-test connected stub active: no transport will be created and reconnects are inert")
             connection = stub
@@ -2407,6 +2445,7 @@ final class AppState: ObservableObject {
             isConnecting = false
             // A fresh healthy session never inherits an older banner error.
             errorMessage = nil
+            lastConnectionFailure = nil
             reconnectAttempts = 0
             connectedAt = Date()
             KeychainHelper.saveConnection(conn)
@@ -2464,11 +2503,168 @@ final class AppState: ObservableObject {
             isConnected = false
             turnState = .reconnecting
             errorMessage = error.localizedDescription
+            // The typed classification is retained for Repair Connection's
+            // seeding and routing; the raw error never reaches the UI.
+            lastConnectionFailure = ConnectionFailureClassifier.classify(error)
             // Only an explicit dashboard 401/403 may return the user to the
             // sign-in screen. A transient gateway or WebKit startup failure
             // must retain the saved dashboard session and retry.
             showLogin = false
             scheduleReconnect(purpose: continuation.purpose)
+        }
+    }
+
+    // MARK: - Connection Repair (Round 6)
+
+    /// Builds the Repair seed from the configuration that actually failed:
+    /// the active (failed) connection's exact URL, safely available
+    /// credentials for it, and the origin-matched Cloudflare token. Nil when
+    /// there is no failed target to repair.
+    func makeConnectionRepairContext() -> ConnectionRepairContext? {
+        guard let failedURL = connection?.baseUrl else { return nil }
+        return repairContext(for: failedURL)
+    }
+
+    /// Repair seed for a failed SAVED-credential reconnect (login screen):
+    /// the failed target is the saved record's dashboard, and the record
+    /// itself — kept intact by the failure path — supplies the seed under
+    /// the normal seeding rules (a Face ID-protected record surrenders its
+    /// username only).
+    func makeSavedConnectionRepairContext() -> ConnectionRepairContext? {
+        guard let credentials = KeychainHelper.loadCredentials() else { return nil }
+        return repairContext(for: credentials.baseURL)
+    }
+
+    private func repairContext(for failedURL: String) -> ConnectionRepairContext {
+        let seeded = ConnectionSetupSeeding.wizardCredentials(
+            for: failedURL,
+            saved: KeychainHelper.loadCredentials()
+        )
+        return ConnectionRepairContext(
+            draft: ConnectionSetupDraft(
+                existingServerURL: failedURL,
+                username: seeded?.username ?? "",
+                password: seeded?.password ?? ""
+            ),
+            cloudflareAccess: KeychainHelper.loadCloudflareAccess(for: failedURL),
+            cloudflareOriginURL: failedURL,
+            failure: lastConnectionFailure
+        )
+    }
+
+    /// Entering Repair is an explicit user takeover of connection recovery:
+    /// outstanding automatic recovery — the scheduled reconnect timer, its
+    /// operations, and its automatic work — loses authority here, so a stale
+    /// automatic reconnect can never install a connection or select a
+    /// session over the user's explicit repair. Dismissal does not silently
+    /// restart the loop; the user is left in the stable disconnected state.
+    @discardableResult
+    func beginConnectionRepair() -> ConnectionRepairContext? {
+        guard let context = makeConnectionRepairContext() else { return nil }
+        cancelChatResumeTransportRecovery()
+        return context
+    }
+
+    /// The wizard's activation handler for the Repair entry: runs the
+    /// explicit reconnect through the authoritative connection path and
+    /// persists the tested configuration only after activation succeeds.
+    func connectionRepairActivationHandler(
+    ) -> (ConnectionRepairHandoff) async -> ConnectionRepairActivationOutcome {
+        let activator = AppStateConnectionRepairActivator(appState: self)
+        return { handoff in await activator.activate(handoff) }
+    }
+
+    /// The explicit repair activation behind Reconnect Now / Sign In to
+    /// Reconnect. Revokes outstanding automatic recovery authority first,
+    /// commits the validated transaction's cookies (native only — browser
+    /// sign-in publishes its own cookies through the AuthWebView flow), then
+    /// connects with `.preserveCurrent`: the server confirms the preserved
+    /// session identity, never automatic-return selection.
+    func performConnectionRepair(
+        _ handoff: ConnectionRepairHandoff
+    ) async -> ConnectionRepairActivationOutcome {
+        // The PRE-activation target anchors persistence: it decides whether
+        // the tested URL counts as changed (remember it) and whether the
+        // Cloudflare token needs a same-origin re-bind.
+        let failedTarget = connection?.baseUrl
+        cancelChatResumeTransportRecovery()
+        let outcome: ConnectionRepairActivationOutcome
+        switch handoff {
+        case .native(let candidate):
+            // The one-shot candidate is consumed here, whether activation
+            // succeeds or fails: its cookies are committed exactly once, and
+            // a failed activation requires a fresh test, never a retry of a
+            // spent transaction.
+            candidate.nativeConnection.commitCookies()
+            outcome = await activateRepairedConnection(with: HermesConnection(
+                baseUrl: candidate.configuration.serverURL,
+                ticket: candidate.nativeConnection.ticket
+            ))
+        case .browserSignIn(let ticket, let baseURL, _):
+            outcome = await activateRepairedConnection(with: HermesConnection(
+                baseUrl: baseURL,
+                ticket: ticket
+            ))
+        }
+        guard outcome == .activated else { return outcome }
+        persistActivatedRepair(handoff, failedTarget: failedTarget)
+        return outcome
+    }
+
+    /// The authoritative activation step. A test success is not a guarantee
+    /// the world is unchanged; if the websocket activation fails, the
+    /// failure is classified, the reconnect `connect` armed is cancelled (no
+    /// automatic retry), the remembered dashboard URL is restored, and the
+    /// caller stays in Repair.
+    private func activateRepairedConnection(
+        with conn: HermesConnection
+    ) async -> ConnectionRepairActivationOutcome {
+        // connect() remembers the URL it attempts by design; a FAILED
+        // activation must not move the remembered dashboard (the saved
+        // connection and credentials are untouched by the failure path
+        // already).
+        let rememberedURL = defaults.string(forKey: dashboardURLKey)
+        await connect(
+            with: conn,
+            profile: activeProfile,
+            syncPurpose: .preserveCurrent,
+            cancelsResumeRestoration: false
+        )
+        guard isConnected else {
+            if let rememberedURL { defaults.set(rememberedURL, forKey: dashboardURLKey) }
+            // connect() armed an automatic retry in its failure path; the
+            // explicit repair owns recovery, so the loop stays stopped until
+            // the user tests and reconnects again.
+            cancelChatResumeTransportRecovery()
+            return .failed(lastConnectionFailure ?? .unknown)
+        }
+        return .activated
+    }
+
+    /// Persists the tested configuration ONLY after successful activation.
+    /// Reuses the Round-5 apply plan (replace-never-create credentials,
+    /// same-origin Cloudflare rewrites) anchored at the failed target so a
+    /// changed URL is remembered and a path-only move re-binds the token.
+    private func persistActivatedRepair(
+        _ handoff: ConnectionRepairHandoff,
+        failedTarget: String?
+    ) {
+        switch handoff {
+        case .native(let candidate):
+            let anchor = failedTarget ?? candidate.configuration.serverURL
+            let plan = ConnectionSetupApplication.plan(
+                result: candidate.configuration,
+                currentDashboardURL: anchor,
+                savedCredentials: KeychainHelper.loadCredentials(),
+                savedCloudflareAccess: KeychainHelper.loadCloudflareAccess(for: anchor)
+            )
+            plan.perform(appState: self)
+        case .browserSignIn(_, let baseURL, _):
+            // Existing browser-auth semantics: no reusable password exists,
+            // stale native credentials are cleared, the activated dashboard
+            // is remembered, and same-origin Cloudflare rules are untouched.
+            rememberDashboardURL(baseURL)
+            KeychainHelper.clearCredentials()
         }
     }
 
@@ -2482,6 +2678,7 @@ final class AppState: ObservableObject {
         chatResumeRestorationRequest = nil
         invalidateReconciliation()
         cancelScenePhaseAttempt()
+        lastConnectionFailure = nil
         client?.disconnect()
         isConnected = false
         isConnecting = false
@@ -2602,16 +2799,18 @@ final class AppState: ObservableObject {
             authenticatedConnection.commitCookies()
             await connect(with: HermesConnection(baseUrl: credentials.baseURL, ticket: authenticatedConnection.ticket), profile: activeProfile)
         } catch is CancellationError {
-            // Intentional cancellation (e.g. a superseded connect) is not a
-            // login failure; fall back to the login screen silently.
+            // A superseded connect owns the flow from here; fall back to the
+            // login screen silently.
             showLogin = true
         } catch {
             // A rejected saved password falls back to the native login screen
             // without erasing it, allowing the user to correct the account.
             // The typed classified handoff replaces the old string write, so
             // the composer banner never inherits a stale sign-in message.
+            let failure = ConnectionFailureClassifier.classify(error)
+            lastConnectionFailure = failure
             showLogin = true
-            pendingLoginFailure = .presenting(ConnectionFailureClassifier.classify(error))
+            pendingLoginFailure = .presenting(failure)
         }
     }
 
@@ -4693,9 +4892,10 @@ final class AppState: ObservableObject {
 
     func reconnectForRetry(purpose requestedPurpose: ChatResumeSyncPurpose) async {
         #if DEBUG
-        // The UI-test stubbed session has no transport to restore; every
-        // automatic or explicit reconnect is a deterministic no-op for it.
-        guard Self.uiTestConnectedStub() == nil else { return }
+        // The UI-test stubbed sessions have no transport to restore; every
+        // automatic or explicit reconnect is a deterministic no-op for them.
+        guard Self.uiTestConnectedStub() == nil,
+              Self.uiTestFailedConnectionStub() == nil else { return }
         #endif
         guard let savedConnection = connection else { return }
         let purpose = beginChatResumeRecovery(purpose: requestedPurpose)
@@ -4789,6 +4989,9 @@ final class AppState: ObservableObject {
                     }
                 }
                 guard refreshTransportContinuation() else { return }
+                // The dashboard's session is gone (sign-in required): the
+                // typed classification routes Repair toward browser sign-in.
+                lastConnectionFailure = .loginRequired
                 requireSignIn(
                     failure: Self.silentRenewalSignInFailure(
                         reauthError: silentRenewalReauthError,
@@ -4800,6 +5003,7 @@ final class AppState: ObservableObject {
                 isConnected = false
                 isConnecting = false
                 turnState = .reconnecting
+                lastConnectionFailure = ConnectionFailureClassifier.classify(error)
                 errorMessage = "Failed to refresh the dashboard session: \(error.localizedDescription)"
                 scheduleReconnect(purpose: continuationPurpose)
             }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -5041,8 +5041,12 @@ final class AppState: ObservableObject {
                   let activeClient = self.client, activeClient === client else { return }
             isConnected = true
             isConnecting = false
-            // A fresh healthy session never inherits an older banner error.
+            // A fresh healthy session never inherits an older banner error —
+            // including the typed classification Repair Connection seeds
+            // from: a successful reconnect makes any previous failure stale,
+            // so a LATER unrelated failure must route repair from itself.
             errorMessage = nil
+            lastConnectionFailure = nil
             reconnectAttempts = 0
             connectedAt = Date()
             guard let continuation = await synchronizeTransportContinuation(

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -773,8 +773,10 @@ final class AppState: ObservableObject {
     /// attempt (saved-credential reconnect, repair activation, or a failed
     /// explicit connect). Typed — never recovered from user-facing strings —
     /// so Repair Connection can seed its routing from the actual problem.
-    /// Cleared by any successful connection and by explicit disconnect.
-    @Published private(set) var lastConnectionFailure: ConnectionFailure?
+    /// Cleared by any successful connection, by explicit disconnect, and
+    /// when the user starts a manual login (which abandons the prior
+    /// failure's repair context).
+    @Published var lastConnectionFailure: ConnectionFailure?
     @Published var showLogin = true
     @Published private(set) var composerPrefillText = ""
     @Published private(set) var composerPrefillToken = UUID()
@@ -2519,9 +2521,10 @@ final class AppState: ObservableObject {
     /// Builds the Repair seed from the configuration that actually failed:
     /// the active (failed) connection's exact URL, safely available
     /// credentials for it, and the origin-matched Cloudflare token. Nil when
-    /// there is no failed target to repair.
+    /// there is no failed target — a healthy connected session is never a
+    /// repair candidate.
     func makeConnectionRepairContext() -> ConnectionRepairContext? {
-        guard let failedURL = connection?.baseUrl else { return nil }
+        guard let failedURL = connection?.baseUrl, !isConnected else { return nil }
         return repairContext(for: failedURL)
     }
 
@@ -2550,6 +2553,17 @@ final class AppState: ObservableObject {
             cloudflareOriginURL: failedURL,
             failure: lastConnectionFailure
         )
+    }
+
+    /// Repair entry for a failed SAVED-credential reconnect (login screen).
+    /// Like the composer entry, this is an explicit user takeover: any
+    /// outstanding automatic recovery loses authority before the wizard
+    /// opens, so it can never install a connection underneath the repair.
+    @discardableResult
+    func beginSavedConnectionRepair() -> ConnectionRepairContext? {
+        guard let context = makeSavedConnectionRepairContext() else { return nil }
+        cancelChatResumeTransportRecovery()
+        return context
     }
 
     /// Entering Repair is an explicit user takeover of connection recovery:
@@ -2594,7 +2608,11 @@ final class AppState: ObservableObject {
             // The one-shot candidate is consumed here, whether activation
             // succeeds or fails: its cookies are committed exactly once, and
             // a failed activation requires a fresh test, never a retry of a
-            // spent transaction.
+            // spent transaction. If activation fails after the commit, the
+            // committed cookies belong to a genuinely authenticated session
+            // (login and ticket mint both succeeded first) — they are
+            // naturally superseded by the next explicit test or sign-in and
+            // are deliberately not rolled back.
             candidate.nativeConnection.commitCookies()
             outcome = await activateRepairedConnection(with: HermesConnection(
                 baseUrl: candidate.configuration.serverURL,

--- a/Conduit/Services/ConnectionFailure.swift
+++ b/Conduit/Services/ConnectionFailure.swift
@@ -198,6 +198,13 @@ enum ConnectionHelpDestination: Equatable, Hashable, Identifiable, CaseIterable 
     /// first-run readiness questions and seeds the wizard from the current
     /// configuration instead.
     case currentConnection
+    /// Round 6: the Repair entry for a failed existing connection. Distinct
+    /// from `.currentConnection` so Settings (things may be working) and
+    /// failure recovery (a connection actually failed) never share one
+    /// semantic: Repair seeds from the failed target, routes near the
+    /// classified problem, and owns the Reconnect Now / Sign In to
+    /// Reconnect actions.
+    case repairConnection
 
     var id: Self { self }
 }

--- a/Conduit/Services/ConnectionRepair.swift
+++ b/Conduit/Services/ConnectionRepair.swift
@@ -1,0 +1,126 @@
+//
+//  ConnectionRepair.swift
+//  Conduit
+//
+//  Round 6: the explicit Repair Connection flow's value types and its
+//  activation boundary. Repair reuses the Connection Setup wizard, probe,
+//  failure taxonomy, and the authoritative AppState connection path; this
+//  file only owns the small set of types that let a validated test result
+//  become an explicit reconnect WITHOUT widening access to secrets.
+//
+//  Security shape: a validated native transaction (ticket + transaction
+//  cookies) lives only inside ConnectionRepairCandidate — memory only,
+//  never logged, never persisted, never Equatable, absent from every debug
+//  description. It is invalidated by draft edits, newer test runs,
+//  cancellation, dismissal, and consumption; the wizard checks the same
+//  revision/generation that produced the staged success before use.
+//
+
+import Foundation
+
+/// The seed for a Repair Connection launch: the configuration that actually
+/// failed, plus everything safely available about it at the failure site.
+/// Built by AppState (or the login screen for a failed saved-credential
+/// reconnect); never reconstructed from strings.
+struct ConnectionRepairContext: Equatable, Identifiable {
+    let id = UUID()
+    /// The failed dashboard configuration, expert URL preserved exactly.
+    let draft: ConnectionSetupDraft
+    /// The origin-matched Cloudflare Access service token, inherited for the
+    /// probe only under the existing same-origin rules.
+    let cloudflareAccess: CloudflareAccessCredentials?
+    let cloudflareOriginURL: String
+    /// The classified failure that surfaced, when one was retained. Routes
+    /// the wizard's entry near the likely problem; never parsed from a
+    /// user-facing string.
+    let failure: ConnectionFailure?
+}
+
+/// Memory-only validated native authentication transaction produced by a
+/// successful staged test in Repair mode. Bound to the flow revision and
+/// generation that produced the staged success so a stale candidate can
+/// never reconnect a newer edited draft.
+struct ConnectionRepairCandidate {
+    let configuration: ConnectionSetupResult
+    let nativeConnection: NativeAuthConnection
+    let validatedRevision: Int
+    let generation: Int
+
+    /// The candidate is usable only while the flow still shows the staged
+    /// success at exactly the revision and generation that produced it.
+    /// Draft edits, newer runs, and cancellation all break one of the three.
+    func isCurrent(
+        hasCurrentSuccessfulTest: Bool,
+        testGeneration: Int,
+        testSucceededAtRevision: Int?
+    ) -> Bool {
+        hasCurrentSuccessfulTest
+            && generation == testGeneration
+            && validatedRevision == testSucceededAtRevision
+    }
+
+    var description: String { "ConnectionRepairCandidate(redacted)" }
+    var debugDescription: String { description }
+}
+
+/// The wizard's handoff on an explicit final Repair action. Reconnect Now
+/// and Sign In to Reconnect are the only connection-changing actions in
+/// Repair mode, and both are user-initiated.
+enum ConnectionRepairHandoff {
+    /// A validated native transaction from the staged test (Reconnect Now).
+    case native(ConnectionRepairCandidate)
+    /// A browser sign-in completed over the existing AuthWebView
+    /// (Sign In to Reconnect).
+    case browserSignIn(ticket: String, baseURL: String, configuration: ConnectionSetupResult)
+}
+
+/// The result of an explicit repair activation. Session identity questions
+/// (preserved vs. absent on the replacement endpoint) are owned by the
+/// existing `.preserveCurrent` sync machinery, not by this outcome.
+enum ConnectionRepairActivationOutcome: Equatable {
+    case activated
+    case failed(ConnectionFailure)
+}
+
+/// The activation boundary for Repair mode. Production wraps the
+/// authoritative AppState connection path; DEBUG UI tests script
+/// deterministic outcomes so no test touches a real websocket.
+@MainActor
+protocol ConnectionRepairActivating: AnyObject {
+    func activate(_ handoff: ConnectionRepairHandoff) async -> ConnectionRepairActivationOutcome
+}
+
+/// Production activation. `performConnectionRepair` revokes outstanding
+/// automatic recovery authority, commits the validated transaction's
+/// cookies, connects through the standard path with `.preserveCurrent`
+/// session semantics, and persists the tested configuration only after
+/// activation succeeds.
+@MainActor
+final class AppStateConnectionRepairActivator: ConnectionRepairActivating {
+    private unowned let appState: AppState
+
+    init(appState: AppState) {
+        self.appState = appState
+    }
+
+    func activate(_ handoff: ConnectionRepairHandoff) async -> ConnectionRepairActivationOutcome {
+        #if DEBUG
+        if let scripted = Self.scriptedActivationOutcome() { return scripted }
+        #endif
+        return await appState.performConnectionRepair(handoff)
+    }
+
+    #if DEBUG
+    /// UI-test-only scripted outcome (`-CONDUIT_REPAIR_ACTIVATION success`
+    /// or `transportFailure`). Scripted activations are fully inert: no
+    /// cookies, no AppState connection, no persistence.
+    private static func scriptedActivationOutcome() -> ConnectionRepairActivationOutcome? {
+        let arguments = ProcessInfo.processInfo.arguments
+        guard let index = arguments.firstIndex(of: "-CONDUIT_REPAIR_ACTIVATION"),
+              index + 1 < arguments.count else { return nil }
+        return arguments[index + 1] == "transportFailure"
+            ? .failed(.connectionRefused)
+            : .activated
+    }
+    #endif
+}

--- a/Conduit/Services/ConnectionRepair.swift
+++ b/Conduit/Services/ConnectionRepair.swift
@@ -40,7 +40,7 @@ struct ConnectionRepairContext: Equatable, Identifiable {
 /// successful staged test in Repair mode. Bound to the flow revision and
 /// generation that produced the staged success so a stale candidate can
 /// never reconnect a newer edited draft.
-struct ConnectionRepairCandidate {
+struct ConnectionRepairCandidate: CustomStringConvertible, CustomDebugStringConvertible {
     let configuration: ConnectionSetupResult
     let nativeConnection: NativeAuthConnection
     let validatedRevision: Int
@@ -59,6 +59,9 @@ struct ConnectionRepairCandidate {
             && validatedRevision == testSucceededAtRevision
     }
 
+    // Intentionally non-Equatable, and redacted against accidental
+    // interpolation or dump: the value carries an authenticated transaction
+    // (ticket + transaction cookies) and a password-bearing configuration.
     var description: String { "ConnectionRepairCandidate(redacted)" }
     var debugDescription: String { description }
 }
@@ -66,12 +69,35 @@ struct ConnectionRepairCandidate {
 /// The wizard's handoff on an explicit final Repair action. Reconnect Now
 /// and Sign In to Reconnect are the only connection-changing actions in
 /// Repair mode, and both are user-initiated.
-enum ConnectionRepairHandoff {
+enum ConnectionRepairHandoff: CustomStringConvertible, CustomDebugStringConvertible {
     /// A validated native transaction from the staged test (Reconnect Now).
     case native(ConnectionRepairCandidate)
     /// A browser sign-in completed over the existing AuthWebView
     /// (Sign In to Reconnect).
     case browserSignIn(ticket: String, baseURL: String, configuration: ConnectionSetupResult)
+
+    // Redacted: the native case carries a ticket-bearing transaction and the
+    // browser case a raw ticket.
+    var description: String { "ConnectionRepairHandoff(redacted)" }
+    var debugDescription: String { description }
+}
+
+/// Round 6: the Repair review's action model, built by ConnectionSetupView
+/// when the wizard runs in Repair mode. The view evaluates candidate
+/// currency; the form only renders states and forwards taps.
+struct ConnectionSetupRepairReview {
+    /// The staged test ended in the browser sign-in outcome — the final
+    /// action is Sign In to Reconnect, not Reconnect Now.
+    let isInteractive: Bool
+    /// A validated native transaction exists and is still current. Reconnect
+    /// Now requires it; a consumed candidate forces a fresh test.
+    let isCandidateAvailable: Bool
+    /// The classified failure of the last explicit activation attempt.
+    let activationFailure: ConnectionFailure?
+    let isActivating: Bool
+    let reconnectNow: () -> Void
+    let signInToReconnect: () -> Void
+    let testAgain: () -> Void
 }
 
 /// The result of an explicit repair activation. Session identity questions

--- a/Conduit/Services/ConnectionSetupFlow.swift
+++ b/Conduit/Services/ConnectionSetupFlow.swift
@@ -149,6 +149,9 @@ struct ConnectionSetupFlow: Equatable {
     private(set) var inheritedCloudflareOriginURL: String
     private(set) var validationError: ConnectionSetupValidationError?
     private let entry: ConnectionHelpDestination
+    /// Round 6 (Repair): the classified failure that surfaced at the failed
+    /// connection, used only to route the entry near the likely problem.
+    private let repairFailure: ConnectionFailure?
     /// The draft exactly as the wizard was seeded. The Settings
     /// current-connection entry compares against it so a tested-but-unchanged
     /// configuration can offer plain Done instead of an apply.
@@ -178,14 +181,16 @@ struct ConnectionSetupFlow: Equatable {
         entry: ConnectionHelpDestination = .start,
         draft: ConnectionSetupDraft = ConnectionSetupDraft(),
         inheritedCloudflareAccess: CloudflareAccessCredentials? = nil,
-        inheritedCloudflareOriginURL: String = ""
+        inheritedCloudflareOriginURL: String = "",
+        repairFailure: ConnectionFailure? = nil
     ) {
         self.entry = entry
+        self.repairFailure = repairFailure
         self.seededDraft = draft
         self.draft = draft
         self.inheritedCloudflareAccess = inheritedCloudflareAccess
         self.inheritedCloudflareOriginURL = inheritedCloudflareOriginURL
-        path = Self.initialPath(for: entry, draft: draft)
+        path = Self.initialPath(for: entry, draft: draft, repairFailure: repairFailure)
     }
 
     /// Failure-driven Round-1 destinations land at sensible parts of the
@@ -199,6 +204,36 @@ struct ConnectionSetupFlow: Equatable {
         case .tls: return .tlsTroubleshooting
         case .cloudflare: return .cloudflareTroubleshooting
         case .currentConnection: return .connectionDetails
+        case .repairConnection: return .connectionDetails
+        }
+    }
+
+    /// Round 6 (Repair): start near the classified problem, always with the
+    /// editable address one Back-step away. Deliberately not over-optimized —
+    /// the user can navigate Back and edit the address if the initial
+    /// diagnosis was wrong.
+    static func repairPath(for draft: ConnectionSetupDraft, failure: ConnectionFailure?) -> [ConnectionSetupStep] {
+        let details: [ConnectionSetupStep] = [.connectionDetails]
+        switch failure {
+        case .authenticationRejected:
+            return details + [.loginCredentials]
+        case .cloudflareTokenRejected:
+            return details + [.cloudflareTroubleshooting]
+        case .tlsUntrusted, .tlsBadDate, .tlsFailure:
+            return details + [.tlsTroubleshooting]
+        // Transport/dashboard/address problems and a password-login throttle
+        // all start at the address editor. A throttled login in particular
+        // must never route toward another login.
+        case .invalidAddress, .insecureTransport, .hostNotFound, .unreachable,
+             .connectionRefused, .timedOut, .offline, .rateLimited,
+             .dashboardUnavailable, .unexpectedServerResponse:
+            return details
+        // No strong diagnosis (or none retained): the seeded staged test is
+        // the diagnostic.
+        case .loginRequired, .sessionTicketFailure, .unknown, nil:
+            return (try? draft.testConfiguration()) != nil
+                ? details + [.connectionTest]
+                : details
         }
     }
 
@@ -223,7 +258,14 @@ struct ConnectionSetupFlow: Equatable {
     ///   credentials are present.
     /// * An address that cannot even be built falls back to the details
     ///   screen, which surfaces the validation.
-    static func initialPath(for destination: ConnectionHelpDestination, draft: ConnectionSetupDraft) -> [ConnectionSetupStep] {
+    static func initialPath(
+        for destination: ConnectionHelpDestination,
+        draft: ConnectionSetupDraft,
+        repairFailure: ConnectionFailure? = nil
+    ) -> [ConnectionSetupStep] {
+        if destination == .repairConnection {
+            return repairPath(for: draft, failure: repairFailure)
+        }
         guard destination == .currentConnection else {
             return [entryStep(for: destination)]
         }
@@ -240,6 +282,26 @@ struct ConnectionSetupFlow: Equatable {
     /// distinctions that would otherwise sound wrong to an already-connected
     /// user can be made without forking the wizard's wording.
     var enteredFromCurrentConnection: Bool { entry == .currentConnection }
+
+    /// Round 6: true for the Repair entry, which owns the context-specific
+    /// final actions (Reconnect Now / Sign In to Reconnect) and never the
+    /// login-form handoff or the Settings Done/apply paths.
+    var isRepairingConnection: Bool { entry == .repairConnection }
+
+    /// Round 6 (Repair): a consumed or failed reconnect attempt invalidates
+    /// the staged success that produced it — a fresh explicit test is
+    /// required before another reconnect. Pops Review so the test screen is
+    /// showing, with the same generation rotation as any other reset, so no
+    /// late event from the consumed run can resurrect it.
+    mutating func invalidateTestForRepairRetry() {
+        testGeneration += 1
+        testState = ConnectionSetupTestState()
+        testSucceededAtRevision = nil
+        validationError = nil
+        if step == .review {
+            path.removeLast()
+        }
+    }
 
     mutating func back() {
         guard canGoBack else { return }
@@ -314,13 +376,15 @@ struct ConnectionSetupFlow: Equatable {
 
     mutating func submitCredentials() {
         guard step == .loginCredentials else { return }
-        // The Settings current-connection entry may proceed with no
-        // credentials at all: an interactive-auth dashboard signs in through
-        // the browser, so empty fields are its normal shape — including when
-        // returning here after editing a failed test's address. LoginView
-        // entries keep the strict requirement; a first-run user must not
-        // spend a real server's login attempt on empty credentials.
-        let credentialsOptional = enteredFromCurrentConnection
+        // The Settings current-connection and Repair entries may proceed with
+        // no credentials at all: provider discovery decides the auth mode,
+        // and both contexts legitimately seed without credentials (a
+        // browser-auth deployment, or an active connection whose password is
+        // not saved). A missing-password stop is the supported partial
+        // outcome. LoginView entries keep the strict requirement; a
+        // first-run user must not spend a real server's login attempt on
+        // empty credentials.
+        let credentialsOptional = (enteredFromCurrentConnection || isRepairingConnection)
             && draft.username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             && draft.password.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         do {

--- a/Conduit/Services/ConnectionSetupTest.swift
+++ b/Conduit/Services/ConnectionSetupTest.swift
@@ -541,14 +541,14 @@ struct ConnectionSetupTestProbeStub: ConnectionSetupTesting {
         onEvent: @escaping (ConnectionSetupTestEvent) -> Void
     ) async -> ConnectionSetupTestAcquisition? {
         script.run(onEvent)
-        // Same-file construction: the stub's transaction carries an inert
-        // empty cookie set. Repair UI tests script the ACTIVATION outcome
+        // The stub's transaction is built through the DEBUG factory (inert
+        // empty cookie set). Repair UI tests script the ACTIVATION outcome
         // separately (`-CONDUIT_REPAIR_ACTIVATION`), so this transaction is
         // never committed by the stub itself.
         guard script == .success else { return nil }
         return ConnectionSetupTestAcquisition(
             configuration: result,
-            nativeConnection: NativeAuthConnection(ticket: "connection-setup-stub-ticket", cookies: [])
+            nativeConnection: .debugStub(ticket: "connection-setup-stub-ticket")
         )
     }
 }

--- a/Conduit/Services/ConnectionSetupTest.swift
+++ b/Conduit/Services/ConnectionSetupTest.swift
@@ -320,9 +320,13 @@ protocol ConnectionSetupTesting {
 /// successful staged test. The probe commits nothing itself:
 /// `commitCookies()` happens only when an explicit reconnect later promotes
 /// this acquisition into the active connection.
-struct ConnectionSetupTestAcquisition {
+struct ConnectionSetupTestAcquisition: CustomStringConvertible, CustomDebugStringConvertible {
     let configuration: ConnectionSetupResult
     let nativeConnection: NativeAuthConnection
+
+    // Redacted: the transaction carries a ticket and cookies.
+    var description: String { "ConnectionSetupTestAcquisition(redacted)" }
+    var debugDescription: String { description }
 }
 
 /// The production probe. Reuses `NativeAuthClient` unchanged for every

--- a/Conduit/Services/ConnectionSetupTest.swift
+++ b/Conduit/Services/ConnectionSetupTest.swift
@@ -20,8 +20,11 @@
 //  credentials ends in the supported `requiresCredentials` partial outcome —
 //  credential absence is not an authentication mode, and an empty-credential
 //  login is never sent. The probe commits nothing: no cookie store write, no
-//  Keychain, no AppState mutation, no websocket, no screen changes. The
-//  resulting ticket and transaction cookies are discarded here.
+//  Keychain, no AppState mutation, no websocket, no screen changes. A
+//  successful native test RETURNS the validated transaction memory-only
+//  (Round 6): Repair mode may promote it to an explicit reconnect, and the
+//  transaction's cookies reach the shared store only when that reconnect
+//  commits them.
 //
 
 import Foundation
@@ -155,6 +158,12 @@ struct ConnectionSetupTestState: Equatable {
     /// "connection ready" claim.
     static let credentialsRequiredMessage = "This dashboard uses username and password sign-in. "
         + "Enter your credentials to finish testing the connection."
+
+    /// Round 6 (Repair): the interactive-auth message in the Repair context,
+    /// where the next step is signing in over the existing AuthWebView —
+    /// not returning to the login screen.
+    static let repairInteractiveMessage = "This dashboard uses browser-based sign-in. "
+        + "Sign in now to reconnect to it."
 
     subscript(stage: ConnectionSetupTestStage) -> ConnectionSetupStageState {
         get {
@@ -293,11 +302,27 @@ struct ConnectionSetupTestRecoveryPlan: Equatable {
 /// every other wizard state mutation.
 @MainActor
 protocol ConnectionSetupTesting {
+    /// Runs the staged test, reporting progress through `onEvent`. A
+    /// successful NATIVE test also returns the validated transaction —
+    /// memory only, nothing committed — which Repair mode may promote into
+    /// an explicit reconnect candidate. Every diagnostic outcome returns
+    /// nil, and testing never commits cookies, writes Keychain, or touches
+    /// AppState.
+    @discardableResult
     func runTest(
         result: ConnectionSetupResult,
         cloudflareAccess: CloudflareAccessCredentials?,
         onEvent: @escaping (ConnectionSetupTestEvent) -> Void
-    ) async
+    ) async -> ConnectionSetupTestAcquisition?
+}
+
+/// Memory-only validated native authentication transaction from a
+/// successful staged test. The probe commits nothing itself:
+/// `commitCookies()` happens only when an explicit reconnect later promotes
+/// this acquisition into the active connection.
+struct ConnectionSetupTestAcquisition {
+    let configuration: ConnectionSetupResult
+    let nativeConnection: NativeAuthConnection
 }
 
 /// The production probe. Reuses `NativeAuthClient` unchanged for every
@@ -319,7 +344,7 @@ struct ConnectionSetupProbe: ConnectionSetupTesting {
         result: ConnectionSetupResult,
         cloudflareAccess: CloudflareAccessCredentials?,
         onEvent: @escaping (ConnectionSetupTestEvent) -> Void
-    ) async {
+    ) async -> ConnectionSetupTestAcquisition? {
         let client = NativeAuthClient(
             baseURL: result.serverURL,
             cloudflareAccess: cloudflareAccess,
@@ -336,19 +361,19 @@ struct ConnectionSetupProbe: ConnectionSetupTesting {
         do {
             discovery = try await client.authProviderDiscovery()
         } catch {
-            guard !Self.wasCancelled(error) else { return }
+            guard !Self.wasCancelled(error) else { return nil }
             if let authError = error as? AuthClientError {
                 if case .invalidURL = authError {
                     Self.reportFailure(.server, ConnectionFailureClassifier.classify(authError), to: onEvent)
-                    return
+                    return nil
                 }
                 onEvent(.succeeded(.server))
                 onEvent(.started(.dashboard))
                 Self.reportFailure(.dashboard, ConnectionFailureClassifier.classify(authError), to: onEvent)
-                return
+                return nil
             }
             Self.reportFailure(.server, ConnectionFailureClassifier.classify(error), to: onEvent)
-            return
+            return nil
         }
         onEvent(.succeeded(.server))
 
@@ -366,19 +391,19 @@ struct ConnectionSetupProbe: ConnectionSetupTesting {
             // identity plus the expected auth behavior — and reports the
             // supported terminal outcome. It stays side-effect-free: no
             // native login attempt, no ticket mint, no WebView, no
-            // cookie/Keychain writes. The actual sign-in happens in
-            // LoginView over the normal handoff.
+            // cookie/Keychain writes. The actual sign-in happens over the
+            // existing AuthWebView, never inside the probe.
             onEvent(.succeeded(.dashboard))
             onEvent(.started(.authentication))
             onEvent(.requiresInteractiveSignIn(.authentication))
-            return
+            return nil
         case .unrecognized:
             Self.reportFailure(.dashboard, .unexpectedServerResponse, to: onEvent)
-            return
+            return nil
         case .providers(let providers):
             guard HermesProviderCheck.supportsPassword(providers) else {
                 Self.reportFailure(.dashboard, .unexpectedServerResponse, to: onEvent)
-                return
+                return nil
             }
         }
         onEvent(.succeeded(.dashboard))
@@ -386,29 +411,31 @@ struct ConnectionSetupProbe: ConnectionSetupTesting {
         // Stage 3: the full native credential proof — password login plus
         // the ws-ticket mint that proves the session is actually usable.
         // This is the exact milestone normal login requires before it would
-        // commit cookies. The transaction (ticket + transaction cookies) is
-        // deliberately discarded: the test persists nothing and connects
-        // nothing.
+        // commit cookies. The transaction is RETURNED memory-only, never
+        // committed: the test persists nothing and connects nothing.
         //
         // A password-capable dashboard WITHOUT present credentials stops
         // here at the supported credentials-required outcome. Credential
-        // absence is not an authentication mode — it only means the Settings
-        // seed could not supply the secret — and an empty-credential login
-        // would be a real, rate-limited authentication attempt against a
+        // absence is not an authentication mode — it only means the seed
+        // could not supply the secret — and an empty-credential login would
+        // be a real, rate-limited authentication attempt against a
         // connection that may already be known to work.
         onEvent(.started(.authentication))
         guard result.hasUsableCredentials else {
             onEvent(.requiresCredentials(.authentication))
-            return
+            return nil
         }
         do {
-            // Deliberately discarded: commitCookies() is never called, so
-            // the transaction never reaches the shared cookie store.
-            _ = try await client.connect(username: result.username, password: result.password)
+            let authenticatedConnection = try await client.connect(username: result.username, password: result.password)
             onEvent(.succeeded(.authentication))
+            return ConnectionSetupTestAcquisition(
+                configuration: result,
+                nativeConnection: authenticatedConnection
+            )
         } catch {
-            guard !Self.wasCancelled(error) else { return }
+            guard !Self.wasCancelled(error) else { return nil }
             Self.reportFailure(.authentication, ConnectionFailureClassifier.classify(error), to: onEvent)
+            return nil
         }
     }
 
@@ -512,8 +539,17 @@ struct ConnectionSetupTestProbeStub: ConnectionSetupTesting {
         result: ConnectionSetupResult,
         cloudflareAccess: CloudflareAccessCredentials?,
         onEvent: @escaping (ConnectionSetupTestEvent) -> Void
-    ) async {
+    ) async -> ConnectionSetupTestAcquisition? {
         script.run(onEvent)
+        // Same-file construction: the stub's transaction carries an inert
+        // empty cookie set. Repair UI tests script the ACTIVATION outcome
+        // separately (`-CONDUIT_REPAIR_ACTIVATION`), so this transaction is
+        // never committed by the stub itself.
+        guard script == .success else { return nil }
+        return ConnectionSetupTestAcquisition(
+            configuration: result,
+            nativeConnection: NativeAuthConnection(ticket: "connection-setup-stub-ticket", cookies: [])
+        )
     }
 }
 #endif

--- a/Conduit/Services/NativeAuthClient.swift
+++ b/Conduit/Services/NativeAuthClient.swift
@@ -80,6 +80,17 @@ struct NativeAuthConnection {
     }
 }
 
+#if DEBUG
+extension NativeAuthConnection {
+    /// Test/UI-test construction only: an in-memory transaction with an
+    /// empty (inert) cookie set, for repair-flow seams that script a
+    /// validated test without a real login. Never shipped.
+    static func debugStub(ticket: String) -> NativeAuthConnection {
+        NativeAuthConnection(ticket: ticket, cookies: [])
+    }
+}
+#endif
+
 /// What provider discovery learned about a dashboard's sign-in modes. The
 /// two zero-provider shapes are deliberately different outcomes: an
 /// unauthenticated redirect to a sign-in page is the NORMAL interactive-auth

--- a/Conduit/Views/Components/ComposerBar.swift
+++ b/Conduit/Views/Components/ComposerBar.swift
@@ -393,18 +393,7 @@ struct ComposerBar: View {
         .animation(ConduitMotion.transition, value: action)
         .preferredColorScheme(appState.themePreference.colorScheme)
         .sheet(item: $repairContext) { context in
-            ConnectionSetupView(
-                initialDestination: .repairConnection,
-                initialDraft: context.draft,
-                initialCloudflareAccess: context.cloudflareAccess,
-                initialCloudflareOriginURL: context.cloudflareOriginURL,
-                repairFailure: context.failure,
-                onComplete: { _ in
-                    // Unreachable in Repair mode: the Review's final actions
-                    // are Reconnect Now / Sign In to Reconnect.
-                },
-                onRepair: appState.connectionRepairActivationHandler()
-            )
+            ConnectionRepairSetupSheet(context: context)
         }
     }
 
@@ -435,13 +424,15 @@ struct ComposerBar: View {
             }
 
             // Round 6: Repair Connection appears only once the connection is
-            // actually down AND a failed attempt has surfaced its error —
-            // never during normal automatic recovery, and never uninvited.
+            // actually down AND a failed attempt has surfaced — through the
+            // typed classified failure or the visible error banner — never
+            // during normal automatic recovery, and never uninvited.
             // Entering repair hands recovery authority to the user; the
             // automatic retry loop stays stopped until the repair reconnects
             // or the user retries manually.
             if appState.connection != nil, !appState.isConnected,
-               let error = appState.errorMessage, !error.isEmpty {
+               appState.lastConnectionFailure != nil
+                   || !(appState.errorMessage ?? "").isEmpty {
                 Button {
                     Haptics.light()
                     repairContext = appState.beginConnectionRepair()

--- a/Conduit/Views/Components/ComposerBar.swift
+++ b/Conduit/Views/Components/ComposerBar.swift
@@ -430,9 +430,10 @@ struct ComposerBar: View {
             // Entering repair hands recovery authority to the user; the
             // automatic retry loop stays stopped until the repair reconnects
             // or the user retries manually.
-            if appState.connection != nil, !appState.isConnected,
-               appState.lastConnectionFailure != nil
-                   || !(appState.errorMessage ?? "").isEmpty {
+            if appState.connection != nil,
+               !appState.isConnected,
+               (appState.lastConnectionFailure != nil
+                   || !(appState.errorMessage ?? "").isEmpty) {
                 Button {
                     Haptics.light()
                     repairContext = appState.beginConnectionRepair()

--- a/Conduit/Views/Components/ComposerBar.swift
+++ b/Conduit/Views/Components/ComposerBar.swift
@@ -40,6 +40,9 @@ struct ComposerBar: View {
     @State private var documentImportContext: AsyncAttachmentContext?
     @State private var attachmentGeneration: UInt64 = 0
     @State private var suppressNextTextChangeSuggestions = false
+    /// Round 6: non-nil presents the Repair Connection wizard seeded from
+    /// the failed connection.
+    @State private var repairContext: ConnectionRepairContext?
     /// Local, device-only input preference. Defaults to off so existing
     /// users keep Return inserting a newline after updating.
     @AppStorage(ComposerReturnKey.preferenceKey) private var returnKeySends = false
@@ -389,6 +392,20 @@ struct ComposerBar: View {
         .opacity(appState.turnState == .unsupportedGateway ? 0.7 : 1)
         .animation(ConduitMotion.transition, value: action)
         .preferredColorScheme(appState.themePreference.colorScheme)
+        .sheet(item: $repairContext) { context in
+            ConnectionSetupView(
+                initialDestination: .repairConnection,
+                initialDraft: context.draft,
+                initialCloudflareAccess: context.cloudflareAccess,
+                initialCloudflareOriginURL: context.cloudflareOriginURL,
+                repairFailure: context.failure,
+                onComplete: { _ in
+                    // Unreachable in Repair mode: the Review's final actions
+                    // are Reconnect Now / Sign In to Reconnect.
+                },
+                onRepair: appState.connectionRepairActivationHandler()
+            )
+        }
     }
 
     @ViewBuilder
@@ -415,6 +432,30 @@ struct ComposerBar: View {
                     .font(.caption)
                     .foregroundStyle(.red)
                     .fixedSize(horizontal: false, vertical: true)
+            }
+
+            // Round 6: Repair Connection appears only once the connection is
+            // actually down AND a failed attempt has surfaced its error —
+            // never during normal automatic recovery, and never uninvited.
+            // Entering repair hands recovery authority to the user; the
+            // automatic retry loop stays stopped until the repair reconnects
+            // or the user retries manually.
+            if appState.connection != nil, !appState.isConnected,
+               let error = appState.errorMessage, !error.isEmpty {
+                Button {
+                    Haptics.light()
+                    repairContext = appState.beginConnectionRepair()
+                } label: {
+                    Label("Repair Connection", systemImage: "wrench.and.screwdriver")
+                        .font(.footnote.weight(.semibold))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 34)
+                }
+                .buttonStyle(.bordered)
+                .tint(.conduitAccent)
+                .accessibilityIdentifier("composer.repair-connection")
+                .accessibilityLabel("Repair Connection")
+                .accessibilityHint("Test and fix the failed connection, then reconnect")
             }
         }
         .padding(.horizontal, 14)

--- a/Conduit/Views/ConnectionSetupForm.swift
+++ b/Conduit/Views/ConnectionSetupForm.swift
@@ -151,8 +151,9 @@ struct ConnectionSetupForm: View {
         VStack(alignment: .leading, spacing: 18) {
             Text("Test connection").font(.title2.weight(.semibold))
             // Entries that skipped the details form (the Settings
-            // current-connection entry) still show what is being tested.
-            if flow.enteredFromCurrentConnection,
+            // current-connection and Repair entries) still show what is
+            // being tested.
+            if (flow.enteredFromCurrentConnection || flow.isRepairingConnection),
                let address = try? ConnectionSetupAddressBuilder.build(flow.draft) {
                 Text(address).font(.subheadline).textSelection(.enabled)
                     .accessibilityIdentifier("setup.address-preview")

--- a/Conduit/Views/ConnectionSetupForm.swift
+++ b/Conduit/Views/ConnectionSetupForm.swift
@@ -258,6 +258,10 @@ struct ConnectionSetupForm: View {
                         .font(.headline)
                         .fixedSize(horizontal: false, vertical: true)
                         .accessibilityIdentifier("setup.test.interactive-ready")
+                } else if repairReview?.activationFailure != nil {
+                    // Repair: the explicit reconnect failed after a verified
+                    // test. The failure text below carries the meaning — the
+                    // "ready to use" headline would contradict it.
                 } else {
                     Text(ConnectionSetupTestState.readyMessage)
                         .font(.headline)

--- a/Conduit/Views/ConnectionSetupForm.swift
+++ b/Conduit/Views/ConnectionSetupForm.swift
@@ -1,10 +1,32 @@
 import SwiftUI
 
+/// Round 6: the Repair review's action model, built by ConnectionSetupView
+/// when the wizard runs in Repair mode. The view evaluates candidate
+/// currency; the form only renders states and forwards taps.
+struct ConnectionSetupRepairReview {
+    /// The staged test ended in the browser sign-in outcome — the final
+    /// action is Sign In to Reconnect, not Reconnect Now.
+    let isInteractive: Bool
+    /// A validated native transaction exists and is still current. Reconnect
+    /// Now requires it; a consumed candidate forces a fresh test.
+    let isCandidateAvailable: Bool
+    /// The classified failure of the last explicit activation attempt.
+    let activationFailure: ConnectionFailure?
+    let isActivating: Bool
+    let reconnectNow: () -> Void
+    let signInToReconnect: () -> Void
+    let testAgain: () -> Void
+}
+
 /// Form rendering only: navigation and final validation stay in the flow.
 struct ConnectionSetupForm: View {
     @Binding var flow: ConnectionSetupFlow
     let onStartTest: () -> Void
     let onComplete: (ConnectionSetupResult) -> Void
+    /// Round 6: non-nil only in Repair mode, where the Review's final
+    /// actions are Reconnect Now / Sign In to Reconnect instead of the
+    /// login-form handoff or the Settings Done/apply paths.
+    let repairReview: ConnectionSetupRepairReview?
     @FocusState private var focusedField: Field?
 
     private enum Field: Hashable { case host, port, url, username, password }
@@ -247,7 +269,9 @@ struct ConnectionSetupForm: View {
                 if flow.testState.requiresInteractiveSignIn {
                     // The user has NOT authenticated: say what happens next
                     // instead of claiming success. Never "Login successful".
-                    Text(ConnectionSetupTestState.interactiveReadyMessage)
+                    Text(flow.isRepairingConnection
+                         ? ConnectionSetupTestState.repairInteractiveMessage
+                         : ConnectionSetupTestState.interactiveReadyMessage)
                         .font(.headline)
                         .fixedSize(horizontal: false, vertical: true)
                         .accessibilityIdentifier("setup.test.interactive-ready")
@@ -260,19 +284,65 @@ struct ConnectionSetupForm: View {
             // Revalidate for rendering only: a draft that stopped validating
             // after reaching Review must never silently blank the card.
             reviewContent
-            Text(flow.enteredFromCurrentConnection
-                 ? "Applying saves these settings for your next reconnect. Your current session stays connected."
-                 : "These settings will fill the login form. You’ll tap Connect there when you’re ready.")
-                .foregroundStyle(.secondary)
-            validationNotice
-            // From Settings with unchanged, successfully tested settings
-            // there is nothing to apply — Done simply closes the wizard.
-            Button(flow.testedSettingsUnchanged ? "Done" : "Use these settings") {
-                if let result = flow.complete() { onComplete(result) }
+            if let repair = repairReview {
+                repairReviewFooter(repair)
+            } else {
+                Text(flow.enteredFromCurrentConnection
+                     ? "Applying saves these settings for your next reconnect. Your current session stays connected."
+                     : "These settings will fill the login form. You’ll tap Connect there when you’re ready.")
+                    .foregroundStyle(.secondary)
+                validationNotice
+                // From Settings with unchanged, successfully tested settings
+                // there is nothing to apply — Done simply closes the wizard.
+                Button(flow.testedSettingsUnchanged ? "Done" : "Use these settings") {
+                    if let result = flow.complete() { onComplete(result) }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!reviewIsValid)
+                .accessibilityIdentifier("setup.use-settings")
             }
-            .buttonStyle(.borderedProminent)
-            .disabled(!reviewIsValid)
-            .accessibilityIdentifier("setup.use-settings")
+        }
+    }
+
+    /// Round 6: the Repair review's final actions. Reconnect Now requires a
+    /// current validated candidate (a consumed one forces a fresh test);
+    /// Sign In to Reconnect opens the existing AuthWebView; an activation
+    /// failure is shown classified with the explicit next step. Never an
+    /// automatic retry, never an automatic reconnection.
+    @ViewBuilder
+    private func repairReviewFooter(_ repair: ConnectionSetupRepairReview) -> some View {
+        if repair.isActivating {
+            HStack(spacing: 8) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Reconnecting…")
+                    .font(.headline)
+            }
+            .accessibilityIdentifier("setup.review.reconnecting")
+        } else {
+            if let failure = repair.activationFailure {
+                Text(failure.userMessage)
+                    .font(.subheadline)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("setup.review.reconnect-failure")
+            }
+            if repair.isInteractive {
+                Button("Sign In to Reconnect") { repair.signInToReconnect() }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.conduitAccent)
+                    .accessibilityIdentifier("setup.review.sign-in-reconnect")
+            } else if repair.isCandidateAvailable {
+                Button("Reconnect Now") { repair.reconnectNow() }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.conduitAccent)
+                    .accessibilityIdentifier("setup.review.reconnect-now")
+            } else {
+                Button("Test Connection Again") { repair.testAgain() }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.conduitAccent)
+                    .accessibilityIdentifier("setup.review.test-again")
+            }
         }
     }
 

--- a/Conduit/Views/ConnectionSetupForm.swift
+++ b/Conduit/Views/ConnectionSetupForm.swift
@@ -1,23 +1,5 @@
 import SwiftUI
 
-/// Round 6: the Repair review's action model, built by ConnectionSetupView
-/// when the wizard runs in Repair mode. The view evaluates candidate
-/// currency; the form only renders states and forwards taps.
-struct ConnectionSetupRepairReview {
-    /// The staged test ended in the browser sign-in outcome — the final
-    /// action is Sign In to Reconnect, not Reconnect Now.
-    let isInteractive: Bool
-    /// A validated native transaction exists and is still current. Reconnect
-    /// Now requires it; a consumed candidate forces a fresh test.
-    let isCandidateAvailable: Bool
-    /// The classified failure of the last explicit activation attempt.
-    let activationFailure: ConnectionFailure?
-    let isActivating: Bool
-    let reconnectNow: () -> Void
-    let signInToReconnect: () -> Void
-    let testAgain: () -> Void
-}
-
 /// Form rendering only: navigation and final validation stay in the flow.
 struct ConnectionSetupForm: View {
     @Binding var flow: ConnectionSetupFlow

--- a/Conduit/Views/ConnectionSetupView.swift
+++ b/Conduit/Views/ConnectionSetupView.swift
@@ -25,7 +25,20 @@ struct ConnectionSetupView: View {
     /// by the flow's generation guard, so correctness never relies on view
     /// destruction.
     @State private var testTask: Task<Void, Never>?
+    /// Round 6 (Repair): the memory-only validated native transaction from
+    /// the current successful test, bound to the revision/generation that
+    /// produced it. One-shot: consumed by Reconnect Now whether activation
+    /// succeeds or fails, and invalidated by edits, newer runs, and
+    /// cancellation. Never logged, never persisted.
+    @State private var repairCandidate: ConnectionRepairCandidate?
+    @State private var isActivating = false
+    @State private var activationFailure: ConnectionFailure?
+    @State private var showRepairSignIn = false
+    @State private var repairSignInConfiguration: ConnectionSetupResult?
     private let onComplete: (ConnectionSetupResult) -> Void
+    /// Round 6 (Repair): the explicit activation boundary. Nil outside
+    /// Repair mode, in which case the Review shows its normal context action.
+    private let onRepair: ((ConnectionRepairHandoff) async -> ConnectionRepairActivationOutcome)?
     private let prober: any ConnectionSetupTesting
 
     init(
@@ -33,15 +46,19 @@ struct ConnectionSetupView: View {
         initialDraft: ConnectionSetupDraft = ConnectionSetupDraft(),
         initialCloudflareAccess: CloudflareAccessCredentials? = nil,
         initialCloudflareOriginURL: String = "",
-        onComplete: @escaping (ConnectionSetupResult) -> Void
+        repairFailure: ConnectionFailure? = nil,
+        onComplete: @escaping (ConnectionSetupResult) -> Void,
+        onRepair: ((ConnectionRepairHandoff) async -> ConnectionRepairActivationOutcome)? = nil
     ) {
         _flow = State(initialValue: ConnectionSetupFlow(
             entry: initialDestination,
             draft: initialDraft,
             inheritedCloudflareAccess: initialCloudflareAccess,
-            inheritedCloudflareOriginURL: initialCloudflareOriginURL
+            inheritedCloudflareOriginURL: initialCloudflareOriginURL,
+            repairFailure: repairFailure
         ))
         self.onComplete = onComplete
+        self.onRepair = onRepair
         self.prober = Self.makeProber()
     }
 
@@ -57,10 +74,15 @@ struct ConnectionSetupView: View {
             Group {
                 switch flow.step {
                 case .connectionDetails, .loginCredentials, .connectionTest, .review:
-                    ConnectionSetupForm(flow: $flow, onStartTest: { startTestRun() }) { result in
-                        onComplete(result)
-                        dismiss()
-                    }
+                    ConnectionSetupForm(
+                        flow: $flow,
+                        onStartTest: { startTestRun() },
+                        onComplete: { result in
+                            onComplete(result)
+                            dismiss()
+                        },
+                        repairReview: repairReview
+                    )
                 default:
                     ScrollView {
                         content
@@ -95,6 +117,117 @@ struct ConnectionSetupView: View {
                         .accessibilityIdentifier("connection-setup.done")
                 }
             }
+            .sheet(isPresented: $showRepairSignIn) {
+                repairSignInSheet
+            }
+        }
+    }
+
+    /// The Repair review's action model, nil outside Repair mode. The
+    /// candidate's currency is evaluated here — the flow's staged success
+    /// must still be current at exactly the revision and generation that
+    /// produced the candidate.
+    private var repairReview: ConnectionSetupRepairReview? {
+        guard flow.isRepairingConnection, onRepair != nil else { return nil }
+        let candidateCurrent = repairCandidate?.isCurrent(
+            hasCurrentSuccessfulTest: flow.hasCurrentSuccessfulTest,
+            testGeneration: flow.testGeneration,
+            testSucceededAtRevision: flow.testSucceededAtRevision
+        ) ?? false
+        return ConnectionSetupRepairReview(
+            isInteractive: flow.testState.requiresInteractiveSignIn,
+            isCandidateAvailable: candidateCurrent,
+            activationFailure: activationFailure,
+            isActivating: isActivating,
+            reconnectNow: { reconnectNow() },
+            signInToReconnect: { beginRepairSignIn() },
+            testAgain: { testAgainAfterFailedActivation() }
+        )
+    }
+
+    /// The existing AuthWebView, pointed at the tested address with the
+    /// wizard's same-origin Cloudflare state. The probe never hosts a
+    /// WebView; sign-in happens only on this explicit action.
+    @ViewBuilder
+    private var repairSignInSheet: some View {
+        if let configuration = repairSignInConfiguration {
+            AuthWebView(
+                url: configuration.serverURL,
+                cloudflareAccess: flow.cloudflareAccessForDraft(),
+                onTicket: { ticket, baseURL in
+                    Task { @MainActor in
+                        showRepairSignIn = false
+                        await activate(.browserSignIn(
+                            ticket: ticket,
+                            baseURL: baseURL,
+                            configuration: configuration
+                        ))
+                    }
+                },
+                onError: { classifiedFailure, _ in
+                    showRepairSignIn = false
+                    // Sign-in failure consumed no transaction: the user may
+                    // retry sign-in directly, without re-testing.
+                    activationFailure = classifiedFailure
+                }
+            )
+        } else {
+            // Unreachable: the sheet is only presented with a configuration.
+            Color.clear.onAppear { showRepairSignIn = false }
+        }
+    }
+
+    // MARK: - Repair activation (Round 6)
+
+    private func reconnectNow() {
+        guard !isActivating,
+              let candidate = repairCandidate,
+              candidate.isCurrent(
+                hasCurrentSuccessfulTest: flow.hasCurrentSuccessfulTest,
+                testGeneration: flow.testGeneration,
+                testSucceededAtRevision: flow.testSucceededAtRevision
+              ),
+              let onRepair else { return }
+        // The candidate is one-shot: consumed here, whether activation
+        // succeeds or fails. A failed activation requires a fresh test.
+        repairCandidate = nil
+        Task { @MainActor in
+            await activate(.native(candidate))
+        }
+    }
+
+    private func beginRepairSignIn() {
+        guard !isActivating, flow.canUseSettings, onRepair != nil else { return }
+        guard let result = flow.complete() else { return }
+        repairSignInConfiguration = result
+        showRepairSignIn = true
+    }
+
+    private func testAgainAfterFailedActivation() {
+        activationFailure = nil
+        flow.invalidateTestForRepairRetry()
+    }
+
+    private func activate(_ handoff: ConnectionRepairHandoff) async {
+        guard let onRepair else { return }
+        activationFailure = nil
+        isActivating = true
+        let outcome = await onRepair(handoff)
+        isActivating = false
+        switch outcome {
+        case .activated:
+            UIAccessibility.post(
+                notification: .announcement,
+                argument: "Reconnected to Hermes."
+            )
+            dismiss()
+        case .failed(let failure):
+            UIAccessibility.post(
+                notification: .announcement,
+                argument: failure.userTitle
+            )
+            activationFailure = failure
+            flow.invalidateTestForRepairRetry()
         }
     }
 
@@ -111,7 +244,7 @@ struct ConnectionSetupView: View {
         let flow = $flow
         testTask?.cancel()
         testTask = Task { @MainActor in
-            await prober.runTest(result: run, cloudflareAccess: access, onEvent: { event in
+            let acquisition = await prober.runTest(result: run, cloudflareAccess: access, onEvent: { event in
                 // Announce only events the model actually applied — dropped
                 // stale events never speak.
                 guard flow.wrappedValue.applyTestEvent(event, generation: generation) else { return }
@@ -139,12 +272,30 @@ struct ConnectionSetupView: View {
                     break
                 }
             })
+            // Round 6 (Repair): promote the validated transaction into the
+            // reconnect candidate ONLY while the flow still shows the staged
+            // success this run produced — a superseded or cancelled run's
+            // acquisition is dropped, exactly like its late events.
+            guard let acquisition,
+                  !Task.isCancelled,
+                  flow.wrappedValue.hasCurrentSuccessfulTest,
+                  flow.wrappedValue.testGeneration == generation else { return }
+            repairCandidate = ConnectionRepairCandidate(
+                configuration: acquisition.configuration,
+                nativeConnection: acquisition.nativeConnection,
+                validatedRevision: flow.wrappedValue.testSucceededAtRevision ?? 0,
+                generation: generation
+            )
         }
     }
 
     private func stopTestRun() {
         testTask?.cancel()
         testTask = nil
+        // Leaving the test step resets the staged state; the candidate is
+        // invalidated with it (new runs and cancellation rotate the
+        // generation regardless — correctness never relies on this nil).
+        repairCandidate = nil
         flow.cancelTest()
     }
 
@@ -614,6 +765,7 @@ extension ConnectionHelpDestination {
         case .tls: return "HTTPS & certificates"
         case .cloudflare: return "Cloudflare Access"
         case .currentConnection: return "Current connection"
+        case .repairConnection: return "Repair connection"
         }
     }
 
@@ -637,7 +789,7 @@ extension ConnectionHelpDestination {
                 "Make sure a Service Auth policy allows that token to reach this Access application.",
                 "Or turn off \"Use Cloudflare Access service token\" to sign in interactively through the in-app browser."
             ]
-        case .start, .dashboard, .credentials, .network, .currentConnection:
+        case .start, .dashboard, .credentials, .network, .currentConnection, .repairConnection:
             return []
         }
     }

--- a/Conduit/Views/ConnectionSetupView.swift
+++ b/Conduit/Views/ConnectionSetupView.swift
@@ -16,6 +16,32 @@
 import SwiftUI
 import UIKit
 
+// MARK: - Round-6 Repair sheet
+
+/// The shared Repair-mode presentation used by every failure surface (the
+/// composer banner and the login card), so seeding, the intentionally
+/// unreachable login handoff, and the activation handler cannot drift
+/// between them.
+struct ConnectionRepairSetupSheet: View {
+    let context: ConnectionRepairContext
+    @EnvironmentObject private var appState: AppState
+
+    var body: some View {
+        ConnectionSetupView(
+            initialDestination: .repairConnection,
+            initialDraft: context.draft,
+            initialCloudflareAccess: context.cloudflareAccess,
+            initialCloudflareOriginURL: context.cloudflareOriginURL,
+            repairFailure: context.failure,
+            onComplete: { _ in
+                // Unreachable in Repair mode: the Review's final actions are
+                // Reconnect Now / Sign In to Reconnect.
+            },
+            onRepair: appState.connectionRepairActivationHandler()
+        )
+    }
+}
+
 struct ConnectionSetupView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var flow: ConnectionSetupFlow
@@ -226,8 +252,11 @@ struct ConnectionSetupView: View {
                 notification: .announcement,
                 argument: failure.userTitle
             )
+            // Stay on Review: the candidate is consumed (Reconnect Now can
+            // neither re-fire nor be retried automatically), and the footer
+            // renders the classified failure with Test Connection Again —
+            // which invalidates the staged result only when the user asks.
             activationFailure = failure
-            flow.invalidateTestForRepairRetry()
         }
     }
 
@@ -236,7 +265,9 @@ struct ConnectionSetupView: View {
     private func startTestRun() {
         // Credentials are optional here: provider discovery decides whether a
         // password applies, so an interactive-auth dashboard is testable
-        // without typing one first.
+        // without typing one first. A fresh run also clears the spent
+        // activation failure of any previous reconnect attempt.
+        activationFailure = nil
         guard let run = try? flow.draft.testConfiguration(),
               let generation = flow.beginTest() else { return }
         let access = flow.cloudflareAccessForDraft()
@@ -292,11 +323,15 @@ struct ConnectionSetupView: View {
     private func stopTestRun() {
         testTask?.cancel()
         testTask = nil
-        // Leaving the test step resets the staged state; the candidate is
-        // invalidated with it (new runs and cancellation rotate the
-        // generation regardless — correctness never relies on this nil).
-        repairCandidate = nil
+        // Leaving the test step resets RUNNING work. A sealed success (and
+        // its candidate) survives non-editing Back/forward walks — the
+        // candidate's currency is still enforced at use time — so the view
+        // and the flow model never disagree about whether a test is current.
+        let wasRunning = flow.testState.isRunning
         flow.cancelTest()
+        if wasRunning {
+            repairCandidate = nil
+        }
     }
 
     // MARK: - Step routing

--- a/Conduit/Views/LoginView.swift
+++ b/Conduit/Views/LoginView.swift
@@ -33,6 +33,9 @@ struct LoginView: View {
     /// Non-nil presents the Connection Setup shell, pre-seeded with the
     /// classified help destination (or `.start` from the entry point).
     @State private var connectionSetupDestination: ConnectionHelpDestination?
+    /// Round 6: non-nil presents Repair Connection, seeded from the failed
+    /// saved-credential reconnect.
+    @State private var connectionRepairContext: ConnectionRepairContext?
     /// Set only by the user's Cloudflare toggle (never by the onAppear
     /// Keychain restore), so a returning saved-token user is not scrolled
     /// away from the top of the form every time the login screen appears.
@@ -137,6 +140,20 @@ struct LoginView: View {
                 failure = nil
                 focusedField = nil
             }
+        }
+        .sheet(item: $connectionRepairContext) { context in
+            ConnectionSetupView(
+                initialDestination: .repairConnection,
+                initialDraft: context.draft,
+                initialCloudflareAccess: context.cloudflareAccess,
+                initialCloudflareOriginURL: context.cloudflareOriginURL,
+                repairFailure: context.failure,
+                onComplete: { _ in
+                    // Unreachable in Repair mode: the Review's final actions
+                    // are Reconnect Now / Sign In to Reconnect.
+                },
+                onRepair: appState.connectionRepairActivationHandler()
+            )
         }
         .sheet(isPresented: $showWebView) {
             AuthWebView(
@@ -368,6 +385,16 @@ struct LoginView: View {
                                         connectionSetupDestination = destination
                                     }
                                     .accessibilityIdentifier("login.error.troubleshoot")
+                                }
+
+                                // Round 6: a failed saved-credential reconnect
+                                // is a failed EXISTING connection — offer the
+                                // repair flow seeded from that record.
+                                if appState.makeSavedConnectionRepairContext() != nil {
+                                    Button("Repair Connection") {
+                                        connectionRepairContext = appState.makeSavedConnectionRepairContext()
+                                    }
+                                    .accessibilityIdentifier("login.repair-connection")
                                 }
                             }
                             .font(.footnote.weight(.semibold))

--- a/Conduit/Views/LoginView.swift
+++ b/Conduit/Views/LoginView.swift
@@ -36,6 +36,10 @@ struct LoginView: View {
     /// Round 6: non-nil presents Repair Connection, seeded from the failed
     /// saved-credential reconnect.
     @State private var connectionRepairContext: ConnectionRepairContext?
+    /// Whether a repairable saved connection exists, computed once when a
+    /// failure is presented (pure reads in `body`; the takeover happens at
+    /// tap time).
+    @State private var savedRepairAvailable = false
     /// Set only by the user's Cloudflare toggle (never by the onAppear
     /// Keychain restore), so a returning saved-token user is not scrolled
     /// away from the top of the form every time the login screen appears.
@@ -106,6 +110,7 @@ struct LoginView: View {
             // both orderings are covered. Consume once.
             guard let pending else { return }
             failure = pending
+            savedRepairAvailable = appState.makeSavedConnectionRepairContext() != nil
             appState.pendingLoginFailure = nil
         }
         .sheet(item: $connectionSetupDestination) { destination in
@@ -142,18 +147,7 @@ struct LoginView: View {
             }
         }
         .sheet(item: $connectionRepairContext) { context in
-            ConnectionSetupView(
-                initialDestination: .repairConnection,
-                initialDraft: context.draft,
-                initialCloudflareAccess: context.cloudflareAccess,
-                initialCloudflareOriginURL: context.cloudflareOriginURL,
-                repairFailure: context.failure,
-                onComplete: { _ in
-                    // Unreachable in Repair mode: the Review's final actions
-                    // are Reconnect Now / Sign In to Reconnect.
-                },
-                onRepair: appState.connectionRepairActivationHandler()
-            )
+            ConnectionRepairSetupSheet(context: context)
         }
         .sheet(isPresented: $showWebView) {
             AuthWebView(
@@ -387,12 +381,16 @@ struct LoginView: View {
                                     .accessibilityIdentifier("login.error.troubleshoot")
                                 }
 
-                                // Round 6: a failed saved-credential reconnect
+                                // Round 6: a failed SAVED-credential reconnect
                                 // is a failed EXISTING connection — offer the
-                                // repair flow seeded from that record.
-                                if appState.makeSavedConnectionRepairContext() != nil {
+                                // repair flow seeded from that record. The
+                                // typed failure proves provenance (manual
+                                // login failures never set it), and entering
+                                // repair revokes any outstanding automatic
+                                // recovery authority.
+                                if savedRepairAvailable, appState.lastConnectionFailure != nil {
                                     Button("Repair Connection") {
-                                        connectionRepairContext = appState.makeSavedConnectionRepairContext()
+                                        connectionRepairContext = appState.beginSavedConnectionRepair()
                                     }
                                     .accessibilityIdentifier("login.repair-connection")
                                 }
@@ -461,6 +459,10 @@ struct LoginView: View {
         // the return-key chain also reach this method: never let a second
         // auth sequence run concurrently (Hermes throttles password login).
         guard !isConnecting else { return }
+        // A manual login attempt abandons any prior existing-connection
+        // failure context: Repair Connection is for the connection that
+        // actually failed, not for whatever the user is typing now.
+        appState.lastConnectionFailure = nil
         let cleaned = serverUrl.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !cleaned.isEmpty else {
             // The return-key chain can reach submit without the Connect

--- a/ConduitTests/ConnectionRepairTests.swift
+++ b/ConduitTests/ConnectionRepairTests.swift
@@ -335,25 +335,25 @@ final class ConnectionRepairTests: XCTestCase {
         let scheduler = RepairControlledReconnectScheduler()
         let harness = makeHarness(
             lifecycleOperations: ChatResumeLifecycleOperations(
-            connectClient: { _ in },
-            loadCatalog: { _, _ in [self.session("stored-a")] },
-            mintTicket: { _ in
-                mintAttempts += 1
-                if mintAttempts == 1 {
-                    throw URLError(.cannotFindHost)
-                }
-                return "fresh-ticket"
-            },
-            openSession: { _, id, _ in
-                SessionResumeResult(sessionId: id, messages: [],
-                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)]))
-            },
-            refreshContext: { _, _ in },
-            loadProfiles: {},
-            loadBusyInputMode: { _ in },
-            loadProfileDisplayPreferences: {},
-            loadSlashCommands: {}
-        ),
+                connectClient: { _ in },
+                loadCatalog: { _, _ in [self.session("stored-a")] },
+                mintTicket: { _ in
+                    mintAttempts += 1
+                    if mintAttempts == 1 {
+                        throw URLError(.cannotFindHost)
+                    }
+                    return "fresh-ticket"
+                },
+                openSession: { _, id, _ in
+                    SessionResumeResult(sessionId: id, messages: [],
+                        snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)]))
+                },
+                refreshContext: { _, _ in },
+                loadProfiles: {},
+                loadBusyInputMode: { _ in },
+                loadProfileDisplayPreferences: {},
+                loadSlashCommands: {}
+            ),
             reconnectScheduler: scheduler.schedule(after:operation:)
         )
         harness.appState.connection = HermesConnection(baseUrl: ConnectionRepairTests.failedURL, ticket: "stale-ticket")

--- a/ConduitTests/ConnectionRepairTests.swift
+++ b/ConduitTests/ConnectionRepairTests.swift
@@ -334,7 +334,6 @@ final class ConnectionRepairTests: XCTestCase {
         var mintAttempts = 0
         let scheduler = RepairControlledReconnectScheduler()
         let harness = makeHarness(
-            reconnectScheduler: scheduler.schedule(after:operation:),
             lifecycleOperations: ChatResumeLifecycleOperations(
             connectClient: { _ in },
             loadCatalog: { _, _ in [self.session("stored-a")] },
@@ -354,7 +353,9 @@ final class ConnectionRepairTests: XCTestCase {
             loadBusyInputMode: { _ in },
             loadProfileDisplayPreferences: {},
             loadSlashCommands: {}
-        ))
+        ),
+            reconnectScheduler: scheduler.schedule(after:operation:)
+        )
         harness.appState.connection = HermesConnection(baseUrl: ConnectionRepairTests.failedURL, ticket: "stale-ticket")
         harness.appState.client = HermesClient(connection: HermesConnection(baseUrl: ConnectionRepairTests.failedURL, ticket: "t"), profile: "default")
 

--- a/ConduitTests/ConnectionRepairTests.swift
+++ b/ConduitTests/ConnectionRepairTests.swift
@@ -402,13 +402,13 @@ final class ConnectionRepairTests: XCTestCase {
         let harness = makeHarness(lifecycleOperations: ChatResumeLifecycleOperations(
             connectClient: { _ in connectCount.value += 1 },
             loadCatalog: { _, _ in [self.session("stored-a")] },
-            openSession: { _, id, _ in
-                SessionResumeResult(sessionId: id, messages: [],
-                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)]))
-            },
             mintTicket: { _ in
                 await mintGate.suspend()
                 return "late-ticket"
+            },
+            openSession: { _, id, _ in
+                SessionResumeResult(sessionId: id, messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)]))
             },
             refreshContext: { _, _ in },
             loadProfiles: {},
@@ -510,7 +510,7 @@ final class RepairControlledReconnectScheduler {
 
     func schedule(
         after delay: TimeInterval,
-        operation: @MainActor () async -> Void
+        operation: @escaping @MainActor () async -> Void
     ) -> ChatResumeReconnectCancellation {
         pending.append(Pending(operation: operation))
         return { [weak self] in

--- a/ConduitTests/ConnectionRepairTests.swift
+++ b/ConduitTests/ConnectionRepairTests.swift
@@ -254,8 +254,10 @@ final class ConnectionRepairTests: XCTestCase {
             testSucceededAtRevision: flow.testSucceededAtRevision
         ))
 
-        // Cancellation rotates the generation and invalidates everything.
-        flow.cancelTest()
+        // A newer test run rotates the generation and invalidates everything
+        // (cancelling a FINISHED success is a deliberate no-op — Round-4
+        // semantics — so the invalidation trigger is the next run).
+        XCTAssertNotNil(flow.beginTest())
         XCTAssertFalse(candidateB.isCurrent(
             hasCurrentSuccessfulTest: flow.hasCurrentSuccessfulTest,
             testGeneration: flow.testGeneration,

--- a/ConduitTests/ConnectionRepairTests.swift
+++ b/ConduitTests/ConnectionRepairTests.swift
@@ -377,6 +377,9 @@ final class ConnectionRepairTests: XCTestCase {
                      "A successful reconnect makes any previous classification stale")
         XCTAssertNil(harness.appState.errorMessage)
         XCTAssertEqual(mintAttempts, 2)
+        // The retry armed by the failure was cancelled when the explicit
+        // reconnect began; a successful reconnect leaves nothing scheduled.
+        XCTAssertEqual(scheduler.pendingCount, 0)
     }
 
     // MARK: - Activation (spec 13, 14, 16, 28, 30)

--- a/ConduitTests/ConnectionRepairTests.swift
+++ b/ConduitTests/ConnectionRepairTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 @MainActor
 final class ConnectionRepairTests: XCTestCase {
-    private let failedURL = "https://hermes.example:9443/hermes"
+    private static let failedURL = "https://hermes.example:9443/hermes"
 
     // MARK: - Harness (mirrors AppStateChatResumeTests)
 
@@ -284,7 +284,7 @@ final class ConnectionRepairTests: XCTestCase {
     // MARK: - Repair takeover of automatic recovery (spec 8, 27)
 
     func testEnteringRepairStopsTheAutomaticRetryLoopWithoutSideEffects() async {
-        let reconnectSpy = ReconnectExecutionSpy()
+        let reconnectSpy = RepairReconnectExecutionSpy()
         let scheduler = RepairControlledReconnectScheduler()
         let suite = "ConnectionRepairTests.scheduler.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
@@ -321,7 +321,7 @@ final class ConnectionRepairTests: XCTestCase {
     // MARK: - Activation (spec 13, 14, 16, 28, 30)
 
     func testSameConnectionRepairActivatesOnceAndPreservesTheSession() async {
-        let connectCount = ConnectCount()
+        let connectCount = RepairConnectCount()
         let harness = makeHarness(lifecycleOperations: sessionPreservingFakes(connectClient: { _ in
             connectCount.value += 1
         }))
@@ -398,7 +398,7 @@ final class ConnectionRepairTests: XCTestCase {
 
     func testExplicitRepairOutranksLateAutomaticReconnect() async {
         let mintGate = RepairControlledSuspension()
-        let connectCount = ConnectCount()
+        let connectCount = RepairConnectCount()
         let harness = makeHarness(lifecycleOperations: ChatResumeLifecycleOperations(
             connectClient: { _ in connectCount.value += 1 },
             loadCatalog: { _, _ in [self.session("stored-a")] },
@@ -460,14 +460,14 @@ enum RepairControlledError: Error {
 }
 
 @MainActor
-final class ReconnectExecutionSpy {
+final class RepairReconnectExecutionSpy {
     var purposes: [ChatResumeSyncPurpose] = []
 }
 
 /// Minimal replicas of the AppStateChatResumeTests test doubles (those are
 /// file-private there).
 @MainActor
-final class ConnectCount {
+final class RepairConnectCount {
     var value = 0
 }
 

--- a/ConduitTests/ConnectionRepairTests.swift
+++ b/ConduitTests/ConnectionRepairTests.swift
@@ -21,7 +21,8 @@ final class ConnectionRepairTests: XCTestCase {
     // MARK: - Harness (mirrors AppStateChatResumeTests)
 
     private func makeHarness(
-        lifecycleOperations: ChatResumeLifecycleOperations = .live
+        lifecycleOperations: ChatResumeLifecycleOperations = .live,
+        reconnectScheduler: ChatResumeReconnectScheduler? = nil
     ) -> (appState: AppState, coordinator: ChatResumeCoordinator, store: ChatResumeStore,
           recoverySequence: ChatResumeRecoverySequence, defaults: UserDefaults) {
         let suite = "ConnectionRepairTests.\(UUID().uuidString)"
@@ -37,6 +38,7 @@ final class ConnectionRepairTests: XCTestCase {
             chatResumeCoordinator: coordinator,
             recoverySequence: recoverySequence,
             loadSavedConnection: false,
+            reconnectScheduler: reconnectScheduler,
             chatResumeLifecycleOperations: lifecycleOperations
         )
         return (appState, coordinator, store, recoverySequence, defaults)
@@ -294,7 +296,10 @@ final class ConnectionRepairTests: XCTestCase {
         let reconnectSpy = RepairReconnectExecutionSpy()
         let scheduler = RepairControlledReconnectScheduler()
         let suite = "ConnectionRepairTests.scheduler.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suite)!
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            XCTFail("Failed to create test defaults suite")
+            return
+        }
         addTeardownBlock { defaults.removePersistentDomain(forName: suite) }
         let coordinator = ChatResumeCoordinator(store: ChatResumeStore(defaults: defaults))
         let appState = AppState(
@@ -323,6 +328,54 @@ final class ConnectionRepairTests: XCTestCase {
         // connection target is untouched and no failure state appeared.
         XCTAssertNotNil(appState.connection)
         XCTAssertFalse(appState.isConnected)
+    }
+
+    func testFailedReconnectRetainsTypedFailureUntilRecoverySucceeds() async {
+        var mintAttempts = 0
+        let scheduler = RepairControlledReconnectScheduler()
+        let harness = makeHarness(
+            reconnectScheduler: scheduler.schedule(after:operation:),
+            lifecycleOperations: ChatResumeLifecycleOperations(
+            connectClient: { _ in },
+            loadCatalog: { _, _ in [self.session("stored-a")] },
+            mintTicket: { _ in
+                mintAttempts += 1
+                if mintAttempts == 1 {
+                    throw URLError(.cannotFindHost)
+                }
+                return "fresh-ticket"
+            },
+            openSession: { _, id, _ in
+                SessionResumeResult(sessionId: id, messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)]))
+            },
+            refreshContext: { _, _ in },
+            loadProfiles: {},
+            loadBusyInputMode: { _ in },
+            loadProfileDisplayPreferences: {},
+            loadSlashCommands: {}
+        ))
+        harness.appState.connection = HermesConnection(baseUrl: ConnectionRepairTests.failedURL, ticket: "stale-ticket")
+        harness.appState.client = HermesClient(connection: HermesConnection(baseUrl: ConnectionRepairTests.failedURL, ticket: "t"), profile: "default")
+
+        // First reconnect fails: the typed classification must remain
+        // available for Repair seeding and routing.
+        await harness.appState.reconnectForRetry(purpose: .preserveCurrent)
+        XCTAssertFalse(harness.appState.isConnected)
+        XCTAssertNotNil(harness.appState.lastConnectionFailure,
+                        "A failed reconnect must leave the typed classification available for Repair")
+        XCTAssertNotNil(harness.appState.errorMessage)
+        XCTAssertEqual(scheduler.pendingCount, 1, "The failure arms the ordinary automatic retry")
+
+        // The later reconnect succeeds: the stale classification is cleared
+        // alongside the banner, so a future unrelated failure routes Repair
+        // from itself, not from this stale event.
+        await harness.appState.reconnectForRetry(purpose: .preserveCurrent)
+        XCTAssertTrue(harness.appState.isConnected)
+        XCTAssertNil(harness.appState.lastConnectionFailure,
+                     "A successful reconnect makes any previous classification stale")
+        XCTAssertNil(harness.appState.errorMessage)
+        XCTAssertEqual(mintAttempts, 2)
     }
 
     // MARK: - Activation (spec 13, 14, 16, 28, 30)

--- a/ConduitTests/ConnectionRepairTests.swift
+++ b/ConduitTests/ConnectionRepairTests.swift
@@ -85,7 +85,7 @@ final class ConnectionRepairTests: XCTestCase {
     }
 
     private func candidate(
-        serverURL: String = failedURL,
+        serverURL: String = ConnectionRepairTests.failedURL,
         ticket: String,
         revision: Int,
         generation: Int
@@ -102,7 +102,7 @@ final class ConnectionRepairTests: XCTestCase {
 
     func testRepairRoutingStartsNearTheClassifiedProblem() {
         let draft = ConnectionSetupDraft(
-            existingServerURL: failedURL, username: "u", password: "p"
+            existingServerURL: ConnectionRepairTests.failedURL, username: "u", password: "p"
         )
         XCTAssertEqual(
             ConnectionSetupFlow.initialPath(for: .repairConnection, draft: draft, repairFailure: .authenticationRejected),
@@ -141,7 +141,7 @@ final class ConnectionRepairTests: XCTestCase {
     }
 
     func testRepairEntryAlwaysKeepsTheAddressOneBackStepAway() throws {
-        let draft = ConnectionSetupDraft(existingServerURL: failedURL, username: "u", password: "p")
+        let draft = ConnectionSetupDraft(existingServerURL: ConnectionRepairTests.failedURL, username: "u", password: "p")
         var flow = ConnectionSetupFlow(
             entry: .repairConnection,
             draft: draft,
@@ -170,7 +170,7 @@ final class ConnectionRepairTests: XCTestCase {
         // full test runs.
         var flow = ConnectionSetupFlow(
             entry: .repairConnection,
-            draft: ConnectionSetupDraft(existingServerURL: failedURL)
+            draft: ConnectionSetupDraft(existingServerURL: ConnectionRepairTests.failedURL)
         )
         XCTAssertEqual(flow.step, .connectionTest)
         flow.back()
@@ -201,7 +201,7 @@ final class ConnectionRepairTests: XCTestCase {
 
     func testCandidateLifecycleTracksTheFlowRevisionAndGeneration() throws {
         let seed = ConnectionSetupDraft(
-            existingServerURL: failedURL, username: "u", password: "p"
+            existingServerURL: ConnectionRepairTests.failedURL, username: "u", password: "p"
         )
         var flow = ConnectionSetupFlow(entry: .repairConnection, draft: seed)
         XCTAssertEqual(flow.step, .connectionDetails)
@@ -263,7 +263,7 @@ final class ConnectionRepairTests: XCTestCase {
 
     func testInvalidateTestForRepairRetryRequiresAFreshTest() throws {
         let seed = ConnectionSetupDraft(
-            existingServerURL: failedURL, username: "u", password: "p"
+            existingServerURL: ConnectionRepairTests.failedURL, username: "u", password: "p"
         )
         var flow = ConnectionSetupFlow(entry: .repairConnection, draft: seed)
         flow.submitDetails()
@@ -298,7 +298,7 @@ final class ConnectionRepairTests: XCTestCase {
             reconnectScheduler: scheduler.schedule(after:operation:),
             reconnectExecutor: { purpose in reconnectSpy.purposes.append(purpose) }
         )
-        appState.connection = HermesConnection(baseUrl: failedURL, ticket: "failed-ticket")
+        appState.connection = HermesConnection(baseUrl: ConnectionRepairTests.failedURL, ticket: "failed-ticket")
 
         // The existing system schedules its automatic retry.
         appState.scheduleReconnect(purpose: .preserveCurrent)
@@ -307,7 +307,7 @@ final class ConnectionRepairTests: XCTestCase {
         // Entering Repair hands recovery authority to the user: the loop
         // stops, and running the (cancelled) schedule executes nothing.
         let context = appState.beginConnectionRepair()
-        XCTAssertEqual(context?.draft.existingServerURL, failedURL)
+        XCTAssertEqual(context?.draft.existingServerURL, ConnectionRepairTests.failedURL)
         XCTAssertEqual(scheduler.pendingCount, 0)
         await scheduler.runAll()
         XCTAssertEqual(reconnectSpy.purposes, [], "No background connection attempt may follow repair entry")
@@ -325,7 +325,7 @@ final class ConnectionRepairTests: XCTestCase {
         let harness = makeHarness(lifecycleOperations: sessionPreservingFakes(connectClient: { _ in
             connectCount.value += 1
         }))
-        let failedConnection = HermesConnection(baseUrl: failedURL, ticket: "stale-ticket")
+        let failedConnection = HermesConnection(baseUrl: ConnectionRepairTests.failedURL, ticket: "stale-ticket")
         harness.appState.connection = failedConnection
         harness.appState.client = HermesClient(connection: failedConnection, profile: "default")
         harness.appState.activeSessionId = "stored-a"
@@ -348,8 +348,8 @@ final class ConnectionRepairTests: XCTestCase {
             connectClient: { _ in },
             loadCatalog: { _, _ in [self.session("stored-new")] }
         ))
-        harness.appState.connection = HermesConnection(baseUrl: failedURL, ticket: "stale-ticket")
-        harness.appState.client = HermesClient(connection: HermesConnection(baseUrl: failedURL, ticket: "t"), profile: "default")
+        harness.appState.connection = HermesConnection(baseUrl: ConnectionRepairTests.failedURL, ticket: "stale-ticket")
+        harness.appState.client = HermesClient(connection: HermesConnection(baseUrl: ConnectionRepairTests.failedURL, ticket: "t"), profile: "default")
         harness.appState.activeSessionId = "old-session"
 
         let outcome = await harness.appState.performConnectionRepair(.native(candidate(
@@ -416,7 +416,7 @@ final class ConnectionRepairTests: XCTestCase {
             loadProfileDisplayPreferences: {},
             loadSlashCommands: {}
         ))
-        let failedConnection = HermesConnection(baseUrl: failedURL, ticket: "stale-ticket")
+        let failedConnection = HermesConnection(baseUrl: ConnectionRepairTests.failedURL, ticket: "stale-ticket")
         harness.appState.connection = failedConnection
         harness.appState.client = HermesClient(connection: failedConnection, profile: "default")
         harness.appState.activeSessionId = "stored-a"

--- a/ConduitTests/ConnectionRepairTests.swift
+++ b/ConduitTests/ConnectionRepairTests.swift
@@ -405,14 +405,14 @@ final class ConnectionRepairTests: XCTestCase {
 
     func testBrowserSignInRepairActivatesAndRemembersWithoutInventingCredentials() async {
         let harness = makeHarness(lifecycleOperations: sessionPreservingFakes(connectClient: { _ in }))
-        harness.appState.connection = HermesConnection(baseUrl: failedURL, ticket: "stale-ticket")
-        harness.appState.client = HermesClient(connection: HermesConnection(baseUrl: failedURL, ticket: "t"), profile: "default")
-        harness.defaults.set(failedURL, forKey: "conduit.dashboardURL")
+        harness.appState.connection = HermesConnection(baseUrl: ConnectionRepairTests.failedURL, ticket: "stale-ticket")
+        harness.appState.client = HermesClient(connection: HermesConnection(baseUrl: ConnectionRepairTests.failedURL, ticket: "t"), profile: "default")
+        harness.defaults.set(ConnectionRepairTests.failedURL, forKey: "conduit.dashboardURL")
 
         let outcome = await harness.appState.performConnectionRepair(.browserSignIn(
             ticket: "browser-ticket",
-            baseURL: failedURL,
-            configuration: ConnectionSetupResult(serverURL: failedURL, username: "", password: "")
+            baseURL: ConnectionRepairTests.failedURL,
+            configuration: ConnectionSetupResult(serverURL: ConnectionRepairTests.failedURL, username: "", password: "")
         ))
 
         XCTAssertEqual(outcome, .activated)
@@ -420,7 +420,7 @@ final class ConnectionRepairTests: XCTestCase {
         XCTAssertEqual(harness.appState.connection?.ticket, "browser-ticket")
         // Existing browser-auth semantics: the activated dashboard is
         // remembered and no native credentials are invented.
-        XCTAssertEqual(harness.defaults.string(forKey: "conduit.dashboardURL"), failedURL)
+        XCTAssertEqual(harness.defaults.string(forKey: "conduit.dashboardURL"), ConnectionRepairTests.failedURL)
     }
 
     // MARK: - Race: explicit repair outranks late automatic recovery (spec 26)

--- a/ConduitTests/ConnectionRepairTests.swift
+++ b/ConduitTests/ConnectionRepairTests.swift
@@ -403,6 +403,26 @@ final class ConnectionRepairTests: XCTestCase {
         XCTAssertFalse(harness.appState.isConnected)
     }
 
+    func testBrowserSignInRepairActivatesAndRemembersWithoutInventingCredentials() async {
+        let harness = makeHarness(lifecycleOperations: sessionPreservingFakes(connectClient: { _ in }))
+        harness.appState.connection = HermesConnection(baseUrl: failedURL, ticket: "stale-ticket")
+        harness.appState.client = HermesClient(connection: HermesConnection(baseUrl: failedURL, ticket: "t"), profile: "default")
+        harness.defaults.set(failedURL, forKey: "conduit.dashboardURL")
+
+        let outcome = await harness.appState.performConnectionRepair(.browserSignIn(
+            ticket: "browser-ticket",
+            baseURL: failedURL,
+            configuration: ConnectionSetupResult(serverURL: failedURL, username: "", password: "")
+        ))
+
+        XCTAssertEqual(outcome, .activated)
+        XCTAssertTrue(harness.appState.isConnected)
+        XCTAssertEqual(harness.appState.connection?.ticket, "browser-ticket")
+        // Existing browser-auth semantics: the activated dashboard is
+        // remembered and no native credentials are invented.
+        XCTAssertEqual(harness.defaults.string(forKey: "conduit.dashboardURL"), failedURL)
+    }
+
     // MARK: - Race: explicit repair outranks late automatic recovery (spec 26)
 
     func testExplicitRepairOutranksLateAutomaticReconnect() async {

--- a/ConduitTests/ConnectionRepairTests.swift
+++ b/ConduitTests/ConnectionRepairTests.swift
@@ -204,9 +204,6 @@ final class ConnectionRepairTests: XCTestCase {
             existingServerURL: ConnectionRepairTests.failedURL, username: "u", password: "p"
         )
         var flow = ConnectionSetupFlow(entry: .repairConnection, draft: seed)
-        XCTAssertEqual(flow.step, .connectionDetails)
-        flow.submitDetails()
-        flow.submitCredentials()
         XCTAssertEqual(flow.step, .connectionTest)
         StagedTestDriver.runSuccessfulTest(on: &flow)
 
@@ -223,6 +220,8 @@ final class ConnectionRepairTests: XCTestCase {
 
         // A draft edit invalidates the staged success and the candidate.
         flow.back()
+        flow.submitDetails()
+        XCTAssertEqual(flow.step, .loginCredentials)
         flow.draft.password = "edited"
         XCTAssertFalse(flow.hasCurrentSuccessfulTest)
         XCTAssertFalse(candidateA.isCurrent(
@@ -328,6 +327,8 @@ final class ConnectionRepairTests: XCTestCase {
         let failedConnection = HermesConnection(baseUrl: ConnectionRepairTests.failedURL, ticket: "stale-ticket")
         harness.appState.connection = failedConnection
         harness.appState.client = HermesClient(connection: failedConnection, profile: "default")
+        // The visible session A is the established, durably stored identity.
+        harness.store.setLastSessionID("stored-a", for: "default")
         harness.appState.activeSessionId = "stored-a"
 
         let outcome = await harness.appState.performConnectionRepair(.native(candidate(
@@ -420,6 +421,7 @@ final class ConnectionRepairTests: XCTestCase {
         harness.appState.connection = failedConnection
         harness.appState.client = HermesClient(connection: failedConnection, profile: "default")
         harness.appState.activeSessionId = "stored-a"
+        harness.store.setLastSessionID("stored-a", for: "default")
 
         // Automatic reconnect A begins and suspends at the mint boundary.
         let taskA = Task { @MainActor in

--- a/ConduitTests/ConnectionRepairTests.swift
+++ b/ConduitTests/ConnectionRepairTests.swift
@@ -449,7 +449,7 @@ final class ConnectionRepairTests: XCTestCase {
 
         XCTAssertEqual(harness.appState.connection?.ticket, "repaired-ticket", "A cannot overwrite B's connection")
         XCTAssertEqual(harness.appState.activeSessionId, "stored-a", "A cannot choose a different session")
-        XCTAssertEqual(harness.appState.recoverySequence.currentPurpose, .preserveCurrent,
+        XCTAssertEqual(harness.recoverySequence.currentPurpose, .preserveCurrent,
                        "No automaticReturn selection occurs after B wins")
         XCTAssertEqual(connectCount.value, 1, "Only the explicit repair ever reached a connection")
     }

--- a/ConduitTests/ConnectionRepairTests.swift
+++ b/ConduitTests/ConnectionRepairTests.swift
@@ -1,0 +1,528 @@
+//
+//  ConnectionRepairTests.swift
+//  Conduit
+//
+//  Round 6: the explicit Repair Connection flow. Covers the failure-taxonomy
+//  entry routing, the validated-transaction candidate lifecycle (edits, new
+//  runs, cancellation, consumption), the activation path through the
+//  authoritative AppState connection machinery with .preserveCurrent session
+//  semantics, persistence timing (only after successful activation), the
+//  takeover of automatic recovery authority, and the major race: an explicit
+//  repair reconnect must outrank a late automatic reconnect.
+//
+
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class ConnectionRepairTests: XCTestCase {
+    private let failedURL = "https://hermes.example:9443/hermes"
+
+    // MARK: - Harness (mirrors AppStateChatResumeTests)
+
+    private func makeHarness(
+        lifecycleOperations: ChatResumeLifecycleOperations = .live
+    ) -> (appState: AppState, coordinator: ChatResumeCoordinator, store: ChatResumeStore,
+          recoverySequence: ChatResumeRecoverySequence, defaults: UserDefaults) {
+        let suite = "ConnectionRepairTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Failed to create test defaults suite")
+        }
+        addTeardownBlock { defaults.removePersistentDomain(forName: suite) }
+        let store = ChatResumeStore(defaults: defaults)
+        let coordinator = ChatResumeCoordinator(store: store)
+        let recoverySequence = ChatResumeRecoverySequence()
+        let appState = AppState(
+            defaults: defaults,
+            chatResumeCoordinator: coordinator,
+            recoverySequence: recoverySequence,
+            loadSavedConnection: false,
+            chatResumeLifecycleOperations: lifecycleOperations
+        )
+        return (appState, coordinator, store, recoverySequence, defaults)
+    }
+
+    private func session(_ id: String) -> SessionSummary {
+        SessionSummary(
+            id: id,
+            storedSessionId: nil,
+            alternateIds: [],
+            title: id,
+            model: "Hermes",
+            updatedLabel: "now",
+            profile: "default",
+            source: .chat,
+            isActive: false,
+            isArchived: false,
+            lineageRootId: nil
+        )
+    }
+
+    /// Activation fakes: the connect boundary plus the post-connect profile/
+    /// preference loaders, which must never fall through to live network
+    /// calls under the fake client.
+    private func activationFakes(
+        connectClient: @escaping @MainActor (HermesClient) async throws -> Void,
+        loadCatalog: @escaping @MainActor (HermesClient, Bool) async throws -> [SessionSummary]
+    ) -> ChatResumeLifecycleOperations {
+        ChatResumeLifecycleOperations(
+            connectClient: connectClient,
+            loadCatalog: loadCatalog,
+            openSession: { _, id, _ in
+                SessionResumeResult(sessionId: id, messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)]))
+            },
+            refreshContext: { _, _ in },
+            loadProfiles: {},
+            loadBusyInputMode: { _ in },
+            loadProfileDisplayPreferences: {},
+            loadSlashCommands: {}
+        )
+    }
+
+    private func sessionPreservingFakes(connectClient: @escaping @MainActor (HermesClient) async throws -> Void) -> ChatResumeLifecycleOperations {
+        activationFakes(connectClient: connectClient, loadCatalog: { _, _ in [self.session("stored-a")] })
+    }
+
+    private func candidate(
+        serverURL: String = failedURL,
+        ticket: String,
+        revision: Int,
+        generation: Int
+    ) -> ConnectionRepairCandidate {
+        ConnectionRepairCandidate(
+            configuration: ConnectionSetupResult(serverURL: serverURL, username: "u", password: "p"),
+            nativeConnection: .debugStub(ticket: ticket),
+            validatedRevision: revision,
+            generation: generation
+        )
+    }
+
+    // MARK: - Entry routing (spec 6)
+
+    func testRepairRoutingStartsNearTheClassifiedProblem() {
+        let draft = ConnectionSetupDraft(
+            existingServerURL: failedURL, username: "u", password: "p"
+        )
+        XCTAssertEqual(
+            ConnectionSetupFlow.initialPath(for: .repairConnection, draft: draft, repairFailure: .authenticationRejected),
+            [.connectionDetails, .loginCredentials]
+        )
+        XCTAssertEqual(
+            ConnectionSetupFlow.initialPath(for: .repairConnection, draft: draft, repairFailure: .cloudflareTokenRejected),
+            [.connectionDetails, .cloudflareTroubleshooting]
+        )
+        XCTAssertEqual(
+            ConnectionSetupFlow.initialPath(for: .repairConnection, draft: draft, repairFailure: .tlsUntrusted),
+            [.connectionDetails, .tlsTroubleshooting]
+        )
+        for failure: ConnectionFailure in [.invalidAddress, .hostNotFound, .unreachable, .connectionRefused, .timedOut, .offline, .dashboardUnavailable, .unexpectedServerResponse] {
+            XCTAssertEqual(
+                ConnectionSetupFlow.initialPath(for: .repairConnection, draft: draft, repairFailure: failure),
+                [.connectionDetails],
+                "\(failure) should route to the editable address"
+            )
+        }
+        // A throttled login must never route toward another login.
+        XCTAssertEqual(
+            ConnectionSetupFlow.initialPath(for: .repairConnection, draft: draft, repairFailure: .rateLimited),
+            [.connectionDetails]
+        )
+        // No strong diagnosis: the seeded staged test is the diagnostic.
+        XCTAssertEqual(
+            ConnectionSetupFlow.initialPath(for: .repairConnection, draft: draft, repairFailure: .unknown),
+            [.connectionDetails, .connectionTest]
+        )
+        XCTAssertEqual(
+            ConnectionSetupFlow.initialPath(for: .repairConnection, draft: draft, repairFailure: nil),
+            [.connectionDetails, .connectionTest]
+        )
+        XCTAssertEqual(ConnectionSetupFlow.entryStep(for: .repairConnection), .connectionDetails)
+    }
+
+    func testRepairEntryAlwaysKeepsTheAddressOneBackStepAway() throws {
+        let draft = ConnectionSetupDraft(existingServerURL: failedURL, username: "u", password: "p")
+        var flow = ConnectionSetupFlow(
+            entry: .repairConnection,
+            draft: draft,
+            repairFailure: .authenticationRejected
+        )
+        XCTAssertEqual(flow.step, .loginCredentials)
+        XCTAssertTrue(flow.canGoBack)
+        flow.back()
+        XCTAssertEqual(flow.step, .connectionDetails, "The initial diagnosis being wrong must not strand the user")
+
+        var testFirst = ConnectionSetupFlow(
+            entry: .repairConnection,
+            draft: draft,
+            repairFailure: .unknown
+        )
+        XCTAssertEqual(testFirst.step, .connectionTest)
+        XCTAssertTrue(testFirst.isRepairingConnection)
+        testFirst.back()
+        XCTAssertEqual(testFirst.step, .connectionDetails)
+    }
+
+    func testRepairEntryCanTestWithoutCredentialsThenEnterThem() {
+        // The no-saved-credentials repair: the staged test runs discovery
+        // first (Credentials required stops before any login), and Enter
+        // Credentials routes to the credentials step, from which the fresh
+        // full test runs.
+        var flow = ConnectionSetupFlow(
+            entry: .repairConnection,
+            draft: ConnectionSetupDraft(existingServerURL: failedURL)
+        )
+        XCTAssertEqual(flow.step, .connectionTest)
+        flow.back()
+        XCTAssertEqual(flow.step, .connectionDetails)
+        flow.submitDetails()
+        XCTAssertEqual(flow.step, .loginCredentials)
+        XCTAssertTrue(flow.draft.username.isEmpty)
+        XCTAssertTrue(flow.draft.password.isEmpty)
+        flow.submitCredentials()
+        XCTAssertEqual(flow.step, .connectionTest, "Empty credentials must not block the repair test path")
+        XCTAssertNil(flow.validationError)
+
+        // The credentials-required partial outcome routes to credentials and
+        // never authorizes reconnect.
+        let generation = flow.beginTest()
+        XCTAssertNotNil(generation)
+        for event in StagedTestDriver.successEvents.prefix(5) {
+            flow.applyTestEvent(event, generation: generation!)
+        }
+        flow.applyTestEvent(.requiresCredentials(.authentication), generation: generation!)
+        XCTAssertTrue(flow.testState.requiresCredentials)
+        XCTAssertFalse(flow.canUseSettings, "Credentials required never authorizes Reconnect Now")
+        flow.editAfterFailedTest(.loginCredentials)
+        XCTAssertEqual(flow.step, .loginCredentials)
+    }
+
+    // MARK: - Candidate lifecycle (spec 11, 17, 32)
+
+    func testCandidateLifecycleTracksTheFlowRevisionAndGeneration() throws {
+        let seed = ConnectionSetupDraft(
+            existingServerURL: failedURL, username: "u", password: "p"
+        )
+        var flow = ConnectionSetupFlow(entry: .repairConnection, draft: seed)
+        XCTAssertEqual(flow.step, .connectionDetails)
+        flow.submitDetails()
+        flow.submitCredentials()
+        XCTAssertEqual(flow.step, .connectionTest)
+        StagedTestDriver.runSuccessfulTest(on: &flow)
+
+        let candidateA = candidate(
+            ticket: "candidate-a",
+            revision: try XCTUnwrap(flow.testSucceededAtRevision),
+            generation: flow.testGeneration
+        )
+        XCTAssertTrue(candidateA.isCurrent(
+            hasCurrentSuccessfulTest: flow.hasCurrentSuccessfulTest,
+            testGeneration: flow.testGeneration,
+            testSucceededAtRevision: flow.testSucceededAtRevision
+        ))
+
+        // A draft edit invalidates the staged success and the candidate.
+        flow.back()
+        flow.draft.password = "edited"
+        XCTAssertFalse(flow.hasCurrentSuccessfulTest)
+        XCTAssertFalse(candidateA.isCurrent(
+            hasCurrentSuccessfulTest: flow.hasCurrentSuccessfulTest,
+            testGeneration: flow.testGeneration,
+            testSucceededAtRevision: flow.testSucceededAtRevision
+        ))
+
+        // A newer run mints a newer generation; candidate B is the only
+        // current one, and a late candidate A can never reconnect.
+        flow.submitCredentials()
+        StagedTestDriver.runSuccessfulTest(on: &flow)
+        let candidateB = candidate(
+            ticket: "candidate-b",
+            revision: try XCTUnwrap(flow.testSucceededAtRevision),
+            generation: flow.testGeneration
+        )
+        XCTAssertTrue(candidateB.isCurrent(
+            hasCurrentSuccessfulTest: flow.hasCurrentSuccessfulTest,
+            testGeneration: flow.testGeneration,
+            testSucceededAtRevision: flow.testSucceededAtRevision
+        ))
+        XCTAssertNotEqual(candidateA.generation, candidateB.generation)
+        XCTAssertFalse(candidateA.isCurrent(
+            hasCurrentSuccessfulTest: flow.hasCurrentSuccessfulTest,
+            testGeneration: flow.testGeneration,
+            testSucceededAtRevision: flow.testSucceededAtRevision
+        ))
+
+        // Cancellation rotates the generation and invalidates everything.
+        flow.cancelTest()
+        XCTAssertFalse(candidateB.isCurrent(
+            hasCurrentSuccessfulTest: flow.hasCurrentSuccessfulTest,
+            testGeneration: flow.testGeneration,
+            testSucceededAtRevision: flow.testSucceededAtRevision
+        ))
+    }
+
+    func testInvalidateTestForRepairRetryRequiresAFreshTest() throws {
+        let seed = ConnectionSetupDraft(
+            existingServerURL: failedURL, username: "u", password: "p"
+        )
+        var flow = ConnectionSetupFlow(entry: .repairConnection, draft: seed)
+        flow.submitDetails()
+        flow.submitCredentials()
+        StagedTestDriver.runSuccessfulTest(on: &flow)
+        XCTAssertEqual(flow.step, .review)
+        XCTAssertTrue(flow.canUseSettings)
+        XCTAssertNotNil(flow.complete())
+
+        flow.invalidateTestForRepairRetry()
+
+        XCTAssertEqual(flow.step, .connectionTest, "The wizard returns to the test screen")
+        XCTAssertFalse(flow.canUseSettings, "A consumed or failed attempt authorizes nothing")
+        XCTAssertNil(flow.complete())
+        XCTAssertEqual(flow.testState, ConnectionSetupTestState())
+    }
+
+    // MARK: - Repair takeover of automatic recovery (spec 8, 27)
+
+    func testEnteringRepairStopsTheAutomaticRetryLoopWithoutSideEffects() async {
+        let reconnectSpy = ReconnectExecutionSpy()
+        let scheduler = RepairControlledReconnectScheduler()
+        let suite = "ConnectionRepairTests.scheduler.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        addTeardownBlock { defaults.removePersistentDomain(forName: suite) }
+        let coordinator = ChatResumeCoordinator(store: ChatResumeStore(defaults: defaults))
+        let appState = AppState(
+            defaults: defaults,
+            chatResumeCoordinator: coordinator,
+            recoverySequence: ChatResumeRecoverySequence(),
+            loadSavedConnection: false,
+            reconnectScheduler: scheduler.schedule(after:operation:),
+            reconnectExecutor: { purpose in reconnectSpy.purposes.append(purpose) }
+        )
+        appState.connection = HermesConnection(baseUrl: failedURL, ticket: "failed-ticket")
+
+        // The existing system schedules its automatic retry.
+        appState.scheduleReconnect(purpose: .preserveCurrent)
+        XCTAssertEqual(scheduler.pendingCount, 1)
+
+        // Entering Repair hands recovery authority to the user: the loop
+        // stops, and running the (cancelled) schedule executes nothing.
+        let context = appState.beginConnectionRepair()
+        XCTAssertEqual(context?.draft.existingServerURL, failedURL)
+        XCTAssertEqual(scheduler.pendingCount, 0)
+        await scheduler.runAll()
+        XCTAssertEqual(reconnectSpy.purposes, [], "No background connection attempt may follow repair entry")
+
+        // Cancellation has no persistence side effects: the saved-in-memory
+        // connection target is untouched and no failure state appeared.
+        XCTAssertNotNil(appState.connection)
+        XCTAssertFalse(appState.isConnected)
+    }
+
+    // MARK: - Activation (spec 13, 14, 16, 28, 30)
+
+    func testSameConnectionRepairActivatesOnceAndPreservesTheSession() async {
+        let connectCount = ConnectCount()
+        let harness = makeHarness(lifecycleOperations: sessionPreservingFakes(connectClient: { _ in
+            connectCount.value += 1
+        }))
+        let failedConnection = HermesConnection(baseUrl: failedURL, ticket: "stale-ticket")
+        harness.appState.connection = failedConnection
+        harness.appState.client = HermesClient(connection: failedConnection, profile: "default")
+        harness.appState.activeSessionId = "stored-a"
+
+        let outcome = await harness.appState.performConnectionRepair(.native(candidate(
+            ticket: "repaired-ticket",
+            revision: 4,
+            generation: 2
+        )))
+
+        XCTAssertEqual(outcome, .activated)
+        XCTAssertTrue(harness.appState.isConnected)
+        XCTAssertEqual(harness.appState.connection?.ticket, "repaired-ticket")
+        XCTAssertEqual(harness.appState.activeSessionId, "stored-a", "The server confirmed the preserved session")
+        XCTAssertEqual(connectCount.value, 1, "Exactly one activation")
+    }
+
+    func testChangedEndpointFailsSafelyIntoTheExistingIdentityBoundary() async {
+        let harness = makeHarness(lifecycleOperations: activationFakes(
+            connectClient: { _ in },
+            loadCatalog: { _, _ in [self.session("stored-new")] }
+        ))
+        harness.appState.connection = HermesConnection(baseUrl: failedURL, ticket: "stale-ticket")
+        harness.appState.client = HermesClient(connection: HermesConnection(baseUrl: failedURL, ticket: "t"), profile: "default")
+        harness.appState.activeSessionId = "old-session"
+
+        let outcome = await harness.appState.performConnectionRepair(.native(candidate(
+            serverURL: "https://other.example",
+            ticket: "repaired-ticket",
+            revision: 4,
+            generation: 2
+        )))
+
+        XCTAssertEqual(outcome, .activated, "Activation itself succeeded")
+        XCTAssertEqual(harness.appState.connection?.baseUrl, "https://other.example")
+        // A different server identity clears the old session through the
+        // existing boundary; the replacement endpoint's SERVER-CONFIRMED
+        // catalog is what selects the next conversation — the old session
+        // identity is never blindly reused.
+        XCTAssertNotEqual(harness.appState.activeSessionId, "old-session")
+    }
+
+    func testFailedActivationPersistsNothingAndRequiresAFreshTest() async {
+        let remembered = "https://hermes.example:9443/hermes"
+        let harness = makeHarness(lifecycleOperations: activationFakes(
+            connectClient: { _ in throw RepairControlledError.activationFailed },
+            loadCatalog: { _, _ in [] }
+        ))
+        harness.appState.connection = HermesConnection(baseUrl: remembered, ticket: "stale-ticket")
+        harness.appState.client = HermesClient(connection: HermesConnection(baseUrl: remembered, ticket: "t"), profile: "default")
+        harness.defaults.set(remembered, forKey: "conduit.dashboardURL")
+
+        let outcome = await harness.appState.performConnectionRepair(.native(candidate(
+            serverURL: "https://replacement.example",
+            ticket: "candidate-ticket",
+            revision: 4,
+            generation: 2
+        )))
+
+        guard case .failed = outcome else {
+            return XCTFail("A failed activation must be a classified failure, got: \(outcome)")
+        }
+        XCTAssertNotNil(harness.appState.lastConnectionFailure, "The activation failure arrives classified")
+        XCTAssertEqual(harness.defaults.string(forKey: "conduit.dashboardURL"), remembered,
+                       "A failed activation must not move the remembered dashboard")
+        XCTAssertFalse(harness.appState.isConnected)
+    }
+
+    // MARK: - Race: explicit repair outranks late automatic recovery (spec 26)
+
+    func testExplicitRepairOutranksLateAutomaticReconnect() async {
+        let mintGate = RepairControlledSuspension()
+        let connectCount = ConnectCount()
+        let harness = makeHarness(lifecycleOperations: ChatResumeLifecycleOperations(
+            connectClient: { _ in connectCount.value += 1 },
+            loadCatalog: { _, _ in [self.session("stored-a")] },
+            openSession: { _, id, _ in
+                SessionResumeResult(sessionId: id, messages: [],
+                    snapshot: SessionRuntimeSnapshot(object: ["running": .bool(false)]))
+            },
+            mintTicket: { _ in
+                await mintGate.suspend()
+                return "late-ticket"
+            },
+            refreshContext: { _, _ in },
+            loadProfiles: {},
+            loadBusyInputMode: { _ in },
+            loadProfileDisplayPreferences: {},
+            loadSlashCommands: {}
+        ))
+        let failedConnection = HermesConnection(baseUrl: failedURL, ticket: "stale-ticket")
+        harness.appState.connection = failedConnection
+        harness.appState.client = HermesClient(connection: failedConnection, profile: "default")
+        harness.appState.activeSessionId = "stored-a"
+
+        // Automatic reconnect A begins and suspends at the mint boundary.
+        let taskA = Task { @MainActor in
+            await harness.appState.reconnectForRetry(purpose: .automaticReturn)
+        }
+        await mintGate.waitUntilSuspended()
+
+        // The user enters Repair: automatic recovery loses authority.
+        XCTAssertNotNil(harness.appState.beginConnectionRepair())
+
+        // Reconnect Now (candidate B) wins: explicit, preserveCurrent.
+        let outcome = await harness.appState.performConnectionRepair(.native(candidate(
+            ticket: "repaired-ticket",
+            revision: 4,
+            generation: 2
+        )))
+        XCTAssertEqual(outcome, .activated)
+        XCTAssertEqual(harness.appState.connection?.ticket, "repaired-ticket")
+        XCTAssertEqual(harness.appState.activeSessionId, "stored-a")
+        XCTAssertEqual(harness.recoverySequence.currentPurpose, .preserveCurrent,
+                       "The explicit repair reconnect never becomes an automaticReturn selection")
+
+        // A finishes late — it must abort at its post-mint continuation
+        // checkpoint, leaving B's connection and session untouched.
+        mintGate.resume()
+        await taskA.value
+
+        XCTAssertEqual(harness.appState.connection?.ticket, "repaired-ticket", "A cannot overwrite B's connection")
+        XCTAssertEqual(harness.appState.activeSessionId, "stored-a", "A cannot choose a different session")
+        XCTAssertEqual(harness.appState.recoverySequence.currentPurpose, .preserveCurrent,
+                       "No automaticReturn selection occurs after B wins")
+        XCTAssertEqual(connectCount.value, 1, "Only the explicit repair ever reached a connection")
+    }
+}
+
+enum RepairControlledError: Error {
+    case activationFailed
+}
+
+@MainActor
+final class ReconnectExecutionSpy {
+    var purposes: [ChatResumeSyncPurpose] = []
+}
+
+/// Minimal replicas of the AppStateChatResumeTests test doubles (those are
+/// file-private there).
+@MainActor
+final class ConnectCount {
+    var value = 0
+}
+
+@MainActor
+final class RepairControlledSuspension {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var resumed = false
+
+    func suspend() async {
+        if resumed {
+            return
+        }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            self.continuation = continuation
+        }
+    }
+
+    func resume() {
+        resumed = true
+        continuation?.resume()
+        continuation = nil
+    }
+
+    func waitUntilSuspended() async {
+        while continuation == nil {
+            await Task.yield()
+        }
+    }
+}
+
+@MainActor
+final class RepairControlledReconnectScheduler {
+    struct Pending {
+        let operation: @MainActor () async -> Void
+    }
+
+    private(set) var pending: [Pending] = []
+
+    var pendingCount: Int { pending.count }
+
+    func schedule(
+        after delay: TimeInterval,
+        operation: @MainActor () async -> Void
+    ) -> ChatResumeReconnectCancellation {
+        pending.append(Pending(operation: operation))
+        return { [weak self] in
+            self?.pending.removeAll()
+        }
+    }
+
+    func runAll() async {
+        let operations = pending.map(\.operation)
+        pending.removeAll()
+        for operation in operations {
+            await operation()
+        }
+    }
+}

--- a/ConduitTests/ConnectionRepairTests.swift
+++ b/ConduitTests/ConnectionRepairTests.swift
@@ -256,7 +256,10 @@ final class ConnectionRepairTests: XCTestCase {
 
         // A newer test run rotates the generation and invalidates everything
         // (cancelling a FINISHED success is a deliberate no-op — Round-4
-        // semantics — so the invalidation trigger is the next run).
+        // semantics — so the invalidation trigger is the next run). Back to
+        // the test screen first: the still-current success survives Back.
+        flow.back()
+        XCTAssertTrue(flow.hasCurrentSuccessfulTest)
         XCTAssertNotNil(flow.beginTest())
         XCTAssertFalse(candidateB.isCurrent(
             hasCurrentSuccessfulTest: flow.hasCurrentSuccessfulTest,

--- a/ConduitTests/ConnectionRepairTests.swift
+++ b/ConduitTests/ConnectionRepairTests.swift
@@ -218,7 +218,10 @@ final class ConnectionRepairTests: XCTestCase {
             testSucceededAtRevision: flow.testSucceededAtRevision
         ))
 
-        // A draft edit invalidates the staged success and the candidate.
+        // A draft edit invalidates the staged success and the candidate:
+        // Back walks Review → test → details, then Continue reaches the
+        // credentials step.
+        flow.back()
         flow.back()
         flow.submitDetails()
         XCTAssertEqual(flow.step, .loginCredentials)

--- a/ConduitTests/ConnectionSetupTestTests.swift
+++ b/ConduitTests/ConnectionSetupTestTests.swift
@@ -731,6 +731,46 @@ final class ConnectionSetupTestTests: XCTestCase {
         XCTAssertEqual(events, StagedTestDriver.successEvents)
     }
 
+    // MARK: - Validated transaction acquisition (Round 6)
+
+    @MainActor
+    private func runProbeWithAcquisition(
+        _ baseURL: String
+    ) async -> (events: [ConnectionSetupTestEvent], acquisition: ConnectionSetupTestAcquisition?) {
+        let probe = ConnectionSetupProbe(sessionConfiguration: Self.makeProbeConfiguration())
+        var events: [ConnectionSetupTestEvent] = []
+        let acquisition = await probe.runTest(
+            result: ConnectionSetupResult(
+                serverURL: baseURL,
+                username: "probe-user",
+                password: "probe-password-fixture"
+            ),
+            cloudflareAccess: nil,
+            onEvent: { events.append($0) }
+        )
+        return (events, acquisition)
+    }
+
+    func testProbeFullSuccessReturnsTheValidatedTransactionMemoryOnly() async throws {
+        // Round 6: a successful native test hands back the validated
+        // transaction (memory only — the probe never commits it), so Repair
+        // can reconnect without repeating the password login.
+        let (events, acquisition) = await runProbeWithAcquisition("https://probe-success.example")
+        XCTAssertEqual(events, StagedTestDriver.successEvents)
+        let validated = try XCTUnwrap(acquisition)
+        XCTAssertEqual(validated.configuration.serverURL, "https://probe-success.example")
+        XCTAssertEqual(validated.nativeConnection.ticket, "probe-ticket")
+    }
+
+    func testProbeDiagnosticOutcomesReturnNoAcquisition() async {
+        let interactive = await runProbeWithAcquisition("https://probe-interactive.example")
+        XCTAssertNil(interactive.acquisition, "The interactive outcome produces no native transaction")
+        let rejected = await runProbeWithAcquisition("https://probe-auth401.example")
+        XCTAssertNil(rejected.acquisition, "A rejected login produces no native transaction")
+        let dns = await runProbeWithAcquisition("https://probe-dns.example")
+        XCTAssertNil(dns.acquisition, "A transport failure produces no native transaction")
+    }
+
     func testProbeDNSFailureMapsToHostNotFoundAtServerStage() async {
         let events = await runProbe("https://probe-dns.example")
         XCTAssertEqual(events, [.started(.server), .failed(.server, .hostNotFound)])

--- a/ConduitUITests/ConnectionRepairUITests.swift
+++ b/ConduitUITests/ConnectionRepairUITests.swift
@@ -188,8 +188,11 @@ final class ConnectionRepairUITests: XCTestCase {
         tapVisible(app.buttons[Identity.reconnectNow], in: app)
 
         // Still on Review with the classified failure — never a silent drop
-        // to a wiped test screen, never a retry.
-        XCTAssertTrue(app.buttons[Identity.reconnectNow].waitForExistence(timeout: 5), "Wizard did not stay on Review. Tree:\n\(app.debugDescription)")
+        // to a wiped test screen, never a retry. The consumed candidate
+        // means the only way forward is a fresh Test Connection.
+        XCTAssertTrue(app.staticTexts["setup.review.reconnect-failure"].waitForExistence(timeout: 5), "Classified activation failure not shown. Tree:\n\(app.debugDescription)")
+        XCTAssertTrue(app.buttons["setup.review.test-again"].exists, "Test Connection Again must be the offered next step")
+        XCTAssertFalse(app.buttons[Identity.reconnectNow].exists, "A consumed candidate must not authorize another Reconnect Now")
         XCTAssertFalse(app.staticTexts["setup.test.ready"].exists, "A failed reconnect must not claim the connection is ready")
         XCTAssertFalse(app.textFields["login.server-url"].exists, "A failed activation must never strand the user on the login card")
     }

--- a/ConduitUITests/ConnectionRepairUITests.swift
+++ b/ConduitUITests/ConnectionRepairUITests.swift
@@ -1,0 +1,170 @@
+import XCTest
+
+/// Round-6 Repair Connection UI coverage. All paths are deterministic:
+/// `-CONDUIT_UI_TEST_FAILED_CONNECTION` starts the app on a failed stubbed
+/// session (Repair Connection visible), `-CONNECTION_SETUP_TEST_RESULT`
+/// scripts the staged probe, and `-CONDUIT_REPAIR_ACTIVATION` scripts the
+/// explicit activation outcome. No test touches a real Hermes server.
+final class ConnectionRepairUITests: XCTestCase {
+    private enum Identity {
+        static let stubDashboardURL = "https://repair-uitest.example"
+        static let repairButton = "composer.repair-connection"
+        static let urlField = "setup.url"
+        static let username = "setup.username"
+        static let password = "setup.password"
+        static let next = "setup.next"
+        static let back = "setup.back"
+        static let testRun = "setup.test.run"
+        static let reconnectNow = "setup.review.reconnect-now"
+        static let signInReconnect = "setup.review.sign-in-reconnect"
+        static let enterCredentials = "setup.test.enter-credentials"
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testFailedConnectionOffersRepairSeededWithTheCurrentURL() {
+        // The stable failure surfaces the Repair entry; the wizard opens
+        // seeded from the failed connection's exact URL.
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-CONDUIT_UI_TEST_FAILED_CONNECTION", Identity.stubDashboardURL,
+            "-CONNECTION_SETUP_TEST_RESULT", "server:hostNotFound"
+        ]
+        app.launch()
+
+        let repair = app.buttons[Identity.repairButton]
+        XCTAssertTrue(repair.waitForExistence(timeout: 10), "Repair Connection did not appear. Tree:\n\(app.debugDescription)")
+        repair.tap()
+
+        let urlField = app.textFields[Identity.urlField]
+        XCTAssertTrue(urlField.waitForExistence(timeout: 5), "Repair did not open on the details screen. Tree:\n\(app.debugDescription)")
+        XCTAssertEqual(urlField.value as? String, Identity.stubDashboardURL)
+    }
+
+    func testNativeRepairTestsReconnectsAndReturnsToChat() {
+        // Full native repair: seeded URL → credentials → staged success →
+        // Reconnect Now (scripted activation) → back on chat, never bounced
+        // to the login card.
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-CONDUIT_UI_TEST_FAILED_CONNECTION", Identity.stubDashboardURL,
+            "-CONNECTION_SETUP_TEST_RESULT", "success",
+            "-CONDUIT_REPAIR_ACTIVATION", "success"
+        ]
+        app.launch()
+
+        let repair = app.buttons[Identity.repairButton]
+        XCTAssertTrue(repair.waitForExistence(timeout: 10))
+        tapVisible(repair, in: app)
+
+        let urlField = app.textFields[Identity.urlField]
+        XCTAssertTrue(urlField.waitForExistence(timeout: 5))
+        XCTAssertEqual(urlField.value as? String, Identity.stubDashboardURL)
+        tapVisible(app.buttons[Identity.next], in: app)
+
+        let username = app.textFields[Identity.username]
+        XCTAssertTrue(username.waitForExistence(timeout: 5))
+        tapVisible(username, in: app)
+        username.typeText("repair-user")
+        let password = app.secureTextFields[Identity.password]
+        tapVisible(password, in: app)
+        password.typeText("repair-fixture")
+        dismissKeyboard(app)
+        tapVisible(app.buttons[Identity.next], in: app)
+
+        XCTAssertTrue(app.buttons[Identity.testRun].waitForExistence(timeout: 5), "Test screen did not appear. Tree:\n\(app.debugDescription)")
+        tapVisible(app.buttons[Identity.testRun], in: app)
+        XCTAssertTrue(app.staticTexts["setup.test.ready"].waitForExistence(timeout: 5))
+
+        // Reconnect Now is the Repair review's final action (not "Use these
+        // settings"), and it activates the validated transaction from the
+        // test — the scripted activation reports success and the wizard
+        // closes.
+        XCTAssertTrue(app.buttons[Identity.reconnectNow].waitForExistence(timeout: 5), "Reconnect Now did not appear. Tree:\n\(app.debugDescription)")
+        XCTAssertFalse(app.buttons["setup.use-settings"].exists, "Repair mode must not show the login handoff")
+        tapVisible(app.buttons[Identity.reconnectNow], in: app)
+
+        // Back on the chat surface: still the (stubbed) failed session in
+        // its stable state — never the login card.
+        XCTAssertTrue(app.buttons[Identity.repairButton].waitForExistence(timeout: 5), "Wizard did not return to chat. Tree:\n\(app.debugDescription)")
+        XCTAssertFalse(app.textFields["login.server-url"].exists, "Repair must never strand the user on the login card")
+    }
+
+    func testRepairWithoutCredentialsStopsAtCredentialsRequiredAndRoutesToEntry() {
+        // A repair whose seed has no credentials: discovery finds a password
+        // dashboard and the staged test stops at Credentials required —
+        // Enter Credentials routes to the credentials step. No empty-credential
+        // login ever fires.
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-CONDUIT_UI_TEST_FAILED_CONNECTION", Identity.stubDashboardURL,
+            "-CONDUIT_UI_TEST_FAILURE_KIND", "none",
+            "-CONNECTION_SETUP_TEST_RESULT", "auth:credentialsRequired"
+        ]
+        app.launch()
+
+        let repair = app.buttons[Identity.repairButton]
+        XCTAssertTrue(repair.waitForExistence(timeout: 10))
+        tapVisible(repair, in: app)
+
+        // No retained failure: the repair opens straight on the staged test.
+        let preview = app.descendants(matching: .any).matching(identifier: "setup.address-preview").firstMatch
+        XCTAssertTrue(preview.waitForExistence(timeout: 5), "Repair did not open on the staged test. Tree:\n\(app.debugDescription)")
+        XCTAssertEqual(preview.label, Identity.stubDashboardURL)
+        tapVisible(app.buttons[Identity.testRun], in: app)
+
+        XCTAssertTrue(app.staticTexts["setup.test.credentials-required"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.buttons[Identity.reconnectNow].exists, "A partial test must never authorize Reconnect Now")
+        tapVisible(app.buttons[Identity.enterCredentials], in: app)
+        XCTAssertTrue(app.textFields[Identity.username].waitForExistence(timeout: 5), "Enter Credentials did not route to the credentials step. Tree:\n\(app.debugDescription)")
+        XCTAssertTrue(app.buttons[Identity.back].exists, "Back keeps the tested address reachable")
+    }
+
+    func testInteractiveRepairOffersSignInToReconnect() {
+        // A browser-auth deployment: the review offers Sign In to Reconnect
+        // (the existing AuthWebView runs on tap) and never claims login
+        // success.
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-CONDUIT_UI_TEST_FAILED_CONNECTION", Identity.stubDashboardURL,
+            "-CONDUIT_UI_TEST_FAILURE_KIND", "none",
+            "-CONNECTION_SETUP_TEST_RESULT", "auth:interactiveSignInRequired"
+        ]
+        app.launch()
+
+        let repair = app.buttons[Identity.repairButton]
+        XCTAssertTrue(repair.waitForExistence(timeout: 10))
+        tapVisible(repair, in: app)
+
+        let preview = app.descendants(matching: .any).matching(identifier: "setup.address-preview").firstMatch
+        XCTAssertTrue(preview.waitForExistence(timeout: 5))
+        tapVisible(app.buttons[Identity.testRun], in: app)
+
+        let interactiveReady = app.staticTexts["setup.test.interactive-ready"]
+        XCTAssertTrue(interactiveReady.waitForExistence(timeout: 5))
+        XCTAssertTrue(interactiveReady.label.contains("Sign in now to reconnect"), "Got: \(interactiveReady.label)")
+        XCTAssertFalse(app.staticTexts["setup.test.ready"].exists, "Interactive auth must never claim login success")
+        XCTAssertTrue(app.buttons[Identity.signInReconnect].waitForExistence(timeout: 5), "Sign In to Reconnect did not appear. Tree:\n\(app.debugDescription)")
+        XCTAssertFalse(app.buttons[Identity.reconnectNow].exists)
+    }
+
+    // MARK: - Walk helpers
+
+    private func tapVisible(_ element: XCUIElement, in app: XCUIApplication) {
+        XCTAssertTrue(element.waitForExistence(timeout: 5))
+        for _ in 0..<6 {
+            if element.isHittable { break }
+            app.swipeUp()
+        }
+        XCTAssertTrue(element.isHittable)
+        element.tap()
+    }
+
+    private func dismissKeyboard(_ app: XCUIApplication) {
+        let done = app.buttons["setup.keyboard-done"]
+        guard done.waitForExistence(timeout: 2) else { return }
+        done.tap()
+    }
+}

--- a/ConduitUITests/ConnectionRepairUITests.swift
+++ b/ConduitUITests/ConnectionRepairUITests.swift
@@ -150,6 +150,50 @@ final class ConnectionRepairUITests: XCTestCase {
         XCTAssertFalse(app.buttons[Identity.reconnectNow].exists)
     }
 
+    func testFailedActivationShowsClassifiedFailureAndForcesFreshTest() {
+        // A test success is not a guarantee the world is unchanged: when the
+        // explicit activation fails, the classified failure is shown on
+        // Review, the candidate is consumed, and the only way forward is a
+        // fresh Test Connection — no automatic retry.
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-CONDUIT_UI_TEST_FAILED_CONNECTION", Identity.stubDashboardURL,
+            "-CONNECTION_SETUP_TEST_RESULT", "success",
+            "-CONDUIT_REPAIR_ACTIVATION", "transportFailure"
+        ]
+        app.launch()
+
+        let repair = app.buttons[Identity.repairButton]
+        XCTAssertTrue(repair.waitForExistence(timeout: 10))
+        tapVisible(repair, in: app)
+
+        let urlField = app.textFields[Identity.urlField]
+        XCTAssertTrue(urlField.waitForExistence(timeout: 5))
+        XCTAssertEqual(urlField.value as? String, Identity.stubDashboardURL)
+        tapVisible(app.buttons[Identity.next], in: app)
+
+        let username = app.textFields[Identity.username]
+        XCTAssertTrue(username.waitForExistence(timeout: 5))
+        tapVisible(username, in: app)
+        username.typeText("repair-user")
+        let password = app.secureTextFields[Identity.password]
+        tapVisible(password, in: app)
+        password.typeText("repair-fixture")
+        dismissKeyboard(app)
+        tapVisible(app.buttons[Identity.next], in: app)
+
+        XCTAssertTrue(app.buttons[Identity.testRun].waitForExistence(timeout: 5))
+        tapVisible(app.buttons[Identity.testRun], in: app)
+        XCTAssertTrue(app.staticTexts["setup.test.ready"].waitForExistence(timeout: 5))
+        tapVisible(app.buttons[Identity.reconnectNow], in: app)
+
+        // Still on Review with the classified failure — never a silent drop
+        // to a wiped test screen, never a retry.
+        XCTAssertTrue(app.buttons[Identity.reconnectNow].waitForExistence(timeout: 5), "Wizard did not stay on Review. Tree:\n\(app.debugDescription)")
+        XCTAssertFalse(app.staticTexts["setup.test.ready"].exists, "A failed reconnect must not claim the connection is ready")
+        XCTAssertFalse(app.textFields["login.server-url"].exists, "A failed activation must never strand the user on the login card")
+    }
+
     // MARK: - Walk helpers
 
     private func tapVisible(_ element: XCUIElement, in app: XCUIApplication) {


### PR DESCRIPTION
## Round 6: Connection Repair + Explicit Tested Reconnect

Closes the runtime recovery loop after Rounds 1–5 (#131 → #136 → #138 → #142). **Not a redesign** — this is orchestration around the systems already built: the same wizard, probe, failure taxonomy, apply plan, `NativeAuthClient`, `AuthWebView`, and AppState recovery machinery.

> When an existing Hermes connection fails, the user can enter a repair flow seeded from that failed connection, diagnose/test corrected settings, and explicitly reconnect using the configuration they just verified.

### Failure surfaces wired to Repair

- **ComposerBar** (connected-state): when the connection is down and a failed attempt has surfaced (typed classified failure or visible error banner), a **Repair Connection** action appears next to the error — never during healthy operation, never uninvited, never for transient hiccups while automatic recovery is still working.
- **LoginView**: a failed **saved-credential reconnect** (the typed `lastConnectionFailure` proves provenance; manual login failures clear it at attempt start) offers **Repair Connection** seeded from that saved record.

### Exact Repair launch context

`ConnectionRepairContext` — the failed target's **exact URL** (scheme/host/port/path preserved, never reconstructed), safely available credentials under the Round-5 seeding rules (Face ID-protected records surrender username only), the origin-matched Cloudflare token, and the classified `ConnectionFailure` for routing. Built in AppState at the failure site; no string parsing anywhere (`AppState.lastConnectionFailure: ConnectionFailure?` is the minimal typed addition).

### Failure-taxonomy entry routing

`initialPath` routes near the likely problem, always with the editable address one Back-step away: `authenticationRejected` → credentials; `cloudflareTokenRejected` → Cloudflare troubleshooting; TLS failures → TLS troubleshooting; transport/address/dashboard failures and `rateLimited` → details; `unknown`/no diagnosis → seeded staged test. Deliberately not over-optimized.

### Explicit reconnect ownership

Entering Repair calls `cancelChatResumeTransportRecovery()`: the scheduled retry, its operations, and its automatic work all lose authority, so a stale automatic reconnect can never install a connection or select a session over the user's repair. Dismissal leaves the stable disconnected state — no surprise background attempts. The explicit activation then connects through the standard path with **`.preserveCurrent`** — never `.automaticReturn`; the server confirms the preserved session identity (and a different endpoint falls through the existing identity-clearing boundary — no blind session-ID reuse, no arbitrary switching).

### Validated-transaction lifecycle (the Round-6 core)

- The probe now **returns** the validated `NativeAuthConnection` memory-only on native success (`ConnectionSetupTestAcquisition`). Nothing is committed during testing — Round-4 testing remains side-effect-free.
- Repair promotes it into a one-shot `ConnectionRepairCandidate` bound to the producing revision **and** generation. Edits, newer runs, cancellation, dismissal, and consumption each invalidate it; `isCurrent` checks all three at use time.
- **Reconnect Now** verifies currency, consumes the candidate, commits its cookies exactly once, and activates. **Total network cost for Test + Reconnect: 1 discovery / 1 password login / 1 ticket mint — not 2/2.** Test-then-cancel: 1/1/1 with **0 cookie commits, 0 AppState connects**.

### Interactive-auth repair

A `Browser sign-in required` review offers **Sign In to Reconnect** (never Reconnect Now, never a login-success claim). On tap the **existing AuthWebView** opens over the tested URL with the same-origin Cloudflare state; the normal ticket callback drives the same explicit activation with `.preserveCurrent`. Persistence follows existing browser-auth semantics: remember the activated URL, clear stale native credentials, no invented stores. The probe never hosts a WebView.

### Persistence timing (intentionally stricter than Round 5)

Persist **only after successful activation**, via the Round-5 `ConnectionSetupApplication.plan` anchored at the **pre-activation target** (replace-never-create credentials, same-origin Cloudflare rebind, URL remembered when changed). Failed activation: replacement URL/credentials not persisted, remembered URL restored, candidate consumed, classified failure shown on Review with **Test Connection Again** as the only way forward — no automatic retry, fresh test required.

### Repair cancellation

Opening Repair, editing, testing, failing, and dismissing have no persistence or auth side effects; the automatic loop stays stopped (per the takeover contract) until the user reconnects or retries manually.

### UI-test seams (all deterministic, no real server)

`-CONDUIT_UI_TEST_FAILED_CONNECTION <url>` (failed stubbed session), `-CONDUIT_UI_TEST_FAILURE_KIND none` (no retained failure → test-first entry), the existing probe stub, and `-CONDUIT_REPAIR_ACTIVATION success|transportFailure` (scripted, fully inert activation). Five new UI tests: seeded entry, native test→Reconnect Now→back to chat (never login), credentials-required→Enter Credentials, interactive→Sign In to Reconnect, and failed-activation→classified failure→forced fresh test.

### Tests & results (Mac, at this exact HEAD)

- New `ConnectionRepairTests` (11): routing, address-always-reachable, candidate lifecycle (edit/new-run/consume), invalidation-after-failure, repair-takeover stops the retry loop, same-connection repair (one auth, session preserved), changed-endpoint identity boundary, failed activation persists nothing, browser-sign-in activation, and the §26 race — **explicit repair outranks a late automatic reconnect** (connection and session remain B's, `.preserveCurrent` throughout, A aborts at its post-mint checkpoint, exactly one connect).
- Probe acquisition pins (validated transaction returned on success; nil for every diagnostic outcome).
- Full `ConduitTests`: **2044/2044, 0 failures** (baseline 2029 → +15).
- UI: all Connection Setup suites + 5 new Repair tests green locally (17 UI tests).
- `git diff --check` clean.

### Hosted CI

**Green** — [CI run 34136038801](https://github.com/kaishi00/hermes-conduit/actions/runs/34136038801): Plan & validate, Build test products, unit-1..unit-4, UI tests (incl. the 5 new Repair paths), CodeRabbit, and opencode-review all pass.


### Final pre-merge cleanup (head 0ff419e + e875652)

- **Bug fix:** a successful `reconnectForRetry` cleared the visible banner but left `lastConnectionFailure` set, so a later unrelated failure could route Repair Connection from a stale classification. The successful-reconnect branch now clears the typed failure alongside the banner — only there, only on genuine success (failure paths still set it; scheduling, purpose semantics, and ownership untouched).
- **Regression test:** `testFailedReconnectRetainsTypedFailureUntilRecoverySucceeds` — a failed reconnect retains the typed classification (and arms the ordinary retry); the later successful reconnect clears classification + banner, reports connected, and leaves nothing scheduled.
- **Clarity:** explicit parentheses around the ComposerBar eligibility OR-group (semantic no-op).
- **Hygiene:** the remaining test-defaults force unwrap replaced with a guarded XCTFail path.
- Cleanup re-review: **1 APPROVE + 2 APPROVE_WITH_NITS, zero blockers/warnings** (nits applied: armed-retry disposition pinned, indentation aligned).

### Review gate

3-reviewer cycle (1 APPROVE, 2 REQUEST_CHANGES) → 1 BLOCKER (failed activation hid the classified failure behind the step pop — now it stays on Review with the failure rendered and Test Connection Again as the explicit next step) plus warnings all fixed (login-entry authority parity, stale-failure clearing, typed-state gating, real `CustomStringConvertible` redaction, health guard, dedicated activation-failure UI test, browser persist test). Follow-up re-review of the fixes: **APPROVE, zero findings**.

### Intentionally deferred

- Reconnect Now on the healthy Settings `.currentConnection` path (Round 5's save-for-next-reconnect contract stands).
- Committed-cookie rollback after failed activation (documented: the transaction was genuinely authenticated; superseded by the next explicit test/sign-in).
- Face ID username-only repair landing directly on the staged test (keeps option-A parity with Settings; safe either way).
- Spec's out-of-scope list: no Bonjour/QR/Tailscale-API/multi-server/history/auto-reconnect-after-test/etc.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guided **Repair Connection** flow for failed existing or saved-credential connections.
  * Repair troubleshooting now starts with context-specific steps for authentication, Cloudflare, TLS, and other connection failures.
  * Users can test updated settings, reconnect, sign in again, or retry testing before applying changes.
  * Added clearer connection failure classification and recovery messaging.
* **Bug Fixes**
  * Successful reconnections now clear previous failure notices.
  * Connection settings are applied only after a repair succeeds, preventing unsuccessful attempts from replacing working settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->