### PR TITLE
test: stabilize copy confirmation and CI UI launches

### DIFF
--- a/Conduit/Views/AskHermesPromptView.swift
+++ b/Conduit/Views/AskHermesPromptView.swift
@@ -16,6 +16,11 @@ struct AskHermesPromptView: View {
 
     @State private var copied = false
     @State private var copyCount = 0
+    // Keep the successful copy available as durable accessibility state even
+    // after the intentionally short visual confirmation disappears. Tying it
+    // to the prompt prevents a reused view from claiming a different prompt
+    // was copied.
+    @State private var lastCopiedPrompt: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -33,12 +38,14 @@ struct AskHermesPromptView: View {
                 Button {
                     UIPasteboard.general.string = prompt
                     copied = true
+                    lastCopiedPrompt = prompt
                     copyCount += 1
                 } label: {
                     Label("Copy Prompt", systemImage: copied ? "checkmark" : "doc.on.doc")
                         .font(.footnote.weight(.semibold))
                 }
                 .accessibilityIdentifier("setup.copy-prompt")
+                .accessibilityValue(Text(lastCopiedPrompt == prompt ? "Copied" : ""))
 
                 if copied {
                     Text("Copied")

--- a/ConduitUITests/ConnectionSetupUITests.swift
+++ b/ConduitUITests/ConnectionSetupUITests.swift
@@ -172,9 +172,18 @@ final class ConnectionSetupUITests: XCTestCase {
         XCTAssertTrue(copyPrompt.waitForExistence(timeout: 5), "Copy Prompt must appear on the No path")
         if !copyPrompt.isHittable { app.swipeUp() }
         copyPrompt.tap()
-        XCTAssertTrue(
-            app.staticTexts["setup.copied-confirmation"].waitForExistence(timeout: 3),
-            "Copying must confirm to the user"
+        // The visual "Copied" label is intentionally transient (2s), which
+        // is shorter than XCTest's post-tap idle/snapshot work on hosted
+        // runners. Assert the button's durable accessibility state instead:
+        // it proves the copy action happened without racing the visual toast.
+        let copied = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "value == %@", "Copied"),
+            object: copyPrompt
+        )
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [copied], timeout: 3),
+            .completed,
+            "Copying must confirm to accessibility after the visual toast expires"
         )
 
         let continueButton = app.buttons["setup.continue"]

--- a/project.yml
+++ b/project.yml
@@ -59,3 +59,23 @@ targets:
         GENERATE_INFOPLIST_FILE: YES
     dependencies:
       - target: Conduit
+
+# CI gets its own shared scheme so local Cmd+U / debugger behavior stays
+# unchanged. UI tests do not need LLDB attached in hosted CI, and Xcode 26.x's
+# debugger-backed simulator launcher is the source of the intermittent
+# DebuggerVersionStore / "Timed out while launching application via Xcode"
+# failures seen on GitHub runners. PosixSpawn keeps the same tests and app
+# binary while removing that debugger-only launch path.
+schemes:
+  ConduitCI:
+    build:
+      targets:
+        Conduit: all
+        ConduitTests: [test]
+        ConduitUITests: [test]
+    test:
+      config: Debug
+      debugEnabled: false
+      targets:
+        - ConduitTests
+        - ConduitUITests

--- a/scripts/ci-build-for-testing.sh
+++ b/scripts/ci-build-for-testing.sh
@@ -14,7 +14,12 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/ci-lib.sh"
 
 PROJECT="Conduit.xcodeproj"
-SCHEME="Conduit"
+# CI uses a dedicated shared scheme whose test action has debugging disabled.
+# Local developers keep using the normal Conduit scheme with debugger-backed
+# tests; hosted UI tests do not need LLDB and avoid Xcode 26.x's flaky
+# debugger simulator-launch path this way. Override remains available for
+# diagnosis or local script use.
+SCHEME="${SCHEME:-ConduitCI}"
 # Workspace-anchored by default: GITHUB_WORKSPACE is byte-identical across
 # GitHub-hosted runners for the same repository, which is what makes the
 # absolute paths inside the .xctestrun portable without rewriting anything.

--- a/scripts/tests/test_ci_scheme_contract.py
+++ b/scripts/tests/test_ci_scheme_contract.py
@@ -1,0 +1,39 @@
+"""Contracts for the CI-only Xcode scheme used by build-for-testing."""
+
+import os
+import unittest
+
+from _util import SCRIPTS_DIR
+
+REPO_ROOT = os.path.dirname(SCRIPTS_DIR)
+PROJECT_SPEC = os.path.join(REPO_ROOT, "project.yml")
+BUILD_SCRIPT = os.path.join(SCRIPTS_DIR, "ci-build-for-testing.sh")
+
+
+class CISchemeContractTests(unittest.TestCase):
+    def test_ci_scheme_disables_test_debugger_without_changing_local_scheme(self):
+        with open(PROJECT_SPEC, encoding="utf-8") as fh:
+            text = fh.read()
+
+        marker = "  ConduitCI:\n"
+        self.assertIn(marker, text)
+        ci_scheme = text.split(marker, 1)[1]
+        self.assertIn("    test:\n", ci_scheme)
+        self.assertIn("      debugEnabled: false\n", ci_scheme)
+        self.assertIn("        - ConduitTests\n", ci_scheme)
+        self.assertIn("        - ConduitUITests\n", ci_scheme)
+
+        # The normal local scheme remains XcodeGen's target-generated default;
+        # CI gets a separate explicit scheme instead of changing developer
+        # Cmd+U/debugger behavior globally.
+        self.assertNotIn("  Conduit:\n    test:\n", text)
+
+    def test_build_for_testing_defaults_to_ci_scheme_but_can_be_overridden(self):
+        with open(BUILD_SCRIPT, encoding="utf-8") as fh:
+            text = fh.read()
+        self.assertIn('SCHEME="${SCHEME:-ConduitCI}"', text)
+        self.assertIn('-scheme "$SCHEME"', text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Stack dependency

**Stacked on #152. Do not merge this PR before #152.**

The branch is exactly one commit (`a484f15`) on top of #152 head `4418384`. It targets `main` temporarily so the normal PR CI workflow runs; after #152 merges, this diff collapses to the stabilization commit only.

## Problems

Two recurring failures surfaced once #152 made UI flakes attributable by class/test:

1. `ConnectionSetupUITests.testWizardAdvancesThroughQuestionsToTailscaleBranchAndBack` races the intentionally transient 2-second **Copied** label. On hosted runners XCTest can spend longer than that in post-tap idle/snapshot work before it starts querying the confirmation.
2. `ConnectionRepairUITests` is being blamed for a failure that occurs before Repair logic runs. The failing artifacts show the first `XCUIApplication.launch()` timing out in Xcode's debugger-backed simulator launcher (`IDELaunchiPhoneSimulatorLauncher` / `DebuggerVersionStore`). After a clean retry, the first launch can fail again while a subsequent launch on the same warmed simulator succeeds. Deleting or weakening the named Repair test would just move the failure to whichever test launches first.

## Fix

### Durable accessibility confirmation, unchanged visual UX

`AskHermesPromptView` still shows the visual **Copied** label for exactly 2 seconds. It now also keeps the successful copy as durable accessibility state on the Copy Prompt button (`accessibilityValue == "Copied"` for the prompt actually copied).

The UI test asserts that semantic state with `XCTNSPredicateExpectation` instead of racing the transient label.

This does **not** lengthen the toast or add sleeps.

### CI-only no-debug test scheme

Adds a separate shared `ConduitCI` scheme whose test action has `debugEnabled: false` and makes `ci-build-for-testing.sh` use it by default (with `SCHEME` still overridable).

The normal local `Conduit` scheme is unchanged, so developer Cmd+U/debugger behavior stays intact. Hosted XCUITests do not need LLDB attached; the experiment removes Xcode 26.x's debugger-backed simulator-launch path that is producing the observed `Timed out while launching application via Xcode` failures.

No Repair assertions or coverage are removed or relaxed.

## Evidence behind the Repair diagnosis

From #152 run `34332769496`, `ui-3`:

- attempt 1: the first Repair test fails at `app.launch()` with `Timed out while launching application via Xcode`; a later launch wedges until the class watchdog;
- attempt 2 after simulator erase: the first Repair launch fails the same way again;
- later Repair launches on that same warmed simulator proceed, including one that emits a DTX signal warning and still passes;
- extracted result: 5 Repair tests, only the first test failed, at launch time before the Repair assertions ran.

That makes broad DTX/debugger-warning matching unsafe and makes deleting the first test ineffective. The no-debug CI scheme is intentionally a narrow source-level experiment.

## Guardrail

Adds a stdlib CI contract test pinning:

- `ConduitCI` exists;
- its test action has `debugEnabled: false`;
- it contains both unit/UI test targets;
- `ci-build-for-testing.sh` defaults to `ConduitCI` but remains overridable;
- the normal local scheme is not replaced.

## Validation target

The PR CI run should prove:

1. XcodeGen accepts/generates `ConduitCI` and build-for-testing succeeds.
2. Existing unit/UI coverage still executes through the shared `.xctestrun` artifact.
3. The Copy Prompt test no longer races the 2-second label.
4. `ConnectionRepairUITests` no longer hits the debugger-backed Xcode app-launch timeout.

If #4 still reproduces with debugging disabled, this experiment should be reverted rather than papered over; the next fallback would be bounded per-test XCTest execution time, not weaker Repair assertions or larger class watchdogs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Copy Prompt now provides a persistent “Copied” status to assistive technologies, accurately reflecting the currently displayed prompt.

* **Bug Fixes**
  * Prevented reused prompt views from incorrectly reporting that a different prompt was copied.

* **Tests**
  * Updated automated coverage to verify the persistent copy status and CI build configuration.

* **Chores**
  * Improved continuous integration builds with a dedicated, configurable build scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->