### PR TITLE
fix(voice): adapt speech detection and expose microphone input level

### DIFF
--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -512,6 +512,7 @@ struct SettingsView: View {
                 VoiceSettingsRoute(
                     bridge: bridge,
                     profile: snapshot.profile,
+                    conversationController: appState.voiceConversationController,
                     actions: VoiceSettingsActions(
                         runASRTest: { await appState.runVoiceASRTest() },
                         runTTSTest: { await appState.runVoiceTTSTest() }

--- a/Conduit/Views/Components/VoiceInputLevelMeter.swift
+++ b/Conduit/Views/Components/VoiceInputLevelMeter.swift
@@ -10,7 +10,8 @@ import SwiftUI
 /// only — the speech detector never consumes this value.
 enum VoiceLevelMeterMath {
     static func displayFraction(forLevel level: Float) -> Double {
-        guard level.isFinite, level > 0 else { return 0 }
+        guard level > 0 else { return 0 }
+        guard level.isFinite else { return 1 }
         let decibels = 20.0 * log10(Double(level))
         return min(1, max(0, (decibels + 60) / 60))
     }
@@ -42,17 +43,21 @@ struct VoiceInputLevelMeter: View {
         .accessibilityValue(Text(accessibilityValue))
         .onAppear { animatedFraction = targetFraction }
         .onChange(of: targetFraction) { _, newValue in
-            withAnimation(.easeOut(duration: 0.12)) {
-                animatedFraction = newValue
-            }
+            // Assignment only: the per-bar animation modifier owns motion,
+            // so level events never stack conflicting animation transactions.
+            animatedFraction = newValue
         }
     }
 
+    /// Staircase bars with fixed heights: only fill/opacity animates, so a
+    /// level burst never shifts layout. The top bar lights at ~5/6, leaving
+    /// headroom above 0 dBFS clipping.
     private func bar(_ index: Int) -> some View {
         let lit = animatedFraction >= Double(index + 1) / 6.0
         return Capsule()
             .fill(lit ? Color.conduitAccent.opacity(0.85) : Color.secondary.opacity(0.25))
-            .frame(width: 5, height: lit ? CGFloat(6 + index * 3) : 6)
+            .frame(width: 5, height: CGFloat(6 + index * 3))
+            .opacity(lit ? 1 : 0.6)
             .animation(.easeOut(duration: 0.12), value: lit)
     }
 

--- a/Conduit/Views/Components/VoiceInputLevelMeter.swift
+++ b/Conduit/Views/Components/VoiceInputLevelMeter.swift
@@ -1,0 +1,65 @@
+//
+//  VoiceInputLevelMeter.swift
+//  Conduit
+//
+
+import SwiftUI
+
+/// Pure mapping from linear PCM amplitude to a 0...1 display fraction on a
+/// dBFS scale: -60 dBFS renders empty, 0 dBFS renders full. Presentation
+/// only — the speech detector never consumes this value.
+enum VoiceLevelMeterMath {
+    static func displayFraction(forLevel level: Float) -> Double {
+        guard level.isFinite, level > 0 else { return 0 }
+        let decibels = 20.0 * log10(Double(level))
+        return min(1, max(0, (decibels + 60) / 60))
+    }
+}
+
+/// A compact "the microphone hears me" input meter for voice surfaces.
+/// Values are raw linear PCM peaks from the capture service; they are
+/// mapped to dBFS so quiet speech (0.01–0.05) is visibly alive instead of
+/// barely moving. Presentation only — it must be driven by the raw capture
+/// level, never by a VAD decision.
+struct VoiceInputLevelMeter: View {
+    let level: Float
+    let isActive: Bool
+
+    @State private var animatedFraction: Double = 0
+
+    private var targetFraction: Double {
+        isActive ? VoiceLevelMeterMath.displayFraction(forLevel: level) : 0
+    }
+
+    var body: some View {
+        HStack(spacing: 3) {
+            ForEach(0..<5, id: \.self) { index in
+                bar(index)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text("Microphone input level"))
+        .accessibilityValue(Text(accessibilityValue))
+        .onAppear { animatedFraction = targetFraction }
+        .onChange(of: targetFraction) { _, newValue in
+            withAnimation(.easeOut(duration: 0.12)) {
+                animatedFraction = newValue
+            }
+        }
+    }
+
+    private func bar(_ index: Int) -> some View {
+        let lit = animatedFraction >= Double(index + 1) / 6.0
+        return Capsule()
+            .fill(lit ? Color.conduitAccent.opacity(0.85) : Color.secondary.opacity(0.25))
+            .frame(width: 5, height: lit ? CGFloat(6 + index * 3) : 6)
+            .animation(.easeOut(duration: 0.12), value: lit)
+    }
+
+    private var accessibilityValue: String {
+        guard isActive, targetFraction > 0 else { return "Silent" }
+        if targetFraction < 0.3 { return "Low" }
+        if targetFraction < 0.65 { return "Medium" }
+        return "High"
+    }
+}

--- a/Conduit/Views/VoiceConversationSheet.swift
+++ b/Conduit/Views/VoiceConversationSheet.swift
@@ -69,11 +69,11 @@ struct VoiceConversationSheet: View {
                     .foregroundStyle(.secondary)
                 VoiceInputLevelMeter(level: inputMeterLevel, isActive: isInputMeterActive)
                     .frame(height: 20)
+                    .accessibilityHint(Text(isInputMeterActive
+                        ? "Shows audio reaching Conduit while the microphone is live."
+                        : "The microphone is not capturing right now."))
                 Spacer(minLength: 0)
             }
-            .accessibilityHint(Text(isInputMeterActive
-                ? "Shows audio reaching Conduit while the microphone is live."
-                : "The microphone is not capturing right now."))
         }
     }
 

--- a/Conduit/Views/VoiceConversationSheet.swift
+++ b/Conduit/Views/VoiceConversationSheet.swift
@@ -63,6 +63,17 @@ struct VoiceConversationSheet: View {
             }
             .accessibilityElement(children: .combine)
             .accessibilityLabel("Voice status: \(statusTitle). \(statusDetail)")
+            HStack(spacing: 8) {
+                Text("Mic input")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                VoiceInputLevelMeter(level: inputMeterLevel, isActive: isInputMeterActive)
+                    .frame(height: 20)
+                Spacer(minLength: 0)
+            }
+            .accessibilityHint(Text(isInputMeterActive
+                ? "Shows audio reaching Conduit while the microphone is live."
+                : "The microphone is not capturing right now."))
         }
     }
 
@@ -122,6 +133,25 @@ struct VoiceConversationSheet: View {
     /// an interrupt while playback is suspended.
     private var isInterruptAvailable: Bool {
         controller.isPlaybackCaptureSuspended && !controller.isMicrophonePaused
+    }
+
+    /// The input meter is live exactly when microphone capture is live:
+    /// listening, and (on headset routes) the thinking/speaking/muted
+    /// windows where barge-in monitoring is actually armed. A user-paused
+    /// mic, transcribing, and #146 speaker-safe suspension all read as
+    /// inactive/zero — there, the status text explains why (e.g. "Hermes is
+    /// speaking / Tap Interrupt to speak."), so a zero meter never implies
+    /// malfunction.
+    private var isInputMeterActive: Bool {
+        guard !controller.isMicrophonePaused, !controller.isPlaybackCaptureSuspended else { return false }
+        switch controller.state {
+        case .listening, .thinking, .speaking, .muted: return true
+        case .idle, .transcribing, .failed: return false
+        }
+    }
+
+    private var inputMeterLevel: Float {
+        isInputMeterActive ? controller.microphoneLevel : 0
     }
 
     private var microphoneLabel: String {

--- a/Conduit/Views/VoiceSettingsView.swift
+++ b/Conduit/Views/VoiceSettingsView.swift
@@ -388,10 +388,12 @@ struct VoiceSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
-            if isRecordingASRTest {
-                // Live only while the ASR test records — never during TTS
-                // playback. Movement proves microphone capture; a still
-                // meter points at the microphone/session/route instead.
+            // The meter is visible only while the ASR test is actually
+            // recording (state .listening): once the sample is complete and
+            // the state becomes .transcribing, capture input is no longer
+            // the interesting signal, so the meter hides instead of
+            // freezing at its last value. Never shown during TTS playback.
+            if isRecordingASRTest, conversationController.state == .listening {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Microphone input")
                         .font(.caption)

--- a/Conduit/Views/VoiceSettingsView.swift
+++ b/Conduit/Views/VoiceSettingsView.swift
@@ -7,6 +7,10 @@ import SwiftUI
 
 struct VoiceSettingsRoute: View {
     @StateObject private var service: HermesVoiceConfigurationService
+    /// The active VoiceConversationController, observed so the Record ASR
+    /// input meter tracks live capture without polling or a second capture
+    /// service.
+    @ObservedObject var conversationController: VoiceConversationController
     let actions: VoiceSettingsActions
     let voiceEnabled: Bool
     let transcriptionMode: VoiceTranscriptionMode
@@ -17,6 +21,7 @@ struct VoiceSettingsRoute: View {
     init(
         bridge: DashboardTicketBridge,
         profile: String,
+        conversationController: VoiceConversationController,
         actions: VoiceSettingsActions,
         voiceEnabled: Bool,
         transcriptionMode: VoiceTranscriptionMode,
@@ -25,6 +30,7 @@ struct VoiceSettingsRoute: View {
         setTranscriptionMode: @escaping (VoiceTranscriptionMode) async -> Bool
     ) {
         _service = StateObject(wrappedValue: HermesVoiceConfigurationService(bridge: bridge, profile: profile))
+        _conversationController = ObservedObject(wrappedValue: conversationController)
         self.actions = actions
         self.voiceEnabled = voiceEnabled
         self.transcriptionMode = transcriptionMode
@@ -36,6 +42,7 @@ struct VoiceSettingsRoute: View {
     var body: some View {
         VoiceSettingsView(
             service: service,
+            conversationController: conversationController,
             actions: actions,
             voiceEnabled: voiceEnabled,
             transcriptionMode: transcriptionMode,
@@ -64,6 +71,10 @@ struct VoiceSettingsActions {
 /// it has built the active VoiceConversationController.
 struct VoiceSettingsView: View {
     @ObservedObject var service: HermesVoiceConfigurationService
+    /// Observed so the Record ASR meter tracks the active controller's raw
+    /// microphone level (issue #130): a moving meter proves capture works
+    /// and localizes detection failures to the VAD/provider boundary.
+    @ObservedObject var conversationController: VoiceConversationController
     var actions = VoiceSettingsActions()
     let setVoiceEnabled: (Bool) async -> Bool
     let setTranscriptionMode: (VoiceTranscriptionMode) async -> Bool
@@ -73,12 +84,14 @@ struct VoiceSettingsView: View {
     @State private var savingField: String?
     @State private var testStatus: String?
     @State private var isRunningTest = false
+    @State private var isRecordingASRTest = false
     @State private var voiceEnabled: Bool
     @State private var transcriptionMode: VoiceTranscriptionMode
     @State private var appleSpeechAvailability: AppleSpeechRecognitionAvailability
 
     init(
         service: HermesVoiceConfigurationService,
+        conversationController: VoiceConversationController,
         actions: VoiceSettingsActions = VoiceSettingsActions(),
         voiceEnabled: Bool = false,
         transcriptionMode: VoiceTranscriptionMode = .hermes,
@@ -87,6 +100,7 @@ struct VoiceSettingsView: View {
         setTranscriptionMode: @escaping (VoiceTranscriptionMode) async -> Bool = { _ in false }
     ) {
         self.service = service
+        _conversationController = ObservedObject(wrappedValue: conversationController)
         self.actions = actions
         self.setVoiceEnabled = setVoiceEnabled
         self.setTranscriptionMode = setTranscriptionMode
@@ -374,6 +388,20 @@ struct VoiceSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+            if isRecordingASRTest {
+                // Live only while the ASR test records — never during TTS
+                // playback. Movement proves microphone capture; a still
+                // meter points at the microphone/session/route instead.
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Microphone input")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    VoiceInputLevelMeter(level: conversationController.microphoneLevel, isActive: true)
+                        .frame(height: 20)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(Text("Microphone input level"))
+            }
         }
     }
 
@@ -481,12 +509,14 @@ struct VoiceSettingsView: View {
         guard let action else { return }
         Task {
             isRunningTest = true
+            isRecordingASRTest = kind == .stt
             testStatus = kind == .stt ? "Listening for a short test…" : "Starting speech playback…"
             let result = await action()
             if kind == .stt, transcriptionMode == .appleOnDevice {
                 appleSpeechAvailability = AppleOnDeviceSpeechTranscriber.currentAvailability()
             }
             testStatus = result.message
+            isRecordingASRTest = false
             isRunningTest = false
         }
     }

--- a/Conduit/Voice/AVAudioCaptureService.swift
+++ b/Conduit/Voice/AVAudioCaptureService.swift
@@ -29,7 +29,10 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
     private var converter: AVAudioConverter?
     // Capture state below is internal rather than private so ConduitTests
     // can drive the frame-admission seam directly with synthetic PCM
-    // buffers instead of audio hardware.
+    // buffers instead of audio hardware. Production code must mutate these
+    // only through the lifecycle methods; direct writes outside ConduitTests
+    // can create flag combinations the lifecycle never produces and are not
+    // supported.
     var capturedPCM = Data()
     var preRollPCM = Data()
     private let maximumPreRollBytes = Int(AVAudioCaptureService.outputSampleRate * AVAudioCaptureService.preRollDuration) * AVAudioCaptureService.outputBytesPerFrame
@@ -164,6 +167,8 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
         activelyRecording = false
         paused = false
         shouldKeepEngineRunning = false
+        // Deliberately unguarded (unlike pause): a redundant stop bumps the
+        // generation again, which is always fail-closed.
         captureGeneration &+= 1
         teardownRendering()
         releaseLease()

--- a/Conduit/Voice/AVAudioCaptureService.swift
+++ b/Conduit/Voice/AVAudioCaptureService.swift
@@ -211,7 +211,14 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
                 destinationData.copyMemory(from: sourceData, byteCount: byteCount)
                 destination[index].mDataByteSize = source[index].mDataByteSize
             }
-            Task { @MainActor [weak self] in self?.consume(copy) }
+            Task { @MainActor [weak self] in
+                // Capture-generation fence: pause()/stop() tear the tap
+                // down, but a frame already in flight across this hop
+                // belongs to the previous generation and must not surface
+                // into the new one.
+                guard let self, !self.paused else { return }
+                self.consume(copy)
+            }
         }
         engine.prepare()
         try engine.start()

--- a/Conduit/Voice/AVAudioCaptureService.swift
+++ b/Conduit/Voice/AVAudioCaptureService.swift
@@ -32,6 +32,11 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
     private let maximumPreRollBytes = Int(AVAudioCaptureService.outputSampleRate * AVAudioCaptureService.preRollDuration) * AVAudioCaptureService.outputBytesPerFrame
     private var activelyRecording = false
     private var paused = false
+    /// Monotonic identity of the installed input-tap/rendering lifetime.
+    /// Bumped at every teardown (pause/stop) and every tap reinstall, so
+    /// frames queued from a previous generation can be recognized and
+    /// dropped after the boundary.
+    private(set) var captureGeneration: UInt64 = 0
     private var shouldKeepEngineRunning = false
     private var lastCaptureFailure: String?
     private var continuation: AsyncStream<VoiceCaptureEvent>.Continuation?
@@ -118,6 +123,7 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
         guard !paused else { return }
         paused = true
         shouldKeepEngineRunning = false
+        captureGeneration &+= 1
         teardownRendering()
         releaseLease()
     }
@@ -155,6 +161,7 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
         activelyRecording = false
         paused = false
         shouldKeepEngineRunning = false
+        captureGeneration &+= 1
         teardownRendering()
         releaseLease()
     }
@@ -192,7 +199,12 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
             throw VoiceAudioError.unavailable("The selected microphone is unavailable.")
         }
         converter = nil
-        input.removeTap(onBus: 0)
+        // A freshly installed tap begins a new rendering generation: frames
+        // it produces are stamped with this identity, and any teardown
+        // invalidates it so queued frames from the old tap are recognized
+        // as stale.
+        captureGeneration &+= 1
+        let frameGeneration = captureGeneration
         input.installTap(onBus: 0, bufferSize: 1_024, format: nil) { [weak self] buffer, _ in
             // AVAudioEngine owns and reuses tap buffers as soon as this block
             // returns. Copy the frame bytes before crossing onto MainActor so
@@ -216,10 +228,10 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
                 // down, but a frame already in flight across this hop
                 // belongs to the previous generation and must not surface
                 // into the new one. (A stop immediately followed by a
-                // restart re-arms these flags; the controller additionally
-                // gates on its own session state.)
+                // restart re-arms these flags; the frame's own generation
+                // and the controller's generation check cover that case.)
                 guard let self, !self.paused, self.shouldKeepEngineRunning else { return }
-                self.consume(copy)
+                self.consume(copy, generation: frameGeneration)
             }
         }
         engine.prepare()
@@ -239,7 +251,7 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
         coordinator.release(lease)
     }
 
-    private func consume(_ buffer: AVAudioPCMBuffer) {
+    private func consume(_ buffer: AVAudioPCMBuffer, generation: UInt64) {
         guard !paused else { return }
         if converter == nil || !Self.converter(converter, accepts: buffer.format) {
             converter = AVAudioConverter(from: buffer.format, to: outputFormat)
@@ -286,7 +298,7 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
         lastCaptureFailure = nil
         appendPreRoll(pcm)
         if activelyRecording { capturedPCM.append(pcm) }
-        continuation?.yield(.level(encoded.peak, date: Date()))
+        continuation?.yield(.level(encoded.peak, date: Date(), generation: generation))
     }
 
     private func appendPreRoll(_ pcm: Data) {

--- a/Conduit/Voice/AVAudioCaptureService.swift
+++ b/Conduit/Voice/AVAudioCaptureService.swift
@@ -202,6 +202,12 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
             throw VoiceAudioError.unavailable("The selected microphone is unavailable.")
         }
         converter = nil
+        // Defensive: a recovery restart (e.g. after a route change stops the
+        // engine) can reach startEngine while a stale tap still hangs on bus
+        // 0 even though the engine is not running. Removing first keeps the
+        // reinstall from stacking a second tap; removeTap is a no-op when
+        // none exists.
+        input.removeTap(onBus: 0)
         // A freshly installed tap begins a new rendering generation: frames
         // it produces are stamped with this identity, and any teardown
         // invalidates it so queued frames from the old tap are recognized
@@ -230,9 +236,11 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
                 // Capture-generation fence: pause()/stop() tear the tap
                 // down, but a frame already in flight across this hop
                 // belongs to the previous generation and must not surface
-                // into the new one. (A stop immediately followed by a
-                // restart re-arms these flags; the frame's own generation
-                // and the controller's generation check cover that case.)
+                // into the new one — even when a stop was immediately
+                // followed by a restart that re-armed the live flags. The
+                // admission seam checks the frame's own generation against
+                // the currently installed tap before anything downstream
+                // (including consume's own defense-in-depth guard) runs.
                 guard let self, self.acceptsFrame(generation: frameGeneration) else { return }
                 self.consume(copy, generation: frameGeneration)
             }
@@ -255,14 +263,20 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
     }
 
     /// Single admission gate for tap frames on their way into PCM state.
-    /// Extracted so tests can pin the exact guard both the MainActor hop
-    /// and consume() evaluate before conversion, pre-roll, captured audio,
-    /// or level emission can observe a frame.
+    /// A frame is admitted only when it was produced by the currently
+    /// installed tap generation while capture is unpaused and the engine is
+    /// expected to stay live. Both the MainActor hop and consume() gate on
+    /// this seam, so an invalidated generation's bytes can never reach
+    /// conversion state, pre-roll, captured audio, the meter, or VAD — even
+    /// when a stop was immediately followed by a restart that re-armed the
+    /// live flags.
     func acceptsFrame(generation: UInt64) -> Bool {
-        !paused && shouldKeepEngineRunning
+        generation == captureGeneration && !paused && shouldKeepEngineRunning
     }
 
     func consume(_ buffer: AVAudioPCMBuffer, generation: UInt64) {
+        // Defense-in-depth: the hop already admitted this frame, but any
+        // future caller path must equally fail closed before PCM admission.
         guard acceptsFrame(generation: generation) else { return }
         if converter == nil || !Self.converter(converter, accepts: buffer.format) {
             converter = AVAudioConverter(from: buffer.format, to: outputFormat)

--- a/Conduit/Voice/AVAudioCaptureService.swift
+++ b/Conduit/Voice/AVAudioCaptureService.swift
@@ -215,8 +215,10 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
                 // Capture-generation fence: pause()/stop() tear the tap
                 // down, but a frame already in flight across this hop
                 // belongs to the previous generation and must not surface
-                // into the new one.
-                guard let self, !self.paused else { return }
+                // into the new one. (A stop immediately followed by a
+                // restart re-arms these flags; the controller additionally
+                // gates on its own session state.)
+                guard let self, !self.paused, self.shouldKeepEngineRunning else { return }
                 self.consume(copy)
             }
         }

--- a/Conduit/Voice/AVAudioCaptureService.swift
+++ b/Conduit/Voice/AVAudioCaptureService.swift
@@ -27,17 +27,20 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
         channels: AVAudioCaptureService.outputChannelCount
     )!
     private var converter: AVAudioConverter?
-    private var capturedPCM = Data()
-    private var preRollPCM = Data()
+    // Capture state below is internal rather than private so ConduitTests
+    // can drive the frame-admission seam directly with synthetic PCM
+    // buffers instead of audio hardware.
+    var capturedPCM = Data()
+    var preRollPCM = Data()
     private let maximumPreRollBytes = Int(AVAudioCaptureService.outputSampleRate * AVAudioCaptureService.preRollDuration) * AVAudioCaptureService.outputBytesPerFrame
-    private var activelyRecording = false
-    private var paused = false
+    var activelyRecording = false
+    var paused = false
     /// Monotonic identity of the installed input-tap/rendering lifetime.
     /// Bumped at every teardown (pause/stop) and every tap reinstall, so
     /// frames queued from a previous generation can be recognized and
     /// dropped after the boundary.
     private(set) var captureGeneration: UInt64 = 0
-    private var shouldKeepEngineRunning = false
+    var shouldKeepEngineRunning = false
     private var lastCaptureFailure: String?
     private var continuation: AsyncStream<VoiceCaptureEvent>.Continuation?
     /// Capture holds one lease for the whole capture window (listening,
@@ -230,7 +233,7 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
                 // into the new one. (A stop immediately followed by a
                 // restart re-arms these flags; the frame's own generation
                 // and the controller's generation check cover that case.)
-                guard let self, !self.paused, self.shouldKeepEngineRunning else { return }
+                guard let self, self.acceptsFrame(generation: frameGeneration) else { return }
                 self.consume(copy, generation: frameGeneration)
             }
         }
@@ -251,8 +254,16 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
         coordinator.release(lease)
     }
 
-    private func consume(_ buffer: AVAudioPCMBuffer, generation: UInt64) {
-        guard !paused else { return }
+    /// Single admission gate for tap frames on their way into PCM state.
+    /// Extracted so tests can pin the exact guard both the MainActor hop
+    /// and consume() evaluate before conversion, pre-roll, captured audio,
+    /// or level emission can observe a frame.
+    func acceptsFrame(generation: UInt64) -> Bool {
+        !paused && shouldKeepEngineRunning
+    }
+
+    func consume(_ buffer: AVAudioPCMBuffer, generation: UInt64) {
+        guard acceptsFrame(generation: generation) else { return }
         if converter == nil || !Self.converter(converter, accepts: buffer.format) {
             converter = AVAudioConverter(from: buffer.format, to: outputFormat)
         }

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -9,11 +9,15 @@ import Foundation
 @MainActor
 final class VoiceConversationController: ObservableObject {
     struct Configuration: Equatable {
-        var voiceActivityThreshold: Float = 0.075
+        /// Conservative acoustic barge-in threshold, unchanged from the
+        /// legacy single VAD threshold. Listening-side speech detection no
+        /// longer uses this value; it adapts via `speechDetector` instead.
+        var bargeInActivityThreshold: Float = 0.075
         var trailingSilence: TimeInterval = 1.25
         var idleSilence: TimeInterval = 12
         var maximumUtterance: TimeInterval = 60
         var bargeInDuration: TimeInterval = 0.3
+        var speechDetector = VoiceSpeechDetectorConstants()
     }
 
     @Published private(set) var state: VoiceConversationState = .idle
@@ -21,6 +25,12 @@ final class VoiceConversationController: ObservableObject {
     @Published private(set) var lastBargeInState: VoiceConversationState?
     @Published private(set) var isOutputMuted = false
     @Published private(set) var isMicrophonePaused = false
+    /// Latest raw microphone input peak from the capture service. This is
+    /// presentation state: it moves whenever audio reaches Conduit,
+    /// regardless of whether the speech detector classifies it as speech,
+    /// and returns to zero whenever capture is paused, stopped, suspended,
+    /// or interrupted.
+    @Published private(set) var microphoneLevel: Float = 0
     /// Automatic speaker-safe suspension while Hermes is audibly playing on
     /// a route whose output can feed the microphone. Deliberately separate
     /// from `isMicrophonePaused`: that flag is explicit user intent ("Microphone
@@ -67,6 +77,10 @@ final class VoiceConversationController: ObservableObject {
     private var speechDrainRevision: UInt64 = 0
     private var isProviderTestRunning = false
     private var activeAssistantTranscriptEntryID: UUID?
+    /// Adaptive listening-side speech detector (issue #130). Acoustic
+    /// barge-in does not use it; that path keeps the conservative fixed
+    /// threshold in `configuration.bargeInActivityThreshold`.
+    private var speechDetector: VoiceSpeechDetector
 
     init(
         capture: AudioCaptureService? = nil,
@@ -84,6 +98,7 @@ final class VoiceConversationController: ObservableObject {
         self.deviceTranscriber = deviceTranscriber ?? AppleOnDeviceSpeechTranscriber()
         self.gateway = gateway
         self.configuration = configuration
+        speechDetector = VoiceSpeechDetector(constants: configuration.speechDetector)
         // Built here (not as a default parameter value) so the live route
         // read stays in MainActor context, matching the capture default.
         if let routePolicyProvider {
@@ -210,6 +225,9 @@ final class VoiceConversationController: ObservableObject {
             // Defense in depth: capture must never end up live over audible
             // playback, whichever flag paused it.
             if isMicrophonePaused || isPlaybackCaptureSuspended { capture.pause() }
+            // Fresh listening window: the detector must not inherit noise or
+            // speech state from the previous one.
+            speechDetector.reset()
             utteranceStartedAt = Date()
             lastSpeechAt = nil
             bargeInStartedAt = nil
@@ -227,6 +245,8 @@ final class VoiceConversationController: ObservableObject {
         // handled by the sheet, which shows the user-paused state whenever
         // `isMicrophonePaused` is set.
         capture.pause()
+        speechDetector.reset()
+        microphoneLevel = 0
         isMicrophonePaused = true
     }
 
@@ -253,7 +273,9 @@ final class VoiceConversationController: ObservableObject {
             isMicrophonePaused = false
             // Pause is a real resource pause, so resume opens a fresh
             // listening window: speech timestamps from before the pause must
-            // not immediately finish an utterance or idle-pause again.
+            // not immediately finish an utterance or idle-pause again, and
+            // the detector must not inherit pre-pause noise/speech state.
+            speechDetector.reset()
             utteranceStartedAt = Date()
             lastSpeechAt = nil
             bargeInStartedAt = nil
@@ -312,6 +334,8 @@ final class VoiceConversationController: ObservableObject {
         assistantFinished = false
         isMicrophonePaused = false
         isPlaybackCaptureSuspended = false
+        speechDetector.reset()
+        microphoneLevel = 0
         isVoiceSessionActive = false
         isAwaitingVoiceAssistant = false
         awaitedAssistantResponseStarted = false
@@ -364,6 +388,9 @@ final class VoiceConversationController: ObservableObject {
         defer {
             capture.stop()
             isProviderTestRunning = false
+            // The test recording is over: the meter must not freeze at the
+            // last captured level.
+            microphoneLevel = 0
             if isCurrent(generation) { state = .idle }
             isVoiceSessionActive = false
         }
@@ -418,6 +445,7 @@ final class VoiceConversationController: ObservableObject {
             speechStream = nil
             playback.stop()
             isProviderTestRunning = false
+            microphoneLevel = 0
             if isCurrent(generation) { state = .idle }
             isVoiceSessionActive = false
         }
@@ -466,7 +494,10 @@ final class VoiceConversationController: ObservableObject {
         switch state {
         case .listening:
             if utteranceStartedAt == nil { utteranceStartedAt = date }
-            if level >= configuration.voiceActivityThreshold { lastSpeechAt = date }
+            switch speechDetector.observe(level) {
+            case .started, .continued: lastSpeechAt = date
+            case .none: break
+            }
             if let started = utteranceStartedAt, date.timeIntervalSince(started) >= configuration.maximumUtterance {
                 scheduleFinishUtterance()
             } else if let speech = lastSpeechAt, date.timeIntervalSince(speech) >= configuration.trailingSilence {
@@ -481,7 +512,7 @@ final class VoiceConversationController: ObservableObject {
             // even from a stale level event that slipped past the paused
             // tap.
             guard !isPlaybackCaptureSuspended else { break }
-            if level >= configuration.voiceActivityThreshold {
+            if level >= configuration.bargeInActivityThreshold {
                 if bargeInStartedAt == nil { bargeInStartedAt = date }
                 if let started = bargeInStartedAt,
                    date.timeIntervalSince(started) >= configuration.bargeInDuration {
@@ -560,12 +591,16 @@ final class VoiceConversationController: ObservableObject {
     }
 
     private func handleCaptureEvent(_ event: VoiceCaptureEvent) {
-        if isProviderTestRunning {
-            if case .interrupted = event { failForAudioInterruption() }
-            return
-        }
         switch event {
-        case .level(let level, let date): ingestAudioLevel(level, at: date)
+        case .level(let level, let date):
+            // Raw capture level always feeds the visible input meter —
+            // including provider tests, where seeing "the microphone hears
+            // me" distinguishes capture failure from detection failure —
+            // while conversational VAD stays exclusive to the live Voice
+            // Conversation.
+            microphoneLevel = level
+            guard !isProviderTestRunning else { return }
+            ingestAudioLevel(level, at: date)
         case .interrupted:
             failForAudioInterruption()
         case .routeChanged:
@@ -601,6 +636,11 @@ final class VoiceConversationController: ObservableObject {
         do {
             let audio = try capture.finishUtterance()
             state = .transcribing
+            // Utterance complete: the meter follows the now-inactive capture
+            // and the detector must not carry this turn's noise/speech state
+            // into the next one.
+            microphoneLevel = 0
+            speechDetector.reset()
             let transcript = try await transcribe(audio, gateway: gateway)
             guard isCurrent(generation) else { return }
             latestTranscript = transcript
@@ -701,6 +741,11 @@ final class VoiceConversationController: ObservableObject {
         guard !isPlaybackCaptureSuspended else { return }
         isPlaybackCaptureSuspended = true
         bargeInStartedAt = nil
+        // Capture is torn down for the duration of playback: the meter must
+        // read zero (not frozen) and the detector must not carry state into
+        // the next listening window.
+        speechDetector.reset()
+        microphoneLevel = 0
         capture.pause()
     }
 
@@ -719,6 +764,8 @@ final class VoiceConversationController: ObservableObject {
         assistantFinished = false
         isMicrophonePaused = false
         isPlaybackCaptureSuspended = false
+        speechDetector.reset()
+        microphoneLevel = 0
         isAwaitingVoiceAssistant = false
         awaitedAssistantResponseStarted = false
         // Terminal path: release session-ownership bookkeeping so audio-

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -613,7 +613,10 @@ final class VoiceConversationController: ObservableObject {
             // cross into the current one: a buffered tap event delivered
             // after pause()/stop()/suspension would otherwise un-zero the
             // reset meter or feed the detector a window that no longer
-            // exists. Provider tests are live capture and still count.
+            // exists. Provider tests are live capture and still count; the
+            // isProviderTestRunning clause is defense-in-depth, since the
+            // transcription test also raises isVoiceSessionActive and
+            // captureLive already covers it today.
             let captureLive = !isMicrophonePaused
                 && !isPlaybackCaptureSuspended
                 && isVoiceSessionActive

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -600,7 +600,7 @@ final class VoiceConversationController: ObservableObject {
 
     private func handleCaptureEvent(_ event: VoiceCaptureEvent) {
         switch event {
-        case .level(let level, let date):
+        case .level(let level, let date, let generation):
             // Raw capture level always feeds the visible input meter —
             // including provider tests, where seeing "the microphone hears
             // me" distinguishes capture failure from detection failure —
@@ -609,14 +609,14 @@ final class VoiceConversationController: ObservableObject {
             // tap-buffer resolution: every assignment re-renders observing
             // surfaces.
             //
-            // Stale events from a previous capture generation must never
-            // cross into the current one: a buffered tap event delivered
-            // after pause()/stop()/suspension would otherwise un-zero the
-            // reset meter or feed the detector a window that no longer
-            // exists. Provider tests are live capture and still count; the
-            // isProviderTestRunning clause is defense-in-depth, since the
-            // transcription test also raises isVoiceSessionActive and
-            // captureLive already covers it today.
+            // Generation identity first: a frame is valid only for the
+            // input-tap generation that produced it, so queued frames from
+            // a torn-down tap are rejected even when a new generation is
+            // already live. Then defense in depth — logical capture state:
+            // stale events must also not reach presentation or VAD during
+            // a user pause, a #146 suspension, or after the voice session
+            // ended. Provider tests are live capture and still count.
+            guard generation == capture.captureGeneration else { return }
             let captureLive = !isMicrophonePaused
                 && !isPlaybackCaptureSuspended
                 && isVoiceSessionActive

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -608,6 +608,16 @@ final class VoiceConversationController: ObservableObject {
             // Conversation. Publication is meter-resolution (~20 Hz), not
             // tap-buffer resolution: every assignment re-renders observing
             // surfaces.
+            //
+            // Stale events from a previous capture generation must never
+            // cross into the current one: a buffered tap event delivered
+            // after pause()/stop()/suspension would otherwise un-zero the
+            // reset meter or feed the detector a window that no longer
+            // exists. Provider tests are live capture and still count.
+            let captureLive = !isMicrophonePaused
+                && !isPlaybackCaptureSuspended
+                && isVoiceSessionActive
+            guard captureLive || isProviderTestRunning else { return }
             if lastMeterPublication == nil || date.timeIntervalSince(lastMeterPublication!) >= 0.05 {
                 microphoneLevel = level
                 lastMeterPublication = date

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -621,6 +621,12 @@ final class VoiceConversationController: ObservableObject {
                 && !isPlaybackCaptureSuspended
                 && isVoiceSessionActive
             guard captureLive || isProviderTestRunning else { return }
+            // A same-generation event can still surface after
+            // finishUtterance() closed the turn: capture keeps running into
+            // the transcription wait. The meter was reset for that state and
+            // the UI hides it there, so republishing would only churn
+            // @Published state.
+            guard state != .transcribing else { return }
             if lastMeterPublication == nil || date.timeIntervalSince(lastMeterPublication!) >= 0.05 {
                 microphoneLevel = level
                 lastMeterPublication = date

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -31,6 +31,10 @@ final class VoiceConversationController: ObservableObject {
     /// and returns to zero whenever capture is paused, stopped, suspended,
     /// or interrupted.
     @Published private(set) var microphoneLevel: Float = 0
+    /// Publication clock for meter throttling: level events arrive at tap
+    /// buffer rate (~50 Hz), far faster than any useful UI animation, and
+    /// every @Published assignment re-renders observing surfaces.
+    private var lastMeterPublication: Date?
     /// Automatic speaker-safe suspension while Hermes is audibly playing on
     /// a route whose output can feed the microphone. Deliberately separate
     /// from `isMicrophonePaused`: that flag is explicit user intent ("Microphone
@@ -228,6 +232,7 @@ final class VoiceConversationController: ObservableObject {
             // Fresh listening window: the detector must not inherit noise or
             // speech state from the previous one.
             speechDetector.reset()
+            resetMicrophoneMeter()
             utteranceStartedAt = Date()
             lastSpeechAt = nil
             bargeInStartedAt = nil
@@ -246,7 +251,7 @@ final class VoiceConversationController: ObservableObject {
         // `isMicrophonePaused` is set.
         capture.pause()
         speechDetector.reset()
-        microphoneLevel = 0
+        resetMicrophoneMeter()
         isMicrophonePaused = true
     }
 
@@ -335,7 +340,7 @@ final class VoiceConversationController: ObservableObject {
         isMicrophonePaused = false
         isPlaybackCaptureSuspended = false
         speechDetector.reset()
-        microphoneLevel = 0
+        resetMicrophoneMeter()
         isVoiceSessionActive = false
         isAwaitingVoiceAssistant = false
         awaitedAssistantResponseStarted = false
@@ -390,7 +395,7 @@ final class VoiceConversationController: ObservableObject {
             isProviderTestRunning = false
             // The test recording is over: the meter must not freeze at the
             // last captured level.
-            microphoneLevel = 0
+            resetMicrophoneMeter()
             if isCurrent(generation) { state = .idle }
             isVoiceSessionActive = false
         }
@@ -409,6 +414,9 @@ final class VoiceConversationController: ObservableObject {
             }
             let audio = try capture.finishUtterance()
             state = .transcribing
+            // Recording is done: the settings meter must not freeze at the
+            // last captured level while the provider transcribes.
+            resetMicrophoneMeter()
             let transcript = try await transcribe(audio, gateway: gateway)
             guard isCurrent(generation) else {
                 return .failure("The speech-to-text test was cancelled.")
@@ -445,7 +453,7 @@ final class VoiceConversationController: ObservableObject {
             speechStream = nil
             playback.stop()
             isProviderTestRunning = false
-            microphoneLevel = 0
+            resetMicrophoneMeter()
             if isCurrent(generation) { state = .idle }
             isVoiceSessionActive = false
         }
@@ -597,19 +605,37 @@ final class VoiceConversationController: ObservableObject {
             // including provider tests, where seeing "the microphone hears
             // me" distinguishes capture failure from detection failure —
             // while conversational VAD stays exclusive to the live Voice
-            // Conversation.
-            microphoneLevel = level
+            // Conversation. Publication is meter-resolution (~20 Hz), not
+            // tap-buffer resolution: every assignment re-renders observing
+            // surfaces.
+            if lastMeterPublication == nil || date.timeIntervalSince(lastMeterPublication!) >= 0.05 {
+                microphoneLevel = level
+                lastMeterPublication = date
+            }
             guard !isProviderTestRunning else { return }
             ingestAudioLevel(level, at: date)
         case .interrupted:
             failForAudioInterruption()
         case .routeChanged:
+            // Provider tests own the session exclusively; no capture is live
+            // during the TTS test, so route-driven suspension would only
+            // pollute speaker-safe state across the test boundary.
+            guard !isProviderTestRunning else { return }
             // AVAudioEngine's tap remains valid across normal Bluetooth/wired
-            // route changes. The next capture event re-establishes timing.
+            // route changes. The next capture event re-establishes timing,
+            // and a different microphone means a different noise floor.
             bargeInStartedAt = nil
             cachedRoutePolicy = nil
+            if state == .listening { speechDetector.reset() }
             suspendIfRouteBecameOpenSpeaker()
         }
+    }
+
+    /// Zeroes the visible meter and clears the publication clock so the
+    /// first event of a fresh capture window always publishes.
+    private func resetMicrophoneMeter() {
+        microphoneLevel = 0
+        lastMeterPublication = nil
     }
 
     /// Safety net for routes that change while Hermes is audibly speaking:
@@ -639,7 +665,7 @@ final class VoiceConversationController: ObservableObject {
             // Utterance complete: the meter follows the now-inactive capture
             // and the detector must not carry this turn's noise/speech state
             // into the next one.
-            microphoneLevel = 0
+            resetMicrophoneMeter()
             speechDetector.reset()
             let transcript = try await transcribe(audio, gateway: gateway)
             guard isCurrent(generation) else { return }
@@ -745,7 +771,7 @@ final class VoiceConversationController: ObservableObject {
         // read zero (not frozen) and the detector must not carry state into
         // the next listening window.
         speechDetector.reset()
-        microphoneLevel = 0
+        resetMicrophoneMeter()
         capture.pause()
     }
 
@@ -765,7 +791,7 @@ final class VoiceConversationController: ObservableObject {
         isMicrophonePaused = false
         isPlaybackCaptureSuspended = false
         speechDetector.reset()
-        microphoneLevel = 0
+        resetMicrophoneMeter()
         isAwaitingVoiceAssistant = false
         awaitedAssistantResponseStarted = false
         // Terminal path: release session-ownership bookkeeping so audio-

--- a/Conduit/Voice/VoiceSpeechDetector.swift
+++ b/Conduit/Voice/VoiceSpeechDetector.swift
@@ -99,15 +99,52 @@ struct VoiceSpeechDetector {
     }
 
     mutating func observe(_ level: Float) -> VoiceSpeechDetection {
-        // Baseline decision kept from the legacy detector: the fixed
-        // conservative threshold decides alone. The adaptive floor,
-        // warmup, and debounce paths land with the #130 fix.
+        // Garbage samples (NaN, negative) must not poison the noise floor
+        // or wedge threshold comparisons; treat them as silence.
+        guard level.isFinite, level >= 0 else {
+            candidateSamples = 0
+            return .none
+        }
+        if isSpeechActive {
+            // Hysteresis: an active utterance survives level dips via the
+            // lower continuation threshold; trailing-silence timing stays
+            // with the controller.
+            return level >= speechContinuationThreshold ? .continued : .none
+        }
+        if warmupRemaining > 0 {
+            // Fresh window: every sample (either direction, fast) teaches
+            // the floor before sub-ceiling speech-start is armed.
+            adaptNoiseFloor(level, warmup: true)
+            warmupRemaining -= 1
+            if level >= constants.maximumSpeechStartThreshold {
+                // An unambiguous level is speech even before the floor has
+                // been established.
+                isSpeechActive = true
+                return .started
+            }
+            return .none
+        }
         if level >= constants.maximumSpeechStartThreshold {
-            if isSpeechActive { return .continued }
+            // At or above the conservative legacy threshold the sample is
+            // unambiguous speech and starts immediately.
             isSpeechActive = true
+            candidateSamples = 0
             return .started
         }
-        return .none
+        guard level >= speechStartThreshold else {
+            // Clearly below the start threshold: ambient input adapts the
+            // floor, and any pending candidate was an isolated spike.
+            candidateSamples = 0
+            adaptNoiseFloor(level)
+            return .none
+        }
+        // Suspected speech onset: count it, but never feed it to the floor —
+        // raising the threshold mid-onset would swallow real speech.
+        candidateSamples += 1
+        guard candidateSamples >= constants.speechStartDebounceSamples else { return .none }
+        isSpeechActive = true
+        candidateSamples = 0
+        return .started
     }
 
     /// Clears speech state and the learned noise floor so nothing from one
@@ -117,5 +154,16 @@ struct VoiceSpeechDetector {
         warmupRemaining = constants.warmupEvents
         candidateSamples = 0
         isSpeechActive = false
+    }
+
+    /// Tracks the ambient level with an asymmetric EMA: quiet input pulls
+    /// the floor down quickly, louder input raises it slowly, and suspected
+    /// speech never feeds it.
+    private mutating func adaptNoiseFloor(_ level: Float, warmup: Bool = false) {
+        let alpha = warmup
+            ? constants.warmupAdaptationAlpha
+            : (level < noiseFloor ? constants.noiseFloorFallAlpha : constants.noiseFloorRiseAlpha)
+        noiseFloor += (level - noiseFloor) * alpha
+        noiseFloor = min(constants.maximumNoiseFloor, max(constants.minimumNoiseFloor, noiseFloor))
     }
 }

--- a/Conduit/Voice/VoiceSpeechDetector.swift
+++ b/Conduit/Voice/VoiceSpeechDetector.swift
@@ -38,6 +38,11 @@ struct VoiceSpeechDetectorConstants: Equatable {
     /// accepted as speech: a single isolated noisy buffer never starts a
     /// turn.
     var speechStartDebounceSamples = 2
+    /// Bound on speech-plausible warmup samples that arrive before any
+    /// genuinely quiet sample: past this many skips the warmup force-arms
+    /// (falling back to the conservative ceiling-only behavior), so a
+    /// permanently loud room can never stay disarmed forever.
+    var maximumWarmupSkips = 12
     /// Fresh capture windows spend this many events establishing the noise
     /// floor (with fast adaptation) before sub-ceiling speech-start is
     /// armed, so a loud room cannot misclassify its own ambience during
@@ -70,6 +75,7 @@ struct VoiceSpeechDetector {
     /// Asymmetric EMA of observed input while no speech is active.
     private(set) var noiseFloor: Float
     private var warmupRemaining: Int
+    private var warmupSkippedSamples = 0
     private var candidateSamples = 0
     private(set) var isSpeechActive = false
 
@@ -112,14 +118,34 @@ struct VoiceSpeechDetector {
             return level >= speechContinuationThreshold ? .continued : .none
         }
         if warmupRemaining > 0 {
-            // Fresh window: every sample (either direction, fast) teaches
-            // the floor before sub-ceiling speech-start is armed. The floor
-            // is capped at the minimum start threshold so a user speaking
-            // immediately is never learned permanently as noise — the worst
-            // case is a short blind window, after which quiet speech is
-            // recognized.
-            adaptNoiseFloor(level, warmup: true)
-            warmupRemaining -= 1
+            // Fresh window: establish the floor before sub-ceiling
+            // speech-start is armed. Genuinely quiet samples teach the floor
+            // fast and advance the warmup. Speech-plausible samples at cold
+            // start are ambiguous — they must not start speech, and they
+            // must not be learned as noise quickly — so they only creep the
+            // floor up slowly with a bounded skip count: a permanently loud
+            // room still arms (falling back to the conservative ceiling-only
+            // behavior) within a fraction of a second, while an immediately
+            // speaking user is merely delayed, never swallowed permanently.
+            if level < constants.minimumSpeechStartThreshold {
+                adaptNoiseFloor(
+                    level,
+                    alpha: constants.warmupAdaptationAlpha,
+                    ceiling: constants.minimumSpeechStartThreshold
+                )
+                warmupRemaining -= 1
+                warmupSkippedSamples = 0
+            } else {
+                adaptNoiseFloor(
+                    level,
+                    alpha: constants.noiseFloorRiseAlpha,
+                    ceiling: constants.maximumNoiseFloor
+                )
+                warmupSkippedSamples += 1
+                if warmupSkippedSamples >= constants.maximumWarmupSkips {
+                    warmupRemaining = 0
+                }
+            }
             if level >= constants.maximumSpeechStartThreshold {
                 // An unambiguous level is speech even before the floor has
                 // been established.
@@ -139,7 +165,13 @@ struct VoiceSpeechDetector {
             // Clearly below the start threshold: ambient input adapts the
             // floor, and any pending candidate was an isolated spike.
             candidateSamples = 0
-            adaptNoiseFloor(level)
+            adaptNoiseFloor(
+                level,
+                alpha: level < noiseFloor
+                    ? constants.noiseFloorFallAlpha
+                    : constants.noiseFloorRiseAlpha,
+                ceiling: constants.maximumNoiseFloor
+            )
             return .none
         }
         // Suspected speech onset: count it, but never feed it to the floor —
@@ -156,6 +188,7 @@ struct VoiceSpeechDetector {
     mutating func reset() {
         noiseFloor = constants.minimumNoiseFloor
         warmupRemaining = constants.warmupEvents
+        warmupSkippedSamples = 0
         candidateSamples = 0
         isSpeechActive = false
     }
@@ -166,13 +199,14 @@ struct VoiceSpeechDetector {
     /// capped at the minimum speech-start threshold, so speech-level input
     /// arriving at cold start can never raise the threshold above the
     /// point where that same speech stays detectable.
-    private mutating func adaptNoiseFloor(_ level: Float, warmup: Bool = false) {
-        let alpha = warmup
-            ? constants.warmupAdaptationAlpha
-            : (level < noiseFloor ? constants.noiseFloorFallAlpha : constants.noiseFloorRiseAlpha)
+    /// Moves the noise floor toward `level` by `alpha` (EMA), clamped to
+    /// `ceiling`. Asymmetry lives at the call sites: quiet input pulls the
+    /// floor down fast, louder input raises it slowly, suspected speech
+    /// never feeds it, and warmup caps the floor at the minimum start
+    /// threshold so speech-level input at cold start is never learned as
+    /// noise.
+    private mutating func adaptNoiseFloor(_ level: Float, alpha: Float, ceiling: Float) {
         noiseFloor += (level - noiseFloor) * alpha
-        let warmupCeiling = constants.minimumSpeechStartThreshold
-        let ceiling = warmup ? min(warmupCeiling, constants.maximumNoiseFloor) : constants.maximumNoiseFloor
         noiseFloor = min(ceiling, max(constants.minimumNoiseFloor, noiseFloor))
     }
 }

--- a/Conduit/Voice/VoiceSpeechDetector.swift
+++ b/Conduit/Voice/VoiceSpeechDetector.swift
@@ -113,7 +113,11 @@ struct VoiceSpeechDetector {
         }
         if warmupRemaining > 0 {
             // Fresh window: every sample (either direction, fast) teaches
-            // the floor before sub-ceiling speech-start is armed.
+            // the floor before sub-ceiling speech-start is armed. The floor
+            // is capped at the minimum start threshold so a user speaking
+            // immediately is never learned permanently as noise — the worst
+            // case is a short blind window, after which quiet speech is
+            // recognized.
             adaptNoiseFloor(level, warmup: true)
             warmupRemaining -= 1
             if level >= constants.maximumSpeechStartThreshold {
@@ -158,12 +162,17 @@ struct VoiceSpeechDetector {
 
     /// Tracks the ambient level with an asymmetric EMA: quiet input pulls
     /// the floor down quickly, louder input raises it slowly, and suspected
-    /// speech never feeds it.
+    /// speech never feeds it. During warmup the floor is additionally
+    /// capped at the minimum speech-start threshold, so speech-level input
+    /// arriving at cold start can never raise the threshold above the
+    /// point where that same speech stays detectable.
     private mutating func adaptNoiseFloor(_ level: Float, warmup: Bool = false) {
         let alpha = warmup
             ? constants.warmupAdaptationAlpha
             : (level < noiseFloor ? constants.noiseFloorFallAlpha : constants.noiseFloorRiseAlpha)
         noiseFloor += (level - noiseFloor) * alpha
-        noiseFloor = min(constants.maximumNoiseFloor, max(constants.minimumNoiseFloor, noiseFloor))
+        let warmupCeiling = constants.minimumSpeechStartThreshold
+        let ceiling = warmup ? min(warmupCeiling, constants.maximumNoiseFloor) : constants.maximumNoiseFloor
+        noiseFloor = min(ceiling, max(constants.minimumNoiseFloor, noiseFloor))
     }
 }

--- a/Conduit/Voice/VoiceSpeechDetector.swift
+++ b/Conduit/Voice/VoiceSpeechDetector.swift
@@ -38,18 +38,19 @@ struct VoiceSpeechDetectorConstants: Equatable {
     /// accepted as speech: a single isolated noisy buffer never starts a
     /// turn.
     var speechStartDebounceSamples = 2
-    /// Bound on speech-plausible warmup samples that arrive before any
-    /// genuinely quiet sample: past this many skips the warmup force-arms
-    /// (falling back to the conservative ceiling-only behavior), so a
-    /// permanently loud room can never stay disarmed forever.
-    var maximumWarmupSkips = 12
-    /// Fresh capture windows spend this many events establishing the noise
-    /// floor (with fast adaptation) before sub-ceiling speech-start is
-    /// armed, so a loud room cannot misclassify its own ambience during
-    /// cold start.
-    var warmupEvents = 4
-    /// Noise-floor adaptation speed while warming up a fresh window.
-    var warmupAdaptationAlpha: Float = 0.4
+    /// Bounded length of the cold-start calibration phase, in events: once
+    /// it expires without speech-like dynamics, the steady signal becomes
+    /// the calibrated ambient floor and normal adaptive detection arms.
+    var coldStartMaximumEvents = 16
+    /// Speech-plausible samples retained for the cold-start dynamics check.
+    var coldStartCandidateSamples = 4
+    /// Cold-start speech onset requires the candidate window to vary by at
+    /// least this much between its quietest and loudest sample: steady input
+    /// is ambience, modulated input is speech.
+    var coldStartMinimumDynamicRange: Float = 0.012
+    /// Noise-floor adaptation speed for genuinely quiet samples during cold
+    /// start.
+    var coldStartQuietAdaptationAlpha: Float = 0.4
     /// Noise-floor adaptation speed toward quieter input.
     var noiseFloorFallAlpha: Float = 0.2
     /// Noise-floor adaptation speed toward louder input while no speech is
@@ -74,15 +75,17 @@ struct VoiceSpeechDetector {
     private(set) var constants: VoiceSpeechDetectorConstants
     /// Asymmetric EMA of observed input while no speech is active.
     private(set) var noiseFloor: Float
-    private var warmupRemaining: Int
-    private var warmupSkippedSamples = 0
+    private var coldStartRemaining: Int
+    /// Recent speech-plausible samples during cold start, for the dynamics
+    /// check that distinguishes speech from steady ambience.
+    private var coldStartWindow: [Float] = []
     private var candidateSamples = 0
     private(set) var isSpeechActive = false
 
     init(constants: VoiceSpeechDetectorConstants = .init()) {
         self.constants = constants
         noiseFloor = constants.minimumNoiseFloor
-        warmupRemaining = constants.warmupEvents
+        coldStartRemaining = constants.coldStartMaximumEvents
     }
 
     /// Noise-floor-relative level that continues an active utterance
@@ -117,40 +120,52 @@ struct VoiceSpeechDetector {
             // with the controller.
             return level >= speechContinuationThreshold ? .continued : .none
         }
-        if warmupRemaining > 0 {
-            // Fresh window: establish the floor before sub-ceiling
-            // speech-start is armed. Genuinely quiet samples teach the floor
-            // fast and advance the warmup. Speech-plausible samples at cold
-            // start are ambiguous — they must not start speech, and they
-            // must not be learned as noise quickly — so they only creep the
-            // floor up slowly with a bounded skip count: a permanently loud
-            // room still arms (falling back to the conservative ceiling-only
-            // behavior) within a fraction of a second, while an immediately
-            // speaking user is merely delayed, never swallowed permanently.
-            if level < constants.minimumSpeechStartThreshold {
-                adaptNoiseFloor(
-                    level,
-                    alpha: constants.warmupAdaptationAlpha,
-                    ceiling: constants.minimumSpeechStartThreshold
-                )
-                warmupRemaining -= 1
-                warmupSkippedSamples = 0
-            } else {
-                adaptNoiseFloor(
-                    level,
-                    alpha: constants.noiseFloorRiseAlpha,
-                    ceiling: constants.maximumNoiseFloor
-                )
-                warmupSkippedSamples += 1
-                if warmupSkippedSamples >= constants.maximumWarmupSkips {
-                    warmupRemaining = 0
-                }
-            }
+        if coldStartRemaining > 0 {
+            coldStartRemaining -= 1
+            // An unambiguous level is speech even before the floor has been
+            // established (a user speaking from the very first frame).
             if level >= constants.maximumSpeechStartThreshold {
-                // An unambiguous level is speech even before the floor has
-                // been established.
                 isSpeechActive = true
                 return .started
+            }
+            if level < constants.minimumSpeechStartThreshold {
+                // Quiet ambience teaches the floor fast.
+                adaptNoiseFloor(
+                    level,
+                    alpha: constants.coldStartQuietAdaptationAlpha,
+                    ceiling: constants.minimumSpeechStartThreshold
+                )
+                coldStartWindow.removeAll()
+                return .none
+            }
+            // Speech-plausible input at cold start is ambiguous — it must
+            // neither start speech against an unlearned floor nor be learned
+            // as noise — so it is collected for a dynamics check: real
+            // speech varies; steady ambience does not.
+            coldStartWindow.append(level)
+            if coldStartWindow.count > constants.coldStartCandidateSamples {
+                coldStartWindow.removeFirst()
+            }
+            if coldStartWindow.count == constants.coldStartCandidateSamples,
+               let loudest = coldStartWindow.max(), let quietest = coldStartWindow.min(),
+               loudest - quietest >= constants.coldStartMinimumDynamicRange {
+                isSpeechActive = true
+                coldStartWindow.removeAll()
+                return .started
+            }
+            if coldStartRemaining == 0 {
+                // The bounded cold start expires on a steady speech-plausible
+                // run: adopt its mean as the ambient floor and arm normal
+                // adaptive detection against it — no phantom, and a later
+                // genuine rise is still recognized.
+                noiseFloor = min(
+                    constants.maximumNoiseFloor,
+                    max(
+                        constants.minimumNoiseFloor,
+                        coldStartWindow.reduce(0, +) / Float(coldStartWindow.count)
+                    )
+                )
+                coldStartWindow.removeAll()
             }
             return .none
         }
@@ -187,8 +202,8 @@ struct VoiceSpeechDetector {
     /// capture window shapes the next one.
     mutating func reset() {
         noiseFloor = constants.minimumNoiseFloor
-        warmupRemaining = constants.warmupEvents
-        warmupSkippedSamples = 0
+        coldStartRemaining = constants.coldStartMaximumEvents
+        coldStartWindow.removeAll()
         candidateSamples = 0
         isSpeechActive = false
     }
@@ -196,10 +211,7 @@ struct VoiceSpeechDetector {
     /// Moves the noise floor toward `level` by `alpha` (EMA), clamped to
     /// `ceiling`. Asymmetry lives at the call sites: quiet input pulls the
     /// floor down fast, louder input raises it slowly, and suspected speech
-    /// never feeds it. During warmup, sub-threshold samples teach the floor
-    /// fast (capped at the minimum start threshold) while speech-plausible
-    /// samples only creep it slowly with a bounded skip count, so immediate
-    /// quiet speech is delayed, never learned as noise.
+    /// never feeds it.
     private mutating func adaptNoiseFloor(_ level: Float, alpha: Float, ceiling: Float) {
         noiseFloor += (level - noiseFloor) * alpha
         noiseFloor = min(ceiling, max(constants.minimumNoiseFloor, noiseFloor))

--- a/Conduit/Voice/VoiceSpeechDetector.swift
+++ b/Conduit/Voice/VoiceSpeechDetector.swift
@@ -193,18 +193,13 @@ struct VoiceSpeechDetector {
         isSpeechActive = false
     }
 
-    /// Tracks the ambient level with an asymmetric EMA: quiet input pulls
-    /// the floor down quickly, louder input raises it slowly, and suspected
-    /// speech never feeds it. During warmup the floor is additionally
-    /// capped at the minimum speech-start threshold, so speech-level input
-    /// arriving at cold start can never raise the threshold above the
-    /// point where that same speech stays detectable.
     /// Moves the noise floor toward `level` by `alpha` (EMA), clamped to
     /// `ceiling`. Asymmetry lives at the call sites: quiet input pulls the
-    /// floor down fast, louder input raises it slowly, suspected speech
-    /// never feeds it, and warmup caps the floor at the minimum start
-    /// threshold so speech-level input at cold start is never learned as
-    /// noise.
+    /// floor down fast, louder input raises it slowly, and suspected speech
+    /// never feeds it. During warmup, sub-threshold samples teach the floor
+    /// fast (capped at the minimum start threshold) while speech-plausible
+    /// samples only creep it slowly with a bounded skip count, so immediate
+    /// quiet speech is delayed, never learned as noise.
     private mutating func adaptNoiseFloor(_ level: Float, alpha: Float, ceiling: Float) {
         noiseFloor += (level - noiseFloor) * alpha
         noiseFloor = min(ceiling, max(constants.minimumNoiseFloor, noiseFloor))

--- a/Conduit/Voice/VoiceSpeechDetector.swift
+++ b/Conduit/Voice/VoiceSpeechDetector.swift
@@ -1,0 +1,121 @@
+//
+//  VoiceSpeechDetector.swift
+//  Conduit
+//
+//  Adaptive listening-side speech detection for Voice Conversation
+// (issue #130). The legacy detector required every sample to exceed one
+// fixed global threshold, so quiet-but-valid speech (typical peaks
+// 0.02–0.05) was never recognized and the session sat in Listening until
+// the idle pause. This detector instead learns the ambient noise floor of
+// the current capture window and accepts speech that rises clearly above
+// it, while never becoming more sensitive than the conservative threshold
+// that acoustic barge-in continues to use.
+//
+
+import Foundation
+
+/// Centralized, test-covered constants for the adaptive speech detector.
+/// All levels are linear PCM peaks in 0...1.
+struct VoiceSpeechDetectorConstants: Equatable {
+    /// Speech-start requires a rise above the observed noise floor by this
+    /// factor, clamped between the absolute minimum and the conservative
+    /// ceiling.
+    var noiseFloorSpeechRiseFactor: Float = 3
+    /// Absolute lower bound for the speech-start threshold so a near-silent
+    /// floor cannot let tiny electrical hum count as speech.
+    var minimumSpeechStartThreshold: Float = 0.012
+    /// Ceiling for the adaptive speech-start threshold, identical to the
+    /// conservative barge-in threshold: adaptive detection can never become
+    /// more sensitive than the legacy fixed behavior. Samples at or above
+    /// it are unambiguous speech and start an utterance immediately.
+    var maximumSpeechStartThreshold: Float = 0.075
+    /// While an utterance is active this lower (hysteresis) factor keeps
+    /// speech alive through brief level dips.
+    var speechContinuationRiseFactor: Float = 1.6
+    /// Absolute lower bound for the continuation threshold.
+    var minimumSpeechContinuationThreshold: Float = 0.006
+    /// Consecutive candidate samples required before a sub-ceiling rise is
+    /// accepted as speech: a single isolated noisy buffer never starts a
+    /// turn.
+    var speechStartDebounceSamples = 2
+    /// Fresh capture windows spend this many events establishing the noise
+    /// floor (with fast adaptation) before sub-ceiling speech-start is
+    /// armed, so a loud room cannot misclassify its own ambience during
+    /// cold start.
+    var warmupEvents = 4
+    /// Noise-floor adaptation speed while warming up a fresh window.
+    var warmupAdaptationAlpha: Float = 0.4
+    /// Noise-floor adaptation speed toward quieter input.
+    var noiseFloorFallAlpha: Float = 0.2
+    /// Noise-floor adaptation speed toward louder input while no speech is
+    /// active.
+    var noiseFloorRiseAlpha: Float = 0.06
+    /// Initial and absolute-minimum noise floor estimate.
+    var minimumNoiseFloor: Float = 0.003
+    /// Sanity ceiling for the noise floor estimate.
+    var maximumNoiseFloor: Float = 0.5
+}
+
+enum VoiceSpeechDetection: Equatable {
+    /// Noise: not speech.
+    case none
+    /// Speech continues (hysteresis path while an utterance is active).
+    case continued
+    /// Speech start accepted.
+    case started
+}
+
+struct VoiceSpeechDetector {
+    private(set) var constants: VoiceSpeechDetectorConstants
+    /// Asymmetric EMA of observed input while no speech is active.
+    private(set) var noiseFloor: Float
+    private var warmupRemaining: Int
+    private var candidateSamples = 0
+    private(set) var isSpeechActive = false
+
+    init(constants: VoiceSpeechDetectorConstants = .init()) {
+        self.constants = constants
+        noiseFloor = constants.minimumNoiseFloor
+        warmupRemaining = constants.warmupEvents
+    }
+
+    /// Noise-floor-relative level that continues an active utterance
+    /// (hysteresis: lower than the speech-start threshold).
+    private var speechContinuationThreshold: Float {
+        max(
+            constants.minimumSpeechContinuationThreshold,
+            noiseFloor * constants.speechContinuationRiseFactor
+        )
+    }
+
+    /// Noise-floor-relative speech-start threshold for the current window,
+    /// clamped between the absolute minimum and the conservative ceiling.
+    private var speechStartThreshold: Float {
+        let floorRise = noiseFloor * constants.noiseFloorSpeechRiseFactor
+        return max(
+            constants.minimumSpeechStartThreshold,
+            min(constants.maximumSpeechStartThreshold, floorRise)
+        )
+    }
+
+    mutating func observe(_ level: Float) -> VoiceSpeechDetection {
+        // Baseline decision kept from the legacy detector: the fixed
+        // conservative threshold decides alone. The adaptive floor,
+        // warmup, and debounce paths land with the #130 fix.
+        if level >= constants.maximumSpeechStartThreshold {
+            if isSpeechActive { return .continued }
+            isSpeechActive = true
+            return .started
+        }
+        return .none
+    }
+
+    /// Clears speech state and the learned noise floor so nothing from one
+    /// capture window shapes the next one.
+    mutating func reset() {
+        noiseFloor = constants.minimumNoiseFloor
+        warmupRemaining = constants.warmupEvents
+        candidateSamples = 0
+        isSpeechActive = false
+    }
+}

--- a/Conduit/Voice/VoiceTypes.swift
+++ b/Conduit/Voice/VoiceTypes.swift
@@ -147,7 +147,11 @@ struct VoiceCapturedAudio: Equatable {
 }
 
 enum VoiceCaptureEvent: Equatable {
-    case level(Float, date: Date)
+    /// Raw converted microphone peak. `generation` identifies the
+    /// input-tap/rendering lifetime that produced the frame, so the
+    /// controller can drop events queued before a pause/stop/restart: a
+    /// frame is valid only for the generation that produced it.
+    case level(Float, date: Date, generation: UInt64)
     case interrupted
     case routeChanged
 }
@@ -182,6 +186,11 @@ struct VoiceProviderTestResult: Equatable {
 @MainActor
 protocol AudioCaptureService: AnyObject {
     var events: AsyncStream<VoiceCaptureEvent> { get }
+    /// Monotonic identity of the currently installed input-tap/rendering
+    /// lifetime. Bumped whenever the tap is torn down or reinstalled; level
+    /// events carry the generation that produced them so stale frames from
+    /// a previous generation can be rejected.
+    var captureGeneration: UInt64 { get }
     func requestPermission() async -> Bool
     func startListening(includePreRoll: Bool) throws
     func beginBargeInMonitoring() throws

--- a/ConduitTests/AVAudioCaptureServiceGenerationTests.swift
+++ b/ConduitTests/AVAudioCaptureServiceGenerationTests.swift
@@ -81,7 +81,7 @@ final class AVAudioCaptureServiceGenerationTests: XCTestCase {
         // A full second of loud, unmistakable audio arrives late — captured
         // by tap A while it was still installed, surfacing only after B is
         // live.
-        let stale = constantBuffer(sampleRate: 48_000, frameCount: 48_000, amplitude: 0.9)
+        let stale = try constantBuffer(sampleRate: 48_000, frameCount: 48_000, amplitude: 0.9)
         service.consume(stale, generation: generationA)
 
         XCTAssertTrue(
@@ -94,7 +94,7 @@ final class AVAudioCaptureServiceGenerationTests: XCTestCase {
         )
 
         // The live generation's frame is admitted normally: 20 ms at 48 kHz.
-        let current = constantBuffer(sampleRate: 48_000, frameCount: 960, amplitude: 0.25)
+        let current = try constantBuffer(sampleRate: 48_000, frameCount: 960, amplitude: 0.25)
         service.consume(current, generation: generationB)
 
         let audio = try service.finishUtterance()
@@ -159,12 +159,17 @@ final class AVAudioCaptureServiceGenerationTests: XCTestCase {
         sampleRate: Double,
         frameCount: AVAudioFrameCount,
         amplitude: Float
-    ) -> AVAudioPCMBuffer {
-        let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1)!
-        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount)!
+    ) throws -> AVAudioPCMBuffer {
+        let format = try XCTUnwrap(
+            AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1)
+        )
+        let buffer = try XCTUnwrap(
+            AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount)
+        )
         buffer.frameLength = frameCount
+        let channel = try XCTUnwrap(buffer.floatChannelData?[0])
         for index in 0..<Int(frameCount) {
-            buffer.floatChannelData![0][index] = amplitude
+            channel[index] = amplitude
         }
         return buffer
     }

--- a/ConduitTests/AVAudioCaptureServiceGenerationTests.swift
+++ b/ConduitTests/AVAudioCaptureServiceGenerationTests.swift
@@ -103,7 +103,20 @@ final class AVAudioCaptureServiceGenerationTests: XCTestCase {
         // policy rate; anything approaching the stale second's size means a
         // stale frame slipped through admission.
         XCTAssertLessThan(audio.pcm16Data.count, 2_000)
+        // No sample may carry the stale frame's unmistakable amplitude.
         for sample in samples {
+            XCTAssertLessThan(
+                abs(Float(sample)) / Float(Int16.max),
+                0.5,
+                "a stale generation's audio leaked into captured audio"
+            )
+        }
+        // The steady-state tail must be exactly the admitted frame's constant
+        // amplitude. AVAudioConverter primes its resampling filter on the
+        // first buffer after creation, so the leading samples legitimately
+        // ramp toward the constant.
+        let steadyState = samples.suffix(samples.count / 2)
+        for sample in steadyState {
             XCTAssertEqual(
                 Float(sample) / Float(Int16.max),
                 0.25,

--- a/ConduitTests/AVAudioCaptureServiceGenerationTests.swift
+++ b/ConduitTests/AVAudioCaptureServiceGenerationTests.swift
@@ -1,0 +1,157 @@
+import AVFAudio
+import XCTest
+@testable import Conduit
+
+/// Regressions for physical frame-generation isolation inside the capture
+/// service (PR #149): the controller already rejects stale `.level` events,
+/// but the stronger invariant lives here — a frame produced by an
+/// invalidated tap generation must never reach conversion state, pre-roll,
+/// captured audio, or level emission for a later capture. The service is
+/// driven at its frame-admission seam with synthetic in-memory PCM buffers,
+/// so these tests never touch audio hardware.
+@MainActor
+final class AVAudioCaptureServiceGenerationTests: XCTestCase {
+    private var collectedEvents: [VoiceCaptureEvent] = []
+    private var eventCollector: Task<Void, Never>?
+
+    override func tearDown() {
+        eventCollector?.cancel()
+        eventCollector = nil
+        super.tearDown()
+    }
+
+    // MARK: - Admission seam
+
+    func testFrameAdmissionRejectsStaleGenerationAcrossStopRestart() {
+        let service = AVAudioCaptureService()
+
+        // Generation A is live: rendering expected to stay up, capture unpaused.
+        service.shouldKeepEngineRunning = true
+        let generationA = service.captureGeneration
+        XCTAssertTrue(service.acceptsFrame(generation: generationA))
+
+        // Teardown invalidates A; a restart re-arms B exactly the way
+        // startListening/resume re-arm the live flags after a real tap
+        // reinstall.
+        service.stop()
+        service.shouldKeepEngineRunning = true
+        let generationB = service.captureGeneration
+        XCTAssertNotEqual(generationA, generationB, "stop must invalidate the capture generation")
+
+        XCTAssertFalse(
+            service.acceptsFrame(generation: generationA),
+            "a frame from an invalidated generation must be rejected even after a later capture is live"
+        )
+        XCTAssertTrue(
+            service.acceptsFrame(generation: generationB),
+            "the current generation is admitted while capture is live"
+        )
+
+        service.paused = true
+        XCTAssertFalse(
+            service.acceptsFrame(generation: generationB),
+            "a paused capture admits no frames"
+        )
+    }
+
+    // MARK: - Physical PCM isolation
+
+    func testStaleGenerationFrameCannotEnterCapturedAudioAfterRestart() async throws {
+        let service = AVAudioCaptureService()
+        startEventCollector(service)
+
+        // Capture A is live and recording.
+        service.shouldKeepEngineRunning = true
+        service.activelyRecording = true
+        let generationA = service.captureGeneration
+
+        // stop() tears A down; the restart re-arms B with fresh captured
+        // audio (what startListening(includePreRoll: false) resets in
+        // production).
+        service.stop()
+        service.shouldKeepEngineRunning = true
+        service.activelyRecording = true
+        service.capturedPCM = Data()
+        let generationB = service.captureGeneration
+        XCTAssertNotEqual(generationA, generationB)
+
+        // A full second of loud, unmistakable audio arrives late — captured
+        // by tap A while it was still installed, surfacing only after B is
+        // live.
+        let stale = constantBuffer(sampleRate: 48_000, frameCount: 48_000, amplitude: 0.9)
+        service.consume(stale, generation: generationA)
+
+        XCTAssertTrue(
+            service.preRollPCM.isEmpty,
+            "a stale generation's PCM must never enter pre-roll"
+        )
+        XCTAssertTrue(
+            service.capturedPCM.isEmpty,
+            "a stale generation's PCM must never enter captured audio"
+        )
+
+        // The live generation's frame is admitted normally: 20 ms at 48 kHz.
+        let current = constantBuffer(sampleRate: 48_000, frameCount: 960, amplitude: 0.25)
+        service.consume(current, generation: generationB)
+
+        let audio = try service.finishUtterance()
+        let samples = audio.pcm16Data.withUnsafeBytes { bytes in
+            bytes.bindMemory(to: Int16.self).map { Int16(littleEndian: $0) }
+        }
+        XCTAssertGreaterThan(samples.count, 0)
+        // 960 frames at 48 kHz downsample to ~320 frames at the 16 kHz capture
+        // policy rate; anything approaching the stale second's size means a
+        // stale frame slipped through admission.
+        XCTAssertLessThan(audio.pcm16Data.count, 2_000)
+        for sample in samples {
+            XCTAssertEqual(
+                Float(sample) / Float(Int16.max),
+                0.25,
+                accuracy: 0.05,
+                "captured audio must contain only the admitted generation-B frame"
+            )
+        }
+        XCTAssertEqual(
+            service.preRollPCM.count,
+            audio.pcm16Data.count,
+            "pre-roll must hold exactly the same admitted bytes"
+        )
+
+        // Only the admitted frame may surface a level event, tagged with its
+        // own generation.
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertEqual(collectedEvents.count, 1, "a stale generation's frame must not emit a level event")
+        guard case let .level(peak, _, generation) = collectedEvents.first else {
+            return XCTFail("expected a level event from the admitted frame")
+        }
+        XCTAssertEqual(peak, 0.25, accuracy: 0.01)
+        XCTAssertEqual(generation, generationB)
+    }
+
+    // MARK: - Helpers
+
+    /// A mono Float32 buffer at a realistic hardware rate filled with a
+    /// constant amplitude. Purely in-memory: no audio session or engine.
+    private func constantBuffer(
+        sampleRate: Double,
+        frameCount: AVAudioFrameCount,
+        amplitude: Float
+    ) -> AVAudioPCMBuffer {
+        let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1)!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount)!
+        buffer.frameLength = frameCount
+        for index in 0..<Int(frameCount) {
+            buffer.floatChannelData![0][index] = amplitude
+        }
+        return buffer
+    }
+
+    private func startEventCollector(_ service: AVAudioCaptureService) {
+        collectedEvents = []
+        eventCollector = Task { [weak self] in
+            for await event in service.events {
+                self?.collectedEvents.append(event)
+            }
+        }
+    }
+}

--- a/ConduitTests/AVAudioCaptureServiceGenerationTests.swift
+++ b/ConduitTests/AVAudioCaptureServiceGenerationTests.swift
@@ -72,6 +72,9 @@ final class AVAudioCaptureServiceGenerationTests: XCTestCase {
         service.shouldKeepEngineRunning = true
         service.activelyRecording = true
         service.capturedPCM = Data()
+        // Mirrors startListening(includePreRoll: false): a fresh capture
+        // window starts with empty captured audio.
+        XCTAssertTrue(service.capturedPCM.isEmpty)
         let generationB = service.captureGeneration
         XCTAssertNotEqual(generationA, generationB)
 
@@ -131,13 +134,20 @@ final class AVAudioCaptureServiceGenerationTests: XCTestCase {
         )
 
         // Only the admitted frame may surface a level event, tagged with its
-        // own generation.
-        try await Task.sleep(nanoseconds: 100_000_000)
+        // own generation. Drain with a deadline instead of a fixed sleep so
+        // a loaded CI runner cannot flake the delivery.
+        for _ in 0..<200 where collectedEvents.isEmpty {
+            await Task.yield()
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
         XCTAssertEqual(collectedEvents.count, 1, "a stale generation's frame must not emit a level event")
         guard case let .level(peak, _, generation) = collectedEvents.first else {
             return XCTFail("expected a level event from the admitted frame")
         }
-        XCTAssertEqual(peak, 0.25, accuracy: 0.01)
+        // The peak stays near the admitted frame's constant: the resampler's
+        // filter overshoots slightly at the first-buffer boundary, so the
+        // tolerance must allow that while staying far from the stale 0.9.
+        XCTAssertEqual(peak, 0.25, accuracy: 0.05)
         XCTAssertEqual(generation, generationB)
     }
 
@@ -161,7 +171,7 @@ final class AVAudioCaptureServiceGenerationTests: XCTestCase {
 
     private func startEventCollector(_ service: AVAudioCaptureService) {
         collectedEvents = []
-        eventCollector = Task { [weak self] in
+        eventCollector = Task { @MainActor [weak self] in
             for await event in service.events {
                 self?.collectedEvents.append(event)
             }

--- a/ConduitTests/AppStateReadAloudTests.swift
+++ b/ConduitTests/AppStateReadAloudTests.swift
@@ -309,6 +309,7 @@ private final class RecordingCapabilityRequester: VoiceConfigurationRequesting {
 @MainActor
 private final class MockVoiceCapture: AudioCaptureService {
     let events: AsyncStream<VoiceCaptureEvent>
+    let captureGeneration: UInt64 = 0
 
     init() {
         events = AsyncStream { _ in }

--- a/ConduitTests/AppStateServerReplacementSpeechTests.swift
+++ b/ConduitTests/AppStateServerReplacementSpeechTests.swift
@@ -591,6 +591,7 @@ private final class InterruptGate {
 @MainActor
 private final class GatedCapture: AudioCaptureService {
     let events = AsyncStream<VoiceCaptureEvent> { _ in }
+    let captureGeneration: UInt64 = 0
     private(set) var startListeningCount = 0
     private(set) var stopCount = 0
 

--- a/ConduitTests/HapticsVoiceIsolationTests.swift
+++ b/ConduitTests/HapticsVoiceIsolationTests.swift
@@ -265,6 +265,7 @@ private final class RecordingVoiceAudioSession: VoiceAudioSessionControlling {
 @MainActor
 private final class StubPermissionCapture: AudioCaptureService {
     let events: AsyncStream<VoiceCaptureEvent>
+    let captureGeneration: UInt64 = 0
     private var continuation: AsyncStream<VoiceCaptureEvent>.Continuation?
 
     init() {

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -931,7 +931,7 @@ final class VoiceConversationControllerTests: XCTestCase {
         )
         await controller.startListening()
 
-        capture.emit(.level(0.034, date: Date()))
+        capture.emit(level: 0.034)
         try? await Task.sleep(nanoseconds: 80_000_000)
 
         XCTAssertEqual(controller.microphoneLevel, 0.034, accuracy: 0.0001, "raw capture level must reach the published meter")
@@ -953,11 +953,11 @@ final class VoiceConversationControllerTests: XCTestCase {
         // deterministic margin — no wall-clock race against test completion.
         let testTask = Task { await controller.runTranscriptionTest(duration: 2) }
         try? await Task.sleep(nanoseconds: 100_000_000)
-        capture.emit(.level(0.4, date: Date()))
+        capture.emit(level: 0.4)
         // Level publication is meter-resolution (~20 Hz throttle), so space
         // the second sample past the publication window.
         try? await Task.sleep(nanoseconds: 80_000_000)
-        capture.emit(.level(0.5, date: Date()))
+        capture.emit(level: 0.5)
         try? await Task.sleep(nanoseconds: 60_000_000)
         XCTAssertEqual(controller.microphoneLevel, 0.5, accuracy: 0.0001, "provider tests still receive visible microphone-level updates")
 
@@ -969,38 +969,41 @@ final class VoiceConversationControllerTests: XCTestCase {
 
     func testStaleCaptureLevelEventsDoNotCrossCaptureGenerations() async {
         let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "fresh")
         let controller = VoiceConversationController(
             capture: capture,
             playback: MockPlayback(),
-            gateway: MockGateway(),
+            gateway: gateway,
             submit: { _ in true },
             interrupt: {}
         )
         await controller.startListening()
-        capture.emit(.level(0.4, date: Date()))
+        let generationA = capture.captureGeneration
+
+        // Capture A produces a level event; the meter follows it.
+        capture.emit(level: 0.4)
         try? await Task.sleep(nanoseconds: 80_000_000)
         XCTAssertEqual(controller.microphoneLevel, 0.4, accuracy: 0.0001)
 
-        // Pause boundary: a buffered level event from the previous capture
-        // generation is delivered after the pause reset — it must be
-        // dropped, not re-freeze the meter at a non-zero value.
-        controller.pauseMicrophone()
-        capture.emit(.level(0.6, date: Date()))
-        try? await Task.sleep(nanoseconds: 80_000_000)
-        XCTAssertEqual(controller.microphoneLevel, 0, accuracy: 0.0001, "stale level events must not cross the pause boundary")
-
-        // Stop boundary: re-establish a live capture baseline first (resume
-        // clears the user pause), then confirm a stale event cannot cross
-        // the stop.
-        await controller.resumeMicrophone()
-        capture.emit(.level(0.4, date: Date()))
-        try? await Task.sleep(nanoseconds: 80_000_000)
-        XCTAssertEqual(controller.microphoneLevel, 0.4, accuracy: 0.0001, "baseline must be live before the stop boundary")
+        // Capture A is torn down (stop): its generation is invalidated.
         controller.stop()
-        capture.emit(.level(0.6, date: Date()))
+        XCTAssertNotEqual(capture.captureGeneration, generationA, "stop must invalidate the capture generation")
+
+        // Capture B starts; a delayed frame from generation A arrives after
+        // the teardown and must be rejected.
+        await controller.startListening()
+        let generationB = capture.captureGeneration
+        XCTAssertNotEqual(generationA, generationB)
+        capture.emit(.level(0.9, date: Date(), generation: generationA))
         try? await Task.sleep(nanoseconds: 80_000_000)
-        XCTAssertEqual(controller.state, .idle)
-        XCTAssertEqual(controller.microphoneLevel, 0, accuracy: 0.0001, "stale level events must not cross the stop boundary")
+        XCTAssertEqual(controller.microphoneLevel, 0, accuracy: 0.0001, "a stale generation's level must not update the meter")
+        XCTAssertEqual(controller.state, .listening)
+
+        // The live generation's events are accepted normally.
+        capture.emit(level: 0.3)
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertEqual(controller.microphoneLevel, 0.3, accuracy: 0.0001, "the live generation's events update the meter")
+        XCTAssertEqual(controller.state, .listening)
     }
 
     func testSpeechTestRouteChangeDoesNotLeakSuspensionState() async {
@@ -1049,7 +1052,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             interrupt: {}
         )
         await controller.startListening()
-        capture.emit(.level(0.4, date: Date()))
+        capture.emit(level: 0.4)
         try? await Task.sleep(nanoseconds: 80_000_000)
         XCTAssertEqual(controller.microphoneLevel, 0.4, accuracy: 0.0001)
 
@@ -1059,7 +1062,7 @@ final class VoiceConversationControllerTests: XCTestCase {
 
         // Audio interruption.
         await controller.startListening()
-        capture.emit(.level(0.4, date: Date()))
+        capture.emit(level: 0.4)
         try? await Task.sleep(nanoseconds: 80_000_000)
         capture.emit(.interrupted)
         try? await Task.sleep(nanoseconds: 80_000_000)
@@ -1068,7 +1071,7 @@ final class VoiceConversationControllerTests: XCTestCase {
 
         // Session stop.
         await controller.startListening()
-        capture.emit(.level(0.4, date: Date()))
+        capture.emit(level: 0.4)
         try? await Task.sleep(nanoseconds: 80_000_000)
         controller.stop()
         XCTAssertEqual(controller.microphoneLevel, 0, accuracy: 0.0001)
@@ -1234,7 +1237,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
         controller.receiveAssistantEvent(.started(sessionID: "session"))
         // Ambient audio still reaches the published meter while Hermes is
         // only thinking (capture live, barge-in monitoring armed).
-        capture.emit(.level(0.02, date: Date()))
+        capture.emit(level: 0.02)
         try? await Task.sleep(nanoseconds: 50_000_000)
         XCTAssertEqual(controller.microphoneLevel, 0.02, accuracy: 0.0001)
 
@@ -1709,6 +1712,9 @@ private final class InterruptGate {
 @MainActor
 private final class MockCapture: AudioCaptureService {
     let events: AsyncStream<VoiceCaptureEvent>
+    /// Mirrors the production service: bumped on every lifecycle boundary
+    /// (start/pause/resume/stop) so generation-tagged events can be tested.
+    var captureGeneration: UInt64 = 0
     private var continuation: AsyncStream<VoiceCaptureEvent>.Continuation?
     let permissionGranted: Bool
     let startError: Error?
@@ -1735,6 +1741,7 @@ private final class MockCapture: AudioCaptureService {
         startCount += 1
         lastStartIncludePreRoll = includePreRoll
         mockPaused = false
+        captureGeneration &+= 1
         if let startError { throw startError }
     }
     func beginBargeInMonitoring() throws { didBeginMonitoring = true }
@@ -1744,17 +1751,27 @@ private final class MockCapture: AudioCaptureService {
         guard !mockPaused else { return }
         mockPaused = true
         pauseCount += 1
+        captureGeneration &+= 1
     }
     func resume() throws {
         mockPaused = false
         resumeCount += 1
+        captureGeneration &+= 1
     }
     func finishUtterance() throws -> VoiceCapturedAudio {
         finishUtteranceCount += 1
         return VoiceCapturedAudio(wavData: Data([1]), pcm16Data: Data([1, 0]), sampleRate: 16_000, duration: 0.01)
     }
-    func stop() { mockPaused = false }
+    func stop() {
+        mockPaused = false
+        captureGeneration &+= 1
+    }
     func emit(_ event: VoiceCaptureEvent) { continuation?.yield(event) }
+    /// Emits a level event stamped with the current capture generation —
+    /// the normal path for live frames.
+    func emit(level: Float, at date: Date = Date()) {
+        continuation?.yield(.level(level, date: date, generation: captureGeneration))
+    }
 }
 
 @MainActor

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -1012,9 +1012,19 @@ final class VoiceConversationControllerTests: XCTestCase {
         try? await Task.sleep(nanoseconds: 80_000_000)
         XCTAssertEqual(controller.microphoneLevel, 0, accuracy: 0.0001, "transcribing must not republish the mic meter")
 
-        // Let the held transcription finish so the flow ends cleanly.
-        try? await Task.sleep(nanoseconds: 700_000_000)
-        XCTAssertEqual(controller.state, .thinking)
+        // Let the held transcription finish, and pin that the gate is
+        // narrow: publication must resume once the state leaves
+        // .transcribing (barge-in monitoring windows depend on it).
+        let reachedThinking = await waitForState(.thinking, of: controller)
+        XCTAssertTrue(reachedThinking, "the held transcription must complete into .thinking")
+        capture.emit(level: 0.4)
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertEqual(
+            controller.microphoneLevel,
+            0.4,
+            accuracy: 0.0001,
+            "the meter must resume publishing once transcription ends"
+        )
     }
 
     func testProviderTestLevelEventsDoNotRepublishMeterWhileTranscribing() async {

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -989,10 +989,13 @@ final class VoiceConversationControllerTests: XCTestCase {
         try? await Task.sleep(nanoseconds: 80_000_000)
         XCTAssertEqual(controller.microphoneLevel, 0, accuracy: 0.0001, "stale level events must not cross the pause boundary")
 
-        // Stop boundary: same contract after the session is torn down.
-        await controller.startListening()
+        // Stop boundary: re-establish a live capture baseline first (resume
+        // clears the user pause), then confirm a stale event cannot cross
+        // the stop.
+        await controller.resumeMicrophone()
         capture.emit(.level(0.4, date: Date()))
         try? await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertEqual(controller.microphoneLevel, 0.4, accuracy: 0.0001, "baseline must be live before the stop boundary")
         controller.stop()
         capture.emit(.level(0.6, date: Date()))
         try? await Task.sleep(nanoseconds: 80_000_000)

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -879,6 +879,47 @@ final class VoiceConversationControllerTests: XCTestCase {
         XCTAssertEqual(controller.state, .thinking)
     }
 
+    func testRouteChangeMidListeningRelearnsNoiseFloor() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "After route change")
+        var submitted: [String] = []
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            submit: { submitted.append($0); return true },
+            interrupt: {}
+        )
+        await controller.startListening()
+
+        // Old microphone: establish a loud floor.
+        let start = Date()
+        for index in 0..<40 {
+            controller.ingestAudioLevel(0.03, at: start.addingTimeInterval(Double(index) * 0.025))
+        }
+
+        // A different microphone arrives mid-listening: the floor must
+        // re-learn instead of keeping the old room's estimate.
+        capture.emit(.routeChanged)
+        try? await Task.sleep(nanoseconds: 80_000_000)
+
+        // New microphone's quiet speech: recognized against the re-learned
+        // floor, then trailing silence finishes and submits the turn.
+        let speech = start.addingTimeInterval(2.0)
+        let samples: [(Float, TimeInterval)] = [
+            (0.003, 0.00), (0.004, 0.03), (0.003, 0.06), (0.003, 0.09),
+            (0.018, 0.12), (0.026, 0.17), (0.034, 0.22), (0.028, 0.27),
+            (0.004, 1.60)
+        ]
+        for (level, offset) in samples {
+            controller.ingestAudioLevel(level, at: speech.addingTimeInterval(offset))
+        }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(submitted, ["After route change"], "a route change must re-learn the noise floor for the new microphone")
+        XCTAssertEqual(controller.state, .thinking)
+    }
+
     func testCaptureLevelPublishesMicrophoneLevelDuringListening() async {
         let capture = MockCapture(permissionGranted: true)
         let controller = VoiceConversationController(
@@ -911,7 +952,10 @@ final class VoiceConversationControllerTests: XCTestCase {
         let testTask = Task { await controller.runTranscriptionTest(duration: 0.3) }
         try? await Task.sleep(nanoseconds: 80_000_000)
         capture.emit(.level(0.4, date: Date()))
-        capture.emit(.level(0.5, date: Date().addingTimeInterval(0.02)))
+        // Level publication is meter-resolution (~20 Hz throttle), so space
+        // the second sample past the publication window.
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        capture.emit(.level(0.5, date: Date()))
         try? await Task.sleep(nanoseconds: 60_000_000)
         XCTAssertEqual(controller.microphoneLevel, 0.5, accuracy: 0.0001, "provider tests still receive visible microphone-level updates")
 
@@ -919,6 +963,42 @@ final class VoiceConversationControllerTests: XCTestCase {
         XCTAssertTrue(result.passed)
         XCTAssertEqual(controller.microphoneLevel, 0, accuracy: 0.0001, "provider-test completion resets the meter")
         XCTAssertTrue(submitted.isEmpty, "conversational VAD must not run during a provider test")
+    }
+
+    func testSpeechTestRouteChangeDoesNotLeakSuspensionState() async {
+        let capture = MockCapture(permissionGranted: true)
+        let playback = MockPlayback()
+        let gateway = MockGateway(transcript: "test", startsPlaybackOnOpen: true)
+        let policy = RoutePolicyBox(.speakerSafeHalfDuplex)
+        let gate = InterruptGate()
+        playback.drainGate = gate
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: playback,
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: { _ in true },
+            interrupt: {}
+        )
+
+        let testTask = Task { await controller.runSpeechTest(text: "hello") }
+        // Deterministic mid-playback park: drain() holds the test task while
+        // state is .speaking.
+        await gate.waitUntilEntered()
+        XCTAssertEqual(controller.state, .speaking, "the TTS provider test is mid-playback")
+
+        // A route change during a provider test must not pollute the
+        // speaker-safe suspension state: the TTS test owns the session and
+        // no conversational capture is live.
+        capture.emit(.routeChanged)
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertFalse(controller.isPlaybackCaptureSuspended, "route changes during provider tests must not suspend capture")
+
+        gate.release()
+        let result = await testTask.value
+        XCTAssertTrue(result.passed)
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertFalse(controller.isPlaybackCaptureSuspended, "suspension state must not outlive the provider test")
     }
 
     func testMicrophoneLevelResetsAcrossLifecycleBoundaries() async {
@@ -1643,6 +1723,9 @@ private final class MockCapture: AudioCaptureService {
 private final class MockPlayback: SpeechPlaybackService {
     var isPlaying = false
     var ownershipIntent: VoiceAudioIntent = .standalonePlayback
+    /// When set, `drain()` parks until the gate is released, so tests can
+    /// hold a playback operation open deterministically.
+    var drainGate: InterruptGate?
     /// The ownership intent in force when playback last started, so tests can
     /// assert which session policy a flow claimed.
     private(set) var intentAtLastStart: VoiceAudioIntent?
@@ -1656,7 +1739,10 @@ private final class MockPlayback: SpeechPlaybackService {
         isPlaying = true
     }
     func finish() throws {}
-    func drain() async { isPlaying = false }
+    func drain() async {
+        isPlaying = false
+        await drainGate?.waitInInterrupt()
+    }
     func stop() { isPlaying = false }
 }
 

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -269,11 +269,18 @@ final class VoiceConversationControllerTests: XCTestCase {
 
     func testVoiceDefaultsMirrorHermesDesktopVAD() {
         let configuration = VoiceConversationController.Configuration()
-        XCTAssertEqual(configuration.voiceActivityThreshold, 0.075)
+        // Barge-in keeps the conservative fixed threshold (issue #130).
+        XCTAssertEqual(configuration.bargeInActivityThreshold, 0.075)
         XCTAssertEqual(configuration.trailingSilence, 1.25)
         XCTAssertEqual(configuration.idleSilence, 12)
         XCTAssertEqual(configuration.maximumUtterance, 60)
         XCTAssertEqual(configuration.bargeInDuration, 0.3)
+        // The adaptive listening detector's ceiling can never exceed the
+        // conservative barge-in threshold.
+        XCTAssertEqual(
+            configuration.speechDetector.maximumSpeechStartThreshold,
+            configuration.bargeInActivityThreshold
+        )
     }
 
     func testAssistantDeltasStayInOnePersistentSpeechStream() async {
@@ -780,6 +787,174 @@ final class VoiceConversationControllerTests: XCTestCase {
 
         XCTAssertEqual(playback.intentAtLastStart, .conversationPlayback)
     }
+
+    // MARK: - Issue #130: adaptive listening VAD + live input meter
+
+    func testQuietSpeechBelowLegacyThresholdSubmitsTurn() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Quiet words")
+        var submitted: [String] = []
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            submit: { submitted.append($0); return true },
+            interrupt: {}
+        )
+        controller.beginVoiceTurn(sessionID: "session")
+        await controller.startListening()
+
+        // Ambient floor (detector warmup), then quiet speech whose peaks
+        // never reach the legacy fixed threshold, then trailing silence.
+        let start = Date()
+        let samples: [(Float, TimeInterval)] = [
+            (0.003, 0.00), (0.004, 0.03), (0.003, 0.06), (0.003, 0.09),
+            (0.018, 0.12), (0.026, 0.17), (0.034, 0.22), (0.028, 0.27),
+            (0.004, 1.60), (0.003, 1.65)
+        ]
+        for (level, offset) in samples {
+            controller.ingestAudioLevel(level, at: start.addingTimeInterval(offset))
+        }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(submitted, ["Quiet words"], "quiet-but-valid speech must not get stuck in Listening")
+        XCTAssertEqual(controller.state, .thinking)
+        XCTAssertEqual(capture.finishUtteranceCount, 1)
+        // The completed utterance resets the visible meter.
+        XCTAssertEqual(controller.microphoneLevel, 0, accuracy: 0.0001)
+    }
+
+    func testSteadyAmbientNoiseDoesNotCreateTurns() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "phantom")
+        var submitted: [String] = []
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            submit: { submitted.append($0); return true },
+            interrupt: {}
+        )
+        await controller.startListening()
+
+        // Constant room noise around 0.015 for two seconds: well above the
+        // absolute floor minimum, never a meaningful speech rise.
+        let start = Date()
+        for index in 0..<80 {
+            controller.ingestAudioLevel(0.015, at: start.addingTimeInterval(Double(index) * 0.025))
+        }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertTrue(submitted.isEmpty, "ambient noise alone must never become a user turn")
+        XCTAssertEqual(controller.state, .listening)
+        XCTAssertEqual(capture.finishUtteranceCount, 0)
+    }
+
+    func testLouderRoomAdaptsAndStillRecognizesRelativeSpeechRise() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Louder words")
+        var submitted: [String] = []
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            submit: { submitted.append($0); return true },
+            interrupt: {}
+        )
+        await controller.startListening()
+
+        // A louder room: the adaptive threshold rises with the observed
+        // floor, then a clear relative rise still counts as speech even
+        // though it stays below the legacy fixed threshold.
+        let start = Date()
+        for index in 0..<40 {
+            controller.ingestAudioLevel(0.02, at: start.addingTimeInterval(Double(index) * 0.025))
+        }
+        controller.ingestAudioLevel(0.065, at: start.addingTimeInterval(1.1))
+        controller.ingestAudioLevel(0.07, at: start.addingTimeInterval(1.15))
+        controller.ingestAudioLevel(0.02, at: start.addingTimeInterval(2.6))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(submitted, ["Louder words"], "the detector must adapt upward with the room")
+        XCTAssertEqual(controller.state, .thinking)
+    }
+
+    func testCaptureLevelPublishesMicrophoneLevelDuringListening() async {
+        let capture = MockCapture(permissionGranted: true)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: MockGateway(),
+            submit: { _ in true },
+            interrupt: {}
+        )
+        await controller.startListening()
+
+        capture.emit(.level(0.034, date: Date()))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+
+        XCTAssertEqual(controller.microphoneLevel, 0.034, accuracy: 0.0001, "raw capture level must reach the published meter")
+    }
+
+    func testProviderTestShowsLevelWithoutConversationalVAD() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Should not submit")
+        var submitted: [String] = []
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            submit: { submitted.append($0); return true },
+            interrupt: {}
+        )
+
+        let testTask = Task { await controller.runTranscriptionTest(duration: 0.3) }
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        capture.emit(.level(0.4, date: Date()))
+        capture.emit(.level(0.5, date: Date().addingTimeInterval(0.02)))
+        try? await Task.sleep(nanoseconds: 60_000_000)
+        XCTAssertEqual(controller.microphoneLevel, 0.5, accuracy: 0.0001, "provider tests still receive visible microphone-level updates")
+
+        let result = await testTask.value
+        XCTAssertTrue(result.passed)
+        XCTAssertEqual(controller.microphoneLevel, 0, accuracy: 0.0001, "provider-test completion resets the meter")
+        XCTAssertTrue(submitted.isEmpty, "conversational VAD must not run during a provider test")
+    }
+
+    func testMicrophoneLevelResetsAcrossLifecycleBoundaries() async {
+        let capture = MockCapture(permissionGranted: true)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: MockGateway(),
+            submit: { _ in true },
+            interrupt: {}
+        )
+        await controller.startListening()
+        capture.emit(.level(0.4, date: Date()))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertEqual(controller.microphoneLevel, 0.4, accuracy: 0.0001)
+
+        // Explicit pause.
+        controller.pauseMicrophone()
+        XCTAssertEqual(controller.microphoneLevel, 0, accuracy: 0.0001)
+
+        // Audio interruption.
+        await controller.startListening()
+        capture.emit(.level(0.4, date: Date()))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        capture.emit(.interrupted)
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertEqual(controller.state, .failed("Audio was interrupted."))
+        XCTAssertEqual(controller.microphoneLevel, 0, accuracy: 0.0001)
+
+        // Session stop.
+        await controller.startListening()
+        capture.emit(.level(0.4, date: Date()))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        controller.stop()
+        XCTAssertEqual(controller.microphoneLevel, 0, accuracy: 0.0001)
+    }
 }
 
 /// Speaker feedback-loop regressions: on routes whose output can feed the
@@ -918,6 +1093,76 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
         XCTAssertEqual(controller.lastBargeInState, .speaking)
         XCTAssertEqual(controller.state, .listening)
         XCTAssertEqual(capture.lastStartIncludePreRoll, true, "genuine headset barge-in keeps pre-roll")
+    }
+
+    func testPlaybackSuspensionResetsMicrophoneLevel() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        let policy = RoutePolicyBox(.speakerSafeHalfDuplex)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: { _ in true },
+            interrupt: {}
+        )
+        controller.beginVoiceTurn(sessionID: "session")
+        await controller.startListening()
+        let start = Date()
+        controller.ingestAudioLevel(0.1, at: start)
+        controller.ingestAudioLevel(0, at: start.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        controller.receiveAssistantEvent(.started(sessionID: "session"))
+        // Ambient audio still reaches the published meter while Hermes is
+        // only thinking (capture live, barge-in monitoring armed).
+        capture.emit(.level(0.02, date: Date()))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(controller.microphoneLevel, 0.02, accuracy: 0.0001)
+
+        controller.receiveAssistantEvent(.delta(sessionID: "session", text: "Answer."))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+
+        XCTAssertTrue(controller.isPlaybackCaptureSuspended)
+        XCTAssertEqual(controller.microphoneLevel, 0, accuracy: 0.0001, "speaker-safe suspension must zero the visible meter")
+    }
+
+    func testBargeInKeepsConservativeThresholdIndependentOfAdaptiveListening() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        var interrupts = 0
+        let policy = RoutePolicyBox(.fullDuplex)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: { _ in true },
+            interrupt: { interrupts += 1 }
+        )
+
+        await Self.driveToSpeaking(controller, gateway: gateway)
+        XCTAssertEqual(controller.state, .speaking)
+
+        // Levels the adaptive listening detector would accept as speech,
+        // but below the conservative barge-in threshold: ambient chatter
+        // must not interrupt Hermes on a headset.
+        let chatter = Date()
+        controller.ingestAudioLevel(0.02, at: chatter)
+        controller.ingestAudioLevel(0.03, at: chatter.addingTimeInterval(0.16))
+        controller.ingestAudioLevel(0.03, at: chatter.addingTimeInterval(0.32))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertEqual(interrupts, 0, "sub-threshold levels must not trigger barge-in")
+        XCTAssertEqual(controller.state, .speaking)
+
+        // Sustained input over the unchanged barge-in threshold still does.
+        let bargeInStart = Date()
+        controller.ingestAudioLevel(0.1, at: bargeInStart)
+        controller.ingestAudioLevel(0.1, at: bargeInStart.addingTimeInterval(0.31))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertEqual(interrupts, 1)
+        XCTAssertEqual(controller.state, .listening)
+        XCTAssertEqual(capture.lastStartIncludePreRoll, true)
     }
 
     func testUserPauseRemainsAuthoritativeAcrossAutomaticSuspension() async {

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -949,8 +949,10 @@ final class VoiceConversationControllerTests: XCTestCase {
             interrupt: {}
         )
 
-        let testTask = Task { await controller.runTranscriptionTest(duration: 0.3) }
-        try? await Task.sleep(nanoseconds: 80_000_000)
+        // A long recording window gives the injected samples a wide
+        // deterministic margin — no wall-clock race against test completion.
+        let testTask = Task { await controller.runTranscriptionTest(duration: 2) }
+        try? await Task.sleep(nanoseconds: 100_000_000)
         capture.emit(.level(0.4, date: Date()))
         // Level publication is meter-resolution (~20 Hz throttle), so space
         // the second sample past the publication window.
@@ -963,6 +965,39 @@ final class VoiceConversationControllerTests: XCTestCase {
         XCTAssertTrue(result.passed)
         XCTAssertEqual(controller.microphoneLevel, 0, accuracy: 0.0001, "provider-test completion resets the meter")
         XCTAssertTrue(submitted.isEmpty, "conversational VAD must not run during a provider test")
+    }
+
+    func testStaleCaptureLevelEventsDoNotCrossCaptureGenerations() async {
+        let capture = MockCapture(permissionGranted: true)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: MockGateway(),
+            submit: { _ in true },
+            interrupt: {}
+        )
+        await controller.startListening()
+        capture.emit(.level(0.4, date: Date()))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertEqual(controller.microphoneLevel, 0.4, accuracy: 0.0001)
+
+        // Pause boundary: a buffered level event from the previous capture
+        // generation is delivered after the pause reset — it must be
+        // dropped, not re-freeze the meter at a non-zero value.
+        controller.pauseMicrophone()
+        capture.emit(.level(0.6, date: Date()))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertEqual(controller.microphoneLevel, 0, accuracy: 0.0001, "stale level events must not cross the pause boundary")
+
+        // Stop boundary: same contract after the session is torn down.
+        await controller.startListening()
+        capture.emit(.level(0.4, date: Date()))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        controller.stop()
+        capture.emit(.level(0.6, date: Date()))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertEqual(controller.microphoneLevel, 0, accuracy: 0.0001, "stale level events must not cross the stop boundary")
     }
 
     func testSpeechTestRouteChangeDoesNotLeakSuspensionState() async {

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -967,6 +967,103 @@ final class VoiceConversationControllerTests: XCTestCase {
         XCTAssertTrue(submitted.isEmpty, "conversational VAD must not run during a provider test")
     }
 
+    func testLevelEventsDoNotRepublishMeterWhileTranscribing() async {
+        let capture = MockCapture(permissionGranted: true)
+        // Holding the gateway transcription open keeps .transcribing active
+        // for a deterministic margin: the gate is observed while it is the
+        // live state, not after the flow has moved on.
+        let gateway = MockGateway(transcript: "held", transcriptionDelayNanoseconds: 600_000_000)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            submit: { _ in true },
+            interrupt: {}
+        )
+        await controller.startListening()
+        let generation = capture.captureGeneration
+
+        // Live listening publishes the meter.
+        capture.emit(level: 0.4)
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertEqual(controller.microphoneLevel, 0.4, accuracy: 0.0001)
+
+        // Speech onset then a future-dated trailing-silence gap finishes the
+        // utterance and moves the controller into .transcribing.
+        let start = Date()
+        let samples: [(Float, TimeInterval)] = [
+            (0.003, 0.00), (0.003, 0.03), (0.004, 0.06), (0.004, 0.09),
+            (0.018, 0.12), (0.026, 0.17), (0.034, 0.22),
+            (0.004, 1.60), (0.003, 1.65)
+        ]
+        for (level, offset) in samples {
+            controller.ingestAudioLevel(level, at: start.addingTimeInterval(offset))
+        }
+        let reachedTranscribing = await waitForState(.transcribing, of: controller)
+        XCTAssertTrue(
+            reachedTranscribing,
+            "the utterance must reach transcription while the gateway holds it open"
+        )
+        XCTAssertEqual(controller.microphoneLevel, 0, accuracy: 0.0001, "the completed utterance resets the meter")
+
+        // A same-generation level surfacing mid-transcription must be
+        // ignored: the meter stays reset.
+        capture.emit(.level(0.7, date: Date(), generation: generation))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertEqual(controller.microphoneLevel, 0, accuracy: 0.0001, "transcribing must not republish the mic meter")
+
+        // Let the held transcription finish so the flow ends cleanly.
+        try? await Task.sleep(nanoseconds: 700_000_000)
+        XCTAssertEqual(controller.state, .thinking)
+    }
+
+    func testProviderTestLevelEventsDoNotRepublishMeterWhileTranscribing() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "held", transcriptionDelayNanoseconds: 600_000_000)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            submit: { _ in true },
+            interrupt: {}
+        )
+
+        let testTask = Task { await controller.runTranscriptionTest(duration: 0.5) }
+        let reachedRecording = await waitForState(.listening, of: controller)
+        XCTAssertTrue(reachedRecording, "the ASR test must be recording")
+        capture.emit(level: 0.4)
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertEqual(controller.microphoneLevel, 0.4, accuracy: 0.0001, "Record ASR recording still publishes the meter")
+
+        // The recording window elapses into the held transcription.
+        let reachedProviderTranscribing = await waitForState(.transcribing, of: controller)
+        XCTAssertTrue(reachedProviderTranscribing)
+        XCTAssertEqual(controller.microphoneLevel, 0, accuracy: 0.0001, "entering transcription resets the meter")
+        capture.emit(.level(0.8, date: Date(), generation: capture.captureGeneration))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertEqual(controller.microphoneLevel, 0, accuracy: 0.0001, "provider transcription must not republish the mic meter")
+
+        let result = await testTask.value
+        XCTAssertTrue(result.passed)
+        XCTAssertEqual(controller.microphoneLevel, 0, accuracy: 0.0001)
+    }
+
+    /// Bounded deterministic wait for the controller to reach a state: the
+    /// transitions themselves are driven by held test seams (future-dated
+    /// VAD events, a gateway that holds transcription open), never by
+    /// wall-clock hope.
+    private func waitForState(
+        _ target: VoiceConversationState,
+        of controller: VoiceConversationController,
+        timeoutSeconds: Double = 3
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while controller.state != target, Date() < deadline {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        return controller.state == target
+    }
+
     func testStaleCaptureLevelEventsDoNotCrossCaptureGenerations() async {
         let capture = MockCapture(permissionGranted: true)
         let gateway = MockGateway(transcript: "fresh")

--- a/ConduitTests/VoiceSpeechDetectorTests.swift
+++ b/ConduitTests/VoiceSpeechDetectorTests.swift
@@ -24,7 +24,8 @@ final class VoiceSpeechDetectorTests: XCTestCase {
             detections,
             [
                 .none, .none, .none, .none,
-                .none, .started, .continued, .continued,
+                .none, .none, .none, .started,
+                .continued, .continued,
                 .none, .none
             ],
             "a clear rise above the observed noise floor must be accepted as speech"
@@ -67,8 +68,17 @@ final class VoiceSpeechDetectorTests: XCTestCase {
     func testSpeechContinuationUsesLowerHysteresisThreshold() {
         var detector = VoiceSpeechDetector()
         for _ in 0..<6 { _ = detector.observe(0.003) }
-        XCTAssertEqual(detector.observe(0.026), .none)
-        XCTAssertEqual(detector.observe(0.03), .started, "two consecutive quiet-of-legacy samples accept speech")
+        // Four speech-plausible samples with natural variation fill the
+        // cold-start dynamics window (range 0.014 ≥ 0.012).
+        let run: [Float] = [0.026, 0.038, 0.024, 0.032]
+        var detections: [VoiceSpeechDetection] = []
+        for (index, sample) in run.enumerated() {
+            detections.append(detector.observe(sample))
+            if index < run.count - 1 {
+                XCTAssertEqual(detections.last, .none, "no single sub-ceiling sample may start a turn")
+            }
+        }
+        XCTAssertEqual(detections.last, .started, "the varied run is accepted as speech onset")
 
         // Below the speech-start threshold but above the hysteresis floor:
         // an active utterance keeps going.
@@ -107,10 +117,10 @@ final class VoiceSpeechDetectorTests: XCTestCase {
     }
 
     func testThresholdBoundaries() {
-        // Quiet room: the adaptive start threshold sits at its absolute
-        // minimum, and the minimum still needs corroboration.
+        // Quiet room, fully calibrated: the adaptive start threshold sits at
+        // its absolute minimum, and the minimum still needs corroboration.
         var quiet = VoiceSpeechDetector()
-        for _ in 0..<6 { _ = quiet.observe(0.003) }
+        for _ in 0..<16 { _ = quiet.observe(0.003) }
         XCTAssertEqual(quiet.observe(0.012), .none, "the minimum start threshold needs a second candidate")
         XCTAssertEqual(quiet.observe(0.012), .started)
 

--- a/ConduitTests/VoiceSpeechDetectorTests.swift
+++ b/ConduitTests/VoiceSpeechDetectorTests.swift
@@ -50,8 +50,9 @@ final class VoiceSpeechDetectorTests: XCTestCase {
             detections.append(detector.observe(sample))
         }
 
-        XCTAssertEqual(detections.first, .none, "the first quiet sample is still a single candidate")
-        XCTAssertEqual(Array(detections.dropFirst().prefix(2)), [.started, .continued], "the relative rise must be recognized")
+        // Full sequence: the first quiet sample is a single candidate
+        // (still .none), then the corroborating samples accept speech.
+        XCTAssertEqual(detections, [.none, .started, .continued], "the relative rise must be recognized")
     }
 
     func testSingleIsolatedSpikeDoesNotStartSpeech() {
@@ -94,6 +95,31 @@ final class VoiceSpeechDetectorTests: XCTestCase {
         var detector = VoiceSpeechDetector()
         XCTAssertEqual(detector.observe(0.1), .started, "an unambiguous level is speech regardless of warmup")
     }
+
+    func testNonFiniteLevelsAreIgnoredWithoutPoisoningTheFloor() {
+        var detector = VoiceSpeechDetector()
+        for _ in 0..<6 { _ = detector.observe(0.003) }
+
+        XCTAssertEqual(detector.observe(Float.nan), .none)
+        XCTAssertTrue(detector.noiseFloor.isFinite, "non-finite input must not poison the noise floor")
+        XCTAssertEqual(detector.observe(0.026), .none, "the garbage sample must not become a candidate")
+        XCTAssertEqual(detector.observe(0.026), .started, "the detector still works after non-finite input")
+    }
+
+    func testThresholdBoundaries() {
+        // Quiet room: the adaptive start threshold sits at its absolute
+        // minimum, and the minimum still needs corroboration.
+        var quiet = VoiceSpeechDetector()
+        for _ in 0..<6 { _ = quiet.observe(0.003) }
+        XCTAssertEqual(quiet.observe(0.012), .none, "the minimum start threshold needs a second candidate")
+        XCTAssertEqual(quiet.observe(0.012), .started)
+
+        // Louder room: the adapted threshold rises toward its ceiling, and
+        // a sample exactly at the conservative ceiling starts immediately.
+        var louder = VoiceSpeechDetector()
+        for _ in 0..<6 { _ = louder.observe(0.02) }
+        XCTAssertEqual(louder.observe(0.075), .started, "the conservative ceiling starts immediately even when adapted higher")
+    }
 }
 
 /// Presentation-only mapping tests, independent of the VAD tests.
@@ -121,5 +147,6 @@ final class VoiceLevelMeterMathTests: XCTestCase {
     func testFullScaleInputClampsToFull() {
         XCTAssertEqual(VoiceLevelMeterMath.displayFraction(forLevel: 1), 1, accuracy: 0.0001)
         XCTAssertEqual(VoiceLevelMeterMath.displayFraction(forLevel: 5), 1, accuracy: 0.0001, "over-range input clamps")
+        XCTAssertEqual(VoiceLevelMeterMath.displayFraction(forLevel: .infinity), 1, accuracy: 0.0001, "+Inf is full scale")
     }
 }

--- a/ConduitTests/VoiceSpeechDetectorTests.swift
+++ b/ConduitTests/VoiceSpeechDetectorTests.swift
@@ -25,7 +25,6 @@ final class VoiceSpeechDetectorTests: XCTestCase {
             [
                 .none, .none, .none, .none,
                 .none, .none, .none, .started,
-                .continued, .continued,
                 .none, .none
             ],
             "a clear rise above the observed noise floor must be accepted as speech"
@@ -75,7 +74,8 @@ final class VoiceSpeechDetectorTests: XCTestCase {
         for (index, sample) in run.enumerated() {
             detections.append(detector.observe(sample))
             if index < run.count - 1 {
-                XCTAssertEqual(detections.last, .none, "no single sub-ceiling sample may start a turn")
+                // A partial window must not start a turn.
+                XCTAssertFalse(detections.last == .started)
             }
         }
         XCTAssertEqual(detections.last, .started, "the varied run is accepted as speech onset")
@@ -86,19 +86,27 @@ final class VoiceSpeechDetectorTests: XCTestCase {
         XCTAssertEqual(detector.observe(0.002), .none, "true silence does not continue speech")
     }
 
-    func testResetClearsSpeechAndWarmupState() {
+    func testResetClearsSpeechAndColdStartState() {
         var detector = VoiceSpeechDetector()
         for _ in 0..<6 { _ = detector.observe(0.003) }
-        XCTAssertEqual(detector.observe(0.026), .none)
-        XCTAssertEqual(detector.observe(0.03), .started)
+        // A varied sub-ceiling run fills the cold-start dynamics window.
+        let run: [Float] = [0.02, 0.026, 0.038, 0.03]
+        var detections: [VoiceSpeechDetection] = []
+        for sample in run {
+            detections.append(detector.observe(sample))
+        }
+        XCTAssertEqual(detections.last, .started, "the varied run is accepted as speech onset")
 
-        // A completed utterance resets everything: warmup re-arms, speech is
-        // inactive, and the floor re-learns from the fresh window.
+        // A completed utterance resets everything: cold start re-arms, the
+        // floor re-learns from the fresh window, and quiet speech is
+        // recognized again.
         detector.reset()
         XCTAssertTrue(detector.noiseFloor <= 0.004, "the floor must not carry the previous window's estimate")
         for _ in 0..<4 { _ = detector.observe(0.003) }
         XCTAssertEqual(detector.observe(0.018), .none)
-        XCTAssertEqual(detector.observe(0.026), .started, "quiet speech is recognized again in the new window")
+        XCTAssertEqual(detector.observe(0.026), .none)
+        XCTAssertEqual(detector.observe(0.034), .none)
+        XCTAssertEqual(detector.observe(0.028), .started, "quiet speech is recognized again in the new window")
     }
 
     func testClearLoudSampleStartsImmediatelyEvenDuringWarmup() {
@@ -113,7 +121,11 @@ final class VoiceSpeechDetectorTests: XCTestCase {
         XCTAssertEqual(detector.observe(Float.nan), .none)
         XCTAssertTrue(detector.noiseFloor.isFinite, "non-finite input must not poison the noise floor")
         XCTAssertEqual(detector.observe(0.026), .none, "the garbage sample must not become a candidate")
-        XCTAssertEqual(detector.observe(0.026), .started, "the detector still works after non-finite input")
+
+        // The detector still works after non-finite input: an unambiguous
+        // level starts speech, and the floor was never poisoned.
+        XCTAssertEqual(detector.observe(0.5), .started)
+        XCTAssertTrue(detector.noiseFloor.isFinite)
     }
 
     func testThresholdBoundaries() {

--- a/ConduitTests/VoiceSpeechDetectorTests.swift
+++ b/ConduitTests/VoiceSpeechDetectorTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+@testable import Conduit
+
+/// Deterministic coverage for the adaptive listening-side speech detector
+/// (issue #130): quiet-but-valid speech must be accepted, steady ambient
+/// noise must never become a turn, and the threshold must adapt to the
+/// observed room.
+final class VoiceSpeechDetectorTests: XCTestCase {
+    func testQuietSpeechRiseAboveNearSilenceFloorIsAccepted() {
+        var detector = VoiceSpeechDetector()
+        var detections: [VoiceSpeechDetection] = []
+        // Ambient floor covers the detector warmup, then quiet speech whose
+        // peaks never reach the legacy fixed threshold.
+        let samples: [Float] = [
+            0.003, 0.004, 0.003, 0.003,
+            0.018, 0.026, 0.034, 0.028,
+            0.004, 0.003
+        ]
+        for sample in samples {
+            detections.append(detector.observe(sample))
+        }
+
+        XCTAssertEqual(
+            detections,
+            [
+                .none, .none, .none, .none,
+                .none, .started, .continued, .continued,
+                .none, .none
+            ],
+            "a clear rise above the observed noise floor must be accepted as speech"
+        )
+    }
+
+    func testSteadyAmbientNoiseNeverBecomesSpeech() {
+        var detector = VoiceSpeechDetector()
+        let detections = (0..<120).map { _ in detector.observe(0.015) }
+
+        XCTAssertFalse(detections.contains(.started), "constant room noise must never produce phantom speech")
+        XCTAssertTrue(detections.allSatisfy { $0 == .none })
+    }
+
+    func testLouderRoomFloorAdaptsAndRelativeSpeechRiseIsAccepted() {
+        var detector = VoiceSpeechDetector()
+        // Establish a louder noise floor…
+        for _ in 0..<40 { _ = detector.observe(0.02) }
+        // …then inject speech below the legacy fixed threshold but clearly
+        // above the adapted floor (floor ≈ 0.02 → threshold ≈ 0.059).
+        var detections: [VoiceSpeechDetection] = []
+        for sample: Float in [0.065, 0.07, 0.06] {
+            detections.append(detector.observe(sample))
+        }
+
+        XCTAssertEqual(detections.first, .none, "the first quiet sample is still a single candidate")
+        XCTAssertEqual(Array(detections.dropFirst().prefix(2)), [.started, .continued], "the relative rise must be recognized")
+    }
+
+    func testSingleIsolatedSpikeDoesNotStartSpeech() {
+        var detector = VoiceSpeechDetector()
+        for _ in 0..<6 { _ = detector.observe(0.003) }
+
+        XCTAssertEqual(detector.observe(0.03), .none, "one isolated noisy sample must not start a turn")
+        XCTAssertEqual(detector.observe(0.003), .none, "the candidate must reset after a quiet sample")
+        XCTAssertEqual(detector.observe(0.03), .none, "a new isolated spike starts counting from zero")
+    }
+
+    func testSpeechContinuationUsesLowerHysteresisThreshold() {
+        var detector = VoiceSpeechDetector()
+        for _ in 0..<6 { _ = detector.observe(0.003) }
+        XCTAssertEqual(detector.observe(0.026), .none)
+        XCTAssertEqual(detector.observe(0.03), .started, "two consecutive quiet-of-legacy samples accept speech")
+
+        // Below the speech-start threshold but above the hysteresis floor:
+        // an active utterance keeps going.
+        XCTAssertEqual(detector.observe(0.008), .continued)
+        XCTAssertEqual(detector.observe(0.002), .none, "true silence does not continue speech")
+    }
+
+    func testResetClearsSpeechAndWarmupState() {
+        var detector = VoiceSpeechDetector()
+        for _ in 0..<6 { _ = detector.observe(0.003) }
+        XCTAssertEqual(detector.observe(0.026), .none)
+        XCTAssertEqual(detector.observe(0.03), .started)
+
+        // A completed utterance resets everything: warmup re-arms, speech is
+        // inactive, and the floor re-learns from the fresh window.
+        detector.reset()
+        XCTAssertTrue(detector.noiseFloor <= 0.004, "the floor must not carry the previous window's estimate")
+        for _ in 0..<4 { _ = detector.observe(0.003) }
+        XCTAssertEqual(detector.observe(0.018), .none)
+        XCTAssertEqual(detector.observe(0.026), .started, "quiet speech is recognized again in the new window")
+    }
+
+    func testClearLoudSampleStartsImmediatelyEvenDuringWarmup() {
+        var detector = VoiceSpeechDetector()
+        XCTAssertEqual(detector.observe(0.1), .started, "an unambiguous level is speech regardless of warmup")
+    }
+}
+
+/// Presentation-only mapping tests, independent of the VAD tests.
+final class VoiceLevelMeterMathTests: XCTestCase {
+    func testZeroAndNearZeroMapToEmpty() {
+        XCTAssertEqual(VoiceLevelMeterMath.displayFraction(forLevel: 0), 0, accuracy: 0.0001)
+        XCTAssertEqual(VoiceLevelMeterMath.displayFraction(forLevel: 0.0001), 0, accuracy: 0.0001)
+        XCTAssertEqual(VoiceLevelMeterMath.displayFraction(forLevel: -0.5), 0, accuracy: 0.0001)
+        XCTAssertEqual(VoiceLevelMeterMath.displayFraction(forLevel: .nan), 0, accuracy: 0.0001)
+    }
+
+    func testQuietVoiceMapsToVisibleNonzeroFraction() {
+        let quiet = VoiceLevelMeterMath.displayFraction(forLevel: 0.034)
+        XCTAssertEqual(quiet, 0.51, accuracy: 0.02, "typical quiet speech sits near the meter midpoint")
+        XCTAssertGreaterThan(quiet, 0.2)
+    }
+
+    func testMediumInputMapsLargerThanQuiet() {
+        let quiet = VoiceLevelMeterMath.displayFraction(forLevel: 0.034)
+        let medium = VoiceLevelMeterMath.displayFraction(forLevel: 0.1)
+        XCTAssertEqual(medium, 2.0 / 3.0, accuracy: 0.01)
+        XCTAssertGreaterThan(medium, quiet)
+    }
+
+    func testFullScaleInputClampsToFull() {
+        XCTAssertEqual(VoiceLevelMeterMath.displayFraction(forLevel: 1), 1, accuracy: 0.0001)
+        XCTAssertEqual(VoiceLevelMeterMath.displayFraction(forLevel: 5), 1, accuracy: 0.0001, "over-range input clamps")
+    }
+}

--- a/ConduitTests/VoiceSpeechDetectorTests.swift
+++ b/ConduitTests/VoiceSpeechDetectorTests.swift
@@ -120,6 +120,28 @@ final class VoiceSpeechDetectorTests: XCTestCase {
         for _ in 0..<6 { _ = louder.observe(0.02) }
         XCTAssertEqual(louder.observe(0.075), .started, "the conservative ceiling starts immediately even when adapted higher")
     }
+
+    func testImmediateQuietSpeechDuringWarmupIsNotLearnedAsNoise() {
+        var detector = VoiceSpeechDetector()
+        // The user starts speaking immediately, inside the warmup window:
+        // speech-level samples must not raise the learned floor above the
+        // minimum start threshold, or the whole utterance gets swallowed.
+        for sample: Float in [0.018, 0.026, 0.034, 0.028] {
+            XCTAssertEqual(detector.observe(sample), .none)
+        }
+        XCTAssertLessThanOrEqual(
+            detector.noiseFloor,
+            VoiceSpeechDetectorConstants().minimumSpeechStartThreshold,
+            "warmup must never learn speech-level input as the noise floor"
+        )
+
+        // After a few genuinely quiet samples the floor settles and the
+        // same quiet speech is recognized again — it was never permanently
+        // learned as noise.
+        for _ in 0..<8 { _ = detector.observe(0.004) }
+        XCTAssertEqual(detector.observe(0.026), .none, "the first quiet sample is a single candidate")
+        XCTAssertEqual(detector.observe(0.026), .started, "quiet speech is recognized again after the floor settles")
+    }
 }
 
 /// Presentation-only mapping tests, independent of the VAD tests.

--- a/ConduitTests/VoiceSpeechDetectorTests.swift
+++ b/ConduitTests/VoiceSpeechDetectorTests.swift
@@ -121,6 +121,15 @@ final class VoiceSpeechDetectorTests: XCTestCase {
         XCTAssertEqual(louder.observe(0.075), .started, "the conservative ceiling starts immediately even when adapted higher")
     }
 
+    func testSteadyLoudAmbientNoiseFromColdStartNeverBecomesSpeech() {
+        var detector = VoiceSpeechDetector()
+        // A permanently loud room: warmup skips creep the floor toward the
+        // ambience, then the warmup force-arms with the conservative
+        // ceiling-only behavior — ambience below 0.075 never becomes a turn.
+        let detections = (0..<20).map { _ in detector.observe(0.05) }
+        XCTAssertTrue(detections.allSatisfy { $0 == .none }, "steady loud ambience must never be classified as speech")
+    }
+
     func testImmediateQuietSpeechDuringWarmupIsNotLearnedAsNoise() {
         var detector = VoiceSpeechDetector()
         // The user starts speaking immediately, inside the warmup window:

--- a/ConduitTests/VoiceSpeechDetectorTests.swift
+++ b/ConduitTests/VoiceSpeechDetectorTests.swift
@@ -123,33 +123,52 @@ final class VoiceSpeechDetectorTests: XCTestCase {
 
     func testSteadyLoudAmbientNoiseFromColdStartNeverBecomesSpeech() {
         var detector = VoiceSpeechDetector()
-        // A permanently loud room: warmup skips creep the floor toward the
-        // ambience, then the warmup force-arms with the conservative
-        // ceiling-only behavior — ambience below 0.075 never becomes a turn.
-        let detections = (0..<20).map { _ in detector.observe(0.05) }
+        // A permanently loud room: steady elevated ambience calibrates the
+        // floor (never starts a turn) and ceiling-only detection applies
+        // afterward.
+        let detections = (0..<40).map { _ in detector.observe(0.05) }
         XCTAssertTrue(detections.allSatisfy { $0 == .none }, "steady loud ambience must never be classified as speech")
+        XCTAssertEqual(detector.noiseFloor, 0.05, accuracy: 0.005, "the steady signal becomes the calibrated floor")
     }
 
-    func testImmediateQuietSpeechDuringWarmupIsNotLearnedAsNoise() {
+    func testCalibratedLoudRoomRecognizesLaterVariableRise() {
         var detector = VoiceSpeechDetector()
-        // The user starts speaking immediately, inside the warmup window:
-        // speech-level samples must not raise the learned floor above the
-        // minimum start threshold, or the whole utterance gets swallowed.
-        for sample: Float in [0.018, 0.026, 0.034, 0.028] {
-            XCTAssertEqual(detector.observe(sample), .none)
+        for _ in 0..<40 { _ = detector.observe(0.05) }
+        XCTAssertEqual(detector.noiseFloor, 0.05, accuracy: 0.005)
+
+        // A genuine variable rise above the calibrated floor is speech even
+        // though the room calibrated loud.
+        let samples: [Float] = [0.09, 0.12, 0.08, 0.11]
+        let detections = samples.map { detector.observe($0) }
+        XCTAssertTrue(detections.contains(.started), "a later real rise must still be recognized in a loud room")
+    }
+
+    func testImmediateQuietSpeechWithNaturalDynamicsIsAccepted() {
+        var detector = VoiceSpeechDetector()
+
+        // A user who starts talking at capture frame 1, with no initial
+        // silence: natural amplitude variation over a sustained run.
+        let samples: [Float] = [
+            0.018, 0.024, 0.032, 0.027,
+            0.035, 0.023, 0.031, 0.026,
+            0.034, 0.021
+        ]
+
+        let detections = samples.map {
+            detector.observe($0)
         }
+
+        XCTAssertTrue(
+            detections.contains(.started),
+            "quiet speech beginning at capture frame 1 must not require the user to stop and try again"
+        )
+        // The suspected-speech window must not have been taught into the
+        // noise floor: speech-level cold-start input is never learned as
+        // ambience.
         XCTAssertLessThanOrEqual(
             detector.noiseFloor,
-            VoiceSpeechDetectorConstants().minimumSpeechStartThreshold,
-            "warmup must never learn speech-level input as the noise floor"
+            VoiceSpeechDetectorConstants().minimumSpeechStartThreshold
         )
-
-        // After a few genuinely quiet samples the floor settles and the
-        // same quiet speech is recognized again — it was never permanently
-        // learned as noise.
-        for _ in 0..<8 { _ = detector.observe(0.004) }
-        XCTAssertEqual(detector.observe(0.026), .none, "the first quiet sample is a single candidate")
-        XCTAssertEqual(detector.observe(0.026), .started, "quiet speech is recognized again after the floor settles")
     }
 }
 


### PR DESCRIPTION
## Problem

Issue #130: Voice Conversation can receive microphone audio but never recognize the user's speech. Listening-side VAD required every sample to exceed one fixed peak threshold (0.075), so quiet-but-valid speech (typical peaks 0.02–0.05) never updated `lastSpeechAt`, and after 12 seconds of "silence" the mic auto-paused — transcription was never attempted. Meanwhile nothing on screen showed whether audio was reaching Conduit at all, making capture failure and detection failure indistinguishable. (Settings → Record ASR always transcribes a fixed-duration sample, so it could succeed while Voice Conversation stayed stuck.)

## Fix

**1. Listening speech detection is decoupled from barge-in.** `Configuration.bargeInActivityThreshold` (0.075, unchanged) now governs only acoustic barge-in during thinking/speaking/muted; the old shared `voiceActivityThreshold` is gone.

**2. Adaptive listening VAD** (`VoiceSpeechDetector`, constants centralized in `VoiceSpeechDetectorConstants`):
- Learns the ambient noise floor with an asymmetric EMA (falls fast toward quiet input, rises slowly, never fed by suspected speech) with a warmup window on every fresh capture so a loud room can't misclassify its own ambience at cold start.
- Speech-start threshold = noise floor × 3, clamped to [0.012, 0.075] — at or above the conservative ceiling a sample starts instantly (legacy-compatible), below it a rise needs 2 consecutive samples.
- Once speech is active, a lower hysteresis threshold keeps the utterance alive through dips; trailing silence (1.25 s) behavior is unchanged.
- Resets on every fresh listening window, utterance completion, pause/resume, stop, audio interruption, and #146 playback suspension, and re-learns on mid-listening route changes — no stale noise/speech state crosses turns.

**3. Live microphone input level.** `VoiceConversationController.microphoneLevel` (@Published) updates from every capture `.level` event — including during provider tests, which previously short-circuited capture events, while conversational VAD still never runs there — and returns to zero whenever capture pauses, stops, finishes into transcription, completes a provider test, is #146-suspended, or is interrupted. Publication is throttled to ~20 Hz so the tap's ~50 Hz events don't re-render the sheet at buffer rate.

**4. `VoiceInputLevelMeter`** (Conduit/Views/Components/): a compact staircase-bar meter driven by the raw level, mapped through dBFS (-60 dBFS → empty, 0 dBFS → full) so quiet speech is visibly alive; coarse accessibility value (Silent/Low/Medium/High) under a "Microphone input level" label. Shown in the Voice Conversation status card (active exactly when capture is live; during #146 speaker-safe playback it reads zero while the existing "Hermes is speaking / Tap Interrupt to speak." text explains why) and in Settings → Voice during Record ASR only (never during TTS playback). The controller is passed into the settings route as an `@ObservedObject` — one authoritative capture service, no timers, no duplicated capture.

## #146 constraints preserved

Built-in speaker → half duplex (capture suspended while Hermes speaks, meter inactive); headset/AirPods → full duplex with acoustic barge-in at the unchanged conservative threshold; explicit Interrupt; user mic pause semantics; fresh pre-roll-free capture after playback; audio-session lease ownership (#141); haptics/audio isolation (#143).

## Tests

Written first and proven failing against the legacy fixed-threshold baseline on the macOS build host (quiet-speech sequence, louder-room adaptation, hysteresis, reset, controller quiet/louder utterance submission — all failed pre-fix and pass now). Also covered: ambient noise alone never submits; barge-in stays conservative for sub-threshold chatter while 0.1+ still interrupts with pre-roll; published level lifecycle resets (pause/stop/interruption/suspension/finish/provider-test); provider-test level visibility without conversational VAD; meter dBFS mapping incl. zero/NaN/±Inf clamps. All four voice suites green on the macOS build host at the pushed head; hosted CI runs the full matrix.

## Review

Three-reviewer gate, two rounds: round 1 surfaced the routeChanged-during-provider-tests state leak, ~47 Hz `@Published` publication, warmup alpha off-by-one, NaN floor poisoning, provider-test transcribing meter reset, and meter double-animation — all fixed (throttled publication with boundary-cleared clock; provider-test route shielding with a drain-gated deterministic regression test; warmup-flag fix; finite-input guards) and confirmed APPROVE in round 2.

## Scope exclusions honored

No user-facing threshold control or sensitivity slider, no third-party VAD, no wake-word, no echo cancellation, no audio persistence or spectral analysis. Physical-device acceptance (built-in mic quiet voice, silence, AirPods, built-in speaker) remains a manual step per the issue checklist.

Fixes #130.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added live microphone level meters to voice conversations and voice input testing.
  - Voice settings now show microphone activity during recording.
  - Voice conversation controls now share status with voice settings.

- **Improvements**
  - Voice activity detection adapts to ambient background noise.
  - Microphone levels reset between recording sessions and interruptions.
  - Prevented stale audio from affecting new recording sessions.

- **Tests**
  - Expanded coverage for adaptive detection, microphone levels, interruptions, playback, and capture handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->