### PR TITLE
fix(decisions): fence native approval/clarify completions to the owning client

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -9506,6 +9506,13 @@ final class AppState: ObservableObject {
             return
         }
         let question = activity.questions[questionIndex]
+        // Ownership snapshot for the gateway-owned respond below — same fence
+        // as `respondToApproval`: a completion (success or failure) from a
+        // replaced client must not touch whatever decision state is current,
+        // even under colliding ids. The relay branch above is deliberately
+        // NOT fenced: it is owned by the relay registration, not by this
+        // HermesClient (push server identity is a separate prerequisite).
+        let profile = activeProfile
         // The wire answer for a multi-select question must be the array form
         // Hermes' batch parser accepts; typed custom text arrives as a bare
         // string and is wrapped here so every multi-select path is uniform.
@@ -9525,6 +9532,7 @@ final class AppState: ObservableObject {
                 // respond shape every gateway generation accepts.
                 questionId: question.isSyntheticID ? nil : question.id
             )
+            guard profile == activeProfile, self.client === client else { return }
             applyClarifyResponseOutcome(
                 outcome,
                 requestId: requestId,
@@ -9532,6 +9540,7 @@ final class AppState: ObservableObject {
                 answer: wireAnswer
             )
         } catch {
+            guard profile == activeProfile, self.client === client else { return }
             if Self.isExpiredPromptError(error) {
                 // Older gateways report expiry as RPC 4009 instead of the
                 // typed `expired` status — same teardown either way.
@@ -10899,12 +10908,23 @@ final class AppState: ObservableObject {
             cacheMessagePresentation()
             return
         }
+        // Ownership snapshot: the completion below may only land while this
+        // exact client (and profile) still owns AppState. A client/server
+        // replacement while the RPC is suspended must turn the stale
+        // continuation inert — success and failure alike — even when profile,
+        // session, and message ids collide across the two connections. This
+        // is the same fence `loadProjects`/`synchronizeTransportContinuation`
+        // use; only client ownership changed here, so no epoch beyond the
+        // pointer identity is needed.
+        let profile = activeProfile
         do {
             try await client.respondToApproval(sessionId: current.sessionId, choice: choice)
+            guard profile == activeProfile, self.client === client else { return }
             guard let updatedIndex = messages.firstIndex(where: { $0.id == messageId }) else { return }
             messages[updatedIndex].approval?.status = choice == "deny" ? .rejected : .approved
             cacheMessagePresentation()
         } catch {
+            guard profile == activeProfile, self.client === client else { return }
             guard let updatedIndex = messages.firstIndex(where: { $0.id == messageId }) else { return }
             messages[updatedIndex].approval?.status = .error
             messages[updatedIndex].approval?.choice = nil

--- a/ConduitTests/AppStateDecisionFenceTests.swift
+++ b/ConduitTests/AppStateDecisionFenceTests.swift
@@ -1,0 +1,367 @@
+//
+//  AppStateDecisionFenceTests.swift
+//  Conduit
+//
+//  Regression coverage for stale-client fencing on native Hermes decision
+//  responses: an approval/clarify respond that was sent through HermesClient
+//  A may complete on A after client B has become authoritative (the wire
+//  mutation already reached A — that is fine), but its continuation must not
+//  mutate AppState. Client identity is the fence, deliberately, so identical
+//  profile/session/message ids across two connections cannot leak state.
+//
+//  The fake socket/transport (shared with ClarifyBatchStateTests) parks the
+//  real RPC between send and response, making "operation in flight across a
+//  client replacement" deterministic without sleeps.
+//
+
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class AppStateDecisionFenceTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func approvalFixture(status: ApprovalActivity.Status = .pending) -> ChatMessage {
+        ChatMessage(
+            id: "approval-msg",
+            role: .approval,
+            content: "Run the deploy?",
+            timestamp: "1",
+            approval: ApprovalActivity(
+                sessionId: "default",
+                command: "deploy",
+                description: "Run the deploy?",
+                choices: nil,
+                allowPermanent: false,
+                smartDenied: false,
+                status: status,
+                choice: nil,
+                error: nil
+            )
+        )
+    }
+
+    private func clarifyFixture(requestId: String = "req-gw") -> ChatMessage {
+        ChatMessage(
+            id: "clarify-\(requestId)",
+            role: .clarify,
+            content: "clarify",
+            timestamp: "2",
+            clarify: ClarifyActivity(
+                requestId: requestId,
+                questions: [
+                    ClarifyQuestion(
+                        id: "environment",
+                        question: "Which environment?",
+                        choices: [ClarifyChoice(label: "staging", value: "staging"), ClarifyChoice(label: "prod", value: "prod")]
+                    )
+                ]
+            )
+        )
+    }
+
+    private func makeAppState() -> AppState {
+        let suite = "AppStateDecisionFenceTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Failed to create test UserDefaults suite")
+        }
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suite)
+        }
+        let cache = SessionPresentationCache(defaults: defaults)
+        return AppState(
+            defaults: defaults,
+            loadSavedConnection: false,
+            clearSessionPresentationCache: {},
+            sessionPresentationCache: cache
+        )
+    }
+
+    private func installConnectedClient(
+        _ appState: AppState,
+        socket: ClarifyFakeSocket,
+        transport: ClarifyFakeTransport
+    ) async throws -> HermesClient {
+        let connection = HermesConnection(baseUrl: "https://one.example", ticket: "ticket")
+        let client = HermesClient(
+            connection: connection,
+            profile: "default",
+            transportFactory: { transport }
+        )
+        transport.nextSocket = { socket }
+        appState.connection = connection
+        appState.client = client
+        let connectTask = Task { try await client.connect() }
+        transport.open(socket)
+        _ = try await connectTask.value
+        return client
+    }
+
+    /// An unconnected client instance: never opens a socket, so it is inert
+    /// by construction, but it is a DIFFERENT HermesClient object — exactly
+    /// what the ownership fence must discriminate.
+    private func makeReplacementClient(baseURL: String) -> HermesClient {
+        HermesClient(
+            connection: HermesConnection(baseUrl: baseURL, ticket: "replaced"),
+            profile: "default"
+        )
+    }
+
+    // MARK: - Park/release helpers
+
+    private struct ParkedRPC {
+        let task: Task<Void, Never>
+        let rpcID: Int
+    }
+
+    private func parkApprovalRespond(
+        appState: AppState,
+        socket: ClarifyFakeSocket,
+        choice: String = "approve"
+    ) async throws -> ParkedRPC {
+        let sent = ClarifyGate()
+        socket.onSend = { sent.signal() }
+        let task = Task {
+            await appState.respondToApproval(messageId: "approval-msg", choice: choice)
+        }
+        try await sent.wait("the approval.respond request to be sent")
+        let request = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(try XCTUnwrap(socket.sentTexts.last).utf8)) as? [String: Any]
+        )
+        return ParkedRPC(task: task, rpcID: try XCTUnwrap(request["id"] as? Int))
+    }
+
+    private func parkClarifyRespond(
+        appState: AppState,
+        socket: ClarifyFakeSocket,
+        requestId: String = "req-gw"
+    ) async throws -> ParkedRPC {
+        let sent = ClarifyGate()
+        socket.onSend = { sent.signal() }
+        let task = Task {
+            await appState.respondToClarify(requestId: requestId, questionId: "environment", answer: "staging")
+        }
+        try await sent.wait("the clarify.respond request to be sent")
+        let request = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(try XCTUnwrap(socket.sentTexts.last).utf8)) as? [String: Any]
+        )
+        return ParkedRPC(task: task, rpcID: try XCTUnwrap(request["id"] as? Int))
+    }
+
+    private func deliverResult(_ socket: ClarifyFakeSocket, rpcID: Int, result: [String: Any]) {
+        socket.deliver(String(
+            decoding: try! JSONSerialization.data(
+                withJSONObject: ["jsonrpc": "2.0", "id": rpcID, "result": result]
+            ),
+            as: UTF8.self
+        ))
+    }
+
+    private func deliverError(_ socket: ClarifyFakeSocket, rpcID: Int, code: Int, message: String) {
+        socket.deliver(String(
+            decoding: try! JSONSerialization.data(
+                withJSONObject: ["jsonrpc": "2.0", "id": rpcID, "error": ["code": code, "message": message]]
+            ),
+            as: UTF8.self
+        ))
+    }
+
+    // MARK: - Stale approval completions
+
+    func testStaleApprovalSuccessCannotMutateReplacedClientState() async throws {
+        let appState = makeAppState()
+        appState.messages = [approvalFixture()]
+        let transport = ClarifyFakeTransport()
+        let socket = ClarifyFakeSocket()
+        _ = try await installConnectedClient(appState, socket: socket, transport: transport)
+
+        let parked = try await parkApprovalRespond(appState: appState, socket: socket)
+
+        // Client B becomes authoritative and rebuilds its own decision state
+        // under IDENTICAL ids (profile "default", session "default", message
+        // "approval-msg"): only client identity may discriminate ownership.
+        appState.client = makeReplacementClient(baseURL: "https://two.example")
+        appState.messages = [approvalFixture()]
+
+        deliverResult(socket, rpcID: parked.rpcID, result: [:])
+        await parked.task.value
+
+        let card = try XCTUnwrap(appState.messages.first?.approval)
+        XCTAssertEqual(card.status, .pending, "A stale approval success must not mark B's card approved")
+        XCTAssertNil(card.choice)
+        XCTAssertNil(card.error)
+        XCTAssertNil(appState.errorMessage)
+    }
+
+    func testStaleApprovalFailureCannotMutateReplacedClientState() async throws {
+        let appState = makeAppState()
+        appState.messages = [approvalFixture()]
+        let transport = ClarifyFakeTransport()
+        let socket = ClarifyFakeSocket()
+        _ = try await installConnectedClient(appState, socket: socket, transport: transport)
+
+        let parked = try await parkApprovalRespond(appState: appState, socket: socket)
+
+        appState.client = makeReplacementClient(baseURL: "https://two.example")
+        appState.messages = [approvalFixture()]
+
+        deliverError(socket, rpcID: parked.rpcID, code: 4002, message: "unknown session")
+        await parked.task.value
+
+        let card = try XCTUnwrap(appState.messages.first?.approval)
+        XCTAssertEqual(card.status, .pending, "A stale approval failure must not mark B's card errored")
+        XCTAssertNil(card.choice)
+        XCTAssertNil(card.error)
+        XCTAssertNil(appState.errorMessage, "A stale failure must not surface a user-facing banner on B")
+    }
+
+    // MARK: - Stale native clarify completions
+
+    func testStaleClarifySuccessCannotMutateReplacedClientState() async throws {
+        let appState = makeAppState()
+        appState.messages = [clarifyFixture()]
+        let transport = ClarifyFakeTransport()
+        let socket = ClarifyFakeSocket()
+        _ = try await installConnectedClient(appState, socket: socket, transport: transport)
+
+        let parked = try await parkClarifyRespond(appState: appState, socket: socket)
+
+        appState.client = makeReplacementClient(baseURL: "https://two.example")
+        appState.messages = [clarifyFixture()]
+
+        deliverResult(socket, rpcID: parked.rpcID, result: ["status": "ok", "remaining": []])
+        await parked.task.value
+
+        let card = try XCTUnwrap(appState.messages.first?.clarify)
+        XCTAssertEqual(card.questions[0].status, .pending, "A stale clarify success must not answer B's question")
+        XCTAssertNil(card.questions[0].answer)
+        XCTAssertEqual(card.status, .pending)
+    }
+
+    func testStaleClarifyFailureCannotMutateReplacedClientState() async throws {
+        let appState = makeAppState()
+        appState.messages = [clarifyFixture()]
+        let transport = ClarifyFakeTransport()
+        let socket = ClarifyFakeSocket()
+        _ = try await installConnectedClient(appState, socket: socket, transport: transport)
+
+        let parked = try await parkClarifyRespond(appState: appState, socket: socket)
+
+        appState.client = makeReplacementClient(baseURL: "https://two.example")
+        appState.messages = [clarifyFixture()]
+
+        deliverError(socket, rpcID: parked.rpcID, code: 4002, message: "unknown question_id")
+        await parked.task.value
+
+        let card = try XCTUnwrap(appState.messages.first?.clarify)
+        XCTAssertEqual(card.questions[0].status, .pending, "A stale clarify failure must not error B's question")
+        XCTAssertNil(card.questions[0].error)
+        XCTAssertNil(appState.errorMessage)
+    }
+
+    // MARK: - Same-client controls: existing behavior unchanged
+
+    func testSameClientApprovalSuccessStillCommits() async throws {
+        let appState = makeAppState()
+        appState.messages = [approvalFixture()]
+        let transport = ClarifyFakeTransport()
+        let socket = ClarifyFakeSocket()
+        _ = try await installConnectedClient(appState, socket: socket, transport: transport)
+
+        let parked = try await parkApprovalRespond(appState: appState, socket: socket)
+        deliverResult(socket, rpcID: parked.rpcID, result: [:])
+        await parked.task.value
+
+        let card = try XCTUnwrap(appState.messages.first?.approval)
+        XCTAssertEqual(card.status, .approved)
+        XCTAssertEqual(card.choice, "approve")
+    }
+
+    func testSameClientApprovalFailureStillReportsOnError() async throws {
+        let appState = makeAppState()
+        appState.messages = [approvalFixture()]
+        let transport = ClarifyFakeTransport()
+        let socket = ClarifyFakeSocket()
+        _ = try await installConnectedClient(appState, socket: socket, transport: transport)
+
+        let parked = try await parkApprovalRespond(appState: appState, socket: socket)
+        deliverError(socket, rpcID: parked.rpcID, code: 4002, message: "denied by policy")
+        await parked.task.value
+
+        let card = try XCTUnwrap(appState.messages.first?.approval)
+        XCTAssertEqual(card.status, .error)
+        XCTAssertEqual(card.error, "Hermes did not accept that decision.")
+        XCTAssertEqual(appState.errorMessage, "denied by policy")
+    }
+
+    func testSameClientClarifySuccessStillCommits() async throws {
+        let appState = makeAppState()
+        appState.messages = [clarifyFixture()]
+        let transport = ClarifyFakeTransport()
+        let socket = ClarifyFakeSocket()
+        _ = try await installConnectedClient(appState, socket: socket, transport: transport)
+
+        let parked = try await parkClarifyRespond(appState: appState, socket: socket)
+        deliverResult(socket, rpcID: parked.rpcID, result: ["status": "ok", "remaining": []])
+        await parked.task.value
+
+        let card = try XCTUnwrap(appState.messages.first?.clarify)
+        XCTAssertEqual(card.questions[0].status, .answered)
+        XCTAssertEqual(card.questions[0].answer, "staging")
+        XCTAssertEqual(card.status, .answered, "A fully answered single-question request completes")
+    }
+
+    // MARK: - A → B → A (ABA)
+
+    func testOriginalOperationStaysStaleAfterABAReconnect() async throws {
+        let appState = makeAppState()
+        appState.messages = [approvalFixture()]
+        let transportA1 = ClarifyFakeTransport()
+        let socketA1 = ClarifyFakeSocket()
+        _ = try await installConnectedClient(appState, socket: socketA1, transport: transportA1)
+
+        let parked = try await parkApprovalRespond(appState: appState, socket: socketA1)
+
+        // A → B → A: the "A" that comes back is a NEW HermesClient instance
+        // even though the server URL matches the original. Pointer identity
+        // must reject the A1 continuation — URL equality must not revive it.
+        appState.client = makeReplacementClient(baseURL: "https://two.example")
+        let transportA2 = ClarifyFakeTransport()
+        let socketA2 = ClarifyFakeSocket()
+        let clientA2 = try await installConnectedClient(appState, socket: socketA2, transport: transportA2)
+        appState.messages = [approvalFixture()]
+
+        deliverResult(socketA1, rpcID: parked.rpcID, result: [:])
+        await parked.task.value
+
+        XCTAssertTrue(appState.client === clientA2, "A2 remains authoritative")
+        let card = try XCTUnwrap(appState.messages.first?.approval)
+        XCTAssertEqual(card.status, .pending, "The A1 completion must stay stale across the ABA reconnect")
+        XCTAssertNil(card.choice)
+    }
+
+    // MARK: - Relay clarify control (B3 out of scope, path must keep working)
+
+    func testRelayClarifyStillRoutesWithoutHermesClient() async {
+        // A relay-prefixed request is owned by the relay registration, not by
+        // the HermesClient: with NO client at all it must still take the
+        // relay branch (and fail with the relay's own error, never the
+        // gateway-unavailable error the client-owned branch would produce).
+        KeychainHelper.clearPushRegistration()
+        let appState = makeAppState()
+        let requestId = PendingDecisionPayload.relayRequestPrefix + "abc"
+        appState.messages = [clarifyFixture(requestId: requestId)]
+        appState.client = nil
+
+        await appState.respondToClarify(requestId: requestId, questionId: "environment", answer: "staging")
+
+        let card = appState.messages.first?.clarify
+        XCTAssertEqual(card?.questions[0].status, .error, "The relay attempt runs and reports its own outcome")
+        XCTAssertNotEqual(
+            card?.questions[0].error,
+            "Gateway connection is unavailable.",
+            "The relay branch must be reachable without any HermesClient"
+        )
+    }
+}

