### PR TITLE
fix(voice): harden Siri App Intent pending-launch lifecycle

### DIFF
--- a/Conduit/ConduitApp.swift
+++ b/Conduit/ConduitApp.swift
@@ -106,7 +106,10 @@ struct ConduitApp: App {
     }
 
     private var voiceIntentRouteKey: String {
-        "\(pendingVoiceIntents.revision):\(appState.isConnected):\(pendingVoiceIntents.pendingSource?.rawValue ?? "none")"
+        let connection = appState.voiceLaunchConnectionSnapshot()
+        // Phase (not a bare isConnected flag) so connecting → stableFailure
+        // re-evaluates the pending request while remaining disconnected.
+        return "\(pendingVoiceIntents.revision):\(connection.phase.rawValue):\(pendingVoiceIntents.pendingSource?.rawValue ?? "none")"
     }
 
     /// Deadline changes (new Siri enqueue / supersede) re-arm the wait; the
@@ -117,11 +120,13 @@ struct ConduitApp: App {
     }
 
     /// Resolves the pending voice launch once. Connected Siri/in-app routes
-    /// consume the request; expired external requests fail with a visible
-    /// error and are discarded so a later reconnect cannot resurrect them.
+    /// consume the request; expired or stable-failed external requests fail
+    /// with a visible error and are discarded so a later reconnect cannot
+    /// resurrect them.
     private func resolvePendingVoiceIntent() async {
         let router = PendingVoiceIntentRouter(store: pendingVoiceIntents)
-        let outcome = await router.routePending(isConnected: appState.isConnected) { intent in
+        let connection = appState.voiceLaunchConnectionSnapshot()
+        let outcome = await router.routePending(connection: connection) { intent in
             await appState.openVoiceConversation(intent)
         }
         if case .failed(let message) = outcome {

--- a/Conduit/ConduitApp.swift
+++ b/Conduit/ConduitApp.swift
@@ -109,7 +109,10 @@ struct ConduitApp: App {
         let connection = appState.voiceLaunchConnectionSnapshot()
         // Phase (not a bare isConnected flag) so connecting → stableFailure
         // re-evaluates the pending request while remaining disconnected.
-        return "\(pendingVoiceIntents.revision):\(connection.phase.rawValue):\(pendingVoiceIntents.pendingSource?.rawValue ?? "none")"
+        // Do not embed pendingSource: take() clears it without a revision
+        // bump, and openVoiceConversation’s @Published mutations would flip
+        // the key mid-handler and cancel the in-flight route task.
+        return "\(pendingVoiceIntents.revision):\(connection.phase.rawValue)"
     }
 
     /// Deadline changes (new Siri enqueue / supersede) re-arm the wait; the
@@ -142,7 +145,7 @@ struct ConduitApp: App {
         let remaining = deadline.timeIntervalSinceNow
         if remaining > 0 {
             do {
-                try await Task.sleep(nanoseconds: UInt64(remaining * 1_000_000_000))
+                try await Task.sleep(for: .seconds(remaining))
             } catch {
                 // Superseded/cancelled waiter must not resolve a different intent.
                 return

--- a/Conduit/ConduitApp.swift
+++ b/Conduit/ConduitApp.swift
@@ -122,35 +122,45 @@ struct ConduitApp: App {
         return "\(pendingVoiceIntents.revision):\(Int(deadline.timeIntervalSinceReferenceDate))"
     }
 
-    /// Resolves the pending voice launch once. Connected Siri/in-app routes
-    /// consume the request; expired or stable-failed external requests fail
-    /// with a visible error and are discarded so a later reconnect cannot
-    /// resurrect them.
+    /// Resolves the pending voice launch once. Ownership token: only the
+    /// claimed request may be routed or failed; a superseded completion is
+    /// discarded without publishing.
     private func resolvePendingVoiceIntent() async {
         let router = PendingVoiceIntentRouter(store: pendingVoiceIntents)
         let connection = appState.voiceLaunchConnectionSnapshot()
         let outcome = await router.routePending(connection: connection) { intent in
             await appState.openVoiceConversation(intent)
         }
-        if case .failed(let message) = outcome {
+        switch outcome {
+        case .failed(let message):
             appState.errorMessage = message
+        case .idle, .routed, .deferred, .superseded:
+            break
         }
     }
 
-    /// Siri external launches are bounded: when the launch window ends
-    /// without Hermes becoming ready, fail the request immediately instead of
-    /// leaving it pending across an arbitrary later reconnect.
+    /// Authoritative 30s backstop. Sleeps on the monotonic clock, then
+    /// expires the exact claim that armed the wait — never routes through
+    /// generic readiness (which could return `.waiting` again).
     private func waitOutPendingVoiceDeadline() async {
-        guard let deadline = pendingVoiceIntents.pendingExternalLaunchDeadline else { return }
-        let remaining = deadline.timeIntervalSinceNow
-        if remaining > 0 {
+        guard let claim = pendingVoiceIntents.peekClaim(),
+              let elapsedDeadline = claim.intent.externalLaunchElapsedDeadline else {
+            return
+        }
+        let now = ContinuousClock.now
+        if now < elapsedDeadline {
             do {
-                try await Task.sleep(for: .seconds(remaining))
+                try await Task.sleep(for: now.duration(to: elapsedDeadline))
             } catch {
                 // Superseded/cancelled waiter must not resolve a different intent.
                 return
             }
         }
-        await resolvePendingVoiceIntent()
+        guard let expired = pendingVoiceIntents.expireClaimIfCurrent(claim) else {
+            return
+        }
+        if expired.source == .siri {
+            appState.errorMessage = PendingVoiceLaunchPolicy.expiredFailureMessage
+        }
     }
 }

--- a/Conduit/ConduitApp.swift
+++ b/Conduit/ConduitApp.swift
@@ -94,11 +94,10 @@ struct ConduitApp: App {
                 }
             }
             .task(id: voiceIntentRouteKey) {
-                guard appState.isConnected else { return }
-                let router = PendingVoiceIntentRouter(store: pendingVoiceIntents)
-                await router.routePending { intent in
-                    await appState.openVoiceConversation(intent)
-                }
+                await resolvePendingVoiceIntent()
+            }
+            .task(id: voiceIntentDeadlineKey) {
+                await waitOutPendingVoiceDeadline()
             }
     }
 
@@ -107,6 +106,43 @@ struct ConduitApp: App {
     }
 
     private var voiceIntentRouteKey: String {
-        "\(pendingVoiceIntents.revision):\(appState.isConnected)"
+        "\(pendingVoiceIntents.revision):\(appState.isConnected):\(pendingVoiceIntents.pendingSource?.rawValue ?? "none")"
+    }
+
+    /// Deadline changes (new Siri enqueue / supersede) re-arm the wait; the
+    /// revision already covers every other store mutation.
+    private var voiceIntentDeadlineKey: String {
+        guard let deadline = pendingVoiceIntents.pendingExternalLaunchDeadline else { return "none" }
+        return "\(pendingVoiceIntents.revision):\(Int(deadline.timeIntervalSinceReferenceDate))"
+    }
+
+    /// Resolves the pending voice launch once. Connected Siri/in-app routes
+    /// consume the request; expired external requests fail with a visible
+    /// error and are discarded so a later reconnect cannot resurrect them.
+    private func resolvePendingVoiceIntent() async {
+        let router = PendingVoiceIntentRouter(store: pendingVoiceIntents)
+        let outcome = await router.routePending(isConnected: appState.isConnected) { intent in
+            await appState.openVoiceConversation(intent)
+        }
+        if case .failed(let message) = outcome {
+            appState.errorMessage = message
+        }
+    }
+
+    /// Siri external launches are bounded: when the launch window ends
+    /// without Hermes becoming ready, fail the request immediately instead of
+    /// leaving it pending across an arbitrary later reconnect.
+    private func waitOutPendingVoiceDeadline() async {
+        guard let deadline = pendingVoiceIntents.pendingExternalLaunchDeadline else { return }
+        let remaining = deadline.timeIntervalSinceNow
+        if remaining > 0 {
+            do {
+                try await Task.sleep(nanoseconds: UInt64(remaining * 1_000_000_000))
+            } catch {
+                // Superseded/cancelled waiter must not resolve a different intent.
+                return
+            }
+        }
+        await resolvePendingVoiceIntent()
     }
 }

--- a/Conduit/Intents/StartVoiceConversationIntent.swift
+++ b/Conduit/Intents/StartVoiceConversationIntent.swift
@@ -40,12 +40,35 @@ struct ConduitProfileEntityQuery: EntityQuery {
 }
 
 /// Siri deliberately launches Conduit before a microphone is opened. The root
-/// scene consumes this pending request once its existing connection is ready.
+/// scene consumes this pending request once Hermes is ready — or fails it so
+/// a stale Siri launch cannot open Voice much later.
+///
+/// Foreground-first: `perform()` only records the request. It never opens the
+/// microphone or a full voice conversation inside the App Intent context.
 @available(iOS 16.0, *)
 struct StartVoiceConversationIntent: AppIntent {
     static var title: LocalizedStringResource = "Talk to Conduit"
     static var description = IntentDescription("Open Conduit and start a voice conversation.")
+
+    /// iOS 26+ deprecates `openAppWhenRun` in favor of `supportedModes`. This
+    /// redeclaration stays only for iOS 17–25 (the project's deployment
+    /// floor) and is marked deprecated at the same OS boundary so current-SDK
+    /// builds do not emit a normal deprecation warning. On iOS 26+,
+    /// `supportedModes` is the modern declaration; both express the same
+    /// foreground-first contract.
+    ///
+    /// The value must be a boolean literal: the App Intents metadata
+    /// processor rejects computed/unknown values for this property.
+    @available(iOS, deprecated: 26.0, message: "Use supportedModes on iOS 26+; retained for iOS 17–25.")
     static var openAppWhenRun: Bool = true
+
+    /// Bring Conduit to the foreground before the pending voice launch is
+    /// consumed. Never background-only: microphone capture and the voice
+    /// conversation belong to the foreground app scene.
+    @available(iOS 26.0, *)
+    static var supportedModes: IntentModes {
+        .foreground(.immediate)
+    }
 
     @Parameter(title: "Profile") var profile: ConduitProfileEntity?
 
@@ -54,11 +77,9 @@ struct StartVoiceConversationIntent: AppIntent {
     init(profile: ConduitProfileEntity?) { self.profile = profile }
 
     func perform() async throws -> some IntentResult {
-        let selectedProfile = profile?.id
+        let pending = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: profile?.id)
         await MainActor.run {
-            PendingVoiceIntentStore.shared.enqueue(
-                PendingVoiceIntent(profile: selectedProfile, startsFreshConversation: true, source: .siri)
-            )
+            PendingVoiceIntentStore.shared.enqueue(pending)
         }
         return .result()
     }

--- a/Conduit/Services/ConnectionFailure.swift
+++ b/Conduit/Services/ConnectionFailure.swift
@@ -219,6 +219,10 @@ struct ConnectionFailurePresentation: Equatable {
     /// Whether Try Again / Troubleshoot Connection actions accompany this
     /// failure.
     let offersRecoveryActions: Bool
+    /// Typed failure when this presentation wraps a classified connection
+    /// error. Nil for hand-authored notices — a notice is not proof of a
+    /// specific ConnectionFailure (e.g. login required).
+    let classifiedFailure: ConnectionFailure?
 
     /// Presentation for a classified connection failure, with recovery
     /// actions and the classified help destination. Rate limiting is the one
@@ -229,7 +233,8 @@ struct ConnectionFailurePresentation: Equatable {
             title: failure.userTitle,
             message: failure.userMessage,
             helpDestination: failure.helpDestination,
-            offersRecoveryActions: failure != .rateLimited
+            offersRecoveryActions: failure != .rateLimited,
+            classifiedFailure: failure
         )
     }
 
@@ -240,7 +245,8 @@ struct ConnectionFailurePresentation: Equatable {
             title: title,
             message: message,
             helpDestination: nil,
-            offersRecoveryActions: false
+            offersRecoveryActions: false,
+            classifiedFailure: nil
         )
     }
 }

--- a/Conduit/Voice/VoiceTypes.swift
+++ b/Conduit/Voice/VoiceTypes.swift
@@ -104,13 +104,13 @@ struct PendingVoiceIntent: Equatable {
     var profile: String?
     var startsFreshConversation: Bool
     var source: Source
-    /// Absolute time after which this request must not start voice.
-    /// Stamped once when a Siri launch is enqueued; nil for in-app launches
-    /// that may wait for a later reconnect without expiring. In-memory only —
-    /// App Intent execution for this main-app target shares the process with
-    /// the scene, so the request never crosses a cold-launch persistence
-    /// boundary that would require UserDefaults.
+    /// Wall-clock deadline metadata (tests / identity). The actual timeout
+    /// wait uses `externalLaunchElapsedDeadline` so a backward clock step
+    /// cannot extend the Siri budget.
     var externalLaunchDeadline: Date? = nil
+    /// Monotonic elapsed deadline armed at enqueue. Authoritative for the
+    /// deadline waiter; nil for requests with no external budget.
+    var externalLaunchElapsedDeadline: ContinuousClock.Instant? = nil
 
     enum Source: String, Equatable { case composer, wakePhrase, siri }
 }

--- a/Conduit/Voice/VoiceTypes.swift
+++ b/Conduit/Voice/VoiceTypes.swift
@@ -104,6 +104,13 @@ struct PendingVoiceIntent: Equatable {
     var profile: String?
     var startsFreshConversation: Bool
     var source: Source
+    /// Absolute time after which this request must not start voice.
+    /// Stamped once when a Siri launch is enqueued; nil for in-app launches
+    /// that may wait for a later reconnect without expiring. In-memory only —
+    /// App Intent execution for this main-app target shares the process with
+    /// the scene, so the request never crosses a cold-launch persistence
+    /// boundary that would require UserDefaults.
+    var externalLaunchDeadline: Date?
 
     enum Source: String, Equatable { case composer, wakePhrase, siri }
 }

--- a/Conduit/Voice/VoiceTypes.swift
+++ b/Conduit/Voice/VoiceTypes.swift
@@ -110,7 +110,7 @@ struct PendingVoiceIntent: Equatable {
     /// App Intent execution for this main-app target shares the process with
     /// the scene, so the request never crosses a cold-launch persistence
     /// boundary that would require UserDefaults.
-    var externalLaunchDeadline: Date?
+    var externalLaunchDeadline: Date? = nil
 
     enum Source: String, Equatable { case composer, wakePhrase, siri }
 }

--- a/Conduit/Voice/Wake/PendingVoiceIntentStore.swift
+++ b/Conduit/Voice/Wake/PendingVoiceIntentStore.swift
@@ -77,11 +77,15 @@ final class PendingVoiceIntentRouter {
     /// - Expired external (Siri) requests are consumed and reported failed —
     ///   they never wait for a later reconnect.
     /// - Connected requests are consumed exactly once via `handler`.
+    /// - Stable connection/auth failures (positive evidence, not connecting)
+    ///   terminal-fail Siri launches immediately — the deadline is only a
+    ///   backstop for inconclusive states.
     /// - A false handler result requeues only in-app launches; Siri launches
     ///   fail terminally so Voice cannot open minutes later.
-    /// - Not-ready requests are retained without calling the handler.
+    /// - Connecting / inconclusive requests are retained without calling the
+    ///   handler.
     func routePending(
-        isConnected: Bool,
+        connection: VoiceLaunchConnectionSnapshot,
         now: Date = Date(),
         using handler: Handler
     ) async -> PendingVoiceIntentRouteOutcome {
@@ -89,7 +93,7 @@ final class PendingVoiceIntentRouter {
 
         switch PendingVoiceLaunchPolicy.readiness(
             for: intent,
-            isConnected: isConnected,
+            connection: connection,
             now: now
         ) {
         case .failed(let message):

--- a/Conduit/Voice/Wake/PendingVoiceIntentStore.swift
+++ b/Conduit/Voice/Wake/PendingVoiceIntentStore.swift
@@ -6,62 +6,124 @@
 import Foundation
 import Combine
 
+/// Ownership token for one pending Siri launch. A claim is only valid while
+/// `generation` still matches the store: any enqueue/clear invalidates it.
+struct PendingVoiceIntentClaim: Equatable {
+    let generation: UInt64
+    let intent: PendingVoiceIntent
+}
+
+/// In-memory mailbox for the single pending external voice launch.
+///
+/// Production enqueue path is the Siri App Intent. Composer calls
+/// `openVoiceConversation` directly and does not use this store.
+///
+/// Invariant: async work started for claim N may only mutate the store when
+/// the claim is still current. Superseded/cleared/expired claims are no-ops.
 @MainActor
 final class PendingVoiceIntentStore: ObservableObject {
     static let shared = PendingVoiceIntentStore()
 
+    /// SwiftUI routing revision. Bumped only on real launches (enqueue) and
+    /// terminal consumption that should re-evaluate the scene (clear / expire).
+    /// Deliberately not bumped on deferred requeues — that would hot-loop
+    /// `.task(id: revision…)` while Hermes is still connecting.
     @Published private(set) var revision: UInt64 = 0
+    /// Monotonic ownership generation. Bumped on every enqueue and clear.
+    private(set) var ownershipGeneration: UInt64 = 0
     private var pending: PendingVoiceIntent?
 
-    /// True while an enqueued intent has not been routed. The store owns this
-    /// fact; presentation decisions (e.g. the preferred return surface) read
-    /// it rather than duplicating routing logic.
     var hasPendingIntent: Bool { pending != nil }
 
-    /// Absolute deadline of the pending external launch, if any.
     var pendingExternalLaunchDeadline: Date? { pending?.externalLaunchDeadline }
 
     var pendingSource: PendingVoiceIntent.Source? { pending?.source }
 
-    /// Test seam: the profile of the still-pending request, if any.
     var pendingProfile: String? { pending?.profile }
 
+    /// Claim without consuming — used by the deadline waiter before sleep.
+    func peekClaim() -> PendingVoiceIntentClaim? {
+        guard let intent = pending else { return nil }
+        return PendingVoiceIntentClaim(generation: ownershipGeneration, intent: intent)
+    }
+
     func enqueue(_ intent: PendingVoiceIntent) {
-        // One voice sheet can only honor one launch request. The newest source
-        // is intentional: it reflects the user's latest explicit action.
+        // Newest explicit launch wins. Bumping ownershipGeneration invalidates
+        // any in-flight claim for a previous request.
         pending = intent
+        ownershipGeneration &+= 1
         revision &+= 1
     }
 
-    /// Puts a temporarily-unroutable request back without treating it as a
-    /// new launch. A newer explicit enqueue (revision already advanced) wins;
-    /// this never resurrects an older request over a newer one. Skipping the
-    /// revision bump keeps the scene's revision-keyed task from hot-looping
-    /// while Hermes is still connecting.
-    func requeueAsDeferred(_ intent: PendingVoiceIntent) {
-        guard pending == nil else { return }
-        pending = intent
+    /// Claim the pending request for routing. Clears the slot; the claim's
+    /// generation stays valid until enqueue/clear/expiry.
+    func takeClaim() -> PendingVoiceIntentClaim? {
+        guard let intent = pending else { return nil }
+        pending = nil
+        return PendingVoiceIntentClaim(generation: ownershipGeneration, intent: intent)
     }
 
-    func take() -> PendingVoiceIntent? {
-        let value = pending
+    func isClaimCurrent(_ claim: PendingVoiceIntentClaim) -> Bool {
+        claim.generation == ownershipGeneration
+    }
+
+    /// Restore a still-current claim without a revision bump (temporary
+    /// not-ready). No-op if a newer launch already claimed the slot.
+    @discardableResult
+    func requeueDeferred(_ claim: PendingVoiceIntentClaim) -> Bool {
+        guard isClaimCurrent(claim), pending == nil else { return false }
+        pending = claim.intent
+        return true
+    }
+
+    /// Authoritative consume for a still-current claim that was already taken
+    /// (slot empty) or still pending. Used for terminal outcomes after an
+    /// await — never restores the request.
+    @discardableResult
+    func consumeClaimIfCurrent(_ claim: PendingVoiceIntentClaim) -> PendingVoiceIntent? {
+        guard isClaimCurrent(claim) else { return nil }
         pending = nil
-        return value
+        return claim.intent
+    }
+
+    /// Hard-backstop expiry. Consumes the request only when the claim still
+    /// owns the store and the pending intent is still that exact claim.
+    /// Never leaves the same external request pending after firing.
+    @discardableResult
+    func expireClaimIfCurrent(_ claim: PendingVoiceIntentClaim) -> PendingVoiceIntent? {
+        guard isClaimCurrent(claim),
+              pending != nil,
+              pending == claim.intent else {
+            return nil
+        }
+        pending = nil
+        ownershipGeneration &+= 1
+        revision &+= 1
+        return claim.intent
     }
 
     func clear() {
         pending = nil
+        ownershipGeneration &+= 1
         revision &+= 1
     }
 }
 
-/// Result of one routing attempt. Terminal outcomes consume the request;
-/// only `.deferred` retains it for a later lifecycle pass.
+/// Result of one routing attempt.
 enum PendingVoiceIntentRouteOutcome: Equatable {
     case idle
     case routed
     case deferred
     case failed(message: String)
+    /// The claim was invalidated (clear / supersede) before completion.
+    /// Callers must not publish errors or touch a newer request.
+    case superseded
+}
+
+/// Terminal outcome when the launch handler could not open Voice.
+enum PendingVoiceHandlerFailure: Equatable {
+    case terminal(message: String)
+    case retryLater
 }
 
 @MainActor
@@ -74,22 +136,16 @@ final class PendingVoiceIntentRouter {
 
     /// Resolves the pending request against the current connection lifecycle.
     ///
-    /// - Expired external (Siri) requests are consumed and reported failed —
-    ///   they never wait for a later reconnect.
-    /// - Connected requests are consumed exactly once via `handler`.
-    /// - Stable connection/auth failures (positive evidence, not connecting)
-    ///   terminal-fail Siri launches immediately — the deadline is only a
-    ///   backstop for inconclusive states.
-    /// - A false handler result requeues only in-app launches; Siri launches
-    ///   fail terminally so Voice cannot open minutes later.
-    /// - Connecting / inconclusive requests are retained without calling the
-    ///   handler.
+    /// Ownership: only the claim taken here may requeue or report a terminal
+    /// result. After `await`, a stale claim returns `.superseded` and mutates
+    /// nothing.
     func routePending(
         connection: VoiceLaunchConnectionSnapshot,
         now: Date = Date(),
         using handler: Handler
     ) async -> PendingVoiceIntentRouteOutcome {
-        guard let intent = store.take() else { return .idle }
+        guard let claim = store.takeClaim() else { return .idle }
+        let intent = claim.intent
 
         switch PendingVoiceLaunchPolicy.readiness(
             for: intent,
@@ -97,23 +153,32 @@ final class PendingVoiceIntentRouter {
             now: now
         ) {
         case .failed(let message):
+            // Consumed by takeClaim; still current (no suspension yet).
             return .failed(message: message)
         case .waiting:
-            store.requeueAsDeferred(intent)
+            store.requeueDeferred(claim)
             return .deferred
         case .ready:
             break
         }
 
-        if await handler(intent) {
+        let didOpen = await handler(intent)
+
+        // Handler may suspend across profile switch / session create. If the
+        // store moved on, this completion is stale — no requeue, no error.
+        guard store.isClaimCurrent(claim) else {
+            return .superseded
+        }
+
+        if didOpen {
             return .routed
         }
 
-        switch PendingVoiceLaunchPolicy.handlerFailureOutcome(for: intent) {
-        case .failed(let message):
+        switch PendingVoiceLaunchPolicy.handlerFailure(for: intent) {
+        case .terminal(let message):
             return .failed(message: message)
-        case .ready, .waiting:
-            store.requeueAsDeferred(intent)
+        case .retryLater:
+            store.requeueDeferred(claim)
             return .deferred
         }
     }

--- a/Conduit/Voice/Wake/PendingVoiceIntentStore.swift
+++ b/Conduit/Voice/Wake/PendingVoiceIntentStore.swift
@@ -18,6 +18,14 @@ final class PendingVoiceIntentStore: ObservableObject {
     /// it rather than duplicating routing logic.
     var hasPendingIntent: Bool { pending != nil }
 
+    /// Absolute deadline of the pending external launch, if any.
+    var pendingExternalLaunchDeadline: Date? { pending?.externalLaunchDeadline }
+
+    var pendingSource: PendingVoiceIntent.Source? { pending?.source }
+
+    /// Test seam: the profile of the still-pending request, if any.
+    var pendingProfile: String? { pending?.profile }
+
     func enqueue(_ intent: PendingVoiceIntent) {
         // One voice sheet can only honor one launch request. The newest source
         // is intentional: it reflects the user's latest explicit action.
@@ -25,15 +33,35 @@ final class PendingVoiceIntentStore: ObservableObject {
         revision &+= 1
     }
 
+    /// Puts a temporarily-unroutable request back without treating it as a
+    /// new launch. A newer explicit enqueue (revision already advanced) wins;
+    /// this never resurrects an older request over a newer one. Skipping the
+    /// revision bump keeps the scene's revision-keyed task from hot-looping
+    /// while Hermes is still connecting.
+    func requeueAsDeferred(_ intent: PendingVoiceIntent) {
+        guard pending == nil else { return }
+        pending = intent
+    }
+
     func take() -> PendingVoiceIntent? {
-        defer { pending = nil }
-        return pending
+        let value = pending
+        pending = nil
+        return value
     }
 
     func clear() {
         pending = nil
         revision &+= 1
     }
+}
+
+/// Result of one routing attempt. Terminal outcomes consume the request;
+/// only `.deferred` retains it for a later lifecycle pass.
+enum PendingVoiceIntentRouteOutcome: Equatable {
+    case idle
+    case routed
+    case deferred
+    case failed(message: String)
 }
 
 @MainActor
@@ -44,11 +72,45 @@ final class PendingVoiceIntentRouter {
 
     init(store: PendingVoiceIntentStore = .shared) { self.store = store }
 
-    /// The UI/app-state integration calls this only after it is authenticated
-    /// and connected. A handler may return false to retain the intent for a
-    /// later lifecycle pass.
-    func routePending(using handler: Handler) async {
-        guard let intent = store.take() else { return }
-        if !(await handler(intent)) { store.enqueue(intent) }
+    /// Resolves the pending request against the current connection lifecycle.
+    ///
+    /// - Expired external (Siri) requests are consumed and reported failed —
+    ///   they never wait for a later reconnect.
+    /// - Connected requests are consumed exactly once via `handler`.
+    /// - A false handler result requeues only in-app launches; Siri launches
+    ///   fail terminally so Voice cannot open minutes later.
+    /// - Not-ready requests are retained without calling the handler.
+    func routePending(
+        isConnected: Bool,
+        now: Date = Date(),
+        using handler: Handler
+    ) async -> PendingVoiceIntentRouteOutcome {
+        guard let intent = store.take() else { return .idle }
+
+        switch PendingVoiceLaunchPolicy.readiness(
+            for: intent,
+            isConnected: isConnected,
+            now: now
+        ) {
+        case .failed(let message):
+            return .failed(message: message)
+        case .waiting:
+            store.requeueAsDeferred(intent)
+            return .deferred
+        case .ready:
+            break
+        }
+
+        if await handler(intent) {
+            return .routed
+        }
+
+        switch PendingVoiceLaunchPolicy.handlerFailureOutcome(for: intent) {
+        case .failed(let message):
+            return .failed(message: message)
+        case .ready, .waiting:
+            store.requeueAsDeferred(intent)
+            return .deferred
+        }
     }
 }

--- a/Conduit/Voice/Wake/PendingVoiceIntentStore.swift
+++ b/Conduit/Voice/Wake/PendingVoiceIntentStore.swift
@@ -76,16 +76,6 @@ final class PendingVoiceIntentStore: ObservableObject {
         return true
     }
 
-    /// Authoritative consume for a still-current claim that was already taken
-    /// (slot empty) or still pending. Used for terminal outcomes after an
-    /// await — never restores the request.
-    @discardableResult
-    func consumeClaimIfCurrent(_ claim: PendingVoiceIntentClaim) -> PendingVoiceIntent? {
-        guard isClaimCurrent(claim) else { return nil }
-        pending = nil
-        return claim.intent
-    }
-
     /// Hard-backstop expiry. Consumes the request only when the claim still
     /// owns the store and the pending intent is still that exact claim.
     /// Never leaves the same external request pending after firing.

--- a/Conduit/Voice/Wake/PendingVoiceLaunchPolicy.swift
+++ b/Conduit/Voice/Wake/PendingVoiceLaunchPolicy.swift
@@ -1,0 +1,97 @@
+//
+//  PendingVoiceLaunchPolicy.swift
+//  Conduit
+//
+//  Deterministic lifecycle for external voice launch requests (Siri).
+//  Voice is foreground-first: the App Intent only records a pending request,
+//  and the root scene consumes it after Hermes is ready — or fails it so an
+//  old Siri launch can never open Voice minutes later.
+//
+
+import Foundation
+
+/// Pure decisions for external (Siri) voice launches. Kept free of App
+/// Intents and networking so unit tests can cover the policy without
+/// mocking the framework or a live socket.
+enum PendingVoiceLaunchPolicy {
+    /// How long a Siri-triggered launch may wait for Hermes during the
+    /// foreground bootstrap before it is treated as unready and failed.
+    /// Long enough for saved-credential restore + first connect on a cold
+    /// launch; short enough that a later manual reconnect cannot resurrect
+    /// the same request.
+    static let externalLaunchBudget: TimeInterval = 30
+
+    /// User-visible explanation when an external launch cannot start voice.
+    static let disconnectedFailureMessage =
+        "Conduit could not connect to Hermes, so voice did not start. Ask again after the connection is restored."
+
+    /// User-visible explanation when a pending Siri request outlived its
+    /// launch window (stable failure or reconnect that arrived too late).
+    static let expiredFailureMessage =
+        "The Siri voice request expired before Hermes was ready. Ask Siri again now that Conduit is open."
+
+    static func normalizedProfile(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Builds the in-memory pending request for one Siri invocation.
+    /// The absolute deadline is stamped once at enqueue time so later
+    /// re-enqueues (temporary not-ready deferrals) cannot extend the window.
+    static func makeSiriPendingIntent(
+        profile: String?,
+        now: Date = Date(),
+        budget: TimeInterval = externalLaunchBudget
+    ) -> PendingVoiceIntent {
+        PendingVoiceIntent(
+            profile: normalizedProfile(profile),
+            startsFreshConversation: true,
+            source: .siri,
+            externalLaunchDeadline: now.addingTimeInterval(budget)
+        )
+    }
+
+    enum Readiness: Equatable {
+        /// Hermes is live — consume the request exactly once.
+        case ready
+        /// Foreground bootstrap / reconnect may still bring Hermes up.
+        case waiting
+        /// Terminal for this request: do not retain across later reconnects.
+        case failed(message: String)
+    }
+
+    /// Lifecycle decision for a pending external launch. Success is
+    /// connection-driven; the deadline only ends the wait so a stale Siri
+    /// request cannot fire after an unrelated reconnect.
+    static func readiness(
+        for intent: PendingVoiceIntent,
+        isConnected: Bool,
+        now: Date
+    ) -> Readiness {
+        if let deadline = intent.externalLaunchDeadline, now > deadline {
+            return .failed(message: expiredFailureMessage)
+        }
+        if isConnected {
+            return .ready
+        }
+        // In-app launches (composer / wake) have no deadline and keep the
+        // original "wait until connected" semantics. Siri requests inside
+        // their window also wait for the normal connection attempt.
+        return .waiting
+    }
+
+    /// Outcome when the launch handler reports it could not open Voice.
+    /// Siri launches are terminal: a failed or partial open must not sit
+    /// pending and surprise the user on a later reconnect. In-app launches
+    /// keep the existing defer-and-retry behavior.
+    static func handlerFailureOutcome(
+        for intent: PendingVoiceIntent
+    ) -> Readiness {
+        if intent.source == .siri {
+            return .failed(message: disconnectedFailureMessage)
+        }
+        return .waiting
+    }
+}
+

--- a/Conduit/Voice/Wake/PendingVoiceLaunchPolicy.swift
+++ b/Conduit/Voice/Wake/PendingVoiceLaunchPolicy.swift
@@ -49,12 +49,17 @@ extension AppState {
     /// failure means recorded lifecycle evidence (`lastConnectionFailure` or
     /// a presented login failure) — not merely “not connecting right now.”
     func voiceLaunchConnectionSnapshot() -> VoiceLaunchConnectionSnapshot {
-        VoiceLaunchConnectionSnapshot(
+        let loginRequiredOnlyEvidence = lastConnectionFailure == nil
+            && pendingLoginFailure != nil
+        return VoiceLaunchConnectionSnapshot(
             isConnected: isConnected,
             isConnecting: isConnecting,
             hasStableFailureEvidence: lastConnectionFailure != nil
                 || pendingLoginFailure != nil,
+            // Auth-required presentation is the positive evidence when the
+            // classifier has not recorded a typed failure yet.
             classifiedFailure: lastConnectionFailure
+                ?? (loginRequiredOnlyEvidence ? .loginRequired : nil)
         )
     }
 }

--- a/Conduit/Voice/Wake/PendingVoiceLaunchPolicy.swift
+++ b/Conduit/Voice/Wake/PendingVoiceLaunchPolicy.swift
@@ -45,21 +45,20 @@ struct VoiceLaunchConnectionSnapshot: Equatable {
 }
 
 extension AppState {
-    /// Deterministic snapshot for external voice-launch routing. Stable
-    /// failure means recorded lifecycle evidence (`lastConnectionFailure` or
-    /// a presented login failure) — not merely “not connecting right now.”
+    /// Deterministic snapshot for external voice-launch routing.
+    ///
+    /// Primary evidence is `lastConnectionFailure`. A presented login-required
+    /// failure is fallback evidence when the classifier is empty. Arbitrary
+    /// `.notice(...)` presentations are not proof of login-required and must
+    /// not synthesize stable failure.
     func voiceLaunchConnectionSnapshot() -> VoiceLaunchConnectionSnapshot {
-        let loginRequiredOnlyEvidence = lastConnectionFailure == nil
-            && pendingLoginFailure != nil
+        let fallbackFailure = pendingLoginFailure?.classifiedFailure
         return VoiceLaunchConnectionSnapshot(
             isConnected: isConnected,
             isConnecting: isConnecting,
             hasStableFailureEvidence: lastConnectionFailure != nil
-                || pendingLoginFailure != nil,
-            // Auth-required presentation is the positive evidence when the
-            // classifier has not recorded a typed failure yet.
-            classifiedFailure: lastConnectionFailure
-                ?? (loginRequiredOnlyEvidence ? .loginRequired : nil)
+                || fallbackFailure != nil,
+            classifiedFailure: lastConnectionFailure ?? fallbackFailure
         )
     }
 }
@@ -91,18 +90,21 @@ enum PendingVoiceLaunchPolicy {
     }
 
     /// Builds the in-memory pending request for one Siri invocation.
-    /// The absolute deadline is stamped once at enqueue time so later
-    /// re-enqueues (temporary not-ready deferrals) cannot extend the window.
+    /// Deadlines are stamped once at enqueue so later deferrals cannot extend
+    /// the window. `Date` is identity/test metadata; the waiter uses the
+    /// monotonic `ContinuousClock.Instant`.
     static func makeSiriPendingIntent(
         profile: String?,
         now: Date = Date(),
-        budget: TimeInterval = externalLaunchBudget
+        budget: TimeInterval = externalLaunchBudget,
+        clock: ContinuousClock = ContinuousClock()
     ) -> PendingVoiceIntent {
         PendingVoiceIntent(
             profile: normalizedProfile(profile),
             startsFreshConversation: true,
             source: .siri,
-            externalLaunchDeadline: now.addingTimeInterval(budget)
+            externalLaunchDeadline: now.addingTimeInterval(budget),
+            externalLaunchElapsedDeadline: clock.now.advanced(by: .seconds(budget))
         )
     }
 
@@ -132,22 +134,21 @@ enum PendingVoiceLaunchPolicy {
     /// - Connecting / inconclusive → wait (Siri window still open).
     /// - Stable failure (positive evidence, not connecting) → terminal fail
     ///   for Siri; do not wait out the deadline.
-    /// - Deadline expiry → terminal fail even if still inconclusive.
+    /// - Deadline metadata (`now >= deadline`) → terminal fail even if still
+    ///   inconclusive. The runtime waiter is authoritative in production;
+    ///   this Date check covers deterministic tests and the boundary case.
     static func readiness(
         for intent: PendingVoiceIntent,
         connection: VoiceLaunchConnectionSnapshot,
         now: Date
     ) -> Readiness {
-        if let deadline = intent.externalLaunchDeadline, now > deadline {
+        if let deadline = intent.externalLaunchDeadline, now >= deadline {
             return .failed(message: expiredFailureMessage)
         }
         switch connection.phase {
         case .connected:
             return .ready
         case .connecting, .inconclusive:
-            // In-app launches (composer / wake) have no deadline and keep
-            // “wait until connected.” Siri requests inside their window also
-            // wait for the normal connection attempt / bootstrap.
             return .waiting
         case .stableFailure:
             if intent.source == .siri {
@@ -158,15 +159,15 @@ enum PendingVoiceLaunchPolicy {
     }
 
     /// Outcome when the launch handler reports it could not open Voice.
-    /// Siri launches are terminal: a failed or partial open must not sit
-    /// pending and surprise the user on a later reconnect. In-app launches
-    /// keep the existing defer-and-retry behavior.
-    static func handlerFailureOutcome(
+    /// Production store traffic is Siri-only (Composer calls
+    /// `openVoiceConversation` directly). Siri launches are terminal so Voice
+    /// cannot open minutes later.
+    static func handlerFailure(
         for intent: PendingVoiceIntent
-    ) -> Readiness {
+    ) -> PendingVoiceHandlerFailure {
         if intent.source == .siri {
-            return .failed(message: disconnectedFailureMessage)
+            return .terminal(message: disconnectedFailureMessage)
         }
-        return .waiting
+        return .retryLater
     }
 }

--- a/Conduit/Voice/Wake/PendingVoiceLaunchPolicy.swift
+++ b/Conduit/Voice/Wake/PendingVoiceLaunchPolicy.swift
@@ -10,23 +10,72 @@
 
 import Foundation
 
+/// Connection facts the pending-voice router needs, derived once from
+/// `AppState` so the policy stays free of Combine / live app state.
+struct VoiceLaunchConnectionSnapshot: Equatable {
+    enum Phase: String, Equatable {
+        /// Hermes is live — consume the request exactly once.
+        case connected
+        /// A connect/reconnect attempt is in flight; keep waiting.
+        case connecting
+        /// Not connected, not connecting, and AppState recorded a real
+        /// login/connection failure (or auth-required presentation).
+        case stableFailure
+        /// Disconnected with no conclusive evidence yet — short cold-launch
+        /// window before async credential restore marks itself connecting.
+        case inconclusive
+    }
+
+    var isConnected: Bool
+    var isConnecting: Bool
+    /// Positive lifecycle evidence of a terminal failure for this launch.
+    /// Never inferred from `!isConnecting` alone.
+    var hasStableFailureEvidence: Bool
+    /// Classified failure when available (better user-facing copy).
+    var classifiedFailure: ConnectionFailure?
+
+    var phase: Phase {
+        if isConnected { return .connected }
+        // An in-flight attempt outranks a previous attempt's failure: the
+        // classifier often stays set until the next successful connect.
+        if isConnecting { return .connecting }
+        if hasStableFailureEvidence { return .stableFailure }
+        return .inconclusive
+    }
+}
+
+extension AppState {
+    /// Deterministic snapshot for external voice-launch routing. Stable
+    /// failure means recorded lifecycle evidence (`lastConnectionFailure` or
+    /// a presented login failure) — not merely “not connecting right now.”
+    func voiceLaunchConnectionSnapshot() -> VoiceLaunchConnectionSnapshot {
+        VoiceLaunchConnectionSnapshot(
+            isConnected: isConnected,
+            isConnecting: isConnecting,
+            hasStableFailureEvidence: lastConnectionFailure != nil
+                || pendingLoginFailure != nil,
+            classifiedFailure: lastConnectionFailure
+        )
+    }
+}
+
 /// Pure decisions for external (Siri) voice launches. Kept free of App
 /// Intents and networking so unit tests can cover the policy without
 /// mocking the framework or a live socket.
 enum PendingVoiceLaunchPolicy {
-    /// How long a Siri-triggered launch may wait for Hermes during the
-    /// foreground bootstrap before it is treated as unready and failed.
-    /// Long enough for saved-credential restore + first connect on a cold
-    /// launch; short enough that a later manual reconnect cannot resurrect
-    /// the same request.
+    /// Backstop budget for a Siri-triggered launch whose connection stays
+    /// inconclusive (never connected, never recorded a stable failure, never
+    /// finished the first bootstrap attempt). Not the primary failure
+    /// detector: known stable failures fail immediately via the snapshot.
     static let externalLaunchBudget: TimeInterval = 30
 
-    /// User-visible explanation when an external launch cannot start voice.
+    /// User-visible explanation when an external launch cannot start voice
+    /// and AppState has no classified failure to show.
     static let disconnectedFailureMessage =
         "Conduit could not connect to Hermes, so voice did not start. Ask again after the connection is restored."
 
     /// User-visible explanation when a pending Siri request outlived its
-    /// launch window (stable failure or reconnect that arrived too late).
+    /// launch window without a conclusive ready/failed outcome.
     static let expiredFailureMessage =
         "The Siri voice request expired before Hermes was ready. Ask Siri again now that Conduit is open."
 
@@ -61,24 +110,46 @@ enum PendingVoiceLaunchPolicy {
         case failed(message: String)
     }
 
-    /// Lifecycle decision for a pending external launch. Success is
-    /// connection-driven; the deadline only ends the wait so a stale Siri
-    /// request cannot fire after an unrelated reconnect.
+    /// User-facing failure copy for a stable connection failure. Prefer the
+    /// classified ConnectionFailure copy when AppState recorded one.
+    static func stableFailureMessage(
+        for connection: VoiceLaunchConnectionSnapshot
+    ) -> String {
+        if let failure = connection.classifiedFailure {
+            return "\(failure.userTitle). \(failure.userMessage) Voice did not start — ask Siri again after reconnecting."
+        }
+        return disconnectedFailureMessage
+    }
+
+    /// Lifecycle decision for a pending external launch.
+    ///
+    /// - Connected → ready (exactly once).
+    /// - Connecting / inconclusive → wait (Siri window still open).
+    /// - Stable failure (positive evidence, not connecting) → terminal fail
+    ///   for Siri; do not wait out the deadline.
+    /// - Deadline expiry → terminal fail even if still inconclusive.
     static func readiness(
         for intent: PendingVoiceIntent,
-        isConnected: Bool,
+        connection: VoiceLaunchConnectionSnapshot,
         now: Date
     ) -> Readiness {
         if let deadline = intent.externalLaunchDeadline, now > deadline {
             return .failed(message: expiredFailureMessage)
         }
-        if isConnected {
+        switch connection.phase {
+        case .connected:
             return .ready
+        case .connecting, .inconclusive:
+            // In-app launches (composer / wake) have no deadline and keep
+            // “wait until connected.” Siri requests inside their window also
+            // wait for the normal connection attempt / bootstrap.
+            return .waiting
+        case .stableFailure:
+            if intent.source == .siri {
+                return .failed(message: stableFailureMessage(for: connection))
+            }
+            return .waiting
         }
-        // In-app launches (composer / wake) have no deadline and keep the
-        // original "wait until connected" semantics. Siri requests inside
-        // their window also wait for the normal connection attempt.
-        return .waiting
     }
 
     /// Outcome when the launch handler reports it could not open Voice.
@@ -94,4 +165,3 @@ enum PendingVoiceLaunchPolicy {
         return .waiting
     }
 }
-

--- a/ConduitTests/PendingVoiceIntentLifecycleTests.swift
+++ b/ConduitTests/PendingVoiceIntentLifecycleTests.swift
@@ -4,7 +4,9 @@
 //
 //  Siri / external voice-launch lifecycle: exactly-once routing, profile
 //  preservation, and terminal failure so a stale Siri request can never open
-//  Voice after an unrelated reconnect.
+//  Voice after an unrelated reconnect. Connection readiness is lifecycle-
+//  driven (connecting vs stable failure vs inconclusive bootstrap); the
+//  30s deadline is only the inconclusive-state backstop.
 //
 
 import XCTest
@@ -22,6 +24,22 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
     override func tearDown() {
         store = nil
         super.tearDown()
+    }
+
+    private func connected() -> VoiceLaunchConnectionSnapshot {
+        .init(isConnected: true, isConnecting: false, hasStableFailureEvidence: false, classifiedFailure: nil)
+    }
+
+    private func connecting() -> VoiceLaunchConnectionSnapshot {
+        .init(isConnected: false, isConnecting: true, hasStableFailureEvidence: false, classifiedFailure: nil)
+    }
+
+    private func inconclusiveBootstrap() -> VoiceLaunchConnectionSnapshot {
+        .init(isConnected: false, isConnecting: false, hasStableFailureEvidence: false, classifiedFailure: nil)
+    }
+
+    private func stableFailure(_ failure: ConnectionFailure = .unreachable) -> VoiceLaunchConnectionSnapshot {
+        .init(isConnected: false, isConnecting: false, hasStableFailureEvidence: true, classifiedFailure: failure)
     }
 
     // MARK: - Siri intent factory
@@ -66,11 +84,81 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         XCTAssertEqual(
             PendingVoiceLaunchPolicy.readiness(
                 for: intent,
-                isConnected: false,
+                connection: stableFailure(),
                 now: .distantFuture
             ),
+            // In-app keeps defer-and-retry even on a classified failure.
             .waiting
         )
+    }
+
+    // MARK: - Connection phase derivation
+
+    func testSnapshotPhasePrefersConnectingOverPriorFailureEvidence() {
+        // lastConnectionFailure often remains set while a new attempt runs.
+        let snapshot = VoiceLaunchConnectionSnapshot(
+            isConnected: false,
+            isConnecting: true,
+            hasStableFailureEvidence: true,
+            classifiedFailure: .unreachable
+        )
+        XCTAssertEqual(snapshot.phase, .connecting)
+    }
+
+    func testSnapshotPhaseIsStableFailureOnlyWithPositiveEvidenceWhileIdle() {
+        XCTAssertEqual(
+            VoiceLaunchConnectionSnapshot(
+                isConnected: false,
+                isConnecting: false,
+                hasStableFailureEvidence: true,
+                classifiedFailure: .loginRequired
+            ).phase,
+            .stableFailure
+        )
+        XCTAssertEqual(inconclusiveBootstrap().phase, .inconclusive)
+        XCTAssertEqual(connected().phase, .connected)
+    }
+
+    func testRoutingKeyPhaseChangesWhenConnectingBecomesStableFailure() {
+        // ConduitApp.voiceIntentRouteKey embeds phase so a disconnect-only
+        // transition still re-evaluates the pending Siri request.
+        let connectingKey = "1:\(connecting().phase.rawValue):siri"
+        let failedKey = "1:\(stableFailure().phase.rawValue):siri"
+        XCTAssertNotEqual(connectingKey, failedKey)
+        XCTAssertEqual(connecting().phase.rawValue, "connecting")
+        XCTAssertEqual(stableFailure().phase.rawValue, "stableFailure")
+    }
+
+    func testAppStateVoiceLaunchSnapshotReflectsRecordedFailure() {
+        let suite = "PendingVoiceIntentLifecycleTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            return XCTFail("Failed to create test UserDefaults suite")
+        }
+        addTeardownBlock { defaults.removePersistentDomain(forName: suite) }
+        let appState = AppState(defaults: defaults, loadSavedConnection: false)
+
+        // Cold bootstrap: no positive failure evidence yet — not terminal.
+        appState.isConnected = false
+        appState.isConnecting = false
+        appState.lastConnectionFailure = nil
+        appState.pendingLoginFailure = nil
+        XCTAssertEqual(appState.voiceLaunchConnectionSnapshot().phase, .inconclusive)
+
+        // Connecting: still wait.
+        appState.isConnecting = true
+        XCTAssertEqual(appState.voiceLaunchConnectionSnapshot().phase, .connecting)
+
+        // Stable failure after the attempt ends: classified evidence.
+        appState.isConnecting = false
+        appState.lastConnectionFailure = .connectionRefused
+        let failed = appState.voiceLaunchConnectionSnapshot()
+        XCTAssertEqual(failed.phase, .stableFailure)
+        XCTAssertEqual(failed.classifiedFailure, .connectionRefused)
+
+        // Auth-required presentation is also positive evidence.
+        appState.lastConnectionFailure = nil
+        appState.pendingLoginFailure = .presenting(.loginRequired)
+        XCTAssertEqual(appState.voiceLaunchConnectionSnapshot().phase, .stableFailure)
     }
 
     // MARK: - Readiness / disconnected lifecycle
@@ -79,21 +167,68 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         let now = Date()
         let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, now: now)
         XCTAssertEqual(
-            PendingVoiceLaunchPolicy.readiness(for: intent, isConnected: true, now: now),
+            PendingVoiceLaunchPolicy.readiness(for: intent, connection: connected(), now: now),
             .ready
         )
     }
 
-    func testSiriLaunchWithinWindowWaitsWhileDisconnected() {
+    func testSiriLaunchWaitsWhileActivelyConnecting() {
         let now = Date()
-        let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, now: now, budget: 30)
+        let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, now: now)
         XCTAssertEqual(
             PendingVoiceLaunchPolicy.readiness(
                 for: intent,
-                isConnected: false,
+                connection: connecting(),
                 now: now.addingTimeInterval(1)
             ),
             .waiting
+        )
+    }
+
+    func testSiriLaunchWaitsDuringColdBootstrapWithoutFailureEvidence() {
+        let now = Date()
+        let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, now: now)
+        // !isConnected && !isConnecting is NOT terminal until failure evidence exists.
+        XCTAssertEqual(
+            PendingVoiceLaunchPolicy.readiness(
+                for: intent,
+                connection: inconclusiveBootstrap(),
+                now: now.addingTimeInterval(1)
+            ),
+            .waiting
+        )
+    }
+
+    func testKnownStableConnectionFailureFailsSiriBeforeDeadline() {
+        let now = Date()
+        let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, now: now, budget: 30)
+        let connection = stableFailure(.unreachable)
+        let message = PendingVoiceLaunchPolicy.stableFailureMessage(for: connection)
+
+        XCTAssertEqual(
+            PendingVoiceLaunchPolicy.readiness(
+                for: intent,
+                connection: connection,
+                now: now.addingTimeInterval(2)
+            ),
+            .failed(message: message)
+        )
+        // Classified copy wins over the generic disconnected string.
+        XCTAssertTrue(message.contains(ConnectionFailure.unreachable.userMessage))
+        XCTAssertNotEqual(message, PendingVoiceLaunchPolicy.disconnectedFailureMessage)
+    }
+
+    func testStableLoginRequiredFailureUsesClassifiedCopy() {
+        let now = Date()
+        let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, now: now)
+        let connection = stableFailure(.loginRequired)
+        XCTAssertEqual(
+            PendingVoiceLaunchPolicy.readiness(for: intent, connection: connection, now: now),
+            .failed(message: PendingVoiceLaunchPolicy.stableFailureMessage(for: connection))
+        )
+        XCTAssertTrue(
+            PendingVoiceLaunchPolicy.stableFailureMessage(for: connection)
+                .contains(ConnectionFailure.loginRequired.userTitle)
         )
     }
 
@@ -102,7 +237,7 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, now: now, budget: 30)
         let later = now.addingTimeInterval(31)
         XCTAssertEqual(
-            PendingVoiceLaunchPolicy.readiness(for: intent, isConnected: false, now: later),
+            PendingVoiceLaunchPolicy.readiness(for: intent, connection: inconclusiveBootstrap(), now: later),
             .failed(message: PendingVoiceLaunchPolicy.expiredFailureMessage)
         )
     }
@@ -113,7 +248,7 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, now: now, budget: 30)
         let minutesLater = now.addingTimeInterval(5 * 60)
         XCTAssertEqual(
-            PendingVoiceLaunchPolicy.readiness(for: intent, isConnected: true, now: minutesLater),
+            PendingVoiceLaunchPolicy.readiness(for: intent, connection: connected(), now: minutesLater),
             .failed(message: PendingVoiceLaunchPolicy.expiredFailureMessage)
         )
     }
@@ -127,14 +262,14 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
 
         var handled: [PendingVoiceIntent] = []
         let router = PendingVoiceIntentRouter(store: store)
-        let first = await router.routePending(isConnected: true) { intent in
+        let first = await router.routePending(connection: connected()) { intent in
             handled.append(intent)
             return true
         }
         XCTAssertEqual(first, .routed)
         XCTAssertFalse(store.hasPendingIntent)
 
-        let second = await router.routePending(isConnected: true) { intent in
+        let second = await router.routePending(connection: connected()) { intent in
             handled.append(intent)
             return true
         }
@@ -151,7 +286,7 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         let router = PendingVoiceIntentRouter(store: store)
         var handlerCalls = 0
 
-        let outcome = await router.routePending(isConnected: false) { _ in
+        let outcome = await router.routePending(connection: connecting()) { _ in
             handlerCalls += 1
             return true
         }
@@ -160,6 +295,62 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         XCTAssertTrue(store.hasPendingIntent)
         XCTAssertEqual(handlerCalls, 0)
         XCTAssertEqual(store.pendingSource, .siri)
+    }
+
+    func testActivelyConnectingDefersWithoutConsuming() async {
+        store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default"))
+        let router = PendingVoiceIntentRouter(store: store)
+        let outcome = await router.routePending(connection: connecting()) { _ in
+            XCTFail("Connecting must not invoke the voice handler")
+            return true
+        }
+        XCTAssertEqual(outcome, .deferred)
+        XCTAssertTrue(store.hasPendingIntent)
+    }
+
+    func testStableFailureConsumesSiriRequestImmediatelyBeforeDeadline() async {
+        store.enqueue(
+            PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default", budget: 30)
+        )
+        let router = PendingVoiceIntentRouter(store: store)
+        let connection = stableFailure(.hostNotFound)
+        var handlerCalls = 0
+
+        let outcome = await router.routePending(connection: connection) { _ in
+            handlerCalls += 1
+            return true
+        }
+
+        let expected = PendingVoiceLaunchPolicy.stableFailureMessage(for: connection)
+        XCTAssertEqual(outcome, .failed(message: expected))
+        XCTAssertFalse(store.hasPendingIntent)
+        XCTAssertEqual(handlerCalls, 0)
+    }
+
+    func testReconnectAfterStableFailureDoesNotLaunchStaleSiriVoice() async {
+        store.enqueue(
+            PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, budget: 30)
+        )
+        let router = PendingVoiceIntentRouter(store: store)
+
+        let failure = await router.routePending(connection: stableFailure(.timedOut)) { _ in
+            XCTFail("Stable failure must not invoke the voice handler")
+            return true
+        }
+        XCTAssertEqual(
+            failure,
+            .failed(message: PendingVoiceLaunchPolicy.stableFailureMessage(for: stableFailure(.timedOut)))
+        )
+
+        // Hermes is healthy again — but the store is empty.
+        var handled = 0
+        let afterReconnect = await router.routePending(connection: connected()) { _ in
+            handled += 1
+            return true
+        }
+        XCTAssertEqual(afterReconnect, .idle)
+        XCTAssertEqual(handled, 0)
+        XCTAssertFalse(store.hasPendingIntent)
     }
 
     func testExpiredDisconnectedSiriLaunchIsClearedNotRetained() async {
@@ -174,7 +365,7 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         let router = PendingVoiceIntentRouter(store: store)
         var handlerCalls = 0
 
-        let outcome = await router.routePending(isConnected: false, now: Date()) { _ in
+        let outcome = await router.routePending(connection: inconclusiveBootstrap(), now: Date()) { _ in
             handlerCalls += 1
             return true
         }
@@ -198,7 +389,7 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         )
         let router = PendingVoiceIntentRouter(store: store)
 
-        let failure = await router.routePending(isConnected: false, now: Date()) { _ in
+        let failure = await router.routePending(connection: inconclusiveBootstrap(), now: Date()) { _ in
             XCTFail("Expired Siri launch must not invoke the voice handler")
             return true
         }
@@ -207,9 +398,8 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
             .failed(message: PendingVoiceLaunchPolicy.expiredFailureMessage)
         )
 
-        // Hermes is healthy again — but the store is empty.
         var handled = 0
-        let afterReconnect = await router.routePending(isConnected: true) { _ in
+        let afterReconnect = await router.routePending(connection: connected()) { _ in
             handled += 1
             return true
         }
@@ -224,7 +414,7 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         )
         let router = PendingVoiceIntentRouter(store: store)
 
-        let outcome = await router.routePending(isConnected: true) { _ in false }
+        let outcome = await router.routePending(connection: connected()) { _ in false }
 
         XCTAssertEqual(
             outcome,
@@ -243,7 +433,7 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         )
         let router = PendingVoiceIntentRouter(store: store)
 
-        let outcome = await router.routePending(isConnected: true) { _ in false }
+        let outcome = await router.routePending(connection: connected()) { _ in false }
 
         XCTAssertEqual(outcome, .deferred)
         XCTAssertTrue(store.hasPendingIntent)
@@ -258,7 +448,7 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
 
         let router = PendingVoiceIntentRouter(store: store)
         var handled: [PendingVoiceIntent] = []
-        let outcome = await router.routePending(isConnected: true) { intent in
+        let outcome = await router.routePending(connection: connected()) { intent in
             handled.append(intent)
             return true
         }
@@ -277,7 +467,7 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         XCTAssertFalse(store.hasPendingIntent)
 
         let router = PendingVoiceIntentRouter(store: store)
-        let outcome = await router.routePending(isConnected: true) { _ in
+        let outcome = await router.routePending(connection: connected()) { _ in
             XCTFail("Cleared request must not route")
             return true
         }
@@ -303,15 +493,13 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         let afterEnqueue = store.revision
         let router = PendingVoiceIntentRouter(store: store)
 
-        let outcome = await router.routePending(isConnected: false) { _ in
+        let outcome = await router.routePending(connection: connecting()) { _ in
             XCTFail("Waiting must not call the handler")
             return true
         }
 
         XCTAssertEqual(outcome, .deferred)
         XCTAssertTrue(store.hasPendingIntent)
-        // A revision bump here would re-fire the scene's revision-keyed task
-        // in a hot loop while Hermes is still connecting.
         XCTAssertEqual(store.revision, afterEnqueue)
     }
 
@@ -319,14 +507,11 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         let older = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "old")
         let newer = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "new")
 
-        // requeue is only valid when the slot is empty (the same request was
-        // just taken). It must never overwrite a newer explicit enqueue.
         store.enqueue(newer)
         store.requeueAsDeferred(older)
 
         XCTAssertTrue(store.hasPendingIntent)
         XCTAssertEqual(store.pendingSource, .siri)
-        // Slot still holds the newer request: requeue was a no-op.
         XCTAssertEqual(store.pendingProfile, "new")
     }
 
@@ -341,17 +526,16 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         let originalDeadline = intent.externalLaunchDeadline
 
         let router = PendingVoiceIntentRouter(store: store)
-        _ = await router.routePending(isConnected: false, now: now.addingTimeInterval(5)) { _ in
+        _ = await router.routePending(connection: connecting(), now: now.addingTimeInterval(5)) { _ in
             XCTFail("Waiting must not call the handler")
             return true
         }
-        _ = await router.routePending(isConnected: false, now: now.addingTimeInterval(10)) { _ in
+        _ = await router.routePending(connection: connecting(), now: now.addingTimeInterval(10)) { _ in
             true
         }
 
-        // Still the original 30s window from first enqueue — not slid forward.
         let expired = await router.routePending(
-            isConnected: false,
+            connection: connecting(),
             now: now.addingTimeInterval(31)
         ) { _ in
             XCTFail("Expired after original deadline")
@@ -371,8 +555,8 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default"))
         let router = PendingVoiceIntentRouter(store: store)
 
-        async let first = router.routePending(isConnected: true) { _ in true }
-        async let second = router.routePending(isConnected: true) { _ in true }
+        async let first = router.routePending(connection: connected()) { _ in true }
+        async let second = router.routePending(connection: connected()) { _ in true }
         let outcomes = await [first, second]
 
         let routed = outcomes.filter { $0 == .routed }.count
@@ -383,30 +567,26 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
     }
 
     func testBootstrapOrderingKeepsSiriRequestUntilConnectedThenRoutesOnce() async {
-        // Scene can observe the store before Hermes finishes cold bootstrap.
         store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default"))
         let router = PendingVoiceIntentRouter(store: store)
 
-        // First lifecycle pass: not connected yet (still restoring).
-        let waiting = await router.routePending(isConnected: false, now: Date()) { _ in
+        let waiting = await router.routePending(connection: inconclusiveBootstrap(), now: Date()) { _ in
             XCTFail("Must wait for Hermes before opening Voice")
             return true
         }
         XCTAssertEqual(waiting, .deferred)
         XCTAssertTrue(store.hasPendingIntent)
 
-        // Connection completes — one route, one consume.
         var routes = 0
-        let connected = await router.routePending(isConnected: true) { _ in
+        let connectedOutcome = await router.routePending(connection: connected()) { _ in
             routes += 1
             return true
         }
-        XCTAssertEqual(connected, .routed)
+        XCTAssertEqual(connectedOutcome, .routed)
         XCTAssertEqual(routes, 1)
         XCTAssertFalse(store.hasPendingIntent)
 
-        // A later scene pass cannot double-route.
-        let again = await router.routePending(isConnected: true) { _ in
+        let again = await router.routePending(connection: connected()) { _ in
             routes += 1
             return true
         }
@@ -414,25 +594,47 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         XCTAssertEqual(routes, 1)
     }
 
+    func testConnectingToStableFailureTransitionFailsPendingSiriRequest() async {
+        // Simulates the scene re-evaluating when phase flips while still
+        // disconnected (voiceIntentRouteKey embeds phase).
+        store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default"))
+        let router = PendingVoiceIntentRouter(store: store)
+
+        let waiting = await router.routePending(connection: connecting()) { _ in
+            XCTFail("Still connecting — keep waiting")
+            return true
+        }
+        XCTAssertEqual(waiting, .deferred)
+        XCTAssertTrue(store.hasPendingIntent)
+
+        let connection = stableFailure(.offline)
+        let failed = await router.routePending(connection: connection) { _ in
+            XCTFail("Stable failure must not open Voice")
+            return true
+        }
+        XCTAssertEqual(
+            failed,
+            .failed(message: PendingVoiceLaunchPolicy.stableFailureMessage(for: connection))
+        )
+        XCTAssertFalse(store.hasPendingIntent)
+    }
+
     func testDeletedProfileStyleHandlerSuccessConsumesWithoutRetryLoop() async {
-        // openVoiceConversation surfaces an error and returns true when the
-        // requested profile cannot be activated — that is a terminal consume,
-        // not a defer.
         store.enqueue(
             PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "deleted-profile")
         )
         let router = PendingVoiceIntentRouter(store: store)
 
         var calls = 0
-        let first = await router.routePending(isConnected: true) { intent in
+        let first = await router.routePending(connection: connected()) { intent in
             calls += 1
             XCTAssertEqual(intent.profile, "deleted-profile")
-            return true // handled (with errorMessage on AppState)
+            return true
         }
         XCTAssertEqual(first, .routed)
         XCTAssertFalse(store.hasPendingIntent)
 
-        let second = await router.routePending(isConnected: true) { _ in
+        let second = await router.routePending(connection: connected()) { _ in
             calls += 1
             return true
         }
@@ -443,8 +645,6 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
     // MARK: - App Intent foreground-mode compatibility
 
     func testStartVoiceConversationIntentDeclaresForegroundFirstExecution() {
-        // Pre-iOS-26 contract: openAppWhenRun must stay true (boolean literal —
-        // App Intents metadata rejects computed values).
         XCTAssertTrue(StartVoiceConversationIntent.openAppWhenRun)
 
         if #available(iOS 26.0, *) {

--- a/ConduitTests/PendingVoiceIntentLifecycleTests.swift
+++ b/ConduitTests/PendingVoiceIntentLifecycleTests.swift
@@ -158,7 +158,9 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         // Auth-required presentation is also positive evidence.
         appState.lastConnectionFailure = nil
         appState.pendingLoginFailure = .presenting(.loginRequired)
-        XCTAssertEqual(appState.voiceLaunchConnectionSnapshot().phase, .stableFailure)
+        let loginRequired = appState.voiceLaunchConnectionSnapshot()
+        XCTAssertEqual(loginRequired.phase, .stableFailure)
+        XCTAssertEqual(loginRequired.classifiedFailure, .loginRequired)
     }
 
     // MARK: - Readiness / disconnected lifecycle
@@ -230,6 +232,20 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
             PendingVoiceLaunchPolicy.stableFailureMessage(for: connection)
                 .contains(ConnectionFailure.loginRequired.userTitle)
         )
+    }
+
+    func testLoginFailureOnlyEvidenceStillSurfacesClassifiedCopy() {
+        // pendingLoginFailure without lastConnectionFailure must not degrade
+        // to the generic disconnected string.
+        let connection = VoiceLaunchConnectionSnapshot(
+            isConnected: false,
+            isConnecting: false,
+            hasStableFailureEvidence: true,
+            classifiedFailure: .loginRequired
+        )
+        let message = PendingVoiceLaunchPolicy.stableFailureMessage(for: connection)
+        XCTAssertTrue(message.contains(ConnectionFailure.loginRequired.userMessage))
+        XCTAssertNotEqual(message, PendingVoiceLaunchPolicy.disconnectedFailureMessage)
     }
 
     func testExpiredSiriLaunchFailsAndNeverWaitsForReconnect() {

--- a/ConduitTests/PendingVoiceIntentLifecycleTests.swift
+++ b/ConduitTests/PendingVoiceIntentLifecycleTests.swift
@@ -2,11 +2,9 @@
 //  PendingVoiceIntentLifecycleTests.swift
 //  Conduit
 //
-//  Siri / external voice-launch lifecycle: exactly-once routing, profile
-//  preservation, and terminal failure so a stale Siri request can never open
-//  Voice after an unrelated reconnect. Connection readiness is lifecycle-
-//  driven (connecting vs stable failure vs inconclusive bootstrap); the
-//  30s deadline is only the inconclusive-state backstop.
+//  Siri pending-launch lifecycle with ownership claims: exactly-once routing,
+//  lifecycle-driven stable failure, authoritative deadline expiry, and no
+//  stale async completion can mutate a later request.
 //
 
 import XCTest
@@ -42,7 +40,7 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         .init(isConnected: false, isConnecting: false, hasStableFailureEvidence: true, classifiedFailure: failure)
     }
 
-    // MARK: - Siri intent factory
+    // MARK: - Factory
 
     func testSiriFactoryCreatesFreshSiriIntentWithBudgetDeadline() {
         let now = Date(timeIntervalSince1970: 1_000_000)
@@ -55,23 +53,14 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         XCTAssertEqual(intent.profile, "default")
         XCTAssertTrue(intent.startsFreshConversation)
         XCTAssertEqual(intent.source, .siri)
-        XCTAssertEqual(
-            intent.externalLaunchDeadline,
-            now.addingTimeInterval(30)
-        )
+        XCTAssertEqual(intent.externalLaunchDeadline, now.addingTimeInterval(30))
+        XCTAssertNotNil(intent.externalLaunchElapsedDeadline)
     }
 
     func testSiriFactoryTrimsAndDropsBlankProfiles() {
-        XCTAssertNil(
-            PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil).profile
-        )
-        XCTAssertNil(
-            PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "   \n\t ").profile
-        )
-        XCTAssertEqual(
-            PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "  work \n").profile,
-            "work"
-        )
+        XCTAssertNil(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil).profile)
+        XCTAssertNil(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "   \n\t ").profile)
+        XCTAssertEqual(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "  work \n").profile, "work")
     }
 
     func testComposerLaunchHasNoExternalDeadline() {
@@ -81,21 +70,16 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
             source: .composer
         )
         XCTAssertNil(intent.externalLaunchDeadline)
+        XCTAssertNil(intent.externalLaunchElapsedDeadline)
         XCTAssertEqual(
-            PendingVoiceLaunchPolicy.readiness(
-                for: intent,
-                connection: stableFailure(),
-                now: .distantFuture
-            ),
-            // In-app keeps defer-and-retry even on a classified failure.
+            PendingVoiceLaunchPolicy.readiness(for: intent, connection: stableFailure(), now: .distantFuture),
             .waiting
         )
     }
 
-    // MARK: - Connection phase derivation
+    // MARK: - Connection phase / AppState provenance
 
     func testSnapshotPhasePrefersConnectingOverPriorFailureEvidence() {
-        // lastConnectionFailure often remains set while a new attempt runs.
         let snapshot = VoiceLaunchConnectionSnapshot(
             isConnected: false,
             isConnecting: true,
@@ -119,17 +103,7 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         XCTAssertEqual(connected().phase, .connected)
     }
 
-    func testRoutingKeyPhaseChangesWhenConnectingBecomesStableFailure() {
-        // ConduitApp.voiceIntentRouteKey embeds phase so a disconnect-only
-        // transition still re-evaluates the pending Siri request.
-        let connectingKey = "1:\(connecting().phase.rawValue):siri"
-        let failedKey = "1:\(stableFailure().phase.rawValue):siri"
-        XCTAssertNotEqual(connectingKey, failedKey)
-        XCTAssertEqual(connecting().phase.rawValue, "connecting")
-        XCTAssertEqual(stableFailure().phase.rawValue, "stableFailure")
-    }
-
-    func testAppStateVoiceLaunchSnapshotReflectsRecordedFailure() {
+    func testAppStateSnapshotMapsClassifiedFailureAndLoginRequiredPresentation() {
         let suite = "PendingVoiceIntentLifecycleTests.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suite) else {
             return XCTFail("Failed to create test UserDefaults suite")
@@ -137,52 +111,45 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         addTeardownBlock { defaults.removePersistentDomain(forName: suite) }
         let appState = AppState(defaults: defaults, loadSavedConnection: false)
 
-        // Cold bootstrap: no positive failure evidence yet — not terminal.
         appState.isConnected = false
         appState.isConnecting = false
         appState.lastConnectionFailure = nil
         appState.pendingLoginFailure = nil
         XCTAssertEqual(appState.voiceLaunchConnectionSnapshot().phase, .inconclusive)
 
-        // Connecting: still wait.
         appState.isConnecting = true
         XCTAssertEqual(appState.voiceLaunchConnectionSnapshot().phase, .connecting)
 
-        // Stable failure after the attempt ends: classified evidence.
         appState.isConnecting = false
         appState.lastConnectionFailure = .connectionRefused
-        let failed = appState.voiceLaunchConnectionSnapshot()
-        XCTAssertEqual(failed.phase, .stableFailure)
-        XCTAssertEqual(failed.classifiedFailure, .connectionRefused)
+        XCTAssertEqual(appState.voiceLaunchConnectionSnapshot().classifiedFailure, .connectionRefused)
 
-        // Auth-required presentation is also positive evidence.
+        // Typed login-required presentation is fallback evidence.
         appState.lastConnectionFailure = nil
         appState.pendingLoginFailure = .presenting(.loginRequired)
         let loginRequired = appState.voiceLaunchConnectionSnapshot()
         XCTAssertEqual(loginRequired.phase, .stableFailure)
         XCTAssertEqual(loginRequired.classifiedFailure, .loginRequired)
+
+        // Hand-authored notice is NOT login-required evidence.
+        appState.pendingLoginFailure = .notice(title: "Something else", message: "")
+        XCTAssertEqual(appState.voiceLaunchConnectionSnapshot().phase, .inconclusive)
+        XCTAssertNil(appState.voiceLaunchConnectionSnapshot().classifiedFailure)
     }
 
-    // MARK: - Readiness / disconnected lifecycle
+    // MARK: - Readiness
 
     func testConnectedSiriLaunchIsReady() {
         let now = Date()
         let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, now: now)
-        XCTAssertEqual(
-            PendingVoiceLaunchPolicy.readiness(for: intent, connection: connected(), now: now),
-            .ready
-        )
+        XCTAssertEqual(PendingVoiceLaunchPolicy.readiness(for: intent, connection: connected(), now: now), .ready)
     }
 
     func testSiriLaunchWaitsWhileActivelyConnecting() {
         let now = Date()
         let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, now: now)
         XCTAssertEqual(
-            PendingVoiceLaunchPolicy.readiness(
-                for: intent,
-                connection: connecting(),
-                now: now.addingTimeInterval(1)
-            ),
+            PendingVoiceLaunchPolicy.readiness(for: intent, connection: connecting(), now: now.addingTimeInterval(1)),
             .waiting
         )
     }
@@ -190,13 +157,8 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
     func testSiriLaunchWaitsDuringColdBootstrapWithoutFailureEvidence() {
         let now = Date()
         let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, now: now)
-        // !isConnected && !isConnecting is NOT terminal until failure evidence exists.
         XCTAssertEqual(
-            PendingVoiceLaunchPolicy.readiness(
-                for: intent,
-                connection: inconclusiveBootstrap(),
-                now: now.addingTimeInterval(1)
-            ),
+            PendingVoiceLaunchPolicy.readiness(for: intent, connection: inconclusiveBootstrap(), now: now.addingTimeInterval(1)),
             .waiting
         )
     }
@@ -208,14 +170,9 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         let message = PendingVoiceLaunchPolicy.stableFailureMessage(for: connection)
 
         XCTAssertEqual(
-            PendingVoiceLaunchPolicy.readiness(
-                for: intent,
-                connection: connection,
-                now: now.addingTimeInterval(2)
-            ),
+            PendingVoiceLaunchPolicy.readiness(for: intent, connection: connection, now: now.addingTimeInterval(2)),
             .failed(message: message)
         )
-        // Classified copy wins over the generic disconnected string.
         XCTAssertTrue(message.contains(ConnectionFailure.unreachable.userMessage))
         XCTAssertNotEqual(message, PendingVoiceLaunchPolicy.disconnectedFailureMessage)
     }
@@ -224,57 +181,46 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         let now = Date()
         let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, now: now)
         let connection = stableFailure(.loginRequired)
+        let message = PendingVoiceLaunchPolicy.stableFailureMessage(for: connection)
         XCTAssertEqual(
             PendingVoiceLaunchPolicy.readiness(for: intent, connection: connection, now: now),
-            .failed(message: PendingVoiceLaunchPolicy.stableFailureMessage(for: connection))
+            .failed(message: message)
         )
-        XCTAssertTrue(
-            PendingVoiceLaunchPolicy.stableFailureMessage(for: connection)
-                .contains(ConnectionFailure.loginRequired.userTitle)
-        )
-    }
-
-    func testLoginFailureOnlyEvidenceStillSurfacesClassifiedCopy() {
-        // pendingLoginFailure without lastConnectionFailure must not degrade
-        // to the generic disconnected string.
-        let connection = VoiceLaunchConnectionSnapshot(
-            isConnected: false,
-            isConnecting: false,
-            hasStableFailureEvidence: true,
-            classifiedFailure: .loginRequired
-        )
-        let message = PendingVoiceLaunchPolicy.stableFailureMessage(for: connection)
-        XCTAssertTrue(message.contains(ConnectionFailure.loginRequired.userMessage))
-        XCTAssertNotEqual(message, PendingVoiceLaunchPolicy.disconnectedFailureMessage)
+        XCTAssertTrue(message.contains(ConnectionFailure.loginRequired.userTitle))
     }
 
     func testExpiredSiriLaunchFailsAndNeverWaitsForReconnect() {
         let now = Date()
         let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, now: now, budget: 30)
-        let later = now.addingTimeInterval(31)
         XCTAssertEqual(
-            PendingVoiceLaunchPolicy.readiness(for: intent, connection: inconclusiveBootstrap(), now: later),
+            PendingVoiceLaunchPolicy.readiness(for: intent, connection: inconclusiveBootstrap(), now: now.addingTimeInterval(31)),
+            .failed(message: PendingVoiceLaunchPolicy.expiredFailureMessage)
+        )
+    }
+
+    func testExpiryAtExactBoundaryCannotReturnToWaiting() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, now: now, budget: 30)
+        let boundary = intent.externalLaunchDeadline!
+        XCTAssertEqual(
+            PendingVoiceLaunchPolicy.readiness(for: intent, connection: inconclusiveBootstrap(), now: boundary),
             .failed(message: PendingVoiceLaunchPolicy.expiredFailureMessage)
         )
     }
 
     func testExpiredSiriLaunchFailsEvenIfConnectionReturnsTooLate() {
-        // Reconnect minutes later must not open Voice from an old Siri request.
         let now = Date()
         let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, now: now, budget: 30)
-        let minutesLater = now.addingTimeInterval(5 * 60)
         XCTAssertEqual(
-            PendingVoiceLaunchPolicy.readiness(for: intent, connection: connected(), now: minutesLater),
+            PendingVoiceLaunchPolicy.readiness(for: intent, connection: connected(), now: now.addingTimeInterval(5 * 60)),
             .failed(message: PendingVoiceLaunchPolicy.expiredFailureMessage)
         )
     }
 
-    // MARK: - Store + router exactly-once
+    // MARK: - Router exactly-once / connecting / stable failure
 
     func testConnectedRouteConsumesExactlyOnceAndDoesNotReenqueue() async {
-        store.enqueue(
-            PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default")
-        )
+        store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default"))
 
         var handled: [PendingVoiceIntent] = []
         let router = PendingVoiceIntentRouter(store: store)
@@ -290,44 +236,26 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
             return true
         }
         XCTAssertEqual(second, .idle)
-        XCTAssertEqual(handled.count, 1)
-        XCTAssertEqual(handled.first?.profile, "default")
-        XCTAssertEqual(handled.first?.source, .siri)
+        XCTAssertEqual(handled.map(\.profile), ["default"])
     }
 
-    func testTemporaryNotReadySiriLaunchIsRetainedWithoutHandler() async {
-        store.enqueue(
-            PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "work")
-        )
-        let router = PendingVoiceIntentRouter(store: store)
-        var handlerCalls = 0
-
-        let outcome = await router.routePending(connection: connecting()) { _ in
-            handlerCalls += 1
-            return true
-        }
-
-        XCTAssertEqual(outcome, .deferred)
-        XCTAssertTrue(store.hasPendingIntent)
-        XCTAssertEqual(handlerCalls, 0)
-        XCTAssertEqual(store.pendingSource, .siri)
-    }
-
-    func testActivelyConnectingDefersWithoutConsuming() async {
+    func testConnectingSiriRequestRemainsPendingWithoutRevisionBump() async {
         store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default"))
+        let afterEnqueue = store.revision
         let router = PendingVoiceIntentRouter(store: store)
+
         let outcome = await router.routePending(connection: connecting()) { _ in
             XCTFail("Connecting must not invoke the voice handler")
             return true
         }
+
         XCTAssertEqual(outcome, .deferred)
         XCTAssertTrue(store.hasPendingIntent)
+        XCTAssertEqual(store.revision, afterEnqueue)
     }
 
     func testStableFailureConsumesSiriRequestImmediatelyBeforeDeadline() async {
-        store.enqueue(
-            PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default", budget: 30)
-        )
+        store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default", budget: 30))
         let router = PendingVoiceIntentRouter(store: store)
         let connection = stableFailure(.hostNotFound)
         var handlerCalls = 0
@@ -337,16 +265,13 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
             return true
         }
 
-        let expected = PendingVoiceLaunchPolicy.stableFailureMessage(for: connection)
-        XCTAssertEqual(outcome, .failed(message: expected))
+        XCTAssertEqual(outcome, .failed(message: PendingVoiceLaunchPolicy.stableFailureMessage(for: connection)))
         XCTAssertFalse(store.hasPendingIntent)
         XCTAssertEqual(handlerCalls, 0)
     }
 
     func testReconnectAfterStableFailureDoesNotLaunchStaleSiriVoice() async {
-        store.enqueue(
-            PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, budget: 30)
-        )
+        store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, budget: 30))
         let router = PendingVoiceIntentRouter(store: store)
 
         let failure = await router.routePending(connection: stableFailure(.timedOut)) { _ in
@@ -358,7 +283,6 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
             .failed(message: PendingVoiceLaunchPolicy.stableFailureMessage(for: stableFailure(.timedOut)))
         )
 
