### PR TITLE
feat(voice): suspend Voice on background instead of hard teardown

### DIFF
--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -810,12 +810,49 @@ final class AppState: ObservableObject {
             return await self.submitVoiceTranscript(transcript)
         },
         interrupt: { [weak self] in
-            await self?.interruptForVoice()
+            guard let self else { return false }
+            return await self.interruptForVoice()
         },
         onEndConversation: { [weak self] in
             self?.closeVoiceConversation()
         }
     )
+    /// Logical identity of a Voice conversation suspended by an app lifecycle
+    /// transition (scene backgrounded / device locked). Identity only: it
+    /// never holds audio resources, gateway or transport references, session
+    /// leases, or task handles. Recorded when the scene deactivates with the
+    /// Voice sheet open, consumed by foreground restoration, and cleared by
+    /// every destructive Voice boundary (explicit Close, spoken End
+    /// Conversation, profile switch, server replacement, disconnect, forced
+    /// sign-out, voice disabled). In memory only — process death
+    /// intentionally loses it.
+    struct SuspendedVoiceConversation: Equatable {
+        let profile: String
+        let sessionID: String
+        let serverIdentity: String?
+    }
+    @Published private(set) var suspendedVoiceConversation: SuspendedVoiceConversation?
+    /// One-shot intent for the Voice sheet's auto-listen on fresh
+    /// presentation. Armed only by `openVoiceConversation` and consumed
+    /// exactly once by the sheet, so a restored suspended conversation can
+    /// never hot-start the microphone when SwiftUI recreates the sheet's
+    /// view identity. Lifecycle suspension and every destructive Voice
+    /// boundary disarm it.
+    internal(set) var voiceSheetShouldAutoListen = false
+
+    func consumeVoiceSheetAutoListen() -> Bool {
+        guard voiceSheetShouldAutoListen else { return false }
+        voiceSheetShouldAutoListen = false
+        return true
+    }
+    /// The profile the voice conversation controller's current session was
+    /// opened for. Close-time mute persistence is keyed on this rather than
+    /// on session liveness alone: an audio interruption or any boundary that
+    /// stops the controller must still let a same-profile Close persist the
+    /// user's mute, while a Close arriving after a profile flip (the sheet's
+    /// deferred `onDismiss`) must not write the outgoing profile's mute into
+    /// the now-active profile's blob.
+    internal(set) var voiceControllerSessionProfile: String?
     /// Manual per-message read aloud for completed assistant responses.
     /// TTS-only: independent of the voice conversation and of STT.
     lazy var messageReadAloudController = MessageReadAloudController(
@@ -2101,6 +2138,11 @@ final class AppState: ObservableObject {
         // from its own bridge (capability refresh, read-aloud assignment).
         voiceConversationController.setGateway(nil)
         readAloudGatewayBridge = nil
+        // Server replacement is a destructive Voice boundary: a suspended
+        // conversation from the outgoing server must never be restored.
+        suspendedVoiceConversation = nil
+        voiceSheetShouldAutoListen = false
+        voiceControllerSessionProfile = nil
         showVoiceSheet = false
     }
 
@@ -2782,6 +2824,9 @@ final class AppState: ObservableObject {
         // never open a stream again, so it must not survive the re-login.
         messageReadAloudController.setGateway(nil)
         readAloudGatewayBridge = nil
+        suspendedVoiceConversation = nil
+        voiceSheetShouldAutoListen = false
+        voiceControllerSessionProfile = nil
         showVoiceSheet = false
         voiceCapabilitySnapshot = .unavailable
         isVoiceEnabled = false
@@ -2949,6 +2994,15 @@ final class AppState: ObservableObject {
         messageReadAloudController.stop()
         messageReadAloudController.setGateway(nil)
         readAloudGatewayBridge = nil
+        // Forced sign-out supersedes any suspended Voice conversation (the
+        // restore-time connection identity check would fail closed anyway);
+        // stop the controller and drop the sheet immediately like
+        // Disconnect does instead of waiting for the next scene cycle.
+        suspendedVoiceConversation = nil
+        voiceSheetShouldAutoListen = false
+        voiceControllerSessionProfile = nil
+        voiceConversationController.stop()
+        showVoiceSheet = false
         projects = []
         supportsProjects = false
         projectsLoading = false
@@ -5206,6 +5260,11 @@ final class AppState: ObservableObject {
             isSceneActive = true
             voiceConversationController.setForegroundActive(true)
             messageReadAloudController.setForegroundActive(true)
+            // Voice restoration deliberately does NOT run here: the socket,
+            // bridge, and runtime session identity may all be stale after a
+            // background suspension. The suspended descriptor is consumed
+            // inside the reconciliation task below, after the authoritative
+            // transport/session state is established (or definitively fails).
             // Consume the background arming even while signed out, so a
             // background → active cycle on the login screen doesn't surface
             // a stale request after the user signs back in.
@@ -5276,13 +5335,13 @@ final class AppState: ObservableObject {
                             // session.
                             self.settleReconciliation(token)
                             await self.reconnectForRetry(purpose: .preserveCurrent)
-                            return
+                        } else {
+                            lifecycleLog.notice(
+                                "Foreground refresh: health check failed (\(error.localizedDescription, privacy: .private)); reconnecting"
+                            )
+                            await self.reconnectForRetry(purpose: .automaticReturn)
+                            self.settleReconciliation(token)
                         }
-                        lifecycleLog.notice(
-                            "Foreground refresh: health check failed (\(error.localizedDescription, privacy: .private)); reconnecting"
-                        )
-                        await self.reconnectForRetry(purpose: .automaticReturn)
-                        self.settleReconciliation(token)
                     }
                 } else {
                     guard self.scenePhaseAttemptIsCurrent(sceneAttemptID) else {
@@ -5292,13 +5351,25 @@ final class AppState: ObservableObject {
                     if !self.automaticChatResumeWorkIsCurrent(automaticWorkToken) {
                         self.settleReconciliation(token)
                         await self.reconnectForRetry(purpose: .preserveCurrent)
-                        return
+                    } else {
+                        lifecycleLog.notice(
+                            "Foreground refresh start: transport=missing-or-unhealthy; reconnecting"
+                        )
+                        await self.reconnectForRetry(purpose: .automaticReturn)
+                        self.settleReconciliation(token)
                     }
-                    lifecycleLog.notice(
-                        "Foreground refresh start: transport=missing-or-unhealthy; reconnecting"
+                }
+                // Voice restoration runs here — after the authoritative
+                // reconciliation above established transport and session
+                // state — and only while this attempt is still current. A
+                // pending suspended conversation forces a capability refresh
+                // first: the pre-background snapshot cannot be trusted across
+                // suspension, and restoration must fail closed when the
+                // refreshed state says a fresh open would be rejected.
+                if self.scenePhaseAttemptIsCurrent(sceneAttemptID) {
+                    await self.refreshCapabilitiesAndRestoreSuspendedVoice(
+                        isCurrent: { self.scenePhaseAttemptIsCurrent(sceneAttemptID) }
                     )
-                    await self.reconnectForRetry(purpose: .automaticReturn)
-                    self.settleReconciliation(token)
                 }
             }
             scenePhaseTask = task
@@ -5333,9 +5404,12 @@ final class AppState: ObservableObject {
                 locallyOwnedInFlightTurn = nil
             }
             foregroundFreshnessCheckArmed = true
-            voiceConversationController.setForegroundActive(false)
             messageReadAloudController.setForegroundActive(false)
-            showVoiceSheet = false
+            // Suspension is not Close: an open Voice conversation releases its
+            // runtime ownership and is recorded for foreground restoration,
+            // and the sheet presentation intentionally survives the
+            // background transition.
+            suspendVoiceConversationForBackground()
             // Drop any armed reconnect timer as well: in-flight cycles abort
             // at their next transportContinuation checkpoint, and foreground
             // activation re-establishes the transport.
@@ -5372,8 +5446,14 @@ final class AppState: ObservableObject {
             // transition too, rather than at its next checkpoint.
             cancelScenePhaseAttempt()
             chatResumeCoordinator.freezeViewport()
-            voiceConversationController.setForegroundActive(false)
             messageReadAloudController.setForegroundActive(false)
+            // A transient .inactive dip (Control Center, an incoming-call
+            // banner, the microphone permission prompt) is NOT a lifecycle
+            // suspension: the socket and audio session survive, in-flight
+            // turns keep flowing, and a pending first-listen must survive the
+            // dip. Voice suspension happens only on the actual .background
+            // transition — a descriptor-less suspension here would tear the
+            // runtime down with no restoration path.
             return nil
 
         @unknown default:
@@ -5383,6 +5463,110 @@ final class AppState: ObservableObject {
 
     private func scenePhaseAttemptIsCurrent(_ id: UUID) -> Bool {
         !Task.isCancelled && scenePhaseAttemptID == id
+    }
+
+    /// Background transition for the Voice conversation. An open Voice sheet
+    /// routes through the controller's lifecycle suspension — runtime
+    /// ownership released, logical conversation preserved — and records the
+    /// suspended descriptor for foreground restoration. A closed Voice sheet
+    /// keeps the existing full-stop semantics. Transient .inactive dips never
+    /// reach this: they leave Voice untouched.
+    private func suspendVoiceConversationForBackground() {
+        // Suspension disarms the fresh-open auto-listen intent: the restored
+        // sheet must never hot-start the microphone, even if SwiftUI
+        // recreates the sheet's view identity while the binding stays true.
+        voiceSheetShouldAutoListen = false
+        voiceConversationController.setForegroundActive(false)
+        guard showVoiceSheet else {
+            voiceConversationController.stop()
+            return
+        }
+        voiceConversationController.suspendRuntimeForLifecycle()
+        suspendedVoiceConversation = SuspendedVoiceConversation(
+            profile: activeProfile,
+            sessionID: activeSessionId ?? "",
+            serverIdentity: Self.voiceSuspensionServerIdentity(connection)
+        )
+    }
+
+    /// Consumes the suspended Voice descriptor on foreground return. Called
+    /// ONLY after the foreground reconciliation task has established the
+    /// authoritative transport/session state (or definitively failed) — never
+    /// synchronously at the scene transition, when the socket, bridge, and
+    /// runtime session identity may all still be stale.
+    ///
+    /// Validation is synchronous against that post-reconciliation state: the
+    /// same authoritative predicate as a fresh `openVoiceConversation`
+    /// (`canStartVoiceConversation`: live connection, voice enabled, usable
+    /// transcription AND speech) plus the suspended conversation's identity —
+    /// same active profile, and the active runtime session is still the
+    /// suspended conversation (unchanged, or a legitimate rebind per the
+    /// session catalog/alias machinery). Anything stale fails CLOSED. A valid
+    /// descriptor reinstalls the gateway and settles open-but-NON-listening;
+    /// capture is NEVER started by restoration (Continuous Conversation
+    /// governs turn-to-turn continuation only, not lifecycle transitions).
+    func restoreSuspendedVoiceConversationIfNeeded() {
+        guard let suspended = suspendedVoiceConversation else { return }
+        suspendedVoiceConversation = nil
+        let conversationStillMatches = suspended.sessionID == activeSessionId
+            || knownSessionIDs(for: suspended.sessionID).contains(activeSessionId ?? "")
+        let identityStillValid = suspended.profile == activeProfile
+            && !suspended.sessionID.isEmpty
+            && conversationStillMatches
+            && connection != nil
+            && suspended.serverIdentity == Self.voiceSuspensionServerIdentity(connection)
+            && canStartVoiceConversation
+            && showVoiceSheet
+            && voiceConversationController.hasLiveVoiceSession
+        guard identityStillValid else {
+            if showVoiceSheet {
+                if suspended.profile == activeProfile {
+                    closeVoiceConversation()
+                } else {
+                    // Cross-profile staleness: the suspended controller's
+                    // live mute belongs to the descriptor's profile. Tear
+                    // down directly — closeVoiceConversation would persist
+                    // that mute into the now-active profile's preferences.
+                    voiceConversationController.stop()
+                    voiceSheetShouldAutoListen = false
+                    voiceControllerSessionProfile = nil
+                    showVoiceSheet = false
+                }
+            }
+            return
+        }
+        // Rebuild the gateway from the current bridge/connection; the
+        // controller keeps its preserved conversation identity and
+        // preferences, settled in .idle.
+        refreshVoiceControllerGateway()
+        // The capability checks above passed, so a gateway that still could
+        // not be built (e.g. the bridge rotated under us) is staleness too:
+        // fail closed instead of restoring an open-but-dead sheet.
+        if !voiceConversationController.isGatewayAttached {
+            closeVoiceConversation()
+        }
+    }
+
+    /// Refreshes Voice capability state when a suspended Voice conversation
+    /// is pending, then validates/restores. The pre-background capability
+    /// snapshot cannot be trusted across suspension, so restoration must run
+    /// against a freshly negotiated answer; `isCurrent` is re-checked after
+    /// that await so a superseded attempt never consumes the descriptor.
+    /// Without a pending descriptor this is a no-op — a plain foreground
+    /// return never pays a redundant capability network refresh here.
+    func refreshCapabilitiesAndRestoreSuspendedVoice(isCurrent: @MainActor () -> Bool) async {
+        guard suspendedVoiceConversation != nil else { return }
+        // The central refreshVoiceCapabilities authority preserves the live
+        // in-session mute for the owning profile during this refresh, so the
+        // restored session keeps the user's Mute state.
+        await refreshVoiceCapabilities()
+        guard isCurrent() else { return }
+        restoreSuspendedVoiceConversationIfNeeded()
+    }
+
+    private static func voiceSuspensionServerIdentity(_ connection: HermesConnection?) -> String? {
+        guard let baseURL = connection?.baseUrl else { return nil }
+        return normalizedChatResumeServerIdentity(baseURL)
     }
 
     private func cancelScenePhaseAttempt() {
@@ -9448,12 +9632,17 @@ final class AppState: ObservableObject {
         }
     }
 
-    func cancelCurrent() async {
-        guard isBusy else { return }
+    /// Cancels the authoritative Hermes turn, reporting whether the
+    /// cancellation succeeded. "Success" also covers nothing being left to
+    /// cancel (the turn already settled server-side).
+    @discardableResult
+    func cancelCurrent() async -> Bool {
+        guard isBusy else { return true }
         let submissionContext = composerSubmissionContext()
-        guard await interruptForReplacement(context: submissionContext) else { return }
-        guard let currentContext = currentComposerSubmissionContextIfOwnedAndAliased(submissionContext) else { return }
+        guard await interruptForReplacement(context: submissionContext) else { return false }
+        guard let currentContext = currentComposerSubmissionContextIfOwnedAndAliased(submissionContext) else { return true }
         await recoverComposerSubmission(using: currentContext)
+        return true
     }
 
     /// Answers one question of a clarification request. Batch questions route
@@ -10669,6 +10858,22 @@ final class AppState: ObservableObject {
             connection = freshConnection
             client = nextClient
             clearPendingDecisionRestorationGuard()
+            // A profile switch ends any live or suspended Voice conversation
+            // from the outgoing profile. Persist the outgoing mute and tear
+            // down BEFORE the identity flip: the sheet's deferred onDismiss
+            // re-enters closeVoiceConversation after the switch, and its
+            // hasLiveVoiceSession guard makes that a no-op so the outgoing
+            // mute can never be persisted under the target profile.
+            if showVoiceSheet {
+                var preferences = loadVoiceProfilePreferences(profile: activeProfile)
+                preferences.outputMuted = voiceConversationController.isOutputMuted
+                saveVoiceProfilePreferences(preferences, profile: activeProfile)
+            }
+            voiceConversationController.stop()
+            showVoiceSheet = false
+            suspendedVoiceConversation = nil
+            voiceSheetShouldAutoListen = false
+            voiceControllerSessionProfile = nil
             // Fence any residual deferred cache write scheduled under the
             // outgoing profile before identities and namespaces change over.
             setActiveProfile(target)
@@ -10846,11 +11051,29 @@ final class AppState: ObservableObject {
     /// filtered and path-prefixed by the explicit profile, so no
     /// cross-profile transcript or cache state leaks in the window before
     /// that reconnect lands.
-    private func adoptAuthoritativeFallbackProfile(_ fallback: String) {
+    ///
+    /// Internal for tests: the fallback adoption is a real destructive Voice
+    /// boundary and the cross-profile fail-closed restore contract is pinned
+    /// through it.
+    func adoptAuthoritativeFallbackProfile(_ fallback: String) {
         guard fallback != activeProfile else { return }
         // A profile change replaces the voice gateway; any in-flight read
         // aloud belongs to the outgoing profile (same as switchProfile).
         messageReadAloudController.stop()
+        // A profile re-home ends any live or suspended Voice conversation
+        // from the outgoing profile. Persist the outgoing mute and tear down
+        // BEFORE the identity flip so it lands in the outgoing profile's
+        // blob, never the fallback's (same contract as switchProfile).
+        if showVoiceSheet {
+            var preferences = loadVoiceProfilePreferences(profile: activeProfile)
+            preferences.outputMuted = voiceConversationController.isOutputMuted
+            saveVoiceProfilePreferences(preferences, profile: activeProfile)
+        }
+        voiceConversationController.stop()
+        showVoiceSheet = false
+        suspendedVoiceConversation = nil
+        voiceSheetShouldAutoListen = false
+        voiceControllerSessionProfile = nil
         flushPendingPresentationCache()
         sessions = []
         cronSessions = []
@@ -12939,9 +13162,10 @@ final class AppState: ObservableObject {
         await submitComposer(text: transcript, attachments: [])
     }
 
-    /// Stops the authoritative Hermes turn when a spoken stop command or
-    /// barge-in wins the race with model generation.
-    func interruptForVoice() async {
+    /// Stops the authoritative Hermes turn when a spoken stop command,
+    /// barge-in, or Voice orphan cancellation wins the race with model
+    /// generation. Reports whether the cancellation succeeded.
+    func interruptForVoice() async -> Bool {
         await cancelCurrent()
     }
 
@@ -13042,7 +13266,16 @@ final class AppState: ObservableObject {
         await service.reload()
         guard profile == activeProfile, bridge === dashboardTicketBridge else { return }
         voiceCapabilitySnapshot = service.snapshot.capability
-        let preferences = loadVoiceProfilePreferences(profile: profile)
+        var preferences = loadVoiceProfilePreferences(profile: profile)
+        // PR #159 authority, enforced centrally: while the controller owns a
+        // live Voice session for THIS profile, its live mute is
+        // authoritative over the persisted blob. Ownership is keyed on the
+        // profile the session was opened for, so a refresh for another
+        // profile never carries a live mute across ownership.
+        if voiceConversationController.hasLiveVoiceSession,
+           voiceControllerSessionProfile == profile {
+            preferences.outputMuted = voiceConversationController.isOutputMuted
+        }
         voiceTranscriptionMode = preferences.resolvedTranscriptionMode
         continuousConversationEnabled = preferences.continuousConversation
         voiceConversationController.setProfilePreferences(preferences)
@@ -13059,6 +13292,9 @@ final class AppState: ObservableObject {
         refreshReadAloudGateway()
         if !enabled {
             voiceConversationController.stop()
+            suspendedVoiceConversation = nil
+            voiceSheetShouldAutoListen = false
+            voiceControllerSessionProfile = nil
             showVoiceSheet = false
         }
         return true
@@ -13190,18 +13426,39 @@ final class AppState: ObservableObject {
             errorMessage = "Hermes could not prepare a voice conversation."
             return true
         }
+        // A fresh user-initiated open supersedes any stale suspension (e.g.
+        // a descriptor retained across sign-out, or one whose reconciliation
+        // task is still in flight): it must never fail-close this new
+        // session on a later scene cycle.
+        suspendedVoiceConversation = nil
         voiceConversationController.setGateway(gateway)
         voiceConversationController.beginVoiceTurn(sessionID: sessionID)
+        voiceControllerSessionProfile = activeProfile
         showSidebar = false
+        voiceSheetShouldAutoListen = true
         showVoiceSheet = true
         return true
     }
 
     func closeVoiceConversation() {
-        var preferences = loadVoiceProfilePreferences(profile: activeProfile)
-        preferences.outputMuted = voiceConversationController.isOutputMuted
-        saveVoiceProfilePreferences(preferences, profile: activeProfile)
+        // Explicit Close (button, swipe, spoken End Conversation) beats any
+        // lifecycle suspension: the conversation is not restorable.
+        suspendedVoiceConversation = nil
+        voiceSheetShouldAutoListen = false
+        // Live-mute persistence obeys the PR #159 authority rule: the
+        // controller's mute wins only for the profile that owns the session.
+        // A same-profile close that arrives after the controller was
+        // already torn down (e.g. audio interruption) still persists; a
+        // close arriving after a profile flip (the sheet's deferred
+        // onDismiss) persists nothing.
+        if voiceConversationController.hasLiveVoiceSession
+            || voiceControllerSessionProfile == activeProfile {
+            var preferences = loadVoiceProfilePreferences(profile: activeProfile)
+            preferences.outputMuted = voiceConversationController.isOutputMuted
+            saveVoiceProfilePreferences(preferences, profile: activeProfile)
+        }
         voiceConversationController.endVoiceSession()
+        voiceControllerSessionProfile = nil
         showVoiceSheet = false
     }
 

--- a/Conduit/Views/RootView.swift
+++ b/Conduit/Views/RootView.swift
@@ -85,7 +85,8 @@ struct MainView: View {
             VoiceConversationSheet(
                 controller: appState.voiceConversationController,
                 profile: appState.activeProfile,
-                onClose: appState.closeVoiceConversation
+                onClose: appState.closeVoiceConversation,
+                shouldAutoListen: { appState.consumeVoiceSheetAutoListen() }
             )
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)

--- a/Conduit/Views/VoiceConversationSheet.swift
+++ b/Conduit/Views/VoiceConversationSheet.swift
@@ -11,6 +11,11 @@ struct VoiceConversationSheet: View {
     @ObservedObject var controller: VoiceConversationController
     let profile: String
     let onClose: () -> Void
+    /// One-shot gate armed by a fresh `openVoiceConversation` and consumed
+    /// exactly once. A restored suspended conversation deliberately does NOT
+    /// auto-listen: the gate stays disarmed even if SwiftUI recreates this
+    /// view's identity while the presentation binding survives.
+    let shouldAutoListen: () -> Bool
     var startsListening: Bool = true
 
     @State private var didRequestStart = false
@@ -41,6 +46,7 @@ struct VoiceConversationSheet: View {
         .task {
             guard startsListening, !didRequestStart else { return }
             didRequestStart = true
+            guard shouldAutoListen() else { return }
             await controller.startListening()
         }
         .accessibilityElement(children: .contain)

--- a/Conduit/Voice/AVAudioCaptureService.swift
+++ b/Conduit/Voice/AVAudioCaptureService.swift
@@ -6,6 +6,7 @@
 import AVFAudio
 import Foundation
 import OSLog
+import os
 
 private let voiceAudioLogger = Logger(subsystem: "com.milim.relay", category: "VoiceAudio")
 
@@ -43,6 +44,22 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
     /// frames queued from a previous generation can be recognized and
     /// dropped after the boundary.
     private(set) var captureGeneration: UInt64 = 0
+    /// Thread-safe mirror of `captureGeneration` for observers that run
+    /// outside the MainActor. Session interruption notifications arrive on
+    /// an arbitrary thread and must record which capture generation they
+    /// belong to SYNCHRONOUSLY, before the MainActor hop — reading the value
+    /// later would observe whatever generation is installed by then, which
+    /// is exactly the stale-teardown race this exists to prevent.
+    private let observedCaptureGeneration = OSAllocatedUnfairLock<UInt64>(initialState: 0)
+
+    nonisolated private var generationForInterruptionObservers: UInt64 {
+        observedCaptureGeneration.withLock { $0 }
+    }
+
+    private func publishGenerationForInterruptionObservers() {
+        let current = captureGeneration
+        observedCaptureGeneration.withLock { $0 = current }
+    }
     var shouldKeepEngineRunning = false
     private var lastCaptureFailure: String?
     private var continuation: AsyncStream<VoiceCaptureEvent>.Continuation?
@@ -130,6 +147,7 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
         paused = true
         shouldKeepEngineRunning = false
         captureGeneration &+= 1
+        publishGenerationForInterruptionObservers()
         teardownRendering()
         releaseLease()
     }
@@ -170,6 +188,7 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
         // Deliberately unguarded (unlike pause): a redundant stop bumps the
         // generation again, which is always fail-closed.
         captureGeneration &+= 1
+        publishGenerationForInterruptionObservers()
         teardownRendering()
         releaseLease()
     }
@@ -218,6 +237,7 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
         // invalidates it so queued frames from the old tap are recognized
         // as stale.
         captureGeneration &+= 1
+        publishGenerationForInterruptionObservers()
         let frameGeneration = captureGeneration
         input.installTap(onBus: 0, bufferSize: 1_024, format: nil) { [weak self] buffer, _ in
             // AVAudioEngine owns and reuses tap buffers as soon as this block
@@ -338,15 +358,43 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
         }
     }
 
+    /// Internal for tests: the deterministic stale-interruption regression
+    /// drives this entry point directly.
+    ///
     /// Hopped through `Task { @MainActor }`: session notifications are not
     /// guaranteed to arrive on the main thread, and stop() now releases the
-    /// capture lease through the MainActor coordinator.
-    @objc private func handleInterruption(_ notification: Notification) {
+    /// capture lease through the MainActor coordinator. The interruption's
+    /// capture generation is captured SYNCHRONOUSLY on the notifying thread
+    /// — reading it later on the MainActor would observe whatever generation
+    /// is installed by then. The fence runs BEFORE any mutation: an
+    /// interruption that observed a torn-down generation must never stop the
+    /// live one, release its lease, or emit a failure that applies to it.
+    @objc func handleInterruption(_ notification: Notification) {
         guard let typeValue = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
               let type = AVAudioSession.InterruptionType(rawValue: typeValue), type == .began else { return }
+        // PRE-STOP generation: identifies the capture runtime the
+        // notification belonged to, captured synchronously on the notifying
+        // thread before any MainActor work.
+        let observedGeneration = generationForInterruptionObservers
         Task { @MainActor [weak self] in
-            self?.stop()
-            self?.continuation?.yield(.interrupted)
+            guard let self else { return }
+            // Stale-callback fence BEFORE mutation: a queued interruption
+            // that observed a torn-down generation must never stop the
+            // live one, release its lease, or emit a failure that applies
+            // to it.
+            guard observedGeneration == captureGeneration else {
+                voiceAudioLogger.notice(
+                    "Discarding interruption for torn-down capture generation \(observedGeneration, privacy: .public); current \(self.captureGeneration, privacy: .public)"
+                )
+                return
+            }
+            stop()
+            // POST-STOP generation: the authoritative service state after
+            // the accepted runtime was torn down. Emitting this (not the
+            // pre-stop value) lets the controller recognize the event as
+            // belonging to the state it actually left behind.
+            let postStopGeneration = captureGeneration
+            continuation?.yield(.interrupted(generation: postStopGeneration))
         }
     }
 
@@ -369,7 +417,7 @@ final class AVAudioCaptureService: NSObject, AudioCaptureService {
                 try startEngine()
             } catch {
                 handleStartupFailure(error, stage: "routeChange")
-                continuation?.yield(.interrupted)
+                continuation?.yield(.interrupted(generation: captureGeneration))
                 return
             }
         }

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -42,6 +42,12 @@ final class VoiceConversationController: ObservableObject {
     /// the assistant's own TTS and must never read as a user-selected pause.
     @Published private(set) var isPlaybackCaptureSuspended = false
     @Published private(set) var conversationTranscript: [VoiceConversationTranscriptEntry] = []
+    /// Set by `suspendRuntimeForLifecycle()` until the runtime is explicitly
+    /// re-armed by a fresh listen or torn down by `stop()`. Suspended runtime
+    /// state rejects capture events outright: `hasLiveVoiceSession` remains
+    /// LOGICAL ownership (the conversation is restorable) and must never be
+    /// read as a claim that capture is live.
+    private(set) var isRuntimeSuspended = false
     private var preferences = VoiceProfilePreferences()
 
     let configuration: Configuration
@@ -54,7 +60,12 @@ final class VoiceConversationController: ObservableObject {
     /// or mutable policy so route classification is deterministic.
     private let routePolicyProvider: @MainActor () -> VoiceBargeInRoutePolicy
     private let submit: @MainActor (String) async -> Bool
-    private let interrupt: @MainActor () async -> Void
+    /// Cancels the authoritative Hermes turn. Returns whether the
+    /// cancellation actually succeeded (true also when there was nothing
+    /// left to cancel). Call sites that only need the interrupt to have been
+    /// *attempted* (barge-in, manual Interrupt, spoken End Conversation)
+    /// discard the result; the suspended-orphan path acts on it.
+    private let interrupt: @MainActor () async -> Bool
     /// Installed by AppState: the authoritative Voice Close teardown
     /// (persist mute → `endVoiceSession` → sheet dismissal). A spoken End
     /// Conversation phrase converges on it instead of a second teardown;
@@ -79,6 +90,11 @@ final class VoiceConversationController: ObservableObject {
     /// routing ids, so raw equality with the captured id alone would silently
     /// drop the assistant's voice the moment a resume rebinds the runtime.
     private var expectedAssistantSessionIDs: Set<String> = []
+    /// Set when a suspension retired the voice-side continuation of a
+    /// still-running Hermes turn. The next user submission cancels that
+    /// orphaned turn first (user-initiated, same seam as Stop) so its late
+    /// events can never alias onto the new turn's ownership.
+    private var suspendedInFlightTurnOrphaned = false
     private var operationGeneration: UInt64 = 0
     private var utteranceTask: Task<Void, Never>?
     private var bargeInTask: Task<Void, Never>?
@@ -99,7 +115,7 @@ final class VoiceConversationController: ObservableObject {
         configuration: Configuration = Configuration(),
         routePolicyProvider: (@MainActor () -> VoiceBargeInRoutePolicy)? = nil,
         submit: @escaping @MainActor (String) async -> Bool,
-        interrupt: @escaping @MainActor () async -> Void,
+        interrupt: @escaping @MainActor () async -> Bool,
         onEndConversation: (@MainActor () -> Void)? = nil
     ) {
         let capture = capture ?? AVAudioCaptureService()
@@ -214,10 +230,12 @@ final class VoiceConversationController: ObservableObject {
     /// the outgoing server's bridge) is behavioral and hard to observe.
     var isGatewayAttached: Bool { gateway != nil }
 
+    /// Foreground liveness flag only. Deactivation-side teardown is owned by
+    /// the caller: AppState routes an open Voice conversation through
+    /// `suspendRuntimeForLifecycle()` (logical preservation) and a closed one
+    /// through `stop()` (full teardown).
     func setForegroundActive(_ active: Bool) {
         isForegroundActive = active
-        guard !active else { return }
-        stop()
     }
 
     func requestOnDeviceTranscriptionPermissions() async -> VoiceProviderTestResult {
@@ -237,6 +255,8 @@ final class VoiceConversationController: ObservableObject {
         guard isForegroundActive else { return }
         let generation = operationGeneration
         isVoiceSessionActive = true
+        // A fresh listen re-arms the runtime: suspended state ends here.
+        rearmRuntimeAfterCaptureRestart()
         guard let gateway else { state = .failed("Voice is unavailable for this gateway."); return }
         _ = gateway // keeps the availability check explicit at the state edge.
         guard await capture.requestPermission() else {
@@ -297,6 +317,11 @@ final class VoiceConversationController: ObservableObject {
         do {
             try capture.resume()
             isMicrophonePaused = false
+            // Un-pausing after a lifecycle suspension is a genuine
+            // recapture: the runtime gate must end here exactly as it does
+            // in startListening(), or a restored previously-paused session
+            // would present Listening with a microphone that hears nothing.
+            rearmRuntimeAfterCaptureRestart()
             // Pause is a real resource pause, so resume opens a fresh
             // listening window: speech timestamps from before the pause must
             // not immediately finish an utterance or idle-pause again, and
@@ -338,7 +363,10 @@ final class VoiceConversationController: ObservableObject {
         // The tap itself is an explicit request to speak now, so a pending
         // user pause ends with it.
         isMicrophonePaused = false
-        await interrupt()
+        // Manual Interrupt proceeds on the attempt regardless of the
+        // cancellation result: the local turn retirement below already
+        // re-opened the listening window.
+        _ = await interrupt()
         // The interruption is a real re-entrant async boundary (Hermes
         // cancellation/recovery), and the sheet can close while it is in
         // flight — stop() then advances the generation and tears the session
@@ -349,6 +377,48 @@ final class VoiceConversationController: ObservableObject {
     }
 
     func stop() {
+        releaseRuntimeResources()
+        isMicrophonePaused = false
+        isVoiceSessionActive = false
+        isAwaitingVoiceAssistant = false
+        awaitedAssistantResponseStarted = false
+        expectedAssistantSessionIDs = []
+        suspendedInFlightTurnOrphaned = false
+        isRuntimeSuspended = false
+        state = .idle
+    }
+
+    /// Lifecycle suspension (app backgrounded / scene inactive) for a Voice
+    /// conversation that stays logically open: releases every runtime audio
+    /// and task ownership through the same primitive as `stop()`, but
+    /// preserves the conversation — transcript, session ownership, and an
+    /// explicit user pause — so AppState can restore it on foreground return.
+    /// State settles to .idle (open, not listening). The in-flight assistant
+    /// turn's voice-side continuation is retired WITHOUT cancelling the
+    /// Hermes turn (its outcome reconciles through the authoritative chat
+    /// transcript); the orphan is remembered so the next user submission
+    /// cancels it, preventing its late events from aliasing onto the new
+    /// turn's ownership.
+    func suspendRuntimeForLifecycle() {
+        releaseRuntimeResources()
+        // Sticky across consecutive suspensions: the first suspension already
+        // cleared isAwaitingVoiceAssistant, so a plain overwrite would forget
+        // an orphan that is still running server-side. Safe to retain — the
+        // cancel seam no-ops once the orphan has settled.
+        suspendedInFlightTurnOrphaned = suspendedInFlightTurnOrphaned || isAwaitingVoiceAssistant
+        isAwaitingVoiceAssistant = false
+        awaitedAssistantResponseStarted = false
+        isRuntimeSuspended = true
+        state = .idle
+    }
+
+    /// Shared teardown primitive for `stop()` and
+    /// `suspendRuntimeForLifecycle()`: releases every audio/task ownership
+    /// and fences all in-flight work with a generation bump. Logical
+    /// conversation identity (session ownership, awaiting state, transcript,
+    /// user pause) is intentionally untouched here — `stop()` erases it for
+    /// Close; suspension preserves it for restoration.
+    private func releaseRuntimeResources() {
         operationGeneration &+= 1
         cachedRoutePolicy = nil
         utteranceTask?.cancel()
@@ -361,15 +431,9 @@ final class VoiceConversationController: ObservableObject {
         playback.stop()
         speechDeltas.removeAll()
         assistantFinished = false
-        isMicrophonePaused = false
         isPlaybackCaptureSuspended = false
         speechDetector.reset()
         resetMicrophoneMeter()
-        isVoiceSessionActive = false
-        isAwaitingVoiceAssistant = false
-        awaitedAssistantResponseStarted = false
-        expectedAssistantSessionIDs = []
-        state = .idle
     }
 
     func setOutputMuted(_ muted: Bool) {
@@ -658,6 +722,10 @@ final class VoiceConversationController: ObservableObject {
             // a user pause, a #146 suspension, or after the voice session
             // ended. Provider tests are live capture and still count.
             guard generation == capture.captureGeneration else { return }
+            // Suspended runtime rejects capture events outright — before the
+            // meter, before VAD: hasLiveVoiceSession is logical ownership
+            // only and never means capture is live here.
+            guard !isRuntimeSuspended else { return }
             let captureLive = !isMicrophonePaused
                 && !isPlaybackCaptureSuspended
                 && isVoiceSessionActive
@@ -674,7 +742,17 @@ final class VoiceConversationController: ObservableObject {
             }
             guard !isProviderTestRunning else { return }
             ingestAudioLevel(level, at: date)
-        case .interrupted:
+        case .interrupted(let generation):
+            // An interruption event against lifecycle-suspended runtime
+            // belongs to the capture that was already released: it must not
+            // destroy the preserved logical session (ownership, orphan
+            // bookkeeping, restoration eligibility). Real interruptions of
+            // live foreground capture still reach failForAudioInterruption.
+            guard !isRuntimeSuspended else { return }
+            // Defense-in-depth (the service fences this before emitting):
+            // only an interruption belonging to the currently installed
+            // capture generation may fail the session.
+            guard generation == capture.captureGeneration else { return }
             failForAudioInterruption()
         case .routeChanged:
             // Provider tests own the session exclusively; no capture is live
@@ -746,7 +824,10 @@ final class VoiceConversationController: ObservableObject {
                 VoiceConversationTranscriptEntry(speaker: .user, text: transcript)
             )
             if isWholeUtteranceStopCommand(transcript) {
-                await interrupt()
+                // Spoken Stop proceeds on the attempt: its local semantics
+                // (cancel, stop playback, relisten) do not depend on the
+                // server-side cancellation result.
+                _ = await interrupt()
                 guard isCurrent(generation) else { return }
                 playback.stop()
                 await startListening()
@@ -754,6 +835,31 @@ final class VoiceConversationController: ObservableObject {
             }
             state = .thinking
             beginBargeInMonitoring()
+            // A turn orphaned by lifecycle suspension is still running
+            // server-side; the user speaking now is a user-initiated
+            // cancellation of that orphan (same seam as Stop), and it must
+            // happen before the new submission so the orphan's late events
+            // can never be consumed as the new turn's reply. The orphan flag
+            // is cleared only on a SUCCESSFUL cancellation in a still-current
+            // operation: a failed cancel (or a superseded await) retains it
+            // and blocks this submission — the orphan's late events must
+            // never be admitted as the new turn's reply.
+            if suspendedInFlightTurnOrphaned {
+                let cancelledOrphan = await interrupt()
+                guard isCurrent(generation) else { return }
+                guard cancelledOrphan else {
+                    // A failed cancellation must not leave the microphone,
+                    // barge-in monitoring, playback, or runtime tasks alive
+                    // under a failed UI state. Release runtime ownership via
+                    // the shared primitive while PRESERVING the logical
+                    // session and the sticky orphan — the user's next
+                    // Listen + utterance retries the cancellation.
+                    releaseRuntimeResources()
+                    state = .failed("Hermes could not cancel the previous response.")
+                    return
+                }
+                suspendedInFlightTurnOrphaned = false
+            }
             // Completion clears ownership for the previous response. Arm the
             // same authoritative session again immediately before each new
             // voice submission so continuous conversation accepts its reply.
@@ -860,13 +966,23 @@ final class VoiceConversationController: ObservableObject {
         isPlaybackCaptureSuspended = false
         speechDetector.reset()
         resetMicrophoneMeter()
+        isVoiceSessionActive = false
         isAwaitingVoiceAssistant = false
         awaitedAssistantResponseStarted = false
+        expectedAssistantSessionIDs = []
+        suspendedInFlightTurnOrphaned = false
+        isRuntimeSuspended = false
         // Terminal path: release session-ownership bookkeeping so audio-
         // adjacent side features (response haptics) do not stand down
         // forever after an interruption.
-        isVoiceSessionActive = false
         state = .failed("Audio was interrupted.")
+    }
+
+    /// Clears the lifecycle-suspension gate after the capture runtime has
+    /// genuinely been re-armed (fresh listen or un-pause recapture). One seam
+    /// so `startListening` and `resumeMicrophone` cannot diverge.
+    private func rearmRuntimeAfterCaptureRestart() {
+        isRuntimeSuspended = false
     }
 
     private func scheduleBargeIn() {
@@ -897,7 +1013,10 @@ final class VoiceConversationController: ObservableObject {
         // Its terminal event belongs to the retired turn, not the next one.
         isAwaitingVoiceAssistant = false
         awaitedAssistantResponseStarted = false
-        await interrupt()
+        // The barge-in proceeds on the attempt: its local recovery (stop
+        // playback, retire the turn, relisten) does not depend on the
+        // server-side cancellation result.
+        _ = await interrupt()
         // Cancellation is re-checked after the await: the suspension may have
         // engaged while the interruption was in flight, and reopening capture
         // now would hear the assistant's own speaker output.
@@ -931,7 +1050,10 @@ final class VoiceConversationController: ObservableObject {
         } else {
             stop()
         }
-        await interrupt()
+        // Spoken End Conversation proceeds on the attempt: the session is
+        // already closed above, so the server-side cancellation result
+        // cannot change local state anymore.
+        _ = await interrupt()
     }
 
     private func isWholeUtteranceEndConversationCommand(_ transcript: String) -> Bool {

--- a/Conduit/Voice/VoiceTypes.swift
+++ b/Conduit/Voice/VoiceTypes.swift
@@ -234,7 +234,11 @@ enum VoiceCaptureEvent: Equatable {
     /// controller can drop events queued before a pause/stop/restart: a
     /// frame is valid only for the generation that produced it.
     case level(Float, date: Date, generation: UInt64)
-    case interrupted
+    /// `generation` identifies the capture runtime the interruption belongs
+    /// to, so a queued interruption observed for a torn-down generation can
+    /// never fail a later capture (the controller rejects foreign
+    /// generations before applying the interrupted-failure semantics).
+    case interrupted(generation: UInt64)
     case routeChanged
 }
 

--- a/ConduitTests/AVAudioCaptureServiceGenerationTests.swift
+++ b/ConduitTests/AVAudioCaptureServiceGenerationTests.swift
@@ -151,6 +151,79 @@ final class AVAudioCaptureServiceGenerationTests: XCTestCase {
         XCTAssertEqual(generation, generationB)
     }
 
+    // MARK: - Interruption generation fence
+
+    static let interruptionBeganNotification = Notification(
+        name: AVAudioSession.interruptionNotification,
+        object: nil,
+        userInfo: [AVAudioSessionInterruptionTypeKey: UInt(AVAudioSession.InterruptionType.began.rawValue)]
+    )
+
+    func testStaleInterruptionFromTornDownGenerationCannotStopLiveCapture() async throws {
+        let service = AVAudioCaptureService()
+        startEventCollector(service)
+
+        // Generation A is live and recording.
+        service.shouldKeepEngineRunning = true
+        service.activelyRecording = true
+        let generationA = service.captureGeneration
+
+        // The interruption notification for A arrives: its identity is
+        // captured synchronously on the notifying thread and the MainActor
+        // teardown is queued.
+        service.handleInterruption(Self.interruptionBeganNotification)
+
+        // Voice suspension tears A down; a later Listen re-arms generation B.
+        service.stop()
+        service.shouldKeepEngineRunning = true
+        service.activelyRecording = true
+        let generationB = service.captureGeneration
+        XCTAssertNotEqual(generationA, generationB)
+
+        // The DELAYED interruption from A finally executes: it is discarded
+        // completely. B stays live — not stopped, lease intact, no failure.
+        for _ in 0..<20 { await Task.yield() }
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        XCTAssertEqual(service.captureGeneration, generationB, "the stale interruption must not tear down B")
+        XCTAssertTrue(service.shouldKeepEngineRunning, "B's runtime stays up")
+        XCTAssertTrue(service.activelyRecording, "B's capture stays live")
+        XCTAssertFalse(
+            collectedEvents.contains { if case .interrupted = $0 { return true }; return false },
+            "no interrupted failure may apply to the live generation"
+        )
+
+        // B remains fully usable: a frame from B is admitted and surfaces as
+        // a level event tagged with B's generation.
+        let current = try constantBuffer(sampleRate: 48_000, frameCount: 960, amplitude: 0.25)
+        service.consume(current, generation: generationB)
+        for _ in 0..<200 where collectedEvents.isEmpty {
+            await Task.yield()
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        guard case let .level(peak, _, levelGeneration) = collectedEvents.first else {
+            return XCTFail("expected a level event from the live generation B")
+        }
+        XCTAssertGreaterThan(peak, 0)
+        XCTAssertEqual(levelGeneration, generationB)
+
+        // Positive case: an interruption belonging to the CURRENT generation
+        // reproduces the normal interrupted teardown semantics — the service
+        // validates the pre-stop generation, stops capture (installing the
+        // next generation), and emits the POST-STOP generation so the
+        // controller recognizes the failure as applying to the state it
+        // actually left behind.
+        service.handleInterruption(Self.interruptionBeganNotification)
+        for _ in 0..<20 { await Task.yield() }
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        XCTAssertEqual(service.captureGeneration, generationB + 1, "the current generation's interruption tears B down")
+        XCTAssertFalse(service.shouldKeepEngineRunning)
+        XCTAssertFalse(service.activelyRecording)
+        guard case let .interrupted(postStopGeneration) = collectedEvents.last else {
+            return XCTFail("expected an interrupted event for the current generation")
+        }
+        XCTAssertEqual(postStopGeneration, generationB + 1, "the emitted generation must be the authoritative post-stop state")
+    }
+
     // MARK: - Helpers
 
     /// A mono Float32 buffer at a realistic hardware rate filled with a

--- a/ConduitTests/AppStateReadAloudTests.swift
+++ b/ConduitTests/AppStateReadAloudTests.swift
@@ -221,7 +221,7 @@ final class AppStateReadAloudTests: XCTestCase {
             deviceTranscriber: MockVoiceTranscriber(),
             gateway: voiceGateway,
             submit: { _ in false },
-            interrupt: {}
+            interrupt: { true }
         )
         appState.voiceConversationController = voiceController
 

--- a/ConduitTests/AppStateServerReplacementSpeechTests.swift
+++ b/ConduitTests/AppStateServerReplacementSpeechTests.swift
@@ -441,7 +441,7 @@ final class AppStateServerReplacementSpeechTests: XCTestCase {
             // real AVAudioSession route.
             routePolicyProvider: { .fullDuplex },
             submit: { _ in true },
-            interrupt: { await interruptGate.wait() }
+            interrupt: { await interruptGate.wait(); return true }
         )
         appState.voiceConversationController = voiceController
 

--- a/ConduitTests/HapticsVoiceIsolationTests.swift
+++ b/ConduitTests/HapticsVoiceIsolationTests.swift
@@ -95,7 +95,7 @@ final class HapticsVoiceIsolationTests: XCTestCase {
             playback: StubPlayback(),
             gateway: StubVoiceGateway(),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         appState.voiceConversationController = controller
 
@@ -136,7 +136,7 @@ final class HapticsVoiceIsolationTests: XCTestCase {
             playback: StubPlayback(),
             gateway: StubVoiceGateway(),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         appState.voiceConversationController = controller
 
@@ -173,14 +173,14 @@ final class HapticsVoiceIsolationTests: XCTestCase {
             playback: StubPlayback(),
             gateway: StubVoiceGateway(),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         appState.voiceConversationController = controller
 
         await controller.startListening()
         XCTAssertFalse(appState.responseHapticsMayUseCoreHaptics, "a live voice session suppresses Core Haptics")
 
-        capture.emit(.interrupted)
+        capture.emit(.interrupted(generation: capture.captureGeneration))
         await waitUntil { controller.state == .failed("Audio was interrupted.") }
 
         XCTAssertFalse(controller.hasLiveVoiceSession, "an interrupted session is terminal: no voice operation is live")
@@ -200,13 +200,13 @@ final class HapticsVoiceIsolationTests: XCTestCase {
             playback: StubPlayback(),
             gateway: StubVoiceGateway(),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
 
         let testTask = Task { await controller.runTranscriptionTest(duration: 1) }
         await waitUntil { controller.state == .listening }
 
-        capture.emit(.interrupted)
+        capture.emit(.interrupted(generation: capture.captureGeneration))
         let result = await testTask.value
 
         XCTAssertFalse(result.passed, "an interrupted provider test must not report success")

--- a/ConduitTests/VoiceBackgroundSuspensionTests.swift
+++ b/ConduitTests/VoiceBackgroundSuspensionTests.swift
@@ -42,7 +42,7 @@ final class VoiceConversationLifecycleSuspensionTests: XCTestCase {
     }
 
     func testSuspensionPreservesExplicitUserPause() async {
-        let (controller, capture, _, _) = makeFixture()
+        let (controller, capture, gateway, flags) = makeFixture()
         controller.beginVoiceTurn(sessionID: "session")
         await controller.startListening()
         controller.pauseMicrophone()
@@ -53,6 +53,30 @@ final class VoiceConversationLifecycleSuspensionTests: XCTestCase {
         XCTAssertTrue(controller.isMicrophonePaused, "an explicit user pause survives suspension")
         XCTAssertEqual(capture.startCount, 1, "restoration must not start capture")
         XCTAssertTrue(controller.hasLiveVoiceSession)
+
+        // The user's Listen tap on the restored sheet unpauses and genuinely
+        // recaptures.
+        await controller.resumeMicrophone()
+        XCTAssertFalse(controller.isMicrophonePaused)
+        XCTAssertEqual(capture.resumeCount, 1, "Listen after a restored pause reacquires capture")
+        XCTAssertEqual(controller.state, .listening)
+        XCTAssertFalse(controller.isRuntimeSuspended, "the suspended-runtime gate ends with the recapture")
+
+        // The recaptured microphone must actually hear: level events flow
+        // through the gate into the meter and VAD.
+        let firstHeard = Date()
+        capture.emit(level: 0.5, at: firstHeard)
+        capture.emit(level: 0.5, at: firstHeard.addingTimeInterval(0.4))
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        XCTAssertGreaterThan(controller.microphoneLevel, 0, "the recaptured microphone hears speech")
+
+        // …and the heard speech completes a full utterance: transcription
+        // then submission.
+        capture.emit(level: 0, at: firstHeard.addingTimeInterval(1.8))
+        try? await Task.sleep(nanoseconds: 250_000_000)
+        XCTAssertEqual(gateway.transcriptionCount, 1, "the utterance reaches transcription")
+        XCTAssertEqual(flags.submitTexts, ["Question"], "and reaches submission")
+        XCTAssertEqual(controller.state, .thinking)
     }
 
     func testSuspensionRetiresInFlightTurnVoiceContinuationWithoutCancellingServerTurn() async {
@@ -77,6 +101,138 @@ final class VoiceConversationLifecycleSuspensionTests: XCTestCase {
         XCTAssertEqual(flags.speechStreamOpens, 0, "no stale TTS after suspension")
     }
 
+    func testNextSubmitAfterSuspensionCancelsOrphanedTurnAndContinues() async {
+        let (controller, capture, gateway, flags) = makeFixture()
+        await driveToThinking(controller, gateway: gateway, flags: flags)
+        controller.suspendRuntimeForLifecycle()
+        controller.setForegroundActive(true)
+
+        // The user taps Listen and speaks again: the orphaned pre-suspension
+        // turn is cancelled through the interrupt seam before the new
+        // submission arms, so its late events can never alias onto the new
+        // turn's ownership.
+        await controller.resumeMicrophone()
+        let start = Date()
+        controller.ingestAudioLevel(0.1, at: start)
+        controller.ingestAudioLevel(0, at: start.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertEqual(flags.interrupts, 1, "the orphaned turn is cancelled by the next user submission")
+        XCTAssertEqual(flags.submitTexts, ["Question", "Question"], "the new turn submits normally")
+
+        // The orphan's cancellation terminal arrives before the new turn
+        // starts; it must not fail or settle the new turn.
+        controller.receiveAssistantEvent(.interrupted(sessionID: "session"))
+        XCTAssertEqual(controller.state, .thinking)
+    }
+
+    func testOrphanSurvivesConsecutiveSuspensions() async {
+        let (controller, capture, gateway, flags) = makeFixture()
+        await driveToThinking(controller, gateway: gateway, flags: flags)
+
+        // background → foreground → background: the second suspension must
+        // not forget the orphan recorded by the first (the awaiting state it
+        // would read from was already cleared).
+        controller.suspendRuntimeForLifecycle()
+        controller.setForegroundActive(true)
+        controller.suspendRuntimeForLifecycle()
+        controller.setForegroundActive(true)
+
+        await controller.resumeMicrophone()
+        let start = Date()
+        controller.ingestAudioLevel(0.1, at: start)
+        controller.ingestAudioLevel(0, at: start.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertEqual(flags.interrupts, 1, "the orphan survives a background/foreground/background cycle")
+        XCTAssertEqual(flags.submitTexts, ["Question", "Question"])
+    }
+
+    func testOrphanProtectionSurvivesSupersededCancelAwait() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question")
+        let flags = Flags()
+        let gate = InterruptGate()
+        let submitAction: @MainActor (String) async -> Bool = { text in
+            flags.submitTexts.append(text)
+            return true
+        }
+        let interruptAction: @MainActor () async -> Bool = {
+            flags.interrupts += 1
+            await gate.waitInInterrupt()
+            return true
+        }
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: GatedPlayback(),
+            gateway: gateway,
+            routePolicyProvider: { .fullDuplex },
+            submit: submitAction,
+            interrupt: interruptAction
+        )
+        await driveToThinking(controller, gateway: gateway, flags: flags)
+        controller.suspendRuntimeForLifecycle()
+        controller.setForegroundActive(true)
+
+        // First post-restore submission enters the orphan-cancel interrupt
+        // and parks mid-await.
+        await controller.resumeMicrophone()
+        let start = Date()
+        controller.ingestAudioLevel(0.1, at: start)
+        controller.ingestAudioLevel(0, at: start.addingTimeInterval(1.3))
+        await gate.waitUntilEntered()
+
+        // A new suspension supersedes the parked cancel: the utterance task
+        // dies, and the sticky orphan flag must survive it.
+        controller.suspendRuntimeForLifecycle()
+        gate.release()
+        try? await Task.sleep(nanoseconds: 120_000_000)
+        XCTAssertEqual(flags.submitTexts, ["Question"], "the superseded submission never reached Hermes")
+
+        controller.setForegroundActive(true)
+        await controller.resumeMicrophone()
+        let secondStart = Date()
+        controller.ingestAudioLevel(0.1, at: secondStart)
+        controller.ingestAudioLevel(0, at: secondStart.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertEqual(flags.interrupts, 2, "the next submission still cancels the orphan")
+        XCTAssertEqual(flags.submitTexts, ["Question", "Question"], "and then submits normally")
+    }
+
+    func testFailedOrphanCancellationRetainsFlagAndBlocksSubmissionUntilRetry() async {
+        let (controller, capture, gateway, flags) = makeFixture()
+        await driveToThinking(controller, gateway: gateway, flags: flags)
+        controller.suspendRuntimeForLifecycle()
+        controller.setForegroundActive(true)
+
+        // The orphan cancellation FAILS: the flag stays armed and the new
+        // utterance is never submitted.
+        flags.interruptSucceeds = false
+        await controller.resumeMicrophone()
+        let start = Date()
+        controller.ingestAudioLevel(0.1, at: start)
+        controller.ingestAudioLevel(0, at: start.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertEqual(flags.interrupts, 1)
+        XCTAssertEqual(gateway.transcriptionCount, 2, "the retry utterance was heard again…")
+        XCTAssertEqual(flags.submitTexts, ["Question"], "…but never submitted while the orphan stands")
+        XCTAssertEqual(controller.state, .failed("Hermes could not cancel the previous response."))
+
+        // A later successful retry clears the orphan and submits normally.
+        flags.interruptSucceeds = true
+        await controller.resumeMicrophone()
+        let retryStart = Date()
+        controller.ingestAudioLevel(0.1, at: retryStart)
+        controller.ingestAudioLevel(0, at: retryStart.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertEqual(flags.interrupts, 2, "the retry cancels the orphan again")
+        XCTAssertEqual(flags.submitTexts, ["Question", "Question"], "the retry submits normally")
+        XCTAssertEqual(controller.state, .thinking)
+    }
+
     func testStopAfterSuspensionStillClosesFully() async {
         let (controller, _, _, _) = makeFixture()
         controller.beginVoiceTurn(sessionID: "session")
@@ -99,8 +255,9 @@ final class VoiceConversationLifecycleSuspensionTests: XCTestCase {
             flags.submitTexts.append(text)
             return true
         }
-        let interruptAction: @MainActor () async -> Void = {
+        let interruptAction: @MainActor () async -> Bool = {
             flags.interrupts += 1
+            return flags.interruptSucceeds
         }
         let controller = VoiceConversationController(
             capture: capture,
@@ -134,9 +291,13 @@ final class VoiceConversationLifecycleSuspensionTests: XCTestCase {
         let gateway = MockGateway(transcript: "Question")
         let flags = Flags()
         let policy = RoutePolicyBox(.speakerSafeHalfDuplex)
-        let submitAction: @MainActor (String) async -> Bool = { _ in true }
-        let interruptAction: @MainActor () async -> Void = {
+        let submitAction: @MainActor (String) async -> Bool = { text in
+            flags.submitTexts.append(text)
+            return true
+        }
+        let interruptAction: @MainActor () async -> Bool = {
             flags.interrupts += 1
+            return flags.interruptSucceeds
         }
         let controller = VoiceConversationController(
             capture: capture,
@@ -166,6 +327,9 @@ final class VoiceConversationLifecycleSuspensionTests: XCTestCase {
         var interrupts = 0
         var speechStreamOpens = 0
         var playbackStopCount = 0
+        /// Toggle per phase: a failed orphan cancellation must retain the
+        /// orphan flag and block the new submission.
+        var interruptSucceeds = true
     }
 
     private func makeFixture() -> (VoiceConversationController, MockCapture, MockGateway, Flags) {
@@ -177,8 +341,9 @@ final class VoiceConversationLifecycleSuspensionTests: XCTestCase {
             flags.submitTexts.append(text)
             return true
         }
-        let interruptAction: @MainActor () async -> Void = {
+        let interruptAction: @MainActor () async -> Bool = {
             flags.interrupts += 1
+            return flags.interruptSucceeds
         }
         playback.onStop = { flags.playbackStopCount += 1 }
         gateway.onStreamOpen = { flags.speechStreamOpens += 1 }
@@ -198,9 +363,13 @@ final class VoiceConversationLifecycleSuspensionTests: XCTestCase {
         let playback = GatedPlayback()
         let gateway = MockGateway(transcript: "Question")
         let flags = Flags()
-        let submitAction: @MainActor (String) async -> Bool = { _ in true }
-        let interruptAction: @MainActor () async -> Void = {
+        let submitAction: @MainActor (String) async -> Bool = { text in
+            flags.submitTexts.append(text)
+            return true
+        }
+        let interruptAction: @MainActor () async -> Bool = {
             flags.interrupts += 1
+            return flags.interruptSucceeds
         }
         gateway.onStreamOpen = { flags.speechStreamOpens += 1 }
         let controller = VoiceConversationController(
@@ -226,7 +395,7 @@ final class VoiceConversationLifecycleSuspensionTests: XCTestCase {
         controller.ingestAudioLevel(0, at: start.addingTimeInterval(1.3))
         try? await Task.sleep(nanoseconds: 150_000_000)
         XCTAssertEqual(controller.state, .thinking)
-        XCTAssertEqual(flags.submitTexts, ["Question"])
+        XCTAssertEqual(flags.submitTexts.last, "Question")
     }
 
     private func driveToSpeaking(
@@ -250,6 +419,7 @@ final class AppStateVoiceSuspensionTests: XCTestCase {
         let harness = makeHarness()
         await harness.openVoice(session: "session-1")
         await harness.driveToThinking()
+        harness.controller.setOutputMuted(true)
         let startsBeforeBackground = harness.capture.startCount
 
         harness.appState.handleScenePhase(.background)
@@ -258,9 +428,290 @@ final class AppStateVoiceSuspensionTests: XCTestCase {
         XCTAssertEqual(harness.appState.suspendedVoiceConversation?.sessionID, "session-1")
         XCTAssertTrue(harness.appState.showVoiceSheet, "suspension is not Close: the sheet intent is preserved")
         XCTAssertEqual(harness.controller.state, .idle)
+        XCTAssertTrue(harness.controller.isRuntimeSuspended, "suspended runtime state is explicit")
         XCTAssertGreaterThanOrEqual(harness.capture.stopCount, 1, "capture is released on suspension")
         XCTAssertEqual(harness.capture.startCount, startsBeforeBackground, "suspension does not start capture")
         XCTAssertTrue(harness.controller.hasLiveVoiceSession, "logical Voice session is preserved")
+        XCTAssertTrue(harness.controller.isOutputMuted, "an explicit mute survives suspension")
+        XCTAssertFalse(
+            harness.appState.consumeVoiceSheetAutoListen(),
+            "suspension disarms the fresh-open auto-listen intent"
+        )
+    }
+
+    func testSuspendedRuntimeRejectsCaptureEventsExplicitly() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        await harness.controller.startListening()
+        harness.appState.handleScenePhase(.background)
+        harness.controller.setForegroundActive(true)
+
+        // Capture events arriving against suspended runtime state are
+        // rejected before the meter — hasLiveVoiceSession is logical
+        // ownership, not a claim that capture is live.
+        let start = Date()
+        harness.capture.emit(level: 0.5, at: start)
+        harness.capture.emit(level: 0.5, at: start.addingTimeInterval(0.4))
+        try? await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertEqual(harness.controller.microphoneLevel, 0, "no meter publication while suspended")
+        XCTAssertEqual(harness.gateway.transcriptionCount, 0)
+    }
+
+    func testTransientInactiveDipLeavesVoiceUntouched() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        await harness.driveToThinking()
+        let stopsBeforeDip = harness.capture.stopCount
+
+        harness.appState.handleScenePhase(.inactive)
+
+        // The .active reconciliation task is cancelled before assertions so
+        // no production reconnect work escapes the test.
+        let scene = harness.appState.handleScenePhase(.active)
+        scene?.cancel()
+
+        XCTAssertNil(harness.appState.suspendedVoiceConversation, "a transient dip records no descriptor")
+        XCTAssertTrue(harness.appState.showVoiceSheet)
+        XCTAssertEqual(harness.controller.state, .thinking, "the in-flight turn keeps flowing through a dip")
+        XCTAssertEqual(harness.capture.stopCount, stopsBeforeDip, "no runtime teardown on a transient dip")
+        XCTAssertTrue(
+            harness.appState.consumeVoiceSheetAutoListen() == false && !harness.controller.isRuntimeSuspended,
+            "the dip neither suspends the runtime nor touches the auto-listen intent"
+        )
+
+        let secondScene = harness.appState.handleScenePhase(.active)
+        secondScene?.cancel()
+
+        XCTAssertEqual(harness.controller.state, .thinking, "the turn continues after the dip")
+        XCTAssertTrue(harness.appState.showVoiceSheet)
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+    }
+
+    func testListeningSurvivesTransientInactiveDip() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        await harness.controller.startListening()
+        XCTAssertEqual(harness.controller.state, .listening)
+
+        harness.appState.handleScenePhase(.inactive)
+        let scene = harness.appState.handleScenePhase(.active)
+        scene?.cancel()
+
+        XCTAssertEqual(harness.controller.state, .listening, "an already-listening dip does not tear the listen down")
+        XCTAssertEqual(harness.capture.startCount, 1)
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+    }
+
+    func testPermissionPromptStyleDipDoesNotLoseInitialListen() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        // A fresh open arms the sheet's one-shot auto-listen (the microphone
+        // permission prompt then dips the scene before it can fire).
+        harness.appState.voiceSheetShouldAutoListen = true
+        await harness.controller.startListening()
+
+        harness.appState.handleScenePhase(.inactive)
+        // Cancel the reconciliation task so no production reconnect work
+        // escapes the test (there is no descriptor to restore here).
+        let scene = harness.appState.handleScenePhase(.active)
+        scene?.cancel()
+
+        XCTAssertTrue(
+            harness.appState.consumeVoiceSheetAutoListen(),
+            "the user's initial Voice-open action must survive a permission-prompt dip"
+        )
+        XCTAssertEqual(harness.controller.state, .listening)
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+    }
+
+    func testSpeechCapabilityLossWhileSuspendedFailsClosed() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        harness.appState.handleScenePhase(.background)
+
+        // Speech is gone by the time Conduit returns (fresh opens are
+        // rejected for the same reason).
+        harness.appState.installVoiceCapabilityStateForTesting(
+            bridge: DashboardTicketBridge(baseURL: "https://example.com"),
+            snapshot: VoiceCapabilitySnapshot(
+                isGatewayConnected: true,
+                supportsTranscription: true,
+                supportsSpeech: false,
+                unavailableReason: nil
+            ),
+            isVoiceEnabled: true
+        )
+        harness.foregroundForRestoration()
+
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+        XCTAssertFalse(harness.appState.showVoiceSheet, "capability loss while suspended fails closed")
+    }
+
+    func testRuntimeRebindOfSameDurableConversationRestores() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        await harness.driveToThinking()
+        harness.appState.handleScenePhase(.background)
+
+        // Foreground reconciliation legitimately rebinds the runtime id; the
+        // session catalog records both ids as one durable conversation.
+        harness.appState.sessions = [SessionSummary(
+            id: "session-2",
+            alternateIds: ["session-1"],
+            title: "Rebound",
+            model: "m",
+            updatedLabel: "",
+            profile: "default",
+            source: .chat,
+            isActive: true,
+            isArchived: false
+        )]
+        harness.appState.activeSessionId = "session-2"
+        harness.foregroundForRestoration()
+
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+        XCTAssertTrue(harness.appState.showVoiceSheet, "a legitimate rebind of the same durable conversation restores")
+    }
+
+    func testProfileFallbackAdoptionEndsSuspendedVoiceAndPersistsMuteUnderOutgoingProfile() throws {
+        let harness = makeHarness()
+        let defaults = harness.defaults
+        let outgoingKey = "conduit.voice.preferences.v1.https://example.com.default"
+        var seed = VoiceProfilePreferences()
+        seed.outputMuted = false
+        if let data = try? JSONEncoder().encode(seed) {
+            defaults.set(data, forKey: outgoingKey)
+        }
+        harness.openVoice(session: "session-1")
+        harness.controller.setOutputMuted(true)
+        harness.appState.handleScenePhase(.background)
+        XCTAssertNotNil(harness.appState.suspendedVoiceConversation)
+
+        // The real destructive profile path (profile discovery proved the
+        // active profile no longer exists).
+        harness.appState.adoptAuthoritativeFallbackProfile("fallback")
+
+        XCTAssertNil(harness.appState.suspendedVoiceConversation, "the fallback re-home ends the suspension")
+        XCTAssertFalse(harness.appState.showVoiceSheet)
+        XCTAssertFalse(harness.controller.hasLiveVoiceSession)
+        let outgoingData = try XCTUnwrap(defaults.data(forKey: outgoingKey))
+        let outgoing = try JSONDecoder().decode(VoiceProfilePreferences.self, from: outgoingData)
+        XCTAssertTrue(outgoing.outputMuted, "the outgoing mute is persisted under the OUTGOING profile")
+        harness.foregroundForRestoration()
+        XCTAssertFalse(harness.appState.showVoiceSheet, "nothing restores into the fallback profile")
+    }
+
+    func testCrossProfileFailClosedRestoreDoesNotWriteMute() async throws {
+        let harness = makeHarness()
+        let defaults = harness.defaults
+        let betaKey = "conduit.voice.preferences.v1.https://example.com.beta"
+        var beta = VoiceProfilePreferences()
+        beta.outputMuted = false
+        if let data = try? JSONEncoder().encode(beta) {
+            defaults.set(data, forKey: betaKey)
+        }
+        await harness.openVoice(session: "session-1")
+        await harness.driveToThinking()
+        harness.controller.setOutputMuted(true)
+        harness.appState.handleScenePhase(.background)
+
+        // The active profile changed by some path outside the suspension.
+        harness.appState.setActiveProfileForTesting("beta")
+        harness.foregroundForRestoration()
+
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+        XCTAssertFalse(harness.appState.showVoiceSheet, "cross-profile staleness fails closed")
+        XCTAssertFalse(harness.controller.hasLiveVoiceSession)
+        let loadedBetaData = try XCTUnwrap(defaults.data(forKey: betaKey))
+        let loadedBeta = try JSONDecoder().decode(VoiceProfilePreferences.self, from: loadedBetaData)
+        XCTAssertFalse(
+            loadedBeta.outputMuted,
+            "the fail-closed teardown must not write the stale profile's mute into beta's preferences"
+        )
+    }
+
+    func testRestorationWaitsForForegroundReconciliationAndAuthFailureFailsClosed() async {
+        let mintGate = ControlledSuspension()
+        let harness = makeHarness(lifecycleOperations: ChatResumeLifecycleOperations(
+            mintTicket: { _ in
+                await mintGate.suspend()
+                throw DashboardTicketBridgeError.signInRequired
+            }
+        ))
+        // A dead socket: the foreground reconciliation must reconnect first.
+        harness.appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://example.com", ticket: "stale-ticket"),
+            profile: "default"
+        )
+        await harness.openVoice(session: "session-1")
+        await harness.driveToThinking()
+        harness.appState.handleScenePhase(.background)
+        XCTAssertNotNil(harness.appState.suspendedVoiceConversation)
+
+        let scene = harness.appState.handleScenePhase(.active)
+        await mintGate.waitUntilSuspended()
+        XCTAssertNotNil(
+            harness.appState.suspendedVoiceConversation,
+            "restoration must not run before reconciliation completes"
+        )
+        XCTAssertTrue(harness.appState.showVoiceSheet)
+
+        // The reconnect fails with a sign-in requirement: never restore
+        // against stale pre-background state.
+        mintGate.resume()
+        await scene?.value
+
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+        XCTAssertFalse(harness.appState.showVoiceSheet, "reconnect/auth failure fails closed")
+        XCTAssertFalse(harness.controller.hasLiveVoiceSession)
+    }
+
+    func testVoiceSheetAutoListenIsConsumedExactlyOnce() {
+        let harness = makeHarness()
+        XCTAssertFalse(harness.appState.consumeVoiceSheetAutoListen())
+        harness.appState.voiceSheetShouldAutoListen = true
+        XCTAssertTrue(harness.appState.consumeVoiceSheetAutoListen())
+        XCTAssertFalse(harness.appState.consumeVoiceSheetAutoListen(), "the intent is consumed exactly once")
+    }
+
+    func testInactiveThenBackgroundThenActiveRestoresExactlyOnce() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        await harness.driveToThinking()
+
+        harness.appState.handleScenePhase(.inactive)
+        XCTAssertNil(harness.appState.suspendedVoiceConversation, "the dip alone records nothing")
+        harness.appState.handleScenePhase(.background)
+        XCTAssertEqual(harness.appState.suspendedVoiceConversation?.sessionID, "session-1")
+
+        harness.foregroundForRestoration()
+
+        XCTAssertTrue(harness.appState.showVoiceSheet)
+        XCTAssertNil(harness.appState.suspendedVoiceConversation, "restoration consumes the descriptor exactly once")
+        XCTAssertEqual(harness.controller.state, .idle)
+    }
+
+    func testCapabilityLossWhileSuspendedFailsClosed() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        harness.appState.handleScenePhase(.background)
+
+        // The transcription provider is gone by the time Conduit returns.
+        harness.appState.installVoiceCapabilityStateForTesting(
+            bridge: DashboardTicketBridge(baseURL: "https://example.com"),
+            snapshot: VoiceCapabilitySnapshot(
+                isGatewayConnected: true,
+                supportsTranscription: false,
+                supportsSpeech: true,
+                unavailableReason: nil
+            ),
+            isVoiceEnabled: true
+        )
+        harness.foregroundForRestoration()
+
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+        XCTAssertFalse(harness.appState.showVoiceSheet, "capability loss while suspended fails closed")
     }
 
     func testBackgroundWhileListeningFencesLateCaptureEvents() async {
@@ -469,16 +920,235 @@ final class AppStateVoiceSuspensionTests: XCTestCase {
         XCTAssertEqual(harness.appState.activeSessionId, "session-2", "restoration must not invent a replacement session")
     }
 
-    func testSceneActiveWiresRestorationAndFailsClosedWhenSignedOut() {
+    func testCaptureInterruptionWhileSuspendedDoesNotDestroyLogicalSession() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        await harness.driveToThinking()
+        harness.appState.handleScenePhase(.background)
+        XCTAssertNotNil(harness.appState.suspendedVoiceConversation)
+        XCTAssertTrue(harness.controller.isRuntimeSuspended)
+
+        // A stale interruption from the RELEASED runtime arrives while the
+        // logical Voice session is dormant: it must not clear ownership,
+        // orphan bookkeeping, or restoration eligibility.
+        harness.capture.emitInterrupted()
+        try? await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertTrue(harness.controller.hasLiveVoiceSession, "logical ownership survives the stale interruption")
+        XCTAssertTrue(harness.controller.isRuntimeSuspended)
+        XCTAssertEqual(harness.controller.state, .idle, "the session is dormant, not failed")
+        XCTAssertFalse(harness.controller.conversationTranscript.isEmpty, "the preserved transcript survives")
+        XCTAssertNotNil(harness.appState.suspendedVoiceConversation, "restoration eligibility survives")
+
+        // Foreground restore still succeeds afterwards.
+        harness.foregroundForRestoration()
+        XCTAssertTrue(harness.appState.showVoiceSheet)
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+    }
+
+    func testLiveMuteSurvivesCapabilityRefreshAndRestore() async {
+        let harness = makeHarness(requesterMode: .fullSupport)
+        harness.defaults.set(true, forKey: "conduit.voice.enabled.v1.https://example.com.default")
+        await harness.openVoice(session: "session-1")
+        await harness.driveToThinking()
+        // The in-session Mute control changes only the live controller state.
+        harness.controller.setOutputMuted(true)
+        harness.appState.handleScenePhase(.background)
+        XCTAssertNotNil(harness.appState.suspendedVoiceConversation)
+
+        // The real restoration path: capability refresh through the gateway
+        // answer, currency re-check, then restore.
+        await harness.appState.refreshCapabilitiesAndRestoreSuspendedVoice(isCurrent: { true })
+
+        XCTAssertTrue(harness.appState.voiceCapabilitySnapshot.supportsSpeech, "the refresh resolved a capable snapshot")
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+        XCTAssertTrue(harness.appState.showVoiceSheet, "restoration succeeds")
+        XCTAssertTrue(harness.controller.isOutputMuted, "the live mute wins over the reloaded persisted blob")
+        // The restored sheet is open but not listening: the runtime gate
+        // stays armed until the user taps Listen.
+        XCTAssertTrue(harness.controller.isRuntimeSuspended)
+    }
+
+    func testLiveUnmuteWinsOverPersistedMuteAcrossRefreshAndRestore() async {
+        let harness = makeHarness(requesterMode: .fullSupport)
+        harness.defaults.set(true, forKey: "conduit.voice.enabled.v1.https://example.com.default")
+        // Persisted blob says muted; the live session unmutes.
+        var persisted = VoiceProfilePreferences()
+        persisted.outputMuted = true
+        harness.defaults.set(
+            try! JSONEncoder().encode(persisted),
+            forKey: "conduit.voice.preferences.v1.https://example.com.default"
+        )
+        await harness.openVoice(session: "session-1")
+        harness.controller.setProfilePreferences(persisted)
+        harness.controller.setOutputMuted(false)
+        await harness.driveToThinking()
+        harness.appState.handleScenePhase(.background)
+
+        await harness.appState.refreshCapabilitiesAndRestoreSuspendedVoice(isCurrent: { true })
+
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+        XCTAssertTrue(harness.appState.showVoiceSheet)
+        XCTAssertFalse(
+            harness.controller.isOutputMuted,
+            "the live value, not whichever persisted value happens to exist, wins"
+        )
+    }
+
+    func testStaleCapturedMuteDoesNotLeakAcrossProfileOnRestore() async {
+        let harness = makeHarness()
+        let betaKey = "conduit.voice.preferences.v1.https://example.com.beta"
+        var beta = VoiceProfilePreferences()
+        beta.outputMuted = false
+        harness.defaults.set(try! JSONEncoder().encode(beta), forKey: betaKey)
+        await harness.openVoice(session: "session-1")
+        harness.controller.setOutputMuted(true)
+        harness.appState.handleScenePhase(.background)
+
+        // The active profile changed by some path outside the suspension.
+        harness.appState.setActiveProfileForTesting("beta")
+        await harness.appState.refreshCapabilitiesAndRestoreSuspendedVoice(isCurrent: { true })
+
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+        XCTAssertFalse(harness.appState.showVoiceSheet, "cross-profile staleness fails closed")
+        let loadedBeta = try! JSONDecoder().decode(
+            VoiceProfilePreferences.self,
+            from: harness.defaults.data(forKey: betaKey)!
+        )
+        XCTAssertFalse(
+            loadedBeta.outputMuted,
+            "the preserved mute is never reapplied to a different profile's blob"
+        )
+    }
+
+    func testSupersededRefreshDoesNotRestoreOrReapplyMute() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        harness.controller.setOutputMuted(true)
+        harness.appState.handleScenePhase(.background)
+
+        await harness.appState.refreshCapabilitiesAndRestoreSuspendedVoice(isCurrent: { false })
+
+        XCTAssertNotNil(harness.appState.suspendedVoiceConversation, "a superseded attempt leaves the descriptor")
+        XCTAssertTrue(harness.appState.showVoiceSheet)
+        XCTAssertTrue(harness.controller.isOutputMuted)
+    }
+
+    func testVoiceStillRestoresWhenAutomaticWorkInvalidatedDuringReconnect() async {
+        let connectGate = ControlledSuspension()
+        let harness = makeHarness(
+            lifecycleOperations: ChatResumeLifecycleOperations(
+                connectClient: { _ in await connectGate.suspend() },
+                loadCatalog: { _, _ in [] },
+                mintTicket: { _ in "fresh-ticket" }
+            ),
+            requesterMode: .fullSupport
+        )
+        harness.defaults.set(
+            true,
+            forKey: "conduit.voice.enabled.v1.https://example.com.default"
+        )
+        harness.appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://example.com", ticket: "stale-ticket"),
+            profile: "default"
+        )
+        await harness.openVoice(session: "session-1")
+        await harness.driveToThinking()
+        harness.appState.handleScenePhase(.background)
+        XCTAssertNotNil(harness.appState.suspendedVoiceConversation)
+
+        let scene = harness.appState.handleScenePhase(.active)
+        await connectGate.waitUntilSuspended()
+
+        // The composer/viewport invalidates the automatic chat-resume work
+        // while the reconnect runs.
+        harness.appState.noteComposerUserEdit()
+        connectGate.resume()
+        await scene?.value
+
+        XCTAssertNil(harness.appState.suspendedVoiceConversation, "the descriptor is consumed by the authoritative tail")
+        XCTAssertTrue(harness.appState.showVoiceSheet, "Voice still restores after preserve-current reconnect")
+        XCTAssertTrue(harness.controller.hasLiveVoiceSession)
+        XCTAssertEqual(harness.controller.state, .idle, "restoration stays non-listening")
+    }
+
+    func testCapabilityRefreshBeforeRestoreFailsClosedWhenSupportIsGone() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        await harness.driveToThinking()
+        XCTAssertTrue(harness.appState.voiceCapabilitySnapshot.supportsSpeech, "pre-background the snapshot is capable")
+        harness.appState.handleScenePhase(.background)
+        XCTAssertNotNil(harness.appState.suspendedVoiceConversation)
+
+        // The post-reconciliation capability refresh consults the server
+        // again (the harness requester resolves to no voice support) and
+        // restoration fails closed on the refreshed answer instead of the
+        // stale pre-background snapshot.
+        await harness.appState.refreshCapabilitiesAndRestoreSuspendedVoice(isCurrent: { true })
+
+        XCTAssertFalse(harness.appState.voiceCapabilitySnapshot.supportsSpeech, "the refresh replaced the stale snapshot")
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+        XCTAssertFalse(harness.appState.showVoiceSheet, "restoration fails closed instead of reopening from stale state")
+    }
+
+    func testSupersededReconciliationAttemptLeavesDescriptorForSuccessor() async {
+        let mintGate = ControlledSuspension()
+        let harness = makeHarness(lifecycleOperations: ChatResumeLifecycleOperations(
+            mintTicket: { _ in
+                await mintGate.suspend()
+                throw DashboardTicketBridgeError.signInRequired
+            }
+        ))
+        harness.appState.client = HermesClient(
+            connection: HermesConnection(baseUrl: "https://example.com", ticket: "stale-ticket"),
+            profile: "default"
+        )
+        await harness.openVoice(session: "session-1")
+        await harness.driveToThinking()
+        harness.appState.handleScenePhase(.background)
+
+        // Attempt A parks mid-reconnect.
+        let first = harness.appState.handleScenePhase(.active)
+        await mintGate.waitUntilSuspended()
+
+        // A newer .background boundary supersedes attempt A and RE-ARMS the
+        // descriptor (it does not clear it).
+        harness.appState.handleScenePhase(.background)
+        XCTAssertEqual(harness.appState.suspendedVoiceConversation?.sessionID, "session-1")
+
+        // Attempt A finishes while superseded: it must NOT consume the
+        // descriptor against pre-reconciliation state.
+        mintGate.resume()
+        await first?.value
+        XCTAssertEqual(
+            harness.appState.suspendedVoiceConversation?.sessionID, "session-1",
+            "a superseded attempt must leave the descriptor for its successor"
+        )
+
+        // The successor restores normally.
+        harness.foregroundForRestoration()
+        XCTAssertTrue(harness.appState.showVoiceSheet)
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+    }
+
+    func testSignedOutActiveDefersRestorationInsteadOfConsuming() {
         let harness = makeHarnessWithoutConnection()
         harness.openVoice(session: "session-1")
         harness.appState.handleScenePhase(.background)
         XCTAssertNotNil(harness.appState.suspendedVoiceConversation)
 
+        // Signed out, the scene task never reconciles; restoration is
+        // deferred, NOT consumed against stale pre-background state.
         harness.appState.handleScenePhase(.active)
+        XCTAssertNotNil(
+            harness.appState.suspendedVoiceConversation,
+            "the descriptor survives a reconciliation-less signed-out return"
+        )
 
-        XCTAssertNil(harness.appState.suspendedVoiceConversation, "the .active scene path consumes the descriptor")
-        XCTAssertFalse(harness.appState.showVoiceSheet, "signed-out return fails closed")
+        // A later explicit restoration attempt still fails closed.
+        harness.foregroundForRestoration()
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+        XCTAssertFalse(harness.appState.showVoiceSheet, "signed-out restoration fails closed")
     }
 
     func testRestoreThenListenRunsTheFullConversation() async {
@@ -488,6 +1158,11 @@ final class AppStateVoiceSuspensionTests: XCTestCase {
         harness.appState.handleScenePhase(.background)
 
         harness.foregroundForRestoration()
+
+        // Production reinstalls a gateway built from the current bridge;
+        // the mock gateway stands in for it so the conversation runs
+        // without network.
+        harness.controller.setGateway(harness.gateway)
 
         // The user taps Listen and speaks again: the same conversation continues.
         await harness.controller.resumeMicrophone()
@@ -504,18 +1179,21 @@ final class AppStateVoiceSuspensionTests: XCTestCase {
 
     // MARK: harness
 
-    struct Harness {
+    @MainActor
+    private struct Harness {
         let appState: AppState
         let controller: VoiceConversationController
         let capture: MockCapture
         let playback: GatedPlayback
         let gateway: MockGateway
         let flags: Flags
+        let defaults: UserDefaults
 
         func openVoice(session: String) {
             appState.activeSessionId = session
             appState.showVoiceSheet = true
             controller.beginVoiceTurn(sessionID: session)
+            appState.voiceControllerSessionProfile = appState.activeProfile
         }
 
         /// Drives one submitted user turn end to end (listening → thinking).
@@ -534,8 +1212,10 @@ final class AppStateVoiceSuspensionTests: XCTestCase {
 
         /// Speaks one utterance through the live capture. With
         /// `sessionArmed` the capture is already listening (post-restore
-        /// Listen), otherwise the turn is armed first.
+        /// Listen), otherwise the turn is armed first. The mock recognizer
+        /// returns the spoken text, matching per-phase utterance pinning.
         func speakUtterance(_ text: String, sessionArmed: Bool = false) async {
+            gateway.transcript = text
             if !sessionArmed {
                 controller.beginVoiceTurn(sessionID: appState.activeSessionId ?? "session-1")
                 await controller.startListening()
@@ -561,9 +1241,13 @@ final class AppStateVoiceSuspensionTests: XCTestCase {
     final class Flags {
         var submitTexts: [String] = []
         var interrupts = 0
+        var interruptSucceeds = true
     }
 
-    private func makeHarness() -> Harness {
+    private func makeHarness(
+        lifecycleOperations: ChatResumeLifecycleOperations = .live,
+        requesterMode: ImmediateVoiceConfigRequester.Mode = .failing
+    ) -> Harness {
         let suite = "AppStateVoiceSuspensionTests.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suite) else {
             fatalError("Failed to create test UserDefaults suite")
@@ -573,7 +1257,12 @@ final class AppStateVoiceSuspensionTests: XCTestCase {
         }
         defaults.set("default", forKey: "conduit.activeProfile")
 
-        let appState = AppState(defaults: defaults, loadSavedConnection: false)
+        let appState = AppState(
+            defaults: defaults,
+            loadSavedConnection: false,
+            chatResumeLifecycleOperations: lifecycleOperations
+        )
+        appState.voiceCapabilityRequesterForTesting = ImmediateVoiceConfigRequester(mode: requesterMode)
         appState.connection = HermesConnection(baseUrl: "https://example.com", ticket: "test-ticket")
         appState.isConnected = true
         appState.installVoiceCapabilityStateForTesting(
@@ -586,7 +1275,6 @@ final class AppStateVoiceSuspensionTests: XCTestCase {
             ),
             isVoiceEnabled: true
         )
-        appState.voiceCapabilityRequesterForTesting = ImmediateVoiceConfigRequester()
 
         let capture = MockCapture(permissionGranted: true)
         let playback = GatedPlayback()
@@ -596,8 +1284,9 @@ final class AppStateVoiceSuspensionTests: XCTestCase {
             flags.submitTexts.append(text)
             return true
         }
-        let interruptAction: @MainActor () async -> Void = {
+        let interruptAction: @MainActor () async -> Bool = {
             flags.interrupts += 1
+            return flags.interruptSucceeds
         }
         let appStateRef = appState
         let controller = VoiceConversationController(
@@ -619,7 +1308,8 @@ final class AppStateVoiceSuspensionTests: XCTestCase {
             capture: capture,
             playback: playback,
             gateway: gateway,
-            flags: flags
+            flags: flags,
+            defaults: defaults
         )
     }
 
@@ -655,7 +1345,7 @@ final class AppStateVoiceSuspensionTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { .fullDuplex },
             submit: { _ in true },
-            interrupt: {},
+            interrupt: { true },
             onEndConversation: { [weak appStateRef] in
                 appStateRef?.closeVoiceConversation()
             }
@@ -668,16 +1358,69 @@ final class AppStateVoiceSuspensionTests: XCTestCase {
             capture: capture,
             playback: GatedPlayback(),
             gateway: gateway,
-            flags: Flags()
+            flags: Flags(),
+            defaults: defaults
         )
     }
 }
 
-/// Fail-fast requester so capability refreshes skip the network.
+/// A parkable async step for hermetic reconciliation tests.
+@MainActor
+private final class ControlledSuspension {
+    private var suspension: CheckedContinuation<Void, Never>?
+    private var observer: CheckedContinuation<Void, Never>?
+
+    func suspend() async {
+        await withCheckedContinuation { continuation in
+            suspension = continuation
+            observer?.resume()
+            observer = nil
+        }
+    }
+
+    func waitUntilSuspended() async {
+        guard suspension == nil else { return }
+        await withCheckedContinuation { continuation in
+            observer = continuation
+        }
+    }
+
+    func resume() {
+        suspension?.resume()
+        suspension = nil
+    }
+}
+
+/// Capability-requester doubles for the restoration path: `.failing` keeps
+/// capability refreshes off the network and resolves the snapshot to
+/// "no support"; `.fullSupport` answers a minimal config plus a ready Edge
+/// TTS toolset row so a refreshed snapshot is genuinely capable.
 @MainActor
 private final class ImmediateVoiceConfigRequester: VoiceConfigurationRequesting {
+    enum Mode { case failing, fullSupport }
+
+    private let mode: Mode
+
+    init(mode: Mode = .failing) { self.mode = mode }
+
     func requestJSON(path: String, method: String, body: [String: Any]?) async throws -> [String: Any] {
-        throw URLError(.notConnectedToInternet)
+        switch mode {
+        case .failing:
+            throw URLError(.notConnectedToInternet)
+        case .fullSupport:
+            if path.hasSuffix("/api/config") {
+                return ["stt": ["enabled": true], "tts": ["provider": "edge"]]
+            }
+            if path.hasSuffix("/api/tools/toolsets/tts/config") {
+                return ["providers": [[
+                    "name": "Microsoft Edge TTS",
+                    "tts_provider": "edge",
+                    "status": "ready",
+                    "is_active": true,
+                ]]]
+            }
+            throw URLError(.notConnectedToInternet)
+        }
     }
 }
 
@@ -691,6 +1434,7 @@ private final class MockCapture: AudioCaptureService {
     private let permissionGranted: Bool
     private(set) var startCount = 0
     private(set) var stopCount = 0
+    private(set) var resumeCount = 0
 
     init(permissionGranted: Bool) {
         self.permissionGranted = permissionGranted
@@ -705,7 +1449,10 @@ private final class MockCapture: AudioCaptureService {
     }
     func beginBargeInMonitoring() throws {}
     func pause() { captureGeneration &+= 1 }
-    func resume() throws { captureGeneration &+= 1 }
+    func resume() throws {
+        resumeCount += 1
+        captureGeneration &+= 1
+    }
     func finishUtterance() throws -> VoiceCapturedAudio {
         VoiceCapturedAudio(wavData: Data([1]), pcm16Data: Data([1, 0]), sampleRate: 16_000, duration: 0.01)
     }
@@ -715,6 +1462,9 @@ private final class MockCapture: AudioCaptureService {
     }
     func emit(level: Float, at date: Date = Date()) {
         continuation?.yield(.level(level, date: date, generation: captureGeneration))
+    }
+    func emitInterrupted(generation: UInt64? = nil) {
+        continuation?.yield(.interrupted(generation: generation ?? captureGeneration))
     }
 }
 
@@ -737,7 +1487,9 @@ private final class GatedPlayback: SpeechPlaybackService {
 @MainActor
 private final class MockGateway: VoiceGatewayService {
     let profile = "default"
-    let transcript: String
+    /// Mutable so multi-utterance tests can pin what the recognizer returns
+    /// per phase (normal turn, spoken command, follow-up).
+    var transcript: String
     var onStreamOpen: (() -> Void)?
     private(set) var transcriptionCount = 0
     init(transcript: String) { self.transcript = transcript }
@@ -800,9 +1552,12 @@ private final class GatedTranscriptionGateway: VoiceGatewayService {
     }
 
     func releaseTranscription() {
+        // Guarded: the cancellation handler may already have consumed the
+        // parked continuation when suspension cancelled the utterance task.
+        guard !isReleased, let continuation = pendingContinuation else { return }
         isReleased = true
-        pendingContinuation?.resume(with: .success(transcript))
         pendingContinuation = nil
+        continuation.resume(with: .success(transcript))
     }
 
     func openSpeechStream(
@@ -828,4 +1583,36 @@ private final class StubSpeechStream: VoiceSpeechStream {
 private final class RoutePolicyBox {
     var policy: VoiceBargeInRoutePolicy
     init(_ policy: VoiceBargeInRoutePolicy) { self.policy = policy }
+}
+
+/// An interruption closure that parks mid-flight so tests can interleave
+/// suspension into the cancel await. `release()` disarms the gate: later
+/// interrupts pass through immediately.
+@MainActor
+private final class InterruptGate {
+    private(set) var count = 0
+    private var parked: [CheckedContinuation<Void, Never>] = []
+    private var entryWaiters: [CheckedContinuation<Void, Never>] = []
+    private var isDisarmed = false
+
+    func waitInInterrupt() async {
+        count += 1
+        let waiters = entryWaiters
+        entryWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+        guard !isDisarmed else { return }
+        await withCheckedContinuation { parked.append($0) }
+    }
+
+    func waitUntilEntered() async {
+        guard count == 0 else { return }
+        await withCheckedContinuation { entryWaiters.append($0) }
+    }
+
+    func release() {
+        isDisarmed = true
+        let parkedContinuations = parked
+        parked.removeAll()
+        parkedContinuations.forEach { $0.resume() }
+    }
 }

--- a/ConduitTests/VoiceBackgroundSuspensionTests.swift
+++ b/ConduitTests/VoiceBackgroundSuspensionTests.swift
@@ -1,0 +1,831 @@
+//
+//  VoiceBackgroundSuspensionTests.swift
+//  Conduit
+//
+//  Voice background behavior: lifecycle suspension (logical preservation +
+//  runtime release) instead of hard teardown, and conservative foreground
+//  restoration gated on profile/session/server identity.
+//
+
+import XCTest
+@testable import Conduit
+
+// MARK: - Controller-level suspension semantics
+
+@MainActor
+final class VoiceConversationLifecycleSuspensionTests: XCTestCase {
+    func testSuspensionReleasesRuntimeButPreservesConversationIdentity() async {
+        let (controller, capture, gateway, flags) = makeFixture()
+        await driveToThinking(controller, gateway: gateway, flags: flags)
+        let transcriptAfterTurn = controller.conversationTranscript
+
+        controller.suspendRuntimeForLifecycle()
+
+        XCTAssertEqual(controller.state, .idle, "suspension settles open, not listening")
+        XCTAssertGreaterThanOrEqual(capture.stopCount, 1, "capture is released")
+        XCTAssertTrue(controller.hasLiveVoiceSession, "the logical Voice session is preserved")
+        XCTAssertEqual(controller.conversationTranscript, transcriptAfterTurn, "the in-sheet transcript survives suspension")
+    }
+
+    func testSuspensionWhileSpeakingStopsPlaybackAndPreservesIdentity() async {
+        let (controller, capture, playback, gateway, flags) = makeFixtureWithPlayback()
+        await driveToSpeaking(controller, gateway: gateway, flags: flags)
+        XCTAssertTrue(playback.isPlaying)
+
+        controller.suspendRuntimeForLifecycle()
+
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertFalse(playback.isPlaying, "local TTS stops on suspension")
+        XCTAssertGreaterThanOrEqual(capture.stopCount, 1)
+        XCTAssertTrue(controller.hasLiveVoiceSession)
+        XCTAssertFalse(controller.conversationTranscript.isEmpty, "assistant transcript survives suspension")
+    }
+
+    func testSuspensionPreservesExplicitUserPause() async {
+        let (controller, capture, _, _) = makeFixture()
+        controller.beginVoiceTurn(sessionID: "session")
+        await controller.startListening()
+        controller.pauseMicrophone()
+
+        controller.suspendRuntimeForLifecycle()
+        controller.setForegroundActive(true)
+
+        XCTAssertTrue(controller.isMicrophonePaused, "an explicit user pause survives suspension")
+        XCTAssertEqual(capture.startCount, 1, "restoration must not start capture")
+        XCTAssertTrue(controller.hasLiveVoiceSession)
+    }
+
+    func testSuspensionRetiresInFlightTurnVoiceContinuationWithoutCancellingServerTurn() async {
+        let (controller, capture, gateway, flags) = makeFixture()
+        await driveToThinking(controller, gateway: gateway, flags: flags)
+        XCTAssertEqual(flags.submitTexts, ["Question"], "the turn was submitted before suspension")
+
+        controller.suspendRuntimeForLifecycle()
+
+        XCTAssertEqual(flags.interrupts, 0, "the Hermes turn is not cancelled by suspension")
+        let startsAtSuspension = capture.startCount
+
+        // The suspended turn's terminal events belong to the retired turn:
+        // they must not speak, append, or relisten.
+        controller.receiveAssistantEvent(.started(sessionID: "session"))
+        controller.receiveAssistantEvent(.delta(sessionID: "session", text: "late"))
+        controller.receiveAssistantEvent(.completed(sessionID: "session", content: "late answer"))
+        try? await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertEqual(controller.state, .idle)
+        XCTAssertEqual(capture.startCount, startsAtSuspension, "no stale relisten after suspension")
+        XCTAssertEqual(flags.speechStreamOpens, 0, "no stale TTS after suspension")
+    }
+
+    func testStopAfterSuspensionStillClosesFully() async {
+        let (controller, _, _, _) = makeFixture()
+        controller.beginVoiceTurn(sessionID: "session")
+        await controller.startListening()
+
+        controller.suspendRuntimeForLifecycle()
+        XCTAssertTrue(controller.hasLiveVoiceSession)
+
+        controller.stop()
+
+        XCTAssertFalse(controller.hasLiveVoiceSession, "explicit Close tears the suspended session down")
+        XCTAssertEqual(controller.state, .idle)
+    }
+
+    func testLateUtteranceTranscriptionAfterSuspensionCannotSubmit() async {
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = GatedTranscriptionGateway(transcript: "Question")
+        let flags = Flags()
+        let submitAction: @MainActor (String) async -> Bool = { text in
+            flags.submitTexts.append(text)
+            return true
+        }
+        let interruptAction: @MainActor () async -> Void = {
+            flags.interrupts += 1
+        }
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: GatedPlayback(),
+            gateway: gateway,
+            routePolicyProvider: { .fullDuplex },
+            submit: submitAction,
+            interrupt: interruptAction
+        )
+        controller.beginVoiceTurn(sessionID: "session")
+        await controller.startListening()
+
+        // Drive the utterance into the parked transcription await.
+        let start = Date()
+        controller.ingestAudioLevel(0.1, at: start)
+        controller.ingestAudioLevel(0, at: start.addingTimeInterval(1.3))
+        await gateway.waitUntilTranscribing()
+        XCTAssertEqual(gateway.transcriptionCount, 1, "transcription is in flight")
+
+        controller.suspendRuntimeForLifecycle()
+        gateway.releaseTranscription()
+        try? await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertEqual(flags.submitTexts, [], "the suspended utterance must never submit")
+        XCTAssertEqual(controller.state, .idle)
+    }
+
+    func testSpeakerRouteRemainsHalfDuplexInTurnsAfterRestore() async {
+        let capture = MockCapture(permissionGranted: true)
+        let playback = GatedPlayback()
+        let gateway = MockGateway(transcript: "Question")
+        let flags = Flags()
+        let policy = RoutePolicyBox(.speakerSafeHalfDuplex)
+        let submitAction: @MainActor (String) async -> Bool = { _ in true }
+        let interruptAction: @MainActor () async -> Void = {
+            flags.interrupts += 1
+        }
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: playback,
+            gateway: gateway,
+            routePolicyProvider: { policy.policy },
+            submit: submitAction,
+            interrupt: interruptAction
+        )
+
+        await driveToSpeaking(controller, gateway: gateway, flags: flags)
+        XCTAssertTrue(controller.isPlaybackCaptureSuspended)
+        controller.suspendRuntimeForLifecycle()
+        XCTAssertFalse(controller.isPlaybackCaptureSuspended, "suspension releases the playback-suspension state")
+        controller.setForegroundActive(true)
+
+        // A fresh turn after restoration behaves exactly like before: the
+        // speaker-safe route suspends capture during TTS again.
+        await driveToSpeaking(controller, gateway: gateway, flags: flags)
+        XCTAssertTrue(controller.isPlaybackCaptureSuspended, "route safety is unchanged after restoration")
+    }
+
+    // MARK: fixtures
+
+    final class Flags {
+        var submitTexts: [String] = []
+        var interrupts = 0
+        var speechStreamOpens = 0
+        var playbackStopCount = 0
+    }
+
+    private func makeFixture() -> (VoiceConversationController, MockCapture, MockGateway, Flags) {
+        let capture = MockCapture(permissionGranted: true)
+        let playback = GatedPlayback()
+        let gateway = MockGateway(transcript: "Question")
+        let flags = Flags()
+        let submitAction: @MainActor (String) async -> Bool = { text in
+            flags.submitTexts.append(text)
+            return true
+        }
+        let interruptAction: @MainActor () async -> Void = {
+            flags.interrupts += 1
+        }
+        playback.onStop = { flags.playbackStopCount += 1 }
+        gateway.onStreamOpen = { flags.speechStreamOpens += 1 }
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: playback,
+            gateway: gateway,
+            routePolicyProvider: { .fullDuplex },
+            submit: submitAction,
+            interrupt: interruptAction
+        )
+        return (controller, capture, gateway, flags)
+    }
+
+    private func makeFixtureWithPlayback() -> (VoiceConversationController, MockCapture, GatedPlayback, MockGateway, Flags) {
+        let capture = MockCapture(permissionGranted: true)
+        let playback = GatedPlayback()
+        let gateway = MockGateway(transcript: "Question")
+        let flags = Flags()
+        let submitAction: @MainActor (String) async -> Bool = { _ in true }
+        let interruptAction: @MainActor () async -> Void = {
+            flags.interrupts += 1
+        }
+        gateway.onStreamOpen = { flags.speechStreamOpens += 1 }
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: playback,
+            gateway: gateway,
+            routePolicyProvider: { .fullDuplex },
+            submit: submitAction,
+            interrupt: interruptAction
+        )
+        return (controller, capture, playback, gateway, flags)
+    }
+
+    private func driveToThinking(
+        _ controller: VoiceConversationController,
+        gateway: MockGateway,
+        flags: Flags
+    ) async {
+        controller.beginVoiceTurn(sessionID: "session")
+        await controller.startListening()
+        let start = Date()
+        controller.ingestAudioLevel(0.1, at: start)
+        controller.ingestAudioLevel(0, at: start.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        XCTAssertEqual(controller.state, .thinking)
+        XCTAssertEqual(flags.submitTexts, ["Question"])
+    }
+
+    private func driveToSpeaking(
+        _ controller: VoiceConversationController,
+        gateway: MockGateway,
+        flags: Flags
+    ) async {
+        await driveToThinking(controller, gateway: gateway, flags: flags)
+        controller.receiveAssistantEvent(.started(sessionID: "session"))
+        controller.receiveAssistantEvent(.delta(sessionID: "session", text: "Answer."))
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        XCTAssertEqual(controller.state, .speaking)
+    }
+}
+
+// MARK: - AppState-level suspension and restoration
+
+@MainActor
+final class AppStateVoiceSuspensionTests: XCTestCase {
+    func testBackgroundWithOpenVoiceSuspendsRuntimeAndRetainsDescriptor() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        await harness.driveToThinking()
+        let startsBeforeBackground = harness.capture.startCount
+
+        harness.appState.handleScenePhase(.background)
+
+        XCTAssertEqual(harness.appState.suspendedVoiceConversation?.profile, "default")
+        XCTAssertEqual(harness.appState.suspendedVoiceConversation?.sessionID, "session-1")
+        XCTAssertTrue(harness.appState.showVoiceSheet, "suspension is not Close: the sheet intent is preserved")
+        XCTAssertEqual(harness.controller.state, .idle)
+        XCTAssertGreaterThanOrEqual(harness.capture.stopCount, 1, "capture is released on suspension")
+        XCTAssertEqual(harness.capture.startCount, startsBeforeBackground, "suspension does not start capture")
+        XCTAssertTrue(harness.controller.hasLiveVoiceSession, "logical Voice session is preserved")
+    }
+
+    func testBackgroundWhileListeningFencesLateCaptureEvents() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        await harness.controller.startListening()
+
+        harness.appState.handleScenePhase(.background)
+        harness.controller.setForegroundActive(true)
+
+        let start = Date()
+        harness.capture.emit(level: 0.4, at: start)
+        harness.capture.emit(level: 0.4, at: start.addingTimeInterval(0.4))
+        harness.capture.emit(level: 0, at: start.addingTimeInterval(1.6))
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        XCTAssertEqual(harness.gateway.transcriptionCount, 0, "suspended capture events must not transcribe")
+        XCTAssertEqual(harness.flags.submitTexts, [])
+    }
+
+    func testBackgroundWhileSpeakingStopsPlaybackAndFencesLateCompletion() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        await harness.driveToThinking()
+        await harness.driveToSpeaking()
+        XCTAssertTrue(harness.playback.isPlaying)
+        let startsBeforeBackground = harness.capture.startCount
+
+        harness.appState.handleScenePhase(.background)
+        XCTAssertFalse(harness.playback.isPlaying, "local TTS stops on suspension")
+
+        // The assistant completes while Conduit is away; the late completion
+        // must neither speak nor relisten.
+        harness.controller.receiveAssistantEvent(
+            .completed(sessionID: "session-1", content: "Answer.")
+        )
+        harness.controller.setForegroundActive(true)
+        try? await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertEqual(harness.capture.startCount, startsBeforeBackground, "late completion must not relisten")
+        XCTAssertEqual(harness.controller.state, .idle)
+    }
+
+    func testBackgroundWhileThinkingDoesNotCancelServerTurn() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        await harness.driveToThinking()
+
+        harness.appState.handleScenePhase(.background)
+
+        XCTAssertEqual(harness.flags.interrupts, 0, "suspension must not cancel the running Hermes turn")
+        XCTAssertNotNil(harness.appState.suspendedVoiceConversation)
+    }
+
+    func testForegroundRestoreReinstallsGatewayWithoutStartingMic() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        await harness.driveToThinking()
+        harness.appState.handleScenePhase(.background)
+        // Simulate the gateway not surviving the suspension.
+        harness.controller.setGateway(nil)
+        XCTAssertFalse(harness.controller.isGatewayAttached)
+
+        harness.foregroundForRestoration()
+
+        XCTAssertNil(harness.appState.suspendedVoiceConversation, "restoration consumes the descriptor")
+        XCTAssertTrue(harness.appState.showVoiceSheet, "the Voice sheet is restored")
+        XCTAssertTrue(harness.controller.isGatewayAttached, "the gateway is reinstalled")
+        XCTAssertEqual(harness.controller.state, .idle, "restoration is open but non-listening")
+        XCTAssertEqual(harness.capture.startCount, 1, "restoration never activates the microphone")
+    }
+
+    func testContinuousConversationOnStillRestoresNonListening() async {
+        let harness = makeHarness()
+        XCTAssertTrue(harness.appState.setContinuousConversation(true))
+        await harness.openVoice(session: "session-1")
+        await harness.driveToThinking()
+        harness.appState.handleScenePhase(.background)
+
+        harness.foregroundForRestoration()
+
+        XCTAssertEqual(harness.controller.state, .idle)
+        XCTAssertEqual(harness.capture.startCount, 1, "Continuous Conversation is not permission to hot-start the mic after a lifecycle transition")
+    }
+
+    func testContinuousConversationOffRestoresNonListening() async {
+        let harness = makeHarness()
+        XCTAssertTrue(harness.appState.setContinuousConversation(false))
+        await harness.openVoice(session: "session-1")
+        await harness.driveToThinking()
+        harness.appState.handleScenePhase(.background)
+
+        harness.foregroundForRestoration()
+
+        XCTAssertEqual(harness.controller.state, .idle)
+        XCTAssertEqual(harness.capture.startCount, 1)
+        XCTAssertTrue(harness.appState.showVoiceSheet)
+    }
+
+    func testExplicitCloseBeforeBackgroundPreventsRestoration() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        harness.appState.closeVoiceConversation()
+
+        harness.appState.handleScenePhase(.background)
+        XCTAssertNil(harness.appState.suspendedVoiceConversation, "a closed Voice conversation is not suspendable")
+
+        harness.foregroundForRestoration()
+        XCTAssertFalse(harness.appState.showVoiceSheet, "background/foreground must not resurrect a closed Voice session")
+    }
+
+    func testSpokenGoodbyeBeforeBackgroundPreventsRestoration() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        await harness.speakUtterance("Goodbye.")
+        try? await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertFalse(harness.appState.showVoiceSheet, "the spoken End Conversation closed Voice through the Close path")
+        harness.appState.handleScenePhase(.background)
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+
+        harness.foregroundForRestoration()
+        XCTAssertFalse(harness.appState.showVoiceSheet)
+    }
+
+    func testStaleRestoreCannotReopenAfterExplicitClose() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        await harness.driveToThinking()
+        harness.appState.handleScenePhase(.background)
+
+        harness.foregroundForRestoration()
+        XCTAssertTrue(harness.appState.showVoiceSheet)
+
+        // Explicit Close wins over any restoration.
+        harness.appState.closeVoiceConversation()
+        harness.appState.handleScenePhase(.background)
+        harness.foregroundForRestoration()
+
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+        XCTAssertFalse(harness.appState.showVoiceSheet, "a stale restore must not reopen closed Voice")
+    }
+
+    func testProfileChangeWhileBackgroundedPreventsRestoration() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        harness.appState.handleScenePhase(.background)
+
+        harness.appState.setActiveProfileForTesting("beta")
+        harness.foregroundForRestoration()
+
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+        XCTAssertFalse(harness.appState.showVoiceSheet, "Voice must not be restored into a different profile")
+    }
+
+    func testServerIdentityChangePreventsRestoration() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        harness.appState.handleScenePhase(.background)
+
+        harness.appState.connection = HermesConnection(baseUrl: "https://other-server.example.com", ticket: "t")
+        harness.foregroundForRestoration()
+
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+        XCTAssertFalse(harness.appState.showVoiceSheet, "a replaced server is a destructive Voice boundary")
+    }
+
+    func testDisconnectClearsSuspension() {
+        let harness = makeHarness()
+        harness.openVoice(session: "session-1")
+        harness.appState.handleScenePhase(.background)
+        XCTAssertNotNil(harness.appState.suspendedVoiceConversation)
+
+        harness.appState.disconnect()
+
+        XCTAssertNil(harness.appState.suspendedVoiceConversation, "logout/disconnect clears suspended Voice")
+        XCTAssertFalse(harness.appState.showVoiceSheet)
+
+        harness.foregroundForRestoration()
+        XCTAssertFalse(harness.appState.showVoiceSheet)
+    }
+
+    func testVoiceDisabledWhileSuspendedPreventsRestoration() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        harness.appState.handleScenePhase(.background)
+
+        await harness.appState.setVoiceEnabled(false)
+
+        XCTAssertNil(harness.appState.suspendedVoiceConversation, "disabling Voice clears the suspended descriptor")
+        harness.foregroundForRestoration()
+        XCTAssertFalse(harness.appState.showVoiceSheet)
+    }
+
+    func testInvalidSuspendedSessionFailsClosedWithoutReplacementSession() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        harness.appState.handleScenePhase(.background)
+
+        // The authoritative session changed while Conduit was away.
+        harness.appState.activeSessionId = "session-2"
+        harness.foregroundForRestoration()
+
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+        XCTAssertFalse(harness.appState.showVoiceSheet, "stale session identity fails closed")
+        XCTAssertEqual(harness.appState.activeSessionId, "session-2", "restoration must not invent a replacement session")
+    }
+
+    func testSceneActiveWiresRestorationAndFailsClosedWhenSignedOut() {
+        let harness = makeHarnessWithoutConnection()
+        harness.openVoice(session: "session-1")
+        harness.appState.handleScenePhase(.background)
+        XCTAssertNotNil(harness.appState.suspendedVoiceConversation)
+
+        harness.appState.handleScenePhase(.active)
+
+        XCTAssertNil(harness.appState.suspendedVoiceConversation, "the .active scene path consumes the descriptor")
+        XCTAssertFalse(harness.appState.showVoiceSheet, "signed-out return fails closed")
+    }
+
+    func testRestoreThenListenRunsTheFullConversation() async {
+        let harness = makeHarness()
+        await harness.openVoice(session: "session-1")
+        await harness.driveToThinking()
+        harness.appState.handleScenePhase(.background)
+
+        harness.foregroundForRestoration()
+
+        // The user taps Listen and speaks again: the same conversation continues.
+        await harness.controller.resumeMicrophone()
+        XCTAssertEqual(harness.controller.state, .listening)
+        await harness.speakUtterance("Follow-up question", sessionArmed: true)
+        try? await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertEqual(harness.flags.submitTexts, ["Question", "Follow-up question"])
+        harness.controller.receiveAssistantEvent(.started(sessionID: "session-1"))
+        harness.controller.receiveAssistantEvent(.delta(sessionID: "session-1", text: "Reply."))
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        XCTAssertEqual(harness.controller.state, .speaking, "assistant replies are voiced for the restored conversation")
+    }
+
+    // MARK: harness
+
+    struct Harness {
+        let appState: AppState
+        let controller: VoiceConversationController
+        let capture: MockCapture
+        let playback: GatedPlayback
+        let gateway: MockGateway
+        let flags: Flags
+
+        func openVoice(session: String) {
+            appState.activeSessionId = session
+            appState.showVoiceSheet = true
+            controller.beginVoiceTurn(sessionID: session)
+        }
+
+        /// Drives one submitted user turn end to end (listening → thinking).
+        func driveToThinking() async {
+            await controller.startListening()
+            speakUtteranceIntoVAD("Question")
+            try? await Task.sleep(nanoseconds: 150_000_000)
+        }
+
+        /// Drives the assistant reply until audible playback.
+        func driveToSpeaking() async {
+            controller.receiveAssistantEvent(.started(sessionID: "session-1"))
+            controller.receiveAssistantEvent(.delta(sessionID: "session-1", text: "Answer."))
+            try? await Task.sleep(nanoseconds: 150_000_000)
+        }
+
+        /// Speaks one utterance through the live capture. With
+        /// `sessionArmed` the capture is already listening (post-restore
+        /// Listen), otherwise the turn is armed first.
+        func speakUtterance(_ text: String, sessionArmed: Bool = false) async {
+            if !sessionArmed {
+                controller.beginVoiceTurn(sessionID: appState.activeSessionId ?? "session-1")
+                await controller.startListening()
+            }
+            speakUtteranceIntoVAD(text)
+        }
+
+        private func speakUtteranceIntoVAD(_ text: String) {
+            let start = Date()
+            capture.emit(level: 0.1, at: start)
+            capture.emit(level: 0, at: start.addingTimeInterval(1.3))
+        }
+
+        /// Foreground return WITHOUT the reconnect task: flips the controller
+        /// foreground flag and runs the synchronous restoration validation —
+        /// exactly what the .active scene phase does before its transport work.
+        func foregroundForRestoration() {
+            controller.setForegroundActive(true)
+            appState.restoreSuspendedVoiceConversationIfNeeded()
+        }
+    }
+
+    final class Flags {
+        var submitTexts: [String] = []
+        var interrupts = 0
+    }
+
+    private func makeHarness() -> Harness {
+        let suite = "AppStateVoiceSuspensionTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Failed to create test UserDefaults suite")
+        }
+        addTeardownBlock { [defaults] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        defaults.set("default", forKey: "conduit.activeProfile")
+
+        let appState = AppState(defaults: defaults, loadSavedConnection: false)
+        appState.connection = HermesConnection(baseUrl: "https://example.com", ticket: "test-ticket")
+        appState.isConnected = true
+        appState.installVoiceCapabilityStateForTesting(
+            bridge: DashboardTicketBridge(baseURL: "https://example.com"),
+            snapshot: VoiceCapabilitySnapshot(
+                isGatewayConnected: true,
+                supportsTranscription: true,
+                supportsSpeech: true,
+                unavailableReason: nil
+            ),
+            isVoiceEnabled: true
+        )
+        appState.voiceCapabilityRequesterForTesting = ImmediateVoiceConfigRequester()
+
+        let capture = MockCapture(permissionGranted: true)
+        let playback = GatedPlayback()
+        let gateway = MockGateway(transcript: "Question")
+        let flags = Flags()
+        let submitAction: @MainActor (String) async -> Bool = { text in
+            flags.submitTexts.append(text)
+            return true
+        }
+        let interruptAction: @MainActor () async -> Void = {
+            flags.interrupts += 1
+        }
+        let appStateRef = appState
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: playback,
+            gateway: gateway,
+            routePolicyProvider: { .fullDuplex },
+            submit: submitAction,
+            interrupt: interruptAction,
+            onEndConversation: { [weak appStateRef] in
+                appStateRef?.closeVoiceConversation()
+            }
+        )
+        appState.voiceConversationController = controller
+
+        return Harness(
+            appState: appState,
+            controller: controller,
+            capture: capture,
+            playback: playback,
+            gateway: gateway,
+            flags: flags
+        )
+    }
+
+    private func makeHarnessWithoutConnection() -> Harness {
+        let suite = "AppStateVoiceSuspensionTests.SignedOut.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Failed to create test UserDefaults suite")
+        }
+        addTeardownBlock { [defaults] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        defaults.set("default", forKey: "conduit.activeProfile")
+
+        let appState = AppState(defaults: defaults, loadSavedConnection: false)
+        appState.isConnected = false
+        appState.installVoiceCapabilityStateForTesting(
+            bridge: DashboardTicketBridge(baseURL: "https://example.com"),
+            snapshot: VoiceCapabilitySnapshot(
+                isGatewayConnected: true,
+                supportsTranscription: true,
+                supportsSpeech: true,
+                unavailableReason: nil
+            ),
+            isVoiceEnabled: true
+        )
+
+        let capture = MockCapture(permissionGranted: true)
+        let gateway = MockGateway(transcript: "Question")
+        let appStateRef = appState
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: GatedPlayback(),
+            gateway: gateway,
+            routePolicyProvider: { .fullDuplex },
+            submit: { _ in true },
+            interrupt: {},
+            onEndConversation: { [weak appStateRef] in
+                appStateRef?.closeVoiceConversation()
+            }
+        )
+        appState.voiceConversationController = controller
+
+        return Harness(
+            appState: appState,
+            controller: controller,
+            capture: capture,
+            playback: GatedPlayback(),
+            gateway: gateway,
+            flags: Flags()
+        )
+    }
+}
+
+/// Fail-fast requester so capability refreshes skip the network.
+@MainActor
+private final class ImmediateVoiceConfigRequester: VoiceConfigurationRequesting {
+    func requestJSON(path: String, method: String, body: [String: Any]?) async throws -> [String: Any] {
+        throw URLError(.notConnectedToInternet)
+    }
+}
+
+// MARK: - Mocks (file-local copies of the established voice doubles)
+
+@MainActor
+private final class MockCapture: AudioCaptureService {
+    let events: AsyncStream<VoiceCaptureEvent>
+    var captureGeneration: UInt64 = 0
+    private var continuation: AsyncStream<VoiceCaptureEvent>.Continuation?
+    private let permissionGranted: Bool
+    private(set) var startCount = 0
+    private(set) var stopCount = 0
+
+    init(permissionGranted: Bool) {
+        self.permissionGranted = permissionGranted
+        var captured: AsyncStream<VoiceCaptureEvent>.Continuation?
+        events = AsyncStream { captured = $0 }
+        continuation = captured
+    }
+    func requestPermission() async -> Bool { permissionGranted }
+    func startListening(includePreRoll: Bool) throws {
+        startCount += 1
+        captureGeneration &+= 1
+    }
+    func beginBargeInMonitoring() throws {}
+    func pause() { captureGeneration &+= 1 }
+    func resume() throws { captureGeneration &+= 1 }
+    func finishUtterance() throws -> VoiceCapturedAudio {
+        VoiceCapturedAudio(wavData: Data([1]), pcm16Data: Data([1, 0]), sampleRate: 16_000, duration: 0.01)
+    }
+    func stop() {
+        stopCount += 1
+        captureGeneration &+= 1
+    }
+    func emit(level: Float, at date: Date = Date()) {
+        continuation?.yield(.level(level, date: date, generation: captureGeneration))
+    }
+}
+
+@MainActor
+private final class GatedPlayback: SpeechPlaybackService {
+    var isPlaying = false
+    var ownershipIntent: VoiceAudioIntent = .standalonePlayback
+    var onStop: (() -> Void)?
+    func start(sampleRate: Double) throws { isPlaying = true }
+    func enqueuePCM16(_ data: Data, sampleRate: Double) throws -> Int { data.count - (data.count % 2) }
+    func playEncodedAudioData(_ data: Data) throws { isPlaying = true }
+    func finish() throws {}
+    func drain() async { isPlaying = false }
+    func stop() {
+        isPlaying = false
+        onStop?()
+    }
+}
+
+@MainActor
+private final class MockGateway: VoiceGatewayService {
+    let profile = "default"
+    let transcript: String
+    var onStreamOpen: (() -> Void)?
+    private(set) var transcriptionCount = 0
+    init(transcript: String) { self.transcript = transcript }
+    func transcribe(_ audio: VoiceCapturedAudio) async throws -> String {
+        transcriptionCount += 1
+        return transcript
+    }
+    func openSpeechStream(
+        onStart: @escaping @MainActor (Double) throws -> Void,
+        onPCM16: @escaping @MainActor (Data, Double) throws -> Void,
+        onEncodedAudio: @escaping @MainActor (Data) throws -> Void
+    ) async throws -> VoiceSpeechStream {
+        // Mirror the production streaming provider: opening a stream for a
+        // drain that has deltas delivers the start control immediately.
+        try onStart(24_000)
+        onStreamOpen?()
+        return StubSpeechStream()
+    }
+}
+
+/// Transcription that parks until released, so a test can suspend Voice
+/// while a transcription is provably in flight.
+@MainActor
+private final class GatedTranscriptionGateway: VoiceGatewayService {
+    let profile = "default"
+    let transcript: String
+    private(set) var transcriptionCount = 0
+    private var pendingContinuation: CheckedContinuation<String, Error>?
+    private var transcribingWaiters: [CheckedContinuation<Void, Never>] = []
+    private var isReleased = false
+
+    init(transcript: String) { self.transcript = transcript }
+
+    func transcribe(_ audio: VoiceCapturedAudio) async throws -> String {
+        transcriptionCount += 1
+        let waiters = transcribingWaiters
+        transcribingWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+        if isReleased { return transcript }
+        return try await withTaskCancellationHandler(operation: {
+            try await withCheckedThrowingContinuation { continuation in
+                self.pendingContinuation = continuation
+                if self.isReleased || Task.isCancelled {
+                    self.pendingContinuation = nil
+                    continuation.resume(with: .success(self.transcript))
+                }
+            }
+        }, onCancel: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self, let continuation = self.pendingContinuation else { return }
+                self.pendingContinuation = nil
+                continuation.resume(throwing: CancellationError())
+            }
+        })
+    }
+
+    func waitUntilTranscribing() async {
+        if transcriptionCount > 0 { return }
+        await withCheckedContinuation { transcribingWaiters.append($0) }
+    }
+
+    func releaseTranscription() {
+        isReleased = true
+        pendingContinuation?.resume(with: .success(transcript))
+        pendingContinuation = nil
+    }
+
+    func openSpeechStream(
+        onStart: @escaping @MainActor (Double) throws -> Void,
+        onPCM16: @escaping @MainActor (Data, Double) throws -> Void,
+        onEncodedAudio: @escaping @MainActor (Data) throws -> Void
+    ) async throws -> VoiceSpeechStream {
+        try onStart(24_000)
+        return StubSpeechStream()
+    }
+}
+
+@MainActor
+private final class StubSpeechStream: VoiceSpeechStream {
+    func append(_ text: String) async throws {}
+    func finish() async throws -> Bool { false }
+    func cancel() {}
+}
+
+/// Mutable route policy so tests can pin route classification
+/// deterministically; production reads the live AVAudioSession route.
+@MainActor
+private final class RoutePolicyBox {
+    var policy: VoiceBargeInRoutePolicy
+    init(_ policy: VoiceBargeInRoutePolicy) { self.policy = policy }
+}

--- a/ConduitTests/VoiceConversationControllerTests.swift
+++ b/ConduitTests/VoiceConversationControllerTests.swift
@@ -30,7 +30,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: MockGateway(),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
 
         await controller.startListening()
@@ -46,7 +46,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: MockGateway(),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
 
         await controller.resumeMicrophone()
@@ -62,7 +62,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: MockGateway(),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
 
         await controller.startListening()
@@ -77,7 +77,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: MockGateway(),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
 
         let result = await controller.runTranscriptionTest(duration: 0)
@@ -97,7 +97,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: gateway,
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
 
         let result = await controller.runTranscriptionTest(duration: 0)
@@ -113,7 +113,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: MockGateway(transcript: "Captured locally"),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
 
         let result = await controller.runTranscriptionTest(duration: 0)
@@ -129,7 +129,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             deviceTranscriber: MockDeviceTranscriber(transcript: "", permissionGranted: false),
             gateway: MockGateway(),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
 
         let result = await controller.requestOnDeviceTranscriptionPermissions()
@@ -146,7 +146,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             deviceTranscriber: deviceTranscriber,
             gateway: MockGateway(),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
 
         let result = await controller.requestOnDeviceTranscriptionPermissions()
@@ -164,7 +164,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             deviceTranscriber: deviceTranscriber,
             gateway: MockGateway(),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
 
         let result = await controller.requestOnDeviceTranscriptionPermissions()
@@ -197,7 +197,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: gateway,
             submit: { text in submitted.append(text); return true },
-            interrupt: {}
+            interrupt: { true }
         )
         controller.beginVoiceTurn(sessionID: "session")
         await controller.startListening()
@@ -224,7 +224,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             deviceTranscriber: deviceTranscriber,
             gateway: gateway,
             submit: { submitted.append($0); return true },
-            interrupt: {}
+            interrupt: { true }
         )
         var preferences = VoiceProfilePreferences()
         preferences.transcriptionMode = .appleOnDevice
@@ -249,7 +249,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: MockGateway(),
             submit: { _ in true },
-            interrupt: { interrupts += 1 }
+            interrupt: { interrupts += 1; return true }
         )
         await controller.startListening()
         let start = Date()
@@ -291,7 +291,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: gateway,
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         controller.beginVoiceTurn(sessionID: "session")
         await controller.startListening()
@@ -318,7 +318,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: gateway,
             submit: { submitted.append($0); return true },
-            interrupt: {}
+            interrupt: { true }
         )
         controller.beginVoiceTurn(sessionID: "voice-session")
         await controller.startListening()
@@ -341,7 +341,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: gateway,
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         controller.beginVoiceTurn(sessionID: "voice-session")
         await controller.startListening()
@@ -365,7 +365,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: gateway,
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         controller.beginVoiceTurn(sessionID: "session")
         await controller.startListening()
@@ -400,7 +400,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: gateway,
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         controller.beginVoiceTurn(sessionID: "voice-session")
         await controller.startListening()
@@ -434,7 +434,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: gateway,
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         controller.beginVoiceTurn(sessionID: "voice-session")
         await controller.startListening()
@@ -465,7 +465,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: gateway,
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         // No beginVoiceTurn: the extension is a no-op and a later turn
         // captures only its own id.
@@ -497,14 +497,14 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: gateway,
             submit: { submitted.append($0); return true },
-            interrupt: {}
+            interrupt: { true }
         )
         await controller.startListening()
         let start = Date()
         controller.ingestAudioLevel(0.1, at: start)
         controller.ingestAudioLevel(0, at: start.addingTimeInterval(1.3))
         try? await Task.sleep(nanoseconds: 20_000_000)
-        capture.emit(.interrupted)
+        capture.emit(.interrupted(generation: capture.captureGeneration))
         try? await Task.sleep(nanoseconds: 200_000_000)
 
         XCTAssertTrue(submitted.isEmpty)
@@ -518,7 +518,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: MockGateway(),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         await controller.startListening()
         controller.ingestAudioLevel(0, at: Date().addingTimeInterval(12.1))
@@ -535,7 +535,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: gateway,
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         controller.beginVoiceTurn(sessionID: "session")
         await controller.startListening()
@@ -560,7 +560,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: MockGateway(transcript: "Question"),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         controller.beginVoiceTurn(sessionID: "session")
         await controller.startListening()
@@ -583,7 +583,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: MockGateway(transcript: "Keep me"),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         controller.beginVoiceTurn(sessionID: "first")
         await controller.startListening()
@@ -611,7 +611,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         controller.beginVoiceTurn(sessionID: "session")
         await controller.startListening()
@@ -655,7 +655,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: gateway,
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         controller.beginVoiceTurn(sessionID: "session")
         await controller.startListening()
@@ -688,7 +688,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: MockGateway(transcript: "Next turn"),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         controller.beginVoiceTurn(sessionID: "session")
         await controller.startListening()
@@ -723,7 +723,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: MockGateway(),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
 
         await controller.startListening()
@@ -756,7 +756,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: playback,
             gateway: MockGateway(deliversPCM: true),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
 
         let result = await controller.runSpeechTest(text: "test")
@@ -774,7 +774,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: MockGateway(startsPlaybackOnOpen: true),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
 
         let result = await controller.runSpeechTest(text: "test")
@@ -789,7 +789,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: MockGateway(deliversPCM: true),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
 
         let result = await controller.runSpeechTest(text: "test")
@@ -807,7 +807,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: playback,
             gateway: MockGateway(deliversEncodedAudio: true),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
 
         let result = await controller.runSpeechTest(text: "test")
@@ -826,7 +826,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: playback,
             gateway: MockGateway(deliversPartialPCM: true),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
 
         let result = await controller.runSpeechTest(text: "test")
@@ -841,7 +841,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: playback,
             gateway: MockGateway(startsPlaybackOnOpen: true),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         controller.beginVoiceTurn(sessionID: "session")
         await controller.startListening()
@@ -868,7 +868,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: gateway,
             submit: { submitted.append($0); return true },
-            interrupt: {}
+            interrupt: { true }
         )
         controller.beginVoiceTurn(sessionID: "session")
         await controller.startListening()
@@ -902,7 +902,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: gateway,
             submit: { submitted.append($0); return true },
-            interrupt: {}
+            interrupt: { true }
         )
         await controller.startListening()
 
@@ -928,7 +928,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: gateway,
             submit: { submitted.append($0); return true },
-            interrupt: {}
+            interrupt: { true }
         )
         await controller.startListening()
 
@@ -957,7 +957,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: gateway,
             submit: { submitted.append($0); return true },
-            interrupt: {}
+            interrupt: { true }
         )
         await controller.startListening()
 
@@ -996,7 +996,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: MockGateway(),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         await controller.startListening()
 
@@ -1015,7 +1015,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: gateway,
             submit: { submitted.append($0); return true },
-            interrupt: {}
+            interrupt: { true }
         )
 
         // A long recording window gives the injected samples a wide
@@ -1047,7 +1047,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: gateway,
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         await controller.startListening()
         let generation = capture.captureGeneration
@@ -1104,7 +1104,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: gateway,
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
 
         let testTask = Task { await controller.runTranscriptionTest(duration: 0.5) }
@@ -1151,7 +1151,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: gateway,
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         await controller.startListening()
         let generationA = capture.captureGeneration
@@ -1195,7 +1195,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
 
         let testTask = Task { await controller.runSpeechTest(text: "hello") }
@@ -1225,7 +1225,7 @@ final class VoiceConversationControllerTests: XCTestCase {
             playback: MockPlayback(),
             gateway: MockGateway(),
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         await controller.startListening()
         capture.emit(level: 0.4)
@@ -1240,7 +1240,7 @@ final class VoiceConversationControllerTests: XCTestCase {
         await controller.startListening()
         capture.emit(level: 0.4)
         try? await Task.sleep(nanoseconds: 80_000_000)
-        capture.emit(.interrupted)
+        capture.emit(.interrupted(generation: capture.captureGeneration))
         try? await Task.sleep(nanoseconds: 80_000_000)
         XCTAssertEqual(controller.state, .failed("Audio was interrupted."))
         XCTAssertEqual(controller.microphoneLevel, 0, accuracy: 0.0001)
@@ -1273,7 +1273,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { submitted.append($0); return true },
-            interrupt: { interrupts += 1 }
+            interrupt: { interrupts += 1; return true }
         )
 
         await Self.driveToSpeaking(controller, gateway: gateway)
@@ -1309,7 +1309,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { _ in true },
-            interrupt: { interrupts += 1 }
+            interrupt: { interrupts += 1; return true }
         )
 
         await Self.driveToSpeaking(controller, gateway: gateway)
@@ -1336,7 +1336,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { _ in true },
-            interrupt: { interrupts += 1 }
+            interrupt: { interrupts += 1; return true }
         )
 
         await Self.driveToSpeaking(controller, gateway: gateway)
@@ -1372,7 +1372,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { _ in true },
-            interrupt: { interrupts += 1 }
+            interrupt: { interrupts += 1; return true }
         )
 
         await Self.driveToSpeaking(controller, gateway: gateway)
@@ -1402,7 +1402,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         controller.beginVoiceTurn(sessionID: "session")
         await controller.startListening()
@@ -1435,7 +1435,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { _ in true },
-            interrupt: { interrupts += 1 }
+            interrupt: { interrupts += 1; return true }
         )
 
         await Self.driveToSpeaking(controller, gateway: gateway)
@@ -1473,7 +1473,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { _ in true },
-            interrupt: { interrupts += 1 }
+            interrupt: { interrupts += 1; return true }
         )
         controller.beginVoiceTurn(sessionID: "session")
         await controller.startListening()
@@ -1513,7 +1513,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { _ in true },
-            interrupt: { interrupts += 1 }
+            interrupt: { interrupts += 1; return true }
         )
         controller.beginVoiceTurn(sessionID: "session")
         await controller.startListening()
@@ -1553,7 +1553,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { _ in true },
-            interrupt: { interrupts += 1 }
+            interrupt: { interrupts += 1; return true }
         )
 
         await Self.driveToSpeaking(controller, gateway: gateway)
@@ -1583,7 +1583,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { _ in true },
-            interrupt: { interrupts += 1 }
+            interrupt: { interrupts += 1; return true }
         )
 
         await Self.driveToSpeaking(controller, gateway: gateway)
@@ -1618,7 +1618,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { _ in true },
-            interrupt: { interrupts += 1 }
+            interrupt: { interrupts += 1; return true }
         )
 
         await Self.driveToSpeaking(controller, gateway: gateway)
@@ -1647,7 +1647,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { _ in true },
-            interrupt: { interrupts += 1 }
+            interrupt: { interrupts += 1; return true }
         )
 
         await Self.driveToSpeaking(controller, gateway: gateway)
@@ -1674,7 +1674,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { _ in true },
-            interrupt: { interrupts += 1 }
+            interrupt: { interrupts += 1; return true }
         )
 
         await Self.driveToSpeaking(controller, gateway: gateway)
@@ -1713,7 +1713,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { _ in true },
-            interrupt: { await gate.waitInInterrupt() }
+            interrupt: { await gate.waitInInterrupt(); return true }
         )
 
         await Self.driveToSpeaking(controller, gateway: gateway)
@@ -1756,7 +1756,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { _ in true },
-            interrupt: { await gate.waitInInterrupt() }
+            interrupt: { await gate.waitInInterrupt(); return true }
         )
 
         await Self.driveToSpeaking(controller, gateway: gateway)
@@ -1791,7 +1791,7 @@ final class VoiceSpeakerSafeBargeInTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { _ in true },
-            interrupt: { await gate.waitInInterrupt() }
+            interrupt: { await gate.waitInInterrupt(); return true }
         )
 
         await Self.driveToSpeaking(controller, gateway: gateway)
@@ -1885,7 +1885,7 @@ final class ContinuousConversationPreferenceTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         controller.setProfilePreferences(Self.preferences(continuous: false))
 
@@ -1909,7 +1909,7 @@ final class ContinuousConversationPreferenceTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         controller.setProfilePreferences(Self.preferences(continuous: false))
 
@@ -1969,7 +1969,7 @@ final class ContinuousConversationPreferenceTests: XCTestCase {
             playback: MockPlayback(),
             gateway: gateway,
             submit: { _ in true },
-            interrupt: { interrupts += 1 }
+            interrupt: { interrupts += 1; return true }
         )
         controller.setProfilePreferences(Self.preferences(continuous: false))
         controller.beginVoiceTurn(sessionID: "session")
@@ -1997,7 +1997,7 @@ final class ContinuousConversationPreferenceTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { _ in true },
-            interrupt: { interrupts += 1 }
+            interrupt: { interrupts += 1; return true }
         )
         controller.setProfilePreferences(Self.preferences(continuous: false))
 
@@ -2023,7 +2023,7 @@ final class ContinuousConversationPreferenceTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { _ in true },
-            interrupt: { interrupts += 1 }
+            interrupt: { interrupts += 1; return true }
         )
         controller.setProfilePreferences(Self.preferences(continuous: false))
 
@@ -2051,7 +2051,7 @@ final class ContinuousConversationPreferenceTests: XCTestCase {
             gateway: gateway,
             routePolicyProvider: { policy.policy },
             submit: { _ in true },
-            interrupt: { interrupts += 1 }
+            interrupt: { interrupts += 1; return true }
         )
         controller.setProfilePreferences(Self.preferences(continuous: false))
 
@@ -2134,7 +2134,7 @@ final class ContinuousConversationPreferenceTests: XCTestCase {
             playback: playback,
             gateway: gateway,
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         controller.setProfilePreferences(Self.preferences(continuous: false))
 
@@ -2162,7 +2162,7 @@ final class ContinuousConversationPreferenceTests: XCTestCase {
             playback: MockPlayback(),
             gateway: gateway,
             submit: { _ in true },
-            interrupt: {}
+            interrupt: { true }
         )
         controller.setProfilePreferences(Self.preferences(continuous: continuous))
         return controller

--- a/ConduitTests/VoiceSpokenControlTests.swift
+++ b/ConduitTests/VoiceSpokenControlTests.swift
@@ -347,13 +347,14 @@ final class VoiceConversationSpokenEndCommandTests: XCTestCase {
             flags.submitTexts.append(text)
             return true
         }
-        let interruptAction: @MainActor () async -> Void = {
+        let interruptAction: @MainActor () async -> Bool = {
             // The End Conversation teardown cancels the utterance task that
             // called it; the Hermes interrupt must still run in an
             // uncancelled task (HermesClient.rpc throws CancellationError
             // for cancelled work, which would leave the turn alive).
             XCTAssertFalse(Task.isCancelled)
             flags.interrupts += 1
+            return true
         }
         let endAction: (@MainActor () -> Void)?
         if wiresCloseSeam {


### PR DESCRIPTION
## Summary

Changes Voice background behavior from **hard teardown** to **logical suspension + safe restoration**. Previously, backgrounding Conduit fully closed an open Voice conversation; now it releases all local runtime ownership while preserving the logical conversation, and a conservative identity-validated restoration reopens it on foreground return — never with a live microphone.

## Previous behavior (verified call path at base `113c2ae`)

- **ScenePhase delivery:** `RootView` → `AppState.handleScenePhase(_:)`.
- **`.background`:** turn-staleness/freshness bookkeeping → `voiceConversationController.setForegroundActive(false)` → `VoiceConversationController.stop()` (operation-generation bump, all tasks cancelled, capture/transcriber/playback stopped, speech drain torn down, explicit user-pause flag cleared, `isVoiceSessionActive = false`, `expectedAssistantSessionIDs = []`, state `.idle`) → `messageReadAloudController.setForegroundActive(false)` → **`showVoiceSheet = false`** (sheet dismissed exactly like a user Close) → reconnect timer cancelled, caches flushed, reconciliation invalidated.
- **`.inactive`** (overlay dips, pre-lock): the same full `stop()` — the sheet stayed but the session was dead (this also silently broke post-dip assistant-event ownership until the next fresh open).
- **`.active`:** `setForegroundActive(true)` (flag only, nothing restarted); the scene task re-establishes the transport via `reconnectForRetry(.automaticReturn)`. The user had to reopen Voice from scratch through `openVoiceConversation(_:)`.
- **Other teardown boundaries:** explicit Close / swipe / spoken End Conversation → `closeVoiceConversation()`; server replacement → `retireSpeechOperationsForServerReplacement` (stop + gateways nil + sheet dismissal); `disconnect()`; `setVoiceEnabled(false)`; `switchProfile` (programmatic only).

## New behavior

**Backgrounding is not the same thing as the user ending Voice.**

- **Suspension** (`handleScenePhase` `.background` with the Voice sheet open): `VoiceConversationController.suspendRuntimeForLifecycle()` — a shared `releaseRuntimeResources()` primitive (extracted from `stop()`; no second teardown) releases capture, transcription, playback, speech drain/stream, barge-in monitoring, and every in-flight task behind the existing operation-generation bump. Suspended runtime state explicitly rejects capture events (`isRuntimeSuspended`) — `hasLiveVoiceSession` remains logical ownership, never a claim that capture is live. The logical conversation is preserved: in-sheet transcript, session ownership (`expectedAssistantSessionIDs`), `hasLiveVoiceSession`, and an explicit user pause. A Hermes turn in flight is **not cancelled**; its voice-side continuation is retired (same convention as barge-in/manual Interrupt) and remembered as a sticky orphan — the next user submission cancels it through the same interrupt seam as Stop, and the orphan flag survives superseded cancel awaits and consecutive suspensions, so its late events can never alias onto the new turn. `.background` additionally records an AppState-owned `SuspendedVoiceConversation` descriptor (profile, session ID, normalized server identity — logical fields only, no resources/leases/tasks, in memory only) and the sheet presentation **survives** (suspension is not Close).
- **Transient `.inactive` dips are not suspension.** Control Center, incoming-call banners, and the microphone permission prompt dip the scene without backgrounding it. Voice is left completely untouched across a dip: the socket and audio session survive, in-flight turns keep flowing, and a pending first-listen (fresh open → permission dialog) is not silently lost. Suspension happens only on the actual `.background` transition.
- **Restoration runs only AFTER foreground reconciliation, with a fresh capability check.** `handleScenePhase(.active)` no longer restores synchronously — the socket, bridge, and runtime session identity may all be stale. The suspended descriptor is consumed inside the existing scene-phase reconciliation task, after the authoritative transport/session state is established: retained healthy transport → health check + session sync → restore; dead socket → reconnect → restore; reconnect/session/auth failure → **never restored** against stale pre-background state (the `canStartVoiceConversation` predicate requires the post-reconciliation connection).  No parallel reconnect mechanism exists for Voice. When a suspended descriptor is pending, the authoritative `refreshVoiceCapabilities()` runs after reconciliation (and attempt currency is re-checked after that await) so restoration validates against a freshly negotiated capability answer; the live in-session Mute is preserved across that refresh per the PR #159 authority rule (the Mute control only changes controller state, so the reloaded persisted blob must not clobber it), and a superseded or boundary-cleared attempt never reapplies it — a gateway that no longer reports TTS/transcription support fails closed exactly like a fresh open would. Foregrounds without a pending suspension never pay a redundant capability refresh.
- **Restoration validation uses the same capability gate as a fresh open.** `restoreSuspendedVoiceConversationIfNeeded()` requires `canStartVoiceConversation` — live connection, voice enabled, usable transcription AND usable speech, exactly what `openVoiceConversation` requires — plus the suspended conversation's identity: same active profile, and the active runtime session is still the suspended conversation either unchanged or as a legitimate rebind of the same durable conversation (resolved through the existing session catalog/alias machinery — `knownSessionIDs`/`alternateIds`; never Voice-only aliasing). Anything stale fails CLOSED. Cross-profile staleness tears down directly WITHOUT persisting the suspended profile's live mute into the now-active profile's preferences (the same protection `switchProfile` and the fallback-profile adoption apply by persisting the outgoing mute under the outgoing profile before the identity flip). A valid descriptor reinstalls the gateway from the current bridge (fail-closed too if one cannot be built) and settles **open but non-listening**; the user's Listen tap resumes capture. Restoration never starts the microphone: the sheet's fresh-open auto-listen is a one-shot AppState-owned intent (`voiceSheetShouldAutoListen`), armed only by `openVoiceConversation`, disarmed by suspension and every destructive boundary, and consumed exactly once — so even a SwiftUI view-identity recreation of a restored sheet cannot hot-start the mic.
- **Destructive boundaries clear the suspended state:** explicit Close (button, swipe, spoken Goodbye — user intent beats suspension), profile switch, authoritative fallback-profile adoption, server replacement, disconnect, forced sign-out (`performSignInRequired`), and voice disabled.

## Stale-async fencing

Reuses the existing `operationGeneration`, `speechDrainRevision`, and capture-generation fences exclusively — no new token system. The Voice interrupt seam is result-bearing (`interruptForVoice` → `cancelCurrent` → the Hermes cancellation path reports real success/failure): the suspended-orphan cancellation clears the orphan only on a successful, still-current cancellation — a failed cancel retains the orphan, fails the submission with an explanatory message, and a later successful retry submits normally. Barge-in, spoken Stop, and spoken End Conversation intentionally proceed on the attempt regardless of the result. After suspension: late ASR completions cannot submit; late TTS/drain completions cannot play or relisten; late assistant events cannot reopen audio; suspended runtime explicitly rejects capture events (`isRuntimeSuspended`, including stale `.interrupted` events from the released runtime); interruption events are generation-bearing end to end — `AVAudioCaptureService` captures the observed capture generation synchronously on the notifying thread and fences BEFORE tearing anything down, so a delayed interruption belonging to a torn-down generation can never stop the live one, release its lease, or fail the session, and the controller additionally rejects interrupted events for foreign generations; a superseded foreground-reconciliation attempt never consumes the descriptor (only a still-current attempt restores), so a newer `.background` re-arming the descriptor is honored by the successor; and an old restoration cannot override a newer Close/Siri/profile/server boundary. The orphan record survives superseded cancel awaits and consecutive suspensions.

## Interaction contracts pinned by tests

- **Continuous Conversation** governs turn-to-turn continuation only — background/foreground restores non-listening with it ON or OFF.
- **Explicit Close / spoken Goodbye** prevents restoration; background/foreground afterwards does not resurrect Voice.
- **User Pause** survives suspension and is restored paused/open; Listen then genuinely recaptures.
- **Stop phrases** are unchanged (cancel turn, stop TTS, keep open, relisten) and are not reinterpreted as suspension.
- **Route safety** unchanged: speaker-safe stays half-duplex in post-restore turns; `VoiceAudioSessionCoordinator`, route classification, VAD, pre-roll, Read Aloud mutual exclusion untouched.
- **Siri** (PR #158 lifecycle untouched): an explicit Siri/composer launch supersedes stale suspension state — `openVoiceConversation`'s first act on a presented sheet is `closeVoiceConversation()`, which clears the descriptor; Case C (closed → Siri) has no stale state by construction.
- The existing 12-second silence mic pause, idle behavior, and all PR #159/#160 semantics are unchanged.

## Explicit non-goals

No continuous background Voice, no WebSocket keepalive, no background microphone, no new background modes or entitlements, no VoIP/PushKit/CallKit/BackgroundTasks. iOS remains free to suspend the process and drop networking; the transport is re-established by the existing scene-phase reconnect, and restoration tolerates socket-dead, reconnected, rebound-runtime, and sign-out states (fail-closed). **Process death intentionally loses the transient suspension state** (the descriptor is in-memory only) — the durable Hermes conversation remains recoverable through normal app/session behavior. Idle Voice auto-close and VAD/route/provider changes are untouched.

## Tests

TDD — the suite was committed first (red build on the missing API), then implemented. `ConduitTests/VoiceBackgroundSuspensionTests.swift`: 47 deterministic tests across controller-level suspension semantics (identity preservation, pause survival, orphan retirement/cancel, consecutive-suspension orphan retention, late-transcription fencing, post-restore route safety) and AppState-level lifecycle (descriptor record/consume, dip vs background routing, capability-loss fail-closed, explicit Close/Goodbye precedence, profile/server-identity/disconnect/voice-disabled invalidation, signed-out fail-closed `.active` wiring, full post-restore conversation, auto-listen consume-once, mute preservation).

Also run on the Mac build box: `VoiceConversationControllerTests`, `ContinuousConversationPreferenceTests`, `AppStateContinuousConversationPreferenceTests`, the PR #160 spoken-control suites, `PendingVoiceIntentLifecycleTests` (PR #158), `AppStateServerReplacementSpeechTests`, `VoiceAudioSessionCoordinatorTests`, `VoiceSpeakerSafeBargeInTests`, `HapticsVoiceIsolationTests`, `AppStateReadAloudTests`, and the full `ConduitTests` unit suite in planner lanes. Results recorded in the PR comments.

## Review

Three-model review ran twice on this branch. Round 1 (2× REQUEST-CHANGES → fixed, 1× APPROVE): view-identity hot-mic path (fixed via the AppState-owned auto-listen intent), profile-switch stranding, capability-loss fail-closed, same-session event aliasing (fixed via the orphan-cancel), test-double race, `.inactive` coverage. Round 2 (2× REQUEST-CHANGES → fixed, 1× APPROVE): orphan flag clobbered by consecutive suspensions (sticky-OR), profile-switch mute cross-contamination via the deferred `onDismiss` (fixed by persisting the outgoing mute before the identity flip plus a `hasLiveVoiceSession` authority guard on close-time persistence), forced-sign-out immediate teardown. Round 3 (three-model, on the focused correctness pass): restoration deferred to post-reconciliation with a currency guard (superseded attempts never consume the descriptor), fresh-open supersession of stale descriptors, `canStartVoiceConversation` capability parity (an earlier draft had declined a `supportsSpeech` restore gate on the incorrect claim that fresh opens do not require speech — corrected: `voiceUnavailableReason` requires both transcription and speech), `.inactive` reverted to a no-op for Voice, cross-profile fail-closed mute protection plus `adoptAuthoritativeFallbackProfile` teardown, sticky-orphan survival across superseded cancel awaits, and the explicit `isRuntimeSuspended` capture gate (with the un-pause path clearing it).

## Physical-device acceptance: **outstanding**

1. Start Voice on iPhone, speak normally. 2. Lock the device. 3. Unlock and return. 4. Voice returns open with the mic NOT hot. 5. Tap Listen and continue the same conversation. 6. Repeat after switching apps for several minutes. 7. Repeat with network loss while backgrounded. 8. Repeat on AirPods/headset and on speaker. 9. Spoken Goodbye followed by background/foreground does not resurrect Voice. 10. Battery/privacy indicators disappear while suspended.
