### PR TITLE
feat(voice): expose OpenAI-compatible TTS endpoint overrides in Voice settings

### DIFF
--- a/Conduit/Views/VoiceSettingsView.swift
+++ b/Conduit/Views/VoiceSettingsView.swift
@@ -543,6 +543,13 @@ private struct VoiceProviderFieldEditor: View {
         VoiceConfigurationParser.validationMessage(for: value, key: field.key)
     }
 
+    private var saveHint: Text {
+        if let validationMessage {
+            return Text("Cannot save. \(validationMessage)")
+        }
+        return Text("Saves \(field.label) to this Hermes profile.")
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
             switch field.kind {
@@ -583,7 +590,7 @@ private struct VoiceProviderFieldEditor: View {
                     Button(isSaving ? "Saving…" : "Save") { Task { await save(value) } }
                         .font(.caption.weight(.semibold))
                         .disabled(isSaving || validationMessage != nil)
-                        .accessibilityHint(validationMessage != nil ? Text("Cannot save. \(validationMessage!)") : Text(""))
+                        .accessibilityHint(saveHint)
                 }
             }
         }
@@ -592,7 +599,7 @@ private struct VoiceProviderFieldEditor: View {
 
     /// Keyboard submit must respect the same guard as the Save button.
     private func submitIfValid() {
-        guard validationMessage == nil else { return }
+        guard !isSaving, validationMessage == nil else { return }
         Task { await save(value) }
     }
 }

--- a/Conduit/Views/VoiceSettingsView.swift
+++ b/Conduit/Views/VoiceSettingsView.swift
@@ -501,8 +501,13 @@ struct VoiceSettingsView: View {
 
     private func save(value: String, field: VoiceTypedField) async {
         savingField = field.key
-        let saved = await service.save(value: value, for: field.key)
-        if !saved { values[field.key] = service.snapshot.values[field.key] ?? field.defaultValue }
+        _ = await service.save(value: value, for: field.key)
+        // Re-sync the draft with the confirmed server state either way: a
+        // canonicalized value ("1,5" → "1.5") or a removed override
+        // (blank → the field default) is what the editor should show, and
+        // a failed save restores the server value so the field never
+        // claims an unpersisted edit.
+        values[field.key] = service.snapshot.values[field.key] ?? field.defaultValue
         savingField = nil
     }
 
@@ -554,17 +559,20 @@ private struct VoiceProviderFieldEditor: View {
                     .keyboardType(.decimalPad)
                     .textFieldStyle(.roundedBorder)
                     .onSubmit(submitIfValid)
+                    .accessibilityHint(Text(validationMessage ?? field.help))
             case .text:
                 TextField(field.label, text: $value)
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
                     .textFieldStyle(.roundedBorder)
                     .onSubmit(submitIfValid)
+                    .accessibilityHint(Text(validationMessage ?? field.help))
             }
             if let validationMessage {
                 Text(validationMessage)
                     .font(.caption)
                     .foregroundStyle(.orange)
+                    .accessibilityLabel(Text("Cannot save \(field.label): \(validationMessage)"))
             }
             HStack {
                 Text(field.help).font(.caption).foregroundStyle(.secondary)
@@ -575,6 +583,7 @@ private struct VoiceProviderFieldEditor: View {
                     Button(isSaving ? "Saving…" : "Save") { Task { await save(value) } }
                         .font(.caption.weight(.semibold))
                         .disabled(isSaving || validationMessage != nil)
+                        .accessibilityHint(validationMessage != nil ? Text("Cannot save. \(validationMessage!)") : Text(""))
                 }
             }
         }