-        // Hermes is healthy again — but the store is empty.
         var handled = 0
         let afterReconnect = await router.routePending(connection: connected()) { _ in
             handled += 1
@@ -369,50 +293,16 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         XCTAssertFalse(store.hasPendingIntent)
     }
 
-    func testExpiredDisconnectedSiriLaunchIsClearedNotRetained() async {
-        let enqueuedAt = Date(timeIntervalSinceNow: -60)
-        store.enqueue(
-            PendingVoiceLaunchPolicy.makeSiriPendingIntent(
-                profile: nil,
-                now: enqueuedAt,
-                budget: 30
-            )
-        )
-        let router = PendingVoiceIntentRouter(store: store)
-        var handlerCalls = 0
-
-        let outcome = await router.routePending(connection: inconclusiveBootstrap(), now: Date()) { _ in
-            handlerCalls += 1
-            return true
-        }
-
-        XCTAssertEqual(
-            outcome,
-            .failed(message: PendingVoiceLaunchPolicy.expiredFailureMessage)
-        )
-        XCTAssertFalse(store.hasPendingIntent)
-        XCTAssertEqual(handlerCalls, 0)
-    }
-
-    func testReconnectAfterTerminalFailureDoesNotLaunchStaleSiriVoice() async {
+    func testLaterReconnectAfterExpiryCannotLaunchStaleRequest() async {
         let enqueuedAt = Date(timeIntervalSinceNow: -120)
-        store.enqueue(
-            PendingVoiceLaunchPolicy.makeSiriPendingIntent(
-                profile: nil,
-                now: enqueuedAt,
-                budget: 30
-            )
-        )
+        store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, now: enqueuedAt, budget: 30))
         let router = PendingVoiceIntentRouter(store: store)
 
