### PR TITLE
fix(voice): retire speech ownership at the server-replacement boundary

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -20,6 +20,10 @@ private let sessionYoloLog = Logger(subsystem: "com.milim.conduit", category: "S
 /// resume, and how prompt submissions were classified. Ids only — never
 /// prompt text, credentials, or message content.
 private let lifecycleLog = Logger(subsystem: "com.milim.conduit", category: "TurnLifecycle")
+/// Server-replacement speech retirement: which speech operations were live
+/// when the outgoing server's ownership was revoked. Ids and booleans only —
+/// never prompt text, credentials, or speech content.
+private let speechOwnershipLog = Logger(subsystem: "com.milim.conduit", category: "SpeechOwnership")
 
 typealias ChatResumeReconnectCancellation = @MainActor () -> Void
 typealias ChatResumeReconnectExecutor = @MainActor (ChatResumeSyncPurpose) async -> Void
@@ -2003,6 +2007,7 @@ final class AppState: ObservableObject {
         defaults.set(identity, forKey: chatResumeServerIdentityKey)
         guard let previousIdentity, previousIdentity != identity else { return false }
 
+        retireSpeechOperationsForServerReplacement(previousIdentity: previousIdentity, identity: identity)
         chatResumeCoordinator.clearResumeState()
         cancelOwnedAutomaticOperations()
         activeAutomaticChatResumeWork = nil
@@ -2041,6 +2046,51 @@ final class AppState: ObservableObject {
         conversationIdentityIndex.removeAll()
         sessionYoloStore.clearAllOverrides()
         return true
+    }
+
+    /// Runtime-only speech retirement at the server-replacement boundary.
+    ///
+    /// Voice Conversation and Read Aloud own speech transports that are
+    /// independent of `HermesClient`: a gateway binds one dashboard bridge and
+    /// base URL, and each spoken response opens its own ticket-minted speech
+    /// websocket. Those transports would otherwise keep streaming against —
+    /// and playing audio from — the outgoing server after a new connection
+    /// becomes authoritative, because replacing the client or the gateway
+    /// reference does not terminate an operation that already holds the old
+    /// gateway. This mirrors the voice teardown `disconnect()` performs, with
+    /// the operation generations doing the rest: every parked continuation
+    /// (capture resume, speech drain, playback completion) re-checks its
+    /// generation and turns inert, so nothing the outgoing server owned can
+    /// resurrect capture or playback.
+    ///
+    /// Deliberately NOT logout: no credential, cookie, ticket, or preference
+    /// state is touched here — only the outgoing connection's runtime speech
+    /// ownership. If the incoming connection fails to activate, the retired
+    /// operations stay retired; the outgoing server's speech is not valid
+    /// merely because the replacement failed. Same-server reconnects never
+    /// reach this path: `prepareDashboardBridge(for:)` keeps the bridge (and
+    /// therefore the gateways) when the normalized URL is unchanged, and the
+    /// capability refresh intentionally keeps equivalent gateways alive.
+    private func retireSpeechOperationsForServerReplacement(previousIdentity: String, identity: String) {
+        let voiceWasLive = voiceConversationController.hasLiveVoiceSession
+        let readAloudWasActive: Bool
+        if case .idle = messageReadAloudController.state {
+            readAloudWasActive = false
+        } else {
+            readAloudWasActive = true
+        }
+        speechOwnershipLog.info(
+            "Server replacement \(previousIdentity, privacy: .public) -> \(identity, privacy: .public): retiring speech ownership (voiceLive=\(voiceWasLive ? "yes" : "no", privacy: .public), readAloudActive=\(readAloudWasActive ? "yes" : "no", privacy: .public))"
+        )
+        voiceConversationController.stop()
+        messageReadAloudController.stop()
+        // A swapped gateway must never hand a later operation to the outgoing
+        // server's bridge; the incoming connection rebuilds both references
+        // from its own bridge (capability refresh, read-aloud assignment).
+        voiceConversationController.setGateway(nil)
+        messageReadAloudController.setGateway(nil)
+        readAloudGatewayBridge = nil
+        showVoiceSheet = false
     }
 
     private static func normalizedChatResumeServerIdentity(_ baseURL: String) -> String? {

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2083,12 +2083,15 @@ final class AppState: ObservableObject {
             "Server replacement \(previousIdentity, privacy: .private) -> \(identity, privacy: .private): retiring speech ownership (voiceLive=\(voiceWasLive ? "yes" : "no", privacy: .public), readAloudActive=\(readAloudWasActive ? "yes" : "no", privacy: .public))"
         )
         voiceConversationController.stop()
-        messageReadAloudController.stop()
+        // Read Aloud teardown flows through the controller's own pinned
+        // Option-A semantics: replacing a non-nil gateway performs the single
+        // authoritative stop. A nil gateway means nothing can be live — an
+        // operation cannot start without one.
+        messageReadAloudController.setGateway(nil)
         // A swapped gateway must never hand a later operation to the outgoing
         // server's bridge; the incoming connection rebuilds both references
         // from its own bridge (capability refresh, read-aloud assignment).
         voiceConversationController.setGateway(nil)
-        messageReadAloudController.setGateway(nil)
         readAloudGatewayBridge = nil
         showVoiceSheet = false
     }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -2080,7 +2080,7 @@ final class AppState: ObservableObject {
             readAloudWasActive = true
         }
         speechOwnershipLog.info(
-            "Server replacement \(previousIdentity, privacy: .public) -> \(identity, privacy: .public): retiring speech ownership (voiceLive=\(voiceWasLive ? "yes" : "no", privacy: .public), readAloudActive=\(readAloudWasActive ? "yes" : "no", privacy: .public))"
+            "Server replacement \(previousIdentity, privacy: .private) -> \(identity, privacy: .private): retiring speech ownership (voiceLive=\(voiceWasLive ? "yes" : "no", privacy: .public), readAloudActive=\(readAloudWasActive ? "yes" : "no", privacy: .public))"
         )
         voiceConversationController.stop()
         messageReadAloudController.stop()

--- a/Conduit/Voice/MessageReadAloudController.swift
+++ b/Conduit/Voice/MessageReadAloudController.swift
@@ -100,6 +100,14 @@ final class MessageReadAloudController: ObservableObject {
     /// The active stream belongs to the gateway that opened it. A replaced or
     /// cleared gateway (disconnect, profile change) invalidates the in-flight
     /// operation, so any replacement stops it.
+    ///
+    /// Pinned Option A semantics, deliberately different from
+    /// `VoiceConversationController.setGateway`: a read aloud operation is one
+    /// short single-message stream fully bound to its gateway, so a swap
+    /// mid-operation is always an ownership change and stops playback here.
+    /// The voice conversation instead survives same-server capability
+    /// refreshes that install fresh equivalent instances, so its swap is
+    /// future-operations-only and connection replacement stops it explicitly.
     func setGateway(_ gateway: VoiceGatewayService?) {
         guard activeGateway !== gateway else { return }
         activeGateway = gateway

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -168,6 +168,12 @@ final class VoiceConversationController: ObservableObject {
         isVoiceSessionActive || isProviderTestRunning
     }
 
+    /// Observability seam: whether a gateway reference is currently installed.
+    /// The server-replacement boundary clears this reference; tests pin the
+    /// clearing through here because a stale gateway's failure mode (reaching
+    /// the outgoing server's bridge) is behavioral and hard to observe.
+    var isGatewayAttached: Bool { gateway != nil }
+
     func setForegroundActive(_ active: Bool) {
         isForegroundActive = active
         guard !active else { return }

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -103,6 +103,15 @@ final class VoiceConversationController: ObservableObject {
 
     deinit { captureEventsTask?.cancel() }
 
+    /// Swaps the gateway for FUTURE operations only (pinned Option B
+    /// semantics): an in-flight conversation keeps the gateway it captured at
+    /// its operation boundaries, and the caller that replaces connection
+    /// ownership must stop this controller first — the server-replacement
+    /// boundary in `AppState.retireSpeechOperationsForServerReplacement`
+    /// does. A plain swap is deliberately not an ownership change: capability
+    /// refreshes install fresh-but-equivalent instances (same bridge, server,
+    /// and profile) mid-conversation by design, so pointer inequality is not
+    /// a signal that the old operation's server authority ended.
     func setGateway(_ gateway: VoiceGatewayService?) { self.gateway = gateway }
 
     /// Establishes explicit ownership of assistant events for one voice turn.

--- a/ConduitTests/AppStateServerReplacementSpeechTests.swift
+++ b/ConduitTests/AppStateServerReplacementSpeechTests.swift
@@ -1,0 +1,613 @@
+//
+//  AppStateServerReplacementSpeechTests.swift
+//  Conduit
+//
+//  Regression coverage for the server-replacement speech boundary: when
+//  `prepareChatResumeForConnection(to:)` detects a normalized server change,
+//  every Voice Conversation / Read Aloud / provider-test operation belonging
+//  to the outgoing server is retired and its gateway references are cleared,
+//  so no parked continuation can resurrect capture, playback, or a transport
+//  against the previous server. Same-server identity calls must NOT touch
+//  speech — that preserves the existing recovery model where speech survives
+//  a same-server reconnect (the dashboard bridge is reused).
+//
+
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class AppStateServerReplacementSpeechTests: XCTestCase {
+    private static let serverA = "https://one.example"
+    private static let serverB = "https://two.example"
+
+    // MARK: - 1. Voice conversation A -> B
+
+    func testServerReplacementStopsActiveVoiceConversationAndClearsGateway() async {
+        let harness = makeHarness()
+        let listening = await harness.startVoiceListening()
+        XCTAssertTrue(listening)
+        XCTAssertEqual(harness.voiceController.state, .listening)
+        harness.appState.showVoiceSheet = true
+
+        let changed = harness.appState.prepareChatResumeForConnection(to: Self.serverB)
+        XCTAssertTrue(changed)
+
+        // Equivalent to the voice conversation having been explicitly ended:
+        // idle state, capture retired, sheet closed.
+        XCTAssertEqual(harness.voiceController.state, .idle)
+        XCTAssertEqual(harness.voiceCapture.stopCount, 1)
+        XCTAssertFalse(harness.appState.showVoiceSheet)
+        // The outgoing gateway reference is gone: a later listen attempt with
+        // no new gateway fails closed instead of reaching server A.
+        await harness.voiceController.startListening()
+        XCTAssertEqual(
+            harness.voiceController.state,
+            .failed("Voice is unavailable for this gateway.")
+        )
+        harness.voiceController.stop()
+    }
+
+    // MARK: - 2. Read aloud A -> B
+
+    func testServerReplacementStopsActiveReadAloudAndReleasesStandaloneOwnership() async throws {
+        let harness = makeHarness()
+        let message = ChatMessage(id: "msg-a", role: .assistant, content: "Response A", timestamp: "1")
+
+        harness.appState.toggleReadAloud(message: message)
+        await harness.awaitUntil("read aloud playing on A") {
+            harness.readAloudController.state == .playing(messageID: "msg-a")
+        }
+        let stream = try XCTUnwrap(harness.readAloudGateway.streams.first)
+        XCTAssertTrue(harness.readAloudPlayback.isPlaying)
+        let stopBaseline = harness.readAloudPlayback.stopCount
+
+        let changed = harness.appState.prepareChatResumeForConnection(to: Self.serverB)
+        XCTAssertTrue(changed)
+
+        XCTAssertEqual(harness.readAloudController.state, .idle)
+        XCTAssertNil(harness.readAloudController.gateway)
+        // stop() plus the gateway-clear's own stop() both land on the same
+        // single retirement; the engine ends fully stopped either way.
+        XCTAssertGreaterThan(harness.readAloudPlayback.stopCount, stopBaseline)
+        XCTAssertFalse(harness.readAloudPlayback.isPlaying)
+        XCTAssertEqual(stream.cancelCount, 1)
+    }
+
+    // MARK: - 3. Stale voice continuations cannot resurrect capture
+
+    func testServerReplacementMakesAssistantSpeechDrainContinuationInert() async {
+        let harness = makeHarness()
+        _ = await harness.startVoiceWithAssistantDeltaParkedInDrain()
+
+        let startBaseline = harness.voiceCapture.startListeningCount
+
+        let changed = harness.appState.prepareChatResumeForConnection(to: Self.serverB)
+        XCTAssertTrue(changed)
+
+        // The stop cancelled the parked stream; the drain task resumes,
+        // observes a stale generation/revision, and must settle without
+        // restarting capture or reopening the old server's gateway.
+        let oldStream = harness.voiceGateway.streams[0]
+        await harness.awaitUntil("the parked drain continuation settled") {
+            oldStream.isCancelled && oldStream.cancelCount == 1
+        }
+        for _ in 0..<10 { await Task.yield() }
+        XCTAssertEqual(harness.voiceController.state, .idle)
+        XCTAssertEqual(harness.voiceCapture.startListeningCount, startBaseline)
+        XCTAssertEqual(harness.voiceGateway.openCount, 1)
+    }
+
+    func testServerReplacementMakesParkedBargeInContinuationInert() async {
+        let harness = makeHarness()
+        _ = await harness.startVoiceWithAssistantResponseStarted()
+        XCTAssertEqual(harness.voiceController.state, .thinking)
+
+        // Acoustic barge-in begins and parks inside the injected interrupt
+        // seam (the stand-in for Hermes cancellation/recovery work).
+        let base = Date()
+        harness.voiceController.ingestAudioLevel(0.5, at: base)
+        harness.voiceController.ingestAudioLevel(0.5, at: base.addingTimeInterval(0.5))
+        await harness.awaitUntil("barge-in entered the interrupt seam") {
+            harness.interruptGate.events.contains("entered")
+        }
+        let startBaseline = harness.voiceCapture.startListeningCount
+
+        let changed = harness.appState.prepareChatResumeForConnection(to: Self.serverB)
+        XCTAssertTrue(changed)
+        XCTAssertEqual(harness.voiceController.state, .idle)
+
+        // Release the parked interruption after the replacement: the stale
+        // continuation resumes into a bumped generation and must not reopen
+        // the microphone.
+        harness.interruptGate.release()
+        await harness.awaitUntil("the parked interruption resumed") {
+            harness.interruptGate.events.contains("released")
+        }
+        for _ in 0..<10 { await Task.yield() }
+        XCTAssertEqual(harness.voiceCapture.startListeningCount, startBaseline)
+        XCTAssertEqual(harness.voiceController.state, .idle)
+    }
+
+    // MARK: - 4. Stale read aloud completion cannot touch a newer operation
+
+    func testLateReadAloudStreamFailureAfterReplacementDoesNotDisturbNewOperation() async throws {
+        let harness = makeHarness()
+        let messageA = ChatMessage(id: "msg-a", role: .assistant, content: "Response A", timestamp: "1")
+
+        harness.appState.toggleReadAloud(message: messageA)
+        await harness.awaitUntil("read aloud playing on A") {
+            harness.readAloudController.state == .playing(messageID: "msg-a")
+        }
+        let oldStream = try XCTUnwrap(harness.readAloudGateway.streams.first)
+
+        let changed = harness.appState.prepareChatResumeForConnection(to: Self.serverB)
+        XCTAssertTrue(changed)
+
+        // A fresh operation belonging to server B starts normally.
+        let gatewayB = GatedVoiceGateway()
+        harness.readAloudController.setGateway(gatewayB)
+        let messageB = ChatMessage(id: "msg-b", role: .assistant, content: "Response B", timestamp: "2")
+        harness.appState.toggleReadAloud(message: messageB)
+        await harness.awaitUntil("read aloud playing on B") {
+            harness.readAloudController.state == .playing(messageID: "msg-b")
+        }
+
+        // The old stream's parked append settles (its cancel fired when the
+        // boundary stopped it); the superseded operation must not stop the
+        // newer playback or touch shared state.
+        await harness.awaitUntil("the old stream settled") {
+            oldStream.settled
+        }
+        for _ in 0..<10 { await Task.yield() }
+        XCTAssertEqual(harness.readAloudController.state, .playing(messageID: "msg-b"))
+        XCTAssertTrue(harness.readAloudPlayback.isPlaying)
+        XCTAssertEqual(oldStream.cancelCount, 1)
+        XCTAssertEqual(gatewayB.openCount, 1)
+        harness.readAloudController.stop()
+    }
+
+    // MARK: - 5/6. Fresh B operations are unaffected by late A callbacks
+
+    func testNewVoiceConversationOnReplacedServerIsUnaffectedByLateOldCallbacks() async {
+        let harness = makeHarness()
+        _ = await harness.startVoiceWithAssistantDeltaParkedInDrain()
+
+        let changed = harness.appState.prepareChatResumeForConnection(to: Self.serverB)
+        XCTAssertTrue(changed)
+
+        // Server B conversation: fresh gateway, fresh turn.
+        let gatewayB = GatedVoiceGateway()
+        harness.voiceController.setGateway(gatewayB)
+        harness.voiceController.beginVoiceTurn(sessionID: "b-session")
+        let listening = await harness.startVoiceListening()
+        XCTAssertTrue(listening)
+        XCTAssertEqual(harness.voiceController.state, .listening)
+
+        // The old A stream's cancellation settles its drain task; late A
+        // assistant events carry A's session id, which B's turn never owned.
+        await harness.awaitUntil("the old A stream settled") {
+            harness.voiceGateway.streams[0].settled
+        }
+        harness.voiceController.receiveAssistantEvent(.delta(sessionID: "a-session", text: "late"))
+        harness.voiceController.receiveAssistantEvent(.completed(sessionID: "a-session", content: "late"))
+        for _ in 0..<10 { await Task.yield() }
+
+        XCTAssertEqual(harness.voiceController.state, .listening)
+        XCTAssertTrue(harness.voiceController.conversationTranscript.isEmpty)
+        XCTAssertEqual(gatewayB.openCount, 0)
+        XCTAssertEqual(harness.voiceGateway.openCount, 1)
+        harness.voiceController.stop()
+    }
+
+    func testNewReadAloudOnReplacedServerIsUnaffectedByLateOldCallbacks() async {
+        let harness = makeHarness()
+        let messageA = ChatMessage(id: "msg-a", role: .assistant, content: "Response A", timestamp: "1")
+        harness.appState.toggleReadAloud(message: messageA)
+        await harness.awaitUntil("read aloud playing on A") {
+            harness.readAloudController.state == .playing(messageID: "msg-a")
+        }
+
+        let changed = harness.appState.prepareChatResumeForConnection(to: Self.serverB)
+        XCTAssertTrue(changed)
+
+        let gatewayB = GatedVoiceGateway()
+        harness.readAloudController.setGateway(gatewayB)
+        let messageB = ChatMessage(id: "msg-b", role: .assistant, content: "Response B", timestamp: "2")
+        harness.appState.toggleReadAloud(message: messageB)
+        await harness.awaitUntil("read aloud playing on B") {
+            harness.readAloudController.state == .playing(messageID: "msg-b")
+        }
+
+        await harness.awaitUntil("the old A stream settled") {
+            harness.readAloudGateway.streams[0].settled
+        }
+        for _ in 0..<10 { await Task.yield() }
+
+        XCTAssertEqual(harness.readAloudController.state, .playing(messageID: "msg-b"))
+        XCTAssertTrue(harness.readAloudPlayback.isPlaying)
+        XCTAssertEqual(gatewayB.openCount, 1)
+        harness.readAloudController.stop()
+    }
+
+    // MARK: - 7. Audio-session ownership is released at the boundary
+
+    func testServerReplacementRetiresPlaybackOwnershipAndAllowsFreshClaim() async {
+        let harness = makeHarness()
+        let message = ChatMessage(id: "msg-a", role: .assistant, content: "Response A", timestamp: "1")
+        harness.appState.toggleReadAloud(message: message)
+        await harness.awaitUntil("read aloud playing on A") {
+            harness.readAloudController.state == .playing(messageID: "msg-a")
+        }
+        _ = await harness.startVoiceListening()
+        let voiceStopBaseline = harness.voicePlayback.stopCount
+        let readAloudStopBaseline = harness.readAloudPlayback.stopCount
+
+        let changed = harness.appState.prepareChatResumeForConnection(to: Self.serverB)
+        XCTAssertTrue(changed)
+
+        // Each retired owner ends fully stopped — the voice controller stops
+        // exactly once here (its gateway swap does not stop), the read aloud
+        // engine is stopped by the retirement and stays stopped.
+        XCTAssertEqual(harness.voicePlayback.stopCount, voiceStopBaseline + 1)
+        XCTAssertGreaterThan(harness.readAloudPlayback.stopCount, readAloudStopBaseline)
+        XCTAssertFalse(harness.voicePlayback.isPlaying)
+        XCTAssertFalse(harness.readAloudPlayback.isPlaying)
+
+        // A B-owned operation can claim playback normally afterwards.
+        harness.readAloudController.setGateway(GatedVoiceGateway())
+        let messageB = ChatMessage(id: "msg-b", role: .assistant, content: "Response B", timestamp: "2")
+        harness.appState.toggleReadAloud(message: messageB)
+        await harness.awaitUntil("B read aloud playing") {
+            harness.readAloudController.state == .playing(messageID: "msg-b")
+        }
+        XCTAssertTrue(harness.readAloudPlayback.isPlaying)
+        harness.readAloudController.stop()
+    }
+
+    // MARK: - 8. Failure after takeover keeps A speech retired
+
+    func testSpeechStaysRetiredWhenReplacementIdentityPersistsAfterFailedActivation() async {
+        let harness = makeHarness()
+        _ = await harness.startVoiceListening()
+        harness.appState.showVoiceSheet = true
+
+        let changed = harness.appState.prepareChatResumeForConnection(to: Self.serverB)
+        XCTAssertTrue(changed)
+
+        // The boundary commits the identity before any transport exists; a
+        // failed activation does not roll it back, and the retirement is not
+        // undone. A repeat call for the same (failed) server is a same-server
+        // call now and must not resurrect anything either.
+        let repeated = harness.appState.prepareChatResumeForConnection(to: Self.serverB)
+        XCTAssertFalse(repeated)
+        XCTAssertEqual(
+            harness.defaults.string(forKey: "conduit.chatResumeServerIdentity.v1"),
+            Self.serverB
+        )
+        XCTAssertEqual(harness.voiceController.state, .idle)
+        XCTAssertNil(harness.readAloudController.gateway)
+        XCTAssertFalse(harness.appState.showVoiceSheet)
+    }
+
+    // MARK: - 9. Same-server control: the boundary is not overly broad
+
+    func testSameServerIdentityCallPreservesActiveSpeech() async {
+        let harness = makeHarness()
+        _ = await harness.startVoiceListening()
+        let message = ChatMessage(id: "msg-a", role: .assistant, content: "Response A", timestamp: "1")
+        harness.appState.toggleReadAloud(message: message)
+        await harness.awaitUntil("read aloud playing") {
+            harness.readAloudController.state == .playing(messageID: "msg-a")
+        }
+        let voiceStopBaseline = harness.voicePlayback.stopCount
+        let readAloudStopBaseline = harness.readAloudPlayback.stopCount
+
+        // Identical normalized identity: recovery, not replacement.
+        let same = harness.appState.prepareChatResumeForConnection(to: Self.serverA)
+        XCTAssertFalse(same)
+
+        // Default-port spelling folds to the same identity too.
+        let folded = harness.appState.prepareChatResumeForConnection(to: "https://one.example:443")
+        XCTAssertFalse(folded)
+
+        XCTAssertEqual(harness.voiceController.state, .listening)
+        XCTAssertEqual(harness.readAloudController.state, .playing(messageID: "msg-a"))
+        XCTAssertEqual(harness.voicePlayback.stopCount, voiceStopBaseline)
+        XCTAssertEqual(harness.readAloudPlayback.stopCount, readAloudStopBaseline)
+        XCTAssertNotNil(harness.readAloudController.gateway)
+        harness.readAloudController.stop()
+    }
+
+    // MARK: - 10. Provider tests are server-bound and retired by the boundary
+
+    func testServerReplacementCancelsInFlightTTSSpeechTest() async {
+        let harness = makeHarness()
+        let speechTest = Task {
+            await harness.voiceController.runSpeechTest(text: "Conduit voice is ready for this profile.")
+        }
+        await harness.awaitUntil("the speech test parked in its stream append") {
+            harness.voiceGateway.streams.first?.parkedAppend == true
+        }
+        XCTAssertEqual(harness.voiceController.state, .speaking)
+
+        let changed = harness.appState.prepareChatResumeForConnection(to: Self.serverB)
+        XCTAssertTrue(changed)
+
+        let result = await speechTest.value
+        XCTAssertFalse(result.passed, "a retired speech test must not report success")
+        XCTAssertEqual(harness.voiceController.state, .idle)
+        XCTAssertFalse(harness.voiceController.hasLiveVoiceSession)
+        XCTAssertEqual(harness.voiceGateway.streams[0].cancelCount, 1)
+    }
+
+    // MARK: - Harness
+
+    private func makeHarness() -> Harness {
+        let suite = "AppStateServerReplacementSpeechTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Failed to create test UserDefaults suite")
+        }
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suite)
+        }
+
+        let appState = AppState(defaults: defaults, loadSavedConnection: false)
+        appState.connection = HermesConnection(baseUrl: Self.serverA, ticket: "test-ticket")
+        appState.isConnected = true
+
+        let voicePlayback = CountingPlayback()
+        let voiceCapture = GatedCapture()
+        let voiceGateway = GatedVoiceGateway()
+        let interruptGate = InterruptGate()
+        let voiceController = VoiceConversationController(
+            capture: voiceCapture,
+            playback: voicePlayback,
+            deviceTranscriber: CountingTranscriber(),
+            gateway: voiceGateway,
+            submit: { _ in true },
+            interrupt: { await interruptGate.wait() }
+        )
+        appState.voiceConversationController = voiceController
+
+        let readAloudPlayback = CountingPlayback()
+        let readAloudGateway = GatedVoiceGateway()
+        let readAloudController = MessageReadAloudController(
+            playback: readAloudPlayback,
+            gateway: readAloudGateway,
+            reportError: { _ in }
+        )
+        appState.messageReadAloudController = readAloudController
+
+        let bridge = DashboardTicketBridge(baseURL: Self.serverA)
+        appState.installVoiceCapabilityStateForTesting(
+            bridge: bridge,
+            snapshot: VoiceCapabilitySnapshot(
+                isGatewayConnected: true,
+                supportsTranscription: true,
+                supportsSpeech: true,
+                unavailableReason: nil
+            ),
+            isVoiceEnabled: true
+        )
+
+        // Seed server A's identity the way the resume boundary does: with no
+        // stored identity the first call only records it (returns false).
+        let seeded = appState.prepareChatResumeForConnection(to: Self.serverA)
+        XCTAssertFalse(seeded)
+
+        return Harness(
+            appState: appState,
+            defaults: defaults,
+            voiceController: voiceController,
+            voiceCapture: voiceCapture,
+            voicePlayback: voicePlayback,
+            voiceGateway: voiceGateway,
+            interruptGate: interruptGate,
+            readAloudController: readAloudController,
+            readAloudPlayback: readAloudPlayback,
+            readAloudGateway: readAloudGateway
+        )
+    }
+
+    private struct Harness {
+        let appState: AppState
+        let defaults: UserDefaults
+        let voiceController: VoiceConversationController
+        let voiceCapture: GatedCapture
+        let voicePlayback: CountingPlayback
+        let voiceGateway: GatedVoiceGateway
+        let interruptGate: InterruptGate
+        let readAloudController: MessageReadAloudController
+        let readAloudPlayback: CountingPlayback
+        let readAloudGateway: GatedVoiceGateway
+
+        func awaitUntil(
+            _ description: String,
+            timeout: TimeInterval = 2.0,
+            condition: @MainActor () -> Bool
+        ) async {
+            let deadline = Date().addingTimeInterval(timeout)
+            while !condition() {
+                if Date() >= deadline {
+                    XCTFail("Timed out waiting for \(description)")
+                    return
+                }
+                try? await Task.sleep(nanoseconds: 10_000_000)
+            }
+        }
+
+        /// Arms a live listening voice turn on the injected gateway.
+        @discardableResult
+        func startVoiceListening() async -> Bool {
+            voiceController.beginVoiceTurn(sessionID: "a-session")
+            await voiceController.startListening()
+            return voiceController.state == .listening
+        }
+
+        /// Drives a turn to `.thinking`, reports the assistant start, then a
+        /// delta whose speech-drain append is parked on the mock stream — the
+        /// deterministic stand-in for in-flight assistant playback.
+        func startVoiceWithAssistantDeltaParkedInDrain() async -> GatedVoiceStream {
+            _ = await startVoiceListening()
+            await finishUtteranceToThinking()
+            voiceController.receiveAssistantEvent(.started(sessionID: "a-session"))
+            voiceController.receiveAssistantEvent(.delta(sessionID: "a-session", text: "hello"))
+            await awaitUntil("the drain parked in the stream append") {
+                self.voiceGateway.streams.first?.parkedAppend == true
+            }
+            return voiceGateway.streams[0]
+        }
+
+        /// Drives a turn to `.thinking` with the assistant response started,
+        /// so barge-in monitoring is armed and playback-suspension is not.
+        func startVoiceWithAssistantResponseStarted() async {
+            _ = await startVoiceListening()
+            await finishUtteranceToThinking()
+            voiceController.receiveAssistantEvent(.started(sessionID: "a-session"))
+        }
+
+        /// Utterance finish is date-driven: one speech sample followed by a
+        /// later silent sample deterministically schedules `finishUtterance`,
+        /// and the mock transcriber + submit closure land the turn in
+        /// `.thinking`.
+        private func finishUtteranceToThinking() async {
+            let base = Date()
+            voiceController.ingestAudioLevel(0.5, at: base)
+            voiceController.ingestAudioLevel(0.0, at: base.addingTimeInterval(5))
+            await awaitUntil("the turn to reach thinking") {
+                self.voiceController.state == .thinking
+            }
+        }
+    }
+}
+
+// MARK: - Deterministic test doubles
+
+/// Interruption seam with an explicit gate: `wait()` records entry, parks
+/// until `release()`, and records the resumption so tests can assert against
+/// the exact resumption point instead of sleeping.
+@MainActor
+private final class InterruptGate {
+    private(set) var events: [String] = []
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var released = false
+
+    func wait() async {
+        events.append("entered")
+        if released {
+            events.append("released")
+            return
+        }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+        events.append("released")
+    }
+
+    func release() {
+        released = true
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+@MainActor
+private final class GatedCapture: AudioCaptureService {
+    let events = AsyncStream<VoiceCaptureEvent> { _ in }
+    private(set) var startListeningCount = 0
+    private(set) var stopCount = 0
+
+    func requestPermission() async -> Bool { true }
+    func startListening(includePreRoll: Bool) throws { startListeningCount += 1 }
+    func beginBargeInMonitoring() throws {}
+    func pause() {}
+    func resume() throws {}
+    func finishUtterance() throws -> VoiceCapturedAudio {
+        VoiceCapturedAudio(wavData: Data(), pcm16Data: Data(), sampleRate: 16_000, duration: 0)
+    }
+    func stop() { stopCount += 1 }
+}
+
+@MainActor
+private final class CountingPlayback: SpeechPlaybackService {
+    var isPlaying = false
+    var ownershipIntent: VoiceAudioIntent = .standalonePlayback
+    private(set) var stopCount = 0
+
+    func start(sampleRate: Double) throws { isPlaying = true }
+    func enqueuePCM16(_ data: Data, sampleRate: Double) throws -> Int { data.count / 2 }
+    func playEncodedAudioData(_ data: Data) throws { isPlaying = true }
+    func finish() throws {}
+    func drain() async { isPlaying = false }
+    func stop() {
+        isPlaying = false
+        stopCount += 1
+    }
+}
+
+@MainActor
+private final class CountingTranscriber: DeviceSpeechTranscriptionService {
+    func requestPermission() async -> Bool { true }
+    func transcribe(_ audio: VoiceCapturedAudio) async throws -> String { "transcript" }
+    func cancel() {}
+}
+
+@MainActor
+private final class GatedVoiceGateway: VoiceGatewayService {
+    let profile = "default"
+    private(set) var openCount = 0
+    private(set) var streams: [GatedVoiceStream] = []
+
+    func transcribe(_ audio: VoiceCapturedAudio) async throws -> String { "transcript" }
+
+    func openSpeechStream(
+        onStart: @escaping @MainActor (Double) throws -> Void,
+        onPCM16: @escaping @MainActor (Data, Double) throws -> Void,
+        onEncodedAudio: @escaping @MainActor (Data) throws -> Void
+    ) async throws -> VoiceSpeechStream {
+        openCount += 1
+        let stream = GatedVoiceStream()
+        streams.append(stream)
+        try onStart(24_000)
+        try onPCM16(Data(repeating: 1, count: 8), 24_000)
+        return stream
+    }
+}
+
+/// A stream whose `append` parks on an explicit continuation, giving tests a
+/// deterministic gate for "operation in flight across the boundary". `cancel`
+/// resolves the parked append with a cancellation error, exactly like the
+/// real speech websocket teardown.
+@MainActor
+private final class GatedVoiceStream: VoiceSpeechStream {
+    private(set) var appended: [String] = []
+    private(set) var parkedAppend = false
+    private(set) var cancelCount = 0
+    private(set) var isCancelled = false
+    /// True while no append is parked mid-flight.
+    private(set) var settled = true
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    func append(_ text: String) async throws {
+        appended.append(text)
+        parkedAppend = true
+        settled = false
+        defer {
+            parkedAppend = false
+            settled = true
+        }
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func finish() async throws -> Bool { true }
+
+    func cancel() {
+        guard !isCancelled else { return }
+        isCancelled = true
+        cancelCount += 1
+        continuation?.resume(throwing: URLError(.cancelled))
+        continuation = nil
+    }
+}

--- a/ConduitTests/AppStateServerReplacementSpeechTests.swift
+++ b/ConduitTests/AppStateServerReplacementSpeechTests.swift
@@ -37,8 +37,10 @@ final class AppStateServerReplacementSpeechTests: XCTestCase {
         XCTAssertEqual(harness.voiceController.state, .idle)
         XCTAssertEqual(harness.voiceCapture.stopCount, 1)
         XCTAssertFalse(harness.appState.showVoiceSheet)
-        // The outgoing gateway reference is gone: a later listen attempt with
-        // no new gateway fails closed instead of reaching server A.
+        // The outgoing gateway reference is gone — asserted directly, and
+        // behaviorally: a later listen attempt with no new gateway fails
+        // closed instead of reaching server A.
+        XCTAssertFalse(harness.voiceController.isGatewayAttached)
         await harness.voiceController.startListening()
         XCTAssertEqual(
             harness.voiceController.state,
@@ -143,7 +145,24 @@ final class AppStateServerReplacementSpeechTests: XCTestCase {
         let changed = harness.appState.prepareChatResumeForConnection(to: Self.serverB)
         XCTAssertTrue(changed)
 
-        // A fresh operation belonging to server B starts normally.
+        // A fresh operation belonging to server B starts normally. Installing
+        // the incoming connection's bridge first models the capability
+        // refresh that rebuilds gateway currency after a replacement: with a
+        // B bridge the B-built mock counts as current. Deleting the
+        // retirement's `readAloudGatewayBridge = nil` leaves the stale A
+        // bridge here, the mock is replaced by a real A-bound gateway, and
+        // this test fails — the line is pinned.
+        let bridgeB = DashboardTicketBridge(baseURL: Self.serverB)
+        harness.appState.installVoiceCapabilityStateForTesting(
+            bridge: bridgeB,
+            snapshot: VoiceCapabilitySnapshot(
+                isGatewayConnected: true,
+                supportsTranscription: true,
+                supportsSpeech: true,
+                unavailableReason: nil
+            ),
+            isVoiceEnabled: true
+        )
         let gatewayB = GatedVoiceGateway()
         harness.readAloudController.setGateway(gatewayB)
         let messageB = ChatMessage(id: "msg-b", role: .assistant, content: "Response B", timestamp: "2")
@@ -175,11 +194,13 @@ final class AppStateServerReplacementSpeechTests: XCTestCase {
         let changed = harness.appState.prepareChatResumeForConnection(to: Self.serverB)
         XCTAssertTrue(changed)
 
-        // Server B conversation: fresh gateway, fresh turn.
+        // Server B conversation: fresh gateway, fresh turn owning only B's
+        // session id. The late A deltas are rejected twice over — B's turn
+        // never submitted, so `isAwaitingVoiceAssistant` is false, and the
+        // A session id is not in B's expected set.
         let gatewayB = GatedVoiceGateway()
         harness.voiceController.setGateway(gatewayB)
-        harness.voiceController.beginVoiceTurn(sessionID: "b-session")
-        let listening = await harness.startVoiceListening()
+        let listening = await harness.startVoiceListening(sessionID: "b-session")
         XCTAssertTrue(listening)
         XCTAssertEqual(harness.voiceController.state, .listening)
 
@@ -210,6 +231,20 @@ final class AppStateServerReplacementSpeechTests: XCTestCase {
         let changed = harness.appState.prepareChatResumeForConnection(to: Self.serverB)
         XCTAssertTrue(changed)
 
+        // Install the incoming connection's bridge so the B-built mock counts
+        // as current (models the post-replacement capability refresh, and
+        // pins the retirement's `readAloudGatewayBridge = nil`).
+        let bridgeB = DashboardTicketBridge(baseURL: Self.serverB)
+        harness.appState.installVoiceCapabilityStateForTesting(
+            bridge: bridgeB,
+            snapshot: VoiceCapabilitySnapshot(
+                isGatewayConnected: true,
+                supportsTranscription: true,
+                supportsSpeech: true,
+                unavailableReason: nil
+            ),
+            isVoiceEnabled: true
+        )
         let gatewayB = GatedVoiceGateway()
         harness.readAloudController.setGateway(gatewayB)
         let messageB = ChatMessage(id: "msg-b", role: .assistant, content: "Response B", timestamp: "2")
@@ -252,8 +287,23 @@ final class AppStateServerReplacementSpeechTests: XCTestCase {
         XCTAssertGreaterThan(harness.readAloudPlayback.stopCount, readAloudStopBaseline)
         XCTAssertFalse(harness.voicePlayback.isPlaying)
         XCTAssertFalse(harness.readAloudPlayback.isPlaying)
+        XCTAssertFalse(harness.voiceController.isGatewayAttached)
+        XCTAssertNil(harness.readAloudController.gateway)
 
-        // A B-owned operation can claim playback normally afterwards.
+        // A B-owned operation can claim playback normally afterwards: model
+        // the incoming connection's capability refresh with a B bridge, then
+        // start the fresh read aloud.
+        let bridgeB = DashboardTicketBridge(baseURL: Self.serverB)
+        harness.appState.installVoiceCapabilityStateForTesting(
+            bridge: bridgeB,
+            snapshot: VoiceCapabilitySnapshot(
+                isGatewayConnected: true,
+                supportsTranscription: true,
+                supportsSpeech: true,
+                unavailableReason: nil
+            ),
+            isVoiceEnabled: true
+        )
         harness.readAloudController.setGateway(GatedVoiceGateway())
         let messageB = ChatMessage(id: "msg-b", role: .assistant, content: "Response B", timestamp: "2")
         harness.appState.toggleReadAloud(message: messageB)
@@ -280,6 +330,9 @@ final class AppStateServerReplacementSpeechTests: XCTestCase {
         // call now and must not resurrect anything either.
         let repeated = harness.appState.prepareChatResumeForConnection(to: Self.serverB)
         XCTAssertFalse(repeated)
+        // Literal mirrors AppState's private key; asserted behaviorally
+        // everywhere else, here it pins that the replacement identity
+        // committed even though no transport ever came up.
         XCTAssertEqual(
             harness.defaults.string(forKey: "conduit.chatResumeServerIdentity.v1"),
             Self.serverB
@@ -293,12 +346,20 @@ final class AppStateServerReplacementSpeechTests: XCTestCase {
 
     func testSameServerIdentityCallPreservesActiveSpeech() async {
         let harness = makeHarness()
-        _ = await harness.startVoiceListening()
+
+        // Read aloud first through AppState, THEN the voice conversation via
+        // the controller directly: AppState's read-aloud entry enforces
+        // mutual exclusion and would stop a live voice conversation, while
+        // the controller's own listening start does not touch read aloud.
+        // This setup is what makes both owners simultaneously live.
         let message = ChatMessage(id: "msg-a", role: .assistant, content: "Response A", timestamp: "1")
         harness.appState.toggleReadAloud(message: message)
         await harness.awaitUntil("read aloud playing") {
             harness.readAloudController.state == .playing(messageID: "msg-a")
         }
+        let listening = await harness.startVoiceListening()
+        XCTAssertTrue(listening)
+
         let voiceStopBaseline = harness.voicePlayback.stopCount
         let readAloudStopBaseline = harness.readAloudPlayback.stopCount
 
@@ -322,7 +383,7 @@ final class AppStateServerReplacementSpeechTests: XCTestCase {
 
     func testServerReplacementCancelsInFlightTTSSpeechTest() async {
         let harness = makeHarness()
-        let speechTest = Task {
+        let speechTest = Task { @MainActor in
             await harness.voiceController.runSpeechTest(text: "Conduit voice is ready for this profile.")
         }
         await harness.awaitUntil("the speech test parked in its stream append") {
@@ -333,10 +394,16 @@ final class AppStateServerReplacementSpeechTests: XCTestCase {
         let changed = harness.appState.prepareChatResumeForConnection(to: Self.serverB)
         XCTAssertTrue(changed)
 
+        // Bounded settle: if the retirement ever regresses, this fails at the
+        // awaitUntil timeout instead of hanging on the parked task.
+        await harness.awaitUntil("the retired speech test to settle") {
+            !harness.voiceController.hasLiveVoiceSession
+        }
         let result = await speechTest.value
         XCTAssertFalse(result.passed, "a retired speech test must not report success")
         XCTAssertEqual(harness.voiceController.state, .idle)
         XCTAssertFalse(harness.voiceController.hasLiveVoiceSession)
+        XCTAssertFalse(harness.voiceController.isGatewayAttached)
         XCTAssertEqual(harness.voiceGateway.streams[0].cancelCount, 1)
     }
 
@@ -364,6 +431,10 @@ final class AppStateServerReplacementSpeechTests: XCTestCase {
             playback: voicePlayback,
             deviceTranscriber: CountingTranscriber(),
             gateway: voiceGateway,
+            // Hermetic route: full duplex keeps capture unsuspended during
+            // assistant playback, so no assertion depends on the simulator's
+            // real AVAudioSession route.
+            routePolicyProvider: { .fullDuplex },
             submit: { _ in true },
             interrupt: { await interruptGate.wait() }
         )
@@ -439,8 +510,8 @@ final class AppStateServerReplacementSpeechTests: XCTestCase {
 
         /// Arms a live listening voice turn on the injected gateway.
         @discardableResult
-        func startVoiceListening() async -> Bool {
-            voiceController.beginVoiceTurn(sessionID: "a-session")
+        func startVoiceListening(sessionID: String = "a-session") async -> Bool {
+            voiceController.beginVoiceTurn(sessionID: sessionID)
             await voiceController.startListening()
             return voiceController.state == .listening
         }

--- a/ConduitTests/AppStateServerReplacementSpeechTests.swift
+++ b/ConduitTests/AppStateServerReplacementSpeechTests.swift
@@ -409,6 +409,7 @@ final class AppStateServerReplacementSpeechTests: XCTestCase {
         )
     }
 
+    @MainActor
     private struct Harness {
         let appState: AppState
         let defaults: UserDefaults

--- a/ConduitTests/AppStateServerReplacementSpeechTests.swift
+++ b/ConduitTests/AppStateServerReplacementSpeechTests.swift
@@ -68,9 +68,9 @@ final class AppStateServerReplacementSpeechTests: XCTestCase {
 
         XCTAssertEqual(harness.readAloudController.state, .idle)
         XCTAssertNil(harness.readAloudController.gateway)
-        // stop() plus the gateway-clear's own stop() both land on the same
-        // single retirement; the engine ends fully stopped either way.
-        XCTAssertGreaterThan(harness.readAloudPlayback.stopCount, stopBaseline)
+        // Exactly one teardown: the boundary's setGateway(nil) triggers the
+        // controller's authoritative Option-A stop.
+        XCTAssertEqual(harness.readAloudPlayback.stopCount, stopBaseline + 1)
         XCTAssertFalse(harness.readAloudPlayback.isPlaying)
         XCTAssertEqual(stream.cancelCount, 1)
     }
@@ -280,11 +280,11 @@ final class AppStateServerReplacementSpeechTests: XCTestCase {
         let changed = harness.appState.prepareChatResumeForConnection(to: Self.serverB)
         XCTAssertTrue(changed)
 
-        // Each retired owner ends fully stopped — the voice controller stops
-        // exactly once here (its gateway swap does not stop), the read aloud
-        // engine is stopped by the retirement and stays stopped.
+        // Each retired owner ends fully stopped with exactly one teardown —
+        // the voice controller's stop() and the read aloud controller's
+        // gateway-swap stop respectively.
         XCTAssertEqual(harness.voicePlayback.stopCount, voiceStopBaseline + 1)
-        XCTAssertGreaterThan(harness.readAloudPlayback.stopCount, readAloudStopBaseline)
+        XCTAssertEqual(harness.readAloudPlayback.stopCount, readAloudStopBaseline + 1)
         XCTAssertFalse(harness.voicePlayback.isPlaying)
         XCTAssertFalse(harness.readAloudPlayback.isPlaying)
         XCTAssertFalse(harness.voiceController.isGatewayAttached)
@@ -399,6 +399,11 @@ final class AppStateServerReplacementSpeechTests: XCTestCase {
         await harness.awaitUntil("the retired speech test to settle") {
             !harness.voiceController.hasLiveVoiceSession
         }
+        // Test-only backstop so a broken implementation fails the assertions
+        // instead of hanging the runner: the cancel is idempotent (a no-op
+        // when the retirement already cancelled the stream) and guarantees
+        // the parked task completes.
+        harness.voiceGateway.streams.first?.cancel()
         let result = await speechTest.value
         XCTAssertFalse(result.passed, "a retired speech test must not report success")
         XCTAssertEqual(harness.voiceController.state, .idle)


### PR DESCRIPTION
## Summary

Runtime hardening required before saved multi-server switching (#148). **This PR does not implement issue #148 itself** — no server registry, no Keychain namespacing, no switching UI, no push/notification/approval/Kanban changes.

**The ownership bug:** Voice Conversation and Read Aloud own speech transports that are independent of `HermesClient`. A `HermesVoiceGateway` binds one dashboard bridge + base URL + profile, and each spoken response opens its own ticket-minted speech websocket (`/api/audio/speak-stream` over a bare `URLSessionWebSocketTask`). When Conduit explicitly connected to a *different* Hermes server, `connect(with:)` swapped the client — but a voice conversation mid-utterance, an in-flight speech drain, or a playing Read Aloud kept the old gateway and kept streaming against (and playing audio from) the previous server. Only `disconnect()` stopped them, and its destructive logout semantics (credential/cookie/ticket erasure) are exactly what a future server switch must not trigger.

## The boundary chosen

`AppState.prepareChatResumeForConnection(to:)` is the single authoritative *"this connection belongs to a different Hermes server"* decision — it returns `true` only when the normalized server identity changes, and `connect()` (its only production caller) invokes it before the incoming bridge/client installs. Its identity-changed branch now calls the new `retireSpeechOperationsForServerReplacement(previousIdentity:identity:)`:

- `voiceConversationController.stop()` — generation bump makes every parked continuation (capture resume, speech drain, barge-in, provider tests) inert;
- `messageReadAloudController.setGateway(nil)` — the controller's pinned Option-A semantics perform the single authoritative stop (a nil outgoing gateway means nothing can be live, since an operation cannot start without one);
- `voiceConversationController.setGateway(nil)` + `readAloudGatewayBridge = nil` — the outgoing server's bridge can never be handed to a later operation;
- `showVoiceSheet = false` — the sheet closes as if the conversation had been explicitly ended.

Read Aloud is retired **exactly once** — teardown flows through the controller's own ownership semantics rather than duplicated stop calls from `AppState`.

**Deliberately NOT logout:** no credential, cookie, ticket, Cloudflare, or preference state is touched. If the incoming activation fails, the retirement is not rolled back — the outgoing server's speech is not valid merely because the replacement failed.

## Same-server semantics (deliberate, and pinned by a control test)

Speech survives same-server reconnects, exactly as the existing recovery model expects:

- `prepareDashboardBridge(for:)` **reuses** the bridge when the normalized URL is unchanged, so gateways stay bound to a live bridge across reconnects.
- Scheduled reconnects (`reconnectForRetry`) don't even call `prepareChatResumeForConnection`; silent re-auth calls `connect()` with the same origin → identity unchanged → `false` → no retirement.
- `switchProfile` (same server) never touches the boundary.
- The retirement also covers the stale-gateway-after-signout-then-login-elsewhere hole: signing into a *different* origin after `disconnect()` (which stops speech but leaves the gateway reference) clears that reference too.
- `testSameServerIdentityCallPreservesActiveSpeech` pins the same-server behavior (including the default-port folding case); the harness's seeding call pins that a first identity call with no stored identity retires nothing.

## setGateway semantics — pinned explicitly

- `MessageReadAloudController.setGateway` (**Option A**, pre-existing behavior, now documented): any swap stops the in-flight operation. One short single-message stream fully bound to its gateway, so a swap mid-operation is always an ownership change.
- `VoiceConversationController.setGateway` (**Option B**, now documented): swaps affect future operations only. Capability refreshes deliberately install fresh-*but-equivalent* instances (same bridge/server/profile) mid-conversation, so pointer inequality is not an ownership signal; connection replacement stops the controller explicitly at the boundary. The forbidden sequence (operation on A → `setGateway(B)` → operation continues against A's server) cannot occur: the boundary stops the conversation before any new gateway is installed.

## Provider-test audit (spec §3)

`runTranscriptionTest` / `runSpeechTest` are **server-bound**: they build their gateway via `makeVoiceGateway()` (current bridge + base URL + profile) and share the controller's `operationGeneration` / `isVoiceSessionActive` / `isProviderTestRunning` ownership model. The boundary retires them identically — covered by `testServerReplacementCancelsInFlightTTSSpeechTest`. One residual window is accepted and documented: a transcription/speech HTTP request already in flight when the boundary fires still reaches the outgoing server, but its result is discarded by the post-await generation guard and nothing mutates UI, capture, or playback. That is the same class as the explicitly out-of-scope Kanban HTTP-commit concern (no await exists between the last fence and the request start, so a pre-check would be dead code; cancelling in-flight URL requests would require new gateway cancellation plumbing = scope creep).

## Tests

`ConduitTests/AppStateServerReplacementSpeechTests.swift` — 10 deterministic tests (continuation-gated mock streams, an `InterruptGate` with entry/released markers, explicit-date VAD samples, fixed route policy; no wall-clock ordering, no physical audio hardware):

1. voice conversation A→B stopped, capture retired, gateway cleared, sheet closed
2. read aloud A→B stopped, standalone ownership released, stream cancelled
3. parked assistant-speech drain continuation settles inert (no capture restart, no old-gateway reopen)
4. parked barge-in continuation released *after* the switch cannot resurrect the microphone
5. late A callbacks cannot touch a fresh B voice conversation (session-ID + not-awaiting fences)
6. late A stream failure cannot disturb a fresh B read aloud
7. playback ownership retired once per owner; a B operation claims it normally afterwards
8. replacement identity persists with no transport; a repeat same-identity call resurrects nothing (failed-activation semantics)
9. same-server control: identical + default-port-folded identities leave live speech untouched
10. in-flight TTS provider test is retired and reports failure, never success

The B-operation tests install the incoming connection's bridge first, modeling the post-replacement capability refresh — this also pins the retirement's `readAloudGatewayBridge = nil` line (removing it swaps the mock for a real A-bound gateway and fails the tests).

## Verification

Mac (ios-mac, iPhone 17 Pro simulator), focused runs:

```
@ 7111ae1:  ** TEST SUCCEEDED ** — 361 passed, 0 failed (11 regression suites + the new suite)
@ 97b356e:  ** TEST SUCCEEDED ** —  93 passed, 0 failed (follow-up re-run: the 5 voice/read-aloud suites)
```

Suites: the new `AppStateServerReplacementSpeechTests` (10) plus regression: `VoiceConversationControllerTests`, `MessageReadAloudControllerTests`, `AppStateReadAloudTests`, `VoiceAudioSessionCoordinatorTests`, `VoiceSpeakerSafeBargeInTests`, `VoiceBargeInRoutePolicyTests`, `ConnectionRepairTests`, `AppStateChatResumeTests`, `AppStateForegroundLifecycleTests`, `AppStateVoiceCapabilityTests`, `HapticsVoiceIsolationTests`.

Follow-up (`97b356e`): Read Aloud retirement collapsed to the single authoritative teardown through the controller's Option-A `setGateway` (tests now pin `stopCount` exactly), and the TTS provider-test regression test gained a test-only idempotent backstop so the regression it detects can never hang the runner.

## Review

Three-model review cycle ran before push. Fixed from review: test 5/7 post-replacement gateway-currency setup (would have failed unconditionally), test 9 setup ordering (mutual exclusion killed the voice state it asserted), direct `isGatewayAttached` assertions (new observability seam), bounded settle for test 10, hermetic route policy, `.private` log identities. Rejected with rationale: a pre-`transcribe` `isCurrent` check (no await between the fence and request start on the main actor — dead code), and stopping the voice conversation in `performSignInRequired` (pre-existing gap unrelated to server replacement — flagged as a fast-follow).

## Non-goals (unchanged)

No #148 registry/persistence/UI, no notification server identity, no approval/clarify fencing, no Kanban changes, no cookie-mirror namespacing, no Voice UI/VAD/audio-session-policy changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling when switching servers so active voice conversations, read-aloud playback, and speech tests are stopped cleanly.
  - Prevented delayed callbacks from previous server connections from affecting new speech operations.
  - Preserved ongoing speech when reconnecting to the same server, including equivalent server addresses and default ports.
  - Improved cleanup after unsuccessful server activation to ensure the replacement server remains selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->