### PR TITLE
feat(voice): configurable spoken Stop and End Conversation controls

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -13109,6 +13109,10 @@ final class AppState: ObservableObject {
     /// canonicalized (trimmed, de-duplicated, blanks dropped) at this
     /// boundary — the single write authority for phrase lists.
     func setSpokenStopPhrases(_ phrases: [String]) {
+        // Same connected-state policy as `setContinuousConversation`: the
+        // preference key is gateway-qualified, and a write while
+        // disconnected would land in the orphaned "disconnected" namespace.
+        guard isConnected else { return }
         updateActiveProfileVoicePreferences {
             $0.spokenStopPhrases = VoiceSpokenCommands.canonicalizedPhraseList(phrases)
         }
@@ -13118,6 +13122,7 @@ final class AppState: ObservableObject {
     /// `setSpokenStopPhrases`; an intentionally emptied list persists as
     /// empty and disables that spoken-command category.
     func setSpokenEndConversationPhrases(_ phrases: [String]) {
+        guard isConnected else { return }
         updateActiveProfileVoicePreferences {
             $0.spokenEndConversationPhrases = VoiceSpokenCommands.canonicalizedPhraseList(phrases)
         }

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -811,6 +811,9 @@ final class AppState: ObservableObject {
         },
         interrupt: { [weak self] in
             await self?.interruptForVoice()
+        },
+        onEndConversation: { [weak self] in
+            self?.closeVoiceConversation()
         }
     )
     /// Manual per-message read aloud for completed assistant responses.
@@ -13099,6 +13102,27 @@ final class AppState: ObservableObject {
         return true
     }
 
+    /// Saves an edited spoken Stop phrase list for the active profile and
+    /// reapplies it to the live controller. Goes through the shared Voice
+    /// preference mutation path so live mute is preserved exactly per
+    /// `hasLiveVoiceSession` authority (PR #159 semantics). Entries are
+    /// canonicalized (trimmed, de-duplicated, blanks dropped) at this
+    /// boundary — the single write authority for phrase lists.
+    func setSpokenStopPhrases(_ phrases: [String]) {
+        updateActiveProfileVoicePreferences {
+            $0.spokenStopPhrases = VoiceSpokenCommands.canonicalizedPhraseList(phrases)
+        }
+    }
+
+    /// Saves an edited spoken End Conversation phrase list. Same contract as
+    /// `setSpokenStopPhrases`; an intentionally emptied list persists as
+    /// empty and disables that spoken-command category.
+    func setSpokenEndConversationPhrases(_ phrases: [String]) {
+        updateActiveProfileVoicePreferences {
+            $0.spokenEndConversationPhrases = VoiceSpokenCommands.canonicalizedPhraseList(phrases)
+        }
+    }
+
     /// Loads the active profile's preference blob, applies `mutate`, and
     /// reapplies it to the live controller.
     ///
@@ -13307,6 +13331,13 @@ final class AppState: ObservableObject {
             return VoiceProfilePreferences()
         }
         return preferences
+    }
+
+    /// The active profile's persisted Voice preferences, for display surfaces
+    /// (settings editors seed from this). Mutations go through the dedicated
+    /// setters, never by writing this value back.
+    var activeProfileVoicePreferences: VoiceProfilePreferences {
+        loadVoiceProfilePreferences(profile: activeProfile)
     }
 
     private func saveVoiceProfilePreferences(_ preferences: VoiceProfilePreferences, profile: String) {

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -509,6 +509,8 @@ struct SettingsView: View {
             )
         case .voice:
             if let bridge = appState.dashboardTicketBridge {
+                // One decode per render, not one per seeded field.
+                let voicePreferences = appState.activeProfileVoicePreferences
                 VoiceSettingsRoute(
                     bridge: bridge,
                     profile: snapshot.profile,
@@ -521,8 +523,8 @@ struct SettingsView: View {
                     transcriptionMode: appState.voiceTranscriptionMode,
                     appleSpeechAvailability: appState.appleSpeechAvailability,
                     continuousConversation: appState.continuousConversationEnabled,
-                    spokenStopPhrases: appState.activeProfileVoicePreferences.spokenStopPhrases,
-                    spokenEndConversationPhrases: appState.activeProfileVoicePreferences.spokenEndConversationPhrases,
+                    spokenStopPhrases: voicePreferences.spokenStopPhrases,
+                    spokenEndConversationPhrases: voicePreferences.spokenEndConversationPhrases,
                     setVoiceEnabled: { enabled in
                         await appState.setVoiceEnabled(enabled)
                     },

--- a/Conduit/Views/AuxiliaryViews.swift
+++ b/Conduit/Views/AuxiliaryViews.swift
@@ -521,6 +521,8 @@ struct SettingsView: View {
                     transcriptionMode: appState.voiceTranscriptionMode,
                     appleSpeechAvailability: appState.appleSpeechAvailability,
                     continuousConversation: appState.continuousConversationEnabled,
+                    spokenStopPhrases: appState.activeProfileVoicePreferences.spokenStopPhrases,
+                    spokenEndConversationPhrases: appState.activeProfileVoicePreferences.spokenEndConversationPhrases,
                     setVoiceEnabled: { enabled in
                         await appState.setVoiceEnabled(enabled)
                     },
@@ -529,6 +531,12 @@ struct SettingsView: View {
                     },
                     setContinuousConversation: { enabled in
                         appState.setContinuousConversation(enabled)
+                    },
+                    setStopPhrases: { phrases in
+                        appState.setSpokenStopPhrases(phrases)
+                    },
+                    setEndConversationPhrases: { phrases in
+                        appState.setSpokenEndConversationPhrases(phrases)
                     }
                 )
             } else {

--- a/Conduit/Views/VoiceSettingsView.swift
+++ b/Conduit/Views/VoiceSettingsView.swift
@@ -477,12 +477,14 @@ struct VoiceSettingsView: View {
                 initialPhrases: spokenStopPhrases,
                 onChange: setStopPhrases
             )
+            .id(spokenStopPhrases)
             SpokenPhraseListEditor(
                 title: "End Conversation Phrases",
                 purposeText: "Close the Voice conversation completely.",
                 initialPhrases: spokenEndConversationPhrases,
                 onChange: setEndConversationPhrases
             )
+            .id(spokenEndConversationPhrases)
         }
     }
 
@@ -645,8 +647,10 @@ private struct SpokenPhraseListEditor: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
-            ForEach(phrases.indices, id: \.self) { index in
-                phraseRow(index)
+            // Entries are pairwise distinct after canonicalization, so the
+            // value itself is a stable identity across deletes and dedupes.
+            ForEach(phrases, id: \.self) { phrase in
+                phraseRow(phrase)
             }
             HStack(spacing: 8) {
                 TextField(editingIndex == nil ? "Add a phrase" : "Edit phrase", text: $draft)
@@ -654,51 +658,66 @@ private struct SpokenPhraseListEditor: View {
                     .onSubmit(commitDraft)
                     .accessibilityLabel(Text(editingIndex == nil ? "Add \(title)" : "Edit \(title)"))
                 Button(editingIndex == nil ? "Add" : "Save", action: commitDraft)
-                    .disabled(draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .disabled(draftCanonicalized.isEmpty)
             }
         }
         .accessibilityElement(children: .contain)
     }
 
-    private func phraseRow(_ index: Int) -> some View {
+    private var draftCanonicalized: String {
+        VoiceSpokenCommands.canonicalized(draft)
+    }
+
+    private func phraseRow(_ phrase: String) -> some View {
         HStack(spacing: 10) {
-            Text(phrases[index])
+            Text(phrase)
                 .font(.subheadline)
             Spacer()
             Button {
-                draft = phrases[index]
-                editingIndex = index
+                draft = phrase
+                editingIndex = phrases.firstIndex(of: phrase)
             } label: {
                 Image(systemName: "pencil")
             }
             .buttonStyle(.borderless)
-            .accessibilityLabel(Text("Edit phrase \(phrases[index])"))
+            .accessibilityLabel(Text("Edit phrase \(phrase)"))
             Button {
-                deletePhrase(at: index)
+                deletePhrase(phrase)
             } label: {
                 Image(systemName: "minus.circle.fill")
                     .foregroundStyle(.red)
             }
             .buttonStyle(.borderless)
-            .accessibilityLabel(Text("Delete phrase \(phrases[index])"))
+            .accessibilityLabel(Text("Delete phrase \(phrase)"))
         }
         .padding(.vertical, 2)
     }
 
     private func commitDraft() {
-        let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
+        // A draft that canonicalizes to empty ("   ", "!!!") would be
+        // dropped by the save-time canonicalization anyway — refuse it here
+        // so committing never silently no-ops.
+        guard !draftCanonicalized.isEmpty else { return }
         var updated = phrases
         if let editingIndex, phrases.indices.contains(editingIndex) {
-            updated[editingIndex] = trimmed
+            updated[editingIndex] = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         } else {
-            updated.append(trimmed)
+            updated.append(draft.trimmingCharacters(in: .whitespacesAndNewlines))
         }
         save(updated)
     }
 
-    private func deletePhrase(at index: Int) {
-        guard phrases.indices.contains(index) else { return }
+    private func deletePhrase(_ phrase: String) {
+        guard let index = phrases.firstIndex(of: phrase) else { return }
+        // Deleting the row being edited (or one before it) shifts the
+        // positional edit target — resolve or drop the pending edit instead
+        // of letting it land on the wrong row.
+        if editingIndex == index {
+            editingIndex = nil
+            draft = ""
+        } else if let editIndex = editingIndex, index < editIndex {
+            editingIndex = editIndex - 1
+        }
         var updated = phrases
         updated.remove(at: index)
         save(updated)
@@ -713,7 +732,8 @@ private struct SpokenPhraseListEditor: View {
     }
 }
 
-private struct VoiceProviderFieldEditor: View {    let field: VoiceTypedField
+private struct VoiceProviderFieldEditor: View {
+    let field: VoiceTypedField
     @Binding var value: String
     let isSaving: Bool
     let save: (String) async -> Void

--- a/Conduit/Views/VoiceSettingsView.swift
+++ b/Conduit/Views/VoiceSettingsView.swift
@@ -16,9 +16,13 @@ struct VoiceSettingsRoute: View {
     let transcriptionMode: VoiceTranscriptionMode
     let appleSpeechAvailability: AppleSpeechRecognitionAvailability
     let continuousConversation: Bool
+    let spokenStopPhrases: [String]
+    let spokenEndConversationPhrases: [String]
     let setVoiceEnabled: (Bool) async -> Bool
     let setTranscriptionMode: (VoiceTranscriptionMode) async -> Bool
     let setContinuousConversation: (Bool) async -> Bool
+    let setStopPhrases: ([String]) -> Void
+    let setEndConversationPhrases: ([String]) -> Void
 
     init(
         bridge: DashboardTicketBridge,
@@ -29,9 +33,13 @@ struct VoiceSettingsRoute: View {
         transcriptionMode: VoiceTranscriptionMode,
         appleSpeechAvailability: AppleSpeechRecognitionAvailability,
         continuousConversation: Bool = true,
+        spokenStopPhrases: [String] = VoiceSpokenCommands.defaultStopPhrases,
+        spokenEndConversationPhrases: [String] = VoiceSpokenCommands.defaultEndConversationPhrases,
         setVoiceEnabled: @escaping (Bool) async -> Bool,
         setTranscriptionMode: @escaping (VoiceTranscriptionMode) async -> Bool,
-        setContinuousConversation: @escaping (Bool) async -> Bool = { _ in true }
+        setContinuousConversation: @escaping (Bool) async -> Bool = { _ in true },
+        setStopPhrases: @escaping ([String]) -> Void = { _ in },
+        setEndConversationPhrases: @escaping ([String]) -> Void = { _ in }
     ) {
         _service = StateObject(wrappedValue: HermesVoiceConfigurationService(bridge: bridge, profile: profile))
         _conversationController = ObservedObject(wrappedValue: conversationController)
@@ -40,9 +48,13 @@ struct VoiceSettingsRoute: View {
         self.transcriptionMode = transcriptionMode
         self.appleSpeechAvailability = appleSpeechAvailability
         self.continuousConversation = continuousConversation
+        self.spokenStopPhrases = spokenStopPhrases
+        self.spokenEndConversationPhrases = spokenEndConversationPhrases
         self.setVoiceEnabled = setVoiceEnabled
         self.setTranscriptionMode = setTranscriptionMode
         self.setContinuousConversation = setContinuousConversation
+        self.setStopPhrases = setStopPhrases
+        self.setEndConversationPhrases = setEndConversationPhrases
     }
 
     var body: some View {
@@ -54,9 +66,13 @@ struct VoiceSettingsRoute: View {
             transcriptionMode: transcriptionMode,
             appleSpeechAvailability: appleSpeechAvailability,
             continuousConversation: continuousConversation,
+            spokenStopPhrases: spokenStopPhrases,
+            spokenEndConversationPhrases: spokenEndConversationPhrases,
             setVoiceEnabled: setVoiceEnabled,
             setTranscriptionMode: setTranscriptionMode,
-            setContinuousConversation: setContinuousConversation
+            setContinuousConversation: setContinuousConversation,
+            setStopPhrases: setStopPhrases,
+            setEndConversationPhrases: setEndConversationPhrases
         )
     }
 }
@@ -98,6 +114,10 @@ struct VoiceSettingsView: View {
     @State private var transcriptionMode: VoiceTranscriptionMode
     @State private var appleSpeechAvailability: AppleSpeechRecognitionAvailability
     @State private var continuousConversation: Bool
+    let spokenStopPhrases: [String]
+    let spokenEndConversationPhrases: [String]
+    let setStopPhrases: ([String]) -> Void
+    let setEndConversationPhrases: ([String]) -> Void
 
     init(
         service: HermesVoiceConfigurationService,
@@ -107,9 +127,13 @@ struct VoiceSettingsView: View {
         transcriptionMode: VoiceTranscriptionMode = .hermes,
         appleSpeechAvailability: AppleSpeechRecognitionAvailability = .permissionRequired(localeIdentifier: Locale.current.identifier),
         continuousConversation: Bool = true,
+        spokenStopPhrases: [String] = VoiceSpokenCommands.defaultStopPhrases,
+        spokenEndConversationPhrases: [String] = VoiceSpokenCommands.defaultEndConversationPhrases,
         setVoiceEnabled: @escaping (Bool) async -> Bool = { _ in false },
         setTranscriptionMode: @escaping (VoiceTranscriptionMode) async -> Bool = { _ in false },
-        setContinuousConversation: @escaping (Bool) async -> Bool = { _ in true }
+        setContinuousConversation: @escaping (Bool) async -> Bool = { _ in true },
+        setStopPhrases: @escaping ([String]) -> Void = { _ in },
+        setEndConversationPhrases: @escaping ([String]) -> Void = { _ in }
     ) {
         self.service = service
         _conversationController = ObservedObject(wrappedValue: conversationController)
@@ -117,6 +141,10 @@ struct VoiceSettingsView: View {
         self.setVoiceEnabled = setVoiceEnabled
         self.setTranscriptionMode = setTranscriptionMode
         self.setContinuousConversation = setContinuousConversation
+        self.spokenStopPhrases = spokenStopPhrases
+        self.spokenEndConversationPhrases = spokenEndConversationPhrases
+        self.setStopPhrases = setStopPhrases
+        self.setEndConversationPhrases = setEndConversationPhrases
         _voiceEnabled = State(initialValue: voiceEnabled)
         _transcriptionMode = State(initialValue: transcriptionMode)
         _appleSpeechAvailability = State(initialValue: appleSpeechAvailability)
@@ -138,6 +166,7 @@ struct VoiceSettingsView: View {
                         providerSection(title: "Assistant speech", symbol: "speaker.wave.3", kind: .tts, providers: service.snapshot.ttsProviders)
                         credentialsSection
                         testingSection
+                        spokenControlsSection
                         wakeSection
                     }
                 }
@@ -437,6 +466,26 @@ struct VoiceSettingsView: View {
         }
     }
 
+    private var spokenControlsSection: some View {
+        ConduitSettingsSection(title: "Spoken Controls", symbol: "text.bubble", tint: .conduitAura) {
+            Text("Phrases you can say during a Voice conversation. A phrase matches only when it is the entire spoken utterance — the same words inside a longer sentence do nothing.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            SpokenPhraseListEditor(
+                title: "Stop Phrases",
+                purposeText: "Cancel the current response and keep Voice open.",
+                initialPhrases: spokenStopPhrases,
+                onChange: setStopPhrases
+            )
+            SpokenPhraseListEditor(
+                title: "End Conversation Phrases",
+                purposeText: "Close the Voice conversation completely.",
+                initialPhrases: spokenEndConversationPhrases,
+                onChange: setEndConversationPhrases
+            )
+        }
+    }
+
     private var wakeSection: some View {
         ConduitSettingsSection(title: "Wake phrase", symbol: "ear.and.waveform", tint: .conduitAura) {
             Text("The bundled bilingual wake model is not active yet. Its redistribution terms and checksums must be reviewed before it can be included in Conduit.")
@@ -561,8 +610,110 @@ struct VoiceSettingsView: View {
     private static let appleProviderID = "apple_on_device"
 }
 
-private struct VoiceProviderFieldEditor: View {
-    let field: VoiceTypedField
+/// Compact phrase-list editor for one spoken-command category: view, add,
+/// edit, and delete entries, including down to an empty list (which disables
+/// that command category — defaults are not forced back). Every save
+/// canonicalizes through `VoiceSpokenCommands` so duplicates and blanks never
+/// reach persistence.
+private struct SpokenPhraseListEditor: View {
+    let title: String
+    let purposeText: String
+    let initialPhrases: [String]
+    let onChange: ([String]) -> Void
+
+    @State private var phrases: [String]
+    @State private var draft = ""
+    @State private var editingIndex: Int?
+
+    init(title: String, purposeText: String, initialPhrases: [String], onChange: @escaping ([String]) -> Void) {
+        self.title = title
+        self.purposeText = purposeText
+        self.initialPhrases = initialPhrases
+        self.onChange = onChange
+        _phrases = State(initialValue: initialPhrases)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.subheadline.weight(.semibold))
+            Text(purposeText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if phrases.isEmpty {
+                Label("No phrases. This spoken command is disabled.", systemImage: "minus.circle")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            ForEach(phrases.indices, id: \.self) { index in
+                phraseRow(index)
+            }
+            HStack(spacing: 8) {
+                TextField(editingIndex == nil ? "Add a phrase" : "Edit phrase", text: $draft)
+                    .textFieldStyle(.roundedBorder)
+                    .onSubmit(commitDraft)
+                    .accessibilityLabel(Text(editingIndex == nil ? "Add \(title)" : "Edit \(title)"))
+                Button(editingIndex == nil ? "Add" : "Save", action: commitDraft)
+                    .disabled(draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private func phraseRow(_ index: Int) -> some View {
+        HStack(spacing: 10) {
+            Text(phrases[index])
+                .font(.subheadline)
+            Spacer()
+            Button {
+                draft = phrases[index]
+                editingIndex = index
+            } label: {
+                Image(systemName: "pencil")
+            }
+            .buttonStyle(.borderless)
+            .accessibilityLabel(Text("Edit phrase \(phrases[index])"))
+            Button {
+                deletePhrase(at: index)
+            } label: {
+                Image(systemName: "minus.circle.fill")
+                    .foregroundStyle(.red)
+            }
+            .buttonStyle(.borderless)
+            .accessibilityLabel(Text("Delete phrase \(phrases[index])"))
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func commitDraft() {
+        let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        var updated = phrases
+        if let editingIndex, phrases.indices.contains(editingIndex) {
+            updated[editingIndex] = trimmed
+        } else {
+            updated.append(trimmed)
+        }
+        save(updated)
+    }
+
+    private func deletePhrase(at index: Int) {
+        guard phrases.indices.contains(index) else { return }
+        var updated = phrases
+        updated.remove(at: index)
+        save(updated)
+    }
+
+    private func save(_ updated: [String]) {
+        let canonical = VoiceSpokenCommands.canonicalizedPhraseList(updated)
+        phrases = canonical
+        onChange(canonical)
+        draft = ""
+        editingIndex = nil
+    }
+}
+
+private struct VoiceProviderFieldEditor: View {    let field: VoiceTypedField
     @Binding var value: String
     let isSaving: Bool
     let save: (String) async -> Void

--- a/Conduit/Views/VoiceSettingsView.swift
+++ b/Conduit/Views/VoiceSettingsView.swift
@@ -632,7 +632,10 @@ private struct SpokenPhraseListEditor: View {
         self.purposeText = purposeText
         self.initialPhrases = initialPhrases
         self.onChange = onChange
-        _phrases = State(initialValue: initialPhrases)
+        // Seed through the same canonicalization the write path uses: a
+        // legacy or externally written blob can carry duplicate/non-canonical
+        // entries, and the value-identity ForEach requires distinct values.
+        _phrases = State(initialValue: VoiceSpokenCommands.canonicalizedPhraseList(initialPhrases))
     }
 
     var body: some View {
@@ -709,15 +712,8 @@ private struct SpokenPhraseListEditor: View {
 
     private func deletePhrase(_ phrase: String) {
         guard let index = phrases.firstIndex(of: phrase) else { return }
-        // Deleting the row being edited (or one before it) shifts the
-        // positional edit target — resolve or drop the pending edit instead
-        // of letting it land on the wrong row.
-        if editingIndex == index {
-            editingIndex = nil
-            draft = ""
-        } else if let editIndex = editingIndex, index < editIndex {
-            editingIndex = editIndex - 1
-        }
+        // Deleting any row discards the current in-progress edit: save()
+        // clears the draft and the edit target unconditionally.
         var updated = phrases
         updated.remove(at: index)
         save(updated)

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -55,6 +55,11 @@ final class VoiceConversationController: ObservableObject {
     private let routePolicyProvider: @MainActor () -> VoiceBargeInRoutePolicy
     private let submit: @MainActor (String) async -> Bool
     private let interrupt: @MainActor () async -> Void
+    /// Installed by AppState: the authoritative Voice Close teardown
+    /// (persist mute → `endVoiceSession` → sheet dismissal). A spoken End
+    /// Conversation phrase converges on it instead of a second teardown;
+    /// nil falls back to the controller-owned `stop()`.
+    private let endConversationRequest: (@MainActor () -> Void)?
     private var captureEventsTask: Task<Void, Never>?
     private var speechDeltas: [String] = []
     private var isDrainingSpeech = false
@@ -94,7 +99,8 @@ final class VoiceConversationController: ObservableObject {
         configuration: Configuration = Configuration(),
         routePolicyProvider: (@MainActor () -> VoiceBargeInRoutePolicy)? = nil,
         submit: @escaping @MainActor (String) async -> Bool,
-        interrupt: @escaping @MainActor () async -> Void
+        interrupt: @escaping @MainActor () async -> Void,
+        onEndConversation: (@MainActor () -> Void)? = nil
     ) {
         let capture = capture ?? AVAudioCaptureService()
         self.capture = capture
@@ -112,6 +118,7 @@ final class VoiceConversationController: ObservableObject {
         }
         self.submit = submit
         self.interrupt = interrupt
+        self.endConversationRequest = onEndConversation
         captureEventsTask = Task { [weak self, capture] in
             for await event in capture.events {
                 guard !Task.isCancelled else { return }
@@ -174,6 +181,13 @@ final class VoiceConversationController: ObservableObject {
     /// control session lifetime, user pause, barge-in, or route policy.
     var isContinuousConversationEnabled: Bool {
         preferences.continuousConversation
+    }
+
+    /// Observability seam: the preference blob currently applied to the
+    /// controller (mirrors the last `setProfilePreferences`), so hosts and
+    /// tests can read back what a preference mutation path actually reapplied.
+    var activePreferences: VoiceProfilePreferences {
+        preferences
     }
 
     /// True while a voice session or provider test is armed or live — i.e.
@@ -720,6 +734,14 @@ final class VoiceConversationController: ObservableObject {
                 await startListening()
                 return
             }
+            // Command boundary: spoken commands are recognized only on the
+            // existing transcription completion path, never during raw
+            // capture. End Conversation is checked first so a phrase present
+            // in both lists deterministically takes the stronger action.
+            if isWholeUtteranceEndConversationCommand(transcript) {
+                await endConversationForSpokenCommand()
+                return
+            }
             conversationTranscript.append(
                 VoiceConversationTranscriptEntry(speaker: .user, text: transcript)
             )
@@ -885,12 +907,30 @@ final class VoiceConversationController: ObservableObject {
         await startListening(includePreRoll: true)
     }
 
-    private func isWholeUtteranceStopCommand(_ transcript: String) -> Bool {
-        let normalized = transcript.lowercased()
-            .trimmingCharacters(in: .whitespacesAndNewlines.union(.punctuationCharacters))
-        return preferences.spokenStopPhrases.contains { phrase in
-            normalized == phrase.lowercased()
+    /// A spoken End Conversation phrase consumed the utterance locally: the
+    /// session closes through the same effective teardown as the sheet's
+    /// Close action — AppState installs that path here (persist mute →
+    /// `endVoiceSession` → sheet dismissal); the fallback covers callers
+    /// without the seam. Closing FIRST fences every stale continuation (the
+    /// teardown bumps the operation generation and cancels the in-flight
+    /// tasks) before the interrupt await, so a completion racing the Hermes
+    /// cancellation cannot reopen capture or playback. This runs regardless
+    /// of `continuousConversation` and is never followed by a relisten.
+    private func endConversationForSpokenCommand() async {
+        if let endConversationRequest {
+            endConversationRequest()
+        } else {
+            stop()
         }
+        await interrupt()
+    }
+
+    private func isWholeUtteranceEndConversationCommand(_ transcript: String) -> Bool {
+        VoiceSpokenCommands.matches(transcript, phrases: preferences.spokenEndConversationPhrases)
+    }
+
+    private func isWholeUtteranceStopCommand(_ transcript: String) -> Bool {
+        VoiceSpokenCommands.matches(transcript, phrases: preferences.spokenStopPhrases)
     }
 
     private func appendAssistantTranscriptDelta(_ text: String) {

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -911,12 +911,21 @@ final class VoiceConversationController: ObservableObject {
     /// session closes through the same effective teardown as the sheet's
     /// Close action — AppState installs that path here (persist mute →
     /// `endVoiceSession` → sheet dismissal); the fallback covers callers
-    /// without the seam. Closing FIRST fences every stale continuation (the
-    /// teardown bumps the operation generation and cancels the in-flight
-    /// tasks) before the interrupt await, so a completion racing the Hermes
-    /// cancellation cannot reopen capture or playback. This runs regardless
-    /// of `continuousConversation` and is never followed by a relisten.
+    /// without the seam. This runs regardless of `continuousConversation`
+    /// and is never followed by a relisten.
+    ///
+    /// Closing FIRST fences every stale continuation (the teardown bumps
+    /// the operation generation and cancels the in-flight tasks) before the
+    /// interrupt await, so a completion racing the Hermes cancellation
+    /// cannot reopen capture or playback. One self-interaction needs care:
+    /// this method runs INSIDE `utteranceTask`, and the teardown's
+    /// `utteranceTask?.cancel()` would mark the current task cancelled —
+    /// `HermesClient.rpc` throws `CancellationError` for cancelled tasks,
+    /// which would abort the turn-cancel below exactly when there is a live
+    /// Hermes turn to cancel. Clearing the handle first makes that cancel a
+    /// no-op; the task ends on its own right after.
     private func endConversationForSpokenCommand() async {
+        utteranceTask = nil
         if let endConversationRequest {
             endConversationRequest()
         } else {

--- a/Conduit/Voice/VoiceTypes.swift
+++ b/Conduit/Voice/VoiceTypes.swift
@@ -64,11 +64,13 @@ enum VoiceSpokenCommands {
     static let defaultEndConversationPhrases = ["goodbye", "bye", "end conversation", "that's all"]
 
     /// The single normalization used on both utterances and configured
-    /// phrases: case folding plus leading/trailing whitespace and punctuation
-    /// stripping (internal punctuation such as the apostrophe in
-    /// "that's all" survives).
+    /// phrases: case folding, typographic apostrophe folding (ASR emits
+    /// U+2019 for the U+0027 in defaults like "that's all"), and
+    /// leading/trailing whitespace and punctuation stripping (internal
+    /// punctuation such as the folded apostrophe survives).
     static func canonicalized(_ text: String) -> String {
         text.lowercased()
+            .replacingOccurrences(of: "\u{2019}", with: "'")
             .trimmingCharacters(in: .whitespacesAndNewlines.union(.punctuationCharacters))
     }
 

--- a/Conduit/Voice/VoiceTypes.swift
+++ b/Conduit/Voice/VoiceTypes.swift
@@ -52,6 +52,51 @@ struct VoiceProviderDescriptor: Codable, Equatable, Identifiable {
     }
 }
 
+/// Shared canonicalization and whole-utterance matching for the spoken Voice
+/// command phrase lists (Stop, End Conversation). Matching is deliberately
+/// conservative: a command fires only when the ENTIRE transcribed utterance
+/// equals an ENTIRE configured phrase after normalization — no substring,
+/// fuzzy, or semantic matching. Both the transcript and the configured
+/// phrases are normalized the same way, so stored phrases need not be
+/// pre-trimmed or lowercased.
+enum VoiceSpokenCommands {
+    static let defaultStopPhrases = ["stop", "stop talking", "be quiet"]
+    static let defaultEndConversationPhrases = ["goodbye", "bye", "end conversation", "that's all"]
+
+    /// The single normalization used on both utterances and configured
+    /// phrases: case folding plus leading/trailing whitespace and punctuation
+    /// stripping (internal punctuation such as the apostrophe in
+    /// "that's all" survives).
+    static func canonicalized(_ text: String) -> String {
+        text.lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines.union(.punctuationCharacters))
+    }
+
+    /// True only when the whole utterance matches a whole configured phrase.
+    /// An utterance that canonicalizes to empty never matches.
+    static func matches(_ utterance: String, phrases: [String]) -> Bool {
+        let normalized = canonicalized(utterance)
+        guard !normalized.isEmpty else { return false }
+        return phrases.contains { canonicalized($0) == normalized }
+    }
+
+    /// Save-time canonicalization for a phrase list: trim each entry, drop
+    /// entries that canonicalize to empty, and de-duplicate by the same
+    /// canonical form used at runtime — keeping the first occurrence's
+    /// trimmed display form so user capitalization survives.
+    static func canonicalizedPhraseList(_ phrases: [String]) -> [String] {
+        var seen: Set<String> = []
+        var result: [String] = []
+        for phrase in phrases {
+            let trimmed = phrase.trimmingCharacters(in: .whitespacesAndNewlines)
+            let canonical = canonicalized(trimmed)
+            guard !canonical.isEmpty, seen.insert(canonical).inserted else { continue }
+            result.append(trimmed)
+        }
+        return result
+    }
+}
+
 struct VoiceProfilePreferences: Codable, Equatable {
     var outputMuted: Bool = false
     /// Whether a completed assistant response automatically opens the next
@@ -59,7 +104,10 @@ struct VoiceProfilePreferences: Codable, Equatable {
     /// barge-in, or route policy.
     var continuousConversation: Bool = true
     var continueWakeConversation: Bool = false
-    var spokenStopPhrases: [String] = ["stop", "stop talking", "be quiet"]
+    var spokenStopPhrases: [String] = VoiceSpokenCommands.defaultStopPhrases
+    /// Spoken phrases that close the whole Voice session through the
+    /// existing Close teardown path. An empty list disables the category.
+    var spokenEndConversationPhrases: [String] = VoiceSpokenCommands.defaultEndConversationPhrases
     /// Nil decodes older preferences as the Hermes-hosted route.
     var transcriptionMode: VoiceTranscriptionMode? = nil
 
@@ -82,7 +130,10 @@ struct VoiceProfilePreferences: Codable, Equatable {
         continuousConversation = try container.decodeIfPresent(Bool.self, forKey: .continuousConversation) ?? true
         continueWakeConversation = try container.decodeIfPresent(Bool.self, forKey: .continueWakeConversation) ?? false
         spokenStopPhrases = try container.decodeIfPresent([String].self, forKey: .spokenStopPhrases)
-            ?? ["stop", "stop talking", "be quiet"]
+            ?? VoiceSpokenCommands.defaultStopPhrases
+        spokenEndConversationPhrases = try container.decodeIfPresent(
+            [String].self, forKey: .spokenEndConversationPhrases
+        ) ?? VoiceSpokenCommands.defaultEndConversationPhrases
         transcriptionMode = try container.decodeIfPresent(VoiceTranscriptionMode.self, forKey: .transcriptionMode)
     }
 }

--- a/ConduitTests/VoiceSpokenControlTests.swift
+++ b/ConduitTests/VoiceSpokenControlTests.swift
@@ -309,20 +309,33 @@ final class VoiceConversationSpokenEndCommandTests: XCTestCase {
         let gateway = MockGateway(transcript: transcript)
         let flags = Flags()
         let box = ControllerBox()
+        // Explicitly typed locals: the combined init expression otherwise
+        // blows up the Swift type checker (multiline + ternary closures).
+        let routeProvider: (@MainActor () -> VoiceBargeInRoutePolicy)?
+        if let routePolicy {
+            routeProvider = { routePolicy }
+        } else {
+            routeProvider = nil
+        }
+        let submitAction: @MainActor (String) async -> Bool = { text in
+            flags.submitTexts.append(text)
+            return true
+        }
+        let interruptAction: @MainActor () async -> Void = {
+            flags.interrupts += 1
+        }
+        let endAction: (@MainActor () -> Void)? = wiresCloseSeam ? {
+            flags.endConversationCount += 1
+            box.controller?.endVoiceSession()
+        } : nil
         let controller = VoiceConversationController(
             capture: capture,
             playback: MockPlayback(),
             gateway: gateway,
-            routePolicyProvider: routePolicy.map { policy in { policy } },
-            submit: { text in
-                flags.submitTexts.append(text)
-                return true
-            },
-            interrupt: { flags.interrupts += 1 },
-            onEndConversation: wiresCloseSeam ? {
-                flags.endConversationCount += 1
-                box.controller?.endVoiceSession()
-            } : nil
+            routePolicyProvider: routeProvider,
+            submit: submitAction,
+            interrupt: interruptAction,
+            onEndConversation: endAction
         )
         box.controller = controller
         return (controller, capture, gateway, flags)

--- a/ConduitTests/VoiceSpokenControlTests.swift
+++ b/ConduitTests/VoiceSpokenControlTests.swift
@@ -1,0 +1,635 @@
+//
+//  VoiceSpokenControlTests.swift
+//  Conduit
+//
+//  Configurable spoken Voice controls: Stop phrases (existing semantics,
+//  now editable) and End Conversation phrases (new category that closes the
+//  Voice session through the existing Close teardown path).
+//
+
+import XCTest
+@testable import Conduit
+
+// MARK: - Matching and canonicalization
+
+@MainActor
+final class VoiceSpokenCommandMatchingTests: XCTestCase {
+    func testDefaultStopPhrasesRemainUnchanged() {
+        XCTAssertEqual(VoiceSpokenCommands.defaultStopPhrases, ["stop", "stop talking", "be quiet"])
+        XCTAssertEqual(VoiceProfilePreferences().spokenStopPhrases, ["stop", "stop talking", "be quiet"])
+    }
+
+    func testDefaultEndConversationPhrases() {
+        XCTAssertEqual(
+            VoiceSpokenCommands.defaultEndConversationPhrases,
+            ["goodbye", "bye", "end conversation", "that's all"]
+        )
+        XCTAssertEqual(VoiceProfilePreferences().spokenEndConversationPhrases, ["goodbye", "bye", "end conversation", "that's all"])
+    }
+
+    func testOlderPreferenceBlobWithoutEndConversationFieldDecodesWithDefaults() throws {
+        let data = try XCTUnwrap(
+            #"{"outputMuted":true,"continueWakeConversation":false,"spokenStopPhrases":["stop"]}"#
+                .data(using: .utf8)
+        )
+        let preferences = try JSONDecoder().decode(VoiceProfilePreferences.self, from: data)
+
+        XCTAssertEqual(preferences.spokenEndConversationPhrases, ["goodbye", "bye", "end conversation", "that's all"])
+        XCTAssertEqual(preferences.spokenStopPhrases, ["stop"])
+        XCTAssertTrue(preferences.outputMuted)
+        XCTAssertTrue(preferences.continuousConversation, "absent continuousConversation still decodes as ON")
+        XCTAssertEqual(preferences.resolvedTranscriptionMode, .hermes)
+    }
+
+    func testUtteranceCasePunctuationAndWhitespaceNormalizeToMatch() {
+        let phrases = ["goodbye"]
+        XCTAssertTrue(VoiceSpokenCommands.matches("Goodbye.", phrases: phrases))
+        XCTAssertTrue(VoiceSpokenCommands.matches(" GOODBYE ", phrases: phrases))
+        XCTAssertTrue(VoiceSpokenCommands.matches("goodbye", phrases: phrases))
+        XCTAssertTrue(VoiceSpokenCommands.matches("Goodbye!!!", phrases: phrases))
+    }
+
+    func testConfiguredPhrasesAreNormalizedBeforeMatching() {
+        let phrases = ["  Goodbye!  ", "BYE"]
+        XCTAssertTrue(VoiceSpokenCommands.matches("Goodbye.", phrases: phrases))
+        XCTAssertTrue(VoiceSpokenCommands.matches("bye", phrases: phrases))
+    }
+
+    func testSubstringUtterancesNeverMatch() {
+        XCTAssertTrue(VoiceSpokenCommands.matches("goodbye", phrases: ["goodbye"]))
+        XCTAssertFalse(VoiceSpokenCommands.matches("I said goodbye to them", phrases: ["goodbye"]))
+        XCTAssertFalse(
+            VoiceSpokenCommands.matches("can you stop talking about that", phrases: ["stop", "stop talking"])
+        )
+    }
+
+    func testEmptyCanonicalUtteranceNeverMatches() {
+        XCTAssertFalse(VoiceSpokenCommands.matches("...", phrases: ["!!!"]))
+        XCTAssertFalse(VoiceSpokenCommands.matches("   ", phrases: ["stop"]))
+    }
+
+    func testCanonicalizedPhraseListTrimsDropsBlanksAndDedupesCaseInsensitively() {
+        let canonical = VoiceSpokenCommands.canonicalizedPhraseList(
+            ["  Stop ", "", "STOP", "be quiet", "   ", "stop!"]
+        )
+        XCTAssertEqual(canonical, ["Stop", "be quiet"])
+    }
+
+    func testEmptyListDisablesMatchingEntirely() {
+        XCTAssertFalse(VoiceSpokenCommands.matches("stop", phrases: []))
+        XCTAssertFalse(VoiceSpokenCommands.matches("goodbye", phrases: []))
+    }
+}
+
+// MARK: - Controller runtime behavior
+
+@MainActor
+final class VoiceConversationSpokenEndCommandTests: XCTestCase {
+    func testEndConversationPhraseIsConsumedAndClosesThroughClosePath() async {
+        let (controller, capture, gateway, flags) = makeController(transcript: "Goodbye.")
+        controller.setProfilePreferences(preferences(endConversation: ["goodbye"]))
+        await driveUtterance(controller)
+
+        XCTAssertEqual(flags.endConversationCount, 1, "the Close teardown seam must be requested exactly once")
+        XCTAssertEqual(gateway.transcriptionCount, 1)
+        XCTAssertEqual(flags.submitTexts, [], "the command must never be submitted to Hermes")
+        XCTAssertEqual(flags.interrupts, 1, "an active Hermes turn is cancelled through the same seam as Stop")
+        XCTAssertFalse(controller.hasLiveVoiceSession, "the voice session must be fully closed")
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertEqual(capture.startCount, 1, "closing must not relisten")
+        XCTAssertTrue(controller.conversationTranscript.isEmpty, "locally consumed commands create no transcript entry")
+    }
+
+    func testEndConversationFallbackStopsControllerWithoutCloseSeam() async {
+        let (controller, capture, _, flags) = makeController(transcript: "goodbye", wiresCloseSeam: false)
+        controller.setProfilePreferences(preferences(endConversation: ["goodbye"]))
+        await driveUtterance(controller)
+
+        XCTAssertEqual(flags.endConversationCount, 0)
+        XCTAssertFalse(controller.hasLiveVoiceSession, "without a Close seam the controller must still stop itself")
+        XCTAssertEqual(capture.startCount, 1)
+    }
+
+    func testEndConversationClosesWithContinuousConversationOn() async {
+        let (controller, capture, _, flags) = makeController(transcript: "goodbye")
+        var preferences = preferences(endConversation: ["goodbye"])
+        preferences.continuousConversation = true
+        controller.setProfilePreferences(preferences)
+        await driveUtterance(controller)
+        try? await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertFalse(controller.hasLiveVoiceSession, "continuous ON must not resurrect the session")
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertEqual(capture.startCount, 1)
+        XCTAssertEqual(flags.endConversationCount, 1)
+    }
+
+    func testEndConversationClosesWithContinuousConversationOff() async {
+        let (controller, capture, _, flags) = makeController(transcript: "goodbye")
+        var preferences = preferences(endConversation: ["goodbye"])
+        preferences.continuousConversation = false
+        controller.setProfilePreferences(preferences)
+        await driveUtterance(controller)
+        try? await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertFalse(controller.hasLiveVoiceSession)
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertEqual(capture.startCount, 1)
+        XCTAssertEqual(flags.endConversationCount, 1)
+    }
+
+    func testConflictPrecedenceEndConversationWinsOverStop() async {
+        let (controller, capture, _, flags) = makeController(transcript: "stop")
+        var preferences = preferences(endConversation: ["stop"])
+        preferences.spokenStopPhrases = ["stop"]
+        controller.setProfilePreferences(preferences)
+        await driveUtterance(controller)
+
+        XCTAssertEqual(flags.endConversationCount, 1, "the stronger action must be deterministic")
+        XCTAssertFalse(controller.hasLiveVoiceSession, "end must close, not stop-and-relisten")
+        XCTAssertEqual(flags.interrupts, 1)
+        XCTAssertEqual(capture.startCount, 1)
+    }
+
+    func testConfiguredStopPhraseIsConsumedInterruptsAndRelistensEvenWithContinuousOff() async {
+        let (controller, capture, gateway, flags) = makeController(transcript: "Halt.")
+        var preferences = preferences(endConversation: ["goodbye"])
+        preferences.spokenStopPhrases = [" halt "]
+        preferences.continuousConversation = false
+        controller.setProfilePreferences(preferences)
+        await driveUtterance(controller)
+
+        XCTAssertEqual(gateway.transcriptionCount, 1)
+        XCTAssertEqual(flags.submitTexts, [])
+        XCTAssertEqual(flags.interrupts, 1)
+        XCTAssertEqual(controller.state, .listening, "Stop remains a recovery restart even with continuous OFF")
+        XCTAssertEqual(capture.startCount, 2)
+        XCTAssertTrue(controller.hasLiveVoiceSession)
+        XCTAssertEqual(
+            controller.conversationTranscript.last?.speaker, .user,
+            "existing Stop transcript semantics are preserved"
+        )
+    }
+
+    func testHeadsetBargeInThenGoodbyeEndsSessionWithoutStaleRelisten() async {
+        let (controller, capture, _, flags) = makeController(
+            transcript: "goodbye",
+            routePolicy: .fullDuplex
+        )
+        controller.setProfilePreferences(preferences(endConversation: ["goodbye"]))
+
+        await driveToSpeaking(controller)
+        let bargeInStart = Date()
+        controller.ingestAudioLevel(0.5, at: bargeInStart)
+        controller.ingestAudioLevel(0.5, at: bargeInStart.addingTimeInterval(0.31))
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        XCTAssertEqual(controller.state, .listening, "full-duplex barge-in must reopen listening first")
+        let startsAfterBargeIn = capture.startCount
+
+        await driveUtterance(controller, silentFinish: true)
+
+        XCTAssertFalse(controller.hasLiveVoiceSession)
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertEqual(flags.interrupts, 2, "one barge-in interruption plus one End Conversation interruption")
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        XCTAssertEqual(capture.startCount, startsAfterBargeIn, "no stale relisten after the session closed")
+    }
+
+    func testSpeakerSafeRouteStaysHalfDuplexDuringTTSWithCommandPhrasesConfigured() async {
+        let (controller, capture, _, flags) = makeController(
+            transcript: "goodbye",
+            routePolicy: .speakerSafeHalfDuplex
+        )
+        controller.setProfilePreferences(preferences(endConversation: ["goodbye"]))
+
+        await driveToSpeaking(controller)
+        XCTAssertTrue(controller.isPlaybackCaptureSuspended)
+
+        let leakStart = Date()
+        controller.ingestAudioLevel(0.5, at: leakStart)
+        controller.ingestAudioLevel(0.5, at: leakStart.addingTimeInterval(0.31))
+        controller.ingestAudioLevel(0.5, at: leakStart.addingTimeInterval(0.62))
+        try? await Task.sleep(nanoseconds: 120_000_000)
+
+        XCTAssertEqual(controller.state, .speaking, "half-duplex playback must not open a command window")
+        XCTAssertEqual(flags.endConversationCount, 0, "commands are recognized only on the transcription path")
+        XCTAssertEqual(flags.interrupts, 0)
+        XCTAssertEqual(capture.startCount, 1)
+    }
+
+    func testSpeakerSafeManualInterruptThenGoodbyeEndsSession() async {
+        let (controller, capture, _, flags) = makeController(
+            transcript: "goodbye",
+            routePolicy: .speakerSafeHalfDuplex
+        )
+        controller.setProfilePreferences(preferences(endConversation: ["goodbye"]))
+
+        await driveToSpeaking(controller)
+        await controller.interruptAssistantPlayback()
+        XCTAssertEqual(controller.state, .listening)
+
+        await driveUtterance(controller, silentFinish: true)
+
+        XCTAssertFalse(controller.hasLiveVoiceSession)
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertEqual(flags.interrupts, 2, "manual Interrupt plus End Conversation interruption")
+        XCTAssertEqual(flags.endConversationCount, 1)
+    }
+
+    func testUserPauseSuppressesSpokenCommandRecognition() async {
+        let (controller, capture, gateway, flags) = makeController(transcript: "goodbye")
+        controller.setProfilePreferences(preferences(endConversation: ["goodbye"]))
+        controller.beginVoiceTurn(sessionID: "session")
+        await controller.startListening()
+        controller.pauseMicrophone()
+
+        let start = Date()
+        capture.emit(level: 0.4, at: start)
+        capture.emit(level: 0.4, at: start.addingTimeInterval(0.4))
+        capture.emit(level: 0, at: start.addingTimeInterval(1.4))
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        XCTAssertEqual(gateway.transcriptionCount, 0, "no transcription while the user paused the microphone")
+        XCTAssertEqual(flags.endConversationCount, 0)
+        XCTAssertEqual(flags.submitTexts, [])
+        XCTAssertTrue(controller.isMicrophonePaused)
+        XCTAssertTrue(controller.hasLiveVoiceSession)
+    }
+
+    func testLateAssistantEventsAfterSpokenEndCannotRestartCaptureOrPlayback() async {
+        let (controller, capture, _, flags) = makeController(transcript: "goodbye")
+        controller.setProfilePreferences(preferences(endConversation: ["goodbye"]))
+        await driveUtterance(controller)
+        XCTAssertEqual(flags.endConversationCount, 1)
+        let startsAtClose = capture.startCount
+
+        controller.receiveAssistantEvent(.started(sessionID: "session"))
+        controller.receiveAssistantEvent(.delta(sessionID: "session", text: "late answer"))
+        controller.receiveAssistantEvent(.completed(sessionID: "session", content: "late answer"))
+        try? await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertFalse(controller.hasLiveVoiceSession)
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertEqual(capture.startCount, startsAtClose, "stale events must not reopen capture")
+    }
+
+    func testEmptyPhraseListsSubmitUtterancesNormally() async {
+        let (controller, _, _, flags) = makeController(transcript: "goodbye")
+        var preferences = preferences(endConversation: [])
+        preferences.spokenStopPhrases = []
+        controller.setProfilePreferences(preferences)
+        await driveUtterance(controller)
+
+        XCTAssertEqual(flags.endConversationCount, 0)
+        XCTAssertEqual(flags.submitTexts, ["goodbye"], "with both lists empty nothing is consumed locally")
+        XCTAssertEqual(controller.state, .thinking)
+        XCTAssertTrue(controller.hasLiveVoiceSession)
+    }
+
+    // MARK: fixtures
+
+    final class Flags {
+        var submitTexts: [String] = []
+        var interrupts = 0
+        var endConversationCount = 0
+    }
+
+    /// Weak holder so the Close-seam closure (mirroring AppState
+    /// closeVoiceConversation) can reach the controller after init.
+    private final class ControllerBox {
+        weak var controller: VoiceConversationController?
+    }
+
+    private func makeController(
+        transcript: String,
+        routePolicy: VoiceBargeInRoutePolicy? = nil,
+        wiresCloseSeam: Bool = true
+    ) -> (VoiceConversationController, MockCapture, MockGateway, Flags) {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: transcript)
+        let flags = Flags()
+        let box = ControllerBox()
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: MockPlayback(),
+            gateway: gateway,
+            routePolicyProvider: routePolicy.map { policy in { policy } },
+            submit: { text in
+                flags.submitTexts.append(text)
+                return true
+            },
+            interrupt: { flags.interrupts += 1 },
+            onEndConversation: wiresCloseSeam ? {
+                flags.endConversationCount += 1
+                box.controller?.endVoiceSession()
+            } : nil
+        )
+        box.controller = controller
+        return (controller, capture, gateway, flags)
+    }
+
+    private func preferences(endConversation: [String]) -> VoiceProfilePreferences {
+        var preferences = VoiceProfilePreferences()
+        preferences.spokenEndConversationPhrases = endConversation
+        return preferences
+    }
+
+    /// Drives one complete listening → transcription cycle through the VAD
+    /// finish path (the same deterministic pattern the existing suites use).
+    /// `silentFinish` skips arming a fresh turn for callers whose capture is
+    /// already live (post barge-in / manual Interrupt).
+    private func driveUtterance(_ controller: VoiceConversationController, silentFinish: Bool = false) async {
+        if !silentFinish {
+            controller.beginVoiceTurn(sessionID: "session")
+            await controller.startListening()
+        }
+        let start = Date()
+        controller.ingestAudioLevel(0.1, at: start)
+        controller.ingestAudioLevel(0, at: start.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 150_000_000)
+    }
+
+    private func driveToSpeaking(_ controller: VoiceConversationController) async {
+        controller.beginVoiceTurn(sessionID: "session")
+        await controller.startListening()
+        let utteranceStart = Date()
+        controller.ingestAudioLevel(0.1, at: utteranceStart)
+        controller.ingestAudioLevel(0, at: utteranceStart.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 120_000_000)
+        XCTAssertEqual(controller.state, .thinking)
+        controller.receiveAssistantEvent(.started(sessionID: "session"))
+        controller.receiveAssistantEvent(.delta(sessionID: "session", text: "Answer."))
+        try? await Task.sleep(nanoseconds: 120_000_000)
+        XCTAssertEqual(controller.state, .speaking)
+    }
+}
+
+// MARK: - Mocks (file-local copies of the established voice doubles)
+
+@MainActor
+private final class MockCapture: AudioCaptureService {
+    let events: AsyncStream<VoiceCaptureEvent>
+    var captureGeneration: UInt64 = 0
+    private var continuation: AsyncStream<VoiceCaptureEvent>.Continuation?
+    private let permissionGranted: Bool
+    private(set) var startCount = 0
+
+    init(permissionGranted: Bool) {
+        self.permissionGranted = permissionGranted
+        var captured: AsyncStream<VoiceCaptureEvent>.Continuation?
+        events = AsyncStream { captured = $0 }
+        continuation = captured
+    }
+    func requestPermission() async -> Bool { permissionGranted }
+    func startListening(includePreRoll: Bool) throws {
+        startCount += 1
+        captureGeneration &+= 1
+    }
+    func beginBargeInMonitoring() throws {}
+    func pause() { captureGeneration &+= 1 }
+    func resume() throws { captureGeneration &+= 1 }
+    func finishUtterance() throws -> VoiceCapturedAudio {
+        VoiceCapturedAudio(wavData: Data([1]), pcm16Data: Data([1, 0]), sampleRate: 16_000, duration: 0.01)
+    }
+    func stop() { captureGeneration &+= 1 }
+    func emit(level: Float, at date: Date = Date()) {
+        continuation?.yield(.level(level, date: date, generation: captureGeneration))
+    }
+}
+
+@MainActor
+private final class MockPlayback: SpeechPlaybackService {
+    var isPlaying = false
+    var ownershipIntent: VoiceAudioIntent = .standalonePlayback
+    func start(sampleRate: Double) throws { isPlaying = true }
+    func enqueuePCM16(_ data: Data, sampleRate: Double) throws -> Int { data.count - (data.count % 2) }
+    func playEncodedAudioData(_ data: Data) throws { isPlaying = true }
+    func finish() throws {}
+    func drain() async { isPlaying = false }
+    func stop() { isPlaying = false }
+}
+
+@MainActor
+private final class MockGateway: VoiceGatewayService {
+    let profile = "default"
+    let transcript: String
+    private(set) var transcriptionCount = 0
+    init(transcript: String) { self.transcript = transcript }
+    func transcribe(_ audio: VoiceCapturedAudio) async throws -> String {
+        transcriptionCount += 1
+        return transcript
+    }
+    func openSpeechStream(
+        onStart: @escaping @MainActor (Double) throws -> Void,
+        onPCM16: @escaping @MainActor (Data, Double) throws -> Void,
+        onEncodedAudio: @escaping @MainActor (Data) throws -> Void
+    ) async throws -> VoiceSpeechStream {
+        MockSpeechStream()
+    }
+}
+
+@MainActor
+private final class MockSpeechStream: VoiceSpeechStream {
+    func append(_ text: String) async throws {}
+    func finish() async throws -> Bool { false }
+    func cancel() {}
+}
+
+// MARK: - AppState persistence
+
+@MainActor
+final class AppStateVoiceSpokenPhraseTests: XCTestCase {
+    func testSetSpokenStopPhrasesPersistsWithoutClobberingUnrelatedFields() throws {
+        let (appState, defaults, suite) = makeAppState(profile: "default")
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        var seed = VoiceProfilePreferences()
+        seed.outputMuted = true
+        seed.continuousConversation = false
+        seed.continueWakeConversation = true
+        seed.spokenStopPhrases = ["halt"]
+        seed.spokenEndConversationPhrases = ["bye"]
+        seed.transcriptionMode = .appleOnDevice
+        savePreferences(seed, defaults: defaults, profile: "default", gateway: "https://example.com")
+
+        appState.setSpokenStopPhrases(["Halt", " stop ", "HALT", "  "])
+
+        let loaded = try loadPreferences(defaults: defaults, profile: "default", gateway: "https://example.com")
+        XCTAssertEqual(loaded.spokenStopPhrases, ["Halt", "stop"], "entries canonicalize: trimmed, de-duplicated, blanks dropped")
+        XCTAssertEqual(loaded.spokenEndConversationPhrases, ["bye"], "the other list must be untouched")
+        XCTAssertTrue(loaded.outputMuted)
+        XCTAssertFalse(loaded.continuousConversation)
+        XCTAssertTrue(loaded.continueWakeConversation)
+        XCTAssertEqual(loaded.resolvedTranscriptionMode, .appleOnDevice)
+        XCTAssertEqual(
+            appState.voiceConversationController.activePreferences.spokenStopPhrases, ["Halt", "stop"],
+            "the live controller is reapplied"
+        )
+    }
+
+    func testSetSpokenEndConversationPhrasesPersistsWithoutClobberingUnrelatedFields() throws {
+        let (appState, defaults, suite) = makeAppState(profile: "default")
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        var seed = VoiceProfilePreferences()
+        seed.outputMuted = false
+        seed.spokenStopPhrases = ["stop"]
+        seed.spokenEndConversationPhrases = ["goodbye"]
+        savePreferences(seed, defaults: defaults, profile: "default", gateway: "https://example.com")
+
+        appState.setSpokenEndConversationPhrases(["See ya", " goodbye ", "SEE YA", ""])
+
+        let loaded = try loadPreferences(defaults: defaults, profile: "default", gateway: "https://example.com")
+        XCTAssertEqual(loaded.spokenEndConversationPhrases, ["See ya", "goodbye"])
+        XCTAssertEqual(loaded.spokenStopPhrases, ["stop"])
+        XCTAssertFalse(loaded.outputMuted)
+        XCTAssertTrue(loaded.continuousConversation)
+    }
+
+    func testSpokenPhraseEditsAreProfileScoped() throws {
+        let (appState, defaults, suite) = makeAppState(profile: "alpha")
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        var alpha = VoiceProfilePreferences()
+        alpha.spokenStopPhrases = ["alpha-stop"]
+        alpha.spokenEndConversationPhrases = ["alpha-bye"]
+        savePreferences(alpha, defaults: defaults, profile: "alpha", gateway: "https://example.com")
+
+        var beta = VoiceProfilePreferences()
+        beta.spokenStopPhrases = ["beta-stop"]
+        beta.spokenEndConversationPhrases = ["beta-bye"]
+        savePreferences(beta, defaults: defaults, profile: "beta", gateway: "https://example.com")
+
+        XCTAssertEqual(appState.activeProfile, "alpha")
+        appState.setSpokenStopPhrases(["new-alpha-stop"])
+        appState.setSpokenEndConversationPhrases(["new-alpha-bye"])
+
+        let loadedAlpha = try loadPreferences(defaults: defaults, profile: "alpha", gateway: "https://example.com")
+        XCTAssertEqual(loadedAlpha.spokenStopPhrases, ["new-alpha-stop"])
+        XCTAssertEqual(loadedAlpha.spokenEndConversationPhrases, ["new-alpha-bye"])
+        let loadedBeta = try loadPreferences(defaults: defaults, profile: "beta", gateway: "https://example.com")
+        XCTAssertEqual(loadedBeta.spokenStopPhrases, ["beta-stop"])
+        XCTAssertEqual(loadedBeta.spokenEndConversationPhrases, ["beta-bye"])
+
+        appState.setActiveProfileForTesting("beta")
+        appState.setSpokenStopPhrases(["new-beta-stop"])
+        let reloadedAlpha = try loadPreferences(defaults: defaults, profile: "alpha", gateway: "https://example.com")
+        let reloadedBeta = try loadPreferences(defaults: defaults, profile: "beta", gateway: "https://example.com")
+        XCTAssertEqual(reloadedAlpha.spokenStopPhrases, ["new-alpha-stop"])
+        XCTAssertEqual(reloadedBeta.spokenStopPhrases, ["new-beta-stop"])
+    }
+
+    func testPhraseEditPreservesLiveMuteOnlyWithLiveSession() throws {
+        let (appState, defaults, suite) = makeAppState(profile: "default")
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        var seed = VoiceProfilePreferences()
+        seed.outputMuted = false
+        savePreferences(seed, defaults: defaults, profile: "default", gateway: "https://example.com")
+
+        // Live Voice session muted in memory only (PR #159 semantics).
+        appState.voiceConversationController.beginVoiceTurn(sessionID: "live-session")
+        appState.voiceConversationController.setOutputMuted(true)
+
+        appState.setSpokenStopPhrases(["quiet"])
+
+        let loaded = try loadPreferences(defaults: defaults, profile: "default", gateway: "https://example.com")
+        XCTAssertTrue(loaded.outputMuted, "live mute must be persisted so the reapplied blob cannot regress")
+        XCTAssertEqual(loaded.spokenStopPhrases, ["quiet"])
+    }
+
+    func testPhraseEditDoesNotCopyStaleControllerMuteWithoutLiveSession() throws {
+        let (appState, defaults, suite) = makeAppState(profile: "beta")
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        var alpha = VoiceProfilePreferences()
+        alpha.outputMuted = true
+        savePreferences(alpha, defaults: defaults, profile: "alpha", gateway: "https://example.com")
+        var beta = VoiceProfilePreferences()
+        beta.outputMuted = false
+        savePreferences(beta, defaults: defaults, profile: "beta", gateway: "https://example.com")
+
+        // Controller still holds profile A's mute after a profile switch
+        // before refreshVoiceCapabilities resyncs. No live session.
+        appState.voiceConversationController.setProfilePreferences(alpha)
+        appState.voiceConversationController.setOutputMuted(true)
+        XCTAssertFalse(appState.voiceConversationController.hasLiveVoiceSession)
+        XCTAssertEqual(appState.activeProfile, "beta")
+
+        appState.setSpokenStopPhrases(["beta-quiet"])
+
+        let loadedBeta = try loadPreferences(defaults: defaults, profile: "beta", gateway: "https://example.com")
+        XCTAssertEqual(loadedBeta.spokenStopPhrases, ["beta-quiet"])
+        XCTAssertFalse(loadedBeta.outputMuted, "stale controller mute must not overwrite B's persisted value")
+    }
+
+    func testEmptyEndConversationListRoundTripsAsEmpty() throws {
+        let (appState, defaults, suite) = makeAppState(profile: "default")
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        appState.setSpokenEndConversationPhrases([])
+
+        let loaded = try loadPreferences(defaults: defaults, profile: "default", gateway: "https://example.com")
+        XCTAssertEqual(
+            loaded.spokenEndConversationPhrases, [],
+            "an intentionally emptied list must not silently grow the defaults back"
+        )
+    }
+
+    // MARK: fixtures
+
+    private func makeAppState(profile: String) -> (AppState, UserDefaults, String) {
+        let suite = "AppStateVoiceSpokenPhraseTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Failed to create test UserDefaults suite")
+        }
+        defaults.set(profile, forKey: "conduit.activeProfile")
+        let appState = AppState(defaults: defaults, loadSavedConnection: false)
+        appState.connection = HermesConnection(baseUrl: "https://example.com", ticket: "test-ticket")
+        appState.isConnected = true
+        appState.installVoiceCapabilityStateForTesting(
+            bridge: DashboardTicketBridge(baseURL: "https://example.com"),
+            snapshot: VoiceCapabilitySnapshot(
+                isGatewayConnected: true,
+                supportsTranscription: true,
+                supportsSpeech: true,
+                unavailableReason: nil
+            ),
+            isVoiceEnabled: true
+        )
+        appState.voiceCapabilityRequesterForTesting = ImmediateVoiceConfigRequester()
+        return (appState, defaults, suite)
+    }
+
+    private func preferencesKey(profile: String, gateway: String) -> String {
+        "conduit.voice.preferences.v1.\(gateway.lowercased()).\(profile)"
+    }
+
+    private func savePreferences(
+        _ preferences: VoiceProfilePreferences,
+        defaults: UserDefaults,
+        profile: String,
+        gateway: String
+    ) {
+        guard let data = try? JSONEncoder().encode(preferences) else { return }
+        defaults.set(data, forKey: preferencesKey(profile: profile, gateway: gateway))
+    }
+
+    private func loadPreferences(
+        defaults: UserDefaults,
+        profile: String,
+        gateway: String
+    ) throws -> VoiceProfilePreferences {
+        let data = try XCTUnwrap(defaults.data(forKey: preferencesKey(profile: profile, gateway: gateway)))
+        return try JSONDecoder().decode(VoiceProfilePreferences.self, from: data)
+    }
+}
+
+/// Fail-fast requester so refreshVoiceCapabilities skips the network without
+/// waiting on dashboard timeouts; preference loading still runs.
+@MainActor
+private final class ImmediateVoiceConfigRequester: VoiceConfigurationRequesting {
+    func requestJSON(path: String, method: String, body: [String: Any]?) async throws -> [String: Any] {
+        throw URLError(.notConnectedToInternet)
+    }
+}

--- a/ConduitTests/VoiceSpokenControlTests.swift
+++ b/ConduitTests/VoiceSpokenControlTests.swift
@@ -447,7 +447,11 @@ private final class MockGateway: VoiceGatewayService {
         onPCM16: @escaping @MainActor (Data, Double) throws -> Void,
         onEncodedAudio: @escaping @MainActor (Data) throws -> Void
     ) async throws -> VoiceSpeechStream {
-        MockSpeechStream()
+        // Mirror the production streaming provider: opening a stream for a
+        // drain that has deltas delivers the start control immediately, so
+        // playback state and playback-capture policy engage deterministically.
+        try onStart(24_000)
+        return MockSpeechStream()
     }
 }
 

--- a/ConduitTests/VoiceSpokenControlTests.swift
+++ b/ConduitTests/VoiceSpokenControlTests.swift
@@ -172,13 +172,14 @@ final class VoiceConversationSpokenEndCommandTests: XCTestCase {
     }
 
     func testHeadsetBargeInThenGoodbyeEndsSessionWithoutStaleRelisten() async {
-        let (controller, capture, _, flags) = makeController(
-            transcript: "goodbye",
+        let (controller, capture, gateway, flags) = makeController(
+            transcript: "Question",
             routePolicy: .fullDuplex
         )
         controller.setProfilePreferences(preferences(endConversation: ["goodbye"]))
 
         await driveToSpeaking(controller)
+        gateway.transcript = "goodbye"
         let bargeInStart = Date()
         controller.ingestAudioLevel(0.5, at: bargeInStart)
         controller.ingestAudioLevel(0.5, at: bargeInStart.addingTimeInterval(0.31))
@@ -196,13 +197,14 @@ final class VoiceConversationSpokenEndCommandTests: XCTestCase {
     }
 
     func testSpeakerSafeRouteStaysHalfDuplexDuringTTSWithCommandPhrasesConfigured() async {
-        let (controller, capture, _, flags) = makeController(
-            transcript: "goodbye",
+        let (controller, capture, gateway, flags) = makeController(
+            transcript: "Question",
             routePolicy: .speakerSafeHalfDuplex
         )
         controller.setProfilePreferences(preferences(endConversation: ["goodbye"]))
 
         await driveToSpeaking(controller)
+        gateway.transcript = "goodbye"
         XCTAssertTrue(controller.isPlaybackCaptureSuspended)
 
         let leakStart = Date()
@@ -218,13 +220,14 @@ final class VoiceConversationSpokenEndCommandTests: XCTestCase {
     }
 
     func testSpeakerSafeManualInterruptThenGoodbyeEndsSession() async {
-        let (controller, capture, _, flags) = makeController(
-            transcript: "goodbye",
+        let (controller, capture, gateway, flags) = makeController(
+            transcript: "Question",
             routePolicy: .speakerSafeHalfDuplex
         )
         controller.setProfilePreferences(preferences(endConversation: ["goodbye"]))
 
         await driveToSpeaking(controller)
+        gateway.transcript = "goodbye"
         await controller.interruptAssistantPlayback()
         XCTAssertEqual(controller.state, .listening)
 
@@ -430,7 +433,9 @@ private final class MockPlayback: SpeechPlaybackService {
 @MainActor
 private final class MockGateway: VoiceGatewayService {
     let profile = "default"
-    let transcript: String
+    /// Mutable so multi-phase tests can use a normal utterance to drive the
+    /// assistant turn and a command utterance for the phase under test.
+    var transcript: String
     private(set) var transcriptionCount = 0
     init(transcript: String) { self.transcript = transcript }
     func transcribe(_ audio: VoiceCapturedAudio) async throws -> String {

--- a/ConduitTests/VoiceSpokenControlTests.swift
+++ b/ConduitTests/VoiceSpokenControlTests.swift
@@ -55,6 +55,15 @@ final class VoiceSpokenCommandMatchingTests: XCTestCase {
         XCTAssertTrue(VoiceSpokenCommands.matches("bye", phrases: phrases))
     }
 
+    func testApostropheVariantsMatchAcrossUtteranceAndPhrase() {
+        // The default phrase uses U+0027; ASR often emits U+2019.
+        XCTAssertTrue(VoiceSpokenCommands.matches("that's all", phrases: ["that's all"]))
+        XCTAssertTrue(VoiceSpokenCommands.matches("that’s all", phrases: ["that's all"]))
+        XCTAssertTrue(VoiceSpokenCommands.matches("that's all.", phrases: ["that’s all"]))
+        XCTAssertTrue(VoiceSpokenCommands.matches("That’s All!", phrases: ["  that's all  "]))
+        XCTAssertFalse(VoiceSpokenCommands.matches("that's all folks", phrases: ["that's all"]))
+    }
+
     func testSubstringUtterancesNeverMatch() {
         XCTAssertTrue(VoiceSpokenCommands.matches("goodbye", phrases: ["goodbye"]))
         XCTAssertFalse(VoiceSpokenCommands.matches("I said goodbye to them", phrases: ["goodbye"]))
@@ -325,6 +334,11 @@ final class VoiceConversationSpokenEndCommandTests: XCTestCase {
             return true
         }
         let interruptAction: @MainActor () async -> Void = {
+            // The End Conversation teardown cancels the utterance task that
+            // called it; the Hermes interrupt must still run in an
+            // uncancelled task (HermesClient.rpc throws CancellationError
+            // for cancelled work, which would leave the turn alive).
+            XCTAssertFalse(Task.isCancelled)
             flags.interrupts += 1
         }
         let endAction: (@MainActor () -> Void)?

--- a/ConduitTests/VoiceSpokenControlTests.swift
+++ b/ConduitTests/VoiceSpokenControlTests.swift
@@ -324,10 +324,15 @@ final class VoiceConversationSpokenEndCommandTests: XCTestCase {
         let interruptAction: @MainActor () async -> Void = {
             flags.interrupts += 1
         }
-        let endAction: (@MainActor () -> Void)? = wiresCloseSeam ? {
-            flags.endConversationCount += 1
-            box.controller?.endVoiceSession()
-        } : nil
+        let endAction: (@MainActor () -> Void)?
+        if wiresCloseSeam {
+            endAction = {
+                flags.endConversationCount += 1
+                box.controller?.endVoiceSession()
+            }
+        } else {
+            endAction = nil
+        }
         let controller = VoiceConversationController(
             capture: capture,
             playback: MockPlayback(),

--- a/ConduitTests/VoiceSpokenControlTests.swift
+++ b/ConduitTests/VoiceSpokenControlTests.swift
@@ -84,6 +84,20 @@ final class VoiceSpokenCommandMatchingTests: XCTestCase {
         XCTAssertEqual(canonical, ["Stop", "be quiet"])
     }
 
+    func testCanonicalizedPhraseListProducesPairwiseDistinctEntries() {
+        // The phrase-list editor renders rows with value identity, so the
+        // seeded representation must never contain duplicate raw strings —
+        // including when it seeds from a legacy blob written before
+        // canonicalization existed.
+        let canonical = VoiceSpokenCommands.canonicalizedPhraseList(
+            ["Stop", "stop", "STOP ", "be quiet", "be quiet.", "", "  ", "halt!"]
+        )
+        // Display form is the first occurrence, whitespace-trimmed only;
+        // "halt!" still matches "halt" at runtime via canonicalization.
+        XCTAssertEqual(canonical, ["Stop", "be quiet", "halt!"])
+        XCTAssertEqual(Set(canonical).count, canonical.count)
+    }
+
     func testEmptyListDisablesMatchingEntirely() {
         XCTAssertFalse(VoiceSpokenCommands.matches("stop", phrases: []))
         XCTAssertFalse(VoiceSpokenCommands.matches("goodbye", phrases: []))
@@ -602,6 +616,21 @@ final class AppStateVoiceSpokenPhraseTests: XCTestCase {
         let loadedBeta = try loadPreferences(defaults: defaults, profile: "beta", gateway: "https://example.com")
         XCTAssertEqual(loadedBeta.spokenStopPhrases, ["beta-quiet"])
         XCTAssertFalse(loadedBeta.outputMuted, "stale controller mute must not overwrite B's persisted value")
+    }
+
+    func testSpokenPhraseEditsDoNotPersistWhileDisconnected() {
+        let (appState, defaults, suite) = makeAppState(profile: "default")
+        defer { defaults.removePersistentDomain(forName: suite) }
+        appState.connection = nil
+        appState.isConnected = false
+
+        appState.setSpokenStopPhrases(["quiet"])
+        appState.setSpokenEndConversationPhrases(["bye"])
+
+        XCTAssertNil(
+            defaults.data(forKey: "conduit.voice.preferences.v1.disconnected.default"),
+            "disconnected phrase edits must not write the orphaned gateway namespace"
+        )
     }
 
     func testEmptyEndConversationListRoundTripsAsEmpty() throws {


### PR DESCRIPTION
## Summary

Configurable spoken Voice controls, profile-scoped and editable in Settings:

- **Stop phrases** (existed before this PR — semantics unchanged, now editable): a whole-utterance match consumes the phrase locally, cancels the current Hermes turn, stops TTS, keeps the Voice session open, and relistens. This remains a recovery/control restart even when Continuous Conversation is OFF (PR #159 left spoken-stop recovery ungated; preserved).
- **End Conversation phrases** (new, separate category, defaults `goodbye` / `bye` / `end conversation` / `that's all`): a whole-utterance match consumes the phrase, cancels any active Hermes turn through the same interrupt seam as Stop, and closes the Voice session completely — through the **existing Close teardown path** (`AppState.closeVoiceConversation()`: persist mute → `endVoiceSession()` → sheet dismissal), reached via a minimal `onEndConversation` seam on the controller. No second teardown implementation, no relisten afterward, independent of Continuous Conversation.

Defaults for Stop are unchanged (`stop`, `stop talking`, `be quiet`).

## Command recognition boundary

No new speech-recognition architecture: commands are recognized only where the existing transcription path completes an utterance (`finishUtterance`). No wake-word detector, no keyword spotting during raw capture, no second recognizer.

- **Full-duplex/headset routes:** unchanged — acoustic barge-in interrupts the assistant, the transcribed `goodbye` then matches and closes Voice.
- **Speaker-safe routes (speaker/receiver/CarPlay/unknown):** remain half-duplex. The microphone is NOT reopened during TTS to hear commands; the existing manual Interrupt control stays the way to speak a command during playback on those routes (pinned by tests).

## Matching rules

`VoiceSpokenCommands` is the single shared canonicalization/matching path for both lists. Deliberately conservative:

- whole-utterance matching only — `"I said goodbye to them"` never matches `goodbye`, `"can you stop talking about that"` never matches `stop talking`;
- normalization (case, surrounding whitespace/punctuation) applies to **both** the transcript and the configured phrases;
- no substring, fuzzy, semantic, or regex matching;
- conflict precedence: a phrase present in both lists deterministically takes the stronger action (**End Conversation wins** — end list is checked first).

## Persistence

Both lists live in the existing profile-scoped blob `conduit.voice.preferences.v1.<gateway>.<profile>`:

- `spokenEndConversationPhrases` added to `VoiceProfilePreferences`; older blobs without the key decode successfully and receive the new defaults (backward compatible);
- `outputMuted`, `continuousConversation`, `continueWakeConversation`, `spokenStopPhrases`, `transcriptionMode` are untouched by phrase edits;
- edits go through the PR #159 shared mutation path (`updateActiveProfileVoicePreferences`), so live mute is preserved only when `hasLiveVoiceSession` makes the controller authoritative;
- empty lists are valid and disable that spoken-command category — defaults are never silently restored;
- save-time canonicalization trims, drops blanks, and de-duplicates by the same normalized form used at runtime (display capitalization preserved).

## Generation / stale async work

After a spoken End Conversation closes Voice, the Close-path teardown (`stop()`) bumps the operation generation and cancels in-flight tasks *before* the Hermes interrupt await, so: late transcription continuations cannot submit; stale assistant events cannot restart playback or capture; speech-drain completion cannot relisten; continuous conversation cannot resurrect the session. Existing operation-generation / speech-drain revision fences are reused — no parallel lifecycle token system.

## Settings UI

New **Spoken Controls** section in Voice settings with compact list editors for both categories (view / add / edit / delete, empty allowed). Copy explains the difference ("Cancel the current response and keep Voice open." vs "Close the Voice conversation completely.") and that matching is whole-utterance.

## Explicitly unchanged

`VoiceAudioSessionCoordinator`, `VoiceBargeInRoutePolicy`, route classification, half-duplex eligibility, VAD thresholds, pre-roll, barge-in thresholds, capture suspension rules, Siri/App Intents, CarPlay, wake-word, idle timeout, fillers, provider TTS, AVAudioSession architecture.

## Tests

TDD (tests committed first; red build confirmed, then implementation):

- new `VoiceSpokenCommandMatchingTests` (defaults, backward-compatible decode, normalization both sides, no-substring, empty-list disables, list canonicalization);
- new `VoiceConversationSpokenEndCommandTests` (consume-and-close via the real Close seam, no-submit/no-transcript-entry, relisten-free close on continuous ON and OFF, conflict precedence, stop-still-relistens-when-OFF, barge-in→goodbye without stale relisten, speaker-safe half-duplex + manual Interrupt→goodbye, user-pause authority, late-assistant-event fencing, empty lists submit normally);
- new `AppStateVoiceSpokenPhraseTests` (persistence without clobbering, profile scoping, live-mute preservation with and without a live session, empty-list round-trip);
- regression: `ContinuousConversationPreferenceTests`, `AppStateContinuousConversationPreferenceTests`, `VoiceConversationControllerTests` (incl. existing spoken-stop coverage), plus the full `ConduitTests` unit suite.

Background/disconnect/server-replacement teardown behavior is pinned by the existing suites (`setForegroundActive` stop, server-replacement retirement) and is untouched.

## Review gate

Round 1 (three-model, on the feature): 2× REQUEST-CHANGES → fixed, 1× APPROVE. Accepted and fixed:

- **BLOCKER (2/3 reviewers): self-cancellation of the turn interrupt.** The Close teardown's `stop()` cancelled the very utterance task that then awaited the Hermes interrupt; `HermesClient.rpc` throws `CancellationError` for cancelled tasks, so the turn-cancel RPC would abort exactly when a live Hermes turn exists. Fixed by clearing the utterance-task handle before the teardown (close-first fencing preserved); a fixture assertion pins the interrupt running uncancelled.
- Typographic apostrophe (U+2019 — a common ASR emission) is folded in the shared canonicalization so the default `that's all` matches regardless of which apostrophe the recognizer returns.
- Phrase editor hardening: value-identity rows, punctuation-only drafts refused at commit, delete-while-editing target fix, editor re-seed identity, one preference decode per render.

Declined with reasoning: reordering to interrupt-first (would reintroduce the stale-continuation reopen race the close-first ordering exists to fence); caching pre-canonicalized phrase lists (matching runs once per completed utterance over a tiny list; caching adds invalidation coupling); a dedicated drain-race-after-End test (reaching the transcription path always cancels an active drain first — barge-in/manual Interrupt own that fence, and `stop()`'s drain fencing is already pinned deterministically by `testGenerationFenceBlocksLateCompletionAfterStopWithContinuousOff`).

Round 2 (three-model, on cleanup commit 60f386c): **3× APPROVE, no blocking findings.** The cleanup canonicalizes the phrase editor's seeding (legacy blobs with duplicates cannot collide with value-identity rows), guards the phrase setters on `isConnected` (same policy as `setContinuousConversation` — no writes to the orphaned "disconnected" gateway namespace), and removes dead edit-index bookkeeping in `deletePhrase`. One non-blocking suggestion (returning `Bool` from the phrase setters for failure-signaling parity) declined: the simpler disconnected policy was the explicit product decision for this surface.

## Verification

- macOS/Windows-side: full unit suite run on the Mac build box (result recorded in comments).
- Physical-device acceptance (real speaker/headset/CarPlay routes): **outstanding** — to be verified on device after merge.