-        let failure = await router.routePending(connection: inconclusiveBootstrap(), now: Date()) { _ in
-            XCTFail("Expired Siri launch must not invoke the voice handler")
+        let expired = await router.routePending(connection: inconclusiveBootstrap(), now: Date()) { _ in
+            XCTFail("Expired launch must not invoke the voice handler")
             return true
         }
-        XCTAssertEqual(
-            failure,
-            .failed(message: PendingVoiceLaunchPolicy.expiredFailureMessage)
-        )
+        XCTAssertEqual(expired, .failed(message: PendingVoiceLaunchPolicy.expiredFailureMessage))
 
         var handled = 0
         let afterReconnect = await router.routePending(connection: connected()) { _ in
@@ -421,46 +311,174 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         }
         XCTAssertEqual(afterReconnect, .idle)
         XCTAssertEqual(handled, 0)
-        XCTAssertFalse(store.hasPendingIntent)
     }
 
     func testSiriHandlerFailureIsTerminalAndDoesNotReenqueue() async {
-        store.enqueue(
-            PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default")
-        )
+        store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default"))
         let router = PendingVoiceIntentRouter(store: store)
 
         let outcome = await router.routePending(connection: connected()) { _ in false }
 
-        XCTAssertEqual(
-            outcome,
-            .failed(message: PendingVoiceLaunchPolicy.disconnectedFailureMessage)
-        )
+        XCTAssertEqual(outcome, .failed(message: PendingVoiceLaunchPolicy.disconnectedFailureMessage))
         XCTAssertFalse(store.hasPendingIntent)
     }
 
