### PR TITLE
ci: switch opencode reviewer to deepseek-flash (DeepSeek V4.1 Flash)

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           OPENCODE_GO_API_KEY: ${{ secrets.OPENCODE_GO_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.OPENCODE_GH_PAT }}
-          MODEL: go-custom/deepseek-v4-flash
+          MODEL: go-custom/deepseek-flash
           USE_GITHUB_TOKEN: "true"
           PROMPT: |
             You are a code reviewer. DO NOT modify any files. DO NOT make commits.

--- a/opencode.json
+++ b/opencode.json
@@ -9,8 +9,8 @@
         "apiKey": "{env:OPENCODE_GO_API_KEY}"
       },
       "models": {
-        "deepseek-v4-flash": {
-          "name": "DeepSeek V4 Flash"
+        "deepseek-flash": {
+          "name": "DeepSeek V4.1 Flash"
         }
       }
     }


### PR DESCRIPTION
Renames the opencode reviewer model from `deepseek-v4-flash` to `deepseek-flash` (DeepSeek V4.1 Flash) in both places it is pinned:

- `opencode.json` — provider model definition (id + display name)
- `.github/workflows/opencode-review.yml` — the `MODEL: go-custom/...` env pin

Config-only; no app code. Model id verified live against `opencode.ai/zen/go/v1/models`.

**Review gate:** 3× APPROVE (unanimous, zero BLOCKER/WARNING findings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated review workflow to use the `DeepSeek V4.1 Flash` model configuration.
  * Renamed the model configuration entry and updated its display name for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->