### PR TITLE
ci: deterministic connection-setup UI queries, batched UI shards, overhead-aware lane planning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,15 +3,21 @@ name: CI
 # CI v2 - timing-aware dynamic test lanes for Hermes Conduit.
 #
 # Architecture (docs/CI.md):
-#   plan     (ubuntu, cheap)  validate inventory, run planner regression
-#                             tests, balance test classes into a dynamic
-#                             number of timing-weighted lanes (unit AND UI),
-#                             emit both matrices.
-#   build    (macos, once)    build-for-testing exactly once into a
-#                             workspace-anchored DerivedData path; audit the
-#                             generated .xctestrun for absolute-path
-#                             portability; upload products as an artifact.
-#   unit/ui  (macos, matrix) test-without-building from the downloaded
+#   plan      (ubuntu, cheap)  validate inventory, balance test classes into
+#                              a dynamic number of timing-weighted lanes
+#                              (unit AND UI), emit both matrices. The
+#                              minutes-long CI-tooling meta-suites are NOT
+#                              run here - they must never delay the macOS
+#                              build or risk the job timeout.
+#   self-test (ubuntu)         CI-tooling regression suites (planner,
+#                              lane-runner state machine, destination
+#                              lookup, gate/timing contracts) as their own
+#                              job, concurrent with build.
+#   build     (macos, once)    build-for-testing exactly once into a
+#                              workspace-anchored DerivedData path; audit the
+#                              generated .xctestrun for absolute-path
+#                              portability; upload products as an artifact.
+#   unit/ui   (macos, matrix) test-without-building from the downloaded
 #                             products; measured watchdogs; native flake
 #                             retry (units); one batched invocation per UI
 #                             shard with method-precise retry of only the
@@ -70,6 +76,13 @@ jobs:
             timing-history-v1-
 
       - name: Validate inventory + planner regression tests
+        env:
+          # The minutes-long bash meta-suites (lane-runner state machine,
+          # destination lookup) run in the dedicated self-test job - they
+          # must never delay planning, the macOS build, or risk this job's
+          # timeout (run 34420978966: the suite outlived the 10-minute job
+          # ceiling and GitHub cancelled it mid-run).
+          CONDUIT_CI_SKIP_BASH_WRAPPER_TESTS: "1"
         run: |
           set -euo pipefail
           HISTORY_ARG=""
@@ -111,6 +124,26 @@ jobs:
           name: plan
           path: ci-artifacts/
           retention-days: 7
+
+  self-test:
+    name: CI tooling self-test
+    # No `needs`: the meta-suites test the CI tooling itself, not this run's
+    # plan, so they start immediately and run CONCURRENTLY with the macOS
+    # build instead of serially delaying it.
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run CI tooling regression suites
+        # Full discovery INCLUDING the bash state-machine suites. The
+        # timeout layering must hold: per-case synthetic-hang watchdogs
+        # (<= 6s) < the wrapper's subprocess cap (480s, test_lane_runner.py)
+        # < this job ceiling (12m) - GitHub must never be the first layer to
+        # kill a regression suite.
+        run: |
+          set -euo pipefail
+          python3 -m unittest discover -s scripts/tests -p 'test_*.py' -v
 
   build:
     name: Build test products
@@ -371,7 +404,7 @@ jobs:
   # directly - require "CI Gate" instead (see docs/CI.md).
   ci-gate:
     name: CI Gate
-    needs: [plan, build, unit, ui]
+    needs: [plan, build, unit, ui, self-test]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -384,7 +417,8 @@ jobs:
             --plan "${{ needs.plan.result }}" \
             --build "${{ needs.build.result }}" \
             --unit "${{ needs.unit.result }}" \
-            --ui "${{ needs.ui.result }}"
+            --ui "${{ needs.ui.result }}" \
+            --self-test "${{ needs.self-test.result }}"
 
   timing-history-update:
     name: Update timing history

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,9 +279,9 @@ jobs:
         # shard's classes in ONE batched xcodebuild invocation (watchdog =
         # sum of the planner's per-class budgets; --class-timeouts is the
         # single source of watchdog policy and must cover every assigned
-        # class). A failing batch retries exactly the failed tests - once -
-        # and falls back to per-class diagnosis for timeouts/infrastructure
-        # wedges.
+        # class). A failing batch retries exactly the non-passing tests -
+        # once - and falls back to per-class diagnosis for
+        # timeouts/infrastructure wedges.
         env:
           CONDUIT_PERF_TRACE: "1"
           LANE_NAME: "${{ matrix.lane }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,10 @@ name: CI
 #                             portability; upload products as an artifact.
 #   unit/ui  (macos, matrix) test-without-building from the downloaded
 #                             products; measured watchdogs; native flake
-#                             retry (units); per-class invocations, per-class
-#                             watchdogs and one targeted class retry (UI).
+#                             retry (units); one batched invocation per UI
+#                             shard with method-precise retry of only the
+#                             failed tests and a per-class diagnosis
+#                             fallback for timeouts/infrastructure wedges.
 #   report   (ubuntu, always) aggregate lane results into the step summary.
 #   timing-history-update (main only) EWMA-merge fresh per-class timings into
 #                             the timing-history cache.
@@ -273,11 +275,13 @@ jobs:
       - name: Run UI lane
         # Matrix values enter through the environment, never through bash
         # template interpolation, so even a hostile class name cannot become
-        # code execution in the runner. The lane runner executes each class
-        # as an independent xcodebuild invocation under the planner's
-        # per-class watchdog (--class-timeouts is the single source of
-        # watchdog policy and must cover every assigned class) and retries
-        # only a failed class - once.
+        # code execution in the runner. The lane runner executes all of the
+        # shard's classes in ONE batched xcodebuild invocation (watchdog =
+        # sum of the planner's per-class budgets; --class-timeouts is the
+        # single source of watchdog policy and must cover every assigned
+        # class). A failing batch retries exactly the failed tests - once -
+        # and falls back to per-class diagnosis for timeouts/infrastructure
+        # wedges.
         env:
           CONDUIT_PERF_TRACE: "1"
           LANE_NAME: "${{ matrix.lane }}"