-    func testInAppHandlerFailureStillDefersForRetry() async {
-        store.enqueue(
-            PendingVoiceIntent(
-                profile: "default",
-                startsFreshConversation: false,
-                source: .composer
-            )
-        )
+    // MARK: - Ownership / supersede fencing
+
+    func testClearWhileHandlerSuspendedCannotResurrectOrPublishFailure() async {
+        store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default"))
         let router = PendingVoiceIntentRouter(store: store)
 
-        let outcome = await router.routePending(connection: connected()) { _ in false }
+        let gate = LaunchHandlerGate()
+        async let outcome = router.routePending(connection: connected()) { _ in
+            await gate.markStarted()
+            await gate.waitUntilOpen()
+            return true
+        }
+        await gate.waitUntilStarted()
+        store.clear()
+        await gate.open()
+        let result = await outcome
 
-        XCTAssertEqual(outcome, .deferred)
-        XCTAssertTrue(store.hasPendingIntent)
-        XCTAssertEqual(store.pendingSource, .composer)
+        XCTAssertEqual(result, .superseded)
+        XCTAssertFalse(store.hasPendingIntent)
     }
 
+    func testClearWhileHandlerSuspendedDiscardsHandlerFalseFailure() async {
+        store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default"))
+        let router = PendingVoiceIntentRouter(store: store)
+
+        let gate = LaunchHandlerGate()
+        async let outcome = router.routePending(connection: connected()) { _ in
+            await gate.markStarted()
+            await gate.waitUntilOpen()
+            return false
+        }
+        await gate.waitUntilStarted()
+        store.clear()
+        await gate.open()
+        let result = await outcome
+
+        // Stale completion must not surface a Siri failure for a cleared request.
+        XCTAssertEqual(result, .superseded)
+        XCTAssertFalse(store.hasPendingIntent)
+    }
+
+    func testEnqueueBDuringHandlerASuspensionPreventsAFromTouchingB() async {
+        let a = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "A")
+        store.enqueue(a)
+        let router = PendingVoiceIntentRouter(store: store)
+
+        let gate = LaunchHandlerGate()
+        async let outcome = router.routePending(connection: connected()) { intent in
+            XCTAssertEqual(intent.profile, "A")
+            await gate.markStarted()
+            await gate.waitUntilOpen()
+            return false
+        }
+        await gate.waitUntilStarted()
+        let b = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "B")
+        store.enqueue(b)
+        await gate.open()
+        let result = await outcome
+
+        XCTAssertEqual(result, .superseded)
+        // B still owns the slot — A must not requeue or fail over it.
+        XCTAssertTrue(store.hasPendingIntent)
+        XCTAssertEqual(store.pendingProfile, "B")
+    }
+
+    func testWaiterForACannotAffectReplacementB() {
+        let a = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "A")
+        store.enqueue(a)
+        guard let claimA = store.peekClaim() else {
+            return XCTFail("expected claim A")
+        }
+        _ = store.takeClaim()
+        let b = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "B")
+        store.enqueue(b)
+
+        // A's waiter wakes: must no-op.
+        XCTAssertNil(store.expireClaimIfCurrent(claimA))
+        XCTAssertEqual(store.pendingProfile, "B")
+    }
+
+    func testConsumeAWhileWaiterSleepsMakesOldWaiterNoop() {
+        let a = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "A")
+        store.enqueue(a)
+        guard let claimA = store.peekClaim() else {
+            return XCTFail("expected claim A")
+        }
+        // Simulate successful route consuming A.
+        guard let taken = store.takeClaim() else {
+            return XCTFail("expected take")
+        }
+        XCTAssertEqual(taken.generation, claimA.generation)
+        XCTAssertNil(store.takeClaim())
+
+        // Old waiter expire on a already-taken (consumed) claim: no pending
+        // intent remains, so expiry is a no-op.
+        XCTAssertNil(store.expireClaimIfCurrent(claimA))
+        XCTAssertFalse(store.hasPendingIntent)
+    }
+
+    func testClearInvalidatesClaimSoExpiredWaiterCannotResurrect() {
+        let a = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "A")
+        store.enqueue(a)
+        guard let claimA = store.peekClaim() else {
+            return XCTFail("expected claim A")
+        }
+        store.clear()
+        XCTAssertNil(store.expireClaimIfCurrent(claimA))
+        XCTAssertFalse(store.hasPendingIntent)
+    }
+
+    // MARK: - Authoritative store expiry
+
+    func testAuthoritativeExpiryAlwaysConsumesTheRequest() {
+        store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default"))
+        guard let claim = store.peekClaim() else {
+            return XCTFail("expected claim")
+        }
+        let expired = store.expireClaimIfCurrent(claim)
+        XCTAssertEqual(expired?.profile, "default")
+        XCTAssertFalse(store.hasPendingIntent)
+        // Second expire is a no-op — request is gone, no new timer needed.
+        XCTAssertNil(store.expireClaimIfCurrent(claim))
+    }
+
+    func testDeferralDoesNotExtendOriginalLaunchBudget() async {
+        let now = Date(timeIntervalSince1970: 2_000_000)
+        let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default", now: now, budget: 30)
+        let originalDeadline = intent.externalLaunchDeadline
+        let originalElapsed = intent.externalLaunchElapsedDeadline
+        store.enqueue(intent)
+
+        let router = PendingVoiceIntentRouter(store: store)
+        _ = await router.routePending(connection: connecting(), now: now.addingTimeInterval(5)) { _ in
+            XCTFail("Waiting must not call the handler")
+            return true
+        }
+
+        XCTAssertEqual(store.pendingExternalLaunchDeadline, originalDeadline)
+        XCTAssertEqual(store.pendingProfile, "default")
+        // Elapsed deadline is immutable metadata on the intent.
+        let claim = store.peekClaim()
+        XCTAssertEqual(claim?.intent.externalLaunchElapsedDeadline, originalElapsed)
+
+        let expired = await router.routePending(connection: connecting(), now: now.addingTimeInterval(30)) { _ in
+            XCTFail("Expired at boundary")
+            return true
+        }
+        XCTAssertEqual(expired, .failed(message: PendingVoiceLaunchPolicy.expiredFailureMessage))
+        XCTAssertFalse(store.hasPendingIntent)
+    }
+
+    // MARK: - Supersede / clear / double-route
+
     func testNewerSiriRequestSupersedesOlderPendingRequest() async {
-        let older = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "old")
-        let newer = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "new")
-        store.enqueue(older)
-        store.enqueue(newer)
+        store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "old"))
+        store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "new"))
 
         let router = PendingVoiceIntentRouter(store: store)
         var handled: [PendingVoiceIntent] = []
