### PR TITLE
fix(voice): prevent speaker playback from feeding back into barge-in

### DIFF
--- a/Conduit/Views/VoiceConversationSheet.swift
+++ b/Conduit/Views/VoiceConversationSheet.swift
@@ -114,18 +114,28 @@ struct VoiceConversationSheet: View {
         profile == "default" ? "Default profile" : profile.replacingOccurrences(of: "_", with: " ").capitalized
     }
 
+    /// Automatic speaker-safe suspension while Hermes audibly speaks on an
+    /// open-speaker route: the mic control becomes Interrupt instead of a
+    /// pause, so this never reads as a user-selected mic pause.
+    private var isInterruptAvailable: Bool {
+        controller.isPlaybackCaptureSuspended
+    }
+
     private var microphoneLabel: String {
         if controller.state == .transcribing { return "Transcribing" }
+        if isInterruptAvailable { return "Interrupt" }
         return microphoneIsActive ? "Pause mic" : "Listen"
     }
 
     private var microphoneSymbol: String {
         if controller.state == .transcribing { return "waveform" }
+        if isInterruptAvailable { return "stop.fill" }
         return microphoneIsActive ? "mic.slash.fill" : "mic.fill"
     }
 
     private var microphoneHint: String {
-        microphoneIsActive ? "Pauses microphone capture while keeping the voice session open" : "Starts or resumes microphone capture"
+        if isInterruptAvailable { return "Stops Hermes' speech and starts listening right away" }
+        return microphoneIsActive ? "Pauses microphone capture while keeping the voice session open" : "Starts or resumes microphone capture"
     }
 
     private var microphoneIsActive: Bool {
@@ -137,6 +147,7 @@ struct VoiceConversationSheet: View {
     }
 
     private var statusTitle: String {
+        if isInterruptAvailable { return "Hermes is speaking" }
         if controller.isMicrophonePaused { return "Microphone paused" }
         switch controller.state {
         case .idle: return "Ready to listen"
@@ -150,6 +161,7 @@ struct VoiceConversationSheet: View {
     }
 
     private var statusDetail: String {
+        if isInterruptAvailable { return "Tap Interrupt to speak." }
         if controller.isMicrophonePaused { return "Tap Listen when you are ready to resume." }
         switch controller.state {
         case .idle: return "Tap Listen when you are ready."
@@ -186,7 +198,9 @@ struct VoiceConversationSheet: View {
     }
 
     private func microphoneTapped() {
-        if microphoneIsActive {
+        if isInterruptAvailable {
+            Task { await controller.interruptAssistantPlayback() }
+        } else if microphoneIsActive {
             controller.pauseMicrophone()
         } else {
             Task { await controller.resumeMicrophone() }

--- a/Conduit/Views/VoiceConversationSheet.swift
+++ b/Conduit/Views/VoiceConversationSheet.swift
@@ -116,9 +116,12 @@ struct VoiceConversationSheet: View {
 
     /// Automatic speaker-safe suspension while Hermes audibly speaks on an
     /// open-speaker route: the mic control becomes Interrupt instead of a
-    /// pause, so this never reads as a user-selected mic pause.
+    /// pause, so this never reads as a user-selected mic pause. An explicit
+    /// user pause keeps precedence — the sheet stays in the paused state,
+    /// and its Listen tap routes through `resumeMicrophone`, which acts as
+    /// an interrupt while playback is suspended.
     private var isInterruptAvailable: Bool {
-        controller.isPlaybackCaptureSuspended
+        controller.isPlaybackCaptureSuspended && !controller.isMicrophonePaused
     }
 
     private var microphoneLabel: String {

--- a/Conduit/Voice/VoiceBargeInRoutePolicy.swift
+++ b/Conduit/Voice/VoiceBargeInRoutePolicy.swift
@@ -44,10 +44,13 @@ enum VoiceBargeInRoutePolicy: Equatable {
         // output is clear evidence of a usable headset microphone/output
         // pairing (AirPods, mono headsets): the voice session's output
         // travels the headset's own speaker. Name equality keeps two
-        // different accessories (headset mic + room speaker) conservative.
+        // different accessories (headset mic + room speaker) conservative,
+        // and empty names never pair (two anonymous ports are not evidence).
         let hasPairedHeadsetOutput = outputs.contains { output in
             guard output.type == .bluetoothHFP || output.type == .bluetoothA2DP else { return false }
-            return inputs.contains { $0.type == .bluetoothHFP && $0.name == output.name }
+            return inputs.contains {
+                $0.type == .bluetoothHFP && !$0.name.isEmpty && $0.name == output.name
+            }
         }
         if hasPairedHeadsetOutput { return .fullDuplex }
         // Built-in speaker/receiver, A2DP-only Bluetooth (speakers), AirPlay,

--- a/Conduit/Voice/VoiceBargeInRoutePolicy.swift
+++ b/Conduit/Voice/VoiceBargeInRoutePolicy.swift
@@ -1,0 +1,68 @@
+//
+//  VoiceBargeInRoutePolicy.swift
+//  Conduit
+//
+//  A single, testable seam for deciding whether acoustic barge-in is safe
+//  while Hermes is audibly speaking, so AVAudioSession route inspection
+//  never scatters across controller and UI code.
+//
+
+import AVFAudio
+import Foundation
+
+/// Whether the microphone may stay live while the assistant's own TTS plays.
+enum VoiceBargeInRoutePolicy: Equatable {
+    /// The output is acoustically isolated from this device's microphone
+    /// (wired headset, or a Bluetooth headset-profile pairing where capture
+    /// and playback both travel the headset's own mic/speaker). The user can
+    /// keep speaking over Hermes: live barge-in monitoring stays armed.
+    case fullDuplex
+    /// The output can feed this device's microphone (built-in speaker,
+    /// built-in receiver, or a generic/external output with no clear
+    /// headset pairing). Capture is suspended while Hermes speaks: the
+    /// amplitude-based barge-in detector cannot tell the speaker's own TTS
+    /// from user speech (device-reproduced feedback loop).
+    case speakerSafeHalfDuplex
+
+    /// Classifies a route from its port descriptions. Deliberately
+    /// conservative: anything that is not provably an isolated headset
+    /// output is half duplex.
+    static func resolve(
+        outputs: [VoiceAudioRoutePort],
+        inputs: [VoiceAudioRoutePort]
+    ) -> VoiceBargeInRoutePolicy {
+        // Wired headphones/headset: output sits in the user's ears, away
+        // from the device microphone.
+        if outputs.contains(where: { $0.type == .headphones }) { return .fullDuplex }
+        // A Bluetooth headset-profile INPUT is clear evidence of a usable
+        // headset microphone/output pairing (AirPods, mono headsets): the
+        // voice session's output pairs with the headset's own speaker.
+        let hasHeadsetInput = inputs.contains(where: { $0.type == .bluetoothHFP })
+        let hasBluetoothOutput = outputs.contains {
+            $0.type == .bluetoothHFP || $0.type == .bluetoothA2DP
+        }
+        if hasHeadsetInput, hasBluetoothOutput { return .fullDuplex }
+        // Built-in speaker/receiver, A2DP-only Bluetooth (speakers), AirPlay,
+        // USB, HDMI, CarPlay, and every unknown combination can feed the
+        // microphone: half duplex.
+        return .speakerSafeHalfDuplex
+    }
+
+    /// Classifies the session's live route. MainActor-scoped because
+    /// AVAudioSession is.
+    @MainActor
+    static func current() -> VoiceBargeInRoutePolicy {
+        let route = AVAudioSession.sharedInstance().currentRoute
+        return resolve(
+            outputs: route.outputs.map { VoiceAudioRoutePort(type: $0.portType, name: $0.portName) },
+            inputs: route.inputs.map { VoiceAudioRoutePort(type: $0.portType, name: $0.portName) }
+        )
+    }
+}
+
+/// The port facts the policy classifier needs, decoupled from
+/// AVAudioSessionPortDescription (which cannot be constructed in tests).
+struct VoiceAudioRoutePort: Equatable {
+    var type: AVAudioSession.Port
+    var name: String
+}

--- a/Conduit/Voice/VoiceBargeInRoutePolicy.swift
+++ b/Conduit/Voice/VoiceBargeInRoutePolicy.swift
@@ -24,38 +24,42 @@ enum VoiceBargeInRoutePolicy: Equatable {
     /// from user speech (device-reproduced feedback loop).
     case speakerSafeHalfDuplex
 
-    /// Classifies a route from its port descriptions. Deliberately
-    /// conservative: anything that is not provably an isolated headset
-    /// output is half duplex.
+    /// Classifies a route from its port descriptions. Fail-safe: EVERY
+    /// active output must be proven acoustically safe — one unsafe output
+    /// (an AirPlay or room speaker alongside AirPods, say) vetoes the
+    /// entire route into half duplex.
     static func resolve(
         outputs: [VoiceAudioRoutePort],
         inputs: [VoiceAudioRoutePort]
     ) -> VoiceBargeInRoutePolicy {
-        // An open speaker or receiver anywhere in the output list vetoes
-        // full duplex, even alongside a headset: audio may be rendering to
-        // the open speaker, whose sound feeds the microphone.
-        if outputs.contains(where: { $0.type == .builtInSpeaker || $0.type == .builtInReceiver }) {
-            return .speakerSafeHalfDuplex
-        }
-        // Wired headphones/headset: output sits in the user's ears, away
-        // from the device microphone.
-        if outputs.contains(where: { $0.type == .headphones }) { return .fullDuplex }
+        guard !outputs.isEmpty else { return .speakerSafeHalfDuplex }
         // A Bluetooth headset-profile INPUT paired with the same accessory's
         // output is clear evidence of a usable headset microphone/output
         // pairing (AirPods, mono headsets): the voice session's output
         // travels the headset's own speaker. Name equality keeps two
         // different accessories (headset mic + room speaker) conservative,
         // and empty names never pair (two anonymous ports are not evidence).
-        let hasPairedHeadsetOutput = outputs.contains { output in
-            guard output.type == .bluetoothHFP || output.type == .bluetoothA2DP else { return false }
-            return inputs.contains {
-                $0.type == .bluetoothHFP && !$0.name.isEmpty && $0.name == output.name
+        let pairedHeadsetInputNames = Set(
+            inputs
+                .filter { $0.type == .bluetoothHFP && !$0.name.isEmpty }
+                .map(\.name)
+        )
+        let everyOutputIsSafe = outputs.allSatisfy { output in
+            switch output.type {
+            case .headphones:
+                // Wired headset/earphones: output sits in the user's ears,
+                // away from the device microphone.
+                return true
+            case .bluetoothHFP, .bluetoothA2DP:
+                return pairedHeadsetInputNames.contains(output.name)
+            default:
+                // Built-in speaker/receiver, A2DP-only Bluetooth (speakers),
+                // AirPlay, USB, CarPlay, and every other or unknown output
+                // can feed the microphone: unsafe.
+                return false
             }
         }
-        if hasPairedHeadsetOutput { return .fullDuplex }
-        // A2DP-only Bluetooth (speakers), AirPlay, and every other or
-        // unknown output can feed the microphone: half duplex.
-        return .speakerSafeHalfDuplex
+        return everyOutputIsSafe ? .fullDuplex : .speakerSafeHalfDuplex
     }
 
     /// Classifies the session's live route. MainActor-scoped because

--- a/Conduit/Voice/VoiceBargeInRoutePolicy.swift
+++ b/Conduit/Voice/VoiceBargeInRoutePolicy.swift
@@ -39,6 +39,9 @@ enum VoiceBargeInRoutePolicy: Equatable {
         // travels the headset's own speaker. Name equality keeps two
         // different accessories (headset mic + room speaker) conservative,
         // and empty names never pair (two anonymous ports are not evidence).
+        // Residual limitation: two distinct accessories reporting identical
+        // names are indistinguishable at this seam and may pair —
+        // AVAudioSession exposes no accessory UID to disambiguate them.
         let pairedHeadsetInputNames = Set(
             inputs
                 .filter { $0.type == .bluetoothHFP && !$0.name.isEmpty }
@@ -53,9 +56,9 @@ enum VoiceBargeInRoutePolicy: Equatable {
             case .bluetoothHFP, .bluetoothA2DP:
                 return pairedHeadsetInputNames.contains(output.name)
             default:
-                // Built-in speaker/receiver, A2DP-only Bluetooth (speakers),
-                // AirPlay, USB, CarPlay, and every other or unknown output
-                // can feed the microphone: unsafe.
+                // Built-in speaker/receiver, AirPlay, USB, CarPlay, and
+                // every other or unknown output can feed the microphone:
+                // unsafe. (Unpaired Bluetooth outputs are rejected above.)
                 return false
             }
         }

--- a/Conduit/Voice/VoiceBargeInRoutePolicy.swift
+++ b/Conduit/Voice/VoiceBargeInRoutePolicy.swift
@@ -53,9 +53,8 @@ enum VoiceBargeInRoutePolicy: Equatable {
             }
         }
         if hasPairedHeadsetOutput { return .fullDuplex }
-        // Built-in speaker/receiver, A2DP-only Bluetooth (speakers), AirPlay,
-        // USB, CarPlay, and every unknown combination can feed the
-        // microphone: half duplex.
+        // A2DP-only Bluetooth (speakers), AirPlay, and every other or
+        // unknown output can feed the microphone: half duplex.
         return .speakerSafeHalfDuplex
     }
 

--- a/Conduit/Voice/VoiceBargeInRoutePolicy.swift
+++ b/Conduit/Voice/VoiceBargeInRoutePolicy.swift
@@ -31,19 +31,27 @@ enum VoiceBargeInRoutePolicy: Equatable {
         outputs: [VoiceAudioRoutePort],
         inputs: [VoiceAudioRoutePort]
     ) -> VoiceBargeInRoutePolicy {
+        // An open speaker or receiver anywhere in the output list vetoes
+        // full duplex, even alongside a headset: audio may be rendering to
+        // the open speaker, whose sound feeds the microphone.
+        if outputs.contains(where: { $0.type == .builtInSpeaker || $0.type == .builtInReceiver }) {
+            return .speakerSafeHalfDuplex
+        }
         // Wired headphones/headset: output sits in the user's ears, away
         // from the device microphone.
         if outputs.contains(where: { $0.type == .headphones }) { return .fullDuplex }
-        // A Bluetooth headset-profile INPUT is clear evidence of a usable
-        // headset microphone/output pairing (AirPods, mono headsets): the
-        // voice session's output pairs with the headset's own speaker.
-        let hasHeadsetInput = inputs.contains(where: { $0.type == .bluetoothHFP })
-        let hasBluetoothOutput = outputs.contains {
-            $0.type == .bluetoothHFP || $0.type == .bluetoothA2DP
+        // A Bluetooth headset-profile INPUT paired with the same accessory's
+        // output is clear evidence of a usable headset microphone/output
+        // pairing (AirPods, mono headsets): the voice session's output
+        // travels the headset's own speaker. Name equality keeps two
+        // different accessories (headset mic + room speaker) conservative.
+        let hasPairedHeadsetOutput = outputs.contains { output in
+            guard output.type == .bluetoothHFP || output.type == .bluetoothA2DP else { return false }
+            return inputs.contains { $0.type == .bluetoothHFP && $0.name == output.name }
         }
-        if hasHeadsetInput, hasBluetoothOutput { return .fullDuplex }
+        if hasPairedHeadsetOutput { return .fullDuplex }
         // Built-in speaker/receiver, A2DP-only Bluetooth (speakers), AirPlay,
-        // USB, HDMI, CarPlay, and every unknown combination can feed the
+        // USB, CarPlay, and every unknown combination can feed the
         // microphone: half duplex.
         return .speakerSafeHalfDuplex
     }
@@ -62,6 +70,9 @@ enum VoiceBargeInRoutePolicy: Equatable {
 
 /// The port facts the policy classifier needs, decoupled from
 /// AVAudioSessionPortDescription (which cannot be constructed in tests).
+/// `name` participates in Bluetooth pairing: a full-duplex classification
+/// requires the headset-profile input and the output to belong to the same
+/// named accessory.
 struct VoiceAudioRoutePort: Equatable {
     var type: AVAudioSession.Port
     var name: String

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -192,7 +192,9 @@ final class VoiceConversationController: ObservableObject {
         guard isCurrent(generation) else { return }
         do {
             try capture.startListening(includePreRoll: includePreRoll)
-            if isMicrophonePaused { capture.pause() }
+            // Defense in depth: capture must never end up live over audible
+            // playback, whichever flag paused it.
+            if isMicrophonePaused || isPlaybackCaptureSuspended { capture.pause() }
             utteranceStartedAt = Date()
             lastSpeechAt = nil
             bargeInStartedAt = nil
@@ -251,7 +253,6 @@ final class VoiceConversationController: ObservableObject {
     /// may contain the assistant's own TTS.
     func interruptAssistantPlayback() async {
         guard isPlaybackCaptureSuspended else { return }
-        lastBargeInState = state
         playback.stop()
         cancelSpeechDrainAndStream()
         speechDeltas.removeAll()
@@ -542,6 +543,7 @@ final class VoiceConversationController: ObservableObject {
             // AVAudioEngine's tap remains valid across normal Bluetooth/wired
             // route changes. The next capture event re-establishes timing.
             bargeInStartedAt = nil
+            cachedRoutePolicy = nil
             suspendIfRouteBecameOpenSpeaker()
         }
     }
@@ -551,7 +553,7 @@ final class VoiceConversationController: ObservableObject {
     /// running. Moving onto a headset mid-utterance stays conservative — the
     /// suspension holds until the next playback boundary.
     private func suspendIfRouteBecameOpenSpeaker() {
-        guard routePolicyProvider() == .speakerSafeHalfDuplex else { return }
+        guard currentRoutePolicy() == .speakerSafeHalfDuplex else { return }
         guard state == .speaking || isPlaybackCaptureSuspended else { return }
         suspendCaptureForPlayback()
     }
@@ -630,11 +632,26 @@ final class VoiceConversationController: ObservableObject {
     /// never enter the level detector, pre-roll, or transcription input.
     /// Isolated headset routes keep live barge-in monitoring.
     private func applyPlaybackCapturePolicy() {
-        if routePolicyProvider() == .speakerSafeHalfDuplex {
+        // Fast path for the per-encoded-chunk callback: once suspended, the
+        // policy can only flip back at a playback boundary.
+        guard !isPlaybackCaptureSuspended else { return }
+        if currentRoutePolicy() == .speakerSafeHalfDuplex {
             suspendCaptureForPlayback()
         } else {
             beginBargeInMonitoring()
         }
+    }
+
+    /// Route classification cached between capture `.routeChanged` events:
+    /// `AVAudioSession.currentRoute` materializes port descriptions, which
+    /// is too expensive to repeat on every encoded-audio chunk.
+    private var cachedRoutePolicy: VoiceBargeInRoutePolicy?
+
+    private func currentRoutePolicy() -> VoiceBargeInRoutePolicy {
+        if let cachedRoutePolicy { return cachedRoutePolicy }
+        let policy = routePolicyProvider()
+        cachedRoutePolicy = policy
+        return policy
     }
 
     /// Tears microphone rendering down for the duration of assistant
@@ -643,6 +660,12 @@ final class VoiceConversationController: ObservableObject {
     /// user-pause flag, and freezes barge-in timing so playback audio that
     /// leaked in before the suspension cannot half-schedule a barge-in.
     private func suspendCaptureForPlayback() {
+        // A barge-in scheduled just before audible playback (or before a
+        // route change) must not fire after suspension: it would stop
+        // playback and reopen capture with speaker-contaminated pre-roll.
+        bargeInTask?.cancel()
+        bargeInTask = nil
+        guard !isPlaybackCaptureSuspended else { return }
         isPlaybackCaptureSuspended = true
         bargeInStartedAt = nil
         capture.pause()
@@ -693,6 +716,10 @@ final class VoiceConversationController: ObservableObject {
         awaitedAssistantResponseStarted = false
         await interrupt()
         guard isCurrent(generation) else { return }
+        // A speaker-safe suspension may have engaged while the interruption
+        // was in flight (assistant playback started mid-await). Reopening
+        // capture now would hear the assistant's own speaker output.
+        guard !isPlaybackCaptureSuspended else { return }
         await startListening(includePreRoll: true)
     }
 

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -21,6 +21,12 @@ final class VoiceConversationController: ObservableObject {
     @Published private(set) var lastBargeInState: VoiceConversationState?
     @Published private(set) var isOutputMuted = false
     @Published private(set) var isMicrophonePaused = false
+    /// Automatic speaker-safe suspension while Hermes is audibly playing on
+    /// a route whose output can feed the microphone. Deliberately separate
+    /// from `isMicrophonePaused`: that flag is explicit user intent ("Microphone
+    /// paused"), this one is Conduit protecting the barge-in detector from
+    /// the assistant's own TTS and must never read as a user-selected pause.
+    @Published private(set) var isPlaybackCaptureSuspended = false
     @Published private(set) var conversationTranscript: [VoiceConversationTranscriptEntry] = []
     private var preferences = VoiceProfilePreferences()
 
@@ -29,6 +35,10 @@ final class VoiceConversationController: ObservableObject {
     private let playback: SpeechPlaybackService
     private let deviceTranscriber: DeviceSpeechTranscriptionService
     private var gateway: VoiceGatewayService?
+    /// Decides whether acoustic barge-in is safe while Hermes speaks.
+    /// Production reads the live AVAudioSession route; tests inject a fixed
+    /// or mutable policy so route classification is deterministic.
+    private let routePolicyProvider: @MainActor () -> VoiceBargeInRoutePolicy
     private let submit: @MainActor (String) async -> Bool
     private let interrupt: @MainActor () async -> Void
     private var captureEventsTask: Task<Void, Never>?
@@ -64,6 +74,7 @@ final class VoiceConversationController: ObservableObject {
         deviceTranscriber: DeviceSpeechTranscriptionService? = nil,
         gateway: VoiceGatewayService? = nil,
         configuration: Configuration = Configuration(),
+        routePolicyProvider: (@MainActor () -> VoiceBargeInRoutePolicy)? = nil,
         submit: @escaping @MainActor (String) async -> Bool,
         interrupt: @escaping @MainActor () async -> Void
     ) {
@@ -73,6 +84,13 @@ final class VoiceConversationController: ObservableObject {
         self.deviceTranscriber = deviceTranscriber ?? AppleOnDeviceSpeechTranscriber()
         self.gateway = gateway
         self.configuration = configuration
+        // Built here (not as a default parameter value) so the live route
+        // read stays in MainActor context, matching the capture default.
+        if let routePolicyProvider {
+            self.routePolicyProvider = routePolicyProvider
+        } else {
+            self.routePolicyProvider = { VoiceBargeInRoutePolicy.current() }
+        }
         self.submit = submit
         self.interrupt = interrupt
         captureEventsTask = Task { [weak self, capture] in
@@ -185,12 +203,22 @@ final class VoiceConversationController: ObservableObject {
     }
 
     func pauseMicrophone() {
+        // Explicit user intent supersedes an automatic playback suspension:
+        // the mic is being paused either way, but the sheet must show the
+        // user-paused state, not the Interrupt control.
+        isPlaybackCaptureSuspended = false
         capture.pause()
         isMicrophonePaused = true
     }
 
     func resumeMicrophone() async {
         guard isForegroundActive else { return }
+        if isPlaybackCaptureSuspended {
+            // On a speaker-safe route there is no "listen while Hermes
+            // speaks": a listen request during playback means interrupt.
+            await interruptAssistantPlayback()
+            return
+        }
         if !isMicrophonePaused {
             switch state {
             case .idle, .failed:
@@ -215,6 +243,16 @@ final class VoiceConversationController: ObservableObject {
         }
     }
 
+    /// The speaker-safe manual override for when automatic playback
+    /// suspension is active (the sheet's Interrupt control): stop playback,
+    /// retire the in-flight assistant turn through the authoritative
+    /// interruption seam, and open a fresh microphone window. Pre-roll is
+    /// deliberately not reused — while Hermes spoke on an open speaker it
+    /// may contain the assistant's own TTS.
+    func interruptAssistantPlayback() async {
+        guard isPlaybackCaptureSuspended else { return }
+    }
+
     func stop() {
         operationGeneration &+= 1
         utteranceTask?.cancel()
@@ -228,6 +266,7 @@ final class VoiceConversationController: ObservableObject {
         speechDeltas.removeAll()
         assistantFinished = false
         isMicrophonePaused = false
+        isPlaybackCaptureSuspended = false
         isVoiceSessionActive = false
         isAwaitingVoiceAssistant = false
         awaitedAssistantResponseStarted = false
@@ -242,8 +281,24 @@ final class VoiceConversationController: ObservableObject {
             cancelSpeechDrainAndStream()
             speechDeltas.removeAll()
             if state == .speaking { state = .muted }
+            endPlaybackCaptureSuspensionAfterMute()
         } else if state == .muted {
             state = .thinking
+        }
+    }
+
+    /// Muting stops the audible playback that justified a playback capture
+    /// suspension, so capture becomes live again for monitoring — unless the
+    /// user explicitly paused it, which stays authoritative.
+    private func endPlaybackCaptureSuspensionAfterMute() {
+        guard isPlaybackCaptureSuspended else { return }
+        isPlaybackCaptureSuspended = false
+        guard !isMicrophonePaused, isVoiceSessionActive else { return }
+        do {
+            try capture.resume()
+            beginBargeInMonitoring()
+        } catch {
+            state = .failed(error.localizedDescription)
         }
     }
 
@@ -442,12 +497,14 @@ final class VoiceConversationController: ObservableObject {
             state = .failed(message)
             playback.stop()
             cancelSpeechDrainAndStream()
+            isPlaybackCaptureSuspended = false
         case .interrupted:
             guard awaitedAssistantResponseStarted else { return }
             isAwaitingVoiceAssistant = false
             awaitedAssistantResponseStarted = false
             playback.stop()
             cancelSpeechDrainAndStream()
+            isPlaybackCaptureSuspended = false
             state = .idle
         }
     }
@@ -537,6 +594,29 @@ final class VoiceConversationController: ObservableObject {
         catch { state = .failed(error.localizedDescription) }
     }
 
+    /// Hermes begins audible playback. On routes where the output can feed
+    /// the microphone, capture is suspended so the assistant's own TTS can
+    /// never enter the level detector, pre-roll, or transcription input.
+    /// Isolated headset routes keep live barge-in monitoring.
+    private func applyPlaybackCapturePolicy() {
+        if routePolicyProvider() == .speakerSafeHalfDuplex {
+            suspendCaptureForPlayback()
+        } else {
+            beginBargeInMonitoring()
+        }
+    }
+
+    /// Tears microphone rendering down for the duration of assistant
+    /// playback. Uses the real resource pause (tap, engine, converter, and
+    /// capture session lease all go away) without touching the explicit
+    /// user-pause flag, and freezes barge-in timing so playback audio that
+    /// leaked in before the suspension cannot half-schedule a barge-in.
+    private func suspendCaptureForPlayback() {
+        isPlaybackCaptureSuspended = true
+        bargeInStartedAt = nil
+        capture.pause()
+    }
+
     private func failForAudioInterruption() {
         operationGeneration &+= 1
         utteranceTask?.cancel()
@@ -550,6 +630,7 @@ final class VoiceConversationController: ObservableObject {
         speechDeltas.removeAll()
         assistantFinished = false
         isMicrophonePaused = false
+        isPlaybackCaptureSuspended = false
         isAwaitingVoiceAssistant = false
         awaitedAssistantResponseStarted = false
         // Terminal path: release session-ownership bookkeeping so audio-
@@ -688,6 +769,11 @@ final class VoiceConversationController: ObservableObject {
                 speechStream = nil
                 if assistantFinished {
                     assistantFinished = false
+                    // Speaker-safe: a suspended capture must not resume
+                    // while the cancelled stream's already-scheduled audio
+                    // still renders out of the speaker.
+                    if isPlaybackCaptureSuspended { playback.stop() }
+                    isPlaybackCaptureSuspended = false
                     await startListening()
                 }
                 return
@@ -697,12 +783,14 @@ final class VoiceConversationController: ObservableObject {
             // (The cancellation branch above intentionally keeps ownership —
             // an interrupted stream's already-scheduled audio renders out.)
             playback.stop()
+            isPlaybackCaptureSuspended = false
             if state == .speaking || state == .thinking { state = .failed(error.localizedDescription) }
             return
         }
         if assistantFinished && speechDeltas.isEmpty && speechStream == nil {
             assistantFinished = false
             guard isSpeechDrainCurrent(operation: operation, revision: revision) else { return }
+            isPlaybackCaptureSuspended = false
             await startListening()
         }
     }

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -205,10 +205,12 @@ final class VoiceConversationController: ObservableObject {
     }
 
     func pauseMicrophone() {
-        // Explicit user intent supersedes an automatic playback suspension:
-        // the mic is being paused either way, but the sheet must show the
-        // user-paused state, not the Interrupt control.
-        isPlaybackCaptureSuspended = false
+        // Explicit user intent never discards the speaker-safety fact: while
+        // the suspension flag survives, any later listen request during
+        // audible playback still routes through the interrupt path instead
+        // of resuming a live microphone over Hermes' voice. Presentation is
+        // handled by the sheet, which shows the user-paused state whenever
+        // `isMicrophonePaused` is set.
         capture.pause()
         isMicrophonePaused = true
     }
@@ -253,6 +255,7 @@ final class VoiceConversationController: ObservableObject {
     /// may contain the assistant's own TTS.
     func interruptAssistantPlayback() async {
         guard isPlaybackCaptureSuspended else { return }
+        cachedRoutePolicy = nil
         playback.stop()
         cancelSpeechDrainAndStream()
         speechDeltas.removeAll()
@@ -271,6 +274,7 @@ final class VoiceConversationController: ObservableObject {
 
     func stop() {
         operationGeneration &+= 1
+        cachedRoutePolicy = nil
         utteranceTask?.cancel()
         utteranceTask = nil
         bargeInTask?.cancel()
@@ -620,6 +624,10 @@ final class VoiceConversationController: ObservableObject {
     }
 
     private func beginBargeInMonitoring() {
+        // Seam-level invariant: no barge-in monitoring affordance while a
+        // playback suspension is active, so a future capture service cannot
+        // reintroduce the feedback loop one layer down.
+        guard !isPlaybackCaptureSuspended else { return }
         do {
             try capture.beginBargeInMonitoring()
             if isMicrophonePaused { capture.pause() }
@@ -673,6 +681,7 @@ final class VoiceConversationController: ObservableObject {
 
     private func failForAudioInterruption() {
         operationGeneration &+= 1
+        cachedRoutePolicy = nil
         utteranceTask?.cancel()
         utteranceTask = nil
         bargeInTask?.cancel()
@@ -703,7 +712,15 @@ final class VoiceConversationController: ObservableObject {
     }
 
     private func beginBargeIn(generation: UInt64) async {
-        defer { if operationGeneration == generation { bargeInTask = nil } }
+        // A cancelled task must neither act nor stomp a successor's handle.
+        defer {
+            if operationGeneration == generation, !Task.isCancelled { bargeInTask = nil }
+        }
+        // Cancellation is binding before the destructive prefix: a barge-in
+        // that lost the race to a playback suspension must not stop the
+        // playback or retire the turn it is supposed to protect.
+        guard !Task.isCancelled else { return }
+        guard !isPlaybackCaptureSuspended else { return }
         guard state == .thinking || state == .speaking || state == .muted else { return }
         lastBargeInState = state
         playback.stop()
@@ -715,10 +732,11 @@ final class VoiceConversationController: ObservableObject {
         isAwaitingVoiceAssistant = false
         awaitedAssistantResponseStarted = false
         await interrupt()
+        // Cancellation is re-checked after the await: the suspension may have
+        // engaged while the interruption was in flight, and reopening capture
+        // now would hear the assistant's own speaker output.
+        guard !Task.isCancelled else { return }
         guard isCurrent(generation) else { return }
-        // A speaker-safe suspension may have engaged while the interruption
-        // was in flight (assistant playback started mid-await). Reopening
-        // capture now would hear the assistant's own speaker output.
         guard !isPlaybackCaptureSuspended else { return }
         await startListening(includePreRoll: true)
     }

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -259,6 +259,7 @@ final class VoiceConversationController: ObservableObject {
         // Deliberately leaves lastBargeInState alone: that property records
         // acoustic barge-in provenance, and this path always lands in
         // .listening.
+        let generation = operationGeneration
         playback.stop()
         cancelSpeechDrainAndStream()
         speechDeltas.removeAll()
@@ -272,6 +273,12 @@ final class VoiceConversationController: ObservableObject {
         // user pause ends with it.
         isMicrophonePaused = false
         await interrupt()
+        // The interruption is a real re-entrant async boundary (Hermes
+        // cancellation/recovery), and the sheet can close while it is in
+        // flight — stop() then advances the generation and tears the session
+        // down. The fence stops the stale continuation from resurrecting
+        // capture (isCurrent also covers foreground loss and session teardown).
+        guard isCurrent(generation) else { return }
         await startListening()
     }
 

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -251,6 +251,21 @@ final class VoiceConversationController: ObservableObject {
     /// may contain the assistant's own TTS.
     func interruptAssistantPlayback() async {
         guard isPlaybackCaptureSuspended else { return }
+        lastBargeInState = state
+        playback.stop()
+        cancelSpeechDrainAndStream()
+        speechDeltas.removeAll()
+        assistantFinished = false
+        // The in-flight assistant response is intentionally interrupted; its
+        // terminal event belongs to the retired turn, not the next one.
+        isAwaitingVoiceAssistant = false
+        awaitedAssistantResponseStarted = false
+        isPlaybackCaptureSuspended = false
+        // The tap itself is an explicit request to speak now, so a pending
+        // user pause ends with it.
+        isMicrophonePaused = false
+        await interrupt()
+        await startListening()
     }
 
     func stop() {
@@ -431,6 +446,11 @@ final class VoiceConversationController: ObservableObject {
                 pauseMicrophone()
             }
         case .thinking, .speaking, .muted:
+            // Speaker-safe suspension: while capture is suspended during
+            // assistant playback, no acoustic barge-in may be scheduled —
+            // even from a stale level event that slipped past the paused
+            // tap.
+            guard !isPlaybackCaptureSuspended else { break }
             if level >= configuration.voiceActivityThreshold {
                 if bargeInStartedAt == nil { bargeInStartedAt = date }
                 if let started = bargeInStartedAt,
@@ -522,7 +542,18 @@ final class VoiceConversationController: ObservableObject {
             // AVAudioEngine's tap remains valid across normal Bluetooth/wired
             // route changes. The next capture event re-establishes timing.
             bargeInStartedAt = nil
+            suspendIfRouteBecameOpenSpeaker()
         }
+    }
+
+    /// Safety net for routes that change while Hermes is audibly speaking:
+    /// moving onto an open speaker must never leave live acoustic barge-in
+    /// running. Moving onto a headset mid-utterance stays conservative — the
+    /// suspension holds until the next playback boundary.
+    private func suspendIfRouteBecameOpenSpeaker() {
+        guard routePolicyProvider() == .speakerSafeHalfDuplex else { return }
+        guard state == .speaking || isPlaybackCaptureSuspended else { return }
+        suspendCaptureForPlayback()
     }
 
     private func scheduleFinishUtterance() {
@@ -728,7 +759,7 @@ final class VoiceConversationController: ObservableObject {
                               !self.isOutputMuted else { return }
                         try self.playback.start(sampleRate: rate)
                         self.state = .speaking
-                        self.beginBargeInMonitoring()
+                        self.applyPlaybackCapturePolicy()
                     },
                     onPCM16: { [weak self] data, rate in
                         guard let self,
@@ -742,7 +773,7 @@ final class VoiceConversationController: ObservableObject {
                               !self.isOutputMuted else { return }
                         try self.playback.playEncodedAudioData(data)
                         self.state = .speaking
-                        self.beginBargeInMonitoring()
+                        self.applyPlaybackCapturePolicy()
                     }
                 )
                 guard isSpeechDrainCurrent(operation: operation, revision: revision) else {

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -256,6 +256,9 @@ final class VoiceConversationController: ObservableObject {
     func interruptAssistantPlayback() async {
         guard isPlaybackCaptureSuspended else { return }
         cachedRoutePolicy = nil
+        // Deliberately leaves lastBargeInState alone: that property records
+        // acoustic barge-in provenance, and this path always lands in
+        // .listening.
         playback.stop()
         cancelSpeechDrainAndStream()
         speechDeltas.removeAll()
@@ -866,6 +869,7 @@ final class VoiceConversationController: ObservableObject {
         if assistantFinished && speechDeltas.isEmpty && speechStream == nil {
             assistantFinished = false
             guard isSpeechDrainCurrent(operation: operation, revision: revision) else { return }
+            cachedRoutePolicy = nil
             isPlaybackCaptureSuspended = false
             await startListening()
         }

--- a/ConduitTests/VoiceBargeInRoutePolicyTests.swift
+++ b/ConduitTests/VoiceBargeInRoutePolicyTests.swift
@@ -1,0 +1,118 @@
+import AVFAudio
+import XCTest
+@testable import Conduit
+
+final class VoiceBargeInRoutePolicyTests: XCTestCase {
+    private func port(_ type: AVAudioSession.Port, _ name: String = "") -> VoiceAudioRoutePort {
+        VoiceAudioRoutePort(type: type, name: name)
+    }
+
+    func testBuiltInSpeakerAndReceiverAreHalfDuplex() {
+        XCTAssertEqual(
+            VoiceBargeInRoutePolicy.resolve(
+                outputs: [port(.builtInSpeaker, "Speaker")],
+                inputs: [port(.builtInMic, "Microphone")]
+            ),
+            .speakerSafeHalfDuplex
+        )
+        XCTAssertEqual(
+            VoiceBargeInRoutePolicy.resolve(
+                outputs: [port(.builtInReceiver, "Receiver")],
+                inputs: [port(.builtInMic, "Microphone")]
+            ),
+            .speakerSafeHalfDuplex
+        )
+    }
+
+    func testWiredHeadphonesAreFullDuplexEvenWithBuiltInMic() {
+        XCTAssertEqual(
+            VoiceBargeInRoutePolicy.resolve(
+                outputs: [port(.headphones, "Wired Headphones")],
+                inputs: [port(.builtInMic, "Microphone")]
+            ),
+            .fullDuplex
+        )
+    }
+
+    func testBluetoothHeadsetProfilePairingIsFullDuplex() {
+        // AirPods / HFP headsets during a voice session: capture and playback
+        // both travel the headset's own mic and speaker.
+        XCTAssertEqual(
+            VoiceBargeInRoutePolicy.resolve(
+                outputs: [port(.bluetoothHFP, "AirPods Pro")],
+                inputs: [port(.bluetoothHFP, "AirPods Pro")]
+            ),
+            .fullDuplex
+        )
+        XCTAssertEqual(
+            VoiceBargeInRoutePolicy.resolve(
+                outputs: [port(.bluetoothA2DP, "AirPods Pro")],
+                inputs: [port(.bluetoothHFP, "AirPods Pro")]
+            ),
+            .fullDuplex
+        )
+    }
+
+    func testA2DPOnlyBluetoothOutputIsHalfDuplex() {
+        // A Bluetooth speaker with no headset microphone: its output feeds
+        // the built-in mic.
+        XCTAssertEqual(
+            VoiceBargeInRoutePolicy.resolve(
+                outputs: [port(.bluetoothA2DP, "Boombox")],
+                inputs: [port(.builtInMic, "Microphone")]
+            ),
+            .speakerSafeHalfDuplex
+        )
+        XCTAssertEqual(
+            VoiceBargeInRoutePolicy.resolve(
+                outputs: [port(.bluetoothA2DP, "Boombox")],
+                inputs: []
+            ),
+            .speakerSafeHalfDuplex
+        )
+    }
+
+    func testHeadsetProfileOutputWithoutHeadsetInputIsHalfDuplex() {
+        // Ambiguous: HFP output routed, but capture still on the built-in
+        // mic. Conservative classification wins.
+        XCTAssertEqual(
+            VoiceBargeInRoutePolicy.resolve(
+                outputs: [port(.bluetoothHFP, "Headset")],
+                inputs: [port(.builtInMic, "Microphone")]
+            ),
+            .speakerSafeHalfDuplex
+        )
+    }
+
+    func testGenericAndExternalOutputsAreHalfDuplex() {
+        let genericOutputs: [AVAudioSession.Port] = [.airPlay, .usbAudio, .carAudio]
+        for output in genericOutputs {
+            XCTAssertEqual(
+                VoiceBargeInRoutePolicy.resolve(
+                    outputs: [port(output, "External")],
+                    inputs: [port(.builtInMic, "Microphone")]
+                ),
+                .speakerSafeHalfDuplex,
+                "\(output.rawValue) output must be half duplex"
+            )
+        }
+    }
+
+    func testEmptyOrUnknownRoutesAreHalfDuplex() {
+        XCTAssertEqual(
+            VoiceBargeInRoutePolicy.resolve(outputs: [], inputs: []),
+            .speakerSafeHalfDuplex,
+            "an unclassifiable route must never allow acoustic barge-in during playback"
+        )
+    }
+
+    func testAnyIsolatedHeadsetOutputWinsOverMixedRoutes() {
+        XCTAssertEqual(
+            VoiceBargeInRoutePolicy.resolve(
+                outputs: [port(.builtInSpeaker, "Speaker"), port(.headphones, "Wired")],
+                inputs: [port(.builtInMic, "Microphone")]
+            ),
+            .fullDuplex
+        )
+    }
+}

--- a/ConduitTests/VoiceBargeInRoutePolicyTests.swift
+++ b/ConduitTests/VoiceBargeInRoutePolicyTests.swift
@@ -72,6 +72,19 @@ final class VoiceBargeInRoutePolicyTests: XCTestCase {
         )
     }
 
+    func testMismatchedBluetoothAccessoryNamesAreHalfDuplex() {
+        // HFP input and A2DP output from DIFFERENT accessories (headset mic
+        // selected while a room speaker renders) is exactly the feedback
+        // geometry this policy exists to prevent: stay conservative.
+        XCTAssertEqual(
+            VoiceBargeInRoutePolicy.resolve(
+                outputs: [port(.bluetoothA2DP, "Boombox")],
+                inputs: [port(.bluetoothHFP, "Car Kit")]
+            ),
+            .speakerSafeHalfDuplex
+        )
+    }
+
     func testHeadsetProfileOutputWithoutHeadsetInputIsHalfDuplex() {
         // Ambiguous: HFP output routed, but capture still on the built-in
         // mic. Conservative classification wins.
@@ -106,13 +119,21 @@ final class VoiceBargeInRoutePolicyTests: XCTestCase {
         )
     }
 
-    func testAnyIsolatedHeadsetOutputWinsOverMixedRoutes() {
+    func testOpenSpeakerVetoesHeadsetInMixedOutputs() {
         XCTAssertEqual(
             VoiceBargeInRoutePolicy.resolve(
                 outputs: [port(.builtInSpeaker, "Speaker"), port(.headphones, "Wired")],
                 inputs: [port(.builtInMic, "Microphone")]
             ),
-            .fullDuplex
+            .speakerSafeHalfDuplex,
+            "audio may be rendering to the open speaker, so mixed routes stay half duplex"
+        )
+        XCTAssertEqual(
+            VoiceBargeInRoutePolicy.resolve(
+                outputs: [port(.builtInReceiver, "Receiver"), port(.bluetoothHFP, "AirPods Pro")],
+                inputs: [port(.bluetoothHFP, "AirPods Pro")]
+            ),
+            .speakerSafeHalfDuplex
         )
     }
 }

--- a/ConduitTests/VoiceBargeInRoutePolicyTests.swift
+++ b/ConduitTests/VoiceBargeInRoutePolicyTests.swift
@@ -97,6 +97,30 @@ final class VoiceBargeInRoutePolicyTests: XCTestCase {
         )
     }
 
+    func testHeadphonesPlusAirPlayIsHalfDuplex() {
+        // Every output must be proven safe: an open AirPlay route alongside
+        // wired headphones vetoes full duplex.
+        XCTAssertEqual(
+            VoiceBargeInRoutePolicy.resolve(
+                outputs: [port(.headphones, "Wired"), port(.airPlay, "Living Room")],
+                inputs: [port(.builtInMic, "Microphone")]
+            ),
+            .speakerSafeHalfDuplex
+        )
+    }
+
+    func testPairedAirPodsPlusUnrelatedA2DPRoomSpeakerIsHalfDuplex() {
+        // AirPods' own HFP pairing is real, but the second (unpaired)
+        // Bluetooth output is a room speaker whose audio feeds the mic.
+        XCTAssertEqual(
+            VoiceBargeInRoutePolicy.resolve(
+                outputs: [port(.bluetoothHFP, "AirPods Pro"), port(.bluetoothA2DP, "Room Speaker")],
+                inputs: [port(.bluetoothHFP, "AirPods Pro")]
+            ),
+            .speakerSafeHalfDuplex
+        )
+    }
+
     func testHeadsetProfileOutputWithoutHeadsetInputIsHalfDuplex() {
         // Ambiguous: HFP output routed, but capture still on the built-in
         // mic. Conservative classification wins.

--- a/ConduitTests/VoiceBargeInRoutePolicyTests.swift
+++ b/ConduitTests/VoiceBargeInRoutePolicyTests.swift
@@ -85,6 +85,18 @@ final class VoiceBargeInRoutePolicyTests: XCTestCase {
         )
     }
 
+    func testEmptyBluetoothNamesNeverPair() {
+        // Two anonymous ports reporting empty names are not evidence of a
+        // headset pairing.
+        XCTAssertEqual(
+            VoiceBargeInRoutePolicy.resolve(
+                outputs: [port(.bluetoothA2DP, "")],
+                inputs: [port(.bluetoothHFP, "")]
+            ),
+            .speakerSafeHalfDuplex
+        )
+    }
+
     func testHeadsetProfileOutputWithoutHeadsetInputIsHalfDuplex() {
         // Ambiguous: HFP output routed, but capture still on the built-in
         // mic. Conservative classification wins.

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -594,10 +594,15 @@ final class VoiceConversationControllerTests: XCTestCase {
     func testMicrophonePausePreservesConversationStateAcrossListeningThinkingSpeakingAndMuted() async {
         let capture = MockCapture(permissionGranted: true)
         let gateway = MockGateway(transcript: "Hello", startsPlaybackOnOpen: true)
+        // Full-duplex route: this test pins pause/resume symmetry. The
+        // speaker-safe behavior during playback has dedicated coverage in
+        // VoiceSpeakerSafeBargeInTests.
+        let policy = RoutePolicyBox(.fullDuplex)
         let controller = VoiceConversationController(
             capture: capture,
             playback: MockPlayback(),
             gateway: gateway,
+            routePolicyProvider: { policy.policy },
             submit: { _ in true },
             interrupt: {}
         )
@@ -1191,7 +1196,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
         XCTAssertEqual(controller.state, .speaking)
         XCTAssertTrue(controller.isPlaybackCaptureSuspended)
         XCTAssertEqual(capture.startCount, 1, "the stale barge-in must not reopen capture")
-        XCTAssertNil(capture.lastStartIncludePreRoll, "no speaker-contaminated pre-roll may be requested")
+        XCTAssertEqual(capture.lastStartIncludePreRoll, false, "no barge-in restart may request speaker-contaminated pre-roll")
         XCTAssertEqual(capture.resumeCount, 0)
     }
 

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -1180,7 +1180,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
 
         // The user taps Interrupt; the Hermes interruption parks mid-flight.
         let interruptTask = Task { await controller.interruptAssistantPlayback() }
-        try? await Task.sleep(nanoseconds: 50_000_000)
+        await gate.waitUntilEntered()
         XCTAssertEqual(gate.count, 1, "the interruption is parked in flight")
 
         // While it is parked, the user closes the Voice sheet: stop() tears
@@ -1219,7 +1219,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
 
         await Self.driveToSpeaking(controller, gateway: gateway)
         let interruptTask = Task { await controller.interruptAssistantPlayback() }
-        try? await Task.sleep(nanoseconds: 50_000_000)
+        await gate.waitUntilEntered()
         XCTAssertEqual(gate.count, 1)
 
         // Sheet closed (stop), then reopened: a NEW session goes live before
@@ -1259,7 +1259,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
         let bargeInStart = Date()
         controller.ingestAudioLevel(0.5, at: bargeInStart)
         controller.ingestAudioLevel(0.5, at: bargeInStart.addingTimeInterval(0.31))
-        try? await Task.sleep(nanoseconds: 50_000_000)
+        await gate.waitUntilEntered()
         XCTAssertEqual(gate.count, 1, "the barge-in interruption is parked mid-flight")
 
         // While it is parked, the route becomes an open speaker: suspension
@@ -1309,20 +1309,37 @@ private final class RoutePolicyBox {
 }
 
 /// An interruption closure that parks mid-flight, so tests can interleave
-/// suspension and route changes into the barge-in await window.
+/// suspension and route changes into the barge-in await window. Entry is
+/// signalled explicitly — `waitUntilEntered()` observes the operation
+/// actually being parked instead of relying on fixed sleeps — and every
+/// parked continuation is resumed exactly once by `release()`.
 @MainActor
 private final class InterruptGate {
     private(set) var count = 0
-    private var continuation: CheckedContinuation<Void, Never>?
+    private var parked: [CheckedContinuation<Void, Never>] = []
+    private var entryWaiters: [CheckedContinuation<Void, Never>] = []
 
     func waitInInterrupt() async {
         count += 1
-        await withCheckedContinuation { continuation = $0 }
+        let waiters = entryWaiters
+        entryWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+        await withCheckedContinuation { parked.append($0) }
     }
 
+    /// Returns once `waitInInterrupt` has been entered at least once;
+    /// returns immediately if entry already happened, so the signal cannot
+    /// be missed regardless of scheduling order (both sides are MainActor).
+    func waitUntilEntered() async {
+        guard count == 0 else { return }
+        await withCheckedContinuation { entryWaiters.append($0) }
+    }
+
+    /// Resumes every parked interruption exactly once; safe to call twice.
     func release() {
-        continuation?.resume()
-        continuation = nil
+        let parkedContinuations = parked
+        parked.removeAll()
+        parkedContinuations.forEach { $0.resume() }
     }
 }
 

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -777,6 +777,343 @@ final class VoiceConversationControllerTests: XCTestCase {
     }
 }
 
+/// Speaker feedback-loop regressions: on routes whose output can feed the
+/// device microphone (built-in speaker/receiver), the assistant's own TTS
+/// must never become a new user turn. Capture is suspended during playback
+/// and the mic control becomes Interrupt; isolated headset routes keep the
+/// existing live barge-in.
+@MainActor
+final class VoiceSpeakerSafeBargeInTests: XCTestCase {
+    func testSpeakerRouteAssistantPlaybackCannotBargeInOnItself() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Why is the kanji cursed", startsPlaybackOnOpen: true)
+        var submitted: [String] = []
+        var interrupts = 0
+        let policy = RoutePolicyBox(.speakerSafeHalfDuplex)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: { submitted.append($0); return true },
+            interrupt: { interrupts += 1 }
+        )
+
+        await Self.driveToSpeaking(controller, gateway: gateway)
+
+        XCTAssertEqual(controller.state, .speaking)
+        XCTAssertTrue(controller.isPlaybackCaptureSuspended, "speaker-safe routes suspend capture while Hermes speaks")
+        XCTAssertTrue(capture.didPause)
+
+        // The speaker's own TTS leaks back into the microphone: sustained
+        // level above the voice activity threshold for longer than the
+        // barge-in duration.
+        let leakStart = Date()
+        controller.ingestAudioLevel(0.5, at: leakStart)
+        controller.ingestAudioLevel(0.5, at: leakStart.addingTimeInterval(0.31))
+        controller.ingestAudioLevel(0.5, at: leakStart.addingTimeInterval(0.62))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(interrupts, 0, "assistant TTS must never schedule a barge-in on a speaker route")
+        XCTAssertEqual(controller.state, .speaking)
+        XCTAssertEqual(gateway.transcriptionCount, 0, "assistant output must not be transcribed as user speech")
+        XCTAssertEqual(capture.finishUtteranceCount, 0, "suspended capture must not record assistant output")
+        XCTAssertEqual(submitted.count, 1, "no new user turn may be submitted from speaker leakage")
+    }
+
+    func testSpeakerRouteResumesFreshListeningAfterPlaybackCompletes() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Why is the kanji cursed", startsPlaybackOnOpen: true)
+        var interrupts = 0
+        let policy = RoutePolicyBox(.speakerSafeHalfDuplex)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: { _ in true },
+            interrupt: { interrupts += 1 }
+        )
+
+        await Self.driveToSpeaking(controller, gateway: gateway)
+        XCTAssertEqual(capture.startCount, 1)
+        controller.receiveAssistantEvent(.completed(sessionID: "session", content: "Chorus line answer."))
+        try? await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertFalse(controller.isPlaybackCaptureSuspended)
+        XCTAssertEqual(controller.state, .listening)
+        XCTAssertEqual(capture.startCount, 2, "listening resumes with a fresh capture window after playback")
+        XCTAssertEqual(capture.lastStartIncludePreRoll, false, "the post-playback window must not reuse speaker-contaminated pre-roll")
+        XCTAssertEqual(interrupts, 0)
+    }
+
+    func testInterruptOnSpeakerRouteStopsPlaybackAndStartsFreshListening() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Why is the kanji cursed", startsPlaybackOnOpen: true)
+        let playback = MockPlayback()
+        var interrupts = 0
+        let policy = RoutePolicyBox(.speakerSafeHalfDuplex)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: playback,
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: { _ in true },
+            interrupt: { interrupts += 1 }
+        )
+
+        await Self.driveToSpeaking(controller, gateway: gateway)
+        XCTAssertTrue(controller.isPlaybackCaptureSuspended)
+        XCTAssertTrue(playback.isPlaying)
+
+        await controller.interruptAssistantPlayback()
+
+        XCTAssertEqual(interrupts, 1, "Interrupt retires the assistant turn through the authoritative interruption path")
+        XCTAssertFalse(playback.isPlaying)
+        XCTAssertEqual(gateway.streams.first?.cancelCount, 1, "the in-flight speech stream is retired")
+        XCTAssertFalse(controller.isPlaybackCaptureSuspended)
+        XCTAssertEqual(controller.state, .listening)
+        XCTAssertEqual(capture.startCount, 2)
+        XCTAssertEqual(capture.lastStartIncludePreRoll, false, "no speaker-contaminated pre-roll may be requested")
+        XCTAssertEqual(capture.finishUtteranceCount, 0)
+
+        // The retired turn's late completion must stay retired.
+        controller.receiveAssistantEvent(.completed(sessionID: "session", content: "Late tail"))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertEqual(gateway.openCount, 1, "a retired turn must not reopen speech")
+        XCTAssertEqual(controller.state, .listening)
+    }
+
+    func testHeadsetRouteKeepsLiveBargeInDuringPlayback() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        var interrupts = 0
+        let policy = RoutePolicyBox(.fullDuplex)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: { _ in true },
+            interrupt: { interrupts += 1 }
+        )
+
+        await Self.driveToSpeaking(controller, gateway: gateway)
+
+        XCTAssertEqual(controller.state, .speaking)
+        XCTAssertFalse(controller.isPlaybackCaptureSuspended, "isolated headset routes keep live capture")
+        XCTAssertEqual(capture.pauseCount, 0)
+
+        let bargeInStart = Date()
+        controller.ingestAudioLevel(0.5, at: bargeInStart)
+        controller.ingestAudioLevel(0.5, at: bargeInStart.addingTimeInterval(0.31))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+
+        XCTAssertEqual(interrupts, 1, "genuine headset barge-in still interrupts playback")
+        XCTAssertEqual(controller.lastBargeInState, .speaking)
+        XCTAssertEqual(controller.state, .listening)
+        XCTAssertEqual(capture.lastStartIncludePreRoll, true, "genuine headset barge-in keeps pre-roll")
+    }
+
+    func testUserPauseRemainsAuthoritativeAcrossAutomaticSuspension() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        var interrupts = 0
+        let policy = RoutePolicyBox(.speakerSafeHalfDuplex)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: { _ in true },
+            interrupt: { interrupts += 1 }
+        )
+        controller.beginVoiceTurn(sessionID: "session")
+        await controller.startListening()
+        let utteranceStart = Date()
+        controller.ingestAudioLevel(0.1, at: utteranceStart)
+        controller.ingestAudioLevel(0, at: utteranceStart.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        controller.pauseMicrophone()
+        XCTAssertTrue(controller.isMicrophonePaused)
+
+        controller.receiveAssistantEvent(.started(sessionID: "session"))
+        controller.receiveAssistantEvent(.delta(sessionID: "session", text: "Answer while paused."))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+
+        XCTAssertTrue(controller.isPlaybackCaptureSuspended, "playback on a speaker route still records the automatic suspension")
+        XCTAssertTrue(controller.isMicrophonePaused, "the automatic suspension must not clear the user's pause")
+        XCTAssertEqual(controller.state, .speaking)
+
+        controller.receiveAssistantEvent(.completed(sessionID: "session", content: "Answer."))
+        try? await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertFalse(controller.isPlaybackCaptureSuspended)
+        XCTAssertTrue(controller.isMicrophonePaused, "Hermes finishing playback must not auto-resume a user pause")
+        XCTAssertEqual(controller.state, .listening)
+        XCTAssertEqual(capture.resumeCount, 0, "resume must never be driven by the playback lifecycle")
+        XCTAssertEqual(interrupts, 0)
+    }
+
+    func testMutedOutputNeverSuspendsCaptureAndKeepsBargeIn() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        var interrupts = 0
+        let policy = RoutePolicyBox(.speakerSafeHalfDuplex)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: { _ in true },
+            interrupt: { interrupts += 1 }
+        )
+        controller.beginVoiceTurn(sessionID: "session")
+        await controller.startListening()
+        let utteranceStart = Date()
+        controller.ingestAudioLevel(0.1, at: utteranceStart)
+        controller.ingestAudioLevel(0, at: utteranceStart.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        controller.setOutputMuted(true)
+        controller.receiveAssistantEvent(.started(sessionID: "session"))
+        controller.receiveAssistantEvent(.delta(sessionID: "session", text: "Silenced answer."))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+
+        XCTAssertEqual(controller.state, .muted)
+        XCTAssertFalse(controller.isPlaybackCaptureSuspended, "no audible playback means no suspension")
+        XCTAssertEqual(capture.pauseCount, 0)
+        XCTAssertEqual(gateway.openCount, 0, "muted output never opens a speech stream")
+
+        // With nothing audible playing, the user can still barge in.
+        let bargeInStart = Date()
+        controller.ingestAudioLevel(0.5, at: bargeInStart)
+        controller.ingestAudioLevel(0.5, at: bargeInStart.addingTimeInterval(0.31))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertEqual(interrupts, 1)
+    }
+
+    func testMutingDuringPlaybackEndsSuspensionAndRestoresMonitoring() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        var interrupts = 0
+        let policy = RoutePolicyBox(.speakerSafeHalfDuplex)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: { _ in true },
+            interrupt: { interrupts += 1 }
+        )
+
+        await Self.driveToSpeaking(controller, gateway: gateway)
+        XCTAssertTrue(controller.isPlaybackCaptureSuspended)
+
+        controller.setOutputMuted(true)
+
+        XCTAssertEqual(controller.state, .muted)
+        XCTAssertFalse(controller.isPlaybackCaptureSuspended, "muting stops the audible playback that justified suspension")
+        XCTAssertEqual(capture.resumeCount, 1, "capture becomes live again for monitoring")
+
+        let bargeInStart = Date()
+        controller.ingestAudioLevel(0.5, at: bargeInStart)
+        controller.ingestAudioLevel(0.5, at: bargeInStart.addingTimeInterval(0.31))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertEqual(interrupts, 1, "with output muted nothing audible plays, so barge-in stays live")
+    }
+
+    func testRouteChangeOntoSpeakerDuringPlaybackSuspendsCaptureImmediately() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        var interrupts = 0
+        let policy = RoutePolicyBox(.fullDuplex)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: { _ in true },
+            interrupt: { interrupts += 1 }
+        )
+
+        await Self.driveToSpeaking(controller, gateway: gateway)
+        XCTAssertFalse(controller.isPlaybackCaptureSuspended)
+        XCTAssertEqual(capture.pauseCount, 0)
+
+        // AirPods disconnect mid-utterance: the route becomes the built-in
+        // speaker.
+        policy.policy = .speakerSafeHalfDuplex
+        capture.emit(.routeChanged)
+        try? await Task.sleep(nanoseconds: 80_000_000)
+
+        XCTAssertTrue(controller.isPlaybackCaptureSuspended, "moving onto an open speaker mid-utterance must suspend capture")
+        XCTAssertEqual(capture.pauseCount, 1)
+
+        let leakStart = Date()
+        controller.ingestAudioLevel(0.5, at: leakStart)
+        controller.ingestAudioLevel(0.5, at: leakStart.addingTimeInterval(0.31))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(interrupts, 0, "no acoustic barge-in may survive a transition onto an open speaker")
+        XCTAssertEqual(controller.state, .speaking)
+    }
+
+    func testRouteChangeOntoHeadsetDuringPlaybackStaysConservativeUntilBoundary() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        var interrupts = 0
+        let policy = RoutePolicyBox(.speakerSafeHalfDuplex)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: { _ in true },
+            interrupt: { interrupts += 1 }
+        )
+
+        await Self.driveToSpeaking(controller, gateway: gateway)
+        XCTAssertTrue(controller.isPlaybackCaptureSuspended)
+
+        policy.policy = .fullDuplex
+        capture.emit(.routeChanged)
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertTrue(controller.isPlaybackCaptureSuspended, "mid-utterance upgrade to full duplex stays conservative until the next playback boundary")
+
+        controller.receiveAssistantEvent(.completed(sessionID: "session", content: "Done."))
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        XCTAssertEqual(controller.state, .listening)
+        XCTAssertFalse(controller.isPlaybackCaptureSuspended)
+    }
+
+    /// listening → user utterance → submit → .thinking → assistant .started
+    /// + .delta: the gateway opens its speech stream, playback starts, and
+    /// the controller settles in .speaking.
+    private static func driveToSpeaking(
+        _ controller: VoiceConversationController,
+        gateway: MockGateway,
+        sessionID: String = "session"
+    ) async {
+        controller.beginVoiceTurn(sessionID: sessionID)
+        await controller.startListening()
+        let utteranceStart = Date()
+        controller.ingestAudioLevel(0.1, at: utteranceStart)
+        controller.ingestAudioLevel(0, at: utteranceStart.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(controller.state, .thinking)
+        controller.receiveAssistantEvent(.started(sessionID: sessionID))
+        controller.receiveAssistantEvent(.delta(sessionID: sessionID, text: "From a cursed kanji to a full chibi chorus line."))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+    }
+}
+
+/// Mutable route policy so tests can replay route transitions
+/// deterministically; production reads the live AVAudioSession route.
+@MainActor
+private final class RoutePolicyBox {
+    var policy: VoiceBargeInRoutePolicy
+    init(_ policy: VoiceBargeInRoutePolicy) { self.policy = policy }
+}
+
 @MainActor
 private final class MockCapture: AudioCaptureService {
     let events: AsyncStream<VoiceCaptureEvent>
@@ -787,7 +1124,9 @@ private final class MockCapture: AudioCaptureService {
     var startCount = 0
     var didBeginMonitoring = false
     var didPause = false
+    var pauseCount = 0
     var resumeCount = 0
+    private(set) var lastStartIncludePreRoll: Bool?
     private(set) var finishUtteranceCount = 0
 
     init(permissionGranted: Bool, startError: Error? = nil) {
@@ -801,10 +1140,14 @@ private final class MockCapture: AudioCaptureService {
     func startListening(includePreRoll: Bool) throws {
         didStart = true
         startCount += 1
+        lastStartIncludePreRoll = includePreRoll
         if let startError { throw startError }
     }
     func beginBargeInMonitoring() throws { didBeginMonitoring = true }
-    func pause() { didPause = true }
+    func pause() {
+        didPause = true
+        pauseCount += 1
+    }
     func resume() throws { resumeCount += 1 }
     func finishUtterance() throws -> VoiceCapturedAudio {
         finishUtteranceCount += 1

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -1159,6 +1159,48 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
         XCTAssertEqual(capture.resumeCount, 0, "capture must never resume live over audible playback")
     }
 
+    func testInterruptAcrossSessionTeardownCannotResurrectCapture() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        let playback = MockPlayback()
+        let gate = InterruptGate()
+        let policy = RoutePolicyBox(.speakerSafeHalfDuplex)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: playback,
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: { _ in true },
+            interrupt: { await gate.waitInInterrupt() }
+        )
+
+        await Self.driveToSpeaking(controller, gateway: gateway)
+        XCTAssertTrue(controller.isPlaybackCaptureSuspended)
+        XCTAssertEqual(capture.startCount, 1)
+
+        // The user taps Interrupt; the Hermes interruption parks mid-flight.
+        let interruptTask = Task { await controller.interruptAssistantPlayback() }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(gate.count, 1, "the interruption is parked in flight")
+
+        // While it is parked, the user closes the Voice sheet: stop() tears
+        // the session down and advances the generation.
+        controller.stop()
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertFalse(controller.hasLiveVoiceSession)
+
+        // The stale continuation must not resurrect the voice session.
+        gate.release()
+        await interruptTask.value
+
+        XCTAssertEqual(controller.state, .idle, "stale Interrupt work must stay idle after teardown")
+        XCTAssertFalse(controller.hasLiveVoiceSession)
+        XCTAssertEqual(capture.startCount, 1, "stale Interrupt must not reopen capture")
+        XCTAssertEqual(capture.lastStartIncludePreRoll, false, "no fresh listening window or pre-roll may be requested")
+        XCTAssertFalse(controller.isPlaybackCaptureSuspended)
+        XCTAssertFalse(playback.isPlaying)
+    }
+
     func testBargeInOverlappingPlaybackSuspensionCannotReopenCapture() async {
         let capture = MockCapture(permissionGranted: true)
         let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -816,8 +816,8 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
 
         XCTAssertEqual(interrupts, 0, "assistant TTS must never schedule a barge-in on a speaker route")
         XCTAssertEqual(controller.state, .speaking)
-        XCTAssertEqual(gateway.transcriptionCount, 0, "assistant output must not be transcribed as user speech")
-        XCTAssertEqual(capture.finishUtteranceCount, 0, "suspended capture must not record assistant output")
+        XCTAssertEqual(gateway.transcriptionCount, 1, "only the user's real utterance may be transcribed")
+        XCTAssertEqual(capture.finishUtteranceCount, 1, "suspended capture must not record a second (assistant) utterance")
         XCTAssertEqual(submitted.count, 1, "no new user turn may be submitted from speaker leakage")
     }
 
@@ -875,7 +875,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
         XCTAssertEqual(controller.state, .listening)
         XCTAssertEqual(capture.startCount, 2)
         XCTAssertEqual(capture.lastStartIncludePreRoll, false, "no speaker-contaminated pre-roll may be requested")
-        XCTAssertEqual(capture.finishUtteranceCount, 0)
+        XCTAssertEqual(capture.finishUtteranceCount, 1, "no additional (assistant) utterance may be recorded")
 
         // The retired turn's late completion must stay retired.
         controller.receiveAssistantEvent(.completed(sessionID: "session", content: "Late tail"))
@@ -979,7 +979,10 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
         controller.receiveAssistantEvent(.delta(sessionID: "session", text: "Silenced answer."))
         try? await Task.sleep(nanoseconds: 80_000_000)
 
-        XCTAssertEqual(controller.state, .muted)
+        // Existing mute semantics: muting during .thinking keeps .thinking;
+        // the muted label only replaces an in-flight .speaking. Either way
+        // nothing audible plays, so capture must never suspend.
+        XCTAssertEqual(controller.state, .thinking)
         XCTAssertFalse(controller.isPlaybackCaptureSuspended, "no audible playback means no suspension")
         XCTAssertEqual(capture.pauseCount, 0)
         XCTAssertEqual(gateway.openCount, 0, "muted output never opens a speech stream")

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -1088,6 +1088,60 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
         XCTAssertFalse(controller.isPlaybackCaptureSuspended)
     }
 
+    func testResumeDuringSuspensionActsAsInterrupt() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        let playback = MockPlayback()
+        var interrupts = 0
+        let policy = RoutePolicyBox(.speakerSafeHalfDuplex)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: playback,
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: { _ in true },
+            interrupt: { interrupts += 1 }
+        )
+
+        await Self.driveToSpeaking(controller, gateway: gateway)
+        XCTAssertTrue(controller.isPlaybackCaptureSuspended)
+
+        // On a speaker-safe route there is no listening during playback: a
+        // listen request means interrupt.
+        await controller.resumeMicrophone()
+
+        XCTAssertEqual(interrupts, 1)
+        XCTAssertFalse(playback.isPlaying)
+        XCTAssertFalse(controller.isPlaybackCaptureSuspended)
+        XCTAssertEqual(controller.state, .listening)
+    }
+
+    func testPauseDuringActiveSuspensionClearsInterruptAffordance() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        var interrupts = 0
+        let policy = RoutePolicyBox(.speakerSafeHalfDuplex)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: { _ in true },
+            interrupt: { interrupts += 1 }
+        )
+
+        await Self.driveToSpeaking(controller, gateway: gateway)
+        XCTAssertTrue(controller.isPlaybackCaptureSuspended)
+
+        // Explicit user intent supersedes the automatic suspension: the
+        // sheet falls back to the user-paused presentation.
+        controller.pauseMicrophone()
+
+        XCTAssertFalse(controller.isPlaybackCaptureSuspended)
+        XCTAssertTrue(controller.isMicrophonePaused)
+        XCTAssertEqual(interrupts, 0)
+    }
+
     /// listening → user utterance → submit → .thinking → assistant .started
     /// + .delta: the gateway opens its speech stream, playback starts, and
     /// the controller settles in .speaking.
@@ -1129,6 +1183,7 @@ private final class MockCapture: AudioCaptureService {
     var didPause = false
     var pauseCount = 0
     var resumeCount = 0
+    private var mockPaused = false
     private(set) var lastStartIncludePreRoll: Bool?
     private(set) var finishUtteranceCount = 0
 
@@ -1144,19 +1199,26 @@ private final class MockCapture: AudioCaptureService {
         didStart = true
         startCount += 1
         lastStartIncludePreRoll = includePreRoll
+        mockPaused = false
         if let startError { throw startError }
     }
     func beginBargeInMonitoring() throws { didBeginMonitoring = true }
     func pause() {
         didPause = true
+        // The real service is idempotent (guard !paused); keep counts honest.
+        guard !mockPaused else { return }
+        mockPaused = true
         pauseCount += 1
     }
-    func resume() throws { resumeCount += 1 }
+    func resume() throws {
+        mockPaused = false
+        resumeCount += 1
+    }
     func finishUtterance() throws -> VoiceCapturedAudio {
         finishUtteranceCount += 1
         return VoiceCapturedAudio(wavData: Data([1]), pcm16Data: Data([1, 0]), sampleRate: 16_000, duration: 0.01)
     }
-    func stop() {}
+    func stop() { mockPaused = false }
     func emit(_ event: VoiceCaptureEvent) { continuation?.yield(event) }
 }
 

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -1196,9 +1196,46 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
         XCTAssertEqual(controller.state, .idle, "stale Interrupt work must stay idle after teardown")
         XCTAssertFalse(controller.hasLiveVoiceSession)
         XCTAssertEqual(capture.startCount, 1, "stale Interrupt must not reopen capture")
-        XCTAssertEqual(capture.lastStartIncludePreRoll, false, "no fresh listening window or pre-roll may be requested")
+        // Belt-and-braces only: the load-bearing guarantee above is
+        // startCount == 1; this reads the original window's recorded value.
+        XCTAssertEqual(capture.lastStartIncludePreRoll, false)
         XCTAssertFalse(controller.isPlaybackCaptureSuspended)
         XCTAssertFalse(playback.isPlaying)
+    }
+
+    func testInterruptParkedAcrossStopAndReopenCannotClobberNewSession() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        let gate = InterruptGate()
+        let policy = RoutePolicyBox(.speakerSafeHalfDuplex)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: { _ in true },
+            interrupt: { await gate.waitInInterrupt() }
+        )
+
+        await Self.driveToSpeaking(controller, gateway: gateway)
+        let interruptTask = Task { await controller.interruptAssistantPlayback() }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(gate.count, 1)
+
+        // Sheet closed (stop), then reopened: a NEW session goes live before
+        // the stale Interrupt continuation resumes.
+        controller.stop()
+        controller.beginVoiceTurn(sessionID: "session-2")
+        await controller.startListening()
+        XCTAssertEqual(controller.state, .listening)
+        XCTAssertEqual(capture.startCount, 2)
+
+        gate.release()
+        await interruptTask.value
+
+        XCTAssertEqual(controller.state, .listening, "the new session owns the state machine")
+        XCTAssertEqual(capture.startCount, 2, "stale Interrupt must not stack a second capture start onto the new session")
+        XCTAssertFalse(controller.isPlaybackCaptureSuspended)
     }
 
     func testBargeInOverlappingPlaybackSuspensionCannotReopenCapture() async {

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -1116,7 +1116,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
         XCTAssertEqual(controller.state, .listening)
     }
 
-    func testPauseDuringActiveSuspensionClearsInterruptAffordance() async {
+    func testPauseDuringActiveSuspensionKeepsSuspensionSafetyFlag() async {
         let capture = MockCapture(permissionGranted: true)
         let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
         var interrupts = 0
@@ -1133,13 +1133,66 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
         await Self.driveToSpeaking(controller, gateway: gateway)
         XCTAssertTrue(controller.isPlaybackCaptureSuspended)
 
-        // Explicit user intent supersedes the automatic suspension: the
-        // sheet falls back to the user-paused presentation.
+        // Explicit user intent takes over the presentation (the sheet shows
+        // the paused state), but it must not discard the speaker-safety
+        // fact: a later listen during audible playback has to stay on the
+        // interrupt path.
         controller.pauseMicrophone()
 
-        XCTAssertFalse(controller.isPlaybackCaptureSuspended)
+        XCTAssertTrue(controller.isPlaybackCaptureSuspended, "explicit pause must not discard the speaker-safety fact")
         XCTAssertTrue(controller.isMicrophonePaused)
         XCTAssertEqual(interrupts, 0)
+
+        // Listening again while playback is still audible interrupts rather
+        // than resuming a live microphone over Hermes' voice.
+        await controller.resumeMicrophone()
+
+        XCTAssertEqual(interrupts, 1)
+        XCTAssertFalse(controller.isPlaybackCaptureSuspended)
+        XCTAssertFalse(controller.isMicrophonePaused)
+        XCTAssertEqual(controller.state, .listening)
+        XCTAssertEqual(capture.resumeCount, 0, "capture must never resume live over audible playback")
+    }
+
+    func testBargeInOverlappingPlaybackSuspensionCannotReopenCapture() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        let gate = InterruptGate()
+        let policy = RoutePolicyBox(.fullDuplex)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: { _ in true },
+            interrupt: { await gate.waitInInterrupt() }
+        )
+
+        await Self.driveToSpeaking(controller, gateway: gateway)
+        XCTAssertEqual(controller.state, .speaking)
+
+        // Genuine headset barge-in whose interruption is in flight.
+        let bargeInStart = Date()
+        controller.ingestAudioLevel(0.5, at: bargeInStart)
+        controller.ingestAudioLevel(0.5, at: bargeInStart.addingTimeInterval(0.31))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(gate.count, 1, "the barge-in interruption is parked mid-flight")
+
+        // While it is parked, the route becomes an open speaker: suspension
+        // engages and cancels the parked barge-in task.
+        policy.policy = .speakerSafeHalfDuplex
+        capture.emit(.routeChanged)
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertTrue(controller.isPlaybackCaptureSuspended)
+
+        gate.release()
+        try? await Task.sleep(nanoseconds: 80_000_000)
+
+        XCTAssertEqual(controller.state, .speaking)
+        XCTAssertTrue(controller.isPlaybackCaptureSuspended)
+        XCTAssertEqual(capture.startCount, 1, "the stale barge-in must not reopen capture")
+        XCTAssertNil(capture.lastStartIncludePreRoll, "no speaker-contaminated pre-roll may be requested")
+        XCTAssertEqual(capture.resumeCount, 0)
     }
 
     /// listening → user utterance → submit → .thinking → assistant .started
@@ -1169,6 +1222,24 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
 private final class RoutePolicyBox {
     var policy: VoiceBargeInRoutePolicy
     init(_ policy: VoiceBargeInRoutePolicy) { self.policy = policy }
+}
+
+/// An interruption closure that parks mid-flight, so tests can interleave
+/// suspension and route changes into the barge-in await window.
+@MainActor
+private final class InterruptGate {
+    private(set) var count = 0
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func waitInInterrupt() async {
+        count += 1
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func release() {
+        continuation?.resume()
+        continuation = nil
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## Problem

On an open-speaker route (built-in speaker / receiver), Voice Conversation heard itself: the amplitude-based barge-in detector treated the assistant's own TTS coming out of the loudspeaker as user speech, transcribed it, and submitted it back to Hermes as a new user turn. Device-reproduced example:

> Hermes speaks: "From a cursed kanji to a full chibi chorus line..."
> STT produces: "To a full chubby chorus line in a single evening..."
> Hermes responds to — and corrects — its own mangled TTS.

Root cause: while `.thinking` / `.speaking` / `.muted`, the controller arms barge-in monitoring; when playback starts on a speaker route the microphone is live while Conduit itself is producing speech, and echo cancellation does not protect the level detector. The existing barge-in path also reuses pre-roll, so even a legitimate interruption during playback would ingest the assistant's own audio.

## Fix

Make assistant playback **route-aware** through one testable seam instead of scattering `AVAudioSession.currentRoute` checks:

- **`VoiceBargeInRoutePolicy`** (`fullDuplex` / `speakerSafeHalfDuplex`) classifies the route conservatively:
  - full duplex: wired headphones; Bluetooth headset-profile input **paired by accessory name** with the Bluetooth output (AirPods, HFP headsets).
  - half duplex: built-in speaker/receiver, A2DP-only Bluetooth, AirPlay, and every other/unknown output. Any open speaker in a mixed output list vetoes full duplex; empty port names never pair.
- **`isPlaybackCaptureSuspended`** — a separate published flag from the user-intent `isMicrophonePaused`. When audible playback starts on a half-duplex route, capture is suspended via the existing real resource pause (`capture.pause()` — tap, engine, converter, and session lease all go down), so the assistant's output cannot reach the level detector, pre-roll, or transcription input. `ingestAudioLevel` additionally refuses to schedule a barge-in while suspended.
- **Playback end (normal or cancelled)** clears the suspension and resumes listening through the existing `startListening()` path: fresh capture window, `includePreRoll: false` — speaker-contaminated pre-roll is never reused.
- **Interrupt**: while suspended, the mic control becomes **Interrupt** ("Hermes is speaking / Tap Interrupt to speak."). It stops playback, retires the in-flight assistant turn through the authoritative interruption seam, clears the suspension, and starts fresh listening. No Mute/Pause/reopen dance.
- **User pause stays authoritative**: an explicit pause is never cleared by the playback lifecycle (pause → playback → finish leaves the mic paused; `resumeCount` stays 0). Presentation precedence lives in the sheet: `Interrupt` only shows when the user has *not* paused; the paused "Listen" tap still routes through the interrupt path during audible playback.
- **Muted output never suspends**: nothing audible is playing, so barge-in monitoring stays live and capture is never paused merely because state is `.muted`. Muting during suspension ends it and restores monitoring.
- **Route changes**: onto an open speaker mid-utterance suspends capture immediately (never keep live acoustic barge-in on a speaker); onto a headset mid-utterance stays conservative — suspension holds until the next playback boundary.
- **Race hardening** (review rounds 2–3): a barge-in task parked in `await interrupt()` when suspension engages is cancelled and cannot reopen capture (pre-prefix `Task.isCancelled` + suspension guards, post-await re-checks, non-stomping defer); the route classification is cached between capture `.routeChanged` events so per-encoded-chunk callbacks neither re-read `AVAudioSession` nor churn `@Published`, and the cache is dropped at every session/playback boundary.

Headset UX is unchanged: on full-duplex routes barge-in monitoring stays armed during playback, sustained speech still interrupts, and genuine barge-in still uses pre-roll.

## Tests

Regressions first: the new speaker-route tests were run against the **unfixed** controller on the Mac build host and failed exactly as the device bug predicts (`interrupts == 1`, assistant output transcribed, state fell to `.listening`), then passed after the fix.

- `VoiceSpeakerSafeBargeInTests` (11): speaker route cannot barge-in on itself; fresh listening after playback completes; Interrupt stops playback/retires the turn/starts pre-roll-free listening/ignores the retired turn's late completion; headset barge-in survives with pre-roll; user-pause authority across suspension; muted output never suspends and keeps barge-in; muting during playback restores monitoring; route change onto speaker suspends immediately; conservative hold on upgrade to headset; pause-during-suspension keeps the safety flag; a parked mid-flight barge-in cannot reopen capture.
- `VoiceBargeInRoutePolicyTests` (11): classifier matrix incl. mixed-output speaker veto, matched/mismatched/empty Bluetooth names.
- Pre-existing `VoiceConversationControllerTests` (33) unchanged and green (the pause-symmetry test now opts into an explicit full-duplex policy since the simulator's default route classifies half duplex).

Verification: all three suites green on the Mac build host at the pushed head (iPhone 17 Pro simulator); hosted CI runs the full matrix.

## Review

Ran the three-reviewer gate (two rounds + targeted confirmation): round 1 — 2× APPROVE / 1× COMMENT (warnings adopted: barge-in race, per-chunk route reads, mixed-route veto, pause/sheet precedence); round 2 — 1× REQUEST CHANGES on cancellation binding + pause/suspension interaction (both fixed as suggested, confirmed APPROVE in round 3).

## Scope exclusions

No #130 VAD/sensitivity changes, no adaptive thresholds, no echo cancellation or fingerprinting, no STT/TTS preference work, no PR #141/#143 audio-session redesign, no voice UI redesign beyond the Interrupt control, no wake-word changes.

## Physical-device acceptance (manual, after merge)

- **Built-in speaker**: full response completes with no self-barge-in, no phantom user transcript, no follow-up turn; mic shows Interrupt while Hermes speaks; tapping it lets you speak immediately; listening resumes automatically after.
- **AirPods/headset**: speaking over Hermes still interrupts; next utterance captures normally.

One known conservative degradation (by design): USB-C headsets that surface as `.usbAudio` (not `.headphones`) and Bluetooth accessories whose HFP/A2DP labels differ classify as half duplex — barge-in during playback is unavailable there, fail-safe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an **Interrupt** option while the assistant speaks through the device speaker, allowing users to stop playback and speak immediately.
  - Microphone controls now indicate when interruption is available, paused, or unavailable.

- **Bug Fixes**
  - Prevented unintended microphone capture during speaker playback.
  - Preserved barge-in behavior with compatible wired and Bluetooth headsets.
  - User-paused microphone state now takes precedence over automatic playback handling.
  - Improved reliability when interrupting, stopping, or restarting voice conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->