--- a/Conduit/Views/AskHermesPromptView.swift
+++ b/Conduit/Views/AskHermesPromptView.swift
@@ -16,6 +16,12 @@ struct AskHermesPromptView: View {
 
     @State private var copied = false
     @State private var copyCount = 0
+    /// Durable record of which prompt was last copied. The visible "Copied"
+    /// label intentionally disappears after ~2s, but the fact that THIS
+    /// prompt was copied must stay queryable through accessibility (VoiceOver
+    /// users re-reading the control, and automation) — keyed to the prompt
+    /// string so a reused card can never claim a different prompt was copied.
+    @State private var lastCopiedPrompt: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -33,12 +39,14 @@ struct AskHermesPromptView: View {
                 Button {
                     UIPasteboard.general.string = prompt
                     copied = true
+                    lastCopiedPrompt = prompt
                     copyCount += 1
                 } label: {
                     Label("Copy Prompt", systemImage: copied ? "checkmark" : "doc.on.doc")
                         .font(.footnote.weight(.semibold))
                 }
                 .accessibilityIdentifier("setup.copy-prompt")
+                .accessibilityValue(lastCopiedPrompt == prompt ? "Copied" : "")
 
                 if copied {
                     Text("Copied")

--- a/ConduitUITests/ConnectionRepairUITests.swift
+++ b/ConduitUITests/ConnectionRepairUITests.swift
@@ -110,7 +110,9 @@ final class ConnectionRepairUITests: XCTestCase {
         tapVisible(repair, in: app)
 
         // No retained failure: the repair opens straight on the staged test.
-        let preview = app.descendants(matching: .any).matching(identifier: "setup.address-preview").firstMatch
+        // The preview is a single Text element (exposed as a static text);
+        // a typed query keeps snapshot evaluation out of the whole tree.
+        let preview = app.staticTexts["setup.address-preview"]
         XCTAssertTrue(preview.waitForExistence(timeout: 5), "Repair did not open on the staged test. Tree:\n\(app.debugDescription)")
         XCTAssertEqual(preview.label, Identity.stubDashboardURL)
         tapVisible(app.buttons[Identity.testRun], in: app)
@@ -138,7 +140,7 @@ final class ConnectionRepairUITests: XCTestCase {
         XCTAssertTrue(repair.waitForExistence(timeout: 10))
         tapVisible(repair, in: app)
 
-        let preview = app.descendants(matching: .any).matching(identifier: "setup.address-preview").firstMatch
+        let preview = app.staticTexts["setup.address-preview"]
         XCTAssertTrue(preview.waitForExistence(timeout: 5))
         tapVisible(app.buttons[Identity.testRun], in: app)
 

--- a/ConduitUITests/ConnectionSetupSettingsUITests.swift
+++ b/ConduitUITests/ConnectionSetupSettingsUITests.swift
@@ -45,7 +45,7 @@ final class ConnectionSetupSettingsUITests: XCTestCase {
         // The passwordless seed opens straight on the staged test with the
         // current URL preserved exactly — no first-run readiness questions,
         // no meaningless password field.
-        let preview = row(app, Identity.addressPreview)
+        let preview = addressPreview(app)
         XCTAssertTrue(preview.waitForExistence(timeout: 5), "Wizard did not open on the staged test. Tree:\n\(app.debugDescription)")
         XCTAssertEqual(preview.label, Identity.stubDashboardURL)
 
@@ -108,7 +108,7 @@ final class ConnectionSetupSettingsUITests: XCTestCase {
         openSettings(app)
         tapVisible(app.buttons[Identity.settingsRow], in: app)
 
-        let preview = row(app, Identity.addressPreview)
+        let preview = addressPreview(app)
         XCTAssertTrue(preview.waitForExistence(timeout: 5), "Wizard did not open on the staged test. Tree:\n\(app.debugDescription)")
         XCTAssertEqual(preview.label, Identity.stubDashboardURL)
 
@@ -121,8 +121,8 @@ final class ConnectionSetupSettingsUITests: XCTestCase {
         XCTAssertTrue(interactiveReady.waitForExistence(timeout: 5))
         XCTAssertTrue(interactiveReady.label.contains("browser-based sign-in"), "Got: \(interactiveReady.label)")
         XCTAssertFalse(app.staticTexts["setup.test.ready"].exists, "Interactive auth must never claim the connection is ready to use")
-        let authRow = row(app, "setup.test.stage.authentication")
-        XCTAssertTrue(authRow.exists)
+        let authRow = stageRow(app, "setup.test.stage.authentication")
+        XCTAssertTrue(authRow.waitForExistence(timeout: 5))
         XCTAssertTrue(authRow.label.lowercased().contains("browser sign-in required"), "Got: \(authRow.label)")
 
         tapVisible(app.buttons[Identity.useSettings], in: app)
@@ -147,7 +147,7 @@ final class ConnectionSetupSettingsUITests: XCTestCase {
         openSettings(app)
         tapVisible(app.buttons[Identity.settingsRow], in: app)
 
-        let preview = row(app, Identity.addressPreview)
+        let preview = addressPreview(app)
         XCTAssertTrue(preview.waitForExistence(timeout: 5), "Wizard did not open on the staged test. Tree:\n\(app.debugDescription)")
         XCTAssertEqual(preview.label, Identity.stubDashboardURL)
 
@@ -158,8 +158,8 @@ final class ConnectionSetupSettingsUITests: XCTestCase {
         // ready claim.
         let notice = app.staticTexts["setup.test.credentials-required"]
         XCTAssertTrue(notice.waitForExistence(timeout: 5))
-        let authRow = row(app, "setup.test.stage.authentication")
-        XCTAssertTrue(authRow.exists)
+        let authRow = stageRow(app, "setup.test.stage.authentication")
+        XCTAssertTrue(authRow.waitForExistence(timeout: 5))
         XCTAssertTrue(authRow.label.lowercased().contains("credentials required"), "Got: \(authRow.label)")
         XCTAssertFalse(app.staticTexts["setup.test.ready"].exists)
         XCTAssertFalse(app.staticTexts["setup.test.interactive-ready"].exists)
@@ -172,7 +172,7 @@ final class ConnectionSetupSettingsUITests: XCTestCase {
         XCTAssertTrue(username.waitForExistence(timeout: 5), "Credentials step did not appear. Tree:\n\(app.debugDescription)")
         let urlField = app.textFields[Identity.urlField]
         XCTAssertFalse(urlField.exists, "The URL is owned by the details step; credentials step only asks for credentials")
-        XCTAssertTrue(app.buttons[Identity.back].exists, "Back returns toward the tested connection")
+        XCTAssertTrue(app.buttons[Identity.back].waitForExistence(timeout: 5), "Back returns toward the tested connection")
     }
 
     // MARK: - Walk helpers
@@ -187,10 +187,20 @@ final class ConnectionSetupSettingsUITests: XCTestCase {
         settings.tap()
     }
 
-    /// Stage rows and the address preview are single combined accessibility
-    /// elements, so query by identifier across element types.
-    private func row(_ app: XCUIApplication, _ identifier: String) -> XCUIElement {
-        app.descendants(matching: .any).matching(identifier: identifier).firstMatch
+    /// The address preview is a single `Text` element, which XCTest exposes
+    /// as a static text (verified by hierarchy inspection).
+    private func addressPreview(_ app: XCUIApplication) -> XCUIElement {
+        app.staticTexts[Identity.addressPreview]
+    }
+
+    /// Stage rows are single combined accessibility elements backed by an
+    /// `HStack` with `children: .ignore`, which XCTest exposes as an Other
+    /// element (verified by hierarchy inspection). A typed query evaluates
+    /// one narrow subtree instead of snapshotting every element type in the
+    /// application, which is what the broad `descendants(matching: .any)`
+    /// lookup paid for on every check.
+    private func stageRow(_ app: XCUIApplication, _ identifier: String) -> XCUIElement {
+        app.otherElements[identifier]
     }
 
     private func tapVisible(_ element: XCUIElement, in app: XCUIApplication) {

--- a/ConduitUITests/ConnectionSetupTestConnectionUITests.swift
+++ b/ConduitUITests/ConnectionSetupTestConnectionUITests.swift
@@ -74,7 +74,7 @@ final class ConnectionSetupTestConnectionUITests: XCTestCase {
         XCTAssertTrue(app.buttons["setup.test.edit-credentials"].waitForExistence(timeout: 5))
         // Retry exists but is never the primary action after rejected
         // credentials.
-        XCTAssertTrue(app.buttons["setup.test.retry"].exists)
+        XCTAssertTrue(app.buttons["setup.test.retry"].waitForExistence(timeout: 5))
 
         tapVisible(app.buttons["setup.test.edit-credentials"], in: app)
         let username = app.textFields["setup.username"]

--- a/ConduitUITests/ConnectionSetupTestConnectionUITests.swift
+++ b/ConduitUITests/ConnectionSetupTestConnectionUITests.swift
@@ -9,6 +9,7 @@ final class ConnectionSetupTestConnectionUITests: XCTestCase {
         static let answerYes = "setup.answer-yes"
         static let methodLan = "setup.method-lan"
         static let detailsReady = "setup.details-ready"
+        static let stepLabel = "setup.step-label"
         static let next = "setup.next"
         static let back = "setup.back"
         static let testRun = "setup.test.run"
@@ -175,6 +176,13 @@ final class ConnectionSetupTestConnectionUITests: XCTestCase {
         if !setup.isHittable { app.swipeDown() }
         setup.tap()
 
+        // The entry tap starts a NavigationStack push: right after the tap,
+        // a snapshot can still describe the login card, so interacting with
+        // the first answer races the transition (a hosted failure waited out
+        // exactly this race). The wizard's own step label is the semantic
+        // "Step 1 is active" marker — wait for it before the first answer.
+        waitForStep(app, "Step 1 of 3")
+
         tapVisible(app.buttons[Identity.answerYes], in: app)
         tapVisible(app.buttons[Identity.answerYes], in: app)
         tapVisible(app.buttons[Identity.methodLan], in: app)
@@ -211,6 +219,32 @@ final class ConnectionSetupTestConnectionUITests: XCTestCase {
     /// lookup paid for on every check.
     private func stageRow(_ app: XCUIApplication, _ identifier: String) -> XCUIElement {
         app.otherElements[identifier]
+    }
+
+    /// Polls until the wizard's step label names `expected`, failing with
+    /// the tree if it never does. Polling (not a single assert) matters
+    /// because during the wizard's push/pop transitions both steps can be
+    /// mounted, so the first snapshot may still describe the outgoing step —
+    /// the same contract as ConnectionSetupUITests.stepLabel.
+    private func waitForStep(
+        _ app: XCUIApplication,
+        _ expected: String,
+        timeout: TimeInterval = 5
+    ) {
+        let label = app.staticTexts[Identity.stepLabel]
+        let deadline = Date().addingTimeInterval(timeout)
+
+        while Date() < deadline {
+            if label.exists, label.label == expected {
+                return
+            }
+
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        }
+
+        XCTFail(
+            "Expected wizard step \(expected). Tree:\n\(app.debugDescription)"
+        )
     }
 
     private func tapVisible(_ element: XCUIElement, in app: XCUIApplication) {

--- a/ConduitUITests/ConnectionSetupTestConnectionUITests.swift
+++ b/ConduitUITests/ConnectionSetupTestConnectionUITests.swift
@@ -35,9 +35,9 @@ final class ConnectionSetupTestConnectionUITests: XCTestCase {
         // stage plus the ready message. The password is never rendered as
         // text anywhere.
         XCTAssertTrue(app.staticTexts["setup.test.ready"].waitForExistence(timeout: 5))
-        XCTAssertTrue(row(app, Identity.stageServer).exists)
-        XCTAssertTrue(row(app, Identity.stageDashboard).exists)
-        XCTAssertTrue(row(app, Identity.stageAuthentication).exists)
+        XCTAssertTrue(stageRow(app, Identity.stageServer).waitForExistence(timeout: 5))
+        XCTAssertTrue(stageRow(app, Identity.stageDashboard).waitForExistence(timeout: 5))
+        XCTAssertTrue(stageRow(app, Identity.stageAuthentication).waitForExistence(timeout: 5))
         XCTAssertFalse(app.staticTexts["round4-private-fixture"].exists)
 
         // The Round-3 typed handoff is unchanged: fields populate, nothing
@@ -63,15 +63,15 @@ final class ConnectionSetupTestConnectionUITests: XCTestCase {
         // stages remain visible, and the classified credential guidance
         // appears with Edit Credentials as the primary recovery action.
         XCTAssertTrue(app.staticTexts["setup.test.failure"].waitForExistence(timeout: 5))
-        XCTAssertTrue(row(app, Identity.stageServer).exists)
-        XCTAssertTrue(row(app, Identity.stageDashboard).exists)
-        XCTAssertTrue(row(app, Identity.stageAuthentication).exists)
+        XCTAssertTrue(stageRow(app, Identity.stageServer).waitForExistence(timeout: 5))
+        XCTAssertTrue(stageRow(app, Identity.stageDashboard).waitForExistence(timeout: 5))
+        XCTAssertTrue(stageRow(app, Identity.stageAuthentication).waitForExistence(timeout: 5))
         let failure = app.staticTexts["setup.test.failure"]
         XCTAssertEqual(
             failure.label,
             "Hermes rejected that username or password. Check your dashboard credentials and try again."
         )
-        XCTAssertTrue(app.buttons["setup.test.edit-credentials"].exists)
+        XCTAssertTrue(app.buttons["setup.test.edit-credentials"].waitForExistence(timeout: 5))
         // Retry exists but is never the primary action after rejected
         // credentials.
         XCTAssertTrue(app.buttons["setup.test.retry"].exists)
@@ -95,7 +95,7 @@ final class ConnectionSetupTestConnectionUITests: XCTestCase {
             app.buttons["setup.test.retry"].exists,
             "Rate limiting must not invite an immediate retry"
         )
-        XCTAssertTrue(app.buttons["setup.test.edit-credentials"].exists)
+        XCTAssertTrue(app.buttons["setup.test.edit-credentials"].waitForExistence(timeout: 5))
     }
 
     func testInteractiveSignInOutcomeShowsBrowserSignInAndHandsOff() {
@@ -127,8 +127,8 @@ final class ConnectionSetupTestConnectionUITests: XCTestCase {
             app.staticTexts["setup.test.ready"].exists,
             "The native ready message must not appear for interactive auth"
         )
-        let authRow = row(app, Identity.stageAuthentication)
-        XCTAssertTrue(authRow.exists)
+        let authRow = stageRow(app, Identity.stageAuthentication)
+        XCTAssertTrue(authRow.waitForExistence(timeout: 5))
         // Stage rows expose their combined accessibility label (objective
         // name + lowercase state word), so match case-insensitively.
         XCTAssertTrue(
@@ -144,8 +144,10 @@ final class ConnectionSetupTestConnectionUITests: XCTestCase {
         // screen with a Continue action that returns to Review.
         tapVisible(app.buttons[Identity.back], in: app)
         XCTAssertTrue(app.buttons[Identity.testContinue].waitForExistence(timeout: 5))
+        let authRowAfterBack = stageRow(app, Identity.stageAuthentication)
+        XCTAssertTrue(authRowAfterBack.waitForExistence(timeout: 5))
         XCTAssertTrue(
-            row(app, Identity.stageAuthentication).label.lowercased().contains("browser sign-in required")
+            authRowAfterBack.label.lowercased().contains("browser sign-in required")
         )
         tapVisible(app.buttons[Identity.testContinue], in: app)
         XCTAssertTrue(app.staticTexts["setup.test.interactive-ready"].waitForExistence(timeout: 5))
@@ -196,15 +198,19 @@ final class ConnectionSetupTestConnectionUITests: XCTestCase {
         tapVisible(app.buttons[Identity.next], in: app)
 
         XCTAssertTrue(app.buttons[Identity.testRun].waitForExistence(timeout: 5), "Test screen did not appear. Tree:\n\(app.debugDescription)")
-        XCTAssertTrue(row(app, Identity.stageServer).exists)
-        XCTAssertTrue(row(app, Identity.stageDashboard).exists)
-        XCTAssertTrue(row(app, Identity.stageAuthentication).exists)
+        XCTAssertTrue(stageRow(app, Identity.stageServer).waitForExistence(timeout: 5))
+        XCTAssertTrue(stageRow(app, Identity.stageDashboard).waitForExistence(timeout: 5))
+        XCTAssertTrue(stageRow(app, Identity.stageAuthentication).waitForExistence(timeout: 5))
     }
 
-    /// Stage rows are single combined accessibility elements, so query by
-    /// identifier across element types.
-    private func row(_ app: XCUIApplication, _ identifier: String) -> XCUIElement {
-        app.descendants(matching: .any).matching(identifier: identifier).firstMatch
+    /// Stage rows are single combined accessibility elements backed by an
+    /// `HStack` with `children: .ignore`, which XCTest exposes as an Other
+    /// element (verified by hierarchy inspection). A typed query evaluates
+    /// one narrow subtree instead of snapshotting every element type in the
+    /// application, which is what the broad `descendants(matching: .any)`
+    /// lookup paid for on every check.
+    private func stageRow(_ app: XCUIApplication, _ identifier: String) -> XCUIElement {
+        app.otherElements[identifier]
     }
 
     private func tapVisible(_ element: XCUIElement, in app: XCUIApplication) {

--- a/ConduitUITests/ConnectionSetupUITests.swift
+++ b/ConduitUITests/ConnectionSetupUITests.swift
@@ -172,8 +172,19 @@ final class ConnectionSetupUITests: XCTestCase {
         XCTAssertTrue(copyPrompt.waitForExistence(timeout: 5), "Copy Prompt must appear on the No path")
         if !copyPrompt.isHittable { app.swipeUp() }
         copyPrompt.tap()
-        XCTAssertTrue(
-            app.staticTexts["setup.copied-confirmation"].waitForExistence(timeout: 3),
+        // The visible "Copied" label intentionally disappears after ~2s,
+        // which a hosted runner can outrun between the tap and the first
+        // hierarchy snapshot. The button therefore carries a DURABLE
+        // accessibility value for the current prompt ("Copied"), and the
+        // assertion waits on that semantic state instead of racing the
+        // transient label.
+        let copiedValue = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "value == %@", "Copied"),
+            object: copyPrompt
+        )
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [copiedValue], timeout: 3),
+            .completed,
             "Copying must confirm to the user"
         )
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -236,10 +236,12 @@ components (e.g. `26.0`); xcodebuild-only values such as `latest` are not
 supported by the pin and fail the gate.
 
 The resolved UDID is also what every invocation actually targets:
-`build_destination` emits `platform=iOS Simulator,id=<UDID>` (falling back
-to the `name=` form only when the UDID cannot be resolved), so build and
-lane jobs can never disambiguate a name that matches several
-runtimes/architectures - the source of the "multiple matching destinations"
+`build_destination` emits `platform=iOS Simulator,id=<UDID>,arch=arm64`
+(falling back to the `name=` form only when the UDID cannot be resolved; the
+arch is `SIMULATOR_ARCH`-overridable), so build and lane jobs can never
+disambiguate a name that matches several runtimes and never have to choose
+between the arm64 and Rosetta-x86_64 candidates every Apple Silicon
+simulator registers - the source of the "multiple matching destinations"
 warning, where xcodebuild silently uses the first match and can bypass the
 OS pin.
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -27,8 +27,9 @@ quarantined, or moved to a nightly gate.
  unit-1    unit-2    ...     ui-1   ui-2   ui-3 ...
  (test-without-building from the SHARED products;
   measured watchdogs; units use native flake retry,
-  UI runs each class as its own invocation with a
-  per-class watchdog and one targeted class retry)
+  UI runs each shard as ONE batched invocation with
+  method-precise retry and a per-class diagnosis
+  fallback)
    |         |         |         |
    +---------+----+----+---------+
                   v
@@ -69,45 +70,58 @@ quarantined, or moved to a nightly gate.
 
 Unit classes are balanced with **longest-processing-time-first** (LPT) over
 per-class duration estimates, with deterministic tie-breaking (estimate
-descending, then class name). Lane count is derived, not fixed:
+descending, then class name). Lane count is derived, not fixed, and accounts
+for the fixed cost of an xcodebuild invocation:
 
 ```
-lanes = clamp(ceil(total_predicted / 240s), 4, 8), capped by class count
+modeled wall(n) = invocation_overhead_s (240s) + heaviest LPT lane load
+lanes = smallest n in [1, 8] with modeled wall(n) within 120s of the best
+        achievable wall, capped by class count
 ```
 
-so the suite scales toward more lanes as measured runtime grows. Predicted
-imbalance is reported in the plan summary and the CI Test Report.
+Every lane pays the fixed startup/finalization cost, but lanes run in
+parallel - so adding a lane only rebalances execution while multiplying paid
+invocations. A lane is spawned only when it buys more than the 120 s wall
+tolerance. Splitting 200 s of tests into two 5-minute jobs (when the
+invocation overhead is several minutes) is a net loss; a heavy outlier class
+that dominates every possible split consolidates the suite into fewer lanes.
+Predicted imbalance is reported in the plan summary and the CI Test Report.
 
 ### Parallel UI lanes
 
-UI classes are balanced with the same LPT algorithm into their own parallel
-shards, so normal PR wall clock is governed by the slowest UI shard rather
-than the sum of the whole UI suite:
+UI classes are balanced with the same LPT algorithm and the same overhead-
+aware lane selection (bounds 3-4 instead of 1-8, so normal PR wall clock is
+governed by the slowest UI shard rather than the sum of the whole UI suite).
+Today's ~22 minutes of cumulative UI work lands on 3 lanes of roughly 7-8
+predicted minutes each. The count scales out automatically if the UI suite
+grows (and shrinks if it drops below 3 classes).
 
-```
-ui lanes = clamp(ceil(total_predicted / 480s), 3, 4), capped by class count
-```
+### Batched UI shards, per-class diagnosis
 
-Today's ~22 minutes of cumulative UI work lands on 3 lanes of roughly
-7-8 predicted minutes each. The count scales out automatically if the UI
-suite grows (and shrinks if it drops below 3 classes).
-
-### Per-class UI execution
-
-Inside a UI shard, **every class is its own `xcodebuild
+On the healthy path a UI shard runs **all of its classes in ONE `xcodebuild
 test-without-building` invocation** from the shared build products (the app
-is never rebuilt). This makes hangs attributable to exactly one class,
-enables the per-class watchdogs, restricts any retry to the failed class,
-and records per-class timing history. The simulator is booted once at shard
-start so only the first class pays the cold-boot overhead; classes that pass
-move on immediately; a class that fails gets exactly ONE targeted retry of
-just that class - successful classes are never re-executed, and a retry pass
-is reported as a runner-level FLAKE (with both attempt result bundles kept),
-never hidden as a clean pass. A class whose retry fails again as an
-infrastructure failure is recorded as a persistent infrastructure failure
-and fails the lane, but the remaining classes still run after a clean
-simulator reset; only a confirmed hang or an untrusted recovery stops a
-shard early.
+is never rebuilt), under a watchdog equal to the sum of the planner's
+per-class budgets. A successful shard therefore pays Xcode/CoreSimulator/
+test-session startup once instead of once per class, while per-class timing
+history still comes from the shared extraction.
+
+Recovery never re-executes healthy work:
+
+* **Ordinary test failures** retry ONLY the failed tests in one follow-up
+  invocation - exact `Target/Class/testMethod` filters when the xcresult
+  identifies them, the failing class otherwise. Successful classes are never
+  re-executed, and a retry pass is reported as a runner-level FLAKE (with
+  both attempt result bundles kept), never hidden as a clean pass.
+* **Watchdog timeout / infrastructure wedge** of the batch cannot be
+  attributed to a class: the simulator is erased and the affected classes
+  re-run through **per-class diagnosis** - each class its own invocation
+  under its own planned watchdog, with the same targeted-retry and hang
+  attribution rules as before. A class that hangs twice names the culprit
+  (`hung_class` in the lane result) and stops the shard; a class whose
+  retry fails again as an infrastructure failure is recorded as a persistent
+  infrastructure failure and fails the lane while the remaining classes
+  still run after a clean simulator reset; only an untrusted recovery stops
+  a shard without executing the remaining classes.
 
 ## Timing data
 
@@ -146,9 +160,11 @@ the rest of CI v2.
 1. **Ordinary test failures** never rerun healthy work. Unit attempt 1 runs
    with Xcode-native flake retry (`-retry-tests-on-failure
    -test-iterations N`), which re-executes only the failing tests; survivors
-   fail the lane with the failing tests identified. UI classes get one
-   **targeted retry of just the failed class**; if the retry passes, the
-   class is reported as a runner-level flake and the lane continues.
+   fail the lane with the failing tests identified. A failing UI batch gets
+   one **targeted retry of exactly the failed tests** (methods when the
+   xcresult identifies them, the class otherwise); if the retry passes, the
+   classes involved are reported as runner-level flakes and the lane
+   continues.
 2. **Unclassifiable failure** - if an invocation exits nonzero and the
    XCTest result cannot be classified (timing/result extraction failed),
    the lane FAILS immediately. Timing extraction is best-effort and must
@@ -157,16 +173,18 @@ the rest of CI v2.
 3. **Infrastructure failure** - an invocation that exits nonzero with a
    KNOWN zero failing-test count (simulator crash, runner exit) gets
    exactly one bounded recovery: reset the simulator and retry. Units retry
-   the whole lane (it is one invocation); a UI lane retries only the
-   affected class. If a UI class fails AGAIN as an infrastructure failure,
-   it is recorded as a **persistent infrastructure failure** and the lane
-   fails - but the remaining classes still run after a clean simulator
-   reset, because the culprit is fully identified and a wedge must not
-   suppress otherwise-independent UI coverage. If that recovery itself
-   cannot be trusted (erase failed, UDID unresolvable, boot never
-   completed), later results would be misleading: the lane stops there and
-   the remaining classes are recorded as `not_diagnosed`. A retry that
-   times out falls through to hang handling (4).
+   the whole lane (it is one invocation); a UI batch cannot attribute a
+   wedge to a class, so it erases the simulator and re-runs the affected
+   classes through per-class diagnosis. If a class fails AGAIN as an
+   infrastructure failure there, it is recorded as a **persistent
+   infrastructure failure** and the lane fails - but the remaining classes
+   still run after a clean simulator reset, because the culprit is fully
+   identified and a wedge must not suppress otherwise-independent UI
+   coverage. If that recovery itself cannot be trusted (erase failed, UDID
+   unresolvable, boot never completed), later results would be misleading:
+   the lane stops there and the remaining classes are recorded as
+   `not_diagnosed`. A retry that times out falls through to hang handling
+   (4).
 4. **Hang / timeout** - a watchdog kill is positive identification of a
    hang. Units erase the simulator and enter **isolation** immediately (no
    second full-lane attempt): classes re-run one at a time (heaviest
@@ -174,10 +192,10 @@ the rest of CI v2.
    isolation budget). Isolation STOPS at the first confirmed class-level
    hang - the culprit is identified and later classes are recorded as
    `not_diagnosed` instead of running on a potentially contaminated
-   simulator. UI classes are already isolated: the simulator is erased and
-   the SAME class retries once under its own watchdog; a second timeout
-   names the hung class (`hung_class` in the lane result), fails the lane,
-   and later classes are recorded as `not_diagnosed`. Recovery-to-green is
+   simulator. A UI batch timeout cannot name the hung class, so it erases
+   and enters the same per-class diagnosis; a class that hangs twice names
+   the hung class (`hung_class` in the lane result), fails the lane, and
+   later classes are recorded as `not_diagnosed`. Recovery-to-green is
    only legitimate when the retried class completed successfully; any
    undiagnosed class fails the lane so unexecuted tests stay visible.
 
@@ -204,6 +222,14 @@ destination xcodebuild will use. `SIMULATOR_OS` must be numeric dotted
 components (e.g. `26.0`); xcodebuild-only values such as `latest` are not
 supported by the pin and fail the gate.
 
+The resolved UDID is also what every invocation actually targets:
+`build_destination` emits `platform=iOS Simulator,id=<UDID>` (falling back
+to the `name=` form only when the UDID cannot be resolved), so build and
+lane jobs can never disambiguate a name that matches several
+runtimes/architectures - the source of the "multiple matching destinations"
+warning, where xcodebuild silently uses the first match and can bypass the
+OS pin.
+
 ## Watchdogs
 
 Unit lanes: `timeout = max(min_timeout, ceil(predicted x 2.5))` with a 600 s
@@ -214,7 +240,9 @@ legitimate in-script recovery (the script watchdogs are the real
 enforcement).
 
 UI classes each get their **own** watchdog, planned per class from the same
-timing data that balances the lanes. **`plan-tests.py` is the single
+timing data that balances the lanes: the shard's batched invocation is
+priced at the **sum** of those budgets, and the same table enforces every
+per-class diagnosis fallback invocation. **`plan-tests.py` is the single
 authority for this policy**: every UI lane receives an explicit budget table
 (`--class-timeouts`) and the runner refuses to start unless it covers every
 assigned class - there is no fallback formula in `ci-test-lane.sh` to drift

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -107,14 +107,16 @@ history still comes from the shared extraction.
 
 Recovery never lets ordinary-failure retries re-execute healthy work:
 
-* **Ordinary test failures** retry ONLY the failed tests in one follow-up
-  invocation - exact `Target/Class/testMethod` filters when the xcresult
-  identifies them, the failing class otherwise - and only when every
-  assigned class actually ran (a batch that aborted before a class started
-  falls through to diagnosis below, so unexecuted classes can never be
-  retried into a green lane). Successful classes are never re-executed, and
-  a retry pass is reported as a runner-level FLAKE (with both attempt result
-  bundles kept), never hidden as a clean pass.
+* **Ordinary test failures** retry ONLY the non-passing tests (any final
+  result other than Passed) in one follow-up invocation - exact
+  `Target/Class/testMethod` filters when the xcresult identifies them, the
+  failing class otherwise - and only when every assigned class actually ran
+  (a batch that aborted before a class started - or an exit-0 batch whose
+  xcresult lacks a class's record - falls through to diagnosis below, so
+  unexecuted classes can never be retried into a green lane). Successful
+  classes are never re-executed, and a retry pass is reported as a
+  runner-level FLAKE (with both attempt result bundles kept), never hidden
+  as a clean pass.
 * **Watchdog timeout / infrastructure wedge** of the batch cannot be
   attributed to a class: the simulator is erased and the affected classes
   re-run through **per-class diagnosis** - each class its own invocation
@@ -270,12 +272,14 @@ ui_class_timeout = max(420s, ceil(estimate x 3.0))   # computed in plan-tests.py
   anomalous run cannot inflate a class's watchdog;
 - UI lane ceilings are `sum(per-class budgets)` - the batched shard
   invocation watchdog - and the outer GitHub job ceiling is
-  `ceil((3 x sum + (n_classes + 1) x 600s + 2 x n_classes x 300s
-  + 1200s) / 60)` minutes: the reachable worst in-script path is the batched
-  attempt followed by per-class diagnosis after a batch timeout or wedge
-  (one attempt + one targeted retry per class = 2x more), each failing class
-  paying one bounded erase/reboot recovery, and each attempt's timing
-  extraction wedging to the xcresulttool bound, plus setup slack.
+  `ceil((4 x sum + (n_classes + 1) x 600s + (2 x n_classes + 1) x 300s
+  + 1200s) / 60)` minutes. Two reachable worst paths: the batch times out
+  and per-class diagnosis follows (batch 1x + diagnosis 2x = 3x), or the
+  batch completes with failures in every class, its targeted retry (a full
+  budget sum) times out, and diagnosis of the retried classes follows
+  (1x + 1x + 2x = 4x) - the latter prices the ceiling. Each failing class
+  additionally pays one bounded erase/reboot recovery, and each attempt's
+  timing extraction can wedge to the xcresulttool bound, plus setup slack.
 
 **Finalize grace.** When a watchdog expires but the log already carries
 xcodebuild's terminal result marker (`** TEST EXECUTE SUCCEEDED/FAILED **`),

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -105,18 +105,23 @@ per-class budgets. A successful shard therefore pays Xcode/CoreSimulator/
 test-session startup once instead of once per class, while per-class timing
 history still comes from the shared extraction.
 
-Recovery never re-executes healthy work:
+Recovery never lets ordinary-failure retries re-execute healthy work:
 
 * **Ordinary test failures** retry ONLY the failed tests in one follow-up
   invocation - exact `Target/Class/testMethod` filters when the xcresult
-  identifies them, the failing class otherwise. Successful classes are never
-  re-executed, and a retry pass is reported as a runner-level FLAKE (with
-  both attempt result bundles kept), never hidden as a clean pass.
+  identifies them, the failing class otherwise - and only when every
+  assigned class actually ran (a batch that aborted before a class started
+  falls through to diagnosis below, so unexecuted classes can never be
+  retried into a green lane). Successful classes are never re-executed, and
+  a retry pass is reported as a runner-level FLAKE (with both attempt result
+  bundles kept), never hidden as a clean pass.
 * **Watchdog timeout / infrastructure wedge** of the batch cannot be
   attributed to a class: the simulator is erased and the affected classes
   re-run through **per-class diagnosis** - each class its own invocation
   under its own planned watchdog, with the same targeted-retry and hang
-  attribution rules as before. A class that hangs twice names the culprit
+  attribution rules as before. (Diagnosis necessarily re-runs classes that
+  already passed inside a killed batch - a dead invocation leaves no
+  trustworthy per-class result.) A class that hangs twice names the culprit
   (`hung_class` in the lane result) and stops the shard; a class whose
   retry fails again as an infrastructure failure is recorded as a persistent
   infrastructure failure and fails the lane while the remaining classes
@@ -263,12 +268,14 @@ ui_class_timeout = max(420s, ceil(estimate x 3.0))   # computed in plan-tests.py
   hangs, instead of the old single 2861s (~48 min) suite-level watchdog;
 - estimates come from timing history (EWMA, outlier-clamped), so one
   anomalous run cannot inflate a class's watchdog;
-- UI lane ceilings are `sum(per-class budgets)`, and the outer GitHub job
-  ceiling is `ceil((2 x sum + (n_classes + 1) x 600s + 2 x n_classes x 300s
-  + 1200s) / 60)` minutes - the worst in-script path is every class running
-  its one targeted retry, each failing class paying one bounded
-  erase/reboot recovery, and each attempt's timing extraction wedging to
-  the xcresulttool bound, plus setup slack.
+- UI lane ceilings are `sum(per-class budgets)` - the batched shard
+  invocation watchdog - and the outer GitHub job ceiling is
+  `ceil((3 x sum + (n_classes + 1) x 600s + 2 x n_classes x 300s
+  + 1200s) / 60)` minutes: the reachable worst in-script path is the batched
+  attempt followed by per-class diagnosis after a batch timeout or wedge
+  (one attempt + one targeted retry per class = 2x more), each failing class
+  paying one bounded erase/reboot recovery, and each attempt's timing
+  extraction wedging to the xcresulttool bound, plus setup slack.
 
 **Finalize grace.** When a watchdog expires but the log already carries
 xcodebuild's terminal result marker (`** TEST EXECUTE SUCCEEDED/FAILED **`),

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -10,14 +10,13 @@ quarantined, or moved to a nightly gate.
 ```
                  test inventory (source scan)
                           |
-                   plan-tests.py
+  timing history (Actions cache) -> plan-tests.py
              (LPT timing balance, watchdog math)
-                          |
-             +------------+------------+
-             v                         v
-   plan.json / matrices        timing history (Actions cache)
-   (unit + UI)
-             |
+             |                         |
+   plan.json / matrices       CI tooling self-test (ubuntu;
+   (unit + UI)                planner tests, lane-runner state
+             |                machine, destination lookup - runs
+             |                concurrently, never delays the build)
       build-for-testing (once, workspace-anchored DerivedData)
              |
       .xctestrun + products artifact
@@ -42,12 +41,19 @@ quarantined, or moved to a nightly gate.
 
 | Job | Runner | Purpose |
 |---|---|---|
-| `plan` | ubuntu | Discovery validation + planner unit tests + lane generation (unit AND UI matrices). Cheap guard before any macOS minutes are spent. |
+| `plan` | ubuntu | Discovery validation + lane generation (unit AND UI matrices). Cheap guard before any macOS minutes are spent. |
+| `self-test` | ubuntu | CI-tooling regression suites (planner tests, lane-runner state machine, destination lookup, gate/timing contracts) - concurrent with `build`, so the minutes-long bash state-machine suite never delays macOS work nor risks the plan job's timeout. |
 | `build` | macos-26 | `build-for-testing` exactly once; `.xctestrun` portability audit; uploads products. |
 | `unit` (matrix) | macos-26 | One dynamically planned lane per matrix entry. |
-| `ui` (matrix) | macos-26 | Dynamically planned UI lane; runs each class independently (see below). |
+| `ui` (matrix) | macos-26 | Dynamically planned UI lane; runs each shard as ONE batched invocation (see below). |
 | `report` | ubuntu | Aggregates lane results into the CI Test Report step summary. |
 | `timing-history-update` | ubuntu | Main-only: merges fresh timings into the history cache (EWMA). |
+
+The self-test job's timeout hierarchy is load-bearing: each synthetic hang
+in the state-machine suite is watchdog-killed within a 1-6 s test budget <
+the suite's Python wrapper subprocess cap (480 s; the suite measures
+~3.5-4 min on macOS) < the job's own 12-minute ceiling - GitHub must never
+be the first layer to kill a regression suite.
 
 ## Test discovery
 
@@ -168,7 +174,7 @@ the rest of CI v2.
    with Xcode-native flake retry (`-retry-tests-on-failure
    -test-iterations N`), which re-executes only the failing tests; survivors
    fail the lane with the failing tests identified. A failing UI batch gets
-   one **targeted retry of exactly the failed tests** (methods when the
+   one **targeted retry of exactly the non-passing tests** (methods when the
    xcresult identifies them, the class otherwise); if the retry passes, the
    classes involved are reported as runner-level flakes and the lane
    continues.
@@ -313,7 +319,7 @@ real runtimes.
 The `CI Gate` job is the single stable required status check for branch
 protection. It passes only when:
 
-* `plan`, `build` and every dynamic `unit` lane succeed, and
+* `plan`, `build`, `self-test` and every dynamic `unit` lane succeed, and
 * every dynamic `ui` lane succeeds (or is skipped entirely because the repo
   contains no UI tests).
 

--- a/scripts/ci-gate.py
+++ b/scripts/ci-gate.py
@@ -1,16 +1,20 @@
 #!/usr/bin/env python3
 """CI Gate: the single stable branch-protection verdict for Hermes Conduit.
 
-The unit-test matrix is dynamically sized (4-8 lanes), so individual lane
+The unit-test matrix is dynamically sized (1-8 lanes), so individual lane
 jobs must never be required directly. This job aggregates the upstream
 results into one stable status context ("CI Gate").
 
 Policy:
-  plan  must be success
-  build must be success
-  unit  must be success
-  ui    must be success OR skipped (skipped is legitimate when the repo
-        contains no UI test classes)
+  plan      must be success
+  build     must be success
+  unit      must be success
+  ui        must be success OR skipped (skipped is legitimate when the repo
+            contains no UI test classes)
+  self-test must be success (the CI-tooling regression suites - planner,
+            lane-runner state machine, destination lookup, gate/timing
+            contracts - run as their own job so the expensive bash
+            state-machine suite never delays or outlives planning)
 
 Anything else - failure, cancelled, skipped upstream of a failure - fails
 the gate.
@@ -21,13 +25,14 @@ from __future__ import annotations
 import argparse
 import sys
 
-REQUIRED_SUCCESS = ("plan", "build", "unit")
+REQUIRED_SUCCESS = ("plan", "build", "unit", "self-test")
 UI_ALLOWED = ("success", "skipped")
 
 
-def verdict(plan: str, build: str, unit: str, ui: str) -> tuple:
+def verdict(plan: str, build: str, unit: str, ui: str, self_test: str) -> tuple:
     """Return (passed, reason). Reason lists every violated expectation."""
-    results = {"plan": plan, "build": build, "unit": unit, "ui": ui}
+    results = {"plan": plan, "build": build, "unit": unit, "ui": ui,
+               "self-test": self_test}
     failures = []
     for name in REQUIRED_SUCCESS:
         if results[name] != "success":
@@ -44,11 +49,13 @@ def main(argv=None) -> int:
     parser.add_argument("--build", required=True)
     parser.add_argument("--unit", required=True)
     parser.add_argument("--ui", required=True)
+    parser.add_argument("--self-test", required=True)
     args = parser.parse_args(argv)
 
-    passed, reason = verdict(args.plan, args.build, args.unit, args.ui)
+    passed, reason = verdict(args.plan, args.build, args.unit, args.ui,
+                             args.self_test)
     if passed:
-        print("CI Gate: PASS (plan/build/unit succeeded; ui "
+        print("CI Gate: PASS (plan/build/unit/self-test succeeded; ui "
               f"{args.ui!r})")
         return 0
     print(f"CI Gate: FAIL - {reason}")

--- a/scripts/ci-lib.sh
+++ b/scripts/ci-lib.sh
@@ -311,11 +311,24 @@ disable_pasteboard_sync() {
 }
 
 # Deterministic destination string shared by build and lane jobs. Sets the
-# global DESTINATION from SIMULATOR_NAME (and optional SIMULATOR_OS).
+# global DESTINATION from SIMULATOR_NAME (and optional SIMULATOR_OS). The
+# device is resolved once to its UDID so xcodebuild never disambiguates a
+# name that can match several runtimes/architectures - the source of the
+# "multiple matching destinations ... Using the first of multiple" warning,
+# where the wrong pick silently bypasses the OS pin. When the UDID cannot be
+# resolved (no jq, wedged CoreSimulatorService) the name-based form is kept
+# so behavior degrades to the historical lookup instead of failing.
 build_destination() {
   DESTINATION="platform=iOS Simulator,name=$SIMULATOR_NAME"
   if [ -n "${SIMULATOR_OS:-}" ]; then
     DESTINATION="$DESTINATION,OS=$SIMULATOR_OS"
+  fi
+  local udid
+  if udid=$(simulator_udid) && [ -n "$udid" ]; then
+    DESTINATION="platform=iOS Simulator,id=$udid"
+    echo "destination: '$SIMULATOR_NAME' resolved to UDID $udid"
+  else
+    echo "::warning::could not resolve simulator UDID - falling back to the name-based destination"
   fi
 }
 

--- a/scripts/ci-lib.sh
+++ b/scripts/ci-lib.sh
@@ -144,6 +144,12 @@ run_with_deadline() {
 # captured into BOUNDED_OUTPUT (caller's shell); the return value is the
 # command's status, or 124 when the deadline killed it. BOUNDED_OUTPUT is NOT
 # visible across a subshell boundary.
+#
+# The poll interval is 0.2s: bash's kill -0 keeps succeeding on a freshly
+# finished background child until it is reaped, so every coarse poll adds a
+# fixed floor to EVERY bounded call - and the state-machine suite (and real
+# simulator recovery paths) make many of them. 0.2s keeps the floor at
+# noise level while the deadline math stays identical.
 BOUNDED_OUTPUT=""
 bounded_run() {
   local budget="$1"
@@ -172,7 +178,7 @@ bounded_run() {
       rm -f "$outfile"
       return 124
     fi
-    sleep 2
+    sleep 0.2
   done
   status=0
   wait "$runner" || status=$?

--- a/scripts/ci-lib.sh
+++ b/scripts/ci-lib.sh
@@ -318,12 +318,15 @@ disable_pasteboard_sync() {
 
 # Deterministic destination string shared by build and lane jobs. Sets the
 # global DESTINATION from SIMULATOR_NAME (and optional SIMULATOR_OS). The
-# device is resolved once to its UDID so xcodebuild never disambiguates a
-# name that can match several runtimes/architectures - the source of the
-# "multiple matching destinations ... Using the first of multiple" warning,
-# where the wrong pick silently bypasses the OS pin. When the UDID cannot be
-# resolved (no jq, wedged CoreSimulatorService) the name-based form is kept
-# so behavior degrades to the historical lookup instead of failing.
+# device is resolved once to its UDID so xcodebuild never has to disambiguate
+# a name that can match several runtimes - and the arm64 slice is pinned too
+# (SIMULATOR_ARCH override), because every Apple Silicon simulator device
+# also registers an x86_64-under-Rosetta candidate, which alone triggers
+# xcodebuild's "Using the first of multiple matching destinations" warning
+# (run 34425462004: both candidates were the SAME UDID, differing only by
+# arch). When the UDID cannot be resolved (no jq, wedged
+# CoreSimulatorService) the name-based form is kept so behavior degrades to
+# the historical lookup instead of failing.
 build_destination() {
   DESTINATION="platform=iOS Simulator,name=$SIMULATOR_NAME"
   if [ -n "${SIMULATOR_OS:-}" ]; then
@@ -331,8 +334,8 @@ build_destination() {
   fi
   local udid
   if udid=$(simulator_udid) && [ -n "$udid" ]; then
-    DESTINATION="platform=iOS Simulator,id=$udid"
-    echo "destination: '$SIMULATOR_NAME' resolved to UDID $udid"
+    DESTINATION="platform=iOS Simulator,id=$udid,arch=${SIMULATOR_ARCH:-arm64}"
+    echo "destination: '$SIMULATOR_NAME' resolved to UDID $udid (arch ${SIMULATOR_ARCH:-arm64})"
   else
     echo "::warning::could not resolve simulator UDID - falling back to the name-based destination"
   fi

--- a/scripts/ci-test-lane.sh
+++ b/scripts/ci-test-lane.sh
@@ -4,18 +4,25 @@
 # build products (test-without-building; never rebuilds).
 #
 # Unit lanes run all assigned classes in one xcodebuild invocation. UI lanes
-# are DIFFERENT: each UI class is its own xcodebuild invocation under its own
-# per-class watchdog (budgets planned by plan-tests.py), so one hung class can
-# never hold the rest of the suite hostage and failure is attributed - and
-# retried - at class granularity.
+# batch every class of the shard into ONE invocation on the healthy path
+# (multiple -only-testing filters), so a successful shard pays Xcode/
+# CoreSimulator/test-session startup once instead of once per class. Any
+# batch-level failure falls back to per-class diagnosis (each class its own
+# invocation under its own planned watchdog), so one hung class can never
+# hold the rest of the suite hostage and failure is still attributed - and
+# retried - at class granularity; ordinary test failures never even get
+# there: they retry ONLY the failed test methods (exact method when the
+# xcresult identifies them, the class otherwise) in a single follow-up
+# invocation, and healthy classes are never re-executed.
 #
 # Failure-domain policy (docs/CI.md):
 #   1. Ordinary test failures never rerun healthy work. Unit attempt 1 runs
 #      with Xcode-native flake retry (-retry-tests-on-failure -test-iterations N),
 #      which re-executes only the failing tests. If failures survive those
 #      iterations the lane fails with the failing tests identified - the
-#      healthy classes are never rerun. UI classes get one TARGETED retry of
-#      just the failed class; passing classes are never re-executed.
+#      healthy classes are never rerun. UI batches get one TARGETED retry of
+#      just the failed tests (methods when identifiable, else classes);
+#      passing classes are never re-executed.
 #   2. An invocation whose XCTest result CANNOT be classified (timing/result
 #      extraction failed) is a FAILURE. Timing extraction is best-effort and
 #      must never decide test correctness, so an unclassifiable failure is
@@ -23,22 +30,24 @@
 #   3. An invocation that exits nonzero with a KNOWN zero failing-test count
 #      is confidently an infrastructure failure (simulator crash, runner
 #      exit, ...): reset the simulator once and retry. Units retry the whole
-#      lane (it is one invocation); a UI lane retries only the affected
-#      class. If a UI class fails AGAIN as an infrastructure failure, it is
-#      recorded as a persistent infrastructure failure and the lane FAILS -
-#      but after a clean simulator reset the remaining classes still run, so
-#      one wedged class cannot suppress independent UI coverage. If the
-#      simulator recovery itself cannot be trusted (erase failed, UDID
-#      unresolvable, boot never completed), later results would be
-#      misleading: the lane stops there instead.
+#      lane (it is one invocation); a UI batch cannot attribute a wedge to a
+#      class, so it erases the simulator and re-runs the affected classes
+#      through per-class diagnosis. If a class fails AGAIN as an
+#      infrastructure failure there, it is recorded as a persistent
+#      infrastructure failure and the lane FAILS - but after a clean
+#      simulator reset the remaining classes still run, so one wedged class
+#      cannot suppress independent UI coverage. If the simulator recovery
+#      itself cannot be trusted (erase failed, UDID unresolvable, boot never
+#      completed), later results would be misleading: the lane stops there.
 #   4. A watchdog timeout is positive identification of a hang. Units erase
 #      and enter lane-level class-granular isolation (heaviest estimate
 #      first, bounded by the isolation budget, stopping at the first
-#      confirmed class-level hang). UI classes are already isolated: the
-#      simulator is erased and the SAME class retries once under its own
-#      budget; a second timeout names the hung class, fails the lane, and
-#      later classes are recorded as not_diagnosed so a contaminated
-#      simulator cannot produce misleading secondary failures.
+#      confirmed class-level hang). A UI batch timeout cannot name the hung
+#      class, so it erases and enters the same per-class diagnosis, where a
+#      class that hangs twice names the culprit, fails the lane, and stops
+#      it (its simulator state is contaminated) while earlier results are
+#      kept and later classes are recorded as not_diagnosed so a
+#      contaminated simulator cannot produce misleading secondary failures.
 #
 # UI watchdog budgets are owned by plan-tests.py alone: every UI lane
 # receives an explicit per-class budget table (--class-timeouts) and the
@@ -275,6 +284,65 @@ except Exception:
 " "$1" 2>/dev/null || echo -1
 }
 
+# Method-precise retry filters from an extraction detail file: one
+# ConduitUITests/Class/testMethod line per non-passing test when the
+# xcresult identifies it, ConduitUITests/Class when only the class is known
+# (a class-level line subsumes any method-level lines of the same class).
+# Anything whose FINAL result is not Passed is retried - Failed, but also
+# Crashed/Skipped entries left by an aborted run, so a partial batch can
+# never be retried into a false green. Empty output means nothing was
+# reliably identifiable.
+retry_filter_lines() { # $1 = detail.json
+  python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1], encoding='utf-8') as fh:
+        d = json.load(fh)
+except Exception:
+    sys.exit(0)
+target = sys.argv[2]
+class_only = set()
+lines = []
+for a in d.get('attempts', []):
+    if str(a.get('final', '')).lower() == 'passed':
+        continue
+    cls = a.get('class')
+    if not cls:
+        continue
+    test = a.get('test')
+    if test:
+        lines.append(target + '/' + cls + '/' + test)
+    else:
+        class_only.add(cls)
+out = []
+seen = set()
+for line in lines:
+    cls = line.split('/')[1]
+    if cls in class_only:
+        continue
+    if line not in seen:
+        seen.add(line)
+        out.append(line)
+for cls in sorted(class_only):
+    out.append(target + '/' + cls)
+for line in out:
+    print(line)
+" "$1" "$TARGET" 2>/dev/null || true
+}
+
+# Sum of the planned per-class watchdog budgets for the named classes. Used
+# as the watchdog of a batched invocation (sum of its members' budgets is a
+# safe upper bound: every member budget already covers a full invocation's
+# fixed overhead on its own).
+sum_of_class_budgets() {
+  local total=0 cls budget
+  for cls in "$@"; do
+    budget=$(ui_budget_for "$cls")
+    total=$(( total + budget ))
+  done
+  echo "$total"
+}
+
 # --- lane bookkeeping --------------------------------------------------------
 STARTED_AT=$(now_iso)
 lane_start=$(date +%s)
@@ -345,17 +413,32 @@ persistent_infra_csv() {
   sed '/^$/d' "$PERSISTENT_INFRA_LINES" 2>/dev/null | paste -sd ',' - 2>/dev/null || printf ''
 }
 
-# Every class after $1 (the class being stopped on) that never ran must be
-# visible as not_diagnosed - unexecuted tests may never masquerade as passed
-# or as ordinary failures.
-mark_remaining_not_diagnosed() { # $1 = class the lane stopped on
+# Every class after $1 (the class the diagnosis stopped on) in the diagnosis
+# list ($2 onwards) that never ran must be visible as not_diagnosed -
+# unexecuted tests may never masquerade as passed or as ordinary failures.
+mark_remaining_not_diagnosed() { # $1 = class the diagnosis stopped on
+  local stopped="$1"
+  shift
   local seen=0 cls
-  for cls in "${CLASSES_ARR[@]}"; do
+  for cls in "$@"; do
     if [ "$seen" -eq 1 ]; then
       record_attempt "skipped" 0 "$cls" "not_diagnosed"
-      echo "::error::class $cls was NOT executed (lane stopped at $1) - recorded as not_diagnosed"
+      echo "::error::class $cls was NOT executed (lane stopped at $stopped) - recorded as not_diagnosed"
     fi
-    [ "$cls" = "$1" ] && seen=1
+    [ "$cls" = "$stopped" ] && seen=1
+  done
+}
+
+# Batch-level failures that abort before ANY per-class result exists: every
+# named class is recorded as not_diagnosed. Called with ALL assigned classes
+# when nothing attributable ran, or with just the retried classes when a
+# retry's simulator recovery failed (healthy batch-passing classes keep
+# their recorded results).
+mark_all_not_diagnosed() {
+  local cls
+  for cls in "$@"; do
+    record_attempt "skipped" 0 "$cls" "not_diagnosed"
+    echo "::error::class $cls was NOT executed - recorded as not_diagnosed"
   done
 }
 
@@ -394,11 +477,16 @@ finish_lane() { # $1=status $2=attempts_json $3=isolation_json $4=exit_code
   # Bundles are created inside RESULT_DIR, so failed lanes upload them as
   # failure artifacts automatically. Successful lanes have already had their
   # timings extracted - delete the bundles to keep the artifact small, EXCEPT
-  # for classes that needed their targeted retry (test-flake OR infra-wedge
+  # for attempts that needed their targeted retry (test-flake OR infra-wedge
   # recovery: both attempt bundles are kept, since the attempt-1 bundle is
   # the only evidence of what needed the retry).
   if [ "$1" = "pass" ]; then
     if [ "$KIND" = "ui" ]; then
+      # Batched shard: a clean first-attempt batch leaves no bundle behind;
+      # a batch that needed its targeted retry keeps BOTH bundles.
+      if [ ! -s "$RETRIED_LINES" ] && [ ! -s "$INFRA_RECOVERED_LINES" ]; then
+        rm -rf "$RESULT_DIR"/batch-a*.xcresult 2>/dev/null || true
+      fi
       local b base cls
       for b in "$RESULT_DIR"/class-*.xcresult; do
         [ -e "$b" ] || break
@@ -607,26 +695,194 @@ echo "::error::lane $LANE failed twice with zero failing tests (exit $status1, t
 finish_lane "error" '[{"n": 1, "mode": "lane", "status": "infra-error"}, {"n": 2, "mode": "lane-retry", "status": "infra-error"}]' "" 1
 }
 
-# --- UI lane: one independent invocation PER CLASS ----------------------------
-# Each class runs alone, under its own planned watchdog, and gets at most one
-# targeted retry. A pass moves on immediately; a retry pass is reported as a
-# runner-level flake (never an indistinguishable clean pass); a class that
-# fails both attempts fails the lane while the remaining classes still run;
-# a class that hangs twice names the culprit and stops the lane (its
-# simulator state is contaminated). The simulator is booted once up front so
-# only the first class pays the cold-boot overhead.
+# --- UI lane: one batched invocation per shard on the healthy path ------------
+# Every class of the shard runs in ONE xcodebuild invocation (multiple
+# -only-testing filters), so a healthy shard pays the Xcode/CoreSimulator/
+# test-session startup and result finalization once instead of once per
+# class. Recovery never re-executes healthy work:
+#   * ordinary test failures  -> one targeted retry invocation of ONLY the
+#     failed tests (exact methods when the xcresult identifies them, else
+#     their classes); a passing retry stays a reported flake;
+#   * watchdog timeout or infrastructure wedge -> erase the simulator and
+#     re-run the affected classes through run_class_diagnosis, which keeps
+#     the original per-class failure-domain properties (per-class watchdogs,
+#     one retry, hang attribution).
 run_ui_lane() {
   bounded_run 60 xcrun simctl shutdown all || true
   reset_and_boot_simulator 0
 
+  batch_budget=$(sum_of_class_budgets "${CLASSES_ARR[@]}")
+  status1=0
+  echo "::group::UI shard $LANE batch attempt 1 ("${#CLASSES_ARR[@]}" classes in one invocation, budget "${batch_budget}"s)"
+  xcodebuild_test "$batch_budget" "$LOG_DIR/batch-a1.log" \
+    "$RESULT_DIR/batch-a1.xcresult" 1 "${ONLY_TESTING[@]}" || status1=$?
+  echo "::endgroup::"
+
+  if [ "$status1" -ne 0 ] && [ "$status1" -ne 124 ]; then
+    # Classify the failure before deciding the retry's recovery actions.
+    extract_bundle "$RESULT_DIR/batch-a1.xcresult" \
+      "$RESULT_DIR/parts/observations-batch-a1.json" \
+      "$RESULT_DIR/parts/detail-batch-a1.json" \
+      "$LOG_DIR/extract-batch-a1.log"
+    FAIL_COUNT1=$(count_failures "$RESULT_DIR/parts/detail-batch-a1.json")
+    if [ "$FAIL_COUNT1" -eq -1 ]; then
+      echo "::error::UI shard $LANE batch failed (exit $status1) and its XCTest result could not be classified - failing the lane instead of retrying"
+      record_attempt "batch" 1 "all" "unclassified"
+      mark_all_not_diagnosed "${CLASSES_ARR[@]}"
+      finish_lane "fail" "$(serialize_attempts)" "" 1
+    fi
+  else
+    FAIL_COUNT1=""   # timeout: classified without extraction; pass: not needed
+  fi
+
+  if [ "$status1" -eq 0 ]; then
+    extract_bundle "$RESULT_DIR/batch-a1.xcresult" \
+      "$RESULT_DIR/parts/observations-batch-a1.json" \
+      "$RESULT_DIR/parts/detail-batch-a1.json" \
+      "$LOG_DIR/extract-batch-a1.log"
+    record_attempt "batch" 1 "all" "passed"
+    echo "UI shard $LANE: batch of "${#CLASSES_ARR[@]}" classes passed in one invocation"
+    finish_lane "pass" "$(serialize_attempts)" "" 0
+  fi
+
+  # --- batch timed out: no per-class attribution, diagnose class-by-class ----
+  if [ "$status1" -eq 124 ]; then
+    record_attempt "batch" 1 "all" "timeout"
+    echo "::warning::UI shard $LANE batch exceeded its "${batch_budget}"s watchdog - erasing simulator and entering per-class diagnosis"
+    bounded_run 45 xcrun simctl list devices >"$LOG_DIR/simctl-devices-after-timeout-batch-a1.txt" 2>&1 || true
+    RESET_USED=1
+    ERASE_USED=1
+    if ! reset_and_boot_simulator 1; then
+      echo "::error::simulator recovery after the batch timeout failed - the environment cannot be trusted; stopping the lane"
+      mark_all_not_diagnosed "${CLASSES_ARR[@]}"
+      finish_lane "error" "$(serialize_attempts)" "" 1
+    fi
+    run_class_diagnosis "${CLASSES_ARR[@]}"
+  fi
+
+  # --- batch infra wedge: zero identified failures, nonzero exit -----------
+  # A batch cannot attribute a wedge to a class: erase the simulator and
+  # re-run the whole shard through per-class diagnosis, which keeps the
+  # per-class watchdog, retry, and hang-attribution properties.
+  if [ "$status1" -ne 0 ] && [ "$FAIL_COUNT1" -eq 0 ]; then
+    record_attempt "batch" 1 "all" "infra-error"
+    echo "::warning::UI shard $LANE batch failed with zero failing tests (exit $status1) - infrastructure failure; erasing simulator and entering per-class diagnosis"
+    RESET_USED=1
+    ERASE_USED=1
+    if ! reset_and_boot_simulator 1; then
+      echo "::error::simulator recovery after the batch infrastructure failure failed - the environment cannot be trusted; stopping the lane"
+      mark_all_not_diagnosed "${CLASSES_ARR[@]}"
+      finish_lane "error" "$(serialize_attempts)" "" 1
+    fi
+    run_class_diagnosis "${CLASSES_ARR[@]}"
+  fi
+
+  # --- ordinary test failures: retry ONLY the failed tests --------------------
+  # Method-level when the xcresult identifies the test (the extraction's
+  # failure records carry class + test), class-level otherwise. Healthy
+  # classes are never re-executed, so a single failure can never grow into a
+  # shard-wide rerun.
+  RETRY_LINES=$(retry_filter_lines "$RESULT_DIR/parts/detail-batch-a1.json")
+  if [ -z "$RETRY_LINES" ]; then
+    echo "::error::UI shard $LANE had "${FAIL_COUNT1}" failing test(s) but none could be identified from the xcresult - failing the lane"
+    record_attempt "batch" 1 "all" "unclassified"
+    finish_lane "fail" "$(serialize_attempts)" "" 1
+  fi
+  RETRY_FILTERS=()
+  while IFS= read -r filter; do
+    [ -n "$filter" ] && RETRY_FILTERS+=("-only-testing:$filter")
+  done <<EOF
+$RETRY_LINES
+EOF
+  RETRY_CLASSES=$(printf '%s\n' "$RETRY_LINES" | awk -F/ '{print $2}' | sort -u)
+  retry_budget=$(sum_of_class_budgets $RETRY_CLASSES)
+  record_attempt "batch" 1 "all" "test-failures"
+  echo "UI shard $LANE: "${FAIL_COUNT1}" test(s) failed - targeted retry of only the failed tests ("$(printf '%s ' $RETRY_FILTERS)")"
+
+  status2=0
+  echo "::group::UI shard $LANE targeted retry (budget "${retry_budget}"s)"
+  xcodebuild_test "$retry_budget" "$LOG_DIR/batch-a2.log" \
+    "$RESULT_DIR/batch-a2.xcresult" 1 "${RETRY_FILTERS[@]}" || status2=$?
+  echo "::endgroup::"
+
+  if [ "$status2" -eq 0 ]; then
+    extract_bundle "$RESULT_DIR/batch-a2.xcresult" \
+      "$RESULT_DIR/parts/observations-batch-a2.json" \
+      "$RESULT_DIR/parts/detail-batch-a2.json" \
+      "$LOG_DIR/extract-batch-a2.log"
+    record_attempt "batch-retry" 2 "all" "passed"
+    for cls in $RETRY_CLASSES; do
+      echo "$cls" >> "$RETRIED_LINES"
+    done
+    # A test failure that a retry rescued is a runner-level flake: it stays
+    # visible instead of blending into a clean pass, and both attempt
+    # bundles are kept for diagnosis.
+    echo "::warning::UI shard $LANE PASSED on its targeted retry - runner-level flake ("$(printf '%s, ' $RETRY_CLASSES)"only the failed tests re-ran), reported, not hidden"
+    finish_lane "pass" "$(serialize_attempts)" "" 0
+  fi
+
+  if [ "$status2" -eq 124 ]; then
+    record_attempt "batch-retry" 2 "all" "timeout"
+    echo "::warning::UI shard $LANE targeted retry exceeded its "${retry_budget}"s watchdog - erasing simulator and entering per-class diagnosis of the retried classes"
+    RESET_USED=1
+    ERASE_USED=1
+    if ! reset_and_boot_simulator 1; then
+      echo "::error::simulator recovery after the retry timeout failed - the environment cannot be trusted; stopping the lane"
+      mark_all_not_diagnosed $RETRY_CLASSES
+      finish_lane "error" "$(serialize_attempts)" "" 1
+    fi
+    run_class_diagnosis $RETRY_CLASSES
+  fi
+
+  extract_bundle "$RESULT_DIR/batch-a2.xcresult" \
+    "$RESULT_DIR/parts/observations-batch-a2.json" \
+    "$RESULT_DIR/parts/detail-batch-a2.json" \
+    "$LOG_DIR/extract-batch-a2.log"
+  FAIL_COUNT2=$(count_failures "$RESULT_DIR/parts/detail-batch-a2.json")
+  if [ "$FAIL_COUNT2" -gt 0 ]; then
+    echo "::error::UI shard $LANE tests FAILED again on the targeted retry ("${FAIL_COUNT2}" test(s) - real failures, not flakes) - failing the lane"
+    record_attempt "batch-retry" 2 "all" "test-failures"
+    finish_lane "fail" "$(serialize_attempts)" "" 1
+  fi
+  if [ "$FAIL_COUNT2" -eq -1 ]; then
+    echo "::error::UI shard $LANE targeted retry failed (exit $status2) and its XCTest result could not be classified - failing the lane"
+    record_attempt "batch-retry" 2 "all" "unclassified"
+    finish_lane "fail" "$(serialize_attempts)" "" 1
+  fi
+
+  # Nonzero exit with a known zero failing-test count and no timeout: the
+  # retry itself wedged on the environment. A batch cannot attribute a wedge
+  # to a class, so erase and diagnose the retried classes one by one.
+  record_attempt "batch-retry" 2 "all" "infra-error"
+  echo "::warning::UI shard $LANE targeted retry hit an infrastructure failure (exit $status2, zero failing tests) - erasing simulator and entering per-class diagnosis of the retried classes"
+  RESET_USED=1
+  ERASE_USED=1
+  if ! reset_and_boot_simulator 1; then
+    echo "::error::simulator recovery after the retry infrastructure failure failed - the environment cannot be trusted; stopping the lane"
+    mark_all_not_diagnosed $RETRY_CLASSES
+    finish_lane "error" "$(serialize_attempts)" "" 1
+  fi
+  run_class_diagnosis $RETRY_CLASSES
+}
+
+# --- UI per-class diagnosis loop ----------------------------------------------
+# Each named class runs alone, under its own planned watchdog, and gets at
+# most one targeted retry. A pass moves on immediately; a retry pass is
+# reported as a runner-level flake (never an indistinguishable clean pass); a
+# class that fails both attempts fails the lane while the remaining classes
+# still run; a class that hangs twice names the culprit and stops the lane
+# (its simulator state is contaminated). Entered only after the simulator is
+# in a trusted, freshly-booted state. Always terminates the lane.
+run_class_diagnosis() {
+  DIAG_CLASSES_ARR=("$@")
   LANE_FAILED=0
-  for cls in "${CLASSES_ARR[@]}"; do
+  for cls in "${DIAG_CLASSES_ARR[@]}"; do
     budget=$(ui_budget_for "$cls")
     obs1="$RESULT_DIR/parts/observations-$cls-a1.json"
     det1="$RESULT_DIR/parts/detail-$cls-a1.json"
 
     status1=0
-    echo "::group::UI class $cls attempt 1 (budget "${budget}"s)"
+    echo "::group::UI diagnosis class $cls attempt 1 (budget "${budget}"s)"
     xcodebuild_test "$budget" "$LOG_DIR/class-$cls-a1.log" \
       "$RESULT_DIR/class-$cls-a1.xcresult" 1 "-only-testing:$TARGET/$cls" || status1=$?
     echo "::endgroup::"
@@ -639,7 +895,7 @@ run_ui_lane() {
       if [ "$FAIL_COUNT1" -eq -1 ]; then
         echo "::error::UI class $cls failed (exit $status1) and its XCTest result could not be classified - failing the lane instead of retrying"
         record_attempt "class" 1 "$cls" "unclassified"
-        mark_remaining_not_diagnosed "$cls"
+        mark_remaining_not_diagnosed "$cls" "${DIAG_CLASSES_ARR[@]}"
         finish_lane "fail" "$(serialize_attempts)" "" 1
       fi
     else
@@ -674,7 +930,7 @@ run_ui_lane() {
       ERASE_USED=1
       if ! reset_and_boot_simulator 1; then
         echo "::error::simulator recovery for UI class $cls failed - the environment cannot be trusted; stopping the lane"
-        mark_remaining_not_diagnosed "$cls"
+        mark_remaining_not_diagnosed "$cls" "${DIAG_CLASSES_ARR[@]}"
         finish_lane "error" "$(serialize_attempts)" "" 1
       fi
     elif [ "$FAIL_COUNT1" -eq 0 ]; then
@@ -683,17 +939,33 @@ run_ui_lane() {
       ERASE_USED=1
       if ! reset_and_boot_simulator 1; then
         echo "::error::simulator recovery for UI class $cls failed - the environment cannot be trusted; stopping the lane"
-        mark_remaining_not_diagnosed "$cls"
+        mark_remaining_not_diagnosed "$cls" "${DIAG_CLASSES_ARR[@]}"
         finish_lane "error" "$(serialize_attempts)" "" 1
       fi
     else
-      echo "UI class $cls failed ("${FAIL_COUNT1}" test(s) surviving) - targeted retry of this class once"
+      # Diagnosis mode retries at the same precision as the batch path: the
+      # failed methods when the extraction identifies them, the class
+      # otherwise.
+      DIAG_RETRY_LINES=$(retry_filter_lines "$det1")
+      echo "UI class $cls failed ("${FAIL_COUNT1}" test(s) surviving) - targeted retry"
     fi
+
+    DIAG_RETRY_FILTERS=()
+    if [ -n "${DIAG_RETRY_LINES:-}" ]; then
+      while IFS= read -r filter; do
+        [ -n "$filter" ] && DIAG_RETRY_FILTERS+=("-only-testing:$filter")
+      done <<EOF
+$DIAG_RETRY_LINES
+EOF
+    else
+      DIAG_RETRY_FILTERS+=("-only-testing:$TARGET/$cls")
+    fi
+    DIAG_RETRY_LINES=""
 
     status2=0
     echo "::group::UI class $cls attempt 2 (targeted retry)"
     xcodebuild_test "$budget" "$LOG_DIR/class-$cls-a2.log" \
-      "$RESULT_DIR/class-$cls-a2.xcresult" 1 "-only-testing:$TARGET/$cls" || status2=$?
+      "$RESULT_DIR/class-$cls-a2.xcresult" 1 "${DIAG_RETRY_FILTERS[@]}" || status2=$?
     echo "::endgroup::"
 
     if [ "$status2" -eq 0 ]; then
@@ -719,7 +991,7 @@ run_ui_lane() {
       echo "::error::UI class $cls HUNG again (exceeded its "${budget}"s class budget twice) - it is the identified culprit; failing the lane"
       HUNG_CLASS="$cls"
       record_attempt "class-retry" 2 "$cls" "timeout"
-      mark_remaining_not_diagnosed "$cls"
+      mark_remaining_not_diagnosed "$cls" "${DIAG_CLASSES_ARR[@]}"
       finish_lane "timeout" "$(serialize_attempts)" "" 1
     fi
 
@@ -737,7 +1009,7 @@ run_ui_lane() {
     if [ "$FAIL_COUNT2" -eq -1 ]; then
       echo "::error::UI class $cls failed again (exit $status2) and its XCTest result could not be classified - failing the lane"
       record_attempt "class-retry" 2 "$cls" "unclassified"
-      mark_remaining_not_diagnosed "$cls"
+      mark_remaining_not_diagnosed "$cls" "${DIAG_CLASSES_ARR[@]}"
       finish_lane "fail" "$(serialize_attempts)" "" 1
     fi
 
@@ -758,7 +1030,7 @@ run_ui_lane() {
     ERASE_USED=1
     if ! reset_and_boot_simulator 1; then
       echo "::error::simulator cleanup after the persistent infrastructure failure in UI class $cls failed - the environment cannot be trusted; stopping the lane"
-      mark_remaining_not_diagnosed "$cls"
+      mark_remaining_not_diagnosed "$cls" "${DIAG_CLASSES_ARR[@]}"
       finish_lane "error" "$(serialize_attempts)" "" 1
     fi
   done

--- a/scripts/ci-test-lane.sh
+++ b/scripts/ci-test-lane.sh
@@ -891,7 +891,7 @@ EOF
     # A test failure that a retry rescued is a runner-level flake: it stays
     # visible instead of blending into a clean pass, and both attempt
     # bundles are kept for diagnosis.
-    echo "::warning::UI shard $LANE PASSED on its targeted retry - runner-level flake ("$(printf '%s, ' $RETRY_CLASSES)"only the failed tests re-ran), reported, not hidden"
+    echo "::warning::UI shard $LANE passed on its targeted retry - runner-level flake. Retried tests: $(printf '%s' "$RETRY_LINES" | tr '\n' ' ')- only the non-passing tests were re-run; reported, not hidden"
     finish_lane "pass" "$(serialize_attempts)" "" 0
   fi
 
@@ -1028,12 +1028,14 @@ run_class_diagnosis() {
     fi
 
     DIAG_RETRY_FILTERS=()
+    DIAG_RETRY_METHOD_FILTERED=0
     if [ -n "${DIAG_RETRY_LINES:-}" ]; then
       while IFS= read -r filter; do
         [ -n "$filter" ] && DIAG_RETRY_FILTERS+=("-only-testing:$filter")
       done <<EOF
 $DIAG_RETRY_LINES
 EOF
+      DIAG_RETRY_METHOD_FILTERED=1
     else
       DIAG_RETRY_FILTERS+=("-only-testing:$TARGET/$cls")
     fi
@@ -1050,6 +1052,14 @@ EOF
         "$RESULT_DIR/parts/observations-$cls-a2.json" \
         "$RESULT_DIR/parts/detail-$cls-a2.json" \
         "$LOG_DIR/extract-$cls-a2.log"
+      # A method-filtered retry reran only the failed METHODS, so its
+      # observations carry method-only durations per class - the attempt-1
+      # full-class invocation owns class timing, so the retry's observations
+      # must not fold into the timing history (same rule as the batch path).
+      # The detail part stays: it carries the retry/flake evidence.
+      if [ "$DIAG_RETRY_METHOD_FILTERED" -eq 1 ]; then
+        rm -f "$RESULT_DIR/parts/observations-$cls-a2.json"
+      fi
       record_attempt "class-retry" 2 "$cls" "passed"
       if [ "$a1_status" = "infra-error" ]; then
         echo "$cls" >> "$INFRA_RECOVERED_LINES"
@@ -1076,6 +1086,11 @@ EOF
       "$RESULT_DIR/parts/observations-$cls-a2.json" \
       "$RESULT_DIR/parts/detail-$cls-a2.json" \
       "$LOG_DIR/extract-$cls-a2.log"
+    # Same timing-history rule on the failing path: a method-filtered retry
+    # never becomes the class's duration sample.
+    if [ "$DIAG_RETRY_METHOD_FILTERED" -eq 1 ]; then
+      rm -f "$RESULT_DIR/parts/observations-$cls-a2.json"
+    fi
     FAIL_COUNT2=$(count_failures "$RESULT_DIR/parts/detail-$cls-a2.json")
     if [ "$FAIL_COUNT2" -gt 0 ]; then
       echo "::error::UI class $cls FAILED again ("${FAIL_COUNT2}" test(s)) - failing the lane; remaining classes still run"

--- a/scripts/ci-test-lane.sh
+++ b/scripts/ci-test-lane.sh
@@ -723,8 +723,9 @@ finish_lane "error" '[{"n": 1, "mode": "lane", "status": "infra-error"}, {"n": 2
 # test-session startup and result finalization once instead of once per
 # class. Recovery never re-executes healthy work:
 #   * ordinary test failures  -> one targeted retry invocation of ONLY the
-#     failed tests (exact methods when the xcresult identifies them, else
-#     their classes); a passing retry stays a reported flake;
+#     non-passing tests (final results other than Passed - exact methods
+#     when the xcresult identifies them, else their classes); a passing
+#     retry stays a reported flake;
 #   * watchdog timeout or infrastructure wedge -> erase the simulator and
 #     re-run the affected classes through run_class_diagnosis, which keeps
 #     the original per-class failure-domain properties (per-class watchdogs,
@@ -762,14 +763,34 @@ run_ui_lane() {
       "$RESULT_DIR/parts/observations-batch-a1.json" \
       "$RESULT_DIR/parts/detail-batch-a1.json" \
       "$LOG_DIR/extract-batch-a1.log"
-    record_attempt "batch" 1 "all" "passed"
-    echo "UI shard $LANE: batch of "${#CLASSES_ARR[@]}" classes passed in one invocation"
-    finish_lane "pass" "$(serialize_attempts)" "" 0
+    # Defense in depth: exit 0 should imply every -only-testing filter
+    # executed; if a parseable detail proves an assigned class left no
+    # record, do not trust the exit code - diagnose like any other batch
+    # that cannot account for its classes. An unreadable detail degrades to
+    # the pass (the gate reports nothing).
+    MISSING_CLASSES=$(unexecuted_classes "$RESULT_DIR/parts/detail-batch-a1.json")
+    if [ -z "$MISSING_CLASSES" ]; then
+      record_attempt "batch" 1 "all" "passed"
+      echo "UI shard $LANE: batch of "${#CLASSES_ARR[@]}" classes passed in one invocation"
+      finish_lane "pass" "$(serialize_attempts)" "" 0
+    fi
+    record_attempt "batch" 1 "all" "incomplete"
+    DIAGNOSIS_REASON="batch exit 0 without any record of $(printf '%s ' $MISSING_CLASSES)"
+    echo "::warning::UI shard $LANE batch exited 0 but the xcresult has no record of $(printf '%s ' $MISSING_CLASSES)- erasing simulator and entering per-class diagnosis"
+    RESET_USED=1
+    ERASE_USED=1
+    if ! reset_and_boot_simulator 1; then
+      echo "::error::simulator recovery after the incomplete batch failed - the environment cannot be trusted; stopping the lane"
+      mark_all_not_diagnosed "${CLASSES_ARR[@]}"
+      finish_lane "error" "$(serialize_attempts)" "" 1
+    fi
+    run_class_diagnosis "${CLASSES_ARR[@]}"
   fi
 
   # --- batch timed out: no per-class attribution, diagnose class-by-class ----
   if [ "$status1" -eq 124 ]; then
     record_attempt "batch" 1 "all" "timeout"
+    DIAGNOSIS_REASON="batch watchdog timeout"
     echo "::warning::UI shard $LANE batch exceeded its "${batch_budget}"s watchdog - erasing simulator and entering per-class diagnosis"
     bounded_run 45 xcrun simctl list devices >"$LOG_DIR/simctl-devices-after-timeout-batch-a1.txt" 2>&1 || true
     RESET_USED=1
@@ -788,6 +809,7 @@ run_ui_lane() {
   # per-class watchdog, retry, and hang-attribution properties.
   if [ "$status1" -ne 0 ] && [ "$FAIL_COUNT1" -eq 0 ]; then
     record_attempt "batch" 1 "all" "infra-error"
+    DIAGNOSIS_REASON="batch infrastructure failure (exit $status1, zero failing tests)"
     echo "::warning::UI shard $LANE batch failed with zero failing tests (exit $status1) - infrastructure failure; erasing simulator and entering per-class diagnosis"
     RESET_USED=1
     ERASE_USED=1
@@ -817,7 +839,8 @@ run_ui_lane() {
   MISSING_CLASSES=$(unexecuted_classes "$RESULT_DIR/parts/detail-batch-a1.json")
   if [ -n "$MISSING_CLASSES" ]; then
     record_attempt "batch" 1 "all" "incomplete"
-    echo "::warning::UI shard $LANE batch aborted before executing $(printf '%s, ' $MISSING_CLASSES)- erasing simulator and entering per-class diagnosis"
+    DIAGNOSIS_REASON="batch aborted before executing $(printf '%s ' $MISSING_CLASSES)"
+    echo "::warning::UI shard $LANE batch aborted before executing $(printf '%s ' $MISSING_CLASSES)- erasing simulator and entering per-class diagnosis"
     RESET_USED=1
     ERASE_USED=1
     if ! reset_and_boot_simulator 1; then
@@ -874,6 +897,7 @@ EOF
 
   if [ "$status2" -eq 124 ]; then
     record_attempt "batch-retry" 2 "all" "timeout"
+    DIAGNOSIS_REASON="targeted retry watchdog timeout"
     echo "::warning::UI shard $LANE targeted retry exceeded its "${retry_budget}"s watchdog - erasing simulator and entering per-class diagnosis of the retried classes"
     RESET_USED=1
     ERASE_USED=1
@@ -906,6 +930,7 @@ EOF
   # retry itself wedged on the environment. A batch cannot attribute a wedge
   # to a class, so erase and diagnose the retried classes one by one.
   record_attempt "batch-retry" 2 "all" "infra-error"
+  DIAGNOSIS_REASON="targeted retry infrastructure failure (exit $status2, zero failing tests)"
   echo "::warning::UI shard $LANE targeted retry hit an infrastructure failure (exit $status2, zero failing tests) - erasing simulator and entering per-class diagnosis of the retried classes"
   RESET_USED=1
   ERASE_USED=1
@@ -1089,6 +1114,13 @@ EOF
 
   if [ "$LANE_FAILED" -eq 1 ]; then
     finish_lane "fail" "$(serialize_attempts)" "" 1
+  fi
+  if [ -n "${DIAGNOSIS_REASON:-}" ]; then
+    # A green lane reached through per-class diagnosis re-ran classes after
+    # a batch-level event; keep that visible instead of blending into a
+    # clean pass (the attempt chain in lane-result.json carries the record).
+    echo "::warning::UI shard $LANE passed after per-class diagnosis ($DIAGNOSIS_REASON) - the affected classes re-ran individually and passed"
+    DIAGNOSIS_REASON=""
   fi
   finish_lane "pass" "$(serialize_attempts)" "" 0
 }

--- a/scripts/ci-test-lane.sh
+++ b/scripts/ci-test-lane.sh
@@ -330,6 +330,28 @@ for line in out:
 " "$1" "$TARGET" 2>/dev/null || true
 }
 
+# Classes with NO attempt records in an extraction detail file: a batch that
+# aborted before a class ever started must not be retried into a green lane -
+# the unexecuted classes force per-class diagnosis instead.
+unexecuted_classes() { # $1 = detail.json
+  python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1], encoding='utf-8') as fh:
+        d = json.load(fh)
+except Exception:
+    sys.exit(0)
+seen = set()
+for a in d.get('attempts', []):
+    cls = a.get('class')
+    if cls:
+        seen.add(cls)
+for cls in sys.argv[2].split(','):
+    if cls and cls not in seen:
+        print(cls)
+" "$1" "$CLASSES" 2>/dev/null || true
+}
+
 # Sum of the planned per-class watchdog budgets for the named classes. Used
 # as the watchdog of a batched invocation (sum of its members' budgets is a
 # safe upper bound: every member budget already covers a full invocation's
@@ -788,12 +810,37 @@ run_ui_lane() {
     record_attempt "batch" 1 "all" "unclassified"
     finish_lane "fail" "$(serialize_attempts)" "" 1
   fi
+
+  # A batch that aborted before a class ever started must not be retried
+  # into a green lane: any assigned class without an attempt record forces
+  # a full per-class diagnosis pass instead of the targeted retry.
+  MISSING_CLASSES=$(unexecuted_classes "$RESULT_DIR/parts/detail-batch-a1.json")
+  if [ -n "$MISSING_CLASSES" ]; then
+    record_attempt "batch" 1 "all" "incomplete"
+    echo "::warning::UI shard $LANE batch aborted before executing $(printf '%s, ' $MISSING_CLASSES)- erasing simulator and entering per-class diagnosis"
+    RESET_USED=1
+    ERASE_USED=1
+    if ! reset_and_boot_simulator 1; then
+      echo "::error::simulator recovery after the incomplete batch failed - the environment cannot be trusted; stopping the lane"
+      mark_all_not_diagnosed "${CLASSES_ARR[@]}"
+      finish_lane "error" "$(serialize_attempts)" "" 1
+    fi
+    run_class_diagnosis "${CLASSES_ARR[@]}"
+  fi
+
   RETRY_FILTERS=()
   while IFS= read -r filter; do
     [ -n "$filter" ] && RETRY_FILTERS+=("-only-testing:$filter")
   done <<EOF
 $RETRY_LINES
 EOF
+  if [ "${#RETRY_FILTERS[@]}" -eq 0 ]; then
+    # Unreachable via retry_filter_lines (it only prints non-empty lines),
+    # but an empty array expansion would crash bash 3.2 under set -u.
+    echo "::error::UI shard $LANE could not build retry filters for "${FAIL_COUNT1}" identified failure(s) - failing the lane"
+    record_attempt "batch" 1 "all" "unclassified"
+    finish_lane "fail" "$(serialize_attempts)" "" 1
+  fi
   RETRY_CLASSES=$(printf '%s\n' "$RETRY_LINES" | awk -F/ '{print $2}' | sort -u)
   retry_budget=$(sum_of_class_budgets $RETRY_CLASSES)
   record_attempt "batch" 1 "all" "test-failures"
@@ -810,6 +857,10 @@ EOF
       "$RESULT_DIR/parts/observations-batch-a2.json" \
       "$RESULT_DIR/parts/detail-batch-a2.json" \
       "$LOG_DIR/extract-batch-a2.log"
+    # The retry reran only the failed METHODS, so its observations carry
+    # method-only durations per class - the batch attempt owns class timing,
+    # so the retry's observations must not fold into the timing history.
+    rm -f "$RESULT_DIR/parts/observations-batch-a2.json"
     record_attempt "batch-retry" 2 "all" "passed"
     for cls in $RETRY_CLASSES; do
       echo "$cls" >> "$RETRIED_LINES"
@@ -838,6 +889,7 @@ EOF
     "$RESULT_DIR/parts/observations-batch-a2.json" \
     "$RESULT_DIR/parts/detail-batch-a2.json" \
     "$LOG_DIR/extract-batch-a2.log"
+  rm -f "$RESULT_DIR/parts/observations-batch-a2.json"
   FAIL_COUNT2=$(count_failures "$RESULT_DIR/parts/detail-batch-a2.json")
   if [ "$FAIL_COUNT2" -gt 0 ]; then
     echo "::error::UI shard $LANE tests FAILED again on the targeted retry ("${FAIL_COUNT2}" test(s) - real failures, not flakes) - failing the lane"

--- a/scripts/extract-test-timings.py
+++ b/scripts/extract-test-timings.py
@@ -399,11 +399,20 @@ def merge_detail_parts(parts: list) -> dict:
         cls = _part_class(fname)
         failures_by_class[cls] = _list_field(doc, "failures")
     # The synthetic "batch" key carries the batched shard attempt's failures.
-    # Once any per-class part exists, diagnosis results have superseded that
-    # attempt: keeping the batch entries would double-count failures from a
-    # superseded (possibly killed mid-run) invocation.
-    if "batch" in failures_by_class and any(k != "batch" for k in failures_by_class):
-        del failures_by_class["batch"]
+    # Per-class parts supersede that attempt FOR THE CLASSES THEY RE-EXECUTED
+    # (a per-class part exists exactly for a class diagnosis actually ran),
+    # so their batch entries are dropped; batch evidence for classes
+    # diagnosis never reached - a lane stopped at a hang, with later classes
+    # recorded as not_diagnosed - must SURVIVE so the red lane's report stays
+    # complete. Supersession is therefore per class, keyed on which classes
+    # produced per-class parts, never on mere part presence.
+    if "batch" in failures_by_class:
+        covered = {k for k in failures_by_class if k != "batch"}
+        if covered:
+            survivors = [f for f in failures_by_class.pop("batch")
+                         if f.get("class") not in covered]
+            if survivors:
+                failures_by_class["batch"] = survivors
     failures: list = []
     for cls in failures_by_class:
         failures.extend(failures_by_class[cls])

--- a/scripts/extract-test-timings.py
+++ b/scripts/extract-test-timings.py
@@ -5,11 +5,15 @@ Subcommands
 -----------
 extract      Read an .xcresult bundle via `xcrun xcresulttool` and normalize
              per-XCTest-class durations plus per-test retry attempts into JSON.
-merge-parts  Fold the per-class/per-attempt extraction parts written by the
-             UI lane runner (one xcodebuild invocation per class) into the
-             lane-level observations.json / detail.json documents. The last
-             extracted attempt of a class wins its duration - on a green lane
-             that is always the passing attempt.
+merge-parts  Fold the per-attempt extraction parts written by the
+             UI lane runner - the batched shard attempt (parts named
+             ...-batch-a<n>.json) plus every per-class diagnosis invocation
+             (...-<class>-a<n>.json) - into the lane-level
+             observations.json / detail.json documents. Parts fold in
+             wall-clock order (batch attempt first, per-class diagnosis
+             after, attempts numerically within a group) and the last fold
+             wins per class: on a green lane that is always the passing
+             attempt.
 lane-result  Merge bash-computed lane facts with extraction output into the
              canonical lane-result.json consumed by the report job.
 aggregate    Build the human-readable CI Test Report (GitHub Step Summary)
@@ -287,10 +291,16 @@ def _attempt_index(name: str) -> int:
 
 
 def _part_sort_key(name: str) -> tuple:
-    """Order parts by (class, attempt) so numeric attempts sort correctly
-    (a2 after a10 - plain filename sort would put a10 first)."""
+    """Chronological fold order. The batched shard attempt happens FIRST in
+    wall time and per-class diagnosis supersedes it, so batch-named parts
+    fold before every class-named part regardless of ASCII order (the
+    lowercase stem would otherwise sort after the class names and win
+    last-wins with stale killed-batch data). Within a group, (stem, attempt)
+    orders numeric attempts correctly (a2 after a10 - plain filename sort
+    would put a10 first)."""
     stem = re.sub(r"-a\d+\.json$", "", name)
-    return (stem, _attempt_index(name))
+    is_batch = 0 if _part_class(name) == "batch" else 1
+    return (is_batch, stem, _attempt_index(name))
 
 
 def _part_class(name: str) -> str:
@@ -385,6 +395,12 @@ def merge_detail_parts(parts: list) -> dict:
         retried.extend(_list_field(doc, "retried"))
         cls = _part_class(fname)
         failures_by_class[cls] = _list_field(doc, "failures")
+    # The synthetic "batch" key carries the batched shard attempt's failures.
+    # Once any per-class part exists, diagnosis results have superseded that
+    # attempt: keeping the batch entries would double-count failures from a
+    # superseded (possibly killed mid-run) invocation.
+    if "batch" in failures_by_class and any(k != "batch" for k in failures_by_class):
+        del failures_by_class["batch"]
     failures: list = []
     for cls in failures_by_class:
         failures.extend(failures_by_class[cls])

--- a/scripts/extract-test-timings.py
+++ b/scripts/extract-test-timings.py
@@ -541,8 +541,11 @@ def aggregate(args) -> int:
                 f"| {len(lane.get('classes', []))} |"
             )
         lines.append("")
-        lines.append("Each UI class runs as its own xcodebuild invocation under a "
-                     "per-class watchdog; a retry applies only to the failed class.")
+        lines.append("Each UI shard runs as ONE batched xcodebuild invocation; "
+                     "a failure retries only the failed tests (exact methods "
+                     "when the xcresult identifies them, else the class), and "
+                     "timeouts/infrastructure wedges fall back to per-class "
+                     "diagnosis.")
     else:
         lines.append("")
         lines.append("- No UI tests planned.")

--- a/scripts/extract-test-timings.py
+++ b/scripts/extract-test-timings.py
@@ -291,13 +291,13 @@ def _attempt_index(name: str) -> int:
 
 
 def _part_sort_key(name: str) -> tuple:
-    """Chronological fold order. The batched shard attempt happens FIRST in
-    wall time and per-class diagnosis supersedes it, so batch-named parts
-    fold before every class-named part regardless of ASCII order (the
-    lowercase stem would otherwise sort after the class names and win
-    last-wins with stale killed-batch data). Within a group, (stem, attempt)
-    orders numeric attempts correctly (a2 after a10 - plain filename sort
-    would put a10 first)."""
+    """Chronological fold order, returned as (is_batch, stem, attempt):
+    batch-named parts fold before every class-named part regardless of
+    ASCII order (the lowercase stem would otherwise sort after the class
+    names and win last-wins with stale killed-batch data). Within a group
+    the constant is_batch field collapses and (stem, attempt) orders
+    numeric attempts correctly (a2 after a10 - plain filename sort would
+    put a10 first)."""
     stem = re.sub(r"-a\d+\.json$", "", name)
     is_batch = 0 if _part_class(name) == "batch" else 1
     return (is_batch, stem, _attempt_index(name))
@@ -321,7 +321,9 @@ def _list_field(doc: dict, key: str) -> list:
 
 
 def merge_observation_parts(parts: list) -> dict:
-    """parts: (filename, parsed doc) tuples in (class, attempt) order.
+    """parts: (filename, parsed doc) tuples in chronological fold order (see
+    _part_sort_key: batch attempt first, per-class diagnosis after, numeric
+    attempts within a group).
     Returns the lane-level observations document. A class seen in several
     attempts keeps its LAST attempt's duration: the runner extracts every
     attempt, and on a green lane the last attempt of a retried class is the
@@ -375,7 +377,8 @@ def merge_observation_parts(parts: list) -> dict:
 
 
 def merge_detail_parts(parts: list) -> dict:
-    """parts: (filename, parsed doc) tuples in (class, attempt) order.
+    """parts: (filename, parsed doc) tuples in chronological fold order (see
+    _part_sort_key).
     Attempts and retried tests are concatenated across classes and attempts
     (each entry carries its class). FAILURES are per-class STATE, not an
     append log: the class's highest attempt PART decides, so a class that

--- a/scripts/plan-tests.py
+++ b/scripts/plan-tests.py
@@ -8,11 +8,14 @@ Replaces the static unit-a..unit-d shard system:
   * validates complete, duplicate-free inventory (a new test class cannot
     silently miss CI);
   * assigns unit classes to a dynamic number of lanes with longest-
-    processing-time-first balancing over historical duration estimates;
+    processing-time-first balancing over historical duration estimates,
+    consolidating lanes whose split would not buy more than a wall-clock
+    tolerance once the fixed per-invocation Xcode/simulator startup cost is
+    modeled (predicted lane cost = invocation overhead + predicted execution);
   * balances UI classes into their own parallel lanes the same way, and
-    derives a PER-CLASS watchdog for every UI class (each class runs as its
-    own xcodebuild invocation, so a hang is attributed - and retried - at
-    class granularity);
+    derives a PER-CLASS watchdog for every UI class (the lane runs its
+    classes as one batched invocation priced at the sum of those budgets,
+    and the diagnosis fallback enforces them per class);
   * derives measured per-lane watchdog budgets from those predictions;
   * emits GitHub Actions matrix JSON for the dynamic unit AND UI lanes.
 
@@ -44,17 +47,26 @@ SCHEMA_VERSION = 1
 
 # Planning configuration (overridable via flags for tests).
 DEFAULT_ESTIMATE_S = 20.0          # unseen/new classes: conservative, not sticky
-MIN_LANES = 4
+MIN_LANES = 1
 MAX_LANES = 8
-TARGET_LANE_BUDGET_S = 240.0       # scale-out threshold per lane
 LANE_TIMEOUT_MIN_S = 600           # healthy lanes never get less than 10 min
 LANE_TIMEOUT_MULTIPLIER = 2.5      # headroom over prediction
-# UI sharding. UI classes run in their own parallel lanes (same LPT balance
-# as units), each class as an INDEPENDENT xcodebuild invocation under its own
-# per-class watchdog. ui_target_budget_s decides how many lanes the measured
-# suite is worth; the clamp bounds hosted-runner usage (3 lanes for today's
-# ~22 min of cumulative UI work, more only if the suite grows).
-UI_TARGET_BUDGET_S = 480.0
+# Modeled fixed cost of ONE xcodebuild invocation on a lane: process startup,
+# simulator boot, app/test-host install, and xcresult finalization. Measured
+# on macos-26 hosted runners as lane actual minus predicted execution
+# (~208-295s across the four unit lanes of run 34349843495; the UI per-class
+# floor below independently measured ~3.5 min for the same fixed cost, run
+# #500). A lane must buy more than lane_wall_tolerance_s of wall-clock
+# improvement to be worth spawning: more parallel jobs are not inherently
+# faster when every job pays this cost up front.
+INVOCATION_OVERHEAD_S = 240.0
+LANE_WALL_TOLERANCE_S = 120.0
+# UI sharding. UI classes are balanced into parallel lanes (same overhead-
+# aware consolidation as units) and every lane runs its classes as ONE
+# batched xcodebuild invocation. The clamp bounds hosted-runner usage
+# (3 lanes for today's ~22 min of cumulative UI work, more only if the suite
+# grows); the per-class watchdog table still travels with the lane for the
+# batched budget and the diagnosis fallback.
 UI_MIN_LANES = 3
 UI_MAX_LANES = 4
 # Per-class UI watchdog = max(floor, estimate x multiplier). The floor covers
@@ -265,13 +277,38 @@ def load_estimates(path, purpose: str) -> tuple:
 # planning
 # ---------------------------------------------------------------------------
 
-def lane_count_for(total_predicted: float, n_classes: int, cfg: dict) -> int:
+def lane_count_for(items: list, cfg: dict) -> int:
+    """Smallest lane count whose MODELED WALL CLOCK is within
+    lane_wall_tolerance_s of the best achievable wall clock within bounds.
+
+    Model: predicted lane cost = invocation_overhead_s (fixed: xcodebuild
+    startup + simulator boot + result finalization, paid by every lane) + the
+    lane's predicted test execution; lanes run in parallel, so the modeled
+    wall for n lanes is overhead + the heaviest LPT lane load. Another shard
+    only ever rebalances execution, but multiplies the paid fixed cost, so a
+    lane must buy at least lane_wall_tolerance_s of wall improvement to be
+    worth spawning. Splitting 200s of tests into two lanes is a net loss when
+    the invocation overhead is several minutes.
+
+    items: [(name, seconds)]; returns a count in
+    [min(min_lanes, n_classes), max_lanes], 0 when there are no classes."""
+    n_classes = len(items)
     if n_classes == 0:
         return 0
-    n = math.ceil(total_predicted / cfg["target_budget_s"]) if total_predicted > 0 else 1
-    n = max(cfg["min_lanes"], n)
-    n = min(cfg["max_lanes"], n)
-    return min(n, n_classes)
+    lo = min(cfg["min_lanes"], n_classes)
+    hi = min(cfg["max_lanes"], n_classes)
+    seconds_for = dict(items)
+    walls = {}
+    for n in range(lo, hi + 1):
+        lanes = longest_processing_time_first(items, n)
+        walls[n] = cfg["invocation_overhead_s"] + max(
+            sum(seconds_for[name] for name in lane) for lane in lanes
+        )
+    best = min(walls.values())
+    for n in sorted(walls):
+        if walls[n] <= best + cfg["lane_wall_tolerance_s"]:
+            return n
+    return lo  # unreachable: the best wall itself satisfies the tolerance
 
 
 def longest_processing_time_first(items: list, n_lanes: int) -> list:
@@ -291,43 +328,33 @@ def longest_processing_time_first(items: list, n_lanes: int) -> list:
     return lanes
 
 
-def ui_lane_count_for(total_predicted: float, n_classes: int, cfg: dict) -> int:
-    """Parallel UI lanes for the measured suite. Same shape as the unit
-    policy: ceil(total / per-lane budget), clamped, capped by class count so
-    no lane is ever empty. Today's ~1310s of UI work lands on 3 lanes."""
-    if n_classes == 0:
-        return 0
-    n = math.ceil(total_predicted / cfg["ui_target_budget_s"]) if total_predicted > 0 else 1
-    n = max(cfg["ui_min_lanes"], n)
-    n = min(cfg["ui_max_lanes"], n)
-    return min(n, n_classes)
-
-
 def timeout_for(predicted: float, floor_s: float, multiplier: float) -> int:
     return max(int(floor_s), int(math.ceil(predicted * multiplier)))
 
 
 def ui_class_timeout_for(estimate: float, floor_s: float, multiplier: float) -> int:
-    """Watchdog for ONE UI test class (it runs as its own xcodebuild
-    invocation). The floor carries the fixed per-invocation simulator/Xcode
-    overhead that dominates small classes; the multiplier gives big classes
-    proportional headroom. With today's estimates this bounds worst-case hang
-    detection at 7-17 minutes per class instead of the old 48-minute
-    suite-level watchdog."""
+    """Watchdog for ONE UI test class. It prices the class's share of the
+    batched shard invocation (the runner sums these budgets for the batch
+    watchdog) and the per-class diagnosis fallback invocation. The floor
+    carries the fixed per-invocation simulator/Xcode overhead that dominates
+    small classes; the multiplier gives big classes proportional headroom.
+    With today's estimates this bounds worst-case hang detection at 7-17
+    minutes per class instead of the old 48-minute suite-level watchdog."""
     return max(int(floor_s), int(math.ceil(estimate * multiplier)))
 
 
 def ui_job_timeout_min(lane_timeout_s: int, n_classes: int, cfg: dict) -> int:
-    """Outer emergency ceiling for a UI lane. Worst in-script path: every
-    class runs its targeted retry (2 x sum of per-class budgets), each
-    failing class pays one bounded erase/reboot recovery, and per-attempt
-    timing extraction can wedge to the xcresulttool subprocess bound (up to
-    twice per class, outside the budgets) - plus setup/download slack.
-    Per-class watchdogs inside the runner are the real enforcement; the
-    ceiling only guarantees GitHub can never preempt legitimate in-script
-    recovery (which is what would erase the hung-class attribution this lane
-    exists to provide)."""
-    total = (2 * lane_timeout_s
+    """Outer emergency ceiling for a UI lane. Worst in-script path: the
+    batched attempt (sum of per-class budgets) plus its targeted retry, THEN
+    a batch-level timeout or wedge erases and re-enters per-class diagnosis
+    (attempt + retry per class), each failing class paying one bounded
+    erase/reboot recovery, and per-attempt timing extraction can wedge to the
+    xcresulttool subprocess bound (up to twice per class, outside the
+    budgets) - plus setup/download slack. Per-class watchdogs inside the
+    runner are the real enforcement; the ceiling only guarantees GitHub can
+    never preempt legitimate in-script recovery (which is what would erase
+    the hung-class attribution this lane exists to provide)."""
+    total = (3 * lane_timeout_s
              + (n_classes + 1) * cfg.get("ui_reset_overhead_s", UI_RESET_OVERHEAD_S)
              + 2 * n_classes * cfg.get("ui_extract_bound_s", UI_EXTRACT_BOUND_S)
              + cfg["job_timeout_margin_s"])
@@ -362,18 +389,20 @@ def build_plan(discovery: dict, cfg: dict, estimates: dict) -> dict:
 
     items = sorted(unit_est.items(), key=lambda kv: (-kv[1], kv[0]))
     total = sum(s for _n, s in items)
-    n_lanes = lane_count_for(total, len(items), cfg)
+    n_lanes = lane_count_for(items, cfg)
     lanes = longest_processing_time_first(items, n_lanes)
 
     unit_lanes = []
     for i, classes in enumerate(lanes, start=1):
         predicted = sum(unit_est[c] for c in classes)
+        modeled_wall = cfg["invocation_overhead_s"] + predicted
         timeout = timeout_for(predicted, cfg["lane_timeout_min_s"], cfg["timeout_multiplier"])
         unit_lanes.append({
             "lane": f"unit-{i}",
             "target": UNIT_TARGET,
             "classes": classes,
             "predicted_s": round(predicted, 1),
+            "modeled_wall_s": round(modeled_wall, 1),
             "timeout_s": timeout,
             "job_timeout_min": job_timeout_min(timeout, cfg),
         })
@@ -381,12 +410,14 @@ def build_plan(discovery: dict, cfg: dict, estimates: dict) -> dict:
     ui_lanes = []
     if ui_names:
         ui_items = sorted(ui_est.items(), key=lambda kv: (-kv[1], kv[0]))
-        ui_total = sum(s for _n, s in ui_items)
-        n_ui_lanes = ui_lane_count_for(ui_total, len(ui_items), cfg)
+        # Same overhead-aware selection as units, under the UI bounds.
+        ui_cfg = dict(cfg, min_lanes=cfg["ui_min_lanes"], max_lanes=cfg["ui_max_lanes"])
+        n_ui_lanes = lane_count_for(ui_items, ui_cfg)
         for i, classes in enumerate(longest_processing_time_first(ui_items, n_ui_lanes), start=1):
             predicted = sum(ui_est[c] for c in classes)
             # Watchdog budget per class, from the same timing data that
-            # balanced the lane; the runner enforces them one class at a time.
+            # balanced the lane: it prices the batched invocation (the sum)
+            # and every per-class diagnosis fallback invocation.
             class_timeouts = {
                 c: ui_class_timeout_for(
                     ui_est[c], cfg["ui_class_timeout_min_s"],
@@ -411,8 +442,9 @@ def build_plan(discovery: dict, cfg: dict, estimates: dict) -> dict:
     plan = {
         "schema_version": SCHEMA_VERSION,
         "config": {k: cfg[k] for k in (
-            "default_estimate_s", "min_lanes", "max_lanes", "target_budget_s",
-            "lane_timeout_min_s", "timeout_multiplier", "ui_target_budget_s",
+            "default_estimate_s", "min_lanes", "max_lanes",
+            "invocation_overhead_s", "lane_wall_tolerance_s",
+            "lane_timeout_min_s", "timeout_multiplier",
             "ui_min_lanes", "ui_max_lanes", "ui_class_timeout_min_s",
             "ui_class_timeout_multiplier", "job_timeout_margin_s")},
         "inventory": {"unit": unit_names, "ui": ui_names},
@@ -526,19 +558,26 @@ def plan_summary_md(plan: dict, discovery: dict, source: str) -> str:
         f"**{plan['total_predicted_s']:.0f}s** · lanes **{plan['lane_count']}** "
         f"(bounds {plan['config']['min_lanes']}-{plan['config']['max_lanes']})"
     )
+    lines.append(
+        f"- Modeled per-lane cost: **{plan['config']['invocation_overhead_s']:.0f}s** "
+        "fixed invocation overhead + predicted execution (another lane is only "
+        f"added when it buys more than "
+        f"**{plan['config']['lane_wall_tolerance_s']:.0f}s** of wall clock)"
+    )
     lines.append("")
-    lines.append("| Lane | Predicted | Watchdog | Job ceiling | Classes |")
-    lines.append("|---|---|---|---|---|")
+    lines.append("| Lane | Predicted | Modeled wall | Watchdog | Job ceiling | Classes |")
+    lines.append("|---|---|---|---|---|---|")
     for lane in plan["unit_lanes"]:
         lines.append(
-            f"| {lane['lane']} | {lane['predicted_s']:.0f}s | {lane['timeout_s']}s "
+            f"| {lane['lane']} | {lane['predicted_s']:.0f}s | {lane['modeled_wall_s']:.0f}s "
+            f"| {lane['timeout_s']}s "
             f"| {lane['job_timeout_min']}m | {len(lane['classes'])} |"
         )
     for lane in plan["ui_lanes"]:
         timeouts = [int(p.split("=", 1)[1]) for p in lane["class_timeouts"].split(",") if "=" in p]
         lines.append(
-            f"| {lane['lane']} (UI) | {lane['predicted_s']:.0f}s | "
-            f"{max(timeouts)}s per class "
+            f"| {lane['lane']} (UI) | {lane['predicted_s']:.0f}s | - "
+            f"| {max(timeouts)}s per class "
             f"| {lane['job_timeout_min']}m | {len(lane['classes'])} |"
         )
     lines.append("")
@@ -553,7 +592,8 @@ def plan_summary_md(plan: dict, discovery: dict, source: str) -> str:
         timeouts = dict(p.split("=", 1) for p in lane["class_timeouts"].split(",") if p)
         members = ", ".join(
             f"{c} (watchdog {timeouts.get(c, '?')}s)" for c in lane["classes"])
-        lines.append(f"- **{lane['lane']}** (per-class invocations): {members}")
+        lines.append(f"- **{lane['lane']}** (one batched invocation; per-class "
+                     f"diagnosis budgets): {members}")
     lines.append("")
     lines.append("</details>")
     lines.append("")
@@ -681,10 +721,10 @@ def _cfg_from_args(a) -> dict:
         "default_estimate_s": a.default_estimate_s,
         "min_lanes": a.min_lanes,
         "max_lanes": a.max_lanes,
-        "target_budget_s": a.target_budget_s,
+        "invocation_overhead_s": a.invocation_overhead_s,
+        "lane_wall_tolerance_s": a.lane_wall_tolerance_s,
         "lane_timeout_min_s": a.lane_timeout_min_s,
         "timeout_multiplier": a.timeout_multiplier,
-        "ui_target_budget_s": a.ui_target_budget_s,
         "ui_min_lanes": a.ui_min_lanes,
         "ui_max_lanes": a.ui_max_lanes,
         "ui_class_timeout_min_s": a.ui_class_timeout_min_s,
@@ -729,12 +769,12 @@ def _human_report(plan: dict, discovery: dict, source: str) -> str:
     out.append(f"timing source: {source}")
     for lane in plan["unit_lanes"]:
         out.append(
-            "  {0}: predicted {1}s, watchdog {2}s, job ceiling {3}m, {4} classes".format(
-                lane["lane"], lane["predicted_s"], lane["timeout_s"],
-                lane["job_timeout_min"], len(lane["classes"])))
+            "  {0}: predicted {1}s, modeled wall {2}s, watchdog {3}s, job ceiling {4}m, {5} classes".format(
+                lane["lane"], lane["predicted_s"], lane["modeled_wall_s"],
+                lane["timeout_s"], lane["job_timeout_min"], len(lane["classes"])))
     for lane in plan["ui_lanes"]:
         out.append(
-            "  {0} (UI): predicted {1}s, per-class watchdogs [{2}], job ceiling {3}m".format(
+            "  {0} (UI): predicted {1}s, batched invocation, per-class watchdogs [{2}], job ceiling {3}m".format(
                 lane["lane"], lane["predicted_s"], lane["class_timeouts"],
                 lane["job_timeout_min"]))
     out.append(f"predicted imbalance: {plan['imbalance_predicted_pct']}% unit / "
@@ -754,10 +794,10 @@ def main(argv=None) -> int:
         p.add_argument("--default-estimate-s", type=float, default=DEFAULT_ESTIMATE_S)
         p.add_argument("--min-lanes", type=int, default=MIN_LANES)
         p.add_argument("--max-lanes", type=int, default=MAX_LANES)
-        p.add_argument("--target-budget-s", type=float, default=TARGET_LANE_BUDGET_S)
+        p.add_argument("--invocation-overhead-s", type=float, default=INVOCATION_OVERHEAD_S)
+        p.add_argument("--lane-wall-tolerance-s", type=float, default=LANE_WALL_TOLERANCE_S)
         p.add_argument("--lane-timeout-min-s", type=int, default=LANE_TIMEOUT_MIN_S)
         p.add_argument("--timeout-multiplier", type=float, default=LANE_TIMEOUT_MULTIPLIER)
-        p.add_argument("--ui-target-budget-s", type=float, default=UI_TARGET_BUDGET_S)
         p.add_argument("--ui-min-lanes", type=int, default=UI_MIN_LANES)
         p.add_argument("--ui-max-lanes", type=int, default=UI_MAX_LANES)
         p.add_argument("--ui-class-timeout-min-s", type=int, default=UI_CLASS_TIMEOUT_MIN_S)

--- a/scripts/plan-tests.py
+++ b/scripts/plan-tests.py
@@ -344,16 +344,19 @@ def ui_class_timeout_for(estimate: float, floor_s: float, multiplier: float) -> 
 
 
 def ui_job_timeout_min(lane_timeout_s: int, n_classes: int, cfg: dict) -> int:
-    """Outer emergency ceiling for a UI lane. Worst in-script path: the
-    batched attempt (sum of per-class budgets) plus its targeted retry, THEN
-    a batch-level timeout or wedge erases and re-enters per-class diagnosis
-    (attempt + retry per class), each failing class paying one bounded
-    erase/reboot recovery, and per-attempt timing extraction can wedge to the
-    xcresulttool subprocess bound (up to twice per class, outside the
-    budgets) - plus setup/download slack. Per-class watchdogs inside the
-    runner are the real enforcement; the ceiling only guarantees GitHub can
-    never preempt legitimate in-script recovery (which is what would erase
-    the hung-class attribution this lane exists to provide)."""
+    """Outer emergency ceiling for a UI lane. The reachable worst in-script
+    path is the batched shard attempt (the lane budget = sum of per-class
+    budgets) followed by per-class diagnosis after a batch timeout or wedge
+    (one attempt + one targeted retry per class, i.e. 2x the budget sum) -
+    3x in total. A batch that completes with identified failures costs
+    strictly less (its retry covers a subset of classes), and each failing
+    class pays one bounded erase/reboot recovery; per-attempt timing
+    extraction can wedge to the xcresulttool subprocess bound (up to twice
+    per class, outside the budgets) - plus setup/download slack. Per-class
+    watchdogs inside the runner are the real enforcement; the ceiling only
+    guarantees GitHub can never preempt legitimate in-script recovery (which
+    is what would erase the hung-class attribution this lane exists to
+    provide)."""
     total = (3 * lane_timeout_s
              + (n_classes + 1) * cfg.get("ui_reset_overhead_s", UI_RESET_OVERHEAD_S)
              + 2 * n_classes * cfg.get("ui_extract_bound_s", UI_EXTRACT_BOUND_S)

--- a/scripts/plan-tests.py
+++ b/scripts/plan-tests.py
@@ -344,22 +344,23 @@ def ui_class_timeout_for(estimate: float, floor_s: float, multiplier: float) -> 
 
 
 def ui_job_timeout_min(lane_timeout_s: int, n_classes: int, cfg: dict) -> int:
-    """Outer emergency ceiling for a UI lane. The reachable worst in-script
-    path is the batched shard attempt (the lane budget = sum of per-class
-    budgets) followed by per-class diagnosis after a batch timeout or wedge
-    (one attempt + one targeted retry per class, i.e. 2x the budget sum) -
-    3x in total. A batch that completes with identified failures costs
-    strictly less (its retry covers a subset of classes), and each failing
-    class pays one bounded erase/reboot recovery; per-attempt timing
-    extraction can wedge to the xcresulttool subprocess bound (up to twice
-    per class, outside the budgets) - plus setup/download slack. Per-class
-    watchdogs inside the runner are the real enforcement; the ceiling only
-    guarantees GitHub can never preempt legitimate in-script recovery (which
-    is what would erase the hung-class attribution this lane exists to
-    provide)."""
-    total = (3 * lane_timeout_s
+    """Outer emergency ceiling for a UI lane. Two reachable worst paths:
+    (a) the batched shard attempt (the lane budget = sum of per-class
+    budgets) times out and per-class diagnosis follows (one attempt + one
+    targeted retry per class = 2x more) = 3x; (b) the batch completes with
+    failures in every class, the targeted retry (a budget covering all of
+    them) times out, and diagnosis of the retried classes follows = up to
+    4x. (b) dominates and prices the ceiling. Each failing class then pays
+    one bounded erase/reboot recovery; per-attempt timing extraction can
+    wedge to the xcresulttool subprocess bound (up to twice per diagnosis
+    class plus the batch's own classification extraction, outside the
+    budgets) - plus setup/download slack. Per-class watchdogs inside the
+    runner are the real enforcement; the ceiling only guarantees GitHub can
+    never preempt legitimate in-script recovery (which is what would erase
+    the hung-class attribution this lane exists to provide)."""
+    total = (4 * lane_timeout_s
              + (n_classes + 1) * cfg.get("ui_reset_overhead_s", UI_RESET_OVERHEAD_S)
-             + 2 * n_classes * cfg.get("ui_extract_bound_s", UI_EXTRACT_BOUND_S)
+             + (2 * n_classes + 1) * cfg.get("ui_extract_bound_s", UI_EXTRACT_BOUND_S)
              + cfg["job_timeout_margin_s"])
     return int(math.ceil(total / 60.0))
 

--- a/scripts/tests/_util.py
+++ b/scripts/tests/_util.py
@@ -46,12 +46,12 @@ def make_repo(root, unit_classes=(), ui_classes=(), extra_files=None):
 def default_cfg(**overrides):
     cfg = {
         "default_estimate_s": 20.0,
-        "min_lanes": 4,
+        "min_lanes": 1,
         "max_lanes": 8,
-        "target_budget_s": 240.0,
+        "invocation_overhead_s": 240.0,
+        "lane_wall_tolerance_s": 120.0,
         "lane_timeout_min_s": 600,
         "timeout_multiplier": 2.5,
-        "ui_target_budget_s": 480.0,
         "ui_min_lanes": 3,
         "ui_max_lanes": 4,
         "ui_class_timeout_min_s": 420,

--- a/scripts/tests/test_ci_gate.py
+++ b/scripts/tests/test_ci_gate.py
@@ -15,57 +15,92 @@ SPEC.loader.exec_module(ci_gate)
 
 class VerdictTests(unittest.TestCase):
     def test_all_success_passes(self):
-        passed, _reason = ci_gate.verdict("success", "success", "success", "success")
+        passed, _reason = ci_gate.verdict(
+            "success", "success", "success", "success", "success")
         self.assertTrue(passed)
 
     def test_ui_skipped_passes(self):
-        passed, _reason = ci_gate.verdict("success", "success", "success", "skipped")
+        passed, _reason = ci_gate.verdict(
+            "success", "success", "success", "skipped", "success")
         self.assertTrue(passed)
 
     def test_unit_failure_fails_gate(self):
-        passed, reason = ci_gate.verdict("success", "success", "failure", "success")
+        passed, reason = ci_gate.verdict(
+            "success", "success", "failure", "success", "success")
         self.assertFalse(passed)
         self.assertIn("unit", reason)
 
     def test_build_failure_fails_gate(self):
-        passed, _reason = ci_gate.verdict("success", "failure", "skipped", "skipped")
+        passed, _reason = ci_gate.verdict(
+            "success", "failure", "skipped", "skipped", "skipped")
         self.assertFalse(passed)
 
     def test_plan_failure_fails_gate(self):
-        passed, _reason = ci_gate.verdict("failure", "skipped", "skipped", "skipped")
+        passed, _reason = ci_gate.verdict(
+            "failure", "skipped", "skipped", "skipped", "skipped")
         self.assertFalse(passed)
 
     def test_plan_cancelled_fails_gate(self):
-        passed, _reason = ci_gate.verdict("cancelled", "success", "success", "success")
+        passed, _reason = ci_gate.verdict(
+            "cancelled", "success", "success", "success", "success")
         self.assertFalse(passed)
 
     def test_unit_cancelled_fails_gate(self):
-        passed, _reason = ci_gate.verdict("success", "success", "cancelled", "success")
+        passed, _reason = ci_gate.verdict(
+            "success", "success", "cancelled", "success", "success")
         self.assertFalse(passed)
 
     def test_ui_cancelled_fails_gate(self):
-        passed, _reason = ci_gate.verdict("success", "success", "success", "cancelled")
+        passed, _reason = ci_gate.verdict(
+            "success", "success", "success", "cancelled", "success")
         self.assertFalse(passed)
+
+    def test_self_test_failure_fails_gate(self):
+        passed, reason = ci_gate.verdict(
+            "success", "success", "success", "success", "failure")
+        self.assertFalse(passed)
+        self.assertIn("self-test", reason)
+
+    def test_self_test_cancelled_fails_gate(self):
+        passed, _reason = ci_gate.verdict(
+            "success", "success", "success", "success", "cancelled")
+        self.assertFalse(passed)
+
+    def test_self_test_skipped_fails_gate(self):
+        # The CI-tooling suites have no legitimate skip path: a skip means
+        # an upstream failure suppressed them, which is not a success.
+        passed, reason = ci_gate.verdict(
+            "success", "success", "success", "success", "skipped")
+        self.assertFalse(passed)
+        self.assertIn("self-test", reason)
 
     def test_missing_upstream_results_fail_gate(self):
         # A skip because an upstream job failed is still not a success.
-        passed, _reason = ci_gate.verdict("success", "success", "skipped", "skipped")
+        passed, _reason = ci_gate.verdict(
+            "success", "success", "skipped", "skipped", "skipped")
         self.assertFalse(passed)
 
 
 class CliTests(unittest.TestCase):
-    def _run(self, plan, build, unit, ui):
+    def _run(self, plan, build, unit, ui, self_test="success"):
         return subprocess.run(
             [sys.executable, os.path.join(SCRIPTS_DIR, "ci-gate.py"),
              "--plan", plan, "--build", build,
-             "--unit", unit, "--ui", ui],
+             "--unit", unit, "--ui", ui, "--self-test", self_test],
             capture_output=True, text=True)
 
     def test_cli_exit_codes(self):
-        self.assertEqual(self._run("success", "success", "success", "success").returncode, 0)
-        self.assertEqual(self._run("success", "success", "success", "skipped").returncode, 0)
-        self.assertNotEqual(self._run("success", "failure", "skipped", "skipped").returncode, 0)
-        self.assertNotEqual(self._run("success", "success", "failure", "success").returncode, 0)
+        self.assertEqual(
+            self._run("success", "success", "success", "success").returncode, 0)
+        self.assertEqual(
+            self._run("success", "success", "success", "skipped").returncode, 0)
+        self.assertNotEqual(
+            self._run("success", "failure", "skipped", "skipped").returncode, 0)
+        self.assertNotEqual(
+            self._run("success", "success", "failure", "success").returncode, 0)
+        self.assertNotEqual(
+            self._run("success", "success", "success", "success",
+                      self_test="failure").returncode, 0)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_ci_workflow_contract.py
+++ b/scripts/tests/test_ci_workflow_contract.py
@@ -62,7 +62,7 @@ class WorkflowContractTests(unittest.TestCase):
             out.append(line)
         return "\n".join(out)
 
-    def test_ui_job_is_a_dynamic_matrix_with_per_class_runner(self):
+    def test_ui_job_is_a_dynamic_matrix_with_batched_lane_runner(self):
         text = self._workflow_text()
         ui = self._job_text("ui")
         # Matrix fanout comes from the planner, never a hard-coded class list,
@@ -71,14 +71,16 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("fail-fast: false", ui)
         self.assertIn('needs: [plan, build]', ui,
                       "UI shards must consume the SHARED build products")
-        # Per-class runner invocation with planned watchdogs.
+        # Batched lane runner invocation with the planned per-class watchdog
+        # table (the batch watchdog is its sum; the same table prices the
+        # per-class diagnosis fallback).
         self.assertIn("--kind ui", ui)
         self.assertIn("--class-timeouts", ui)
         self.assertIn('--classes "$LANE_CLASSES"', ui)
         self.assertNotIn(
             "--iterations", ui,
             "UI lanes must not use native multi-iteration retry; the runner "
-            "retries exactly the failed class once")
+            "retries exactly the failed tests once")
         # Watchdog policy has ONE source of truth: the planner's
         # --class-timeouts table. No duplicated floor/multiplier env here.
         self.assertNotIn("UI_CLASS_TIMEOUT_MIN_S", ui)

--- a/scripts/tests/test_ci_workflow_contract.py
+++ b/scripts/tests/test_ci_workflow_contract.py
@@ -91,22 +91,23 @@ class WorkflowContractTests(unittest.TestCase):
 
     def test_ci_gate_script_verdict_matches_spec_examples(self):
         spec = {
-            ("success", "success", "success", "success"): True,
-            ("success", "success", "success", "skipped"): True,
-            ("success", "success", "failure", "success"): False,
-            ("success", "failure", "skipped", "skipped"): False,
-            ("cancelled", "success", "success", "success"): False,
-            ("success", "success", "cancelled", "success"): False,
+            ("success", "success", "success", "success", "success"): True,
+            ("success", "success", "success", "skipped", "success"): True,
+            ("success", "success", "success", "success", "failure"): False,
+            ("success", "success", "failure", "success", "success"): False,
+            ("success", "failure", "skipped", "skipped", "skipped"): False,
+            ("cancelled", "success", "success", "success", "success"): False,
+            ("success", "success", "cancelled", "success", "success"): False,
         }
-        for (plan, build, unit, ui), expected in spec.items():
+        for (plan, build, unit, ui, self_test), expected in spec.items():
             proc = subprocess.run(
                 [sys.executable, os.path.join(SCRIPTS_DIR, "ci-gate.py"),
                  "--plan", plan, "--build", build,
-                 "--unit", unit, "--ui", ui],
+                 "--unit", unit, "--ui", ui, "--self-test", self_test],
                 capture_output=True, text=True)
             self.assertEqual(
                 proc.returncode == 0, expected,
-                f"gate({plan},{build},{unit},{ui}) -> {proc.stdout}")
+                f"gate({plan},{build},{unit},{ui},{self_test}) -> {proc.stdout}")
 
 
 class TimingUpdateCliShapeTests(unittest.TestCase):

--- a/scripts/tests/test_extract_timings.py
+++ b/scripts/tests/test_extract_timings.py
@@ -198,6 +198,50 @@ class MergePartsTests(unittest.TestCase):
             # the retried class keeps its PASSING (last) attempt's duration
             self.assertEqual(obs["classes"], {"AlphaUITests": 41.0, "BetaUITests": 12.0})
 
+    def test_merge_parts_method_only_retry_never_shrinks_class_timing(self):
+        # The runner deletes a method-filtered retry's observations part
+        # (batch AND per-class diagnosis paths) BEFORE folding, because a
+        # method-only rerun must never become the class's duration sample.
+        # This pins the invariant end-to-end at the merge layer by folding
+        # exactly the parts the runner leaves behind: full class = 100s,
+        # method-only retry = 5s -> merged class timing stays 100s.
+        with tempfile.TemporaryDirectory() as tmp:
+            parts = Path(tmp) / "parts"
+            parts.mkdir()
+            self._write_part(parts, "observations-AlphaUITests-a1.json",
+                             self._observation({"AlphaUITests": 100.0}))
+            # What the runner leaves for a method-only retry: a DETAIL part
+            # (retry/flake evidence) and NO observations part.
+            self._write_part(parts, "detail-AlphaUITests-a1.json", {
+                "schema_version": 1, "generated_at": "t", "xcresult": "a1",
+                "attempts": [{"class": "AlphaUITests", "test": "testSlow()",
+                              "attempts": [{"result": "Failed", "seconds": 99.0}],
+                              "final": "Failed", "attempts_count": 1}],
+                "failures": [{"class": "AlphaUITests", "test": "testSlow()"}],
+                "retried": [],
+            })
+            self._write_part(parts, "detail-AlphaUITests-a2.json", {
+                "schema_version": 1, "generated_at": "t", "xcresult": "a2",
+                "attempts": [{"class": "AlphaUITests", "test": "testSlow()",
+                              "attempts": [{"result": "Passed", "seconds": 5.0}],
+                              "final": "Passed", "attempts_count": 1}],
+                "failures": [],
+                "retried": [{"class": "AlphaUITests", "test": "testSlow()",
+                             "attempts": [{"result": "Failed", "seconds": 99.0},
+                                          {"result": "Passed", "seconds": 5.0}],
+                             "final": "Passed"}],
+            })
+            obs_out = Path(tmp) / "observations.json"
+            det_out = Path(tmp) / "detail.json"
+            rc = ext.merge_parts(str(parts), str(obs_out), str(det_out))
+            self.assertEqual(rc, ext.EXIT_OK)
+            obs = json.loads(obs_out.read_text(encoding="utf-8"))
+            det = json.loads(det_out.read_text(encoding="utf-8"))
+            self.assertEqual(obs["classes"], {"AlphaUITests": 100.0})
+            # the retry's flake evidence still folds
+            self.assertEqual(len(det["retried"]), 1)
+            self.assertEqual(det["failures"], [])
+
     def test_merge_parts_diagnosis_supersedes_batch_parts(self):
         # The batched shard attempt folds FIRST (it runs first in wall time);
         # per-class diagnosis parts written after a killed batch must win
@@ -236,6 +280,43 @@ class MergePartsTests(unittest.TestCase):
             # batch's stale failure must not survive the superseding pass
             self.assertEqual(obs["classes"], {"AlphaUITests": 200.0, "BetaUITests": 0.1})
             self.assertEqual(det["failures"], [])
+
+    def test_merge_parts_keeps_batch_failures_for_undiagnosed_classes(self):
+        # Diagnosis that stopped at a hang produced a part for Alpha only;
+        # the batch's failure record for Gamma (never re-executed, recorded
+        # not_diagnosed) must SURVIVE so the red lane's report stays
+        # complete. Supersession is per class, not per part presence.
+        with tempfile.TemporaryDirectory() as tmp:
+            parts = Path(tmp) / "parts"
+            parts.mkdir()
+            self._write_part(parts, "detail-batch-a1.json", {
+                "schema_version": 1, "generated_at": "t", "xcresult": "batch-a1",
+                "attempts": [
+                    {"class": "AlphaUITests", "test": "testA()",
+                     "attempts": [{"result": "Failed", "seconds": 1.0}],
+                     "final": "Failed", "attempts_count": 1},
+                    {"class": "GammaUITests", "test": "testG()",
+                     "attempts": [{"result": "Failed", "seconds": 2.0}],
+                     "final": "Failed", "attempts_count": 1},
+                ],
+                "failures": [{"class": "AlphaUITests", "test": "testA()"},
+                             {"class": "GammaUITests", "test": "testG()"}],
+                "retried": [],
+            })
+            self._write_part(parts, "detail-AlphaUITests-a1.json", {
+                "schema_version": 1, "generated_at": "t", "xcresult": "a1",
+                "attempts": [{"class": "AlphaUITests", "test": "testA()",
+                              "attempts": [{"result": "Passed", "seconds": 9.0}],
+                              "final": "Passed", "attempts_count": 1}],
+                "failures": [],
+                "retried": [],
+            })
+            det_out = Path(tmp) / "detail.json"
+            rc = ext.merge_parts(str(parts), "", str(det_out))
+            self.assertEqual(rc, ext.EXIT_OK)
+            det = json.loads(det_out.read_text(encoding="utf-8"))
+            self.assertEqual(det["failures"],
+                             [{"class": "GammaUITests", "test": "testG()"}])
 
     def test_merge_parts_folds_details_across_classes(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/tests/test_extract_timings.py
+++ b/scripts/tests/test_extract_timings.py
@@ -550,8 +550,8 @@ simulator_erase=False, hung_class="", retried_classes="", persistent_infra_class
             rc = ext.aggregate(args)
             self.assertEqual(rc, ext.EXIT_OK)
             text = out.read_text(encoding="utf-8")
-            self.assertIn("per-class watchdog", text)
-            self.assertIn("a retry applies only to the failed class", text)
+            self.assertIn("ONE batched xcodebuild invocation", text)
+            self.assertIn("retries only the failed tests", text)
 
     def test_report_falls_back_to_legacy_ui_lane_shape(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/tests/test_extract_timings.py
+++ b/scripts/tests/test_extract_timings.py
@@ -198,6 +198,45 @@ class MergePartsTests(unittest.TestCase):
             # the retried class keeps its PASSING (last) attempt's duration
             self.assertEqual(obs["classes"], {"AlphaUITests": 41.0, "BetaUITests": 12.0})
 
+    def test_merge_parts_diagnosis_supersedes_batch_parts(self):
+        # The batched shard attempt folds FIRST (it runs first in wall time);
+        # per-class diagnosis parts written after a killed batch must win
+        # last-wins for durations AND drop the batch attempt's failures, even
+        # though the lowercase "batch" stem would sort after the class names.
+        with tempfile.TemporaryDirectory() as tmp:
+            parts = Path(tmp) / "parts"
+            parts.mkdir()
+            self._write_part(parts, "observations-batch-a1.json",
+                             self._observation({"AlphaUITests": 60.0, "BetaUITests": 0.1}))
+            self._write_part(parts, "detail-batch-a1.json", {
+                "schema_version": 1, "generated_at": "t", "xcresult": "batch-a1",
+                "attempts": [{"class": "AlphaUITests", "test": "testA()",
+                              "attempts": [{"result": "Failed", "seconds": 1.0}],
+                              "final": "Failed", "attempts_count": 1}],
+                "failures": [{"class": "AlphaUITests", "test": "testA()"}],
+                "retried": [],
+            })
+            self._write_part(parts, "observations-AlphaUITests-a1.json",
+                             self._observation({"AlphaUITests": 200.0}))
+            self._write_part(parts, "detail-AlphaUITests-a1.json", {
+                "schema_version": 1, "generated_at": "t", "xcresult": "a1",
+                "attempts": [{"class": "AlphaUITests", "test": "testA()",
+                              "attempts": [{"result": "Passed", "seconds": 190.0}],
+                              "final": "Passed", "attempts_count": 1}],
+                "failures": [],
+                "retried": [],
+            })
+            obs_out = Path(tmp) / "observations.json"
+            det_out = Path(tmp) / "detail.json"
+            rc = ext.merge_parts(str(parts), str(obs_out), str(det_out))
+            self.assertEqual(rc, ext.EXIT_OK)
+            obs = json.loads(obs_out.read_text(encoding="utf-8"))
+            det = json.loads(det_out.read_text(encoding="utf-8"))
+            # diagnosis re-measured Alpha after the killed batch, and the
+            # batch's stale failure must not survive the superseding pass
+            self.assertEqual(obs["classes"], {"AlphaUITests": 200.0, "BetaUITests": 0.1})
+            self.assertEqual(det["failures"], [])
+
     def test_merge_parts_folds_details_across_classes(self):
         with tempfile.TemporaryDirectory() as tmp:
             parts = Path(tmp) / "parts"

--- a/scripts/tests/test_lane_runner.py
+++ b/scripts/tests/test_lane_runner.py
@@ -1,8 +1,18 @@
 """Runner for the bash lane-runner state-machine tests.
 
 The assertions live in scripts/tests/test_lane_runner.sh; this wrapper makes
-them part of the standard unittest discovery run (ubuntu CI plan job and
-macOS). Skipped on platforms without bash.
+them part of the standard unittest discovery run. Skipped on platforms
+without bash, and when CONDUIT_CI_SKIP_BASH_WRAPPER_TESTS=1 (the plan job
+sets it: the state-machine suite is minutes-long, so it runs in the
+dedicated self-test job instead of delaying planning and the macOS build).
+
+Measured cost: ~3.5-4 minutes wall on macOS with the harness's 1s
+xcodebuild poll cadence (124 assertions over 25 lane states, including
+watchdog kills of synthetic hangs at 2-6s budgets); expect similar or a
+little slower on hosted ubuntu. The subprocess cap below must stay larger
+than that measured runtime but SMALLER than the self-test job's own GitHub
+timeout, so this suite can always report its own failure before GitHub
+kills the job: per-case watchdogs (<= 6s) < this cap < job timeout.
 """
 
 import os
@@ -16,13 +26,12 @@ SCRIPT = os.path.join(SCRIPTS_DIR, "tests", "test_lane_runner.sh")
 
 
 @unittest.skipUnless(os.name == "posix" and shutil.which("bash"), "bash is required to exercise the lane runner")
+@unittest.skipIf(os.environ.get("CONDUIT_CI_SKIP_BASH_WRAPPER_TESTS") == "1",
+                 "bash meta-suites run in the dedicated self-test job")
 class LaneRunnerScriptTests(unittest.TestCase):
     def test_lane_runner_state_machine(self):
-        # The suite runs with a 1s xcodebuild poll cadence (test harness
-        # env), so the full unit+UI state machine finishes in ~1-2 minutes;
-        # the cap only exists to bound a truly wedged run.
         proc = subprocess.run(["bash", SCRIPT], capture_output=True,
-                              text=True, timeout=900)
+                              text=True, timeout=480)
         if proc.returncode != 0:
             self.fail("lane-runner state machine test failed:\n"
                       + proc.stdout[-4000:] + proc.stderr[-2000:])

--- a/scripts/tests/test_lane_runner.sh
+++ b/scripts/tests/test_lane_runner.sh
@@ -114,6 +114,14 @@ begin_case() { # $1=name $2=workdir
   current="$1"
   WORKCASE="$2"
   mkdir -p "$2"
+  CASE_START=$(date +%s)
+  echo "START $current"
+}
+
+end_case() { # closes the current case's timing line (suite-progress telemetry)
+  [ -n "${current:-}" ] || return 0
+  echo "END $current $(( $(date +%s) - CASE_START ))s"
+  current=""
 }
 
 run_lane() { # $1=classes $2=timeout $3=mode $4=iterations
@@ -334,6 +342,7 @@ class_invocations() { # $1=class -> how many diagnosis invocations it got
 
 
 # --- case 1: pass -------------------------------------------------------------
+end_case
 begin_case "pass path" "$WORK/c1"
 write_canned "$WORK/canned-pass.json" "AlphaTests" "Passed"
 run_lane "AlphaTests" 300 pass 3
@@ -342,6 +351,7 @@ assert_eq "verdict" "$(lane_field "['status']")" "pass"
 assert_eq "attempts" "$(attempts_statuses)" "['passed']"
 
 # --- case 2: ordinary failure -> fail, no lane retry --------------------------
+end_case
 begin_case "ordinary failure" "$WORK/c2"
 write_canned "$WORK/canned-fail.json" "AlphaTests" "Failed"
 run_lane "AlphaTests" 300 fail65 3
@@ -355,6 +365,7 @@ else
 fi
 
 # --- case 3: unclassified failure -> fail, never retried ----------------------
+end_case
 begin_case "unclassified failure" "$WORK/c3"
 # Extraction must fail: xcrun returns an invalid document (no canned file).
 export FAKE_CANNED="$WORK/does-not-exist.json"
@@ -368,6 +379,7 @@ else
 fi
 
 # --- case 4: infra failure -> exactly one full-lane retry, then error ---------
+end_case
 begin_case "infra failure retry" "$WORK/c4"
 write_canned "$WORK/canned-pass2.json" "AlphaTests" "Passed"
 run_lane "AlphaTests" 300 infra70 1
@@ -377,6 +389,7 @@ assert_eq "attempts" "$(attempts_statuses)" "['infra-error', 'infra-error']"
 
 
 # --- case 5: timeout -> isolation directly, hang identified -------------------
+end_case
 begin_case "timeout isolation" "$WORK/c5"
 export ISOLATION_BUDGET_S=200 CLASS_TIMEOUT_MIN_S=1 CLASS_TIMEOUT_MULTIPLIER=0.1
 run_lane "AlphaTests,BetaTests" 3 hang 1
@@ -392,6 +405,7 @@ fi
 assert_eq "isolation ran" "$(isolation_statuses)" "['timeout', 'not_diagnosed']"
 
 # --- case 6: incomplete isolation fails the lane ------------------------------
+end_case
 begin_case "incomplete isolation" "$WORK/c6"
 export ISOLATION_BUDGET_S=2 CLASS_TIMEOUT_MIN_S=1 CLASS_TIMEOUT_MULTIPLIER=0.1
 run_lane "AlphaTests,BetaTests" 3 hang 1
@@ -409,6 +423,7 @@ fi
 # Spec scenario: AlphaTests PASSES, BetaTests TIMES OUT, GammaTests
 # would pass if called - but must NEVER run on the contaminated
 # simulator. Tracks exact xcodebuild invocation counts via the stub.
+end_case
 begin_case "stop after hang" "$WORK/c7"
 cat > "$STUBS/xcodebuild" <<'EOF'
 #!/bin/bash
@@ -445,6 +460,7 @@ assert_eq "GammaTests never invoked" "$(grep -c '^iso:GammaTests$' "$INVOCATION_
 # finalizing the xcresult when the watchdog expired. The deadline must be
 # extended ONCE (bounded grace) so the finished session can exit with its
 # real status; success still comes from the exit status, never the marker.
+end_case
 begin_case "finalize grace lets a finished invocation pass" "$WORK/c8"
 cat > "$STUBS/xcodebuild" <<'EOF'
 #!/bin/bash
@@ -469,6 +485,7 @@ else
 fi
 
 # --- case 9: grace is bounded - a wedged finalize is still a timeout ----------
+end_case
 begin_case "finalize grace expiry kills and isolates" "$WORK/c9"
 cat > "$STUBS/xcodebuild" <<'EOF'
 #!/bin/bash
@@ -491,6 +508,7 @@ else
 fi
 
 # --- case 10: infra failure recovers on the single post-reset retry -----------
+end_case
 begin_case "infra retry recovers to green" "$WORK/c10"
 cat > "$STUBS/xcodebuild" <<'EOF'
 #!/bin/bash
@@ -513,6 +531,7 @@ assert_eq "verdict" "$(lane_field "['status']")" "pass"
 assert_eq "attempts" "$(attempts_statuses)" "['infra-recovered', 'passed']"
 
 # --- case 11: class failure during isolation fails the lane --------------------
+end_case
 begin_case "class failure during isolation" "$WORK/c11"
 cat > "$STUBS/xcodebuild" <<'EOF'
 #!/bin/bash
@@ -531,6 +550,7 @@ assert_eq "verdict" "$(lane_field "['status']")" "fail"
 assert_eq "isolation statuses" "$(isolation_statuses)" "['fail', 'fail']"
 
 echo ""
+end_case
 echo "unit+isolation state machine: $pass_count passed, $fail_count failed so far"
 
 # ===========================================================================
@@ -547,6 +567,7 @@ export FAKE_CANNED="$WORK/canned-ui.json"
 UI_DEFAULTS='FAKE_BATCH_A1=pass FAKE_BATCH_RETRY=pass FAKE_BATCH_FAIL_CLASSES= FAKE_UI_NO_DOC='
 
 # --- UI case 1: every class passes once - ONE batched invocation --------------
+end_case
 begin_case "ui batch all pass" "$WORK/u1"
 export INVOCATION_LOG="$WORK/u1-invocations.log"; : > "$INVOCATION_LOG"
 export FAKE_BATCH_A1="pass" FAKE_BATCH_RETRY="pass" FAKE_BATCH_FAIL_CLASSES="" FAKE_UI_NO_DOC=""
@@ -576,6 +597,7 @@ else
 fi
 
 # --- UI case 2: flaky test recovered by a METHOD-precise retry ----------------
+end_case
 begin_case "ui flaky test recovered via method retry" "$WORK/u2"
 export INVOCATION_LOG="$WORK/u2-invocations.log"; : > "$INVOCATION_LOG"
 export FAKE_BATCH_A1="fail-test" FAKE_BATCH_FAIL_CLASSES="BetaUITests" FAKE_BATCH_RETRY="pass"
@@ -588,8 +610,9 @@ assert_eq "one batch attempt + one retry invocation" \
   "$(batch_invocations 'batch-a1')$(batch_invocations 'batch-a2 (filters: BetaUITests/testC())')" "11"
 assert_eq "healthy classes never re-invoked" \
   "$(class_invocations AlphaUITests)$(class_invocations GammaUITests)" "00"
-if grep -q "PASSED on its targeted retry" "$WORKCASE/stdout.log"; then
-  ok "recovered flake reported loudly"
+if grep -q "passed on its targeted retry" "$WORKCASE/stdout.log" \
+   && grep -q "Retried tests:" "$WORKCASE/stdout.log"; then
+  ok "recovered flake reported loudly with the retried tests"
 else
   bad "a retry pass must be reported as a flake, not hidden"
 fi
@@ -600,6 +623,7 @@ else
 fi
 
 # --- UI case 3: failure survives the retry -> lane fails, no false flake ------
+end_case
 begin_case "ui failure survives retry" "$WORK/u3"
 export INVOCATION_LOG="$WORK/u3-invocations.log"; : > "$INVOCATION_LOG"
 export FAKE_BATCH_A1="fail-test" FAKE_BATCH_FAIL_CLASSES="BetaUITests" FAKE_BATCH_RETRY="fail"
@@ -611,6 +635,7 @@ assert_eq "no false flake" "$(retried_classes)" "[]"
 assert_eq "retry ran exactly once" "$(batch_invocations 'batch-a1')$(batch_invocations 'batch-a2 (filters: BetaUITests/testC())')" "11"
 
 # --- UI case 4: batch timeout -> per-class diagnosis, hang attributed ---------
+end_case
 begin_case "ui batch timeout enters per-class diagnosis" "$WORK/u4"
 export INVOCATION_LOG="$WORK/u4-invocations.log"; : > "$INVOCATION_LOG"
 export FAKE_BATCH_A1="hang" FAKE_BATCH_RETRY="pass" FAKE_BATCH_FAIL_CLASSES=""
@@ -633,6 +658,7 @@ else
 fi
 
 # --- UI case 5: batch infra wedge -> diagnosis; class infra recovers ----------
+end_case
 begin_case "ui batch infra enters diagnosis and recovers" "$WORK/u5"
 export INVOCATION_LOG="$WORK/u5-invocations.log"; : > "$INVOCATION_LOG"
 export FAKE_BATCH_A1="infra" FAKE_UI_HANG=""
@@ -648,6 +674,7 @@ assert_eq "infra recovery reported separately" \
 assert_eq "Alpha diagnosed with its one retry" "$(class_invocations AlphaUITests)" "2"
 
 # --- UI case 6: unclassified batch failure fails the lane without retry -------
+end_case
 begin_case "ui unclassified batch failure" "$WORK/u6"
 export INVOCATION_LOG="$WORK/u6-invocations.log"; : > "$INVOCATION_LOG"
 # Extraction must fail: the canned doc path never exists (and the stub never
@@ -665,6 +692,7 @@ export FAKE_CANNED="$WORK/canned-ui.json"
 export FAKE_UI_NO_DOC=""
 
 # --- UI case 7: persistent infra failure in diagnosis fails the lane ----------
+end_case
 begin_case "ui persistent infra in diagnosis continues lane" "$WORK/u7"
 export INVOCATION_LOG="$WORK/u7-invocations.log"; : > "$INVOCATION_LOG"
 export FAKE_UI_NO_DOC=""
@@ -688,6 +716,7 @@ else
 fi
 
 # --- UI case 8: untrusted simulator recovery stops the lane -------------------
+end_case
 begin_case "ui recovery failure stops lane" "$WORK/u8"
 export INVOCATION_LOG="$WORK/u8-invocations.log"; : > "$INVOCATION_LOG"
 export FAKE_UI_NO_DOC=""
@@ -700,6 +729,7 @@ assert_eq "attempts" "$(attempts_statuses)" "['infra-error', 'not_diagnosed', 'n
 assert_eq "Beta never ran on an untrusted simulator" "$(class_invocations BetaUITests)" "0"
 
 # --- UI case 9: retry-timeout falls back to diagnosis of the retried class ----
+end_case
 begin_case "ui retry timeout diagnoses the retried class" "$WORK/u9"
 export INVOCATION_LOG="$WORK/u9-invocations.log"; : > "$INVOCATION_LOG"
 export FAKE_UI_NO_DOC=""
@@ -716,6 +746,7 @@ assert_eq "Alpha never re-ran after its batch pass" "$(class_invocations AlphaUI
 # --- UI case 12: batch aborted before a class ran -> diagnosis, no retry -----
 # A batch whose xcresult has no record of an assigned class can never be
 # retried into a green lane: the unexecuted class forces per-class diagnosis.
+end_case
 begin_case "ui incomplete batch diagnoses instead of retrying" "$WORK/u12"
 export INVOCATION_LOG="$WORK/u12-invocations.log"; : > "$INVOCATION_LOG"
 export FAKE_UI_NO_DOC="" FAKE_UI_HANG=""
@@ -738,6 +769,7 @@ fi
 export FAKE_BATCH_OMIT_CLASSES=""
 
 # --- UI case 13: a Skipped final is non-passing and joins the retry ----------
+end_case
 begin_case "ui skipped final joins the retry filters" "$WORK/u13"
 export INVOCATION_LOG="$WORK/u13-invocations.log"; : > "$INVOCATION_LOG"
 export FAKE_UI_NO_DOC="" FAKE_UI_HANG="" FAKE_BATCH_OMIT_CLASSES=""
@@ -754,6 +786,7 @@ assert_eq "attempts" "$(attempts_statuses)" "['test-failures', 'passed']"
 # Defense in depth: an exit-0 batch whose parseable xcresult has no record of
 # an assigned class (an -only-testing filter silently matching nothing) must
 # not finish as a clean pass.
+end_case
 begin_case "ui pass with unrecorded class diagnoses" "$WORK/u14"
 export INVOCATION_LOG="$WORK/u14-invocations.log"; : > "$INVOCATION_LOG"
 export FAKE_UI_NO_DOC="" FAKE_UI_HANG=""
@@ -775,7 +808,50 @@ else
 fi
 export FAKE_BATCH_OMIT_CLASSES=""
 
+# --- UI case 15: diagnosis METHOD-only retry never becomes class timing ------
+# A diagnosis retry filtered down to the failed methods must not leave an
+# observations part behind: only the attempt-1 full-class invocation owns the
+# class's timing-history sample (the batch path obeys the same rule).
+begin_case "ui diagnosis method retry keeps class timing" "$WORK/u15"
+export INVOCATION_LOG="$WORK/u15-invocations.log"; : > "$INVOCATION_LOG"
+export FAKE_UI_NO_DOC="" FAKE_BATCH_OMIT_CLASSES="" FAKE_BATCH_SKIP_CLASSES=""
+export FAKE_BATCH_A1="hang" FAKE_BATCH_RETRY="pass" FAKE_BATCH_FAIL_CLASSES=""
+export FAKE_UI_FAIL_ONCE="AlphaUITests" FAKE_UI_FAIL_ALWAYS="" FAKE_UI_INFRA_ONCE="" FAKE_UI_INFRA_ALWAYS="" FAKE_UI_HANG="" FAKE_UI_RECOVERY_FAILS=""
+run_ui_lane "AlphaUITests,BetaUITests,GammaUITests" 3 "AlphaUITests=2,BetaUITests=2,GammaUITests=2"
+assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "0"
+assert_eq "verdict" "$(lane_field "['status']")" "pass"
+assert_eq "attempts" "$(attempts_statuses)" \
+  "['timeout', 'test-failures', 'passed', 'passed', 'passed']"
+assert_eq "retried classes" "$(retried_classes)" "['AlphaUITests']"
+if [ -f "$WORKCASE/parts/observations-AlphaUITests-a2.json" ]; then
+  bad "method-only retry observations must not fold into timing history"
+else
+  ok "method-only retry observations removed"
+fi
+if [ -f "$WORKCASE/parts/detail-AlphaUITests-a2.json" ]; then
+  ok "method-only retry detail kept as flake evidence"
+else
+  bad "method-only retry detail (flake evidence) must be kept"
+fi
+
+# --- UI case 16: same rule when the diagnosis method retry FAILS -------------
+begin_case "ui failing diagnosis method retry keeps rule" "$WORK/u16"
+export INVOCATION_LOG="$WORK/u16-invocations.log"; : > "$INVOCATION_LOG"
+export FAKE_UI_NO_DOC="" FAKE_UI_HANG=""
+export FAKE_BATCH_A1="hang" FAKE_BATCH_RETRY="pass" FAKE_BATCH_FAIL_CLASSES=""
+export FAKE_UI_FAIL_ONCE="" FAKE_UI_FAIL_ALWAYS="AlphaUITests" FAKE_UI_RECOVERY_FAILS=""
+run_ui_lane "AlphaUITests,BetaUITests,GammaUITests" 3 "AlphaUITests=2,BetaUITests=2,GammaUITests=2"
+assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "1"
+assert_eq "verdict" "$(lane_field "['status']")" "fail"
+assert_eq "no false flake" "$(retried_classes)" "[]"
+if [ -f "$WORKCASE/parts/observations-AlphaUITests-a2.json" ]; then
+  bad "failing method-only retry observations must not fold either"
+else
+  ok "failing method-only retry observations removed"
+fi
+
 # --- UI case 10: a class without a planned watchdog refuses to start ----------
+end_case
 begin_case "ui missing watchdog entry rejected" "$WORK/u10"
 export INVOCATION_LOG="$WORK/u10-invocations.log"; : > "$INVOCATION_LOG"
 run_ui_lane "AlphaUITests,BetaUITests" 300 "AlphaUITests=200"
@@ -792,6 +868,7 @@ else
 fi
 
 # --- UI case 11: malformed watchdog entries are rejected ----------------------
+end_case
 begin_case "ui malformed watchdog entry rejected" "$WORK/u11"
 run_ui_lane "AlphaUITests" 300 "AlphaUITests=abc"
 assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "2"
@@ -802,6 +879,7 @@ else
 fi
 
 echo ""
+end_case
 echo "lane-runner state machine: $pass_count passed, $fail_count failed"
 [ "$fail_count" -eq 0 ] || exit 1
 echo "ALL CASES PASSED"

--- a/scripts/tests/test_lane_runner.sh
+++ b/scripts/tests/test_lane_runner.sh
@@ -206,15 +206,22 @@ for a in "$@"; do
 done
 
 # Write the canned extraction document: one Test Suite node per Class:Result.
+# Classes listed in $FAKE_BATCH_SKIP_CLASSES get an extra Skipped test (final
+# != Passed, so the runner's retry filters must include it).
 write_doc_multi() {
   docfile="$1"; shift
   nodes=""
   sep=""
   for pair in "$@"; do
     c="${pair%%:*}"; r="${pair#*:}"
+    extra=""
+    case " $FAKE_BATCH_SKIP_CLASSES " in *" $c "*)
+      extra=",{\"nodeType\": \"Test Case\", \"name\": \"testD()\", \"result\": \"Skipped\",
+        \"durationInSeconds\": 0.1}" ;;
+    esac
     nodes="$nodes$sep{\"nodeType\": \"Test Suite\", \"name\": \"$c\", \"result\": \"$r\",
       \"children\": [{\"nodeType\": \"Test Case\", \"name\": \"testC()\", \"result\": \"$r\",
-      \"durationInSeconds\": 0.1}]}"
+      \"durationInSeconds\": 0.1}$extra]}"
     sep=","
   done
   cat > "$FAKE_CANNED" <<DOC
@@ -231,11 +238,18 @@ write_all_passed() {
   write_doc_multi "$FAKE_CANNED" $pairs
 }
 
+# The canned document must reflect an ABORTED batch: classes listed in
+# $FAKE_BATCH_OMIT_CLASSES never ran and get no Test Suite node at all.
+doc_classes=""
+for c in $classes; do
+  case " $FAKE_BATCH_OMIT_CLASSES " in *" $c "*) ;; *) doc_classes="$doc_classes $c" ;; esac
+done
+
 if [ "$mode" = "batch" ]; then
   case "$kind" in
     a1)
       echo "batch-a1" >> "$INVOCATION_LOG"
-      [ -n "${FAKE_UI_NO_DOC:-}" ] || write_all_passed $classes
+      [ -n "${FAKE_UI_NO_DOC:-}" ] || write_all_passed $doc_classes
       case "$FAKE_BATCH_A1" in
         hang)
           sleep 300
@@ -247,7 +261,7 @@ if [ "$mode" = "batch" ]; then
           ;;
         fail-test)
           pairs=""
-          for c in $classes; do
+          for c in $doc_classes; do
             case " $FAKE_BATCH_FAIL_CLASSES " in *" $c "*) pairs="$pairs $c:Failed" ;; *) pairs="$pairs $c:Passed" ;; esac
           done
           # NO_DOC keeps the canned document stale so extraction fails.
@@ -262,7 +276,7 @@ if [ "$mode" = "batch" ]; then
       ;;
     a2)
       echo "batch-a2 (filters:$methods)" >> "$INVOCATION_LOG"
-      [ -n "${FAKE_UI_NO_DOC:-}" ] || write_all_passed $classes
+      [ -n "${FAKE_UI_NO_DOC:-}" ] || write_all_passed $doc_classes
       case "$FAKE_BATCH_RETRY" in
         hang)
           sleep 300
@@ -274,7 +288,7 @@ if [ "$mode" = "batch" ]; then
           ;;
         fail)
           pairs=""
-          for c in $classes; do pairs="$pairs $c:Failed"; done
+          for c in $doc_classes; do pairs="$pairs $c:Failed"; done
           [ -n "${FAKE_UI_NO_DOC:-}" ] || write_doc_multi "$FAKE_CANNED" $pairs
           echo "Test Case failed (stub)"
           exit 65
@@ -384,12 +398,6 @@ run_lane "AlphaTests,BetaTests" 3 hang 1
 assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "1"
 assert_eq "verdict" "$(lane_field "['status']")" "timeout"
 assert_eq "isolation statuses" "$(isolation_statuses)" "['not_diagnosed', 'not_diagnosed']"
-if grep -q "undiagnosed classes" "$WORKCASE/stdout.log"; then
-  ok "undiagnosed classes reported"
-else
-  bad "undiagnosed classes must be reported loudly"
-fi
-
 if grep -q "undiagnosed classes" "$WORKCASE/stdout.log"; then
   ok "undiagnosed classes reported"
 else
@@ -704,6 +712,43 @@ assert_eq "hung class" "$(lane_field "['hung_class']")" "BetaUITests"
 assert_eq "attempts" "$(attempts_statuses)" \
   "['test-failures', 'timeout', 'timeout', 'timeout']"
 assert_eq "Alpha never re-ran after its batch pass" "$(class_invocations AlphaUITests)" "0"
+
+# --- UI case 12: batch aborted before a class ran -> diagnosis, no retry -----
+# A batch whose xcresult has no record of an assigned class can never be
+# retried into a green lane: the unexecuted class forces per-class diagnosis.
+begin_case "ui incomplete batch diagnoses instead of retrying" "$WORK/u12"
+export INVOCATION_LOG="$WORK/u12-invocations.log"; : > "$INVOCATION_LOG"
+export FAKE_UI_NO_DOC="" FAKE_UI_HANG=""
+export FAKE_BATCH_A1="fail-test" FAKE_BATCH_FAIL_CLASSES="BetaUITests" FAKE_BATCH_RETRY="pass"
+export FAKE_BATCH_SKIP_CLASSES="" FAKE_BATCH_OMIT_CLASSES="GammaUITests"
+export FAKE_UI_FAIL_ONCE="" FAKE_UI_FAIL_ALWAYS="" FAKE_UI_INFRA_ONCE="" FAKE_UI_INFRA_ALWAYS="" FAKE_UI_RECOVERY_FAILS=""
+run_ui_lane "AlphaUITests,BetaUITests,GammaUITests" 300 "AlphaUITests=200,BetaUITests=200,GammaUITests=200"
+assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "0"
+assert_eq "verdict" "$(lane_field "['status']")" "pass"
+assert_eq "attempts" "$(attempts_statuses)" \
+  "['incomplete', 'passed', 'passed', 'passed']"
+assert_eq "no targeted retry for an incomplete batch" "$(batch_invocations 'batch-a1')$(batch_invocations 'batch-a2 (filters: BetaUITests/testC())')" "10"
+assert_eq "every class diagnosed exactly once" \
+  "$(class_invocations AlphaUITests)$(class_invocations BetaUITests)$(class_invocations GammaUITests)" "111"
+if grep -q "batch aborted before executing" "$WORKCASE/stdout.log"; then
+  ok "incomplete batch announced the missing class"
+else
+  bad "an incomplete batch must name the unexecuted class"
+fi
+export FAKE_BATCH_OMIT_CLASSES=""
+
+# --- UI case 13: a Skipped final is non-passing and joins the retry ----------
+begin_case "ui skipped final joins the retry filters" "$WORK/u13"
+export INVOCATION_LOG="$WORK/u13-invocations.log"; : > "$INVOCATION_LOG"
+export FAKE_UI_NO_DOC="" FAKE_UI_HANG="" FAKE_BATCH_OMIT_CLASSES=""
+export FAKE_BATCH_A1="fail-test" FAKE_BATCH_FAIL_CLASSES="BetaUITests" FAKE_BATCH_RETRY="pass"
+export FAKE_BATCH_SKIP_CLASSES="BetaUITests"
+run_ui_lane "AlphaUITests,BetaUITests" 300 "AlphaUITests=200,BetaUITests=200"
+assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "0"
+assert_eq "verdict" "$(lane_field "['status']")" "pass"
+assert_eq "failed and skipped tests both retried" \
+  "$(batch_invocations 'batch-a2 (filters: BetaUITests/testC() BetaUITests/testD())')" "1"
+assert_eq "attempts" "$(attempts_statuses)" "['test-failures', 'passed']"
 
 # --- UI case 10: a class without a planned watchdog refuses to start ----------
 begin_case "ui missing watchdog entry rejected" "$WORK/u10"

--- a/scripts/tests/test_lane_runner.sh
+++ b/scripts/tests/test_lane_runner.sh
@@ -164,58 +164,157 @@ run_ui_lane() { # $1=classes $2=lane-timeout(bookkeeping) $3=class-timeouts
   echo $? > "$WORKCASE/exit-code"
 }
 
-# Stub that decides per class AND per attempt: classes listed in
-# $FAKE_UI_FAIL_ONCE fail attempt 1 (exit 65, Failed canned doc) and pass
-# their retry; $FAKE_UI_FAIL_ALWAYS classes always fail; $FAKE_UI_HANG
-# classes sleep past any budget; $FAKE_UI_INFRA_ONCE classes fail attempt 1
-# with an infrastructure-looking exit 70 and zero failing tests. Every
-# invocation rewrites the canned xcresult document to match its own verdict,
-# so the runner's classification sees the right detail.
+# Stub that decides per invocation SHAPE: the batched shard invocation
+# (result bundle stem batch-a1/batch-a2) is driven by $FAKE_BATCH_A1 /
+# $FAKE_BATCH_RETRY; per-class diagnosis invocations (bundle stem
+# class-<cls>-a1/a2) are driven by the $FAKE_UI_* class tables. Every
+# invocation rewrites the canned xcresult document to match its own verdict
+# for EVERY class it was asked to run, so the runner's classification sees
+# the right detail. Invocation facts land in $INVOCATION_LOG as
+# "batch-a1", "batch-a2 (filters: ...)" and "class:<cls>:<kind>" lines.
 write_ui_stub_xcodebuild() {
   cat > "$STUBS/xcodebuild" <<'EOF'
 #!/bin/bash
-cls=$(printf '%s\n' "$@" | grep 'only-testing:' | head -1 | sed 's|.*/||')
-attempt=a1
-printf '%s\n' "$@" | grep -q '\-a2\.xcresult' && attempt=a2
-echo "ui:$cls:$attempt" >> "$INVOCATION_LOG"
-# Real xcodebuild creates the result bundle directory; create it so cleanup
-# and bundle-preservation assertions exercise the real paths.
+bundle=""
 for a in "$@"; do
   case "$a" in
-    *.xcresult) mkdir -p "$a" ;;
+    *.xcresult) bundle="$a"; mkdir -p "$a" ;;
   esac
 done
-write_doc() { # $1=TestClass $2=Passed|Failed
-  [ -n "${FAKE_UI_NO_DOC:-}" ] && return 0
+kind=a1
+case "$bundle" in
+  *-a2.xcresult) kind=a2 ;;
+esac
+mode=class
+case "$bundle" in
+  *batch-*) mode=batch ;;
+esac
+classes=""
+methods=""
+for a in "$@"; do
+  case "$a" in
+    -only-testing:*)
+      spec="${a#-only-testing:}"
+      rest="${spec#*/}"
+      cls="${rest%%/*}"
+      case "$rest" in
+        */*) methods="$methods $rest" ;;
+      esac
+      case " $classes " in *" $cls "*) ;; *) classes="$classes $cls" ;; esac
+      ;;
+  esac
+done
+
+# Write the canned extraction document: one Test Suite node per Class:Result.
+write_doc_multi() {
+  docfile="$1"; shift
+  nodes=""
+  sep=""
+  for pair in "$@"; do
+    c="${pair%%:*}"; r="${pair#*:}"
+    nodes="$nodes$sep{\"nodeType\": \"Test Suite\", \"name\": \"$c\", \"result\": \"$r\",
+      \"children\": [{\"nodeType\": \"Test Case\", \"name\": \"testC()\", \"result\": \"$r\",
+      \"durationInSeconds\": 0.1}]}"
+    sep=","
+  done
   cat > "$FAKE_CANNED" <<DOC
 {"testNodes": [{"nodeType": "Test Plan", "name": "Conduit", "result": "Passed",
   "children": [{"nodeType": "UI test bundle", "name": "ConduitUITests", "result": "Passed",
-    "children": [{"nodeType": "Test Suite", "name": "$1", "result": "Passed",
-      "children": [{"nodeType": "Test Case", "name": "testC()", "result": "$2",
-        "durationInSeconds": 0.1}]}]}]}]}
+    "children": [$nodes]}]}]}
 DOC
 }
-case " $FAKE_UI_FAIL_ONCE " in *" $cls "*)
-  if [ "$attempt" = a1 ]; then write_doc "$cls" Failed; echo "Test Case failed (stub)"; exit 65; fi
-  write_doc "$cls" Passed; exit 0 ;;
-esac
-case " $FAKE_UI_FAIL_ALWAYS " in *" $cls "*) write_doc "$cls" Failed; echo "Test Case failed (stub)"; exit 65 ;; esac
-case " $FAKE_UI_INFRA_ONCE " in *" $cls "*)
-  if [ "$attempt" = a1 ]; then write_doc "$cls" Passed; echo "simulator crashed (stub)"; exit 70; fi
-  write_doc "$cls" Passed; exit 0 ;;
-esac
-case " $FAKE_UI_INFRA_ALWAYS " in *" $cls "*)
-  write_doc "$cls" Passed; echo "simulator crashed (stub)"; exit 70 ;;
-esac
+
+write_all_passed() {
+  # $@ = class names
+  pairs=""
+  for c in "$@"; do pairs="$pairs $c:Passed"; done
+  write_doc_multi "$FAKE_CANNED" $pairs
+}
+
+if [ "$mode" = "batch" ]; then
+  case "$kind" in
+    a1)
+      echo "batch-a1" >> "$INVOCATION_LOG"
+      [ -n "${FAKE_UI_NO_DOC:-}" ] || write_all_passed $classes
+      case "$FAKE_BATCH_A1" in
+        hang)
+          sleep 300
+          exit 0
+          ;;
+        infra)
+          echo "simulator crashed (stub)"
+          exit 70
+          ;;
+        fail-test)
+          pairs=""
+          for c in $classes; do
+            case " $FAKE_BATCH_FAIL_CLASSES " in *" $c "*) pairs="$pairs $c:Failed" ;; *) pairs="$pairs $c:Passed" ;; esac
+          done
+          # NO_DOC keeps the canned document stale so extraction fails.
+          [ -n "${FAKE_UI_NO_DOC:-}" ] || write_doc_multi "$FAKE_CANNED" $pairs
+          echo "Test Case failed (stub)"
+          exit 65
+          ;;
+        *)
+          exit 0
+          ;;
+      esac
+      ;;
+    a2)
+      echo "batch-a2 (filters:$methods)" >> "$INVOCATION_LOG"
+      [ -n "${FAKE_UI_NO_DOC:-}" ] || write_all_passed $classes
+      case "$FAKE_BATCH_RETRY" in
+        hang)
+          sleep 300
+          exit 0
+          ;;
+        infra)
+          echo "simulator crashed (stub)"
+          exit 70
+          ;;
+        fail)
+          pairs=""
+          for c in $classes; do pairs="$pairs $c:Failed"; done
+          [ -n "${FAKE_UI_NO_DOC:-}" ] || write_doc_multi "$FAKE_CANNED" $pairs
+          echo "Test Case failed (stub)"
+          exit 65
+          ;;
+        *)
+          exit 0
+          ;;
+      esac
+      ;;
+  esac
+  exit 0
+fi
+
+# Class mode: exactly one class per invocation.
+cls=$(printf '%s\n' $classes | head -1)
+echo "class:$cls:$kind" >> "$INVOCATION_LOG"
+# A hanging class hangs on BOTH attempts: the second hang is what names the
+# culprit and stops the lane.
 case " $FAKE_UI_HANG " in *" $cls "*) sleep 300; exit 0 ;; esac
-write_doc "$cls" Passed
+case "$kind" in
+  a1) case " $FAKE_UI_FAIL_ONCE " in *" $cls "*) write_doc_multi "$FAKE_CANNED" "$cls:Failed"; echo "Test Case failed (stub)"; exit 65 ;; esac
+      case " $FAKE_UI_FAIL_ALWAYS " in *" $cls "*) write_doc_multi "$FAKE_CANNED" "$cls:Failed"; echo "Test Case failed (stub)"; exit 65 ;; esac
+      case " $FAKE_UI_INFRA_ONCE " in *" $cls "*) write_doc_multi "$FAKE_CANNED" "$cls:Passed"; echo "simulator crashed (stub)"; exit 70 ;; esac
+      case " $FAKE_UI_INFRA_ALWAYS " in *" $cls "*) write_doc_multi "$FAKE_CANNED" "$cls:Passed"; echo "simulator crashed (stub)"; exit 70 ;; esac
+      ;;
+  a2) case " $FAKE_UI_FAIL_ALWAYS " in *" $cls "*) write_doc_multi "$FAKE_CANNED" "$cls:Failed"; echo "Test Case failed (stub)"; exit 65 ;; esac
+      case " $FAKE_UI_INFRA_ALWAYS " in *" $cls "*) write_doc_multi "$FAKE_CANNED" "$cls:Passed"; echo "simulator crashed (stub)"; exit 70 ;; esac
+      ;;
+esac
+write_doc_multi "$FAKE_CANNED" "$cls:Passed"
 exit 0
 EOF
   chmod +x "$STUBS/xcodebuild"
 }
 
-ui_invocations() { # $1=class -> how many times that class was invoked
-  grep -c "^ui:$1:" "$INVOCATION_LOG" 2>/dev/null || true
+batch_invocations() { # $1 = exact batch line -> count
+  grep -cx "$1" "$INVOCATION_LOG" 2>/dev/null || true
+}
+class_invocations() { # $1=class -> how many diagnosis invocations it got
+  grep -c "^class:$1:" "$INVOCATION_LOG" 2>/dev/null || true
 }
 
 
@@ -427,7 +526,8 @@ echo ""
 echo "unit+isolation state machine: $pass_count passed, $fail_count failed so far"
 
 # ===========================================================================
-# UI lane mode: per-class invocations, per-class watchdogs, targeted retry.
+# UI lane mode: one batched shard invocation on the healthy path, per-class
+# diagnosis + method-precise retry on failure paths.
 # Runs even if unit cases failed so every case reports in one pass; the
 # single summary at the bottom decides the exit code.
 # ===========================================================================
@@ -436,178 +536,176 @@ write_stub_xcrun
 write_ui_stub_xcodebuild
 touch "$WORK/fake.xctestrun"
 export FAKE_CANNED="$WORK/canned-ui.json"
+UI_DEFAULTS='FAKE_BATCH_A1=pass FAKE_BATCH_RETRY=pass FAKE_BATCH_FAIL_CLASSES= FAKE_UI_NO_DOC='
 
-# --- UI case 1: every class passes once - one invocation per class ------------
-begin_case "ui all pass" "$WORK/u1"
+# --- UI case 1: every class passes once - ONE batched invocation --------------
+begin_case "ui batch all pass" "$WORK/u1"
 export INVOCATION_LOG="$WORK/u1-invocations.log"; : > "$INVOCATION_LOG"
+export FAKE_BATCH_A1="pass" FAKE_BATCH_RETRY="pass" FAKE_BATCH_FAIL_CLASSES="" FAKE_UI_NO_DOC=""
 export FAKE_UI_FAIL_ONCE="" FAKE_UI_FAIL_ALWAYS="" FAKE_UI_INFRA_ONCE="" FAKE_UI_INFRA_ALWAYS="" FAKE_UI_HANG="" FAKE_UI_RECOVERY_FAILS=""
-run_ui_lane "AlphaUITests,BetaUITests" 300 "AlphaUITests=200,BetaUITests=200"
-assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "0"
-assert_eq "verdict" "$(lane_field "['status']")" "pass"
-assert_eq "attempts" "$(attempts_statuses)" "['passed', 'passed']"
-assert_eq "Alpha invoked once" "$(ui_invocations AlphaUITests)" "1"
-assert_eq "Beta invoked once" "$(ui_invocations BetaUITests)" "1"
-if grep -q -- "-retry-tests-on-failure" "$WORKCASE/stdout.log"; then
-  bad "UI classes must not run under native multi-iteration retry"
-else
-  ok "UI class invocations run without native retry flags"
-fi
-if [ -f "$WORKCASE/lane-result.json" ] && grep -q '"class": "AlphaUITests"' "$WORKCASE/lane-result.json"; then
-  ok "attempt chain records the owning class"
-else
-  bad "attempt chain must record the owning class"
-fi
-assert_eq "merged per-class timings reach lane-result" \
-  "$(lane_field "['class_seconds']")" \
-  "{'AlphaUITests': 0.1, 'BetaUITests': 0.1}"
-assert_eq "merged case counts" "$(python3 -c "
-import json
-print(json.load(open('$WORKCASE/observations.json'))['counts']['cases'])
-" 2>/dev/null || echo NONE)" "2"
-
-# --- UI case 2: flaky class passes on the targeted retry ----------------------
-begin_case "ui flaky class recovered" "$WORK/u2"
-export INVOCATION_LOG="$WORK/u2-invocations.log"; : > "$INVOCATION_LOG"
-export FAKE_UI_FAIL_ONCE="BetaUITests"
 run_ui_lane "AlphaUITests,BetaUITests,GammaUITests" 300 "AlphaUITests=200,BetaUITests=200,GammaUITests=200"
 assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "0"
 assert_eq "verdict" "$(lane_field "['status']")" "pass"
-assert_eq "attempts" "$(attempts_statuses)" "['passed', 'test-failures', 'passed', 'passed']"
+assert_eq "attempts" "$(attempts_statuses)" "['passed']"
+assert_eq "exactly one batch invocation" "$(batch_invocations 'batch-a1')" "1"
+assert_eq "no per-class invocations on the happy path" "$(class_invocations AlphaUITests)$(class_invocations BetaUITests)$(class_invocations GammaUITests)" "000"
+if grep -q -- "-retry-tests-on-failure" "$WORKCASE/stdout.log"; then
+  bad "UI batches must not run under native multi-iteration retry"
+else
+  ok "UI batch invocation runs without native retry flags"
+fi
+assert_eq "merged per-class timings reach lane-result" \
+  "$(lane_field "['class_seconds']")" \
+  "{'AlphaUITests': 0.1, 'BetaUITests': 0.1, 'GammaUITests': 0.1}"
+assert_eq "merged case counts" "$(python3 -c "
+import json
+print(json.load(open('$WORKCASE/observations.json'))['counts']['cases'])
+" 2>/dev/null || echo NONE)" "3"
+if ls "$WORKCASE"/batch-a*.xcresult >/dev/null 2>&1; then
+  bad "clean batch bundles should be pruned from a green lane artifact"
+else
+  ok "clean batch bundles pruned from a green lane artifact"
+fi
+
+# --- UI case 2: flaky test recovered by a METHOD-precise retry ----------------
+begin_case "ui flaky test recovered via method retry" "$WORK/u2"
+export INVOCATION_LOG="$WORK/u2-invocations.log"; : > "$INVOCATION_LOG"
+export FAKE_BATCH_A1="fail-test" FAKE_BATCH_FAIL_CLASSES="BetaUITests" FAKE_BATCH_RETRY="pass"
+run_ui_lane "AlphaUITests,BetaUITests,GammaUITests" 300 "AlphaUITests=200,BetaUITests=200,GammaUITests=200"
+assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "0"
+assert_eq "verdict" "$(lane_field "['status']")" "pass"
+assert_eq "attempts" "$(attempts_statuses)" "['test-failures', 'passed']"
 assert_eq "retried classes" "$(retried_classes)" "['BetaUITests']"
-assert_eq "Alpha never rerun" "$(ui_invocations AlphaUITests)" "1"
-assert_eq "Beta retried exactly once" "$(ui_invocations BetaUITests)" "2"
-assert_eq "Gamma still ran" "$(ui_invocations GammaUITests)" "1"
+assert_eq "one batch attempt + one retry invocation" \
+  "$(batch_invocations 'batch-a1')$(batch_invocations 'batch-a2 (filters: BetaUITests/testC())')" "11"
+assert_eq "healthy classes never re-invoked" \
+  "$(class_invocations AlphaUITests)$(class_invocations GammaUITests)" "00"
 if grep -q "PASSED on its targeted retry" "$WORKCASE/stdout.log"; then
   ok "recovered flake reported loudly"
 else
   bad "a retry pass must be reported as a flake, not hidden"
 fi
-if [ -d "$WORKCASE" ] && ls "$WORKCASE"/class-BetaUITests-a*.xcresult >/dev/null 2>&1; then
+if ls "$WORKCASE"/batch-a1.xcresult >/dev/null 2>&1 && ls "$WORKCASE"/batch-a2.xcresult >/dev/null 2>&1; then
   ok "both flake attempt bundles kept on a green lane"
 else
   bad "flake attempt bundles must be preserved on a green lane"
 fi
-if ls "$WORKCASE"/class-AlphaUITests-a*.xcresult >/dev/null 2>&1; then
-  bad "clean class bundles should be pruned from a green lane artifact"
-else
-  ok "clean class bundles pruned from a green lane artifact"
-fi
 
-# --- UI case 3: class failing both attempts fails the lane, others still run --
-begin_case "ui class fails twice" "$WORK/u3"
+# --- UI case 3: failure survives the retry -> lane fails, no false flake ------
+begin_case "ui failure survives retry" "$WORK/u3"
 export INVOCATION_LOG="$WORK/u3-invocations.log"; : > "$INVOCATION_LOG"
-export FAKE_UI_FAIL_ONCE="" FAKE_UI_FAIL_ALWAYS="BetaUITests" FAKE_UI_INFRA_ONCE="" FAKE_UI_HANG=""
+export FAKE_BATCH_A1="fail-test" FAKE_BATCH_FAIL_CLASSES="BetaUITests" FAKE_BATCH_RETRY="fail"
 run_ui_lane "AlphaUITests,BetaUITests,GammaUITests" 300 "AlphaUITests=200,BetaUITests=200,GammaUITests=200"
 assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "1"
 assert_eq "verdict" "$(lane_field "['status']")" "fail"
-assert_eq "attempts" "$(attempts_statuses)" "['passed', 'test-failures', 'test-failures', 'passed']"
-assert_eq "Beta retried once, not looped" "$(ui_invocations BetaUITests)" "2"
-assert_eq "Gamma ran after the failure" "$(ui_invocations GammaUITests)" "1"
+assert_eq "attempts" "$(attempts_statuses)" "['test-failures', 'test-failures']"
 assert_eq "no false flake" "$(retried_classes)" "[]"
+assert_eq "retry ran exactly once" "$(batch_invocations 'batch-a1')$(batch_invocations 'batch-a2 (filters: BetaUITests/testC())')" "11"
 
-# --- UI case 4: hung class identified after its one retry; lane stops ---------
-begin_case "ui hang identified and lane stops" "$WORK/u4"
+# --- UI case 4: batch timeout -> per-class diagnosis, hang attributed ---------
+begin_case "ui batch timeout enters per-class diagnosis" "$WORK/u4"
 export INVOCATION_LOG="$WORK/u4-invocations.log"; : > "$INVOCATION_LOG"
-export FAKE_UI_FAIL_ONCE="" FAKE_UI_FAIL_ALWAYS="" FAKE_UI_INFRA_ONCE="" FAKE_UI_HANG="BetaUITests"
-run_ui_lane "AlphaUITests,BetaUITests,GammaUITests" 300 "AlphaUITests=200,BetaUITests=3,GammaUITests=200"
+export FAKE_BATCH_A1="hang" FAKE_BATCH_RETRY="pass" FAKE_BATCH_FAIL_CLASSES=""
+export FAKE_UI_HANG="BetaUITests"
+# Tiny per-class budgets keep the killed batch and the two hung diagnosis
+# invocations fast; Beta's own budget applies in diagnosis mode.
+run_ui_lane "AlphaUITests,BetaUITests,GammaUITests" 3 "AlphaUITests=2,BetaUITests=2,GammaUITests=2"
 assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "1"
 assert_eq "verdict" "$(lane_field "['status']")" "timeout"
 assert_eq "hung class" "$(lane_field "['hung_class']")" "BetaUITests"
-assert_eq "attempts" "$(attempts_statuses)" "['passed', 'timeout', 'timeout', 'not_diagnosed']"
-assert_eq "Beta hung twice, then stopped" "$(ui_invocations BetaUITests)" "2"
-assert_eq "Gamma never ran on the contaminated simulator" "$(ui_invocations GammaUITests)" "0"
+assert_eq "attempts" "$(attempts_statuses)" \
+  "['timeout', 'passed', 'timeout', 'timeout', 'not_diagnosed']"
+assert_eq "Alpha diagnosed once" "$(class_invocations AlphaUITests)" "1"
+assert_eq "Beta hung twice in diagnosis" "$(class_invocations BetaUITests)" "2"
+assert_eq "Gamma never ran on the contaminated simulator" "$(class_invocations GammaUITests)" "0"
+if grep -q "per-class diagnosis" "$WORKCASE/stdout.log"; then
+  ok "batch timeout announced the diagnosis fallback"
+else
+  bad "batch timeout must enter per-class diagnosis"
+fi
 
-# --- UI case 5: infra failure recovers via the single class retry -------------
-begin_case "ui infra failure recovers" "$WORK/u5"
+# --- UI case 5: batch infra wedge -> diagnosis; class infra recovers ----------
+begin_case "ui batch infra enters diagnosis and recovers" "$WORK/u5"
 export INVOCATION_LOG="$WORK/u5-invocations.log"; : > "$INVOCATION_LOG"
-export FAKE_UI_FAIL_ONCE="" FAKE_UI_FAIL_ALWAYS="" FAKE_UI_INFRA_ONCE="AlphaUITests" FAKE_UI_HANG=""
-run_ui_lane "AlphaUITests" 300 "AlphaUITests=200"
+export FAKE_BATCH_A1="infra" FAKE_UI_HANG=""
+export FAKE_UI_INFRA_ONCE="AlphaUITests" FAKE_UI_INFRA_ALWAYS=""
+run_ui_lane "AlphaUITests,BetaUITests" 300 "AlphaUITests=200,BetaUITests=200"
 assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "0"
 assert_eq "verdict" "$(lane_field "['status']")" "pass"
-assert_eq "attempts" "$(attempts_statuses)" "['infra-error', 'passed']"
-assert_eq "Alpha invoked twice" "$(ui_invocations AlphaUITests)" "2"
+assert_eq "attempts" "$(attempts_statuses)" \
+  "['infra-error', 'infra-error', 'passed', 'passed']"
 assert_eq "infra recovery is not a test flake" "$(retried_classes)" "[]"
 assert_eq "infra recovery reported separately" \
   "$(lane_field "['infra_recovered_classes']")" "['AlphaUITests']"
-if ls "$WORKCASE"/class-AlphaUITests-a*.xcresult >/dev/null 2>&1; then
-  ok "infra-recovered class keeps both attempt bundles on a green lane"
-else
-  bad "infra-recovered evidence bundles must be preserved on a green lane"
-fi
+assert_eq "Alpha diagnosed with its one retry" "$(class_invocations AlphaUITests)" "2"
 
-# --- UI case 6: unclassified failure fails the lane without retry -------------
-begin_case "ui unclassified failure" "$WORK/u6"
+# --- UI case 6: unclassified batch failure fails the lane without retry -------
+begin_case "ui unclassified batch failure" "$WORK/u6"
 export INVOCATION_LOG="$WORK/u6-invocations.log"; : > "$INVOCATION_LOG"
 # Extraction must fail: the canned doc path never exists (and the stub never
 # writes it), so the xcrun stub returns an invalid document.
 export FAKE_CANNED="$WORK/does-not-exist-u6.json"
 export FAKE_UI_NO_DOC=1
-export FAKE_UI_FAIL_ONCE="" FAKE_UI_FAIL_ALWAYS="AlphaUITests" FAKE_UI_INFRA_ONCE="" FAKE_UI_INFRA_ALWAYS="" FAKE_UI_HANG="" FAKE_UI_RECOVERY_FAILS=""
+export FAKE_BATCH_A1="fail-test" FAKE_BATCH_RETRY="pass" FAKE_BATCH_FAIL_CLASSES="AlphaUITests"
+export FAKE_UI_FAIL_ONCE="" FAKE_UI_FAIL_ALWAYS="" FAKE_UI_INFRA_ONCE="" FAKE_UI_INFRA_ALWAYS="" FAKE_UI_HANG="" FAKE_UI_RECOVERY_FAILS=""
 run_ui_lane "AlphaUITests,BetaUITests" 300 "AlphaUITests=200,BetaUITests=200"
 assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "1"
 assert_eq "verdict" "$(lane_field "['status']")" "fail"
-assert_eq "attempts" "$(attempts_statuses)" "['unclassified', 'not_diagnosed']"
-assert_eq "Alpha not retried into green" "$(ui_invocations AlphaUITests)" "1"
-assert_eq "Beta never ran" "$(ui_invocations BetaUITests)" "0"
+assert_eq "attempts" "$(attempts_statuses)" "['unclassified', 'not_diagnosed', 'not_diagnosed']"
+assert_eq "no retry after an unclassifiable batch" "$(batch_invocations 'batch-a2 (filters: BetaUITests/testC())')" "0"
+export FAKE_CANNED="$WORK/canned-ui.json"
+export FAKE_UI_NO_DOC=""
 
-# --- UI case 7: per-class watchdogs come from the planner table ---------------
-begin_case "ui per-class budgets honored" "$WORK/u7"
+# --- UI case 7: persistent infra failure in diagnosis fails the lane ----------
+begin_case "ui persistent infra in diagnosis continues lane" "$WORK/u7"
 export INVOCATION_LOG="$WORK/u7-invocations.log"; : > "$INVOCATION_LOG"
-export FAKE_CANNED="$WORK/canned-u7.json"
 export FAKE_UI_NO_DOC=""
-export FAKE_UI_FAIL_ONCE="" FAKE_UI_FAIL_ALWAYS="" FAKE_UI_INFRA_ONCE="" FAKE_UI_HANG="SlowUITests"
-# SlowUITests gets a 2s budget; it must be killed while FastUITests' 300s
-# budget is untouched (a lane-wide budget would kill both or neither).
-run_ui_lane "FastUITests,SlowUITests" 600 "FastUITests=300,SlowUITests=2"
-assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "1"
-assert_eq "verdict" "$(lane_field "['status']")" "timeout"
-assert_eq "hung class" "$(lane_field "['hung_class']")" "SlowUITests"
-assert_eq "Fast passed under its own larger budget" "$(attempts_statuses)" "['passed', 'timeout', 'timeout']"
-assert_eq "lane watchdog sum recorded" "$(lane_field "['timeout_s']")" "600"
-
-# --- UI case 8: persistent infra failure fails the lane, later classes run ---
-# Spec: class A exits nonzero twice with zero failing tests (never hangs, its
-# result stays classifiable). It is recorded as a persistent infrastructure
-# failure and the lane fails, but B and C must still execute - a wedged class
-# must not suppress independent UI coverage the way a hang does.
-begin_case "ui persistent infra failure continues lane" "$WORK/u8"
-export INVOCATION_LOG="$WORK/u8-invocations.log"; : > "$INVOCATION_LOG"
-export FAKE_CANNED="$WORK/canned-u8.json"
-export FAKE_UI_NO_DOC=""
-export FAKE_UI_FAIL_ONCE="" FAKE_UI_FAIL_ALWAYS="" FAKE_UI_INFRA_ONCE="" FAKE_UI_INFRA_ALWAYS="AlphaUITests" FAKE_UI_HANG="" FAKE_UI_RECOVERY_FAILS=""
-run_ui_lane "AlphaUITests,BetaUITests,GammaUITests" 600 "AlphaUITests=200,BetaUITests=200,GammaUITests=200"
+export FAKE_BATCH_A1="infra" FAKE_UI_HANG=""
+export FAKE_UI_INFRA_ONCE="" FAKE_UI_INFRA_ALWAYS="AlphaUITests" FAKE_UI_RECOVERY_FAILS=""
+run_ui_lane "AlphaUITests,BetaUITests,GammaUITests" 300 "AlphaUITests=200,BetaUITests=200,GammaUITests=200"
 assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "1"
 assert_eq "verdict" "$(lane_field "['status']")" "fail"
-assert_eq "attempts" "$(attempts_statuses)" "['infra-error', 'infra-error', 'passed', 'passed']"
+assert_eq "attempts" "$(attempts_statuses)" \
+  "['infra-error', 'infra-error', 'infra-error', 'passed', 'passed']"
 assert_eq "persistent infra class named" \
   "$(lane_field "['persistent_infra_classes']")" "['AlphaUITests']"
 assert_eq "persistent infra is not a flake" "$(retried_classes)" "[]"
-assert_eq "Alpha retried once, not looped" "$(ui_invocations AlphaUITests)" "2"
-assert_eq "Beta executed after the persistent failure" "$(ui_invocations BetaUITests)" "1"
-assert_eq "Gamma executed after the persistent failure" "$(ui_invocations GammaUITests)" "1"
+assert_eq "Alpha retried once, not looped" "$(class_invocations AlphaUITests)" "2"
+assert_eq "Beta executed after the persistent failure" "$(class_invocations BetaUITests)" "1"
+assert_eq "Gamma executed after the persistent failure" "$(class_invocations GammaUITests)" "1"
 if grep -q "not_diagnosed" "$WORKCASE/lane-result.json"; then
   bad "persistent infra failure must not mark healthy classes not_diagnosed"
 else
   ok "no not_diagnosed entries after a persistent infra failure"
 fi
 
-# --- UI case 9: untrusted simulator recovery stops the lane ------------------
-# If the erase/reboot recovery cannot complete, later results would be
-# misleading: unlike a persistent infra failure, the lane stops and the
-# remaining classes are recorded as not_diagnosed.
-begin_case "ui recovery failure stops lane" "$WORK/u9"
-export INVOCATION_LOG="$WORK/u9-invocations.log"; : > "$INVOCATION_LOG"
-export FAKE_CANNED="$WORK/canned-u9.json"
-export FAKE_UI_FAIL_ONCE="" FAKE_UI_FAIL_ALWAYS="" FAKE_UI_INFRA_ONCE="AlphaUITests" FAKE_UI_INFRA_ALWAYS="" FAKE_UI_HANG="" FAKE_UI_RECOVERY_FAILS="1"
-run_ui_lane "AlphaUITests,BetaUITests" 600 "AlphaUITests=200,BetaUITests=200"
+# --- UI case 8: untrusted simulator recovery stops the lane -------------------
+begin_case "ui recovery failure stops lane" "$WORK/u8"
+export INVOCATION_LOG="$WORK/u8-invocations.log"; : > "$INVOCATION_LOG"
+export FAKE_UI_NO_DOC=""
+export FAKE_BATCH_A1="infra" FAKE_UI_HANG=""
+export FAKE_UI_INFRA_ONCE="AlphaUITests" FAKE_UI_INFRA_ALWAYS="" FAKE_UI_RECOVERY_FAILS="1"
+run_ui_lane "AlphaUITests,BetaUITests" 300 "AlphaUITests=200,BetaUITests=200"
 assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "1"
 assert_eq "verdict" "$(lane_field "['status']")" "error"
-assert_eq "attempts" "$(attempts_statuses)" "['infra-error', 'not_diagnosed']"
-assert_eq "Beta never ran on an untrusted simulator" "$(ui_invocations BetaUITests)" "0"
+assert_eq "attempts" "$(attempts_statuses)" "['infra-error', 'not_diagnosed', 'not_diagnosed']"
+assert_eq "Beta never ran on an untrusted simulator" "$(class_invocations BetaUITests)" "0"
 
-# --- UI case 10: a class without a planned watchdog refuses to start ---------
-# plan-tests.py is the single authority for UI watchdog budgets: the runner
-# must fail fast rather than run an unwatched class.
+# --- UI case 9: retry-timeout falls back to diagnosis of the retried class ----
+begin_case "ui retry timeout diagnoses the retried class" "$WORK/u9"
+export INVOCATION_LOG="$WORK/u9-invocations.log"; : > "$INVOCATION_LOG"
+export FAKE_UI_NO_DOC=""
+export FAKE_BATCH_A1="fail-test" FAKE_BATCH_FAIL_CLASSES="BetaUITests" FAKE_BATCH_RETRY="hang"
+export FAKE_UI_HANG="BetaUITests" FAKE_UI_INFRA_ONCE="" FAKE_UI_INFRA_ALWAYS="" FAKE_UI_RECOVERY_FAILS=""
+run_ui_lane "AlphaUITests,BetaUITests" 3 "AlphaUITests=2,BetaUITests=2"
+assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "1"
+assert_eq "verdict" "$(lane_field "['status']")" "timeout"
+assert_eq "hung class" "$(lane_field "['hung_class']")" "BetaUITests"
+assert_eq "attempts" "$(attempts_statuses)" \
+  "['test-failures', 'timeout', 'timeout', 'timeout']"
+assert_eq "Alpha never re-ran after its batch pass" "$(class_invocations AlphaUITests)" "0"
+
+# --- UI case 10: a class without a planned watchdog refuses to start ----------
 begin_case "ui missing watchdog entry rejected" "$WORK/u10"
 export INVOCATION_LOG="$WORK/u10-invocations.log"; : > "$INVOCATION_LOG"
 run_ui_lane "AlphaUITests,BetaUITests" 300 "AlphaUITests=200"
@@ -623,7 +721,7 @@ else
   ok "lane never started with an incomplete watchdog table"
 fi
 
-# --- UI case 11: malformed watchdog entries are rejected ---------------------
+# --- UI case 11: malformed watchdog entries are rejected ----------------------
 begin_case "ui malformed watchdog entry rejected" "$WORK/u11"
 run_ui_lane "AlphaUITests" 300 "AlphaUITests=abc"
 assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "2"

--- a/scripts/tests/test_lane_runner.sh
+++ b/scripts/tests/test_lane_runner.sh
@@ -750,6 +750,31 @@ assert_eq "failed and skipped tests both retried" \
   "$(batch_invocations 'batch-a2 (filters: BetaUITests/testC() BetaUITests/testD())')" "1"
 assert_eq "attempts" "$(attempts_statuses)" "['test-failures', 'passed']"
 
+# --- UI case 14: exit-0 batch missing a class -> diagnosis, never green ------
+# Defense in depth: an exit-0 batch whose parseable xcresult has no record of
+# an assigned class (an -only-testing filter silently matching nothing) must
+# not finish as a clean pass.
+begin_case "ui pass with unrecorded class diagnoses" "$WORK/u14"
+export INVOCATION_LOG="$WORK/u14-invocations.log"; : > "$INVOCATION_LOG"
+export FAKE_UI_NO_DOC="" FAKE_UI_HANG=""
+export FAKE_BATCH_A1="pass" FAKE_BATCH_RETRY="pass" FAKE_BATCH_FAIL_CLASSES=""
+export FAKE_BATCH_SKIP_CLASSES="" FAKE_BATCH_OMIT_CLASSES="BetaUITests"
+export FAKE_UI_FAIL_ONCE="" FAKE_UI_FAIL_ALWAYS="" FAKE_UI_INFRA_ONCE="" FAKE_UI_INFRA_ALWAYS="" FAKE_UI_RECOVERY_FAILS=""
+run_ui_lane "AlphaUITests,BetaUITests" 300 "AlphaUITests=200,BetaUITests=200"
+assert_eq "exit code" "$(cat "$WORKCASE/exit-code")" "0"
+assert_eq "verdict" "$(lane_field "['status']")" "pass"
+assert_eq "attempts" "$(attempts_statuses)" \
+  "['incomplete', 'passed', 'passed']"
+assert_eq "no targeted retry for an unrecorded class" \
+  "$(batch_invocations 'batch-a1')$(batch_invocations 'batch-a2 (filters: testC())')" "10"
+assert_eq "missing class diagnosed" "$(class_invocations BetaUITests)" "1"
+if grep -q "exited 0 but the xcresult has no record" "$WORKCASE/stdout.log"; then
+  ok "exit-0 pass with a missing class announced the diagnosis"
+else
+  bad "an exit-0 batch with an unrecorded class must not pass silently"
+fi
+export FAKE_BATCH_OMIT_CLASSES=""
+
 # --- UI case 10: a class without a planned watchdog refuses to start ----------
 begin_case "ui missing watchdog entry rejected" "$WORK/u10"
 export INVOCATION_LOG="$WORK/u10-invocations.log"; : > "$INVOCATION_LOG"

--- a/scripts/tests/test_plan_tests.py
+++ b/scripts/tests/test_plan_tests.py
@@ -244,11 +244,36 @@ class PlanningTests(unittest.TestCase):
 
     def test_lane_count_edges(self):
         cfg = default_cfg()
-        self.assertEqual(planner.lane_count_for(0.0, 0, cfg), 0)     # no classes
-        self.assertEqual(planner.lane_count_for(20.0, 1, cfg), 1)    # 1 class
-        self.assertEqual(planner.lane_count_for(60.0, 3, cfg), 3)    # fewer than min
-        self.assertEqual(planner.lane_count_for(2000.0, 9, cfg), 8)  # saturates at max
-        self.assertEqual(planner.lane_count_for(961.0, 9, cfg), 5)   # ceil(961/240)=5
+        self.assertEqual(planner.lane_count_for([], cfg), 0)      # no classes
+        self.assertEqual(planner.lane_count_for([("ATests", 20.0)], cfg), 1)
+        # Three 20s classes: 60s of execution cannot justify a second
+        # 240s invocation, so the model consolidates to one lane.
+        tiny = [("ATests", 20.0), ("BTests", 20.0), ("CTests", 20.0)]
+        self.assertEqual(planner.lane_count_for(tiny, cfg), 1)
+        # A heavy outlier dominates every possible split: no extra lane can
+        # shorten the wall clock, so the model consolidates to one lane.
+        outlier = [("HostedTests", 2000.0), ("BTests", 30.0), ("CTests", 30.0)]
+        self.assertEqual(planner.lane_count_for(outlier, cfg), 1)
+        # Evenly huge classes keep scaling out to the configured max: every
+        # added lane removes ~900s of wall clock.
+        huge = [("H{0}Tests".format(i), 900.0) for i in range(8)]
+        self.assertEqual(planner.lane_count_for(huge, cfg), cfg["max_lanes"])
+        # 4 x 100s: modeled walls are 640/440/373/340 - lanes 3 and 4 each
+        # buy less than the 120s tolerance, so the suite lands on 2 lanes.
+        even = [("E{0}Tests".format(i), 100.0) for i in range(4)]
+        self.assertEqual(planner.lane_count_for(even, cfg), 2)
+
+    def test_modeled_wall_includes_invocation_overhead(self):
+        # The plan must carry the modeled wall (overhead + predicted) so the
+        # report shows what a lane actually costs, not just its test time.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(make_repo(Path(tmp), ["AlphaTests"], []))
+            _d, plan = plan_from_tree(root, {"AlphaTests": 100.0})
+            cfg = default_cfg()
+            lane = plan["unit_lanes"][0]
+            self.assertEqual(
+                lane["modeled_wall_s"],
+                cfg["invocation_overhead_s"] + 100.0)
 
     def test_history_wins_over_baseline(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -296,9 +321,10 @@ class UiShardingTests(unittest.TestCase):
                         int(value),
                         planner.ui_class_timeout_for(
                             self.ESTIMATES[name], 420, 3.0))
-                # lane watchdog sum feeds the job ceiling: worst path is a
-                # targeted retry of every class (2x), one bounded erase/
-                # reboot recovery per failing class, plus setup slack.
+                # lane watchdog sum feeds the job ceiling: worst path is the
+                # batched attempt + targeted retry, then a full per-class
+                # diagnosis pass (3x), one bounded erase/reboot recovery per
+                # failing class, plus setup slack.
                 expected_ceiling = planner.ui_job_timeout_min(
                     lane["timeout_s"], len(lane["classes"]), default_cfg())
                 self.assertEqual(lane["job_timeout_min"], expected_ceiling)
@@ -322,15 +348,21 @@ class UiShardingTests(unittest.TestCase):
             self.assertIn("ConnectionSetupUITests", heaviest["classes"])
 
     def test_ui_lane_count_scales_and_never_exceeds_classes(self):
+        # The unit selection function runs under the UI bounds.
         cfg = default_cfg()
-        # tiny suite: cannot have more lanes than classes
-        self.assertEqual(planner.ui_lane_count_for(60.0, 2, cfg), 2)
-        # today's suite: ~1310s of work lands on the 3-lane target
-        self.assertEqual(planner.ui_lane_count_for(1310.4, 6, cfg), 3)
-        # a doubled suite scales out, but saturates at the configured max
-        self.assertEqual(planner.ui_lane_count_for(2600.0, 12, cfg), cfg["ui_max_lanes"])
+        ui_cfg = dict(cfg, min_lanes=cfg["ui_min_lanes"], max_lanes=cfg["ui_max_lanes"])
         # no classes: no lanes
-        self.assertEqual(planner.ui_lane_count_for(0.0, 0, cfg), 0)
+        self.assertEqual(planner.lane_count_for([], ui_cfg), 0)
+        # 2 classes: never more lanes than classes, even with a 3-lane floor
+        two = [("ATests", 200.0), ("BTests", 200.0)]
+        self.assertEqual(planner.lane_count_for(two, ui_cfg), 2)
+        # today's suite: ~1310s over 6 classes lands on the 3-lane clamp
+        today = sorted(self.ESTIMATES.items(), key=lambda kv: (-kv[1], kv[0]))
+        self.assertEqual(planner.lane_count_for(today, ui_cfg), 3)
+        # a doubled suite scales out to the configured max (12 x ~217s: the
+        # 4th lane buys 217s of wall clock, well over the tolerance)
+        doubled = [("D{0}Tests".format(i), 217.0) for i in range(12)]
+        self.assertEqual(planner.lane_count_for(doubled, ui_cfg), cfg["ui_max_lanes"])
 
     def test_default_estimates_balance_ui_lanes_without_history(self):
         names = ["New{0}UITests".format(i) for i in range(6)]
@@ -358,11 +390,14 @@ class UiShardingTests(unittest.TestCase):
             self.assertEqual(matrix["include"][0]["classes"], "LoneUITests")
 
     def test_ui_job_ceiling_covers_worst_in_script_path(self):
-        # Worst legit path: every class runs its targeted retry (2x its
-        # budget), every failing class pays one bounded erase/reboot
-        # recovery, and every attempt's timing extraction can wedge to the
-        # xcresulttool bound - plus setup slack. The GitHub ceiling must
-        # never preempt that path - otherwise the hung class is never named.
+        # Worst legit path: the batched attempt (sum of per-class budgets)
+        # plus its targeted retry, THEN a batch-level timeout or wedge
+        # erases and re-enters per-class diagnosis (attempt + retry per
+        # class = 2x the sum), each failing class paying one bounded
+        # erase/reboot recovery, and every attempt's timing extraction can
+        # wedge to the xcresulttool bound - plus setup slack. The GitHub
+        # ceiling must never preempt that path - otherwise the hung class is
+        # never named.
         cfg = default_cfg()
         for n_classes in (1, 2, 3, 5):
             budgets = [planner.ui_class_timeout_for(est, cfg["ui_class_timeout_min_s"],
@@ -371,7 +406,7 @@ class UiShardingTests(unittest.TestCase):
             lane_timeout = sum(budgets)
             ceiling_s = planner.ui_job_timeout_min(
                 lane_timeout, n_classes, cfg) * 60
-            worst_path = (2 * lane_timeout
+            worst_path = (3 * lane_timeout
                           + (n_classes + 1) * cfg["ui_reset_overhead_s"]
                           + 2 * n_classes * cfg["ui_extract_bound_s"]
                           + cfg["job_timeout_margin_s"])

--- a/scripts/tests/test_plan_tests.py
+++ b/scripts/tests/test_plan_tests.py
@@ -390,23 +390,27 @@ class UiShardingTests(unittest.TestCase):
             self.assertEqual(matrix["include"][0]["classes"], "LoneUITests")
 
     def test_ui_job_ceiling_covers_worst_in_script_path(self):
-        # Worst legit path: the batched attempt (sum of per-class budgets)
-        # plus its targeted retry, THEN a batch-level timeout or wedge
-        # erases and re-enters per-class diagnosis (attempt + retry per
-        # class = 2x the sum), each failing class paying one bounded
-        # erase/reboot recovery, and every attempt's timing extraction can
-        # wedge to the xcresulttool bound - plus setup slack. The GitHub
-        # ceiling must never preempt that path - otherwise the hung class is
-        # never named.
+        # The reachable worst path, derived from the runner's invocation
+        # graph (not from the formula): batched attempt (1x the budget sum,
+        # the lane watchdog) + per-class diagnosis after a batch timeout or
+        # wedge (one attempt + one targeted retry per class = 2x). Each
+        # failing class then pays one bounded erase/reboot recovery, and
+        # every attempt's timing extraction can wedge to the xcresulttool
+        # bound - plus setup slack. The GitHub ceiling must never preempt
+        # that path - otherwise the hung class is never named. (A batch that
+        # completes with identified failures retries a subset of classes and
+        # therefore costs strictly less than 3x.)
         cfg = default_cfg()
         for n_classes in (1, 2, 3, 5):
             budgets = [planner.ui_class_timeout_for(est, cfg["ui_class_timeout_min_s"],
                                                     cfg["ui_class_timeout_multiplier"])
                        for est in (333.0, 296.8, 232.5, 215.9, 129.6)[:n_classes]]
             lane_timeout = sum(budgets)
+            batched_attempt = lane_timeout
+            diagnosis = 2 * lane_timeout
             ceiling_s = planner.ui_job_timeout_min(
                 lane_timeout, n_classes, cfg) * 60
-            worst_path = (3 * lane_timeout
+            worst_path = (batched_attempt + diagnosis
                           + (n_classes + 1) * cfg["ui_reset_overhead_s"]
                           + 2 * n_classes * cfg["ui_extract_bound_s"]
                           + cfg["job_timeout_margin_s"])

--- a/scripts/tests/test_plan_tests.py
+++ b/scripts/tests/test_plan_tests.py
@@ -390,16 +390,18 @@ class UiShardingTests(unittest.TestCase):
             self.assertEqual(matrix["include"][0]["classes"], "LoneUITests")
 
     def test_ui_job_ceiling_covers_worst_in_script_path(self):
-        # The reachable worst path, derived from the runner's invocation
-        # graph (not from the formula): batched attempt (1x the budget sum,
-        # the lane watchdog) + per-class diagnosis after a batch timeout or
-        # wedge (one attempt + one targeted retry per class = 2x). Each
-        # failing class then pays one bounded erase/reboot recovery, and
-        # every attempt's timing extraction can wedge to the xcresulttool
-        # bound - plus setup slack. The GitHub ceiling must never preempt
-        # that path - otherwise the hung class is never named. (A batch that
-        # completes with identified failures retries a subset of classes and
-        # therefore costs strictly less than 3x.)
+        # The reachable worst paths, derived from the runner's invocation
+        # graph (not from the formula):
+        #   (a) batch timeout -> per-class diagnosis = batch (1x budget sum)
+        #       + diagnosis attempt + retry (2x) = 3x;
+        #   (b) batch completes with failures in EVERY class -> the targeted
+        #       retry covers the full budget sum and can time out ->
+        #       diagnosis of the retried classes (2x) = up to 4x. (b) wins.
+        # Each failing class then pays one bounded erase/reboot recovery,
+        # every diagnosis attempt's timing extraction can wedge to the
+        # xcresulttool bound, and the batch's own classification extraction
+        # adds one more bound - plus setup slack. The GitHub ceiling must
+        # never preempt that path - otherwise the hung class is never named.
         cfg = default_cfg()
         for n_classes in (1, 2, 3, 5):
             budgets = [planner.ui_class_timeout_for(est, cfg["ui_class_timeout_min_s"],
@@ -407,12 +409,13 @@ class UiShardingTests(unittest.TestCase):
                        for est in (333.0, 296.8, 232.5, 215.9, 129.6)[:n_classes]]
             lane_timeout = sum(budgets)
             batched_attempt = lane_timeout
+            failed_retry = lane_timeout          # retry covers every class
             diagnosis = 2 * lane_timeout
             ceiling_s = planner.ui_job_timeout_min(
                 lane_timeout, n_classes, cfg) * 60
-            worst_path = (batched_attempt + diagnosis
+            worst_path = (batched_attempt + failed_retry + diagnosis
                           + (n_classes + 1) * cfg["ui_reset_overhead_s"]
-                          + 2 * n_classes * cfg["ui_extract_bound_s"]
+                          + (2 * n_classes + 1) * cfg["ui_extract_bound_s"]
                           + cfg["job_timeout_margin_s"])
             self.assertGreaterEqual(
                 ceiling_s, worst_path,

--- a/scripts/tests/test_simulator_destination.py
+++ b/scripts/tests/test_simulator_destination.py
@@ -22,6 +22,8 @@ SCRIPT = os.path.join(SCRIPTS_DIR, "tests", "test_simulator_destination.sh")
 
 
 @unittest.skipUnless(os.name == "posix" and shutil.which("bash"), "bash is required to exercise the destination lookup")
+@unittest.skipIf(os.environ.get("CONDUIT_CI_SKIP_BASH_WRAPPER_TESTS") == "1",
+                 "bash meta-suites run in the dedicated self-test job")
 class SimulatorDestinationScriptTests(unittest.TestCase):
     def test_destination_lookup(self):
         proc = subprocess.run(["bash", SCRIPT], capture_output=True,

--- a/scripts/tests/test_simulator_destination.sh
+++ b/scripts/tests/test_simulator_destination.sh
@@ -158,6 +158,44 @@ else
     "$(resolve_udid 'iPhone 99 Pro' '')" "MISS"
 fi
 
+echo "# build_destination: UDID-pinned destination with name-based fallback"
+
+resolve_destination() { # $1=name $2=os ('' = unset) $3=resolve-ok(1/0)
+  ( set -u
+    SIMULATOR_NAME="$1"
+    SIMULATOR_OS="$2"
+    FIXTURE="$WORK/devices.json"
+    # shellcheck disable=SC1090
+    source "$CILIB"
+    if [ "$3" = "1" ]; then
+      bounded_run() { BOUNDED_OUTPUT="$(cat "$FIXTURE")"; return 0; }
+    else
+      # A wedged CoreSimulatorService / missing jq: the UDID cannot be
+      # resolved and the historical name-based form must come back.
+      bounded_run() { return 1; }
+    fi
+    build_destination >/dev/null
+    printf '%s\n' "$DESTINATION"
+  )
+}
+
+if ! command -v jq >/dev/null 2>&1; then
+  skipping "build_destination fixture cases (jq not available on this host)"
+else
+  assert_eq "destination pins the resolved device UDID" \
+    "$(resolve_destination 'iPhone 17 Pro' '' 1)" \
+    "platform=iOS Simulator,id=UDID-26-10-PRO"
+  assert_eq "OS pin carries into the resolved destination" \
+    "$(resolve_destination 'iPhone 17 Pro' 26.0 1)" \
+    "platform=iOS Simulator,id=UDID-26-0-PRO"
+  assert_eq "unresolvable UDID falls back to the name-based destination" \
+    "$(resolve_destination 'iPhone 17 Pro' '' 0)" \
+    "platform=iOS Simulator,name=iPhone 17 Pro"
+  assert_eq "OS pin survives in the fallback destination" \
+    "$(resolve_destination 'iPhone 17 Pro' 26.1 0)" \
+    "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.1"
+fi
+
 echo "# bash syntax gate"
 
 assert_status "ci-lib.sh parses" 0 bash -n "$CILIB"

--- a/scripts/tests/test_simulator_destination.sh
+++ b/scripts/tests/test_simulator_destination.sh
@@ -182,12 +182,15 @@ resolve_destination() { # $1=name $2=os ('' = unset) $3=resolve-ok(1/0)
 if ! command -v jq >/dev/null 2>&1; then
   skipping "build_destination fixture cases (jq not available on this host)"
 else
-  assert_eq "destination pins the resolved device UDID" \
+  assert_eq "destination pins the resolved device UDID and arch" \
     "$(resolve_destination 'iPhone 17 Pro' '' 1)" \
-    "platform=iOS Simulator,id=UDID-26-10-PRO"
+    "platform=iOS Simulator,id=UDID-26-10-PRO,arch=arm64"
   assert_eq "OS pin carries into the resolved destination" \
     "$(resolve_destination 'iPhone 17 Pro' 26.0 1)" \
-    "platform=iOS Simulator,id=UDID-26-0-PRO"
+    "platform=iOS Simulator,id=UDID-26-0-PRO,arch=arm64"
+  assert_eq "SIMULATOR_ARCH override carries into the destination" \
+    "$(SIMULATOR_ARCH=x86_64 resolve_destination 'iPhone 17 Pro' '' 1)" \
+    "platform=iOS Simulator,id=UDID-26-10-PRO,arch=x86_64"
   assert_eq "unresolvable UDID falls back to the name-based destination" \
     "$(resolve_destination 'iPhone 17 Pro' '' 0)" \
     "platform=iOS Simulator,name=iPhone 17 Pro"


### PR DESCRIPTION
## CI reliability: deterministic connection-setup UI queries, batched UI shards, overhead-aware lane planning

Scope: **XCUITest reliability + XCTest invocation efficiency.** No application behavior changes; the only app-adjacent surface touched is how UI tests *query* existing accessibility elements (no accessibility instrumentation changed, so VoiceOver behavior is untouched).

### The concrete flaky failure

The most recent green PR run still needed a retry because
`ConnectionSetupSettingsUITests.testInteractiveSignInOutcomeFromSettingsOffersDoneAndDismissesSafely`
failed its first attempt with:

```
Failed to get matching snapshot: Timed out while evaluating UI query.
```

The failure happened while evaluating the authentication-stage-row query — right after the test had already waited for the `setup.test.interactive-ready` terminal marker.

### Root cause (measured, not assumed)

A temporary UI test dumped the full accessibility hierarchy (`app.debugDescription`) at the exact evaluation points, on the Mac, at `origin/main`:

```
Other, identifier: 'setup.test.stage.authentication', label: 'Authentication, browser sign-in required'
StaticText, identifier: 'setup.address-preview', label: 'https://conduit-uitest.example'
```

- Stage rows (an `HStack` collapsed via `.accessibilityElement(children: .ignore)`) are exposed as **`Other`** elements.
- `setup.address-preview` (a `Text`) is a **`StaticText`**.

The old helper — `app.descendants(matching: .any).matching(identifier:).firstMatch` — made every check resolve a snapshot across **every element type in the whole application tree**, and the tests evaluated it with immediate `.exists` checks. During the Review auto-advance the hierarchy is churning; a whole-tree snapshot there is what can starve past Xcode's snapshot timeout. The same broad query was then resolved again for `isHittable`, taps, and label reads.

### The fix (Phase 1)

- `ConnectionSetupSettingsUITests` / `ConnectionSetupTestConnectionUITests`: typed `stageRow()` (`app.otherElements[...]`) and `addressPreview()` (`app.staticTexts[...]`) helpers; `ConnectionRepairUITests`' two identical address-preview lookups fixed the same way.
- Positive existence checks after screen transitions use `waitForExistence(timeout: 5)`; absence assertions stay exactly where a terminal-state marker has already settled the screen (`interactive-ready` / `ready` / `failure` / `credentials-required` / Settings return). No sleeps, no new markers, no weakened assertions, no removed coverage.

**Repeated-test evidence (Mac, iPhone 17 Pro / iOS 26.5, real `test-without-building` invocations, UDID-pinned destination):**

| Suite | Executions | Result |
|---|---|---|
| `testInteractiveSignInOutcome...` (the previously failing test) | **22 consecutive invocations** | 22 pass, ~21-23 s each |
| `ConnectionSetupSettingsUITests` (full class) | 3 × | all pass (88-92 s) |
| `ConnectionSetupTestConnectionUITests` (full class, same helper) | 3 × | all pass (175-177 s) |
| `ConnectionRepairUITests` (full class, same element) | 2 × | all pass (99-101 s) |

`Timed out while evaluating UI query` appears **zero times** across all logs. (No pre-fix local reproduction was attempted — the CI failure is the "before" evidence; the "after" evidence is 30+ consecutive green executions.)

### Healthy-path XCTest invocations (Phase 2)

- **Before:** 4 unit + 6 UI = **10** `xcodebuild` invocations per healthy run (every UI class paid its own test-session startup/finalization).
- **After:** 2 unit + 3 UI = **5** invocations — each UI shard runs all its classes in **one** `test-without-building` invocation (watchdog = sum of the planner's per-class budgets), and the unit suite consolidates to 2 lanes.

**Measured end-to-end on the Mac (real `ci-test-lane.sh` UI shard, 2 classes, real products):** one batched invocation, lane wall **198 s** of which the classes themselves were 143 s — one startup, not two. On hosted runners (run 34349843495) the equivalent 2-class UI shard took 846 s with per-class invocations, and each invocation carries ~210-300 s of fixed cost (unit-lane actual-vs-predicted; the UI per-class floor measured ~3.5 min on run #500) — every dropped invocation saves that fixed cost per shard, per run.

### Failure-path guarantees

- Ordinary UI test failures retry **only the non-passing tests** (any final result ≠ Passed — including Crashed/Skipped residue from aborted runs): exact `ConduitUITests/Class/testMethod` filters derived from the xcresult, falling back to the class when only the class is identifiable. Healthy classes are never re-executed. **A passing retry is still reported as a runner-level flake** (`::warning` naming the retried tests + CI Test Report "FLAKE WARNING" + both attempt bundles kept as artifacts).
- A batch that aborts before a class runs is classified `incomplete` and goes to per-class diagnosis instead of a retry — unexecuted tests can never vanish into a green lane. The same gate guards the exit-0 path: an invocation that returns success while its parseable xcresult has no record of an assigned class diagnoses instead of passing. A green lane reached through diagnosis announces the triggering event instead of blending into a clean pass.
- Batch watchdog timeout / infrastructure wedge: erase the simulator, then per-class diagnosis — per-class watchdogs, one targeted retry, persistent-infrastructure continuation, hung-class naming and lane stop, `not_diagnosed` tail. Unclassifiable failures still fail the lane with no retry.
- Unit lanes keep native `-retry-tests-on-failure -test-iterations` (already method-precise).

### Unit lane count is now measured, not intuited

The planner models `predicted lane cost = invocation_overhead_s + sum(class durations)` and adds a lane only when it buys more than `lane_wall_tolerance_s` (120 s) of modeled wall clock. Defaults are measured: hosted lane actual-vs-predicted in run 34349843495 shows 208-295 s of fixed cost per unit lane against ~96 s of predicted execution in three of the four unit lanes. The hosted 810 s outlier class (`MarkdownRichContentHostedTests`) dominates every possible split, so lanes 3-4 bought nothing — **units go 4 → 2** at identical modeled wall; the UI suite stays at its 3-lane clamp. Bonus from the same data: unit-1 started ~7 minutes after its siblings (hosted-runner concurrency), so fewer lanes also queue less. `target_budget_s` / `ui_target_budget_s` are superseded and removed. The UI job ceiling prices the true reachable worst path (batch + full-sum retry that times out + 2× diagnosis = 4× the budget sum).

### Retry precision, visibility, artifacts, timing history

- Fallback hierarchy: exact failed test → failing class → per-class diagnosis on environment events → **never the whole UI suite** for a test failure.
- Retry passes remain visible: `retried_classes` / attempts chain in `lane-result.json`, `::warning` annotations, FLAKE WARNING rows in the CI Test Report, and both attempt bundles kept on green lanes. PR runs still never write timing history.
- Batch extractions flow through the same `merge-parts` pipeline; per-class diagnosis results supersede batch parts **per class** (wall-clock fold order — and batch failure evidence for classes diagnosis never re-executed survives, so a red lane's report stays complete); a method-filtered retry — batch **or** per-class diagnosis — never contributes its observations to timing history, so a method-only rerun can never shrink a class's duration sample; clean green-lane bundles are still pruned.

### Simulator destination pinning

`build_destination` emits `platform=iOS Simulator,id=<UDID>,arch=arm64` (SIMULATOR_ARCH-overridable; name-based fallback only if the UDID can't be resolved). Verified on hosted CI: run 34425462004 (UDID pin only) still showed one warning per invocation because every Apple Silicon simulator device also registers an x86_64-under-Rosetta candidate — but both candidates were the **same pinned UDID**, so the dangerous cross-device "first match wins" case was already gone; with the arch pin added, run 34426688686 shows **zero ambiguity warnings in all 5 unit/UI lane invocations**. The single remaining informational line is emitted once by the build step's internal destination scan (again the same UDID on both lines — the build makes no device choice).

### ConduitCI / debugger warnings (investigated, no change)

`IDELaunchParametersSnapshot: DebuggerLLDB.DebuggerVersionStore.StoreError error 0` / `no debugger version` were reproduced during **fully passing** local UI runs (exit 0) — they are Xcode 26.x launch-path noise, not related to the snapshot timeout (which was the broad-query cost, now gone). The experimental no-debug `ConduitCI` scheme exists only on the unmerged branch `origin/test/stabilize-repair-copy-ui` (never landed on main); since these warnings occur regardless, that scheme's premise shows no measurable benefit and should not be merged as-is. Nothing needed removing from main.

### Round 3 (CI run 34420978966): Plan-job timeout root cause + fixes

That run's `Plan & validate` job was cancelled at its 10-minute ceiling **before any macOS work started**. The job log shows `test_extract_timings` finishing 7 seconds in, then silence — unittest discovery order puts the lane-runner bash state-machine suite right after it, so that suite consumed the remaining ~10 minutes. No single case hung: per-case `START`/`END` instrumentation (kept in the suite) shows the cost distributed across the new batching recovery cases, each paying many `bounded_run` calls whose poll loop had a fixed 2-second floor (`kill -0` keeps succeeding on an unreaped child), plus a fixed 3 s settle per simulator reset. Measured on macOS: **6:07** for the full suite before the fix.

Fixes:

- `bounded_run` now polls at 0.2 s — identical deadline/kill semantics, no fixed floor per call. Suite on macOS: **3:42** before the two new regression cases, **4:23 with them** (134 assertions), vs 6:07 before.
- The minutes-long CI-tooling meta-suites moved out of `Plan & validate` into a dedicated **`self-test` job** (ubuntu) that runs **concurrently with the macOS build**, so they can never delay planning, the build, or risk another job's timeout. `CI Gate` now requires `--self-test` too.
- The timeout hierarchy is coherent and load-bearing: per-case synthetic-hang watchdogs (≤ 6 s) < the wrapper's subprocess cap (**480 s**; was 900 s — *larger than the old job ceiling*, the invalid contract) < the self-test job's 12-minute ceiling. The plan job skips the bash wrappers via `CONDUIT_CI_SKIP_BASH_WRAPPER_TESTS` and completes in well under a minute.
- Diagnosis method-only retries obey the batch timing rule: the retry's observations part is deleted after extraction (both pass and fail paths) so a method-only rerun can never shrink a class's duration sample; its detail part stays as flake evidence. Regression-tested at the runner level (u15/u16) and the merge level (100 s class vs 5 s method retry → 100 s).
- Batch-failure supersession in `merge_detail_parts` is per class: batch entries survive for classes diagnosis never re-executed (the `not_diagnosed` tail of a lane stopped at a hang) so a red lane's report stays complete.

The batching architecture, typed XCUITest queries, method-precise retry, per-class diagnosis, 2 unit lanes, and overhead modeling are all unchanged — the CI failure was in the harness validating those behaviors, not in the behaviors.

### Verification checklist

1. Previously failing test passes repeatedly — 22 consecutive invocations + class runs, zero failures, zero query timeouts ✔
2. Broad stage-row helper no longer duplicated — typed helpers in both suites (+ Repair's address-preview) ✔
3. No arbitrary sleeps added ✔
4. Stage-row accessibility untouched (query-side change only; VoiceOver labels/identifiers unchanged) ✔
5. Connection Setup UI coverage intact — all tests kept, assertions strengthened to waits ✔
6. Healthy UI shards use fewer Xcode invocations — 6 → 3 (one per shard), proven by a real 2-class shard in one invocation ✔
7. Failed tests isolated and retried precisely — method-level filters, class fallback, diagnosis on environment events ✔
8. Retry passes visible as flakes — annotations (now listing the retried tests), report rows, attempt bundles ✔
9. Destination ambiguity — id-pinned end-to-end; warning removal to be confirmed on CI (not locally reproducible, single runtime) ✔/⏳
10. Unit-lane count from measured startup vs execution — run 34349843495 actuals drive the 240 s default; 4 → 2 ✔
11. Planner regression tests cover the fixed invocation overhead — tolerance rule, outlier consolidation, saturation, bounds, modeled wall, ceiling (4× derivation) ✔
12. CI reporting/artifacts unchanged in usefulness — same lane-result/report/artifact shape, wording updated ✔

**Test suites after this round:** lane-runner state machine **134/134** (macOS bash 3.2, 4:23 with per-case telemetry), Python suite **107/107** (macOS; identical suite green on Windows with the 2 bash wrappers skipped), `plan-tests.py validate` green (99 unit + 6 UI classes exactly once, 2 unit lanes, 3 UI lanes, every UI class carrying an explicit watchdog), no orphaned `sleep`/`bash` processes after the suite.

**Hosted CI on this PR (final head):** run [34426688686](https://github.com/kaishi00/hermes-conduit/actions/runs/34426688686) @ `758e4aa` — every job green, first attempt. Plan & validate **9 s** (was 10m16s cancelled), self-test **4m43s** (concurrent with build), build **3m26s**, unit lanes **6m12s / 6m33s**, UI lanes **14m14s / 14m19s / 14m13s**, overall wall ≈ **21 min** (the prior head's run: 15m40s with no lane retries). Retry visibility proven on real hosted runs: ui-3 in the prior run and ui-1 + ui-3 in this run each needed their targeted batch-retry (`retried_classes` populated, FLAKE WARNING annotations emitted, first-attempt bundles kept) — the previously-failing settings lane passed clean on the first attempt in both runs.

### Round 4 (e2581e5): the two remaining first-attempt UI flakes, fixed at the synchronization contract

The `758e4aa` run was green but needed targeted retries, and both retry-rescued tests had identifiable test-side synchronization holes — fixed directly, no CI policy changes:

1. **Copy Prompt raced its own intentional ephemerality.** The visible "Copied" label lasts ~2 s, and a hosted runner can spend longer than that reaching the first hierarchy snapshot after the tap. `AskHermesPromptView` now also records `lastCopiedPrompt` (keyed to the current prompt, so a reused card can never claim a different prompt was copied) and exposes it as a **durable accessibility value** on the Copy Prompt button; the visible confirmation and its cancellation-aware window are untouched. The UI test asserts `value == "Copied"` on the button via an `XCTNSPredicateExpectation` instead of racing the transient label.
2. **The staged-test walk raced the wizard's push.** `walkToTestScreen` tapped `login.connection-setup` and immediately interacted with the first answer; it now waits for the wizard's own `setup.step-label` to read **"Step 1 of 3"** before the first interaction (polling, same contract as `ConnectionSetupUITests.stepLabel`).

**Stress (Mac, real invocations):** the two previously-flaky methods ran **20× each consecutively — 40/40 first-attempt passes** (wizard 26-27 s, auth-failure 53-54 s), plus full-class runs of both suites, zero `Timed out while evaluating UI query`.

**Final hosted run:** [34432945199](https://github.com/kaishi00/hermes-conduit/actions/runs/34432945199) @ `e2581e5` — all jobs green, and **all three UI shards passed their batch on attempt 1** (`('batch', 'passed')`, empty `retried_classes`, no "passed on its targeted retry" anywhere in the lane logs); unit lanes clean; overall wall ≈ **16 min**. CI-tooling suites unchanged and green (134/134 bash, 107/107 Python).

**Review:** three-model review, two rounds + a focused confirmation pass (all findings fixed; final verdict APPROVE WITH NITS with no open findings beyond a documented extraction-bound nuance absorbed by the ceiling margin).