@@ -471,14 +489,11 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
 
         XCTAssertEqual(outcome, .routed)
         XCTAssertEqual(handled.map(\.profile), ["new"])
-        XCTAssertEqual(handled.count, 1)
         XCTAssertFalse(store.hasPendingIntent)
     }
 
     func testClearCannotLaterResurrectTheRequest() async {
-        store.enqueue(
-            PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default")
-        )
+        store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default"))
         store.clear()
         XCTAssertFalse(store.hasPendingIntent)
 
@@ -492,9 +507,9 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
 
     func testRevisionAdvancesOnEnqueueSupersedeAndClear() {
         let initial = store.revision
-        store.enqueue(PendingVoiceIntent(profile: "a", startsFreshConversation: true, source: .composer))
+        store.enqueue(PendingVoiceIntent(profile: "a", startsFreshConversation: true, source: .siri))
         let afterEnqueue = store.revision
-        store.enqueue(PendingVoiceIntent(profile: "b", startsFreshConversation: true, source: .composer))
+        store.enqueue(PendingVoiceIntent(profile: "b", startsFreshConversation: true, source: .siri))
         let afterSupersede = store.revision
         store.clear()
         let afterClear = store.revision
@@ -504,68 +519,16 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         XCTAssertGreaterThan(afterClear, afterSupersede)
     }
 
-    func testWaitingDeferralDoesNotAdvanceRevision() async {
-        store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default"))
-        let afterEnqueue = store.revision
-        let router = PendingVoiceIntentRouter(store: store)
-
-        let outcome = await router.routePending(connection: connecting()) { _ in
-            XCTFail("Waiting must not call the handler")
-            return true
-        }
-
-        XCTAssertEqual(outcome, .deferred)
-        XCTAssertTrue(store.hasPendingIntent)
-        XCTAssertEqual(store.revision, afterEnqueue)
-    }
-
     func testDeferredRequeueDoesNotClobberNewerPendingRequest() {
         let older = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "old")
-        let newer = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "new")
-
-        store.enqueue(newer)
-        store.requeueAsDeferred(older)
-
-        XCTAssertTrue(store.hasPendingIntent)
-        XCTAssertEqual(store.pendingSource, .siri)
+        store.enqueue(older)
+        guard let claim = store.takeClaim() else {
+            return XCTFail("expected take")
+        }
+        store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "new"))
+        XCTAssertFalse(store.requeueDeferred(claim))
         XCTAssertEqual(store.pendingProfile, "new")
     }