--- a/Conduit/Views/VoiceSettingsView.swift
+++ b/Conduit/Views/VoiceSettingsView.swift
@@ -532,6 +532,12 @@ private struct VoiceProviderFieldEditor: View {
     let isSaving: Bool
     let save: (String) async -> Void
 
+    /// Mirrors the service-side save guard so out-of-range numbers are
+    /// rejected locally before a config round trip.
+    private var validationMessage: String? {
+        VoiceConfigurationParser.validationMessage(for: value, key: field.key)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
             switch field.kind {
@@ -555,6 +561,11 @@ private struct VoiceProviderFieldEditor: View {
                     .textFieldStyle(.roundedBorder)
                     .onSubmit { Task { await save(value) } }
             }
+            if let validationMessage {
+                Text(validationMessage)
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
             HStack {
                 Text(field.help).font(.caption).foregroundStyle(.secondary)
                 Spacer(minLength: 8)
@@ -563,7 +574,7 @@ private struct VoiceProviderFieldEditor: View {
                 } else {
                     Button(isSaving ? "Saving…" : "Save") { Task { await save(value) } }
                         .font(.caption.weight(.semibold))
-                        .disabled(isSaving)
+                        .disabled(isSaving || validationMessage != nil)
                 }
             }
         }

--- a/Conduit/Views/VoiceSettingsView.swift
+++ b/Conduit/Views/VoiceSettingsView.swift
@@ -553,13 +553,13 @@ private struct VoiceProviderFieldEditor: View {
                 TextField(field.label, text: $value)
                     .keyboardType(.decimalPad)
                     .textFieldStyle(.roundedBorder)
-                    .onSubmit { Task { await save(value) } }
+                    .onSubmit(submitIfValid)
             case .text:
                 TextField(field.label, text: $value)
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
                     .textFieldStyle(.roundedBorder)
-                    .onSubmit { Task { await save(value) } }
+                    .onSubmit(submitIfValid)
             }
             if let validationMessage {
                 Text(validationMessage)
@@ -579,5 +579,11 @@ private struct VoiceProviderFieldEditor: View {
             }
         }
         .padding(.vertical, 3)
+    }
+
+    /// Keyboard submit must respect the same guard as the Save button.
+    private func submitIfValid() {
+        guard validationMessage == nil else { return }
+        Task { await save(value) }
     }
 }

--- a/Conduit/Voice/HermesVoiceConfigurationService.swift
+++ b/Conduit/Voice/HermesVoiceConfigurationService.swift
@@ -256,17 +256,18 @@ final class HermesVoiceConfigurationService: ObservableObject {
             errorMessage = message
             return false
         }
+        let stored = VoiceConfigurationParser.storedValue(for: value, key: key)
         guard var config = try? await requester.requestJSON(path: profilePath("/api/config"), method: "GET", body: nil) else {
             errorMessage = "Could not load voice settings to save this change."
             return false
         }
-        Self.setNested(value, in: &config, dottedKey: key)
+        Self.setNested(stored, in: &config, dottedKey: key)
         do {
             _ = try await requester.requestJSON(
                 path: profilePath("/api/config"), method: "PUT",
                 body: ["config": config]
             )
-            snapshot.values[key] = value
+            snapshot.values[key] = stored
             if key == "stt.provider" { snapshot.selectedSTTProvider = value }
             if key == "tts.provider" { snapshot.selectedTTSProvider = value }
             return true
@@ -481,9 +482,9 @@ enum VoiceConfigurationParser {
         // not offered: upstream derives it from base_url when unset.
         if kind == .tts, id == "elevenlabs" {
             return [
-                VoiceTypedField(key: "tts.elevenlabs.voice_id", label: "Voice ID", help: "Voice from your ElevenLabs-compatible endpoint; built-in voices are suggestions.", kind: .text, defaultValue: ""),
+                VoiceTypedField(key: "tts.elevenlabs.voice_id", label: "Voice ID", help: "Voice ID from your ElevenLabs-compatible endpoint. Leave blank for the provider default.", kind: .text, defaultValue: ""),
                 VoiceTypedField(key: "tts.elevenlabs.model_id", label: "Model", help: "You can enter any installed model identifier.", kind: .text, defaultValue: ""),
-                VoiceTypedField(key: "tts.elevenlabs.base_url", label: "Base URL", help: Self.customEndpointHelp, kind: .text, defaultValue: "")
+                VoiceTypedField(key: "tts.elevenlabs.base_url", label: "Base URL", help: Self.customEndpointHelp("ElevenLabs"), kind: .text, defaultValue: "")
             ]
         }
 
@@ -507,7 +508,7 @@ enum VoiceConfigurationParser {
             }
             if id == "openai" || id == "nous" {
                 shared += [
-                    .init(key: "\(root).base_url", label: "Base URL", help: Self.customEndpointHelp, kind: .text, defaultValue: ""),
+                    .init(key: "\(root).base_url", label: "Base URL", help: Self.customEndpointHelp("OpenAI"), kind: .text, defaultValue: ""),
                     .init(key: "\(root).speed", label: "Speed", help: "Speech rate multiplier. Hermes accepts 0.25–4.0.", kind: .decimal, defaultValue: "1", numericRange: 0.25...4.0)
                 ]
             }
@@ -530,33 +531,54 @@ enum VoiceConfigurationParser {
 
     /// Shared help copy for provider endpoint overrides: this redirects the
     /// provider Hermes calls, never Conduit's own dashboard connection.
-    private static let customEndpointHelp = "Optional OpenAI-compatible speech endpoint Hermes should call (for example https://your-host/v1). Leave blank for the provider default. This does not change the server Conduit connects to."
+    private static func customEndpointHelp(_ provider: String) -> String {
+        "Optional \(provider)-compatible speech endpoint Hermes should call (for example https://your-host/v1). Leave blank for the provider default. This does not change the server Conduit connects to."
+    }
 
-    /// Save-time validation from the typed field metadata: a `.decimal`
-    /// field with a `numericRange` must parse and stay inside the range.
-    /// Empty values clear the override and always validate; valid values are
-    /// never rewritten into a default.
-    static func validationMessage(for value: String, key: String) -> String? {
+    private static func decimalField(for key: String) -> VoiceTypedField? {
         let parts = key.split(separator: ".").map(String.init)
         guard parts.count >= 2 else { return nil }
         let kind: VoiceProviderDescriptor.Kind = parts[0] == "stt" ? .stt : .tts
-        let provider = parts[1]
-        var candidateIDs = [provider]
-        if provider == "openai" { candidateIDs.append("nous") }
-        guard let field = candidateIDs.lazy.compactMap({ candidateID in
-            typedFields(id: candidateID, kind: kind).first(where: { $0.key == key })
-        }).first,
+        return typedFields(id: String(parts[1]), kind: kind).first(where: { $0.key == key })
+    }
+
+    /// Save-time validation from the typed field metadata: a `.decimal`
+    /// field with a `numericRange` must parse and stay inside the range.
+    /// A ranged decimal rejects empty values because Conduit's config
+    /// transport can only write strings — it cannot remove a key — and
+    /// Hermes parses the stored value with `float()`, where `""` is an
+    /// error rather than "unset" (text fields keep the clear-by-empty
+    /// contract: upstream treats empty endpoint overrides as unset).
+    /// Valid values are never rewritten into a default.
+    static func validationMessage(for value: String, key: String) -> String? {
+        guard let field = decimalField(for: key),
             case .decimal = field.kind,
             let range = field.numericRange else { return nil }
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-        guard let parsed = Double(trimmed) else {
+        let normalized = normalizedNumber(value)
+        guard !normalized.isEmpty else {
+            return "\(field.label) needs a number between \(range.lowerBound) and \(range.upperBound) (use 1 for the default rate)."
+        }
+        guard let parsed = Double(normalized) else {
             return "\(field.label) must be a number between \(range.lowerBound) and \(range.upperBound)."
         }
         guard range.contains(parsed) else {
             return "\(field.label) must be between \(range.lowerBound) and \(range.upperBound); Hermes rejects values outside that range."
         }
         return nil
+    }
+
+    /// The canonical form to persist for a value: decimal fields are stored
+    /// with "." separators because Hermes parses them with `float()`, and
+    /// iOS decimal pads submit the device locale's separator. Everything
+    /// else passes through unchanged.
+    static func storedValue(for value: String, key: String) -> String {
+        guard let field = decimalField(for: key),
+            case .decimal = field.kind else { return value }
+        return normalizedNumber(value)
+    }
+
+    private static func normalizedNumber(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: ",", with: ".")
     }
 
     private static func providerIDs(_ schema: [String: Any]?) -> (stt: [String], tts: [String]) {

--- a/Conduit/Voice/HermesVoiceConfigurationService.swift
+++ b/Conduit/Voice/HermesVoiceConfigurationService.swift
@@ -43,6 +43,10 @@ struct VoiceTypedField: Equatable, Identifiable {
     let help: String
     let kind: Kind
     let defaultValue: String
+    /// Inclusive bounds for `.decimal` values when the provider documents
+    /// them (Hermes clamps `tts.openai.speed` to 0.25–4.0). Out-of-range
+    /// values are rejected at save time, never silently rewritten.
+    var numericRange: ClosedRange<Double>?
 
     var id: String { key }
 }
@@ -248,6 +252,10 @@ final class HermesVoiceConfigurationService: ObservableObject {
     }
 
     func save(value: String, for key: String) async -> Bool {
+        if let message = VoiceConfigurationParser.validationMessage(for: value, key: key) {
+            errorMessage = message
+            return false
+        }
         guard var config = try? await requester.requestJSON(path: profilePath("/api/config"), method: "GET", body: nil) else {
             errorMessage = "Could not load voice settings to save this change."
             return false
@@ -395,9 +403,12 @@ enum VoiceConfigurationParser {
         readiness: [VoiceProviderReadiness], credentials: [VoiceCredentialStatus]
     ) -> VoiceProviderConfiguration {
         let catalog = catalogDescriptor(id: id, kind: kind)
+        // Unknown providers get a neutral descriptor: Conduit does not claim
+        // streaming capability without positive evidence, and the runtime's
+        // existing whole-file fallback keeps them functional either way.
         let descriptor = catalog ?? VoiceProviderDescriptor(
             id: id, displayName: id.replacingOccurrences(of: "_", with: " ").capitalized,
-            kind: kind, supportsStreaming: kind == .tts
+            kind: kind, supportsStreaming: false
         )
         let row = readiness.first { $0.id == id && $0.kind == kind }
         let fields = typedFields(id: id, kind: kind)
@@ -433,6 +444,15 @@ enum VoiceConfigurationParser {
             return .init(id: id, displayName: "Nous Subscription", kind: kind, supportsStreaming: true)
         case ("openai", .tts):
             return .init(id: id, displayName: "OpenAI", kind: kind, supportsStreaming: true)
+        // Streaming claims mirror upstream's StreamingTTSProvider registry
+        // (tools/tts_streaming.py): elevenlabs, openai, gemini, and xai have
+        // chunked-PCM implementations; everything else stays unlabeled.
+        case ("elevenlabs", .tts):
+            return .init(id: id, displayName: "ElevenLabs", kind: kind, supportsStreaming: true)
+        case ("xai", .tts):
+            return .init(id: id, displayName: "xAI", kind: kind, supportsStreaming: true)
+        case ("gemini", .tts):
+            return .init(id: id, displayName: "Gemini", kind: kind, supportsStreaming: true)
         case ("stepfun", .stt):
             return .init(id: id, displayName: "StepFun", kind: kind, models: ["stepaudio-2.5-asr", "step-asr"], supportsStreaming: false)
         case ("stepfun", .tts):
@@ -453,16 +473,44 @@ enum VoiceConfigurationParser {
         // Hermes keys the ElevenLabs STT model `stt.elevenlabs.model_id`.
         let modelKey = kind == .stt && id == "elevenlabs" ? "model_id" : "model"
         let defaultModel = id == "local" && kind == .stt ? "base" : ""
+
+        // Hermes' ElevenLabs TTS section keys voice/model `voice_id`/`model_id`
+        // (tools/tts_tool_providers.py) and reads `base_url` for both
+        // whole-file and streaming synthesis; the generic `voice`/`model`/
+        // `language` keys were never read there. `wss_url` is deliberately
+        // not offered: upstream derives it from base_url when unset.
+        if kind == .tts, id == "elevenlabs" {
+            return [
+                VoiceTypedField(key: "tts.elevenlabs.voice_id", label: "Voice ID", help: "Voice from your ElevenLabs-compatible endpoint; built-in voices are suggestions.", kind: .text, defaultValue: ""),
+                VoiceTypedField(key: "tts.elevenlabs.model_id", label: "Model", help: "You can enter any installed model identifier.", kind: .text, defaultValue: ""),
+                VoiceTypedField(key: "tts.elevenlabs.base_url", label: "Base URL", help: Self.customEndpointHelp, kind: .text, defaultValue: "")
+            ]
+        }
+
         var shared = [
             VoiceTypedField(key: "\(root).\(modelKey)", label: "Model", help: "You can enter any installed model identifier.", kind: .text, defaultValue: defaultModel),
             VoiceTypedField(key: "\(root).language", label: "Language", help: "Leave blank for automatic language detection.", kind: .text, defaultValue: "")
         ]
         if kind == .tts {
-            let instructionKey = id == "xiaomi_mimo" ? "delivery_instructions" : "instruction"
             shared += [
-                .init(key: "\(root).voice", label: "Voice ID", help: "Built-in voices are suggestions; custom voice IDs remain supported.", kind: .text, defaultValue: ""),
-                .init(key: "\(root).\(instructionKey)", label: "Delivery instruction", help: "Optional speaking style guidance sent to the provider.", kind: .text, defaultValue: "")
+                .init(key: "\(root).voice", label: "Voice ID", help: "Built-in voices are suggestions; custom voice IDs remain supported.", kind: .text, defaultValue: "")
             ]
+            // OpenAI resolves speaking style through the per-request TTS tool
+            // parameter — upstream never reads tts.openai.instruction — so
+            // no editor is offered for that dead key. The managed Nous route
+            // shares the section and the same constraint.
+            if id != "openai" && id != "nous" {
+                let instructionKey = id == "xiaomi_mimo" ? "delivery_instructions" : "instruction"
+                shared += [
+                    .init(key: "\(root).\(instructionKey)", label: "Delivery instruction", help: "Optional speaking style guidance sent to the provider.", kind: .text, defaultValue: "")
+                ]
+            }
+            if id == "openai" || id == "nous" {
+                shared += [
+                    .init(key: "\(root).base_url", label: "Base URL", help: Self.customEndpointHelp, kind: .text, defaultValue: ""),
+                    .init(key: "\(root).speed", label: "Speed", help: "Speech rate multiplier. Hermes accepts 0.25–4.0.", kind: .decimal, defaultValue: "1", numericRange: 0.25...4.0)
+                ]
+            }
         }
         if id == "stepfun" {
             shared += [
@@ -478,6 +526,37 @@ enum VoiceConfigurationParser {
             }
         }
         return shared
+    }
+
+    /// Shared help copy for provider endpoint overrides: this redirects the
+    /// provider Hermes calls, never Conduit's own dashboard connection.
+    private static let customEndpointHelp = "Optional OpenAI-compatible speech endpoint Hermes should call (for example https://your-host/v1). Leave blank for the provider default. This does not change the server Conduit connects to."
+
+    /// Save-time validation from the typed field metadata: a `.decimal`
+    /// field with a `numericRange` must parse and stay inside the range.
+    /// Empty values clear the override and always validate; valid values are
+    /// never rewritten into a default.
+    static func validationMessage(for value: String, key: String) -> String? {
+        let parts = key.split(separator: ".").map(String.init)
+        guard parts.count >= 2 else { return nil }
+        let kind: VoiceProviderDescriptor.Kind = parts[0] == "stt" ? .stt : .tts
+        let provider = parts[1]
+        var candidateIDs = [provider]
+        if provider == "openai" { candidateIDs.append("nous") }
+        guard let field = candidateIDs.lazy.compactMap({ candidateID in
+            typedFields(id: candidateID, kind: kind).first(where: { $0.key == key })
+        }).first,
+            case .decimal = field.kind,
+            let range = field.numericRange else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        guard let parsed = Double(trimmed) else {
+            return "\(field.label) must be a number between \(range.lowerBound) and \(range.upperBound)."
+        }
+        guard range.contains(parsed) else {
+            return "\(field.label) must be between \(range.lowerBound) and \(range.upperBound); Hermes rejects values outside that range."
+        }
+        return nil
     }
 
     private static func providerIDs(_ schema: [String: Any]?) -> (stt: [String], tts: [String]) {

--- a/Conduit/Voice/HermesVoiceConfigurationService.swift
+++ b/Conduit/Voice/HermesVoiceConfigurationService.swift
@@ -267,7 +267,7 @@ final class HermesVoiceConfigurationService: ObservableObject {
         // Clearing REMOVES the override key: Hermes reads provider keys
         // like `config.get(key, default)`, which applies the default only
         // when the key is ABSENT, so a stored "" would be used verbatim.
-        let clears = stored.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let clears = stored.isEmpty
         if clears {
             Self.removeNested(in: &config, dottedKey: key)
         } else {
@@ -481,6 +481,11 @@ enum VoiceConfigurationParser {
         // Streaming claims mirror upstream's StreamingTTSProvider registry
         // (tools/tts_streaming.py): elevenlabs, openai, gemini, and xai have
         // chunked-PCM implementations; everything else stays unlabeled.
+        // stepfun/xiaomi_mimo are NOT upstream builtins — they are plugin
+        // rows observed live on real gateways, whose plugins implement
+        // their own streaming, so their flags come from that observation
+        // rather than the upstream registry. The label is informational;
+        // the runtime relies on the server's fallback signal either way.
         case ("elevenlabs", .tts):
             return .init(id: id, displayName: "ElevenLabs", kind: kind, supportsStreaming: true)
         case ("xai", .tts):
@@ -570,7 +575,7 @@ enum VoiceConfigurationParser {
 
     private static func decimalField(for key: String) -> VoiceTypedField? {
         let parts = key.split(separator: ".").map(String.init)
-        guard parts.count >= 2 else { return nil }
+        guard parts.count >= 2, parts[0] == "stt" || parts[0] == "tts" else { return nil }
         let kind: VoiceProviderDescriptor.Kind = parts[0] == "stt" ? .stt : .tts
         return typedFields(id: String(parts[1]), kind: kind).first(where: { $0.key == key })
     }
@@ -599,17 +604,20 @@ enum VoiceConfigurationParser {
         return nil
     }
 
-    /// The canonical form to persist for a value: RANGED decimal fields
-    /// (the OpenAI speed override) are stored with "." separators because
-    /// Hermes parses them with `float()`, and iOS decimal pads submit the
-    /// device locale's separator. Unranged decimals and text fields pass
-    /// through unchanged — this deliberately does not rewrite unrelated
-    /// values such as a StepFun sample rate of "24,000".
+    /// The canonical form to persist for a value: leading/trailing
+    /// whitespace never survives a save (the clear decision and the stored
+    /// payload derive from the same normalization), and RANGED decimal
+    /// fields (the OpenAI speed override) are additionally stored with "."
+    /// separators because Hermes parses them with `float()` while iOS
+    /// decimal pads submit the device locale's separator. Unranged decimals
+    /// and other text pass through otherwise untouched — this deliberately
+    /// does not rewrite values such as a StepFun sample rate of "24,000".
     static func storedValue(for value: String, key: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let field = decimalField(for: key),
             case .decimal = field.kind,
-            field.numericRange != nil else { return value }
-        return normalizedNumber(value)
+            field.numericRange != nil else { return trimmed }
+        return normalizedNumber(trimmed)
     }
 
     private static func normalizedNumber(_ value: String) -> String {

--- a/Conduit/Voice/HermesVoiceConfigurationService.swift
+++ b/Conduit/Voice/HermesVoiceConfigurationService.swift
@@ -261,13 +261,14 @@ final class HermesVoiceConfigurationService: ObservableObject {
             errorMessage = "Could not load voice settings to save this change."
             return false
         }
-        // Clearing a text field removes the override key instead of writing
-        // an empty string: Hermes reads many provider keys with
-        // `config.get(key, default)`, which uses the default only when the
-        // key is ABSENT, so a stored "" would be used verbatim and break
-        // synthesis. Removal is behavior-identical for keys upstream treats
-        // as unset when empty (the endpoint overrides).
-        if stored.isEmpty {
+        // One clear decision, derived from trimmed input, drives both the
+        // config mutation and the snapshot: whitespace-only input means the
+        // user is clearing the override, never persisting blank text.
+        // Clearing REMOVES the override key: Hermes reads provider keys
+        // like `config.get(key, default)`, which applies the default only
+        // when the key is ABSENT, so a stored "" would be used verbatim.
+        let clears = stored.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        if clears {
             Self.removeNested(in: &config, dottedKey: key)
         } else {
             Self.setNested(stored, in: &config, dottedKey: key)
@@ -279,7 +280,7 @@ final class HermesVoiceConfigurationService: ObservableObject {
             )
             // The snapshot only reflects a confirmed write; a failed PUT
             // must leave it matching the server.
-            if stored.isEmpty {
+            if clears {
                 snapshot.values.removeValue(forKey: key)
             } else {
                 snapshot.values[key] = stored
@@ -541,7 +542,7 @@ enum VoiceConfigurationParser {
             if id == "openai" || id == "nous" {
                 shared += [
                     .init(key: "\(root).base_url", label: "Base URL", help: Self.customEndpointHelp("OpenAI"), kind: .text, defaultValue: ""),
-                    .init(key: "\(root).speed", label: "Speed", help: "Speech rate multiplier. Hermes accepts 0.25–4.0.", kind: .decimal, defaultValue: "1", numericRange: 0.25...4.0)
+                    .init(key: "\(root).speed", label: "Speed", help: "Speech rate multiplier (0.25–4.0); Hermes clamps this range. Leave blank to remove the override. Note: applies to Hermes' whole-file synthesis — upstream's current PCM streaming path does not use this setting.", kind: .decimal, defaultValue: "1", numericRange: 0.25...4.0)
                 ]
             }
         }
@@ -576,36 +577,38 @@ enum VoiceConfigurationParser {
 
     /// Save-time validation from the typed field metadata: a `.decimal`
     /// field with a `numericRange` must parse and stay inside the range.
-    /// A ranged decimal rejects empty because Hermes parses the stored
-    /// value with `float()`, where `""` is an error; Conduit refuses
-    /// rather than silently removing a numeric override — save `1` for
-    /// the default rate. Text fields keep the clear-by-empty contract:
-    /// saving empty removes the override key, which upstream treats as
-    /// "use the default". Valid values are never rewritten into a default.
+    /// Empty/whitespace input clears the override — upstream reads the
+    /// stored speed with `float(config.get("speed", default))`, so a
+    /// REMOVED key restores the default while an empty string would be a
+    /// parse error. For non-empty values, note upstream CLAMPS OpenAI
+    /// speech speed into the range; Conduit chooses to reject values it
+    /// would otherwise silently let upstream rewrite. Text fields always
+    /// validate; saving empty removes the override key.
     static func validationMessage(for value: String, key: String) -> String? {
         guard let field = decimalField(for: key),
             case .decimal = field.kind,
             let range = field.numericRange else { return nil }
         let normalized = normalizedNumber(value)
-        guard !normalized.isEmpty else {
-            return "\(field.label) needs a number between \(range.lowerBound) and \(range.upperBound) (use 1 for the default rate)."
-        }
+        guard !normalized.isEmpty else { return nil }
         guard let parsed = Double(normalized) else {
-            return "\(field.label) must be a number between \(range.lowerBound) and \(range.upperBound)."
+            return "\(field.label) must be a number between \(range.lowerBound) and \(range.upperBound), or leave blank to remove the override."
         }
         guard range.contains(parsed) else {
-            return "\(field.label) must be between \(range.lowerBound) and \(range.upperBound); Hermes rejects values outside that range."
+            return "\(field.label) must be between \(range.lowerBound) and \(range.upperBound). Hermes clamps values into this range; Conduit refuses them instead of saving something upstream would silently rewrite."
         }
         return nil
     }
 
-    /// The canonical form to persist for a value: decimal fields are stored
-    /// with "." separators because Hermes parses them with `float()`, and
-    /// iOS decimal pads submit the device locale's separator. Everything
-    /// else passes through unchanged.
+    /// The canonical form to persist for a value: RANGED decimal fields
+    /// (the OpenAI speed override) are stored with "." separators because
+    /// Hermes parses them with `float()`, and iOS decimal pads submit the
+    /// device locale's separator. Unranged decimals and text fields pass
+    /// through unchanged — this deliberately does not rewrite unrelated
+    /// values such as a StepFun sample rate of "24,000".
     static func storedValue(for value: String, key: String) -> String {
         guard let field = decimalField(for: key),
-            case .decimal = field.kind else { return value }
+            case .decimal = field.kind,
+            field.numericRange != nil else { return value }
         return normalizedNumber(value)
     }
 

--- a/Conduit/Voice/HermesVoiceConfigurationService.swift
+++ b/Conduit/Voice/HermesVoiceConfigurationService.swift
@@ -269,16 +269,21 @@ final class HermesVoiceConfigurationService: ObservableObject {
         // as unset when empty (the endpoint overrides).
         if stored.isEmpty {
             Self.removeNested(in: &config, dottedKey: key)
-            snapshot.values.removeValue(forKey: key)
         } else {
             Self.setNested(stored, in: &config, dottedKey: key)
-            snapshot.values[key] = stored
         }
         do {
             _ = try await requester.requestJSON(
                 path: profilePath("/api/config"), method: "PUT",
                 body: ["config": config]
             )
+            // The snapshot only reflects a confirmed write; a failed PUT
+            // must leave it matching the server.
+            if stored.isEmpty {
+                snapshot.values.removeValue(forKey: key)
+            } else {
+                snapshot.values[key] = stored
+            }
             if key == "stt.provider" { snapshot.selectedSTTProvider = value }
             if key == "tts.provider" { snapshot.selectedTTSProvider = value }
             return true
@@ -571,12 +576,12 @@ enum VoiceConfigurationParser {
 
     /// Save-time validation from the typed field metadata: a `.decimal`
     /// field with a `numericRange` must parse and stay inside the range.
-    /// A ranged decimal rejects empty values because Conduit's config
-    /// transport can only write strings — it cannot remove a key — and
-    /// Hermes parses the stored value with `float()`, where `""` is an
-    /// error rather than "unset" (text fields keep the clear-by-empty
-    /// contract: upstream treats empty endpoint overrides as unset).
-    /// Valid values are never rewritten into a default.
+    /// A ranged decimal rejects empty because Hermes parses the stored
+    /// value with `float()`, where `""` is an error; Conduit refuses
+    /// rather than silently removing a numeric override — save `1` for
+    /// the default rate. Text fields keep the clear-by-empty contract:
+    /// saving empty removes the override key, which upstream treats as
+    /// "use the default". Valid values are never rewritten into a default.
     static func validationMessage(for value: String, key: String) -> String? {
         guard let field = decimalField(for: key),
             case .decimal = field.kind,

--- a/Conduit/Voice/HermesVoiceConfigurationService.swift
+++ b/Conduit/Voice/HermesVoiceConfigurationService.swift
@@ -261,13 +261,24 @@ final class HermesVoiceConfigurationService: ObservableObject {
             errorMessage = "Could not load voice settings to save this change."
             return false
         }
-        Self.setNested(stored, in: &config, dottedKey: key)
+        // Clearing a text field removes the override key instead of writing
+        // an empty string: Hermes reads many provider keys with
+        // `config.get(key, default)`, which uses the default only when the
+        // key is ABSENT, so a stored "" would be used verbatim and break
+        // synthesis. Removal is behavior-identical for keys upstream treats
+        // as unset when empty (the endpoint overrides).
+        if stored.isEmpty {
+            Self.removeNested(in: &config, dottedKey: key)
+            snapshot.values.removeValue(forKey: key)
+        } else {
+            Self.setNested(stored, in: &config, dottedKey: key)
+            snapshot.values[key] = stored
+        }
         do {
             _ = try await requester.requestJSON(
                 path: profilePath("/api/config"), method: "PUT",
                 body: ["config": config]
             )
-            snapshot.values[key] = stored
             if key == "stt.provider" { snapshot.selectedSTTProvider = value }
             if key == "tts.provider" { snapshot.selectedTTSProvider = value }
             return true
@@ -340,6 +351,22 @@ final class HermesVoiceConfigurationService: ObservableObject {
         var child = object[key] as? [String: Any] ?? [:]
         setNested(value, in: &child, path: Array(path.dropFirst()), leaf: leaf)
         object[key] = child
+    }
+
+    /// Removes the value at a dotted key, pruning parent dictionaries that
+    /// become empty so a cleared override cannot leave an empty section
+    /// behind in the profile config.
+    private static func removeNested(in object: inout [String: Any], dottedKey: String) {
+        var path = dottedKey.split(separator: ".").map(String.init)
+        guard let leaf = path.popLast() else { return }
+        removeNested(in: &object, path: path, leaf: leaf)
+    }
+
+    private static func removeNested(in object: inout [String: Any], path: [String], leaf: String) {
+        guard let key = path.first else { object.removeValue(forKey: leaf); return }
+        guard var child = object[key] as? [String: Any] else { return }
+        removeNested(in: &child, path: Array(path.dropFirst()), leaf: leaf)
+        if child.isEmpty { object.removeValue(forKey: key) } else { object[key] = child }
     }
 }
 

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -480,8 +480,12 @@ final class VoiceConversationController: ObservableObject {
                 },
                 onEncodedAudio: { [weak self] data in
                     guard let self else { return }
-                    deliveredAudio = true
+                    // Mirror the PCM path: only audio that actually reaches
+                    // playback counts as delivered, so an empty payload
+                    // cannot turn the test into a false pass.
+                    guard !data.isEmpty else { return }
                     try self.playback.playEncodedAudioData(data)
+                    deliveredAudio = true
                     self.state = .speaking
                 }
             )

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -471,8 +471,12 @@ final class VoiceConversationController: ObservableObject {
                 },
                 onPCM16: { [weak self] data, rate in
                     guard let self else { return }
-                    deliveredAudio = true
-                    _ = try self.playback.enqueuePCM16(data, sampleRate: rate)
+                    // Only PCM the playback service actually accepted and
+                    // scheduled counts as delivered speech — an unaligned
+                    // or empty chunk schedules zero bytes and must not
+                    // turn the provider test into a false pass.
+                    let acceptedBytes = try self.playback.enqueuePCM16(data, sampleRate: rate)
+                    if acceptedBytes > 0 { deliveredAudio = true }
                 },
                 onEncodedAudio: { [weak self] data in
                     guard let self else { return }

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -459,6 +459,10 @@ final class VoiceConversationController: ObservableObject {
         }
         do {
             state = .thinking
+            // The test passes only when the route actually delivered speech:
+            // a stream that connects and finishes silently is a failed
+            // provider test, not a passed one.
+            var deliveredAudio = false
             let stream = try await gateway.openSpeechStream(
                 onStart: { [weak self] rate in
                     guard let self else { return }
@@ -467,10 +471,12 @@ final class VoiceConversationController: ObservableObject {
                 },
                 onPCM16: { [weak self] data, rate in
                     guard let self else { return }
+                    deliveredAudio = true
                     _ = try self.playback.enqueuePCM16(data, sampleRate: rate)
                 },
                 onEncodedAudio: { [weak self] data in
                     guard let self else { return }
+                    deliveredAudio = true
                     try self.playback.playEncodedAudioData(data)
                     self.state = .speaking
                 }
@@ -488,6 +494,9 @@ final class VoiceConversationController: ObservableObject {
             await playback.drain()
             guard isCurrent(generation) else {
                 return .failure("The speech playback test was cancelled.")
+            }
+            guard deliveredAudio else {
+                return .failure("Hermes connected, but the selected speech provider returned no audio.")
             }
             return .success("Speech playback completed.")
         } catch {

--- a/ConduitTests/HermesVoiceConfigurationServiceTests.swift
+++ b/ConduitTests/HermesVoiceConfigurationServiceTests.swift
@@ -768,16 +768,18 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
         XCTAssertEqual(service.snapshot.values["tts.openai.base_url"], "https://tts.example.com/v1")
     }
 
-    /// Clearing saves an empty string through the same path: Hermes treats
-    /// an empty override as unset (`config_base_url or fallback_base or
-    /// DEFAULT_OPENAI_BASE_URL`), returning the provider to its default
-    /// endpoint behavior.
-    func testClearingOpenAIBaseURLSavesEmptyOverride() async throws {
+    /// Clearing a text override REMOVES the key from the profile config
+    /// rather than writing an empty string: Hermes reads provider keys with
+    /// `config.get(key, default)`, which only applies the default when the
+    /// key is absent — a stored "" would be used verbatim and break
+    /// synthesis. Removal is behavior-identical for keys upstream treats as
+    /// unset when empty (`base_url`'s falsy-or chains).
+    func testClearingOpenAIBaseURLRemovesTheOverride() async throws {
         let requester = MockVoiceConfigurationRequester()
         requester.routes = [
             "/api/config": [
                 "stt": ["enabled": true, "provider": "openai"],
-                "tts": ["provider": "openai", "openai": ["base_url": "https://tts.example.com/v1"]]
+                "tts": ["provider": "openai", "openai": ["base_url": "https://tts.example.com/v1", "voice": "alloy"]]
             ],
             "/api/tools/toolsets/stt/config": ["providers": []],
             "/api/tools/toolsets/tts/config": ["providers": []]
@@ -793,8 +795,38 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
         let openai = try XCTUnwrap(
             ((configPUT?.body?["config"] as? [String: Any])?["tts"] as? [String: Any])?["openai"] as? [String: Any]
         )
-        XCTAssertEqual(openai["base_url"] as? String, "")
-        XCTAssertEqual(service.snapshot.values["tts.openai.base_url"], "")
+        XCTAssertNil(openai["base_url"])
+        // Unrelated provider values survive the removal.
+        XCTAssertEqual(openai["voice"] as? String, "alloy")
+        XCTAssertNil(service.snapshot.values["tts.openai.base_url"])
+    }
+
+    /// Clearing the ElevenLabs voice override removes `voice_id` entirely
+    /// (upstream reads it with `.get(key, DEFAULT)`), prunes the provider
+    /// section when it becomes empty, and leaves the snapshot consistent
+    /// with an absent override.
+    func testClearingElevenLabsVoiceIDRemovesTheOverride() async throws {
+        let requester = MockVoiceConfigurationRequester()
+        requester.routes = [
+            "/api/config": [
+                "stt": ["enabled": true, "provider": "local"],
+                "tts": ["provider": "elevenlabs", "elevenlabs": ["voice_id": "custom-voice"]]
+            ],
+            "/api/tools/toolsets/stt/config": ["providers": []],
+            "/api/tools/toolsets/tts/config": ["providers": []]
+        ]
+        let service = HermesVoiceConfigurationService(requester: requester, profile: "default")
+        await service.reload()
+
+        let saved = await service.save(value: "", for: "tts.elevenlabs.voice_id")
+
+        XCTAssertTrue(saved)
+        let configPUT = requester.recorded.first { $0.method == "PUT" && $0.path == "/api/config" }
+        let tts = try XCTUnwrap((configPUT?.body?["config"] as? [String: Any])?["tts"] as? [String: Any])
+        // The emptied section is pruned so no empty {} lingers in config.
+        XCTAssertNil(tts["elevenlabs"])
+        XCTAssertEqual(tts["provider"] as? String, "elevenlabs")
+        XCTAssertNil(service.snapshot.values["tts.elevenlabs.voice_id"])
     }
 
     /// Hermes keys ElevenLabs TTS as `voice_id`/`model_id`

--- a/ConduitTests/HermesVoiceConfigurationServiceTests.swift
+++ b/ConduitTests/HermesVoiceConfigurationServiceTests.swift
@@ -682,7 +682,9 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
 
     /// Locale canonicalization is scoped to the validated ranged decimal:
     /// an unrelated non-ranged decimal value such as a StepFun sample rate
-    /// of "24,000" must pass through untouched.
+    /// of "24,000" must pass through untouched. Text overrides persist
+    /// trimmed (pasted padding never reaches Hermes) while interior
+    /// whitespace stays verbatim.
     func testCommaCanonicalizationDoesNotRewriteUnrangedDecimalFields() {
         XCTAssertEqual(
             VoiceConfigurationParser.storedValue(for: "1,5", key: "tts.openai.speed"),
@@ -693,6 +695,14 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
             "24,000"
         )
         XCTAssertNil(VoiceConfigurationParser.validationMessage(for: "24,000", key: "tts.stepfun.sample_rate"))
+        XCTAssertEqual(
+            VoiceConfigurationParser.storedValue(for: "  https://host/v1  ", key: "tts.openai.base_url"),
+            "https://host/v1"
+        )
+        XCTAssertEqual(
+            VoiceConfigurationParser.storedValue(for: "  alloy  voice  ", key: "tts.elevenlabs.voice_id"),
+            "alloy  voice"
+        )
     }
 
     /// Comma-decimal input from locale decimal pads is canonicalized to the

--- a/ConduitTests/HermesVoiceConfigurationServiceTests.swift
+++ b/ConduitTests/HermesVoiceConfigurationServiceTests.swift
@@ -599,6 +599,208 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
             "This Hermes gateway does not provide voice endpoints. Text chat remains available."
         )
     }
+
+    // MARK: - TTS provider configuration parity (custom OpenAI-compatible endpoints)
+
+    /// Upstream reads `tts.openai.base_url` (tools/tts_tool_openai.py: the
+    /// config override beats the managed-gateway default) and accepts
+    /// `tts.openai.speed` clamped to 0.25–4.0. `tts.openai.instruction` is
+    /// never read upstream — speaking style arrives only through the
+    /// per-request TTS tool parameter — so the editor must not offer it.
+    /// The upstream-supported keys stay singular: no duplicate editors.
+    func testOpenAITTSExposesBaseURLAndSpeedWithoutDeadInstructionKey() {
+        let fields = VoiceConfigurationParser.typedFields(id: "openai", kind: .tts)
+        XCTAssertEqual(fields.first { $0.key == "tts.openai.base_url" }?.kind, .text)
+        let speed = fields.first { $0.key == "tts.openai.speed" }
+        XCTAssertEqual(speed?.kind, .decimal)
+        XCTAssertEqual(speed?.numericRange, 0.25...4.0)
+        XCTAssertFalse(fields.contains { $0.key == "tts.openai.instruction" })
+        XCTAssertEqual(fields.count, Set(fields.map(\.key)).count)
+        XCTAssertTrue(fields.contains { $0.key == "tts.openai.model" })
+        XCTAssertTrue(fields.contains { $0.key == "tts.openai.voice" })
+        XCTAssertTrue(fields.contains { $0.key == "tts.openai.language" })
+    }
+
+    /// The managed Nous TTS route shares the vendor config section upstream,
+    /// so its editors carry the same endpoint keys and the same dead-key
+    /// exclusion.
+    func testManagedNousTTSEditorsShareOpenAIEndpointKeys() {
+        let fields = VoiceConfigurationParser.typedFields(id: "nous", kind: .tts)
+        XCTAssertTrue(fields.contains { $0.key == "tts.openai.base_url" })
+        XCTAssertTrue(fields.contains { $0.key == "tts.openai.speed" })
+        XCTAssertFalse(fields.contains { $0.key == "tts.openai.instruction" })
+    }
+
+    /// Upstream clamps speed to [0.25, 4.0]. Conduit rejects out-of-range
+    /// values instead of silently rewriting them, and clearing (empty
+    /// string) always validates.
+    func testOpenAISpeedValidationRejectsValuesOutsideUpstreamRange() {
+        XCTAssertNil(VoiceConfigurationParser.validationMessage(for: "1", key: "tts.openai.speed"))
+        XCTAssertNil(VoiceConfigurationParser.validationMessage(for: "0.25", key: "tts.openai.speed"))
+        XCTAssertNil(VoiceConfigurationParser.validationMessage(for: "4.0", key: "tts.openai.speed"))
+        XCTAssertNil(VoiceConfigurationParser.validationMessage(for: "", key: "tts.openai.speed"))
+        XCTAssertNotNil(VoiceConfigurationParser.validationMessage(for: "0.1", key: "tts.openai.speed"))
+        XCTAssertNotNil(VoiceConfigurationParser.validationMessage(for: "4.5", key: "tts.openai.speed"))
+        XCTAssertNotNil(VoiceConfigurationParser.validationMessage(for: "fast", key: "tts.openai.speed"))
+    }
+
+    /// The save path must refuse an out-of-range speed before any config
+    /// write reaches the gateway.
+    func testSavingOutOfRangeOpenAISpeedIsRejectedBeforeConfigWrite() async {
+        let requester = MockVoiceConfigurationRequester()
+        requester.routes = [
+            "/api/config": ["stt": ["enabled": true, "provider": "openai"], "tts": ["provider": "openai"]],
+            "/api/tools/toolsets/stt/config": ["providers": []],
+            "/api/tools/toolsets/tts/config": ["providers": []]
+        ]
+        let service = HermesVoiceConfigurationService(requester: requester, profile: "default")
+        await service.reload()
+
+        let saved = await service.save(value: "9", for: "tts.openai.speed")
+
+        XCTAssertFalse(saved)
+        XCTAssertNotNil(service.errorMessage)
+        XCTAssertFalse(requester.recorded.contains { $0.method == "PUT" && $0.path == "/api/config" })
+    }
+
+    /// A configured custom endpoint parses into the snapshot values and the
+    /// OpenAI provider's editable fields.
+    func testConfiguredOpenAIBaseURLParsesIntoSnapshotAndFields() {
+        let snapshot = VoiceConfigurationParser.parse(
+            profile: "default", schema: nil,
+            config: [
+                "stt": ["enabled": true, "provider": "openai"],
+                "tts": ["provider": "openai", "openai": ["base_url": "https://tts.example.com/v1", "speed": 1.5]]
+            ],
+            sttReadiness: ["providers": []],
+            ttsReadiness: ["providers": [["name": "OpenAI TTS", "tts_provider": "openai", "status": "ready", "is_active": true]]],
+            environment: [:],
+            ttsToolsetConfigAvailable: true
+        )
+
+        XCTAssertEqual(snapshot.values["tts.openai.base_url"], "https://tts.example.com/v1")
+        XCTAssertEqual(snapshot.values["tts.openai.speed"], "1.5")
+        let openai = snapshot.ttsProviders.first { $0.descriptor.id == "openai" }
+        XCTAssertTrue(openai?.fields.contains { $0.key == "tts.openai.base_url" } ?? false)
+        XCTAssertTrue(openai?.fields.contains { $0.key == "tts.openai.speed" } ?? false)
+    }
+
+    /// Field saves flow through the profile-scoped full-document config
+    /// write — the exact dotted key, under the profile's request scope, with
+    /// pre-existing provider values preserved.
+    func testSavingOpenAIBaseURLWritesProfileScopedConfigKey() async throws {
+        let requester = MockVoiceConfigurationRequester()
+        requester.routes = [
+            "/api/config?profile=research": [
+                "stt": ["enabled": true, "provider": "openai"],
+                "tts": ["provider": "openai", "openai": ["voice": "alloy"]]
+            ],
+            "/api/tools/toolsets/stt/config?profile=research": ["providers": []],
+            "/api/tools/toolsets/tts/config?profile=research": ["providers": []]
+        ]
+        let service = HermesVoiceConfigurationService(requester: requester, profile: "research")
+        await service.reload()
+
+        let saved = await service.save(value: "https://tts.example.com/v1", for: "tts.openai.base_url")
+
+        XCTAssertTrue(saved)
+        let configPUT = requester.recorded.first { $0.method == "PUT" && $0.path == "/api/config?profile=research" }
+        let tts = try XCTUnwrap((configPUT?.body?["config"] as? [String: Any])?["tts"] as? [String: Any])
+        let openai = try XCTUnwrap(tts["openai"] as? [String: Any])
+        XCTAssertEqual(openai["base_url"] as? String, "https://tts.example.com/v1")
+        XCTAssertEqual(openai["voice"] as? String, "alloy")
+        XCTAssertEqual(service.snapshot.values["tts.openai.base_url"], "https://tts.example.com/v1")
+    }
+
+    /// Clearing saves an empty string through the same path: Hermes treats
+    /// an empty override as unset (`config_base_url or fallback_base or
+    /// DEFAULT_OPENAI_BASE_URL`), returning the provider to its default
+    /// endpoint behavior.
+    func testClearingOpenAIBaseURLSavesEmptyOverride() async throws {
+        let requester = MockVoiceConfigurationRequester()
+        requester.routes = [
+            "/api/config": [
+                "stt": ["enabled": true, "provider": "openai"],
+                "tts": ["provider": "openai", "openai": ["base_url": "https://tts.example.com/v1"]]
+            ],
+            "/api/tools/toolsets/stt/config": ["providers": []],
+            "/api/tools/toolsets/tts/config": ["providers": []]
+        ]
+        let service = HermesVoiceConfigurationService(requester: requester, profile: "default")
+        await service.reload()
+        XCTAssertEqual(service.snapshot.values["tts.openai.base_url"], "https://tts.example.com/v1")
+
+        let saved = await service.save(value: "", for: "tts.openai.base_url")
+
+        XCTAssertTrue(saved)
+        let configPUT = requester.recorded.first { $0.method == "PUT" && $0.path == "/api/config" }
+        let openai = try XCTUnwrap(
+            ((configPUT?.body?["config"] as? [String: Any])?["tts"] as? [String: Any])?["openai"] as? [String: Any]
+        )
+        XCTAssertEqual(openai["base_url"] as? String, "")
+        XCTAssertEqual(service.snapshot.values["tts.openai.base_url"], "")
+    }
+
+    /// Hermes keys ElevenLabs TTS as `voice_id`/`model_id`
+    /// (tools/tts_tool_providers.py) and reads `base_url` for both
+    /// whole-file and streaming synthesis. The old generic
+    /// `voice`/`model`/`language` keys were never read there.
+    func testElevenLabsTTSFieldsTargetUpstreamKeys() {
+        let fields = VoiceConfigurationParser.typedFields(id: "elevenlabs", kind: .tts)
+        XCTAssertEqual(fields.first { $0.key == "tts.elevenlabs.voice_id" }?.kind, .text)
+        XCTAssertEqual(fields.first { $0.key == "tts.elevenlabs.model_id" }?.kind, .text)
+        XCTAssertEqual(fields.first { $0.key == "tts.elevenlabs.base_url" }?.kind, .text)
+        XCTAssertFalse(fields.contains { $0.key == "tts.elevenlabs.model" })
+        XCTAssertFalse(fields.contains { $0.key == "tts.elevenlabs.voice" })
+        XCTAssertFalse(fields.contains { $0.key == "tts.elevenlabs.language" })
+        XCTAssertFalse(fields.contains { $0.key == "tts.elevenlabs.instruction" })
+    }
+
+    /// Provider-specific editors stay scoped: openai/elevenlabs fields must
+    /// not leak into other providers' editors, and unknown providers keep
+    /// the full generic surface (plugin configs live in their own sections
+    /// upstream).
+    func testProviderSpecificFieldsStayScopedToTheirProvider() {
+        for id in ["stepfun", "xiaomi_mimo", "acme_voice"] {
+            let fields = VoiceConfigurationParser.typedFields(id: id, kind: .tts)
+            XCTAssertFalse(fields.contains { $0.key == "tts.openai.base_url" }, id)
+            XCTAssertFalse(fields.contains { $0.key == "tts.openai.speed" }, id)
+            XCTAssertFalse(fields.contains { $0.key == "tts.elevenlabs.base_url" }, id)
+            XCTAssertTrue(fields.allSatisfy { $0.key.hasPrefix("tts.\(id).") }, id)
+        }
+        let unknown = VoiceConfigurationParser.typedFields(id: "acme_voice", kind: .tts)
+        XCTAssertTrue(unknown.contains { $0.key == "tts.acme_voice.model" })
+        XCTAssertTrue(unknown.contains { $0.key == "tts.acme_voice.language" })
+        XCTAssertTrue(unknown.contains { $0.key == "tts.acme_voice.voice" })
+        XCTAssertTrue(unknown.contains { $0.key == "tts.acme_voice.instruction" })
+    }
+
+    /// Streaming labels require positive evidence: a provider Conduit has no
+    /// catalog entry for must not be labeled streaming-capable.
+    func testUnknownTTSProviderDoesNotClaimStreamingCapability() {
+        let snapshot = VoiceConfigurationParser.parse(
+            profile: "default", schema: nil,
+            config: ["stt": ["enabled": true, "provider": "local"], "tts": ["provider": "acme_voice"]],
+            sttReadiness: ["providers": []],
+            ttsReadiness: ["providers": [["name": "Acme Voice", "tts_provider": "acme_voice", "status": "ready", "is_active": true]]],
+            environment: [:],
+            ttsToolsetConfigAvailable: true
+        )
+
+        let unknown = snapshot.ttsProviders.first { $0.descriptor.id == "acme_voice" }
+        XCTAssertEqual(unknown?.descriptor.displayName, "Acme Voice")
+        XCTAssertFalse(unknown?.descriptor.supportsStreaming ?? true)
+    }
+
+    /// Known streaming capability is catalogued from upstream evidence
+    /// (StreamingTTSProvider registrations: elevenlabs, openai, gemini,
+    /// xai) — and the claim stays attached to the right kind.
+    func testKnownStreamingTTSProvidersCarryPositiveEvidence() {
+        for id in ["elevenlabs", "xai", "gemini"] {
+            XCTAssertEqual(VoiceConfigurationParser.catalogDescriptor(id: id, kind: .tts)?.supportsStreaming, true, id)
+        }
+        XCTAssertEqual(VoiceConfigurationParser.catalogDescriptor(id: "elevenlabs", kind: .stt)?.supportsStreaming, false)
+    }
 }
 
 @MainActor

--- a/ConduitTests/HermesVoiceConfigurationServiceTests.swift
+++ b/ConduitTests/HermesVoiceConfigurationServiceTests.swift
@@ -631,34 +631,36 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
         XCTAssertFalse(fields.contains { $0.key == "tts.openai.instruction" })
     }
 
-    /// Upstream clamps speed to [0.25, 4.0] and parses it with float(), so
-    /// Conduit rejects out-of-range values instead of silently rewriting
-    /// them, accepts the comma decimal separator iOS decimal pads submit in
-    /// comma locales, and rejects clearing: Conduit's config transport can
-    /// only write strings, and an empty speed is an upstream parse error,
-    /// not "unset" (unlike base_url, which upstream treats as unset when
-    /// empty).
-    func testOpenAISpeedValidationRejectsValuesOutsideUpstreamRange() {
+    /// Upstream clamps OpenAI speech speed into [0.25, 4.0]
+    /// (`max(0.25, min(4.0, speed))`) and reads the stored value with
+    /// `float(config.get("speed", default))`, so an absent key restores
+    /// the default while a stored empty string would be a parse error.
+    /// Conduit therefore accepts empty/whitespace as a clear (removal),
+    /// accepts comma-decimal input, and rejects malformed or out-of-range
+    /// non-empty values instead of silently letting upstream clamp them.
+    func testOpenAISpeedValidationAcceptsClearAndRejectsInvalidValues() {
         XCTAssertNil(VoiceConfigurationParser.validationMessage(for: "1", key: "tts.openai.speed"))
         XCTAssertNil(VoiceConfigurationParser.validationMessage(for: "0.25", key: "tts.openai.speed"))
         XCTAssertNil(VoiceConfigurationParser.validationMessage(for: "4.0", key: "tts.openai.speed"))
         XCTAssertNil(VoiceConfigurationParser.validationMessage(for: "0,25", key: "tts.openai.speed"))
+        XCTAssertNil(VoiceConfigurationParser.validationMessage(for: "", key: "tts.openai.speed"))
+        XCTAssertNil(VoiceConfigurationParser.validationMessage(for: "   ", key: "tts.openai.speed"))
         XCTAssertNil(VoiceConfigurationParser.validationMessage(for: "", key: "tts.openai.base_url"))
-        XCTAssertNotNil(VoiceConfigurationParser.validationMessage(for: "", key: "tts.openai.speed"))
         XCTAssertNotNil(VoiceConfigurationParser.validationMessage(for: "0.1", key: "tts.openai.speed"))
         XCTAssertNotNil(VoiceConfigurationParser.validationMessage(for: "4.5", key: "tts.openai.speed"))
         XCTAssertNotNil(VoiceConfigurationParser.validationMessage(for: "0,1", key: "tts.openai.speed"))
         XCTAssertNotNil(VoiceConfigurationParser.validationMessage(for: "fast", key: "tts.openai.speed"))
     }
 
-    /// Clearing speed must be refused before any config write: the write
-    /// path cannot delete the key, and Hermes cannot parse an empty speed.
-    func testClearingOpenAISpeedIsRejectedBeforeConfigWrite() async {
+    /// Clearing speed (empty or whitespace-only) removes the override key
+    /// from the profile config — upstream's `.get("speed", default)`
+    /// fallback then applies — and the snapshot no longer carries the key.
+    func testClearingOpenAISpeedRemovesTheOverride() async throws {
         let requester = MockVoiceConfigurationRequester()
         requester.routes = [
             "/api/config": [
                 "stt": ["enabled": true, "provider": "openai"],
-                "tts": ["provider": "openai", "openai": ["speed": 1.5]]
+                "tts": ["provider": "openai", "openai": ["speed": 1.5, "voice": "alloy"]]
             ],
             "/api/tools/toolsets/stt/config": ["providers": []],
             "/api/tools/toolsets/tts/config": ["providers": []]
@@ -666,12 +668,31 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
         let service = HermesVoiceConfigurationService(requester: requester, profile: "default")
         await service.reload()
 
-        let saved = await service.save(value: "", for: "tts.openai.speed")
+        let saved = await service.save(value: "  ", for: "tts.openai.speed")
 
-        XCTAssertFalse(saved)
-        XCTAssertNotNil(service.errorMessage)
-        XCTAssertFalse(requester.recorded.contains { $0.method == "PUT" && $0.path == "/api/config" })
-        XCTAssertEqual(service.snapshot.values["tts.openai.speed"], "1.5")
+        XCTAssertTrue(saved)
+        let configPUT = requester.recorded.first { $0.method == "PUT" && $0.path == "/api/config" }
+        let openai = try XCTUnwrap(
+            ((configPUT?.body?["config"] as? [String: Any])?["tts"] as? [String: Any])?["openai"] as? [String: Any]
+        )
+        XCTAssertNil(openai["speed"])
+        XCTAssertEqual(openai["voice"] as? String, "alloy")
+        XCTAssertNil(service.snapshot.values["tts.openai.speed"])
+    }
+
+    /// Locale canonicalization is scoped to the validated ranged decimal:
+    /// an unrelated non-ranged decimal value such as a StepFun sample rate
+    /// of "24,000" must pass through untouched.
+    func testCommaCanonicalizationDoesNotRewriteUnrangedDecimalFields() {
+        XCTAssertEqual(
+            VoiceConfigurationParser.storedValue(for: "1,5", key: "tts.openai.speed"),
+            "1.5"
+        )
+        XCTAssertEqual(
+            VoiceConfigurationParser.storedValue(for: "24,000", key: "tts.stepfun.sample_rate"),
+            "24,000"
+        )
+        XCTAssertNil(VoiceConfigurationParser.validationMessage(for: "24,000", key: "tts.stepfun.sample_rate"))
     }
 
     /// Comma-decimal input from locale decimal pads is canonicalized to the
@@ -788,7 +809,8 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
         await service.reload()
         XCTAssertEqual(service.snapshot.values["tts.openai.base_url"], "https://tts.example.com/v1")
 
-        let saved = await service.save(value: "", for: "tts.openai.base_url")
+        // Whitespace-only input is a clear, never a persisted override.
+        let saved = await service.save(value: "   ", for: "tts.openai.base_url")
 
         XCTAssertTrue(saved)
         let configPUT = requester.recorded.first { $0.method == "PUT" && $0.path == "/api/config" }

--- a/ConduitTests/HermesVoiceConfigurationServiceTests.swift
+++ b/ConduitTests/HermesVoiceConfigurationServiceTests.swift
@@ -829,6 +829,30 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
         XCTAssertNil(service.snapshot.values["tts.elevenlabs.voice_id"])
     }
 
+    /// A failed config PUT must leave the snapshot matching the server: the
+    /// in-memory values only update once the write is confirmed, so the
+    /// settings UI never shows a cleared override that did not persist.
+    func testFailedClearKeepsSnapshotConsistentWithServer() async {
+        let requester = MockVoiceConfigurationRequester()
+        requester.routes = [
+            "/api/config": [
+                "stt": ["enabled": true, "provider": "openai"],
+                "tts": ["provider": "openai", "openai": ["base_url": "https://tts.example.com/v1"]]
+            ],
+            "/api/tools/toolsets/stt/config": ["providers": []],
+            "/api/tools/toolsets/tts/config": ["providers": []]
+        ]
+        requester.failingPUTPaths = ["/api/config"]
+        let service = HermesVoiceConfigurationService(requester: requester, profile: "default")
+        await service.reload()
+
+        let saved = await service.save(value: "", for: "tts.openai.base_url")
+
+        XCTAssertFalse(saved)
+        XCTAssertNotNil(service.errorMessage)
+        XCTAssertEqual(service.snapshot.values["tts.openai.base_url"], "https://tts.example.com/v1")
+    }
+
     /// Hermes keys ElevenLabs TTS as `voice_id`/`model_id`
     /// (tools/tts_tool_providers.py) and reads `base_url` for both
     /// whole-file and streaming synthesis. The old generic

--- a/ConduitTests/HermesVoiceConfigurationServiceTests.swift
+++ b/ConduitTests/HermesVoiceConfigurationServiceTests.swift
@@ -631,17 +631,73 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
         XCTAssertFalse(fields.contains { $0.key == "tts.openai.instruction" })
     }
 
-    /// Upstream clamps speed to [0.25, 4.0]. Conduit rejects out-of-range
-    /// values instead of silently rewriting them, and clearing (empty
-    /// string) always validates.
+    /// Upstream clamps speed to [0.25, 4.0] and parses it with float(), so
+    /// Conduit rejects out-of-range values instead of silently rewriting
+    /// them, accepts the comma decimal separator iOS decimal pads submit in
+    /// comma locales, and rejects clearing: Conduit's config transport can
+    /// only write strings, and an empty speed is an upstream parse error,
+    /// not "unset" (unlike base_url, which upstream treats as unset when
+    /// empty).
     func testOpenAISpeedValidationRejectsValuesOutsideUpstreamRange() {
         XCTAssertNil(VoiceConfigurationParser.validationMessage(for: "1", key: "tts.openai.speed"))
         XCTAssertNil(VoiceConfigurationParser.validationMessage(for: "0.25", key: "tts.openai.speed"))
         XCTAssertNil(VoiceConfigurationParser.validationMessage(for: "4.0", key: "tts.openai.speed"))
-        XCTAssertNil(VoiceConfigurationParser.validationMessage(for: "", key: "tts.openai.speed"))
+        XCTAssertNil(VoiceConfigurationParser.validationMessage(for: "0,25", key: "tts.openai.speed"))
+        XCTAssertNil(VoiceConfigurationParser.validationMessage(for: "", key: "tts.openai.base_url"))
+        XCTAssertNotNil(VoiceConfigurationParser.validationMessage(for: "", key: "tts.openai.speed"))
         XCTAssertNotNil(VoiceConfigurationParser.validationMessage(for: "0.1", key: "tts.openai.speed"))
         XCTAssertNotNil(VoiceConfigurationParser.validationMessage(for: "4.5", key: "tts.openai.speed"))
+        XCTAssertNotNil(VoiceConfigurationParser.validationMessage(for: "0,1", key: "tts.openai.speed"))
         XCTAssertNotNil(VoiceConfigurationParser.validationMessage(for: "fast", key: "tts.openai.speed"))
+    }
+
+    /// Clearing speed must be refused before any config write: the write
+    /// path cannot delete the key, and Hermes cannot parse an empty speed.
+    func testClearingOpenAISpeedIsRejectedBeforeConfigWrite() async {
+        let requester = MockVoiceConfigurationRequester()
+        requester.routes = [
+            "/api/config": [
+                "stt": ["enabled": true, "provider": "openai"],
+                "tts": ["provider": "openai", "openai": ["speed": 1.5]]
+            ],
+            "/api/tools/toolsets/stt/config": ["providers": []],
+            "/api/tools/toolsets/tts/config": ["providers": []]
+        ]
+        let service = HermesVoiceConfigurationService(requester: requester, profile: "default")
+        await service.reload()
+
+        let saved = await service.save(value: "", for: "tts.openai.speed")
+
+        XCTAssertFalse(saved)
+        XCTAssertNotNil(service.errorMessage)
+        XCTAssertFalse(requester.recorded.contains { $0.method == "PUT" && $0.path == "/api/config" })
+        XCTAssertEqual(service.snapshot.values["tts.openai.speed"], "1.5")
+    }
+
+    /// Comma-decimal input from locale decimal pads is canonicalized to the
+    /// "." form Hermes parses with float().
+    func testSavingCommaDecimalSpeedIsCanonicalizedForHermes() async throws {
+        let requester = MockVoiceConfigurationRequester()
+        requester.routes = [
+            "/api/config": [
+                "stt": ["enabled": true, "provider": "openai"],
+                "tts": ["provider": "openai"]
+            ],
+            "/api/tools/toolsets/stt/config": ["providers": []],
+            "/api/tools/toolsets/tts/config": ["providers": []]
+        ]
+        let service = HermesVoiceConfigurationService(requester: requester, profile: "default")
+        await service.reload()
+
+        let saved = await service.save(value: "1,5", for: "tts.openai.speed")
+
+        XCTAssertTrue(saved)
+        let configPUT = requester.recorded.first { $0.method == "PUT" && $0.path == "/api/config" }
+        let openai = try XCTUnwrap(
+            ((configPUT?.body?["config"] as? [String: Any])?["tts"] as? [String: Any])?["openai"] as? [String: Any]
+        )
+        XCTAssertEqual(openai["speed"] as? String, "1.5")
+        XCTAssertEqual(service.snapshot.values["tts.openai.speed"], "1.5")
     }
 
     /// The save path must refuse an out-of-range speed before any config
@@ -800,6 +856,34 @@ final class HermesVoiceConfigurationServiceTests: XCTestCase {
             XCTAssertEqual(VoiceConfigurationParser.catalogDescriptor(id: id, kind: .tts)?.supportsStreaming, true, id)
         }
         XCTAssertEqual(VoiceConfigurationParser.catalogDescriptor(id: "elevenlabs", kind: .stt)?.supportsStreaming, false)
+    }
+
+    /// Profiles configured before the ElevenLabs key fix may still carry the
+    /// legacy `voice`/`model`/`language` values. They stay visible in the
+    /// parsed values (so nothing is silently dropped), but no editor is
+    /// offered because upstream never reads them.
+    func testLegacyElevenLabsKeysRemainParsedWithoutEditors() {
+        let snapshot = VoiceConfigurationParser.parse(
+            profile: "default", schema: nil,
+            config: [
+                "stt": ["enabled": true, "provider": "local"],
+                "tts": [
+                    "provider": "elevenlabs",
+                    "elevenlabs": ["voice": "legacy-voice", "model": "legacy-model", "voice_id": "current-voice"]
+                ]
+            ],
+            sttReadiness: ["providers": []],
+            ttsReadiness: ["providers": [["name": "ElevenLabs", "tts_provider": "elevenlabs", "status": "ready", "is_active": true]]],
+            environment: [:],
+            ttsToolsetConfigAvailable: true
+        )
+
+        XCTAssertEqual(snapshot.values["tts.elevenlabs.voice"], "legacy-voice")
+        XCTAssertEqual(snapshot.values["tts.elevenlabs.model"], "legacy-model")
+        let elevenlabs = snapshot.ttsProviders.first { $0.descriptor.id == "elevenlabs" }
+        XCTAssertFalse(elevenlabs?.fields.contains { $0.key == "tts.elevenlabs.voice" } ?? true)
+        XCTAssertFalse(elevenlabs?.fields.contains { $0.key == "tts.elevenlabs.model" } ?? true)
+        XCTAssertTrue(elevenlabs?.fields.contains { $0.key == "tts.elevenlabs.voice_id" } ?? false)
     }
 }
 

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -754,7 +754,7 @@ final class VoiceConversationControllerTests: XCTestCase {
         let controller = VoiceConversationController(
             capture: MockCapture(permissionGranted: true),
             playback: playback,
-            gateway: MockGateway(startsPlaybackOnOpen: true),
+            gateway: MockGateway(deliversPCM: true),
             submit: { _ in true },
             interrupt: {}
         )
@@ -763,6 +763,38 @@ final class VoiceConversationControllerTests: XCTestCase {
 
         XCTAssertTrue(result.passed)
         XCTAssertEqual(playback.intentAtLastStart, .standalonePlayback)
+    }
+
+    /// A stream that connects but delivers no usable audio must not pass the
+    /// provider test: socket success alone says nothing about whether the
+    /// configured TTS provider actually speaks.
+    func testSpeechTestFailsWhenStreamDeliversNoAudio() async {
+        let controller = VoiceConversationController(
+            capture: MockCapture(permissionGranted: true),
+            playback: MockPlayback(),
+            gateway: MockGateway(startsPlaybackOnOpen: true),
+            submit: { _ in true },
+            interrupt: {}
+        )
+
+        let result = await controller.runSpeechTest(text: "test")
+
+        XCTAssertFalse(result.passed)
+    }
+
+    /// The success contract: meaningful speech data reached playback.
+    func testSpeechTestSucceedsWhenPCMIsDelivered() async {
+        let controller = VoiceConversationController(
+            capture: MockCapture(permissionGranted: true),
+            playback: MockPlayback(),
+            gateway: MockGateway(deliversPCM: true),
+            submit: { _ in true },
+            interrupt: {}
+        )
+
+        let result = await controller.runSpeechTest(text: "test")
+
+        XCTAssertTrue(result.passed)
     }
 
     func testConversationSpeechClaimsConversationPlaybackOwnership() async {
@@ -1116,7 +1148,7 @@ final class VoiceConversationControllerTests: XCTestCase {
     func testSpeechTestRouteChangeDoesNotLeakSuspensionState() async {
         let capture = MockCapture(permissionGranted: true)
         let playback = MockPlayback()
-        let gateway = MockGateway(transcript: "test", startsPlaybackOnOpen: true)
+        let gateway = MockGateway(transcript: "test", startsPlaybackOnOpen: true, deliversPCM: true)
         let policy = RoutePolicyBox(.speakerSafeHalfDuplex)
         let gate = InterruptGate()
         playback.drainGate = gate
@@ -1933,6 +1965,10 @@ private final class MockGateway: VoiceGatewayService {
     let transcriptionDelayNanoseconds: UInt64
     let startsPlaybackOnOpen: Bool
     let blocksFirstStreamAppend: Bool
+    /// When true, opening a stream immediately delivers one PCM chunk (and
+    /// the matching start control), mirroring a streaming provider that is
+    /// actually producing speech.
+    let deliversPCM: Bool
     private(set) var transcriptionCount = 0
     private(set) var stream: MockSpeechStream?
     private(set) var streams: [MockSpeechStream] = []
@@ -1941,12 +1977,14 @@ private final class MockGateway: VoiceGatewayService {
         transcript: String = "test",
         transcriptionDelayNanoseconds: UInt64 = 0,
         startsPlaybackOnOpen: Bool = false,
-        blocksFirstStreamAppend: Bool = false
+        blocksFirstStreamAppend: Bool = false,
+        deliversPCM: Bool = false
     ) {
         self.transcript = transcript
         self.transcriptionDelayNanoseconds = transcriptionDelayNanoseconds
         self.startsPlaybackOnOpen = startsPlaybackOnOpen
         self.blocksFirstStreamAppend = blocksFirstStreamAppend
+        self.deliversPCM = deliversPCM
     }
     func transcribe(_ audio: VoiceCapturedAudio) async throws -> String {
         transcriptionCount += 1
@@ -1955,7 +1993,8 @@ private final class MockGateway: VoiceGatewayService {
     }
     func openSpeechStream(onStart: @escaping @MainActor (Double) throws -> Void, onPCM16: @escaping @MainActor (Data, Double) throws -> Void, onEncodedAudio: @escaping @MainActor (Data) throws -> Void) async throws -> VoiceSpeechStream {
         openCount += 1
-        if startsPlaybackOnOpen { try onStart(24_000) }
+        if startsPlaybackOnOpen || deliversPCM { try onStart(24_000) }
+        if deliversPCM { try onPCM16(Data([0x01, 0x00, 0x02, 0x00]), 24_000) }
         let stream = MockSpeechStream(blocksAppend: blocksFirstStreamAppend && openCount == 1)
         self.stream = stream
         streams.append(stream)

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -816,6 +816,24 @@ final class VoiceConversationControllerTests: XCTestCase {
         XCTAssertEqual(playback.intentAtLastStart, .standalonePlayback)
     }
 
+    /// A PCM callback whose payload the playback service cannot accept
+    /// (an unaligned single byte schedules zero bytes) is NOT delivered
+    /// speech: the test must fail instead of passing on a fired callback.
+    func testSpeechTestFailsWhenOnlyUnalignedPCMIsDelivered() async {
+        let playback = MockPlayback()
+        let controller = VoiceConversationController(
+            capture: MockCapture(permissionGranted: true),
+            playback: playback,
+            gateway: MockGateway(deliversPartialPCM: true),
+            submit: { _ in true },
+            interrupt: {}
+        )
+
+        let result = await controller.runSpeechTest(text: "test")
+
+        XCTAssertFalse(result.passed)
+    }
+
     func testConversationSpeechClaimsConversationPlaybackOwnership() async {
         let playback = MockPlayback()
         let controller = VoiceConversationController(
@@ -1991,6 +2009,10 @@ private final class MockGateway: VoiceGatewayService {
     /// When true, opening a stream immediately delivers whole-file encoded
     /// audio, mirroring the whole-file fallback route.
     let deliversEncodedAudio: Bool
+    /// When true, opening a stream delivers a single unaligned PCM byte:
+    /// the playback service accepts zero bytes, so nothing was actually
+    /// scheduled for playback.
+    let deliversPartialPCM: Bool
     private(set) var transcriptionCount = 0
     private(set) var stream: MockSpeechStream?
     private(set) var streams: [MockSpeechStream] = []
@@ -2001,7 +2023,8 @@ private final class MockGateway: VoiceGatewayService {
         startsPlaybackOnOpen: Bool = false,
         blocksFirstStreamAppend: Bool = false,
         deliversPCM: Bool = false,
-        deliversEncodedAudio: Bool = false
+        deliversEncodedAudio: Bool = false,
+        deliversPartialPCM: Bool = false
     ) {
         self.transcript = transcript
         self.transcriptionDelayNanoseconds = transcriptionDelayNanoseconds
@@ -2009,6 +2032,7 @@ private final class MockGateway: VoiceGatewayService {
         self.blocksFirstStreamAppend = blocksFirstStreamAppend
         self.deliversPCM = deliversPCM
         self.deliversEncodedAudio = deliversEncodedAudio
+        self.deliversPartialPCM = deliversPartialPCM
     }
     func transcribe(_ audio: VoiceCapturedAudio) async throws -> String {
         transcriptionCount += 1
@@ -2017,9 +2041,10 @@ private final class MockGateway: VoiceGatewayService {
     }
     func openSpeechStream(onStart: @escaping @MainActor (Double) throws -> Void, onPCM16: @escaping @MainActor (Data, Double) throws -> Void, onEncodedAudio: @escaping @MainActor (Data) throws -> Void) async throws -> VoiceSpeechStream {
         openCount += 1
-        if startsPlaybackOnOpen || deliversPCM || deliversEncodedAudio { try onStart(24_000) }
+        if startsPlaybackOnOpen || deliversPCM || deliversEncodedAudio || deliversPartialPCM { try onStart(24_000) }
         if deliversPCM { try onPCM16(Data([0x01, 0x00, 0x02, 0x00]), 24_000) }
         if deliversEncodedAudio { try onEncodedAudio(Data([0xFF, 0xF3, 0x40, 0xC4])) }
+        if deliversPartialPCM { try onPCM16(Data([0x01]), 24_000) }
         let stream = MockSpeechStream(blocksAppend: blocksFirstStreamAppend && openCount == 1)
         self.stream = stream
         streams.append(stream)

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -797,6 +797,25 @@ final class VoiceConversationControllerTests: XCTestCase {
         XCTAssertTrue(result.passed)
     }
 
+    /// The whole-file fallback route counts as delivered speech: a provider
+    /// that cannot stream still passes the test when its encoded audio
+    /// actually reaches playback.
+    func testSpeechTestSucceedsWhenEncodedAudioIsDelivered() async {
+        let playback = MockPlayback()
+        let controller = VoiceConversationController(
+            capture: MockCapture(permissionGranted: true),
+            playback: playback,
+            gateway: MockGateway(deliversEncodedAudio: true),
+            submit: { _ in true },
+            interrupt: {}
+        )
+
+        let result = await controller.runSpeechTest(text: "test")
+
+        XCTAssertTrue(result.passed)
+        XCTAssertEqual(playback.intentAtLastStart, .standalonePlayback)
+    }
+
     func testConversationSpeechClaimsConversationPlaybackOwnership() async {
         let playback = MockPlayback()
         let controller = VoiceConversationController(
@@ -1969,6 +1988,9 @@ private final class MockGateway: VoiceGatewayService {
     /// the matching start control), mirroring a streaming provider that is
     /// actually producing speech.
     let deliversPCM: Bool
+    /// When true, opening a stream immediately delivers whole-file encoded
+    /// audio, mirroring the whole-file fallback route.
+    let deliversEncodedAudio: Bool
     private(set) var transcriptionCount = 0
     private(set) var stream: MockSpeechStream?
     private(set) var streams: [MockSpeechStream] = []
@@ -1978,13 +2000,15 @@ private final class MockGateway: VoiceGatewayService {
         transcriptionDelayNanoseconds: UInt64 = 0,
         startsPlaybackOnOpen: Bool = false,
         blocksFirstStreamAppend: Bool = false,
-        deliversPCM: Bool = false
+        deliversPCM: Bool = false,
+        deliversEncodedAudio: Bool = false
     ) {
         self.transcript = transcript
         self.transcriptionDelayNanoseconds = transcriptionDelayNanoseconds
         self.startsPlaybackOnOpen = startsPlaybackOnOpen
         self.blocksFirstStreamAppend = blocksFirstStreamAppend
         self.deliversPCM = deliversPCM
+        self.deliversEncodedAudio = deliversEncodedAudio
     }
     func transcribe(_ audio: VoiceCapturedAudio) async throws -> String {
         transcriptionCount += 1
@@ -1993,8 +2017,9 @@ private final class MockGateway: VoiceGatewayService {
     }
     func openSpeechStream(onStart: @escaping @MainActor (Double) throws -> Void, onPCM16: @escaping @MainActor (Data, Double) throws -> Void, onEncodedAudio: @escaping @MainActor (Data) throws -> Void) async throws -> VoiceSpeechStream {
         openCount += 1
-        if startsPlaybackOnOpen || deliversPCM { try onStart(24_000) }
+        if startsPlaybackOnOpen || deliversPCM || deliversEncodedAudio { try onStart(24_000) }
         if deliversPCM { try onPCM16(Data([0x01, 0x00, 0x02, 0x00]), 24_000) }
+        if deliversEncodedAudio { try onEncodedAudio(Data([0xFF, 0xF3, 0x40, 0xC4])) }
         let stream = MockSpeechStream(blocksAppend: blocksFirstStreamAppend && openCount == 1)
         self.stream = stream
         streams.append(stream)

--- a/docs/VOICE_SETTINGS.md
+++ b/docs/VOICE_SETTINGS.md
@@ -19,14 +19,18 @@ The OpenAI TTS provider accepts two endpoint overrides:
 - `tts.openai.base_url` — points Hermes at any OpenAI-compatible speech
   endpoint (for example `https://your-host/v1`). This configures the provider
   **Hermes** calls; it does not change the server Conduit connects to, and it
-  is not the Hermes dashboard URL.
+  is not the Hermes dashboard URL. Clearing the field removes the override
+  key from the profile config, returning the provider to its default.
 - `tts.openai.speed` — speech rate multiplier; Hermes accepts 0.25–4.0 and
   Conduit rejects values outside that range rather than rewriting them.
   Clearing the field is refused (Hermes cannot parse an empty speed);
   save `1` to restore the default rate.
 
 The ElevenLabs provider exposes the analogous `tts.elevenlabs.base_url`
-(applied by Hermes to both whole-file and streaming synthesis). Its
+(applied by Hermes to both whole-file and streaming synthesis); its
+`voice_id`/`model_id` editors write the keys upstream actually reads.
+Clearing any text override removes the key from the profile config — Hermes
+falls back to the provider default when a key is absent. Its
 `wss_url` key is intentionally not offered: Hermes derives it from
 `base_url` when unset.
 

--- a/docs/VOICE_SETTINGS.md
+++ b/docs/VOICE_SETTINGS.md
@@ -21,10 +21,13 @@ The OpenAI TTS provider accepts two endpoint overrides:
   **Hermes** calls; it does not change the server Conduit connects to, and it
   is not the Hermes dashboard URL. Clearing the field removes the override
   key from the profile config, returning the provider to its default.
-- `tts.openai.speed` — speech rate multiplier; Hermes accepts 0.25–4.0 and
-  Conduit rejects values outside that range rather than rewriting them.
-  Clearing the field is refused (Hermes cannot parse an empty speed);
-  save `1` to restore the default rate.
+- `tts.openai.speed` — speech rate multiplier. Upstream clamps values into
+  0.25–4.0; Conduit validates and refuses out-of-range or malformed input
+  rather than saving something upstream would silently rewrite, and accepts
+  comma decimals (`1,5` is stored as `1.5`). Clearing the field removes the
+  override key, restoring the upstream/global default. Note: this setting
+  applies to Hermes' whole-file OpenAI synthesis — upstream's current PCM
+  streaming implementation does not consume it.
 
 The ElevenLabs provider exposes the analogous `tts.elevenlabs.base_url`
 (applied by Hermes to both whole-file and streaming synthesis); its

--- a/docs/VOICE_SETTINGS.md
+++ b/docs/VOICE_SETTINGS.md
@@ -1,0 +1,53 @@
+# Voice settings & provider configuration
+
+How Conduit's Voice settings map onto the Hermes profile configuration, and
+what the provider endpoint overrides do and do not change.
+
+## Where TTS requests run
+
+All speech synthesis is relayed through the user's Hermes host: Conduit calls
+`/api/audio/speak-stream` (streamed PCM) on the Hermes server and falls back
+to `/api/audio/speak` (whole-file) when streaming is unavailable. Conduit
+never talks to TTS providers directly, and it never uses Hermes'
+`voice.client_direct` credential hand-off — provider API keys remain on the
+Hermes host, where Conduit can only see whether each key is set.
+
+## Custom OpenAI-compatible endpoints
+
+The OpenAI TTS provider accepts two endpoint overrides:
+
+- `tts.openai.base_url` — points Hermes at any OpenAI-compatible speech
+  endpoint (for example `https://your-host/v1`). This configures the provider
+  **Hermes** calls; it does not change the server Conduit connects to, and it
+  is not the Hermes dashboard URL.
+- `tts.openai.speed` — speech rate multiplier; Hermes accepts 0.25–4.0 and
+  Conduit rejects values outside that range rather than rewriting them.
+
+The ElevenLabs provider exposes the analogous `tts.elevenlabs.base_url`
+(applied by Hermes to both whole-file and streaming synthesis). Its
+`wss_url` key is intentionally not offered: Hermes derives it from
+`base_url` when unset.
+
+`tts.openai.instruction` is deliberately **not** editable: upstream Hermes
+resolves speaking style through the per-request TTS tool parameter and never
+reads that config key.
+
+## Streaming vs fallback
+
+OpenAI-compatible does not guarantee streaming compatibility. Hermes decides
+streaming per provider: when its configured provider has a chunked-PCM
+implementation, `/api/audio/speak-stream` returns streamed PCM; otherwise the
+server explicitly signals `fallback` and Conduit fetches whole-file audio
+from `/api/audio/speak`. A provider selected for streaming whose streaming
+request fails before producing audio also falls back client-side. Conduit's
+provider test therefore reports success only when audible speech data was
+actually delivered — a silent stream is a failed test, not a pass.
+
+## What Conduit does not expose
+
+Local-engine and server-administration knobs (Whisper device/compute
+settings, Piper paths and tuning, command-provider command definitions,
+warm/release commands, process environment) remain Hermes-host
+administration concerns and are intentionally not mirrored here. Unknown or
+plugin providers discovered by Hermes still appear in the pickers with the
+generic model/language/voice fields.

--- a/docs/VOICE_SETTINGS.md
+++ b/docs/VOICE_SETTINGS.md
@@ -22,6 +22,8 @@ The OpenAI TTS provider accepts two endpoint overrides:
   is not the Hermes dashboard URL.
 - `tts.openai.speed` — speech rate multiplier; Hermes accepts 0.25–4.0 and
   Conduit rejects values outside that range rather than rewriting them.
+  Clearing the field is refused (Hermes cannot parse an empty speed);
+  save `1` to restore the default rate.
 
 The ElevenLabs provider exposes the analogous `tts.elevenlabs.base_url`
 (applied by Hermes to both whole-file and streaming synthesis). Its


### PR DESCRIPTION
## Summary

Exposes the highest-value upstream Hermes TTS configuration that Conduit hid, via the existing typed provider-field table. No new configuration transport, no voice runtime changes.

**Now editable (all profile-scoped, saved through the existing `GET → PUT /api/config` dotted-key path):**

| Key | Provider | Notes |
|---|---|---|
| `tts.openai.base_url` | OpenAI (and managed Nous, which shares the section) | Any OpenAI-compatible `/audio/speech` endpoint; clearing removes the override key, restoring Hermes' default endpoint chain |
| `tts.openai.speed` | OpenAI / Nous | Validated locally against upstream's 0.25–4.0 clamp range; malformed or out-of-range input is rejected rather than saved, and comma decimals are canonicalized (`1,5` → `1.5`). Clearing (empty/whitespace) removes the override key — upstream reads the stored value with `float(config.get("speed", default))`, so an absent key restores the upstream/global default. Scope note: this setting drives Hermes' whole-file OpenAI synthesis; upstream's current PCM streaming implementation does not consume it |
| `tts.elevenlabs.base_url` | ElevenLabs | Applied by Hermes to both whole-file and streaming synthesis (`_elevenlabs_environment_kwargs`); clearing removes the override |
| `tts.elevenlabs.voice_id` / `model_id` | ElevenLabs | Fixed mapping — the previous generic editors wrote `voice`/`model`/`language`, keys upstream never reads; clearing removes the key so upstream's `.get(key, DEFAULT)` fallback applies |

**Clear semantics (one contract, upstream-driven).** Clearing any override — empty or whitespace-only input — **removes the key** from the profile config instead of writing a blank string. Hermes reads provider keys with `config.get(key, default)`, which only applies the default when the key is *absent*, so a stored `""` would be used verbatim and break synthesis; removal is behavior-identical for keys upstream treats as unset when empty (the endpoint overrides), and it fixes the same latent hazard in every pre-existing generic text editor. The clear decision and the persisted payload derive from one normalization: pasted leading/trailing padding is trimmed, interior whitespace is preserved verbatim. The one local-rejection rule: malformed or out-of-range *non-empty* speed numbers are refused, because upstream clamps them silently and Conduit prefers failing loud over saving something upstream would rewrite.

**Dead-key fixes (same table):** OpenAI/Nous TTS no longer offers `tts.openai.instruction` — upstream resolves speaking style through the per-request TTS tool parameter and never reads that config key. `tts.elevenlabs.wss_url` is deliberately deferred: upstream derives it from `base_url` when unset (`tools/tts_tool_providers.py:209-216`).

**Streaming labels:** unknown/plugin TTS providers are no longer labeled streaming-capable without positive evidence. The label is presentation-only — transport behavior is unchanged and still relies on Hermes' explicit `fallback` control plus Conduit's client-side fallback. Positive catalog entries added for elevenlabs/xai/gemini TTS, mirroring upstream's `StreamingTTSProvider` registry; the pre-existing stepfun/xiaomi_mimo entries are plugin rows observed live on real gateways (they stream through their own plugin implementations, not the upstream registry) and are kept, now with a comment explaining that distinction.

**TTS provider test:** success now requires audio that the playback service actually accepted — PCM counts only when `enqueuePCM16` scheduled a positive number of bytes (an unaligned chunk that schedules nothing fails the test), and encoded fallback audio counts only when non-empty data reached playback. A stream that connects and finishes silently cannot pass. `HermesSpeechStream`'s existing fallback protections are unchanged.

## Design notes

**Why a typed field table, not a schema-generated settings system?** Upstream `/api/config/schema` carries only the `stt.provider`/`tts.provider` enums — no per-provider field metadata (the bundled dashboard hardcodes its voice field list the same way, `apps/desktop/src/app/settings/constants.ts`). Provider discovery is already dynamic in Conduit (schema options + toolset readiness rows + current selection merge), so new/plugin providers appear automatically with generic model/language/voice fields; the typed table only adds the provider-specific keys a normal user actually needs to point Hermes at the endpoint and voice they want.

**Why local/server-administration knobs are excluded:** local-engine and server-administration settings (Whisper device/compute configuration, Piper paths and tuning, command-provider command definitions, warm/release commands, process environment, minimax region/pitch tuning, etc.) remain Hermes-host administration concerns. A Conduit user does not configure CUDA flags from a phone.

**Custom OpenAI-compatible endpoints vs streaming and fallback:** OpenAI-compatible does not guarantee streaming compatibility. Hermes streams PCM only for providers with chunked-PCM implementations; otherwise the server sends the explicit `fallback` control and Conduit fetches whole-file audio from `/api/audio/speak`. A provider selected for streaming whose streaming request fails before producing audio also falls back client-side — those protections are preserved, not weakened, and the provider test now proves actual delivered speech in both paths. One verified upstream limitation, documented rather than worked around: `OpenAIStreamer.stream` passes only model/voice/input/response_format, so the configured `tts.openai.speed` affects Hermes' whole-file synthesis path but is not consumed by upstream's current PCM streaming implementation. Conduit does not disable streaming when speed is customized and makes no upstream changes.

**API keys stay on Hermes:** no provider keys touch the client. Credential state remains is-set-only metadata via `/api/env`; this PR does not use Hermes' `voice.client_direct` / `/api/audio/voice-config` credential hand-off, and adds no provider SDKs.

**Voice runtime untouched:** zero changes to AVAudioSession ownership (`VoiceAudioSessionCoordinator`), VAD, barge-in thresholds or route classification, playback scheduling, session identity fencing, or haptics. The only `VoiceConversationController` change is the provider test's delivered-audio guard.

## Tests

TDD: `testSpeechTestFailsWhenStreamDeliversNoAudio` was run against unpatched main and failed (47 executed, 1 failure — the new test), proving the false positive, then passed with the guard.

New/extended coverage: field presence/keys/ranges, snapshot parsing of configured values, profile-scoped save (`?profile=` request scope), clear semantics (empty and whitespace-only, for text and speed; removal asserted on the PUT body, section pruning, and snapshot), comma canonicalization on the written config and its scoping (an unranged `24,000` sample rate passes through untouched; text overrides persist trimmed with interior whitespace preserved), out-of-range rejection before any write, provider scoping (no cross-provider field leaks), unknown-provider generic surface + no streaming claim, known-streaming evidence, legacy ElevenLabs keys parsed without editors, and speech-test no-audio failure / PCM success / encoded success / unaligned-PCM failure paths.

Verified on ios-mac (iPhone 17 Pro simulator) at the final head: focused `HermesVoiceConfigurationServiceTests` + `VoiceConversationControllerTests` all green (each new test individually confirmed in the xcodebuild log), and the full unit suite **2153/2153 green**.

## Known follow-ups (deliberately out of scope)

- Generic `.decimal` fields without declared ranges (e.g. `tts.stepfun.speed/volume/sample_rate`) accept whitespace-clears like all overrides but have no range validation and no comma canonicalization — pre-existing; needs the same ranged treatment once valid ranges are confirmed.
- `stt.elevenlabs.language` writes a key upstream doesn't read (`language_code`) — STT scope, deferred.
- `tts.elevenlabs.wss_url` — deferred because upstream derives it from `base_url` when unset.
- stepfun/xiaomi_mimo `supportsStreaming: true` reflects live plugin observation on real gateways, not the upstream builtin registry; revisit if a gateway's plugin loses streaming.

## Manual acceptance

Unit/simulator verification is complete (see Tests). The audible-speech checks need a device plus a real Hermes profile: open Voice settings → OpenAI TTS → set a custom base URL/model/voice/speed → leave and reopen (values persist) → run Play TTS (audible speech) → clear the base URL (override removed) → confirm default OpenAI still works → confirm a non-streaming provider succeeds through fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer validation for voice provider settings, including supported decimal ranges and whitespace handling.
  - Expanded voice provider configuration and streaming metadata for supported text-to-speech providers.
  - Added accessibility labels and hints for validation errors.

- **Bug Fixes**
  - Voice settings now accurately preserve confirmed server values after saving.
  - Clearing optional settings removes their overrides without affecting unrelated provider values.
  - Speech tests no longer report success when audio is empty or rejected.

- **Documentation**
  - Added documentation covering voice settings, provider overrides, validation, streaming, fallback behavior, and test semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->