### PR TITLE
feat(voice): wire continuousConversation preference to post-TTS relisten

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -13096,8 +13096,14 @@ final class AppState: ObservableObject {
 
     @discardableResult
     func setContinuousConversation(_ enabled: Bool) -> Bool {
+        guard isConnected else { return false }
         var preferences = loadVoiceProfilePreferences(profile: activeProfile)
         preferences.continuousConversation = enabled
+        // Live mute is authoritative while the controller holds a session.
+        // Persist it into the blob we reapply so this write cannot silently
+        // unmute an active Voice conversation (mute is otherwise only saved
+        // on sheet close).
+        preferences.outputMuted = voiceConversationController.isOutputMuted
         saveVoiceProfilePreferences(preferences, profile: activeProfile)
         continuousConversationEnabled = enabled
         voiceConversationController.setProfilePreferences(preferences)

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -800,6 +800,7 @@ final class AppState: ObservableObject {
     @Published private(set) var voiceCapabilitySnapshot = VoiceCapabilitySnapshot.unavailable
     @Published private(set) var isVoiceEnabled = false
     @Published private(set) var voiceTranscriptionMode: VoiceTranscriptionMode = .hermes
+    @Published private(set) var continuousConversationEnabled = true
     @Published private(set) var appleSpeechAvailability = AppleOnDeviceSpeechTranscriber.currentAvailability()
 
     private var voiceAssistantObserverID: UUID?
@@ -1227,6 +1228,10 @@ final class AppState: ObservableObject {
     /// of release builds.
     var presentationCacheFlushOperationForTesting: Task<Void, Never>? {
         presentationCacheFlushTask
+    }
+
+    func setActiveProfileForTesting(_ profile: String) {
+        setActiveProfile(profile)
     }
 #endif
 
@@ -2778,6 +2783,7 @@ final class AppState: ObservableObject {
         voiceCapabilitySnapshot = .unavailable
         isVoiceEnabled = false
         voiceTranscriptionMode = .hermes
+        continuousConversationEnabled = true
         appleSpeechAvailability = AppleOnDeviceSpeechTranscriber.currentAvailability()
         retireOutstandingPreferredReturnSurfaceRequests()
         showLogin = true
@@ -13035,6 +13041,7 @@ final class AppState: ObservableObject {
         voiceCapabilitySnapshot = service.snapshot.capability
         let preferences = loadVoiceProfilePreferences(profile: profile)
         voiceTranscriptionMode = preferences.resolvedTranscriptionMode
+        continuousConversationEnabled = preferences.continuousConversation
         voiceConversationController.setProfilePreferences(preferences)
         refreshVoiceControllerGateway()
         refreshReadAloudGateway()
@@ -13084,6 +13091,16 @@ final class AppState: ObservableObject {
         voiceConversationController.setProfilePreferences(preferences)
         refreshVoiceControllerGateway()
         refreshReadAloudGateway()
+        return true
+    }
+
+    @discardableResult
+    func setContinuousConversation(_ enabled: Bool) -> Bool {
+        var preferences = loadVoiceProfilePreferences(profile: activeProfile)
+        preferences.continuousConversation = enabled
+        saveVoiceProfilePreferences(preferences, profile: activeProfile)
+        continuousConversationEnabled = enabled
+        voiceConversationController.setProfilePreferences(preferences)
         return true
     }
 

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -13084,11 +13084,8 @@ final class AppState: ObservableObject {
                 return false
             }
         }
-        var preferences = loadVoiceProfilePreferences(profile: activeProfile)
-        preferences.transcriptionMode = mode
-        saveVoiceProfilePreferences(preferences, profile: activeProfile)
+        updateActiveProfileVoicePreferences { $0.transcriptionMode = mode }
         voiceTranscriptionMode = mode
-        voiceConversationController.setProfilePreferences(preferences)
         refreshVoiceControllerGateway()
         refreshReadAloudGateway()
         return true
@@ -13097,17 +13094,29 @@ final class AppState: ObservableObject {
     @discardableResult
     func setContinuousConversation(_ enabled: Bool) -> Bool {
         guard isConnected else { return false }
-        var preferences = loadVoiceProfilePreferences(profile: activeProfile)
-        preferences.continuousConversation = enabled
-        // Live mute is authoritative while the controller holds a session.
-        // Persist it into the blob we reapply so this write cannot silently
-        // unmute an active Voice conversation (mute is otherwise only saved
-        // on sheet close).
-        preferences.outputMuted = voiceConversationController.isOutputMuted
-        saveVoiceProfilePreferences(preferences, profile: activeProfile)
+        updateActiveProfileVoicePreferences { $0.continuousConversation = enabled }
         continuousConversationEnabled = enabled
-        voiceConversationController.setProfilePreferences(preferences)
         return true
+    }
+
+    /// Loads the active profile's preference blob, applies `mutate`, and
+    /// reapplies it to the live controller.
+    ///
+    /// Live `isOutputMuted` is authoritative only while a Voice session is
+    /// actually armed (`hasLiveVoiceSession`). Otherwise the controller may
+    /// still hold the previous profile's mute until
+    /// `refreshVoiceCapabilities()` resyncs, so the loaded profile's
+    /// persisted `outputMuted` is left unchanged.
+    private func updateActiveProfileVoicePreferences(
+        _ mutate: (inout VoiceProfilePreferences) -> Void
+    ) {
+        var preferences = loadVoiceProfilePreferences(profile: activeProfile)
+        mutate(&preferences)
+        if voiceConversationController.hasLiveVoiceSession {
+            preferences.outputMuted = voiceConversationController.isOutputMuted
+        }
+        saveVoiceProfilePreferences(preferences, profile: activeProfile)
+        voiceConversationController.setProfilePreferences(preferences)
     }
 
     @discardableResult

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -520,11 +520,15 @@ struct SettingsView: View {
                     voiceEnabled: appState.isVoiceEnabled,
                     transcriptionMode: appState.voiceTranscriptionMode,
                     appleSpeechAvailability: appState.appleSpeechAvailability,
+                    continuousConversation: appState.continuousConversationEnabled,
                     setVoiceEnabled: { enabled in
                         await appState.setVoiceEnabled(enabled)
                     },
                     setTranscriptionMode: { mode in
                         await appState.setVoiceTranscriptionMode(mode)
+                    },
+                    setContinuousConversation: { enabled in
+                        appState.setContinuousConversation(enabled)
                     }
                 )
             } else {

--- a/Conduit/Views/VoiceSettingsView.swift
+++ b/Conduit/Views/VoiceSettingsView.swift
@@ -15,8 +15,10 @@ struct VoiceSettingsRoute: View {
     let voiceEnabled: Bool
     let transcriptionMode: VoiceTranscriptionMode
     let appleSpeechAvailability: AppleSpeechRecognitionAvailability
+    let continuousConversation: Bool
     let setVoiceEnabled: (Bool) async -> Bool
     let setTranscriptionMode: (VoiceTranscriptionMode) async -> Bool
+    let setContinuousConversation: (Bool) async -> Bool
 
     init(
         bridge: DashboardTicketBridge,
@@ -26,8 +28,10 @@ struct VoiceSettingsRoute: View {
         voiceEnabled: Bool,
         transcriptionMode: VoiceTranscriptionMode,
         appleSpeechAvailability: AppleSpeechRecognitionAvailability,
+        continuousConversation: Bool = true,
         setVoiceEnabled: @escaping (Bool) async -> Bool,
-        setTranscriptionMode: @escaping (VoiceTranscriptionMode) async -> Bool
+        setTranscriptionMode: @escaping (VoiceTranscriptionMode) async -> Bool,
+        setContinuousConversation: @escaping (Bool) async -> Bool = { _ in true }
     ) {
         _service = StateObject(wrappedValue: HermesVoiceConfigurationService(bridge: bridge, profile: profile))
         _conversationController = ObservedObject(wrappedValue: conversationController)
@@ -35,8 +39,10 @@ struct VoiceSettingsRoute: View {
         self.voiceEnabled = voiceEnabled
         self.transcriptionMode = transcriptionMode
         self.appleSpeechAvailability = appleSpeechAvailability
+        self.continuousConversation = continuousConversation
         self.setVoiceEnabled = setVoiceEnabled
         self.setTranscriptionMode = setTranscriptionMode
+        self.setContinuousConversation = setContinuousConversation
     }
 
     var body: some View {
@@ -47,8 +53,10 @@ struct VoiceSettingsRoute: View {
             voiceEnabled: voiceEnabled,
             transcriptionMode: transcriptionMode,
             appleSpeechAvailability: appleSpeechAvailability,
+            continuousConversation: continuousConversation,
             setVoiceEnabled: setVoiceEnabled,
-            setTranscriptionMode: setTranscriptionMode
+            setTranscriptionMode: setTranscriptionMode,
+            setContinuousConversation: setContinuousConversation
         )
     }
 }
@@ -78,6 +86,7 @@ struct VoiceSettingsView: View {
     var actions = VoiceSettingsActions()
     let setVoiceEnabled: (Bool) async -> Bool
     let setTranscriptionMode: (VoiceTranscriptionMode) async -> Bool
+    let setContinuousConversation: (Bool) async -> Bool
 
     @State private var values: [String: String] = [:]
     @State private var credentialDrafts: [String: String] = [:]
@@ -88,6 +97,7 @@ struct VoiceSettingsView: View {
     @State private var voiceEnabled: Bool
     @State private var transcriptionMode: VoiceTranscriptionMode
     @State private var appleSpeechAvailability: AppleSpeechRecognitionAvailability
+    @State private var continuousConversation: Bool
 
     init(
         service: HermesVoiceConfigurationService,
@@ -96,17 +106,21 @@ struct VoiceSettingsView: View {
         voiceEnabled: Bool = false,
         transcriptionMode: VoiceTranscriptionMode = .hermes,
         appleSpeechAvailability: AppleSpeechRecognitionAvailability = .permissionRequired(localeIdentifier: Locale.current.identifier),
+        continuousConversation: Bool = true,
         setVoiceEnabled: @escaping (Bool) async -> Bool = { _ in false },
-        setTranscriptionMode: @escaping (VoiceTranscriptionMode) async -> Bool = { _ in false }
+        setTranscriptionMode: @escaping (VoiceTranscriptionMode) async -> Bool = { _ in false },
+        setContinuousConversation: @escaping (Bool) async -> Bool = { _ in true }
     ) {
         self.service = service
         _conversationController = ObservedObject(wrappedValue: conversationController)
         self.actions = actions
         self.setVoiceEnabled = setVoiceEnabled
         self.setTranscriptionMode = setTranscriptionMode
+        self.setContinuousConversation = setContinuousConversation
         _voiceEnabled = State(initialValue: voiceEnabled)
         _transcriptionMode = State(initialValue: transcriptionMode)
         _appleSpeechAvailability = State(initialValue: appleSpeechAvailability)
+        _continuousConversation = State(initialValue: continuousConversation)
     }
 
     var body: some View {
@@ -153,6 +167,21 @@ struct VoiceSettingsView: View {
                 }
             ))
             Text("This preference is stored locally for this gateway and profile. Voice starts disabled until you opt in.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Toggle("Continuous Conversation", isOn: Binding(
+                get: { continuousConversation },
+                set: { requested in
+                    let previous = continuousConversation
+                    continuousConversation = requested
+                    Task {
+                        if !(await setContinuousConversation(requested)) {
+                            continuousConversation = previous
+                        }
+                    }
+                }
+            ))
+            Text("When enabled, Conduit automatically listens again after each response. When disabled, the session stays open and you start the next listening turn manually. This does not change Pause Mic, Interrupt, Close, or wake-word settings.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
             HStack(spacing: 10) {

--- a/Conduit/Views/VoiceSettingsView.swift
+++ b/Conduit/Views/VoiceSettingsView.swift
@@ -181,6 +181,7 @@ struct VoiceSettingsView: View {
                     }
                 }
             ))
+            .accessibilityHint("Automatically listens again after each response. Turn off to start each listening turn manually.")
             Text("When enabled, Conduit automatically listens again after each response. When disabled, the session stays open and you start the next listening turn manually. This does not change Pause Mic, Interrupt, Close, or wake-word settings.")
                 .font(.caption)
                 .foregroundStyle(.secondary)

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -169,6 +169,13 @@ final class VoiceConversationController: ObservableObject {
         isOutputMuted = preferences.outputMuted
     }
 
+    /// Whether a completed assistant response automatically opens the next
+    /// listening turn. This is conversation continuation only — it does not
+    /// control session lifetime, user pause, barge-in, or route policy.
+    var isContinuousConversationEnabled: Bool {
+        preferences.continuousConversation
+    }
+
     /// True while a voice session or provider test is armed or live — i.e.
     /// while voice audio ownership may exist or is being acquired — so
     /// audio-adjacent side features (response haptics) stand down.
@@ -284,6 +291,9 @@ final class VoiceConversationController: ObservableObject {
             utteranceStartedAt = Date()
             lastSpeechAt = nil
             bargeInStartedAt = nil
+            // Listen from a settled continuous-OFF session: capture is live
+            // again, so the state must not remain .idle.
+            if state == .idle { state = .listening }
         } catch {
             state = .failed(error.localizedDescription)
         }
@@ -1000,10 +1010,34 @@ final class VoiceConversationController: ObservableObject {
         if assistantFinished && speechDeltas.isEmpty && speechStream == nil {
             assistantFinished = false
             guard isSpeechDrainCurrent(operation: operation, revision: revision) else { return }
-            cachedRoutePolicy = nil
-            isPlaybackCaptureSuspended = false
-            await startListening()
+            // Conversation continuation only. Safety/recovery restarts
+            // (barge-in, manual Interrupt, empty transcript, spoken stop,
+            // stream cancellation after the assistant finished) always
+            // re-listen and are intentionally not gated here.
+            if preferences.continuousConversation {
+                cachedRoutePolicy = nil
+                isPlaybackCaptureSuspended = false
+                await startListening()
+            } else {
+                settleOpenSessionAfterAssistantTurn()
+            }
         }
+    }
+
+    /// Continuous conversation OFF: leave the voice session/sheet open after
+    /// a completed assistant turn without opening the next listening window.
+    /// Capture is paused without the user-pause flag so the sheet's Listen
+    /// control remains "start the next turn", not "unpause".
+    private func settleOpenSessionAfterAssistantTurn() {
+        cachedRoutePolicy = nil
+        isPlaybackCaptureSuspended = false
+        // Full-duplex routes keep capture live through TTS for barge-in.
+        if !isMicrophonePaused {
+            capture.pause()
+        }
+        speechDetector.reset()
+        resetMicrophoneMeter()
+        state = .idle
     }
 
     private func cancelSpeechDrainAndStream() {

--- a/Conduit/Voice/VoiceTypes.swift
+++ b/Conduit/Voice/VoiceTypes.swift
@@ -67,6 +67,11 @@ struct VoiceProfilePreferences: Codable, Equatable {
         transcriptionMode ?? .hermes
     }
 
+    /// Explicit zero-arg initializer: a custom `init(from:)` removes the
+    /// synthesized memberwise/default initializer, and callers use
+    /// `VoiceProfilePreferences()` then mutate fields.
+    init() {}
+
     /// Missing keys decode to the field defaults so a stored blob that never
     /// wrote `continuousConversation` still yields ON (backward compatible).
     /// Synthesized Codable would throw `keyNotFound` for absent non-optional

--- a/Conduit/Voice/VoiceTypes.swift
+++ b/Conduit/Voice/VoiceTypes.swift
@@ -54,6 +54,9 @@ struct VoiceProviderDescriptor: Codable, Equatable, Identifiable {
 
 struct VoiceProfilePreferences: Codable, Equatable {
     var outputMuted: Bool = false
+    /// Whether a completed assistant response automatically opens the next
+    /// listening turn. Does not control session lifetime, user pause,
+    /// barge-in, or route policy.
     var continuousConversation: Bool = true
     var continueWakeConversation: Bool = false
     var spokenStopPhrases: [String] = ["stop", "stop talking", "be quiet"]
@@ -62,6 +65,20 @@ struct VoiceProfilePreferences: Codable, Equatable {
 
     var resolvedTranscriptionMode: VoiceTranscriptionMode {
         transcriptionMode ?? .hermes
+    }
+
+    /// Missing keys decode to the field defaults so a stored blob that never
+    /// wrote `continuousConversation` still yields ON (backward compatible).
+    /// Synthesized Codable would throw `keyNotFound` for absent non-optional
+    /// keys even when the property has a default value.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        outputMuted = try container.decodeIfPresent(Bool.self, forKey: .outputMuted) ?? false
+        continuousConversation = try container.decodeIfPresent(Bool.self, forKey: .continuousConversation) ?? true
+        continueWakeConversation = try container.decodeIfPresent(Bool.self, forKey: .continueWakeConversation) ?? false
+        spokenStopPhrases = try container.decodeIfPresent([String].self, forKey: .spokenStopPhrases)
+            ?? ["stop", "stop talking", "be quiet"]
+        transcriptionMode = try container.decodeIfPresent(VoiceTranscriptionMode.self, forKey: .transcriptionMode)
     }
 }
 

--- a/ConduitTests/AppStateContinuousConversationPreferenceTests.swift
+++ b/ConduitTests/AppStateContinuousConversationPreferenceTests.swift
@@ -21,9 +21,6 @@ final class AppStateContinuousConversationPreferenceTests: XCTestCase {
         seed.spokenStopPhrases = ["halt", "quiet"]
         seed.transcriptionMode = .appleOnDevice
         savePreferences(seed, defaults: defaults, profile: "default", gateway: "https://example.com")
-        // Live mute must match the seeded value so this write does not
-        // intentionally overwrite outputMuted from the controller.
-        appState.voiceConversationController.setOutputMuted(true)
 
         appState.setContinuousConversation(false)
 
@@ -95,8 +92,10 @@ final class AppStateContinuousConversationPreferenceTests: XCTestCase {
         seed.continuousConversation = true
         savePreferences(seed, defaults: defaults, profile: "default", gateway: "https://example.com")
 
-        // Active Voice session is muted in memory only.
+        // Live Voice session muted in memory only.
+        appState.voiceConversationController.beginVoiceTurn(sessionID: "live-session")
         appState.voiceConversationController.setOutputMuted(true)
+        XCTAssertTrue(appState.voiceConversationController.hasLiveVoiceSession)
         XCTAssertTrue(appState.voiceConversationController.isOutputMuted)
 
         XCTAssertTrue(appState.setContinuousConversation(false))
@@ -106,6 +105,38 @@ final class AppStateContinuousConversationPreferenceTests: XCTestCase {
         let loaded = try loadPreferences(defaults: defaults, profile: "default", gateway: "https://example.com")
         XCTAssertTrue(loaded.outputMuted, "live mute is persisted so the reapplied blob cannot regress")
         XCTAssertFalse(loaded.continuousConversation)
+    }
+
+    func testSetContinuousConversationDoesNotCopyStaleControllerMuteWithoutLiveSession() throws {
+        let (appState, defaults, suite) = makeAppState(profile: "beta")
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        var alpha = VoiceProfilePreferences()
+        alpha.outputMuted = true
+        alpha.continuousConversation = true
+        savePreferences(alpha, defaults: defaults, profile: "alpha", gateway: "https://example.com")
+
+        var beta = VoiceProfilePreferences()
+        beta.outputMuted = false
+        beta.continuousConversation = true
+        savePreferences(beta, defaults: defaults, profile: "beta", gateway: "https://example.com")
+
+        // Controller still holds profile A's mute after a profile switch
+        // before refreshVoiceCapabilities has resynced it. No live session.
+        appState.voiceConversationController.setProfilePreferences(alpha)
+        appState.voiceConversationController.setOutputMuted(true)
+        XCTAssertFalse(appState.voiceConversationController.hasLiveVoiceSession)
+        XCTAssertEqual(appState.activeProfile, "beta")
+
+        XCTAssertTrue(appState.setContinuousConversation(false))
+
+        let loadedAlpha = try loadPreferences(defaults: defaults, profile: "alpha", gateway: "https://example.com")
+        let loadedBeta = try loadPreferences(defaults: defaults, profile: "beta", gateway: "https://example.com")
+        XCTAssertTrue(loadedAlpha.continuousConversation)
+        XCTAssertTrue(loadedAlpha.outputMuted)
+        XCTAssertFalse(loadedBeta.outputMuted, "stale controller mute from profile A must not overwrite B's persisted unmuted value")
+        XCTAssertFalse(loadedBeta.continuousConversation)
+        XCTAssertFalse(appState.voiceConversationController.isContinuousConversationEnabled)
     }
 
     func testSetContinuousConversationFailsWhenDisconnected() {

--- a/ConduitTests/AppStateContinuousConversationPreferenceTests.swift
+++ b/ConduitTests/AppStateContinuousConversationPreferenceTests.swift
@@ -1,0 +1,139 @@
+//
+//  AppStateContinuousConversationPreferenceTests.swift
+//  Conduit
+//
+//  Persistence and profile scoping for VoiceProfilePreferences.continuousConversation.
+//
+
+import XCTest
+@testable import Conduit
+
+@MainActor
+final class AppStateContinuousConversationPreferenceTests: XCTestCase {
+    func testSetContinuousConversationPersistsWithoutClobberingUnrelatedFields() throws {
+        let (appState, defaults, suite) = makeAppState(profile: "default")
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        var seed = VoiceProfilePreferences()
+        seed.outputMuted = true
+        seed.continuousConversation = true
+        seed.continueWakeConversation = true
+        seed.spokenStopPhrases = ["halt", "quiet"]
+        seed.transcriptionMode = .appleOnDevice
+        savePreferences(seed, defaults: defaults, profile: "default", gateway: "https://example.com")
+
+        appState.setContinuousConversation(false)
+
+        let loaded = try loadPreferences(defaults: defaults, profile: "default", gateway: "https://example.com")
+        XCTAssertFalse(loaded.continuousConversation)
+        XCTAssertTrue(loaded.outputMuted)
+        XCTAssertTrue(loaded.continueWakeConversation)
+        XCTAssertEqual(loaded.spokenStopPhrases, ["halt", "quiet"])
+        XCTAssertEqual(loaded.resolvedTranscriptionMode, .appleOnDevice)
+        XCTAssertFalse(appState.continuousConversationEnabled)
+    }
+
+    func testSetContinuousConversationIsProfileScoped() throws {
+        let (appState, defaults, suite) = makeAppState(profile: "alpha")
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        var alpha = VoiceProfilePreferences()
+        alpha.continuousConversation = true
+        alpha.spokenStopPhrases = ["alpha-stop"]
+        savePreferences(alpha, defaults: defaults, profile: "alpha", gateway: "https://example.com")
+
+        var beta = VoiceProfilePreferences()
+        beta.continuousConversation = false
+        beta.spokenStopPhrases = ["beta-stop"]
+        savePreferences(beta, defaults: defaults, profile: "beta", gateway: "https://example.com")
+
+        XCTAssertEqual(appState.activeProfile, "alpha")
+        appState.setContinuousConversation(false)
+
+        let loadedAlpha = try loadPreferences(defaults: defaults, profile: "alpha", gateway: "https://example.com")
+        let loadedBeta = try loadPreferences(defaults: defaults, profile: "beta", gateway: "https://example.com")
+        XCTAssertFalse(loadedAlpha.continuousConversation)
+        XCTAssertEqual(loadedAlpha.spokenStopPhrases, ["alpha-stop"])
+        XCTAssertFalse(loadedBeta.continuousConversation)
+        XCTAssertEqual(loadedBeta.spokenStopPhrases, ["beta-stop"])
+
+        // Switching the active profile identity and writing again must not
+        // leak into the previous profile's blob.
+        appState.setActiveProfileForTesting("beta")
+        appState.setContinuousConversation(true)
+        let reloadedAlpha = try loadPreferences(defaults: defaults, profile: "alpha", gateway: "https://example.com")
+        let reloadedBeta = try loadPreferences(defaults: defaults, profile: "beta", gateway: "https://example.com")
+        XCTAssertFalse(reloadedAlpha.continuousConversation)
+        XCTAssertTrue(reloadedBeta.continuousConversation)
+    }
+
+    func testRefreshVoiceCapabilitiesLoadsProfileContinuousConversation() async throws {
+        let (appState, defaults, suite) = makeAppState(profile: "default")
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        var seed = VoiceProfilePreferences()
+        seed.continuousConversation = false
+        seed.spokenStopPhrases = ["keep"]
+        savePreferences(seed, defaults: defaults, profile: "default", gateway: "https://example.com")
+
+        await appState.refreshVoiceCapabilities()
+
+        XCTAssertFalse(appState.continuousConversationEnabled)
+        XCTAssertFalse(appState.voiceConversationController.isContinuousConversationEnabled)
+    }
+
+    private func makeAppState(profile: String) -> (AppState, UserDefaults, String) {
+        let suite = "AppStateContinuousConversationPreferenceTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Failed to create test UserDefaults suite")
+        }
+        defaults.set(profile, forKey: "conduit.activeProfile")
+        let appState = AppState(defaults: defaults, loadSavedConnection: false)
+        appState.connection = HermesConnection(baseUrl: "https://example.com", ticket: "test-ticket")
+        appState.isConnected = true
+        appState.installVoiceCapabilityStateForTesting(
+            bridge: DashboardTicketBridge(baseURL: "https://example.com"),
+            snapshot: VoiceCapabilitySnapshot(
+                isGatewayConnected: true,
+                supportsTranscription: true,
+                supportsSpeech: true,
+                unavailableReason: nil
+            ),
+            isVoiceEnabled: true
+        )
+        appState.voiceCapabilityRequesterForTesting = ImmediateVoiceConfigRequester()
+        return (appState, defaults, suite)
+    }
+
+    private func preferencesKey(profile: String, gateway: String) -> String {
+        "conduit.voice.preferences.v1.\(gateway.lowercased()).\(profile)"
+    }
+
+    private func savePreferences(
+        _ preferences: VoiceProfilePreferences,
+        defaults: UserDefaults,
+        profile: String,
+        gateway: String
+    ) {
+        guard let data = try? JSONEncoder().encode(preferences) else { return }
+        defaults.set(data, forKey: preferencesKey(profile: profile, gateway: gateway))
+    }
+
+    private func loadPreferences(
+        defaults: UserDefaults,
+        profile: String,
+        gateway: String
+    ) throws -> VoiceProfilePreferences {
+        let data = try XCTUnwrap(defaults.data(forKey: preferencesKey(profile: profile, gateway: gateway)))
+        return try JSONDecoder().decode(VoiceProfilePreferences.self, from: data)
+    }
+}
+
+/// Fail-fast requester so refreshVoiceCapabilities skips the network without
+/// waiting on dashboard timeouts; preference loading still runs.
+@MainActor
+private final class ImmediateVoiceConfigRequester: VoiceConfigurationRequesting {
+    func requestJSON(path: String, method: String, body: [String: Any]?) async throws -> [String: Any] {
+        throw URLError(.notConnectedToInternet)
+    }
+}

--- a/ConduitTests/AppStateContinuousConversationPreferenceTests.swift
+++ b/ConduitTests/AppStateContinuousConversationPreferenceTests.swift
@@ -21,6 +21,9 @@ final class AppStateContinuousConversationPreferenceTests: XCTestCase {
         seed.spokenStopPhrases = ["halt", "quiet"]
         seed.transcriptionMode = .appleOnDevice
         savePreferences(seed, defaults: defaults, profile: "default", gateway: "https://example.com")
+        // Live mute must match the seeded value so this write does not
+        // intentionally overwrite outputMuted from the controller.
+        appState.voiceConversationController.setOutputMuted(true)
 
         appState.setContinuousConversation(false)
 
@@ -80,6 +83,39 @@ final class AppStateContinuousConversationPreferenceTests: XCTestCase {
 
         XCTAssertFalse(appState.continuousConversationEnabled)
         XCTAssertFalse(appState.voiceConversationController.isContinuousConversationEnabled)
+    }
+
+    func testSetContinuousConversationPreservesLiveMuteOverStalePersistedUnmuted() throws {
+        let (appState, defaults, suite) = makeAppState(profile: "default")
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        // Persisted blob still says unmuted (mute is written on sheet close).
+        var seed = VoiceProfilePreferences()
+        seed.outputMuted = false
+        seed.continuousConversation = true
+        savePreferences(seed, defaults: defaults, profile: "default", gateway: "https://example.com")
+
+        // Active Voice session is muted in memory only.
+        appState.voiceConversationController.setOutputMuted(true)
+        XCTAssertTrue(appState.voiceConversationController.isOutputMuted)
+
+        XCTAssertTrue(appState.setContinuousConversation(false))
+
+        XCTAssertTrue(appState.voiceConversationController.isOutputMuted, "toggling continuous conversation must not unmute a live session")
+        XCTAssertFalse(appState.continuousConversationEnabled)
+        let loaded = try loadPreferences(defaults: defaults, profile: "default", gateway: "https://example.com")
+        XCTAssertTrue(loaded.outputMuted, "live mute is persisted so the reapplied blob cannot regress")
+        XCTAssertFalse(loaded.continuousConversation)
+    }
+
+    func testSetContinuousConversationFailsWhenDisconnected() {
+        let (appState, defaults, suite) = makeAppState(profile: "default")
+        defer { defaults.removePersistentDomain(forName: suite) }
+        appState.isConnected = false
+
+        XCTAssertFalse(appState.setContinuousConversation(false))
+        XCTAssertTrue(appState.continuousConversationEnabled, "failed write must not flip the published flag")
+        XCTAssertTrue(appState.voiceConversationController.isContinuousConversationEnabled, "controller keeps the previous preference")
     }
 
     private func makeAppState(profile: String) -> (AppState, UserDefaults, String) {

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -1842,6 +1842,367 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
     }
 }
 
+/// `continuousConversation` gates ONLY conversation continuation after a
+/// completed assistant turn. Safety/recovery restarts (empty transcript,
+/// spoken stop, barge-in, manual Interrupt, speech-stream cancellation after
+/// the assistant finished) always re-listen; this suite pins both sides.
+@MainActor
+final class ContinuousConversationPreferenceTests: XCTestCase {
+    func testContinuousConversationDefaultsToTrue() {
+        XCTAssertTrue(VoiceProfilePreferences().continuousConversation)
+    }
+
+    func testOlderPreferenceBlobWithoutFieldDecodesAsContinuousOn() throws {
+        let data = try XCTUnwrap(
+            #"{"outputMuted":false,"continueWakeConversation":false,"spokenStopPhrases":["stop"]}"#
+                .data(using: .utf8)
+        )
+        let preferences = try JSONDecoder().decode(VoiceProfilePreferences.self, from: data)
+        XCTAssertTrue(preferences.continuousConversation)
+    }
+
+    func testContinuousOnPreservesPostAssistantAutomaticRelisten() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        let controller = makeController(capture: capture, gateway: gateway, continuous: true)
+
+        await Self.driveToAssistantCompletion(controller, gateway: gateway)
+
+        XCTAssertEqual(controller.state, .listening)
+        XCTAssertEqual(capture.startCount, 2, "continuous ON restarts capture after TTS")
+        XCTAssertTrue(controller.hasLiveVoiceSession)
+        XCTAssertFalse(controller.isMicrophonePaused)
+        XCTAssertFalse(controller.isPlaybackCaptureSuspended)
+    }
+
+    func testContinuousOffDoesNotAutomaticRelistenAfterAssistantCompletion() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        let policy = RoutePolicyBox(.fullDuplex)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: { _ in true },
+            interrupt: {}
+        )
+        controller.setProfilePreferences(Self.preferences(continuous: false))
+
+        await Self.driveToAssistantCompletion(controller, gateway: gateway)
+
+        XCTAssertEqual(controller.state, .idle, "settled open session must not claim Listening")
+        XCTAssertEqual(capture.startCount, 1, "continuous OFF must not reopen capture after TTS")
+        XCTAssertTrue(capture.didPause, "settle must pause full-duplex capture so the mic tap is not left live")
+        XCTAssertTrue(controller.hasLiveVoiceSession, "the voice session stays open")
+        XCTAssertFalse(controller.isMicrophonePaused, "settling is not a user pause")
+        XCTAssertFalse(controller.isPlaybackCaptureSuspended)
+    }
+
+    func testContinuousOffMuteDuringAssistantStillSettlesWithoutRelisten() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        let policy = RoutePolicyBox(.fullDuplex)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: { _ in true },
+            interrupt: {}
+        )
+        controller.setProfilePreferences(Self.preferences(continuous: false))
+
+        await Self.driveToSpeaking(controller, gateway: gateway)
+        controller.setOutputMuted(true)
+        controller.receiveAssistantEvent(.completed(sessionID: "session", content: "Answer."))
+        try? await Task.sleep(nanoseconds: 120_000_000)
+
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertEqual(capture.startCount, 1)
+        XCTAssertTrue(capture.didPause)
+        XCTAssertTrue(controller.hasLiveVoiceSession)
+
+        // Unmute from the settled idle session must not claim a listening turn.
+        controller.setOutputMuted(false)
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertEqual(capture.startCount, 1)
+    }
+
+    func testContinuousOffUserCanExplicitlyStartAnotherListeningTurn() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        let controller = makeController(capture: capture, gateway: gateway, continuous: false)
+
+        await Self.driveToAssistantCompletion(controller, gateway: gateway)
+        XCTAssertEqual(capture.startCount, 1)
+
+        await controller.resumeMicrophone()
+
+        XCTAssertEqual(controller.state, .listening)
+        XCTAssertEqual(capture.startCount, 2)
+        XCTAssertTrue(controller.hasLiveVoiceSession)
+    }
+
+    func testContinuousOffKeepsEmptyTranscriptListening() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "")
+        let controller = makeController(capture: capture, gateway: gateway, continuous: false)
+        controller.beginVoiceTurn(sessionID: "session")
+        await controller.startListening()
+
+        let start = Date()
+        controller.ingestAudioLevel(0.1, at: start)
+        controller.ingestAudioLevel(0, at: start.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+
+        XCTAssertEqual(controller.state, .listening, "empty transcript stays in the current listening engagement")
+        XCTAssertEqual(capture.startCount, 2)
+    }
+
+    func testContinuousOffKeepsSpokenStopPhraseRelisten() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Stop")
+        var interrupts = 0
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            submit: { _ in true },
+            interrupt: { interrupts += 1 }
+        )
+        controller.setProfilePreferences(Self.preferences(continuous: false))
+        controller.beginVoiceTurn(sessionID: "session")
+        await controller.startListening()
+
+        let start = Date()
+        controller.ingestAudioLevel(0.1, at: start)
+        controller.ingestAudioLevel(0, at: start.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+
+        XCTAssertEqual(interrupts, 1)
+        XCTAssertEqual(controller.state, .listening)
+        XCTAssertEqual(capture.startCount, 2)
+        XCTAssertTrue(controller.hasLiveVoiceSession)
+    }
+
+    func testContinuousOffKeepsSpeakerSafeInterruptRecovery() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        var interrupts = 0
+        let policy = RoutePolicyBox(.speakerSafeHalfDuplex)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: { _ in true },
+            interrupt: { interrupts += 1 }
+        )
+        controller.setProfilePreferences(Self.preferences(continuous: false))
+
+        await Self.driveToSpeaking(controller, gateway: gateway)
+        XCTAssertEqual(controller.isPlaybackCaptureSuspended)
+
+        await controller.interruptAssistantPlayback()
+
+        XCTAssertEqual(interrupts, 1)
+        XCTAssertEqual(controller.state, .listening)
+        XCTAssertEqual(capture.startCount, 2)
+        XCTAssertFalse(controller.isPlaybackCaptureSuspended)
+    }
+
+    func testContinuousOffKeepsHeadsetBargeInRecovery() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        var interrupts = 0
+        let policy = RoutePolicyBox(.fullDuplex)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: { _ in true },
+            interrupt: { interrupts += 1 }
+        )
+        controller.setProfilePreferences(Self.preferences(continuous: false))
+
+        await Self.driveToSpeaking(controller, gateway: gateway)
+        XCTAssertEqual(controller.state, .speaking)
+
+        let bargeInStart = Date()
+        controller.ingestAudioLevel(0.5, at: bargeInStart)
+        controller.ingestAudioLevel(0.5, at: bargeInStart.addingTimeInterval(0.31))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+
+        XCTAssertEqual(interrupts, 1)
+        XCTAssertEqual(controller.state, .listening)
+        XCTAssertEqual(capture.lastStartIncludePreRoll, true)
+    }
+
+    func testContinuousOffSpeakerRouteStillSuspendsCaptureDuringTTS() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        var interrupts = 0
+        let policy = RoutePolicyBox(.speakerSafeHalfDuplex)
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: { _ in true },
+            interrupt: { interrupts += 1 }
+        )
+        controller.setProfilePreferences(Self.preferences(continuous: false))
+
+        await Self.driveToSpeaking(controller, gateway: gateway)
+
+        XCTAssertTrue(controller.isPlaybackCaptureSuspended)
+        let leakStart = Date()
+        controller.ingestAudioLevel(0.5, at: leakStart)
+        controller.ingestAudioLevel(0.5, at: leakStart.addingTimeInterval(0.31))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(interrupts, 0, "route safety is independent of continuousConversation")
+        XCTAssertEqual(controller.state, .speaking)
+    }
+
+    func testProfilePreferenceChangeSwitchesContinuationBehavior() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        let controller = makeController(capture: capture, gateway: gateway, continuous: true)
+
+        await Self.driveToAssistantCompletion(controller, gateway: gateway)
+        XCTAssertEqual(controller.state, .listening)
+        let startsAfterON = capture.startCount
+        XCTAssertEqual(startsAfterON, 2)
+
+        controller.stop()
+        controller.setProfilePreferences(Self.preferences(continuous: false))
+        await Self.driveToAssistantCompletion(controller, gateway: gateway)
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertEqual(capture.startCount, startsAfterON + 1, "OFF only performs the first listen of the turn")
+
+        controller.stop()
+        controller.setProfilePreferences(Self.preferences(continuous: true))
+        await Self.driveToAssistantCompletion(controller, gateway: gateway)
+        XCTAssertEqual(controller.state, .listening)
+    }
+
+    func testUserPauseRemainsAuthoritativeWithContinuousOn() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        let controller = makeController(capture: capture, gateway: gateway, continuous: true)
+
+        await Self.driveToSpeaking(controller, gateway: gateway)
+        controller.pauseMicrophone()
+        controller.receiveAssistantEvent(.completed(sessionID: "session", content: "Done."))
+        try? await Task.sleep(nanoseconds: 120_000_000)
+
+        XCTAssertEqual(controller.state, .listening)
+        XCTAssertTrue(controller.isMicrophonePaused)
+        XCTAssertEqual(capture.resumeCount, 0)
+    }
+
+    func testUserPauseThenListenAfterContinuousOffResumeTurn() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        let controller = makeController(capture: capture, gateway: gateway, continuous: false)
+
+        await Self.driveToSpeaking(controller, gateway: gateway)
+        controller.pauseMicrophone()
+        controller.receiveAssistantEvent(.completed(sessionID: "session", content: "Done."))
+        try? await Task.sleep(nanoseconds: 120_000_000)
+
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertTrue(controller.isMicrophonePaused)
+        XCTAssertEqual(capture.startCount, 1)
+
+        await controller.resumeMicrophone()
+
+        XCTAssertFalse(controller.isMicrophonePaused)
+        XCTAssertEqual(controller.state, .listening)
+    }
+
+    func testGenerationFenceBlocksLateCompletionAfterStopWithContinuousOff() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question", startsPlaybackOnOpen: true)
+        let playback = MockPlayback()
+        let gate = InterruptGate()
+        playback.drainGate = gate
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: playback,
+            gateway: gateway,
+            submit: { _ in true },
+            interrupt: {}
+        )
+        controller.setProfilePreferences(Self.preferences(continuous: false))
+
+        await Self.driveToSpeaking(controller, gateway: gateway)
+        controller.receiveAssistantEvent(.completed(sessionID: "session", content: "Answer."))
+        await gate.waitUntilEntered()
+
+        let startsBeforeStop = capture.startCount
+        controller.stop()
+        gate.release()
+        try? await Task.sleep(nanoseconds: 80_000_000)
+
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertEqual(capture.startCount, startsBeforeStop, "stale drain completion must not reopen capture")
+        XCTAssertFalse(controller.hasLiveVoiceSession)
+    }
+
+    private func makeController(
+        capture: MockCapture,
+        gateway: MockGateway,
+        continuous: Bool
+    ) -> VoiceConversationController {
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            submit: { _ in true },
+            interrupt: {}
+        )
+        controller.setProfilePreferences(Self.preferences(continuous: continuous))
+        return controller
+    }
+
+    private static func preferences(continuous: Bool) -> VoiceProfilePreferences {
+        var preferences = VoiceProfilePreferences()
+        preferences.continuousConversation = continuous
+        return preferences
+    }
+
+    private static func driveToSpeaking(
+        _ controller: VoiceConversationController,
+        gateway: MockGateway,
+        sessionID: String = "session"
+    ) async {
+        controller.beginVoiceTurn(sessionID: sessionID)
+        await controller.startListening()
+        let utteranceStart = Date()
+        controller.ingestAudioLevel(0.1, at: utteranceStart)
+        controller.ingestAudioLevel(0, at: utteranceStart.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(controller.state, .thinking)
+        controller.receiveAssistantEvent(.started(sessionID: sessionID))
+        controller.receiveAssistantEvent(.delta(sessionID: sessionID, text: "Answer."))
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertEqual(controller.state, .speaking)
+    }
+
+    private static func driveToAssistantCompletion(
+        _ controller: VoiceConversationController,
+        gateway: MockGateway,
+        sessionID: String = "session"
+    ) async {
+        await driveToSpeaking(controller, gateway: gateway, sessionID: sessionID)
+        controller.receiveAssistantEvent(.completed(sessionID: sessionID, content: "Answer."))
+        try? await Task.sleep(nanoseconds: 120_000_000)
+    }
+}
+
 /// Mutable route policy so tests can replay route transitions
 /// deterministically; production reads the live AVAudioSession route.
 @MainActor

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -2002,7 +2002,7 @@ final class ContinuousConversationPreferenceTests: XCTestCase {
         controller.setProfilePreferences(Self.preferences(continuous: false))
 
         await Self.driveToSpeaking(controller, gateway: gateway)
-        XCTAssertEqual(controller.isPlaybackCaptureSuspended)
+        XCTAssertTrue(controller.isPlaybackCaptureSuspended)
 
         await controller.interruptAssistantPlayback()
 


### PR DESCRIPTION
## Summary

Continuous conversation already existed before this PR: after assistant TTS finished, `VoiceConversationController.drainSpeechQueue` always called `startListening()` again. The bug was that the stored `VoiceProfilePreferences.continuousConversation` flag was dormant — default `true`, never read at runtime, and never exposed in Voice settings.

This PR wires that existing preference into the existing loop.

### Behavior

- **Continuous Conversation ON (default `true`)**: preserves current behavior. After a completed user → assistant exchange, Conduit automatically listens again. Existing users should see no change unless they disable the preference.
- **Continuous Conversation OFF**: the Voice session and sheet stay open, but Conduit does **not** automatically open the next listening turn. Settled as `.idle` with capture paused (not user-paused). The user starts the next turn with the existing Listen control.

### What this does not change

- Route safety is unchanged (speaker/receiver/CarPlay remain fail-safe half-duplex; proven headset routes keep full-duplex barge-in).
- Pause Microphone semantics remain authoritative.
- Stop phrases, goodbye/idle teardown, wake-word, Siri, CarPlay remain out of scope / future work.
- Safety/recovery restarts stay ungated: empty transcript, spoken stop phrase, acoustic barge-in, manual Interrupt, and speech-stream cancellation after the assistant finished still re-listen.

### Architecture

- `VoiceConversationController` remains the single voice runtime; it receives preferences only via `setProfilePreferences`.
- Persistence reuses the existing profile-scoped blob (`conduit.voice.preferences.v1.<gateway>.<profile>`); a write to `continuousConversation` does not clobber other fields.
- Custom `init(from:)` uses `decodeIfPresent` so a missing key decodes as ON; explicit `init()` restores default construction after the custom decoder removed the synthesized zero-arg initializer.
- Profile scoping is preserved through `loadVoiceProfilePreferences` / `saveVoiceProfilePreferences` / `refreshVoiceCapabilities`.

### Commits

1. `4419577` — feature wiring + tests
2. `e291d5c` — restore `VoiceProfilePreferences()` zero-arg initializer (compile fix)
3. `a70c3d8` — fix one-argument `XCTAssertEqual` in a new test (compile fix)

### Tests

Added `ContinuousConversationPreferenceTests` and `AppStateContinuousConversationPreferenceTests` covering default ON, older-blob decode, persistence without clobbering, ON/OFF continuation behavior, session stays open, explicit Listen after OFF, profile switching, user Pause, speaker-safe suspension, headset barge-in, empty transcript, stop phrase, manual Interrupt, mute, full-duplex settle pause, and generation fencing.

### Verification (Mac @ `a70c3d8`)

- `xcodegen generate` — OK
- `xcodebuild build-for-testing` (iPhone 17 Pro sim) — **TEST BUILD SUCCEEDED**
- Focused: `ContinuousConversationPreferenceTests`, `AppStateContinuousConversationPreferenceTests`, `VoiceConversationControllerTests`, `VoiceSpeakerSafeBargeInTests` — **83 tests, 0 failures**
- Full unit suite `ConduitTests` — **2208 tests, 0 failures**
- Post-fix multi-model re-review — **APPROVE**, no open behavioral findings
- Physical-device acceptance: outstanding (not required for this preference gate)

Do not merge until a human reviewer signs off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a **Continuous Conversation** setting for voice interactions.
  - Users can disable automatic listening after the assistant finishes speaking and resume listening manually when needed.
  - The setting is available in Voice Settings and saved separately for each voice profile.
  - Existing safety and recovery actions continue to restart listening as expected.

- **Bug Fixes**
  - Voice settings now preserve the current mute state during updates to an active voice session.
  - Improved voice session state handling when microphone capture resumes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->