-
-    func testTemporaryDeferenceDoesNotExtendExternalDeadline() async {
-        let now = Date(timeIntervalSince1970: 2_000_000)
-        let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(
-            profile: "default",
-            now: now,
-            budget: 30
-        )
-        store.enqueue(intent)
-        let originalDeadline = intent.externalLaunchDeadline
-
-        let router = PendingVoiceIntentRouter(store: store)
-        _ = await router.routePending(connection: connecting(), now: now.addingTimeInterval(5)) { _ in
-            XCTFail("Waiting must not call the handler")
-            return true
-        }
-        _ = await router.routePending(connection: connecting(), now: now.addingTimeInterval(10)) { _ in
-            true
-        }
-
-        let expired = await router.routePending(
-            connection: connecting(),
-            now: now.addingTimeInterval(31)
-        ) { _ in
-            XCTFail("Expired after original deadline")
-            return true
-        }
-        XCTAssertEqual(
-            expired,
-            .failed(message: PendingVoiceLaunchPolicy.expiredFailureMessage)
-        )
-        XCTAssertFalse(store.hasPendingIntent)
-        _ = originalDeadline
-    }
-
-    // MARK: - Cold-start / double-route guards
 
     func testTwoLaunchAttemptsCannotCauseDuplicateConsumption() async {
         store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default"))
@@ -575,10 +538,8 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         async let second = router.routePending(connection: connected()) { _ in true }
         let outcomes = await [first, second]
 
-        let routed = outcomes.filter { $0 == .routed }.count
-        let idle = outcomes.filter { $0 == .idle }.count
-        XCTAssertEqual(routed, 1)
-        XCTAssertEqual(idle, 1)
+        XCTAssertEqual(outcomes.filter { $0 == .routed }.count, 1)
+        XCTAssertEqual(outcomes.filter { $0 == .idle }.count, 1)
         XCTAssertFalse(store.hasPendingIntent)
     }
 