--- a/ConduitTests/AppStateDecisionFenceTests.swift
+++ b/ConduitTests/AppStateDecisionFenceTests.swift
@@ -269,13 +269,29 @@ final class AppStateDecisionFenceTests: XCTestCase {
         let socket = ClarifyFakeSocket()
         _ = try await installConnectedClient(appState, socket: socket, transport: transport)
 
-        let parked = try await parkApprovalRespond(appState: appState, socket: socket)
+        let parked = try await parkApprovalRespond(appState: appState, socket: socket, choice: "approve")
         deliverResult(socket, rpcID: parked.rpcID, result: [:])
         await parked.task.value
 
         let card = try XCTUnwrap(appState.messages.first?.approval)
         XCTAssertEqual(card.status, .approved)
         XCTAssertEqual(card.choice, "approve")
+    }
+
+    func testSameClientApprovalDenyStillRejects() async throws {
+        let appState = makeAppState()
+        appState.messages = [approvalFixture()]
+        let transport = ClarifyFakeTransport()
+        let socket = ClarifyFakeSocket()
+        _ = try await installConnectedClient(appState, socket: socket, transport: transport)
+
+        let parked = try await parkApprovalRespond(appState: appState, socket: socket, choice: "deny")
+        deliverResult(socket, rpcID: parked.rpcID, result: [:])
+        await parked.task.value
+
+        let card = try XCTUnwrap(appState.messages.first?.approval)
+        XCTAssertEqual(card.status, .rejected)
+        XCTAssertEqual(card.choice, "deny")
     }
 
     func testSameClientApprovalFailureStillReportsOnError() async throws {
@@ -348,7 +364,15 @@ final class AppStateDecisionFenceTests: XCTestCase {
         // the HermesClient: with NO client at all it must still take the
         // relay branch (and fail with the relay's own error, never the
         // gateway-unavailable error the client-owned branch would produce).
+        // The registration clear is global state — save/restore around it so
+        // the test stays hermetic for other suites.
+        let priorRegistration = KeychainHelper.loadPushRegistration()
         KeychainHelper.clearPushRegistration()
+        addTeardownBlock {
+            if let priorRegistration {
+                KeychainHelper.savePushRegistration(priorRegistration)
+            }
+        }
         let appState = makeAppState()
         let requestId = PendingDecisionPayload.relayRequestPrefix + "abc"
         appState.messages = [clarifyFixture(requestId: requestId)]

--- a/ConduitTests/ClarifyBatchStateTests.swift
+++ b/ConduitTests/ClarifyBatchStateTests.swift
@@ -1143,7 +1143,8 @@ final class ClarifyBatchStateTests: XCTestCase {
     }
 }
 
-// MARK: - Test doubles (mirrors the HermesClientTests fakes; private to this file)
+// MARK: - Test doubles (mirrors the HermesClientTests fakes; internal to the
+// ConduitTests target so AppStateDecisionFenceTests can reuse them)
 
 final class ClarifyGate: @unchecked Sendable {
     private let lock = NSLock()

--- a/ConduitTests/ClarifyBatchStateTests.swift
+++ b/ConduitTests/ClarifyBatchStateTests.swift
@@ -1145,7 +1145,7 @@ final class ClarifyBatchStateTests: XCTestCase {
 
 // MARK: - Test doubles (mirrors the HermesClientTests fakes; private to this file)
 
-private final class ClarifyGate: @unchecked Sendable {
+final class ClarifyGate: @unchecked Sendable {
     private let lock = NSLock()
     private var signalled = false
     private var continuation: CheckedContinuation<Bool, Never>?
@@ -1201,7 +1201,7 @@ private struct ClarifyTestTimedOut: Error {
     let phase: String
 }
 
-private final class ClarifyFakeSocket: HermesWebSocket {
+final class ClarifyFakeSocket: HermesWebSocket {
     var closeCode: URLSessionWebSocketTask.CloseCode = .invalid
     private(set) var sentTexts: [String] = []
     var onSend: (() -> Void)?
@@ -1235,7 +1235,7 @@ private final class ClarifyFakeSocket: HermesWebSocket {
     }
 }
 
-private final class ClarifyFakeTransport: HermesWebSocketTransport {
+final class ClarifyFakeTransport: HermesWebSocketTransport {
     var nextSocket: (() -> ClarifyFakeSocket)?
     private var openCallbacks: [ObjectIdentifier: () -> Void] = [:]
     private var earlyOpenRequests = Set<ObjectIdentifier>()


### PR DESCRIPTION
## Summary

B2 runtime hardening required before saved multi-server switching (#148). **This PR does not implement issue #148 itself** — no server registry, no Keychain namespacing, no switching UI, and it does **not** solve push/relay server identity (that is B3, a separate prerequisite). It fences native approval/clarify response completions to the exact Hermes client that initiated them.

**The bug (from the multi-server recon):** `AppState.respondToApproval(...)` and the gateway branch of `AppState.respondToClarify(...)` were the only unfenced post-`await` state commits of their kind in `AppState`. They captured the current `HermesClient`, awaited the RPC, and then mutated decision-card/message state — but because `AppState` is an actor, a connection replacement can re-enter while the RPC is suspended. A stale continuation from outgoing client A would then mark whatever decision state is current as approved/rejected/answered/error — or surface A's failure banner — even when server B collides on every string id (`profile = default`, `session = default`, same message/request/question ids). Every other long-lived operation in `AppState` already uses this fence; these two paths simply never got it.

## The fix

Both paths snapshot ownership **before** the first re-entrant await:

```swift
let profile = activeProfile
...await client.respondToApproval/respondToClarification...
guard profile == activeProfile, self.client === client else { return }
```

- **Both continuations are fenced** — success and failure alike (stale errors must not produce "Failed to respond" state or a banner on B).
- **Stale continuations return silently.** No compensating mutations, no restoring pending, no logging of decision content. The `.submitting` state the outgoing connection set before the await is intentionally left alone — the server-change boundary (PR #150's `prepareChatResumeForConnection` + this same fence family) rebuilds outgoing state.
- **ABA is covered by pointer identity.** A1 → B → A2 (fresh `HermesClient`, same URL) does not revive A1's completion: `HermesClient.connection` is a `let` and every `self.client` write swaps the whole object, so `===` can never pass wrongly. A dedicated test pins this with URL-matched A1/A2.
- **Same-client behavior is byte-for-byte unchanged** (verified by direct pre/post diff and controls): submitting → approved/rejected by choice; failure → `.error` with the existing texts and banner; clarify success → per-question `remaining` semantics; clarify failure → error-restore; expired (4009) → teardown. Same-server navigation away still legitimately completes.
- **No cancellation plumbing** — a wire mutation that already reached server A completing there is accepted; the invariant is only that A's completion cannot mutate B's local state.

## Relay clarifies are deliberately NOT fenced

`respondToClarify` branches on `PendingDecisionPayload.relayRequestPrefix` before the client guard: relay-backed cards are answered through the notifier relay registration, not the active `HermesClient`, so client fencing is meaningless there — and fencing it on client identity would break answering from a freshly-resumed push while the gateway client reconnects. A control test proves the relay branch executes with **no** client installed and reports the relay's own outcome (never the gateway-unavailable error). Cross-server push routing and relay continuation ownership are exactly prerequisite **B3**, not this PR.

## Tests

`ConduitTests/AppStateDecisionFenceTests.swift` — 10 deterministic tests driving the **real `HermesClient` RPC** through the fake WebSocket (fakes shared with `ClarifyBatchStateTests`, promoted to internal): the operation parks between send and response, the client is replaced, then the parked continuation is released. Gates only — no sleeps.

1. stale approval success after A→B cannot mutate B's state (B rebuilds colliding ids first)
2. stale approval failure after A→B: no error card, no banner
3. stale clarify success after A→B: question untouched
4. stale clarify failure after A→B: no error, no banner
5. colliding identifiers: tests 1–4 model B state with literally identical profile/session/message/request/question ids — client identity is the only discriminator
6. same-client approval success control (approved)
7. same-client approval deny control (rejected)
8. same-client approval failure control (`.error` + banner text)
9. same-client clarify success control (answered + remaining semantics)
10. A→B→A ABA: URL-matched fresh client does not revive A1
11. relay clarify control: routes and reports without any `HermesClient` (registration cleared + restored around the test)

Also promoted `ClarifyGate`/`ClarifyFakeSocket`/`ClarifyFakeTransport` from file-private to internal (no symbol collisions; only these two suites use them).

## Verification

Mac (ios-mac, temp worktree @ `266dbfe`, iPhone 17 Pro simulator), focused run:

```
** TEST SUCCEEDED ** — 352 passed, 0 failed (10 fence tests + 342 regression)
```

Suites: the new `AppStateDecisionFenceTests` plus `ClarifyBatchStateTests` (batch clarify lifecycle through the new fences), `AppStateChatResumeTests` (resume + pending-decision promotion), `SessionIdentityContractTests` (decision routing contracts), `MessageNormalizerTests` (payload normalization), `SessionPresentationCacheTests` (decision-card presentation).

## Non-goals (unchanged)

No saved servers/registry/`activeServerID`, no Keychain namespacing or migration, no server picker, no push server identity or relay changes (B3), no cookie partitioning, no Kanban/voice changes, no generic cancellation framework, no changes to PR #150's speech-retirement behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented delayed approval and clarification responses from updating decision cards after a client or profile switch.
  - Improved reliability during reconnects, including cases where a previous connection is replaced and later restored.
  - Preserved expected behavior for responses from the currently active connection and for relay-based clarification requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->