### PR TITLE
feat(signing): enable CarPlay Voice Based Conversation entitlement

### DIFF
--- a/Conduit/Conduit.entitlements
+++ b/Conduit/Conduit.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>com.apple.developer.carplay-voice-based-conversation</key>
+    <true/>
     <key>aps-environment</key>
     <string>production</string>
 </dict>


### PR DESCRIPTION
## Summary

Declares the Apple-approved **CarPlay Voice Based Conversation** managed capability for Conduit and proves the full signing contract end-to-end on the Mac build machine.

> **This PR only establishes and verifies CarPlay Voice Based Conversation provisioning. CarPlay application/UI integration will be implemented separately.**

Deliberately boring by design: a later CarPlay implementation failure can now be clearly distinguished from a signing/provisioning failure. **Do not merge yet** (decision left to the maintainer; no release action is bundled).

## Approved entitlement

```text
com.apple.developer.carplay-voice-based-conversation
```

## What changed

One file, two lines — `Conduit/Conduit.entitlements`:

```diff
 <dict>
+    <key>com.apple.developer.carplay-voice-based-conversation</key>
+    <true/>
     <key>aps-environment</key>
     <string>production</string>
 </dict>
```

- **Target receiving it:** `Conduit` (app) only — `project.yml` already wires `CODE_SIGN_ENTITLEMENTS: Conduit/Conduit.entitlements` to the app target; test targets are unaffected. No `project.yml` change, no XcodeGen output change (`Conduit.xcodeproj` is generated and never committed).
- Nothing else: no CarPlay UI/scene/template/navigation code, no `CPTemplateApplicationScene`, no `CPVoiceControlTemplate`, no scene delegate, no background modes, no VoIP/PushKit/CallKit, no lifecycle changes from PR #161.

## Provisioning: what it took (the interesting part)

Apple's approval made the capability **available but not enabled**. Verified empirically before any change was requested of the account: a freshly minted App Store profile (via ASC API) did **not** contain the entitlement. Enabling it proved impossible to automate by design:

- The App Store Connect public API cannot express it — a `POST /v1/bundleIdCapabilities` attempt returned 409 with the server's own complete `capabilityType` enumeration, which contains **no CarPlay value**.
- Xcode CLI automatic signing (`xcodebuild archive -allowProvisioningUpdates`) is blocked on this team: development-profile generation requires at least one registered device, and the team has none (App Store distribution only).
- So the capability was enabled interactively in App Store Connect (Identifiers → `com.milim.relay` → CarPlay → Voice Based Conversation) by the account holder, and a gated re-run then confirmed `GATE_OK`: new profiles carry the entitlement.

Both pinned App Store profiles were then regenerated in place via the ASC API — same names, same team:

| Profile | Before | After |
|---|---|---|
| `Conduit App Store` (pinned by `project.yml`) | pre-CarPlay, cert exp 2027-08-07 | CarPlay ✓, cert `8ZTJ86ZV93`, exp 2027-05-21 |
| `Hermes Conduit App Store` (pinned by the TestFlight turnkey script) | pre-CarPlay, cert exp 2027-05-21 | CarPlay ✓, cert `8ZTJ86ZV93`, exp 2027-05-21 |

One deliberate correction surfaced by the archive step: the old `Conduit App Store` profile referenced a distribution certificate whose **private key is not on the build Mac** (`security find-identity -v -p codesigning` shows exactly one Apple Distribution identity, exp 2027-05-21). The regenerated profile therefore pins the cert that actually matches the signing identity — the same cert the turnkey pipeline has been shipping with. Stale/duplicate portal profiles were removed; exactly one copy of each name remains. Old `.mobileprovision` files were backed up on the Mac and **not** committed. No profiles, certificates, keys, archives, or DerivedData are committed by this PR.

Note: the portal-side CarPlay enable also authorized `com.apple.developer.carplay-communication` at the **profile level** (App ID state, not something this PR declares). The app's entitlements file requests only the voice-based-conversation key, so the effective signed entitlements contain only the voice key; the extra profile authorization is inert for this build but is flagged here for the maintainer's awareness.

## Archive (Release, existing manual signing setup)

```bash
xcodebuild archive \
  -project Conduit.xcodeproj -scheme Conduit \
  -archivePath /tmp/carplay-canonical.xcarchive \
  -destination "generic/platform=iOS" \
  CODE_SIGN_IDENTITY="Apple Distribution" \
  PROVISIONING_PROFILE_SPECIFIER="Conduit App Store"
# ** ARCHIVE SUCCEEDED **
```

## Verification A — signed application entitlements

```text
$ codesign -d --entitlements :- Conduit.app
...<key>com.apple.developer.carplay-voice-based-conversation</key><true/>
...<key>aps-environment</key><string>production</string>
...<key>get-task-allow</key><false/>
```

The effective signed entitlements contain `com.apple.developer.carplay-voice-based-conversation = true` ✓

## Verification B — embedded provisioning profile

```text
$ security cms -D -i Conduit.app/embedded.mobileprovision
PROFILE_NAME=Conduit App Store
PROFILE_UUID=e55a6274-de93-4a88-a632-5dfc07963173
PROFILE_EXPIRES=2027-05-21T00:31:16Z
--- Entitlements ---
    <key>com.apple.developer.carplay-voice-based-conversation</key>
    <true/>
    <key>aps-environment</key>
    <string>production</string>
```

The profile authorizes `com.apple.developer.carplay-voice-based-conversation = true` ✓

**Three-way agreement:** project entitlements ∩ signed app entitlements ∩ profile authorization all contain the key with Boolean `true`.

## Tests

- Full unit suite on the Mac build machine with this branch: **2290/2290 passed, 0 failures** (Debug, unsigned simulator, iPhone 17 Pro). The local UI lane was not run on that machine due to its known accessibility-runner wedge; hosted CI runs the UI lanes.
- Hosted CI continues to do exactly what it did before: unsigned simulator builds/tests (`CODE_SIGNING_ALLOWED=NO`). No CI changes, nothing weakened; CI does not verify code signing by design.

## Out of scope (next PRs)

- Any CarPlay UI/scene/template/voice behavior.
- The optional CI-hygiene ideas from review (`plutil -lint` entitlements preflight, entitlements allowlist guard) — declined here to keep this PR provisioning-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for voice-based conversations through Apple CarPlay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->