@@ -600,7 +561,6 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         }
         XCTAssertEqual(connectedOutcome, .routed)
         XCTAssertEqual(routes, 1)
-        XCTAssertFalse(store.hasPendingIntent)
 
         let again = await router.routePending(connection: connected()) { _ in
             routes += 1
@@ -611,34 +571,28 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
     }
 
     func testConnectingToStableFailureTransitionFailsPendingSiriRequest() async {
-        // Simulates the scene re-evaluating when phase flips while still
-        // disconnected (voiceIntentRouteKey embeds phase).
         store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default"))
         let router = PendingVoiceIntentRouter(store: store)
 
         let waiting = await router.routePending(connection: connecting()) { _ in
-            XCTFail("Still connecting — keep waiting")
+            XCTFail("Still connecting")
             return true
         }
         XCTAssertEqual(waiting, .deferred)
-        XCTAssertTrue(store.hasPendingIntent)
 
         let connection = stableFailure(.offline)
         let failed = await router.routePending(connection: connection) { _ in
             XCTFail("Stable failure must not open Voice")
             return true
         }
-        XCTAssertEqual(
-            failed,
-            .failed(message: PendingVoiceLaunchPolicy.stableFailureMessage(for: connection))
-        )
+        XCTAssertEqual(failed, .failed(message: PendingVoiceLaunchPolicy.stableFailureMessage(for: connection)))
         XCTAssertFalse(store.hasPendingIntent)
     }
 
-    func testDeletedProfileStyleHandlerSuccessConsumesWithoutRetryLoop() async {
-        store.enqueue(
-            PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "deleted-profile")
-        )
+    /// `openVoiceConversation` surfaces an error and returns true when the
+    /// requested profile cannot be activated — a terminal consume, not a loop.
+    func testUnusableProfileStyleHandlerSuccessConsumesWithoutRetryLoop() async {
+        store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "deleted-profile"))
         let router = PendingVoiceIntentRouter(store: store)
 
         var calls = 0
@@ -658,16 +612,48 @@ final class PendingVoiceIntentLifecycleTests: XCTestCase {
         XCTAssertEqual(calls, 1)
     }
 
-    // MARK: - App Intent foreground-mode compatibility
+    // MARK: - App Intent foreground-mode
 
     func testStartVoiceConversationIntentDeclaresForegroundFirstExecution() {
         XCTAssertTrue(StartVoiceConversationIntent.openAppWhenRun)
-
         if #available(iOS 26.0, *) {
-            XCTAssertEqual(
-                StartVoiceConversationIntent.supportedModes,
-                .foreground(.immediate)
-            )
+            XCTAssertEqual(StartVoiceConversationIntent.supportedModes, .foreground(.immediate))
         }
+    }
+}
+
+// MARK: - Continuation gate (no timing sleeps)
+
+/// Deterministic suspension gate for handler-ownership tests. The handler
+/// signals `markStarted()` then parks on `waitUntilOpen()`; the test mutates
+/// the store before `open()`.
+actor LaunchHandlerGate {
+    private var isOpen = false
+    private var isStarted = false
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+    private var openWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func markStarted() {
+        isStarted = true
+        let waiters = startWaiters
+        startWaiters = []
+        for waiter in waiters { waiter.resume() }
+    }
+
+    func open() {
+        isOpen = true
+        let waiters = openWaiters
+        openWaiters = []
+        for waiter in waiters { waiter.resume() }
+    }
+
+    func waitUntilStarted() async {
+        if isStarted { return }
+        await withCheckedContinuation { startWaiters.append($0) }
+    }
+
+    func waitUntilOpen() async {
+        if isOpen { return }
+        await withCheckedContinuation { openWaiters.append($0) }
     }
 }

--- a/ConduitTests/PendingVoiceIntentLifecycleTests.swift
+++ b/ConduitTests/PendingVoiceIntentLifecycleTests.swift
@@ -1,0 +1,457 @@
+//
+//  PendingVoiceIntentLifecycleTests.swift
+//  Conduit
+//
+//  Siri / external voice-launch lifecycle: exactly-once routing, profile
+//  preservation, and terminal failure so a stale Siri request can never open
+//  Voice after an unrelated reconnect.
+//
+
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class PendingVoiceIntentLifecycleTests: XCTestCase {
+    private var store: PendingVoiceIntentStore!
+
+    override func setUp() {
+        super.setUp()
+        store = PendingVoiceIntentStore()
+    }
+
+    override func tearDown() {
+        store = nil
+        super.tearDown()
+    }
+
+    // MARK: - Siri intent factory
+
+    func testSiriFactoryCreatesFreshSiriIntentWithBudgetDeadline() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(
+            profile: "default",
+            now: now,
+            budget: 30
+        )
+
+        XCTAssertEqual(intent.profile, "default")
+        XCTAssertTrue(intent.startsFreshConversation)
+        XCTAssertEqual(intent.source, .siri)
+        XCTAssertEqual(
+            intent.externalLaunchDeadline,
+            now.addingTimeInterval(30)
+        )
+    }
+
+    func testSiriFactoryTrimsAndDropsBlankProfiles() {
+        XCTAssertNil(
+            PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil).profile
+        )
+        XCTAssertNil(
+            PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "   \n\t ").profile
+        )
+        XCTAssertEqual(
+            PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "  work \n").profile,
+            "work"
+        )
+    }
+
+    func testComposerLaunchHasNoExternalDeadline() {
+        let intent = PendingVoiceIntent(
+            profile: "default",
+            startsFreshConversation: false,
+            source: .composer
+        )
+        XCTAssertNil(intent.externalLaunchDeadline)
+        XCTAssertEqual(
+            PendingVoiceLaunchPolicy.readiness(
+                for: intent,
+                isConnected: false,
+                now: .distantFuture
+            ),
+            .waiting
+        )
+    }
+
+    // MARK: - Readiness / disconnected lifecycle
+
+    func testConnectedSiriLaunchIsReady() {
+        let now = Date()
+        let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, now: now)
+        XCTAssertEqual(
+            PendingVoiceLaunchPolicy.readiness(for: intent, isConnected: true, now: now),
+            .ready
+        )
+    }
+
+    func testSiriLaunchWithinWindowWaitsWhileDisconnected() {
+        let now = Date()
+        let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, now: now, budget: 30)
+        XCTAssertEqual(
+            PendingVoiceLaunchPolicy.readiness(
+                for: intent,
+                isConnected: false,
+                now: now.addingTimeInterval(1)
+            ),
+            .waiting
+        )
+    }
+
+    func testExpiredSiriLaunchFailsAndNeverWaitsForReconnect() {
+        let now = Date()
+        let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, now: now, budget: 30)
+        let later = now.addingTimeInterval(31)
+        XCTAssertEqual(
+            PendingVoiceLaunchPolicy.readiness(for: intent, isConnected: false, now: later),
+            .failed(message: PendingVoiceLaunchPolicy.expiredFailureMessage)
+        )
+    }
+
+    func testExpiredSiriLaunchFailsEvenIfConnectionReturnsTooLate() {
+        // Reconnect minutes later must not open Voice from an old Siri request.
+        let now = Date()
+        let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: nil, now: now, budget: 30)
+        let minutesLater = now.addingTimeInterval(5 * 60)
+        XCTAssertEqual(
+            PendingVoiceLaunchPolicy.readiness(for: intent, isConnected: true, now: minutesLater),
+            .failed(message: PendingVoiceLaunchPolicy.expiredFailureMessage)
+        )
+    }
+
+    // MARK: - Store + router exactly-once
+
+    func testConnectedRouteConsumesExactlyOnceAndDoesNotReenqueue() async {
+        store.enqueue(
+            PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default")
+        )
+
+        var handled: [PendingVoiceIntent] = []
+        let router = PendingVoiceIntentRouter(store: store)
+        let first = await router.routePending(isConnected: true) { intent in
+            handled.append(intent)
+            return true
+        }
+        XCTAssertEqual(first, .routed)
+        XCTAssertFalse(store.hasPendingIntent)
+
+        let second = await router.routePending(isConnected: true) { intent in
+            handled.append(intent)
+            return true
+        }
+        XCTAssertEqual(second, .idle)
+        XCTAssertEqual(handled.count, 1)
+        XCTAssertEqual(handled.first?.profile, "default")
+        XCTAssertEqual(handled.first?.source, .siri)
+    }
+
+    func testTemporaryNotReadySiriLaunchIsRetainedWithoutHandler() async {
+        store.enqueue(
+            PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "work")
+        )
+        let router = PendingVoiceIntentRouter(store: store)
+        var handlerCalls = 0
+
+        let outcome = await router.routePending(isConnected: false) { _ in
+            handlerCalls += 1
+            return true
+        }
+
+        XCTAssertEqual(outcome, .deferred)
+        XCTAssertTrue(store.hasPendingIntent)
+        XCTAssertEqual(handlerCalls, 0)
+        XCTAssertEqual(store.pendingSource, .siri)
+    }
+
+    func testExpiredDisconnectedSiriLaunchIsClearedNotRetained() async {
+        let enqueuedAt = Date(timeIntervalSinceNow: -60)
+        store.enqueue(
+            PendingVoiceLaunchPolicy.makeSiriPendingIntent(
+                profile: nil,
+                now: enqueuedAt,
+                budget: 30
+            )
+        )
+        let router = PendingVoiceIntentRouter(store: store)
+        var handlerCalls = 0
+
+        let outcome = await router.routePending(isConnected: false, now: Date()) { _ in
+            handlerCalls += 1
+            return true
+        }
+
+        XCTAssertEqual(
+            outcome,
+            .failed(message: PendingVoiceLaunchPolicy.expiredFailureMessage)
+        )
+        XCTAssertFalse(store.hasPendingIntent)
+        XCTAssertEqual(handlerCalls, 0)
+    }
+
+    func testReconnectAfterTerminalFailureDoesNotLaunchStaleSiriVoice() async {
+        let enqueuedAt = Date(timeIntervalSinceNow: -120)
+        store.enqueue(
+            PendingVoiceLaunchPolicy.makeSiriPendingIntent(
+                profile: nil,
+                now: enqueuedAt,
+                budget: 30
+            )
+        )
+        let router = PendingVoiceIntentRouter(store: store)
+
+        let failure = await router.routePending(isConnected: false, now: Date()) { _ in
+            XCTFail("Expired Siri launch must not invoke the voice handler")
+            return true
+        }
+        XCTAssertEqual(
+            failure,
+            .failed(message: PendingVoiceLaunchPolicy.expiredFailureMessage)
+        )
+
+        // Hermes is healthy again — but the store is empty.
+        var handled = 0
+        let afterReconnect = await router.routePending(isConnected: true) { _ in
+            handled += 1
+            return true
+        }
+        XCTAssertEqual(afterReconnect, .idle)
+        XCTAssertEqual(handled, 0)
+        XCTAssertFalse(store.hasPendingIntent)
+    }
+
+    func testSiriHandlerFailureIsTerminalAndDoesNotReenqueue() async {
+        store.enqueue(
+            PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default")
+        )
+        let router = PendingVoiceIntentRouter(store: store)
+
+        let outcome = await router.routePending(isConnected: true) { _ in false }
+
+        XCTAssertEqual(
+            outcome,
+            .failed(message: PendingVoiceLaunchPolicy.disconnectedFailureMessage)
+        )
+        XCTAssertFalse(store.hasPendingIntent)
+    }
+
+    func testInAppHandlerFailureStillDefersForRetry() async {
+        store.enqueue(
+            PendingVoiceIntent(
+                profile: "default",
+                startsFreshConversation: false,
+                source: .composer
+            )
+        )
+        let router = PendingVoiceIntentRouter(store: store)
+
+        let outcome = await router.routePending(isConnected: true) { _ in false }
+
+        XCTAssertEqual(outcome, .deferred)
+        XCTAssertTrue(store.hasPendingIntent)
+        XCTAssertEqual(store.pendingSource, .composer)
+    }
+
+    func testNewerSiriRequestSupersedesOlderPendingRequest() async {
+        let older = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "old")
+        let newer = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "new")
+        store.enqueue(older)
+        store.enqueue(newer)
+
+        let router = PendingVoiceIntentRouter(store: store)
+        var handled: [PendingVoiceIntent] = []
+        let outcome = await router.routePending(isConnected: true) { intent in
+            handled.append(intent)
+            return true
+        }
+
+        XCTAssertEqual(outcome, .routed)
+        XCTAssertEqual(handled.map(\.profile), ["new"])
+        XCTAssertEqual(handled.count, 1)
+        XCTAssertFalse(store.hasPendingIntent)
+    }
+
+    func testClearCannotLaterResurrectTheRequest() async {
+        store.enqueue(
+            PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default")
+        )
+        store.clear()
+        XCTAssertFalse(store.hasPendingIntent)
+
+        let router = PendingVoiceIntentRouter(store: store)
+        let outcome = await router.routePending(isConnected: true) { _ in
+            XCTFail("Cleared request must not route")
+            return true
+        }
+        XCTAssertEqual(outcome, .idle)
+    }
+
+    func testRevisionAdvancesOnEnqueueSupersedeAndClear() {
+        let initial = store.revision
+        store.enqueue(PendingVoiceIntent(profile: "a", startsFreshConversation: true, source: .composer))
+        let afterEnqueue = store.revision
+        store.enqueue(PendingVoiceIntent(profile: "b", startsFreshConversation: true, source: .composer))
+        let afterSupersede = store.revision
+        store.clear()
+        let afterClear = store.revision
+
+        XCTAssertGreaterThan(afterEnqueue, initial)
+        XCTAssertGreaterThan(afterSupersede, afterEnqueue)
+        XCTAssertGreaterThan(afterClear, afterSupersede)
+    }
+
+    func testWaitingDeferralDoesNotAdvanceRevision() async {
+        store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default"))
+        let afterEnqueue = store.revision
+        let router = PendingVoiceIntentRouter(store: store)
+
+        let outcome = await router.routePending(isConnected: false) { _ in
+            XCTFail("Waiting must not call the handler")
+            return true
+        }
+
+        XCTAssertEqual(outcome, .deferred)
+        XCTAssertTrue(store.hasPendingIntent)
+        // A revision bump here would re-fire the scene's revision-keyed task
+        // in a hot loop while Hermes is still connecting.
+        XCTAssertEqual(store.revision, afterEnqueue)
+    }
+
+    func testDeferredRequeueDoesNotClobberNewerPendingRequest() {
+        let older = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "old")
+        let newer = PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "new")
+
+        // requeue is only valid when the slot is empty (the same request was
+        // just taken). It must never overwrite a newer explicit enqueue.
+        store.enqueue(newer)
+        store.requeueAsDeferred(older)
+
+        XCTAssertTrue(store.hasPendingIntent)
+        XCTAssertEqual(store.pendingSource, .siri)
+        // Slot still holds the newer request: requeue was a no-op.
+        XCTAssertEqual(store.pendingProfile, "new")
+    }
+
+    func testTemporaryDeferenceDoesNotExtendExternalDeadline() async {
+        let now = Date(timeIntervalSince1970: 2_000_000)
+        let intent = PendingVoiceLaunchPolicy.makeSiriPendingIntent(
+            profile: "default",
+            now: now,
+            budget: 30
+        )
+        store.enqueue(intent)
+        let originalDeadline = intent.externalLaunchDeadline
+
+        let router = PendingVoiceIntentRouter(store: store)
+        _ = await router.routePending(isConnected: false, now: now.addingTimeInterval(5)) { _ in
+            XCTFail("Waiting must not call the handler")
+            return true
+        }
+        _ = await router.routePending(isConnected: false, now: now.addingTimeInterval(10)) { _ in
+            true
+        }
+
+        // Still the original 30s window from first enqueue — not slid forward.
+        let expired = await router.routePending(
+            isConnected: false,
+            now: now.addingTimeInterval(31)
+        ) { _ in
+            XCTFail("Expired after original deadline")
+            return true
+        }
+        XCTAssertEqual(
+            expired,
+            .failed(message: PendingVoiceLaunchPolicy.expiredFailureMessage)
+        )
+        XCTAssertFalse(store.hasPendingIntent)
+        _ = originalDeadline
+    }
+
+    // MARK: - Cold-start / double-route guards
+
+    func testTwoLaunchAttemptsCannotCauseDuplicateConsumption() async {
+        store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default"))
+        let router = PendingVoiceIntentRouter(store: store)
+
+        async let first = router.routePending(isConnected: true) { _ in true }
+        async let second = router.routePending(isConnected: true) { _ in true }
+        let outcomes = await [first, second]
+
+        let routed = outcomes.filter { $0 == .routed }.count
+        let idle = outcomes.filter { $0 == .idle }.count
+        XCTAssertEqual(routed, 1)
+        XCTAssertEqual(idle, 1)
+        XCTAssertFalse(store.hasPendingIntent)
+    }
+
+    func testBootstrapOrderingKeepsSiriRequestUntilConnectedThenRoutesOnce() async {
+        // Scene can observe the store before Hermes finishes cold bootstrap.
+        store.enqueue(PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "default"))
+        let router = PendingVoiceIntentRouter(store: store)
+
+        // First lifecycle pass: not connected yet (still restoring).
+        let waiting = await router.routePending(isConnected: false, now: Date()) { _ in
+            XCTFail("Must wait for Hermes before opening Voice")
+            return true
+        }
+        XCTAssertEqual(waiting, .deferred)
+        XCTAssertTrue(store.hasPendingIntent)
+
+        // Connection completes — one route, one consume.
+        var routes = 0
+        let connected = await router.routePending(isConnected: true) { _ in
+            routes += 1
+            return true
+        }
+        XCTAssertEqual(connected, .routed)
+        XCTAssertEqual(routes, 1)
+        XCTAssertFalse(store.hasPendingIntent)
+
+        // A later scene pass cannot double-route.
+        let again = await router.routePending(isConnected: true) { _ in
+            routes += 1
+            return true
+        }
+        XCTAssertEqual(again, .idle)
+        XCTAssertEqual(routes, 1)
+    }
+
+    func testDeletedProfileStyleHandlerSuccessConsumesWithoutRetryLoop() async {
+        // openVoiceConversation surfaces an error and returns true when the
+        // requested profile cannot be activated — that is a terminal consume,
+        // not a defer.
+        store.enqueue(
+            PendingVoiceLaunchPolicy.makeSiriPendingIntent(profile: "deleted-profile")
+        )
+        let router = PendingVoiceIntentRouter(store: store)
+
+        var calls = 0
+        let first = await router.routePending(isConnected: true) { intent in
+            calls += 1
+            XCTAssertEqual(intent.profile, "deleted-profile")
+            return true // handled (with errorMessage on AppState)
+        }
+        XCTAssertEqual(first, .routed)
+        XCTAssertFalse(store.hasPendingIntent)
+
+        let second = await router.routePending(isConnected: true) { _ in
+            calls += 1
+            return true
+        }
+        XCTAssertEqual(second, .idle)
+        XCTAssertEqual(calls, 1)
+    }
+
+    // MARK: - App Intent foreground-mode compatibility
+
+    func testStartVoiceConversationIntentDeclaresForegroundFirstExecution() {
+        // Pre-iOS-26 contract: openAppWhenRun must stay true (boolean literal —
+        // App Intents metadata rejects computed values).
+        XCTAssertTrue(StartVoiceConversationIntent.openAppWhenRun)
+
+        if #available(iOS 26.0, *) {
+            XCTAssertEqual(
+                StartVoiceConversationIntent.supportedModes,
+                .foreground(.immediate)
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Harden the Siri/App Intent entry point so "Talk to Conduit" either starts the requested voice conversation **exactly once** after Hermes is ready, or **fails visibly** — and never leaves an immortal pending request that fires minutes later on an unrelated reconnect.

**Acceptance invariant:** Once a Siri request has been superseded, cleared, successfully routed, failed, or expired, no async work created for that request can ever mutate a later pending request or surface a stale result.

This PR is intentionally small and limited to the Siri/App Intent launch + pending-intent lifecycle. `VoiceConversationController` remains the single voice runtime. Composer still calls `openVoiceConversation` directly and does not enqueue through this store.

## What changed

### Old Siri behavior
- `StartVoiceConversationIntent` used only `openAppWhenRun = true` (deprecated on iOS 26).
- `perform()` enqueued a `PendingVoiceIntent` into an in-memory store.
- The root scene gated routing on `appState.isConnected`. A request received while disconnected stayed pending forever and could open Voice much later when connectivity returned.

### New foreground execution API / compatibility
- Deployment target stays **iOS 17.0**.
- iOS 26+: `supportedModes = .foreground(.immediate)`.
- iOS 17–25: `openAppWhenRun` retained as a **boolean literal** (App Intents metadata requires a literal), marked deprecated at the iOS 26 boundary.
- Foreground-first only; `perform()` only records the request.

### Ownership claims (invariant)
- `enqueue` bumps a monotonic `ownershipGeneration` and `revision`.
- `takeClaim()` returns `{ generation, intent }`.
- After any suspension (`openVoiceConversation`), the router revalidates `isClaimCurrent`. Stale completions return `.superseded` and **do not** requeue, fail, or publish `errorMessage`.
- `requeueDeferred(claim)` restores only a still-current claim into an empty slot; never over a newer enqueue; **no revision bump** (no `.task(id:)` hot loop).
- Clear/supersede invalidates the generation, fencing old deadline waiters from replacement requests.

### Authoritative deadline (backstop)
- Siri launches stamp a **30s** budget at enqueue: wall-clock `Date` for tests/identity + **monotonic `ContinuousClock.Instant`** for the actual wait (immune to wall-clock steps).
- The deadline waiter peeks a claim, sleeps on ContinuousClock until that claim’s elapsed deadline, then calls `expireClaimIfCurrent` — **never** re-enters generic readiness (which could return `.waiting` again).
- Boundary uses `>=`. No repeating timer. Expired → consume once + visible expired message.

### Lifecycle-driven readiness
- **Connected** → route once and consume.
- **Connecting / inconclusive bootstrap** (no positive failure evidence) → wait. `!isConnecting` alone is not terminal.
- **Stable failure** = `lastConnectionFailure` or a **typed** `pendingLoginFailure.classifiedFailure` (e.g. `.presenting(.loginRequired)`), and not currently connecting → fail immediately with classified copy.
- Arbitrary `.notice(...)` presentations are **not** treated as login-required and do not terminal-fail Siri.
- 30s deadline remains only the inconclusive-state backstop.

### Stale-request prevention / exactly-once
- Newest explicit Siri request supersedes an older pending one.
- Successful routing and terminal failure/expiry both consume.
- Temporary not-ready may retain the request without sliding the budget.
- Reconnect after terminal failure/expiry does not open stale Voice.

### Profile semantics (preserved)
- Optional `ConduitProfileEntity` is trimmed and carried through.
- Unusable/deleted profile still surfaces `errorMessage` from `openVoiceConversation` and **consumes** (no permanent retry loop).

## Tests run (Mac, iPhone 17 Pro sim, iOS 26.5)

- Focused: `PendingVoiceIntentLifecycleTests` (**37**) + `ChatReturnSurfaceTests` — green.
- Full unit suite: **2190 tests, 0 failures**.
- App Intents metadata export succeeds; no `openAppWhenRun` deprecation warning on current-SDK builds.

Coverage includes (continuation-gated, no 30s sleeps): connected once-only; connecting deferral without revision bump; stable failure immediate consume; cold bootstrap wait; authoritative expiry; exact-boundary expiry; reconnect after expiry/stable failure; waiter-A cannot affect B; clear/handler-suspend fencing; enqueue-B-during-handler; notice ≠ loginRequired; login-required classified presentation; deferral does not extend budget.

## Multi-model review

Re-reviewed on the ownership-token head. Deterministic findings applied before push (see prior cycles for requeue hot-loop / route-key cancel / loginRequired provenance).

## Manual / physical-device acceptance

**Outstanding** — unit tests + simulator build only. Device checklist:

1. Force-quit Conduit → "Talk to Conduit" → launch + voice starts once.
2. Repeat foregrounded / backgrounded / with explicit profile.
3. Hermes unavailable → Siri → classified failure; restore later → old request does **not** start Voice; new Siri works.
4. Cold launch Siri while credentials restore → waits, does not fail early.

## Deliberately out of scope

- CarPlay, continuous conversation, wake word, fillers, Apple Watch
- TTS/provider config, AVAudioSession redesign, VAD/barge-in
- Second voice controller, background mic capture
- Hermes API / backend changes
- UserDefaults persistence of pending intents
- ComposerBar direct-voice path (unchanged)

## Reviewer notes

- Do not restore `pendingSource` in `.task(id:)` keys (cancels in-flight routes).
- Do not re-derive expiry via generic `readiness()` in the deadline waiter.
- Do not treat `pendingLoginFailure != nil` as stable failure without `classifiedFailure`.
- Do not bump `revision` on deferred requeues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Siri voice-launch handling with foreground-first activation.
  * Added clearer feedback when voice launches expire or cannot connect.
  * Voice requests now wait during connection setup and respond appropriately to confirmed connection failures.

* **Bug Fixes**
  * Prevented expired or superseded voice requests from launching later.
  * Preserved the original launch timeout while requests wait for readiness.
  * Improved connection-failure messaging using more specific failure information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->