### PR TITLE
feat(carplay): CarPlay Voice V1 over the shared Voice runtime

### DIFF
--- a/Conduit/CarPlay/AppStateRuntimeRegistry.swift
+++ b/Conduit/CarPlay/AppStateRuntimeRegistry.swift
@@ -1,0 +1,38 @@
+//
+//  AppStateRuntimeRegistry.swift
+//  Conduit
+//
+//  Process-wide home of the single AppState instance.
+//
+//  SwiftUI's `@StateObject` evaluates its factory lazily when the foreground
+//  scene first renders, but a CarPlay-first launch can connect the CarPlay
+//  scene before any phone scene exists. Both surfaces therefore resolve the
+//  AppState through this MainActor registry: whoever needs it first creates
+//  it, and the other surface adopts the exact same instance. The registry is
+//  a reference/lifecycle seam only — it owns no business logic.
+//
+
+@MainActor
+final class AppStateRuntimeRegistry {
+    static let shared = AppStateRuntimeRegistry()
+
+    private var stored: AppState?
+
+    /// The process-wide AppState, created on first access. AppState's own
+    /// initializer performs the authoritative cold-launch bootstrap (saved
+    /// connection restore), so a CarPlay-first launch establishes connection
+    /// readiness without waiting for any phone view to run.
+    var appState: AppState {
+        if let stored { return stored }
+        let created = AppState()
+        stored = created
+        return created
+    }
+
+    internal init() {}
+
+    /// Test isolation only.
+    internal func resetForTesting() {
+        stored = nil
+    }
+}

--- a/Conduit/CarPlay/CarPlayVoiceCoordinator.swift
+++ b/Conduit/CarPlay/CarPlayVoiceCoordinator.swift
@@ -1,0 +1,335 @@
+//
+//  CarPlayVoiceCoordinator.swift
+//  Conduit
+//
+//  MainActor bridge between the UIKit CarPlay scene (scene delegate +
+//  CPInterfaceController) and the process-wide AppState/Voice stack.
+//
+//  Responsibilities are deliberately narrow — a reference, presentation, and
+//  lifecycle seam, NOT a second Voice owner:
+//    • installs the root CPVoiceControlTemplate on connect;
+//    • observes the shared VoiceConversationController's published state and
+//      forwards DEDUPLICATED, mapped states to CarPlay (never mic-level or
+//      transcript content);
+//    • rotates a connection generation so a stale async readiness completion
+//      after disconnect/reconnect can never reopen Voice or touch a dead
+//      interface controller — and applies the no-surface release contract
+//      when a prepare was in flight across a disconnect;
+//    • reports CarPlay surface (de)activation to AppState, which owns the
+//      Voice lifecycle policy (PR #161 rules stay authoritative).
+//
+
+import Combine
+import CarPlay
+import Foundation
+import OSLog
+
+private let carPlayLogger = Logger(subsystem: "com.milim.relay", category: "CarPlayVoice")
+
+/// Seam over `CPInterfaceController` so coordinator behavior is testable
+/// without a vehicle session.
+@MainActor
+protocol CarPlayInterfacing: AnyObject {
+    func setRootTemplate(
+        _ rootTemplate: CPTemplate,
+        animated: Bool,
+        completion: ((Bool, (any Error)?) -> Void)?
+    )
+}
+
+extension CPInterfaceController: CarPlayInterfacing {}
+
+@MainActor
+final class CarPlayVoiceCoordinator {
+    static let shared = CarPlayVoiceCoordinator()
+
+    private(set) weak var interfacing: (any CarPlayInterfacing)?
+    private(set) var template: CPVoiceControlTemplate?
+    /// Monotonic fence: every connect and disconnect rotates the generation;
+    /// async completions captured under an older generation are discarded.
+    private(set) var connectionGeneration: UInt64 = 0
+    private(set) var lastActivatedState: CarPlayVoiceState?
+    /// True once the root template's `setRootTemplate` completion reported
+    /// success for the CURRENT generation. `activateVoiceControlState` is a
+    /// documented no-op before presentation, and calling it early would
+    /// poison duplicate suppression (the pre-presentation activation is
+    /// ignored, then the dedupe never forwards the real transition) — so no
+    /// state is forwarded until this flips.
+    private(set) var isTemplatePresented = false
+    /// Latest desired CarPlay state while the template is not yet presented.
+    /// Retained (not activated); consumed exactly once on presentation.
+    private(set) var pendingPresentationState: CarPlayVoiceState?
+    /// The AppState this coordinator bound to on connect. Disconnect and the
+    /// controls converge on THIS instance (never a fresh provider resolve),
+    /// so a swapped provider cannot split surface bookkeeping across two
+    /// AppStates. Test-only observability; intentionally retained.
+    private(set) var lastBoundAppState: AppState?
+
+    var isConnected: Bool { interfacing != nil }
+
+    /// Test seam; production resolves the process-wide registry.
+    var appStateProvider: @MainActor () -> AppState = { AppStateRuntimeRegistry.shared.appState }
+    /// Production connects always spawn the establish task; tests disable
+    /// this and call `establishVoice(generation:)` directly so async Voice
+    /// establishment is deterministic.
+    var autoEstablishOnConnect = true
+    /// Test seam over template state activation (rate-limited by the system
+    /// template and a no-op before the template is presented).
+    var stateActivator: @MainActor (CPVoiceControlTemplate, CarPlayVoiceState) -> Void = {
+        $0.activateVoiceControlState(withIdentifier: $1.identifier)
+    }
+
+    private var stateObservation: AnyCancellable?
+
+    internal init() {}
+
+    // MARK: - Scene lifecycle
+
+    /// `CPTemplateApplicationSceneDelegate` connect. Installs the root
+    /// template synchronously (before returning from the scene callback),
+    /// binds the shared AppState, and starts async Voice establishment under
+    /// the current generation.
+    func handleConnect(_ interfacing: any CarPlayInterfacing) {
+        connectionGeneration &+= 1
+        let generation = connectionGeneration
+        // Defensive: never two live sinks, even for an unpaired re-connect.
+        stateObservation?.cancel()
+        stateObservation = nil
+        self.interfacing = interfacing
+        lastActivatedState = nil
+        isTemplatePresented = false
+        pendingPresentationState = nil
+
+        // The template install satisfies the scene time budget first; it
+        // needs no AppState. Registry resolution (which may construct the
+        // AppState and run its cold-launch bootstrap) happens right after.
+        installRootTemplate()
+
+        let appState = appStateProvider()
+        lastBoundAppState = appState
+        appState.setCarPlayVoiceSurfaceActive(true)
+        // Re-assert the Voice gate: the phone may be locked/backgrounded with
+        // a gate left false by an earlier CarPlay-only disconnect, and the
+        // driver's next Listen must be able to re-arm capture.
+        appState.handleCarPlayVoiceSurfaceActivated()
+        beginObservingController(appState.voiceConversationController)
+
+        if autoEstablishOnConnect {
+            Task { @MainActor [weak self] in
+                await self?.establishVoice(generation: generation)
+            }
+        }
+    }
+
+    /// `CPTemplateApplicationSceneDelegate` disconnect. Rotates the fence so
+    /// in-flight establishment becomes stale, unbinds presentation, and hands
+    /// the lifecycle decision to the BOUND AppState: an active phone Voice
+    /// surface keeps the conversation; a CarPlay-only conversation releases
+    /// the runtime exactly like the PR #161 background boundary.
+    func handleDisconnect() {
+        connectionGeneration &+= 1
+        interfacing = nil
+        template = nil
+        stateObservation?.cancel()
+        stateObservation = nil
+        lastActivatedState = nil
+        isTemplatePresented = false
+        pendingPresentationState = nil
+
+        let appState = lastBoundAppState ?? appStateProvider()
+        appState.setCarPlayVoiceSurfaceActive(false)
+        appState.handleCarPlayVoiceSurfaceRemoved()
+    }
+
+    // MARK: - Template
+
+    private func installRootTemplate() {
+        guard let interfacing else { return }
+        let generation = connectionGeneration
+        let handlers = CarPlayVoiceActionHandlers(
+            startListening: { [weak self] in self?.startListeningTurn() },
+            endConversation: { [weak self] in self?.endConversation() }
+        )
+        let template = CarPlayVoiceTemplateFactory.makeTemplate(handlers: handlers)
+        self.template = template
+        interfacing.setRootTemplate(template, animated: false) { [weak self] success, error in
+            // MainActor Task hop (never a trapping assumeIsolated): the
+            // completion is expected on the main queue, but a wrong-queue
+            // delivery must degrade to a hop, not crash the process in a car.
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                // A completion from a superseded connection must never mark
+                // the new connection's template presented.
+                guard self.isCurrent(generation), self.interfacing === interfacing else {
+                    carPlayLogger.notice("stale root-template install completion ignored")
+                    return
+                }
+                guard success, error == nil else {
+                    carPlayLogger.error("root template install failed: \(String(describing: error), privacy: .public)")
+                    return
+                }
+                self.isTemplatePresented = true
+                // The template presents its FIRST state (ready) by default;
+                // activate a retained pending state exactly once when it
+                // differs, then resume normal dedupe against the presented
+                // state. If the factory ever changes its default first state,
+                // keep this coupling in sync.
+                let pending = self.pendingPresentationState ?? .ready
+                self.pendingPresentationState = nil
+                self.lastActivatedState = pending
+                if pending != .ready {
+                    self.stateActivator(template, pending)
+                }
+            }
+        }
+    }
+
+    private func beginObservingController(_ controller: VoiceConversationController) {
+        stateObservation?.cancel()
+        stateObservation = controller.$state
+            .sink { [weak self] state in
+                self?.handleControllerState(state)
+            }
+    }
+
+    /// The single forwarding path from controller state to CarPlay. Internal
+    /// so the duplicate-suppression policy is deterministically testable.
+    func handleControllerState(_ state: VoiceConversationState) {
+        guard isConnected else { return }
+        guard let template else { return }
+        let target = CarPlayVoiceState.map(state)
+        guard isTemplatePresented else {
+            // Pre-presentation: activateVoiceControlState has no effect, so
+            // only RETAIN the latest desired state. Recording it as
+            // activated would suppress the real post-presentation activation
+            // and freeze the surface on the template's default state.
+            pendingPresentationState = target
+            return
+        }
+        guard let activated = CarPlayVoiceStateActivation.activationTarget(
+            lastActivated: lastActivatedState,
+            newState: target
+        ) else { return }
+        lastActivatedState = activated
+        stateActivator(template, activated)
+    }
+
+    // MARK: - Controls
+
+    /// Listen button (Ready/Error states). Reuses the shared prepare/attach
+    /// path — never forces Continuous Conversation on and never creates a
+    /// parallel session decision.
+    func startListeningTurn() {
+        let generation = connectionGeneration
+        Task { @MainActor [weak self] in
+            await self?.performStartListeningTurn(generation: generation)
+        }
+    }
+
+    func performStartListeningTurn(generation: UInt64) async {
+        guard isCurrent(generation), isConnected else { return }
+        let appState = lastBoundAppState ?? appStateProvider()
+        let controller = appState.voiceConversationController
+        var outcome = AppState.VoiceConversationPrepareOutcome.handled
+        if controller.hasLiveVoiceSession {
+            // Attach (re-arm the gateway if the runtime was suspended); a
+            // failed attach settles the surface into the error state instead
+            // of a silent no-op listen.
+            guard appState.attachToLiveVoiceConversation() else {
+                handleControllerState(.failed(""))
+                return
+            }
+        } else {
+            outcome = await appState.prepareVoiceConversation(
+                profile: nil,
+                startsFreshConversation: false
+            )
+        }
+        await completeListenTurn(generation: generation, outcome: outcome)
+    }
+
+    /// End button. Converges on the authoritative Close teardown — no
+    /// parallel CarPlay teardown exists.
+    func endConversation() {
+        (lastBoundAppState ?? appStateProvider()).closeVoiceConversation()
+    }
+
+    // MARK: - Voice establishment
+
+    /// Connect-time Voice establishment. A live conversation is attached
+    /// display-only (no restart, no new session, no listen start — the phone
+    /// may be mid-turn); otherwise the shared prepare path runs and, on
+    /// success, listening starts: the CarPlay launcher tap is the listen
+    /// intent, and Continuous Conversation governs only turn-to-turn
+    /// continuation.
+    func establishVoice(generation: UInt64) async {
+        guard isCurrent(generation), isConnected else { return }
+        let appState = lastBoundAppState ?? appStateProvider()
+        let controller = appState.voiceConversationController
+        if controller.hasLiveVoiceSession {
+            guard appState.attachToLiveVoiceConversation() else {
+                handleControllerState(.failed(""))
+                return
+            }
+            return
+        }
+        let outcome = await appState.prepareVoiceConversation(
+            profile: nil,
+            startsFreshConversation: false
+        )
+        await completeVoiceEstablishment(generation: generation, outcome: outcome)
+    }
+
+    /// Post-prepare continuation of connect-time establishment, split out so
+    /// the stale-completion fence is deterministically testable without
+    /// racing a real in-flight prepare.
+    func completeVoiceEstablishment(
+        generation: UInt64,
+        outcome: AppState.VoiceConversationPrepareOutcome
+    ) async {
+        guard fence(generation) else { return }
+        let appState = lastBoundAppState ?? appStateProvider()
+        let controller = appState.voiceConversationController
+        guard outcome == .handled, controller.hasLiveVoiceSession else {
+            handleControllerState(.failed(""))
+            return
+        }
+        await controller.startListening()
+    }
+
+    /// Post-prepare continuation of the Listen button, split out for the same
+    /// deterministic fence coverage.
+    func completeListenTurn(
+        generation: UInt64,
+        outcome: AppState.VoiceConversationPrepareOutcome
+    ) async {
+        guard fence(generation) else { return }
+        let appState = lastBoundAppState ?? appStateProvider()
+        let controller = appState.voiceConversationController
+        guard outcome == .handled, controller.hasLiveVoiceSession else {
+            handleControllerState(.failed(""))
+            return
+        }
+        await controller.startListening()
+    }
+
+    /// The stale-completion fence. A prepare that was in flight across a
+    /// disconnect may have armed a live conversation (session acquisition +
+    /// gateway + beginVoiceTurn) AFTER the surface disappeared; apply the
+    /// no-surface release contract so a stale completion can never orphan a
+    /// live session with nothing presenting it.
+    private func fence(_ generation: UInt64) -> Bool {
+        guard isCurrent(generation), isConnected else {
+            let appState = lastBoundAppState ?? appStateProvider()
+            if !appState.hasActiveVoiceSurface {
+                appState.handleCarPlayVoiceSurfaceRemoved()
+            }
+            return false
+        }
+        return true
+    }
+
+    private func isCurrent(_ generation: UInt64) -> Bool {
+        connectionGeneration == generation
+    }
+}

--- a/Conduit/CarPlay/CarPlayVoiceSceneDelegate.swift
+++ b/Conduit/CarPlay/CarPlayVoiceSceneDelegate.swift
@@ -1,0 +1,34 @@
+//
+//  CarPlayVoiceSceneDelegate.swift
+//  Conduit
+//
+//  The scene delegate declared in Info.plist for
+//  `CPTemplateApplicationSceneSessionRoleApplication`. Thin by design: every
+//  decision lives in CarPlayVoiceCoordinator and AppState. The non-window
+//  `didConnect` variant is used — Conduit is a voice-conversation CarPlay
+//  app, not a navigation app.
+//
+
+import CarPlay
+import UIKit
+
+final class CarPlayVoiceSceneDelegate: NSObject, CPTemplateApplicationSceneDelegate {
+    func templateApplicationScene(
+        _ templateApplicationScene: CPTemplateApplicationScene,
+        didConnect interfaceController: CPInterfaceController
+    ) {
+        // UISceneDelegate callbacks run on the main thread.
+        MainActor.assumeIsolated {
+            CarPlayVoiceCoordinator.shared.handleConnect(interfaceController)
+        }
+    }
+
+    func templateApplicationScene(
+        _ templateApplicationScene: CPTemplateApplicationScene,
+        didDisconnect interfaceController: CPInterfaceController
+    ) {
+        MainActor.assumeIsolated {
+            CarPlayVoiceCoordinator.shared.handleDisconnect()
+        }
+    }
+}

--- a/Conduit/CarPlay/CarPlayVoiceStateMapping.swift
+++ b/Conduit/CarPlay/CarPlayVoiceStateMapping.swift
@@ -1,0 +1,63 @@
+//
+//  CarPlayVoiceStateMapping.swift
+//  Conduit
+//
+//  Pure mapping from the shared VoiceConversationController's published state
+//  to the at-most-five states the CarPlay CPVoiceControlTemplate displays.
+//  CarPlay is a state/control surface, never a mirrored chat window: no
+//  transcript text, reasoning, or failure detail ever crosses this boundary —
+//  the associated failure message of `.failed` is deliberately dropped here.
+//
+
+enum CarPlayVoiceState: String, CaseIterable, Equatable {
+    case ready
+    case listening
+    case processing
+    case responding
+    case error
+
+    /// Stable identifier used with
+    /// `CPVoiceControlTemplate.activateVoiceControlState(withIdentifier:)`.
+    var identifier: String { rawValue }
+
+    /// Driver-safe title variants. CarPlay picks the longest variant that
+    /// fits; keep them short and free of user content.
+    var titleVariants: [String] {
+        switch self {
+        case .ready: return ["Ready"]
+        case .listening: return ["Listening…"]
+        case .processing: return ["Thinking…"]
+        case .responding: return ["Responding…"]
+        case .error: return ["Voice unavailable"]
+        }
+    }
+
+    /// Approximate mapping from the authoritative controller state. Both
+    /// `.transcribing` and `.thinking` are "the assistant is working";
+    /// `.muted` is a playback presentation detail and maps to responding.
+    static func map(_ state: VoiceConversationState) -> CarPlayVoiceState {
+        switch state {
+        case .idle: return .ready
+        case .listening: return .listening
+        case .transcribing, .thinking: return .processing
+        case .speaking, .muted: return .responding
+        case .failed: return .error
+        }
+    }
+}
+
+/// Duplicate-suppression policy for CarPlay state activation. The template
+/// rate-limits activation internally and ignores rapid changes, so callers
+/// must never forward an unchanged state (`.muted` ↔ `.speaking` oscillation
+/// maps to the same CarPlay state and collapses here).
+enum CarPlayVoiceStateActivation {
+    /// The state to activate, or nil when the transition is a duplicate of
+    /// the last activated state and must not be forwarded.
+    static func activationTarget(
+        lastActivated: CarPlayVoiceState?,
+        newState: CarPlayVoiceState
+    ) -> CarPlayVoiceState? {
+        guard newState != lastActivated else { return nil }
+        return newState
+    }
+}

--- a/Conduit/CarPlay/CarPlayVoiceTemplateFactory.swift
+++ b/Conduit/CarPlay/CarPlayVoiceTemplateFactory.swift
@@ -1,0 +1,75 @@
+//
+//  CarPlayVoiceTemplateFactory.swift
+//  Conduit
+//
+//  Builds the single CPVoiceControlTemplate that presents the shared Voice
+//  conversation on CarPlay. Exactly five states (the template's documented
+//  maximum). Action buttons (iOS 26.4+) stay minimal: Listen at Ready/Error,
+//  End while the conversation is active. Handlers arrive from the coordinator
+//  and converge on the existing shared teardown/listen paths — CarPlay adds
+//  no parallel Voice business logic.
+//
+
+import CarPlay
+import UIKit
+
+/// Handlers the template's buttons invoke. MainActor-facing; the coordinator
+/// bridges them into the shared AppState/controller.
+@MainActor
+struct CarPlayVoiceActionHandlers {
+    /// Start (or restart) a listening turn through the shared controller.
+    var startListening: () -> Void
+    /// End the conversation through the authoritative Close teardown.
+    var endConversation: () -> Void
+}
+
+@MainActor
+enum CarPlayVoiceTemplateFactory {
+    static func makeVoiceControlState(
+        for state: CarPlayVoiceState,
+        handlers: CarPlayVoiceActionHandlers
+    ) -> CPVoiceControlState {
+        let voiceControlState = CPVoiceControlState(
+            identifier: state.identifier,
+            titleVariants: state.titleVariants,
+            image: nil,
+            repeats: false
+        )
+        if #available(iOS 26.4, *) {
+            voiceControlState.actionButtons = actionButtons(for: state, handlers: handlers)
+        }
+        return voiceControlState
+    }
+
+    static func makeTemplate(
+        handlers: CarPlayVoiceActionHandlers
+    ) -> CPVoiceControlTemplate {
+        let states = CarPlayVoiceState.allCases.map { makeVoiceControlState(for: $0, handlers: handlers) }
+        return CPVoiceControlTemplate(voiceControlStates: states)
+    }
+
+    private static func actionButtons(
+        for state: CarPlayVoiceState,
+        handlers: CarPlayVoiceActionHandlers
+    ) -> [CPButton] {
+        switch state {
+        case .ready, .error:
+            return [makeButton(title: "Listen", symbol: "mic.fill") { _ in handlers.startListening() }]
+        case .listening, .processing, .responding:
+            return [makeButton(title: "End", symbol: "xmark.circle") { _ in handlers.endConversation() }]
+        }
+    }
+
+    private static func makeButton(
+        title: String,
+        symbol: String,
+        handler: @escaping (CPButton) -> Void
+    ) -> CPButton {
+        let button = CPButton(
+            image: UIImage(systemName: symbol) ?? UIImage(),
+            handler: handler
+        )
+        button.title = title
+        return button
+    }
+}

--- a/Conduit/CarPlay/ConduitWindowClaimKeeper.swift
+++ b/Conduit/CarPlay/ConduitWindowClaimKeeper.swift
@@ -1,0 +1,41 @@
+//
+//  ConduitWindowClaimKeeper.swift
+//  Conduit
+//
+//  Multi-scene support is enabled so the CarPlay scene can coexist with the
+//  phone scene, but a SECOND foreground Conduit window (iPad Stage Manager /
+//  dock "+") is not a supported surface: SwiftUI's singleton `Window` scene
+//  is iOS-unavailable, so the process keeps a simple first-window claim.
+//  The first WindowGroup window to appear claims it; later windows dismiss
+//  themselves, and a closed primary window releases the claim so the next
+//  window can become primary.
+//
+
+@MainActor
+final class ConduitWindowClaimKeeper {
+    /// Process-scoped by design: claims live exactly as long as this process
+    /// launch, and a system kill of the primary window takes the process's
+    /// claim with it. Within one launch, the RootView primary releases on
+    /// close; if a primary ever leaks without onDisappear, new windows stay
+    /// dismissed until relaunch (accepted: the app remains usable via
+    /// CarPlay, and relaunch heals it).
+    private static var isClaimed = false
+
+    /// Returns true when the caller becomes the primary window; false when a
+    /// primary window already exists and the caller should dismiss itself.
+    static func claimPrimaryWindow() -> Bool {
+        if isClaimed { return false }
+        isClaimed = true
+        return true
+    }
+
+    /// The primary window closed: the next window to appear may claim.
+    static func releaseClaim() {
+        isClaimed = false
+    }
+
+    /// Test isolation only.
+    static func resetForTesting() {
+        isClaimed = false
+    }
+}

--- a/Conduit/ConduitApp.swift
+++ b/Conduit/ConduitApp.swift
@@ -59,12 +59,24 @@ final class ConduitAppDelegate: NSObject, UIApplicationDelegate, UNUserNotificat
 @main
 struct ConduitApp: App {
     @UIApplicationDelegateAdaptor(ConduitAppDelegate.self) private var appDelegate
-    @StateObject private var appState = AppState()
+    /// Resolved through the process-wide registry (NOT created directly) so a
+    /// CarPlay-first launch — where the CarPlay scene connects before any
+    /// phone scene renders — binds the exact same AppState instance this
+    /// SwiftUI surface adopts, whichever surface needs it first.
+    @StateObject private var appState = AppStateRuntimeRegistry.shared.appState
     @ObservedObject private var notifications = PushNotificationService.shared
     @ObservedObject private var pendingVoiceIntents = PendingVoiceIntentStore.shared
 
     var body: some Scene {
-        WindowGroup {
+        // Multi-scene support is enabled in the manifest so the CarPlay
+        // CPTemplateApplicationScene can coexist with the phone scene
+        // (Apple: the flag governs ALL scene creation). SwiftUI's singleton
+        // `Window` scene — the ideal foreground counterpart — is
+        // iOS-unavailable (macOS 13+/visionOS only), so the phone surface
+        // stays a `WindowGroup` and duplicate iPad windows are closed by the
+        // RootView first-window guard instead: never an iPad multi-window
+        // product.
+        WindowGroup(id: "conduit-primary") {
 #if DEBUG
             // The fixture is compiled out of release builds, so the launch
             // argument branch must be too.

--- a/Conduit/Info.plist
+++ b/Conduit/Info.plist
@@ -100,7 +100,21 @@
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
-		<false/>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>CPTemplateApplicationSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>CarPlayVoice</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).CarPlayVoiceSceneDelegate</string>
+					<key>UISceneClassName</key>
+					<string>CPTemplateApplicationScene</string>
+				</dict>
+			</array>
+		</dict>
 	</dict>
 </dict>
 </plist>

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -863,14 +863,26 @@ final class AppState: ObservableObject {
         isCarPlayVoiceSurfaceActive = active
     }
 
-    /// Whether at least one legitimate Voice presentation surface (the phone
-    /// scene, CarPlay) is active. This — not the raw phone scene phase — is
-    /// the Voice runtime's foreground gate: live Voice audio is allowed
-    /// exactly while this is true. It deliberately does NOT fake phone
-    /// `.active`: transport/chat reconciliation continues to read
-    /// `isSceneActive` for phone-specific behavior.
+    /// Whether at least one legitimate Voice presentation surface is
+    /// actually presenting Voice: the phone scene counts only while the
+    /// Voice sheet is up (a foreground phone with the sheet closed presents
+    /// nothing), while a connected CarPlay surface presents Voice by
+    /// itself. This — not the raw phone scene phase — is the Voice runtime's
+    /// foreground gate: live Voice audio is allowed exactly while this is
+    /// true. It deliberately does NOT fake phone `.active`:
+    /// transport/chat reconciliation continues to read `isSceneActive` for
+    /// phone-specific behavior.
     var hasActiveVoiceSurface: Bool {
-        isSceneActive || isCarPlayVoiceSurfaceActive
+        (isSceneActive && showVoiceSheet) || isCarPlayVoiceSurfaceActive
+    }
+
+    /// Re-asserts the Voice runtime gate from the current surface
+    /// bookkeeping. Presenting the phone Voice sheet must call this BEFORE
+    /// auto-listen: with CarPlay absent the gate is false while the sheet is
+    /// closed (`hasActiveVoiceSurface` requires the sheet), and
+    /// `startListening` is gated on it.
+    func reassertVoiceSurfaceGate() {
+        voiceConversationController.setForegroundActive(hasActiveVoiceSurface)
     }
 
     /// Manual per-message read aloud for completed assistant responses.
@@ -13452,16 +13464,22 @@ final class AppState: ObservableObject {
         showSidebar = false
         voiceSheetShouldAutoListen = true
         showVoiceSheet = true
+        // The sheet is now the presenting Voice surface: re-assert the gate
+        // before the sheet's auto-listen runs (with CarPlay absent the gate
+        // was false while the sheet was closed).
+        reassertVoiceSurfaceGate()
         return true
     }
 
     /// Outcome of the logical Voice conversation preparation. `.deferred`
     /// means "not connected yet": the phone router keeps the request pending,
-    /// and CarPlay settles into its error state. `.handled` means the request
-    /// was consumed — the conversation is prepared, or a user-visible failure
-    /// was raised. `.failed(String)` means the preparation was rejected
-    /// WITHOUT arming a conversation: the message must be surfaced and no
-    /// presentation attached.
+    /// and CarPlay settles into its error state. `.handled` means the logical
+    /// Voice preparation SUCCEEDED — an existing live conversation was
+    /// attached, or a new/continued conversation was armed. `.failed(String)`
+    /// means the preparation was REJECTED without arming a usable Voice
+    /// conversation (capability unavailable, no session, no gateway, session
+    /// creation failed, turn conflict): the message must be surfaced and NO
+    /// Voice presentation attached.
     enum VoiceConversationPrepareOutcome: Equatable {
         case deferred
         case handled
@@ -13487,7 +13505,7 @@ final class AppState: ObservableObject {
             }
             guard requestedProfile.isEmpty || requestedProfile == activeProfile else {
                 errorMessage = "Conduit could not open the requested voice profile."
-                return .handled
+                return .failed("Conduit could not open the requested voice profile.")
             }
         }
         guard isConnected else { return .deferred }
@@ -13507,26 +13525,26 @@ final class AppState: ObservableObject {
         if turnState.isRunning {
             guard startsFreshConversation else {
                 errorMessage = "Stop the current response before starting voice in this conversation."
-                return .handled
+                return .failed("Stop the current response before starting voice in this conversation.")
             }
             await cancelCurrent()
         }
         await refreshVoiceCapabilities()
         guard canStartVoiceConversation else {
             errorMessage = voiceUnavailableReason
-            return .handled
+            return .failed(voiceUnavailableReason ?? "Voice is unavailable.")
         }
         let previousSessionID = activeSessionId
         if startsFreshConversation || activeSessionId == nil {
             await createNewSession()
             if startsFreshConversation, activeSessionId == previousSessionID {
                 errorMessage = "Hermes could not create the requested voice conversation."
-                return .handled
+                return .failed("Hermes could not create the requested voice conversation.")
             }
         }
         guard let sessionID = activeSessionId, let gateway = makeVoiceGateway() else {
             errorMessage = "Hermes could not prepare a voice conversation."
-            return .handled
+            return .failed("Hermes could not prepare a voice conversation.")
         }
         // A fresh user-initiated open supersedes any stale suspension (e.g.
         // a descriptor retained across sign-out, or one whose reconciliation
@@ -13565,7 +13583,7 @@ final class AppState: ObservableObject {
     /// nothing else heals it), and the driver's next Listen must be able to
     /// re-arm capture. No-op while the phone scene is active.
     func handleCarPlayVoiceSurfaceActivated() {
-        voiceConversationController.setForegroundActive(hasActiveVoiceSurface)
+        reassertVoiceSurfaceGate()
     }
 
     /// Called by the CarPlay coordinator when the CarPlay Voice surface goes

--- a/Conduit/Services/AppState.swift
+++ b/Conduit/Services/AppState.swift
@@ -853,6 +853,26 @@ final class AppState: ObservableObject {
     /// deferred `onDismiss`) must not write the outgoing profile's mute into
     /// the now-active profile's blob.
     internal(set) var voiceControllerSessionProfile: String?
+
+    /// Whether the CarPlay scene currently presents the shared Voice
+    /// conversation. Pure surface bookkeeping: CarPlay is another Voice
+    /// presentation surface over the same runtime, never a second owner.
+    @Published private(set) var isCarPlayVoiceSurfaceActive = false
+
+    func setCarPlayVoiceSurfaceActive(_ active: Bool) {
+        isCarPlayVoiceSurfaceActive = active
+    }
+
+    /// Whether at least one legitimate Voice presentation surface (the phone
+    /// scene, CarPlay) is active. This — not the raw phone scene phase — is
+    /// the Voice runtime's foreground gate: live Voice audio is allowed
+    /// exactly while this is true. It deliberately does NOT fake phone
+    /// `.active`: transport/chat reconciliation continues to read
+    /// `isSceneActive` for phone-specific behavior.
+    var hasActiveVoiceSurface: Bool {
+        isSceneActive || isCarPlayVoiceSurfaceActive
+    }
+
     /// Manual per-message read aloud for completed assistant responses.
     /// TTS-only: independent of the voice conversation and of STT.
     lazy var messageReadAloudController = MessageReadAloudController(
@@ -5258,7 +5278,11 @@ final class AppState: ObservableObject {
         switch phase {
         case .active:
             isSceneActive = true
-            voiceConversationController.setForegroundActive(true)
+            // Voice gate = "a legitimate Voice presentation surface exists".
+            // With the phone scene active this is trivially true; the same
+            // gate also stays true while the phone is backgrounded but the
+            // CarPlay surface is presenting the shared conversation.
+            voiceConversationController.setForegroundActive(hasActiveVoiceSurface)
             messageReadAloudController.setForegroundActive(true)
             // Voice restoration deliberately does NOT run here: the socket,
             // bridge, and runtime session identity may all be stale after a
@@ -5408,8 +5432,17 @@ final class AppState: ObservableObject {
             // Suspension is not Close: an open Voice conversation releases its
             // runtime ownership and is recorded for foreground restoration,
             // and the sheet presentation intentionally survives the
-            // background transition.
-            suspendVoiceConversationForBackground()
+            // background transition. The exception is another active Voice
+            // presentation surface: with CarPlay presenting the shared
+            // conversation, the phone backgrounding is NOT a Voice lifecycle
+            // boundary — Voice must stay live for the driver — so the
+            // suspension (and its restoration descriptor) is skipped
+            // entirely. Read-aloud remains phone-bound and deactivates above.
+            if hasActiveVoiceSurface {
+                voiceConversationController.setForegroundActive(true)
+            } else {
+                suspendVoiceConversationForBackground()
+            }
             // Drop any armed reconnect timer as well: in-flight cycles abort
             // at their next transportContinuation checkpoint, and foreground
             // activation re-establishes the transport.
@@ -5471,6 +5504,12 @@ final class AppState: ObservableObject {
     /// suspended descriptor for foreground restoration. A closed Voice sheet
     /// keeps the existing full-stop semantics. Transient .inactive dips never
     /// reach this: they leave Voice untouched.
+    ///
+    /// Callers guarantee no other legitimate Voice presentation surface is
+    /// active (`hasActiveVoiceSurface == false`): a CarPlay-presented
+    /// conversation skips this path on phone backgrounding, and the CarPlay
+    /// disconnect handler routes through it when the phone scene is inactive
+    /// so both boundaries share exactly one release/restore contract.
     private func suspendVoiceConversationForBackground() {
         // Suspension disarms the fresh-open auto-listen intent: the restored
         // sheet must never hot-start the microphone, even if SwiftUI
@@ -13391,40 +13430,103 @@ final class AppState: ObservableObject {
         // sheet is open, so a read aloud started before must not continue.
         messageReadAloudController.stop()
         if showVoiceSheet { closeVoiceConversation() }
-        if let rawProfile = intent.profile {
+        let outcome = await prepareVoiceConversation(
+            profile: intent.profile,
+            startsFreshConversation: intent.startsFreshConversation
+        )
+        switch outcome {
+        case .deferred:
+            return false
+        case .failed(let message):
+            // A rejected attach never presents the Voice sheet: surface the
+            // failure through the app-level error path instead.
+            errorMessage = message
+            return true
+        case .handled:
+            break
+        }
+        // Phone presentation: the prepared conversation is shown in the
+        // Voice sheet. CarPlay attaches through prepareVoiceConversation /
+        // attachToLiveVoiceConversation instead and never mutates
+        // these presentation flags.
+        showSidebar = false
+        voiceSheetShouldAutoListen = true
+        showVoiceSheet = true
+        return true
+    }
+
+    /// Outcome of the logical Voice conversation preparation. `.deferred`
+    /// means "not connected yet": the phone router keeps the request pending,
+    /// and CarPlay settles into its error state. `.handled` means the request
+    /// was consumed — the conversation is prepared, or a user-visible failure
+    /// was raised. `.failed(String)` means the preparation was rejected
+    /// WITHOUT arming a conversation: the message must be surfaced and no
+    /// presentation attached.
+    enum VoiceConversationPrepareOutcome: Equatable {
+        case deferred
+        case handled
+        case failed(String)
+    }
+
+    /// Prepare/acquire the LOGICAL Voice conversation — capability refresh,
+    /// profile selection, session continuation/creation, Voice gateway
+    /// installation — with no phone presentation attached. Split out of
+    /// `openVoiceConversation` so the CarPlay surface can open Voice through
+    /// the exact same checks; the phone flow additionally presents the sheet.
+    ///
+    /// If a Voice conversation is already live, this re-arms it in place
+    /// (fresh gateway on the same session) without clearing the transcript.
+    func prepareVoiceConversation(
+        profile: String?,
+        startsFreshConversation: Bool
+    ) async -> VoiceConversationPrepareOutcome {
+        if let rawProfile = profile {
             let requestedProfile = rawProfile.trimmingCharacters(in: .whitespacesAndNewlines)
             if !requestedProfile.isEmpty, requestedProfile != activeProfile {
                 await switchProfile(to: requestedProfile)
             }
             guard requestedProfile.isEmpty || requestedProfile == activeProfile else {
                 errorMessage = "Conduit could not open the requested voice profile."
-                return true
+                return .handled
             }
         }
-        guard isConnected else { return false }
+        guard isConnected else { return .deferred }
+        if voiceConversationController.hasLiveVoiceSession, !startsFreshConversation {
+            // Another Voice presentation is attaching to the existing logical
+            // conversation (the sheet presentation is the caller's job): no
+            // beginVoiceTurn, no transcript reset, no session churn, no
+            // in-flight-turn cancellation. This intentionally precedes the
+            // generic turn-running rejection — a running turn owned by the
+            // shared Voice session is the attachment, not a conflict.
+            guard attachToLiveVoiceConversation() else {
+                return .failed(voiceUnavailableReason
+                    ?? "Hermes could not reattach the live voice conversation.")
+            }
+            return .handled
+        }
         if turnState.isRunning {
-            guard intent.startsFreshConversation else {
+            guard startsFreshConversation else {
                 errorMessage = "Stop the current response before starting voice in this conversation."
-                return true
+                return .handled
             }
             await cancelCurrent()
         }
         await refreshVoiceCapabilities()
         guard canStartVoiceConversation else {
             errorMessage = voiceUnavailableReason
-            return true
+            return .handled
         }
         let previousSessionID = activeSessionId
-        if intent.startsFreshConversation || activeSessionId == nil {
+        if startsFreshConversation || activeSessionId == nil {
             await createNewSession()
-            if intent.startsFreshConversation, activeSessionId == previousSessionID {
+            if startsFreshConversation, activeSessionId == previousSessionID {
                 errorMessage = "Hermes could not create the requested voice conversation."
-                return true
+                return .handled
             }
         }
         guard let sessionID = activeSessionId, let gateway = makeVoiceGateway() else {
             errorMessage = "Hermes could not prepare a voice conversation."
-            return true
+            return .handled
         }
         // A fresh user-initiated open supersedes any stale suspension (e.g.
         // a descriptor retained across sign-out, or one whose reconciliation
@@ -13434,10 +13536,48 @@ final class AppState: ObservableObject {
         voiceConversationController.setGateway(gateway)
         voiceConversationController.beginVoiceTurn(sessionID: sessionID)
         voiceControllerSessionProfile = activeProfile
-        showSidebar = false
-        voiceSheetShouldAutoListen = true
-        showVoiceSheet = true
+        return .handled
+    }
+
+    /// Attach the CALLING presentation (phone Voice sheet, CarPlay surface)
+    /// to an ALREADY-LIVE logical Voice conversation. Never restarts a turn,
+    /// never clears the transcript, never creates a session, never cancels an
+    /// in-flight turn: it re-asserts the presentation-surface gate (the phone
+    /// may be locked with a gate left false by an earlier CarPlay-only
+    /// disconnect) and re-arms the gateway reference when needed. The
+    /// restoration descriptor is retired only AFTER the attach is known to
+    /// succeed, so a failed re-arm leaves the phone-restoration path intact.
+    @discardableResult
+    func attachToLiveVoiceConversation() -> Bool {
+        guard voiceConversationController.hasLiveVoiceSession else { return false }
+        voiceConversationController.setForegroundActive(hasActiveVoiceSurface)
+        if !voiceConversationController.isGatewayAttached {
+            refreshVoiceControllerGateway()
+        }
+        guard voiceConversationController.isGatewayAttached else { return false }
+        suspendedVoiceConversation = nil
         return true
+    }
+
+    /// CarPlay surface presented. Re-asserts the Voice gate: the phone scene
+    /// may be inactive with a gate left false by an earlier CarPlay-only
+    /// disconnect (no scene-phase event fires while the phone is locked, so
+    /// nothing else heals it), and the driver's next Listen must be able to
+    /// re-arm capture. No-op while the phone scene is active.
+    func handleCarPlayVoiceSurfaceActivated() {
+        voiceConversationController.setForegroundActive(hasActiveVoiceSurface)
+    }
+
+    /// Called by the CarPlay coordinator when the CarPlay Voice surface goes
+    /// away. While the phone scene is active, the phone still presents Voice
+    /// and nothing is touched. With no active Voice surface left, this is
+    /// exactly the PR #161 background boundary: the sheet's presentation
+    /// intent (if any) survives through the suspended descriptor, and a
+    /// CarPlay-only conversation is released — never treated as spoken
+    /// Goodbye, which is Close.
+    func handleCarPlayVoiceSurfaceRemoved() {
+        guard !hasActiveVoiceSurface else { return }
+        suspendVoiceConversationForBackground()
     }
 
     func closeVoiceConversation() {

--- a/Conduit/Views/RootView.swift
+++ b/Conduit/Views/RootView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct RootView: View {
     @EnvironmentObject var appState: AppState
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.dismissWindow) private var dismissWindow
+    @State private var isPrimaryWindow = false
 
     var body: some View {
         ZStack {
@@ -31,7 +33,28 @@ struct RootView: View {
         }
         .animation(.easeInOut(duration: 0.2), value: appState.showLogin)
         .onChange(of: scenePhase) { _, newPhase in
-            appState.handleScenePhase(newPhase)
+            // Only the primary window drives the process-wide lifecycle: a
+            // transient duplicate window's .background must never suspend a
+            // conversation the primary window still presents.
+            if isPrimaryWindow {
+                appState.handleScenePhase(newPhase)
+            }
+        }
+        .onAppear {
+            guard !isPrimaryWindow else { return }
+            // Multi-scene support exists for the CarPlay scene; a SECOND
+            // foreground Conduit window is not a supported surface and
+            // closes itself (the primary window releases its claim on close).
+            if ConduitWindowClaimKeeper.claimPrimaryWindow() {
+                isPrimaryWindow = true
+            } else {
+                dismissWindow(id: "conduit-primary")
+            }
+        }
+        .onDisappear {
+            if isPrimaryWindow {
+                ConduitWindowClaimKeeper.releaseClaim()
+            }
         }
     }
 }

--- a/Conduit/Views/RootView.swift
+++ b/Conduit/Views/RootView.swift
@@ -48,7 +48,10 @@ struct RootView: View {
             if ConduitWindowClaimKeeper.claimPrimaryWindow() {
                 isPrimaryWindow = true
             } else {
-                dismissWindow(id: "conduit-primary")
+                // Environment-scoped dismissal: close THIS duplicate window
+                // only. ID-scoped dismissal targets the WindowGroup and
+                // would take the primary window down with it.
+                dismissWindow()
             }
         }
         .onDisappear {

--- a/Conduit/Voice/VoiceConversationController.swift
+++ b/Conduit/Voice/VoiceConversationController.swift
@@ -230,10 +230,13 @@ final class VoiceConversationController: ObservableObject {
     /// the outgoing server's bridge) is behavioral and hard to observe.
     var isGatewayAttached: Bool { gateway != nil }
 
-    /// Foreground liveness flag only. Deactivation-side teardown is owned by
-    /// the caller: AppState routes an open Voice conversation through
-    /// `suspendRuntimeForLifecycle()` (logical preservation) and a closed one
-    /// through `stop()` (full teardown).
+    /// Voice presentation-surface gate (AppState feeds it): true while at
+    /// least one legitimate Voice presentation surface is active — the phone
+    /// foreground scene, or CarPlay presenting the shared conversation.
+    /// Listening and microphone work only under this gate. Deactivation-side
+    /// teardown is owned by the caller: AppState routes an open Voice
+    /// conversation through `suspendRuntimeForLifecycle()` (logical
+    /// preservation) and a closed one through `stop()` (full teardown).
     func setForegroundActive(_ active: Bool) {
         isForegroundActive = active
     }

--- a/ConduitTests/CarPlayVoiceTests.swift
+++ b/ConduitTests/CarPlayVoiceTests.swift
@@ -760,48 +760,51 @@ final class CarPlayVoiceLifecycleRegressionTests: XCTestCase {
         XCTAssertEqual(harness.activations.last, .listening)
     }
 
-    func testStalePrepareCompletionWithActivePhoneSurfaceKeepsTheConversation() async {
-        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
-        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
-            defaults.removePersistentDomain(forName: suite)
-        }
-        harness.appState.activeSessionId = "session-1"
-        harness.controller.beginVoiceTurn(sessionID: "session-1")
-        await harness.controller.startListening()
-
-        // A prepare captured under a DIFFERENT generation completes while the
-        // phone surface is active: the conversation is not torn down — the
-        // phone still legitimately presents it.
-        await harness.coordinator.completeVoiceEstablishment(
-            generation: harness.coordinator.connectionGeneration &+ 1,
-            outcome: .handled
-        )
-
-        XCTAssertTrue(harness.controller.hasLiveVoiceSession, "the phone surface keeps the conversation")
-        XCTAssertEqual(harness.controller.state, .listening)
-        XCTAssertNil(harness.appState.suspendedVoiceConversation)
-    }
-
-    func testStalePrepareCompletionWithNoActiveSurfaceDoesNotOrphanAnArmedSession() async {
+    func testStalePrepareCompletionWithPhoneSheetPresentingKeepsTheConversation() async {
         let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
         addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
             defaults.removePersistentDomain(forName: suite)
         }
         harness.openVoice(session: "session-1")
         await harness.controller.startListening()
-        harness.appState.handleScenePhase(.background)
-        XCTAssertTrue(harness.controller.isRuntimeSuspended)
 
-        // A prepare completing after the surface disappeared must apply the
-        // no-surface release contract instead of leaving the session armed.
+        // A prepare captured under a DIFFERENT generation completes while the
+        // phone sheet still presents Voice: the conversation is not torn
+        // down — the phone legitimately presents it.
         await harness.coordinator.completeVoiceEstablishment(
             generation: harness.coordinator.connectionGeneration &+ 1,
             outcome: .handled
         )
 
-        XCTAssertTrue(harness.controller.isRuntimeSuspended, "the session stays released, not resurrected-armed")
-        XCTAssertEqual(harness.appState.suspendedVoiceConversation?.sessionID, "session-1", "still restorable")
-        XCTAssertEqual(harness.capture.startCount, 1, "no capture was (re)started by the stale completion")
+        XCTAssertTrue(harness.controller.hasLiveVoiceSession, "the presenting sheet keeps the conversation")
+        XCTAssertEqual(harness.controller.state, .listening)
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+        XCTAssertEqual(harness.capture.startCount, 1, "and capture keeps running")
+    }
+
+    func testStalePrepareCompletionWithNoPresentingSurfaceReleasesTheConversation() async {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        // The Voice sheet is closed and no CarPlay surface exists: a stale
+        // armed session presents nothing, so the fence releases it.
+        harness.appState.activeSessionId = "session-1"
+        harness.controller.beginVoiceTurn(sessionID: "session-1")
+        await harness.controller.startListening()
+
+        await harness.coordinator.completeVoiceEstablishment(
+            generation: harness.coordinator.connectionGeneration &+ 1,
+            outcome: .handled
+        )
+
+        XCTAssertFalse(
+            harness.controller.hasLiveVoiceSession,
+            "the stale armed session must not survive with no presenting surface"
+        )
+        XCTAssertEqual(harness.controller.state, .idle)
+        XCTAssertGreaterThanOrEqual(harness.capture.stopCount, 1, "capture is released")
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
     }
 
     func testFailedAttachSettlesIntoErrorStateAndKeepsThePhoneRestorePath() async {
@@ -985,6 +988,34 @@ final class ConduitWindowClaimKeeperTests: XCTestCase {
     }
 }
 
+// MARK: - Duplicate-window dismissal source contract
+
+final class CarPlayDuplicateWindowDismissalTests: XCTestCase {
+    /// Static source contract (UIKit/iPad runtime behavior stays on the
+    /// physical checklist): the duplicate-window path must dismiss the
+    /// CURRENT instance via the environment-scoped `dismissWindow()`, and
+    /// must never use ID-scoped `dismissWindow(id:)`, which targets the
+    /// whole WindowGroup — including the primary window.
+    func testDuplicateWindowUsesEnvironmentScopedDismissal() throws {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFile
+            .deletingLastPathComponent()   // ConduitTests
+            .deletingLastPathComponent()   // repo root
+        let rootViewSource = try String(
+            contentsOf: repoRoot.appendingPathComponent("Conduit/Views/RootView.swift"),
+            encoding: .utf8
+        )
+        XCTAssertTrue(
+            rootViewSource.contains("dismissWindow()"),
+            "the duplicate window must dismiss only itself"
+        )
+        XCTAssertFalse(
+            rootViewSource.contains("dismissWindow(id:"),
+            "ID-scoped dismissal would close the entire WindowGroup, primary included"
+        )
+    }
+}
+
 // MARK: - Phone-open attach to a live (CarPlay-owned) Voice session
 
 @MainActor
@@ -1078,6 +1109,192 @@ final class CarPlayVoicePhoneAttachTests: XCTestCase {
             harness.appState.errorMessage,
             "attaching to the live session must not emit the turn-running rejection"
         )
+    }
+}
+
+// MARK: - Prepare outcome semantics + surface-gate matrix
+
+@MainActor
+final class CarPlayVoicePrepareOutcomeTests: XCTestCase {
+    private func makeHarness(
+        voiceEnabled: Bool = true,
+        activeSessionID: String? = nil
+    ) -> CarPlayVoiceCoordinatorTests.Harness {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        harness.appState.activeSessionId = activeSessionID
+        if !voiceEnabled {
+            harness.defaults.set(false, forKey: "conduit.voice.enabled.v1.https://example.com.default")
+        }
+        return harness
+    }
+
+    /// Voice capability unavailable: prepare is REJECTED (.failed), the
+    /// open contract stays router-friendly (returns true = consumed), the
+    /// error is surfaced, and NOTHING Voice-shaped is presented or armed.
+    func testCapabilityUnavailableFailsPreparationWithoutPresentingVoice() async {
+        let harness = makeHarness(voiceEnabled: false)
+
+        let outcome = await harness.appState.prepareVoiceConversation(
+            profile: nil,
+            startsFreshConversation: false
+        )
+
+        guard case .failed(let message) = outcome else {
+            return XCTFail("capability-unavailable preparation must fail, got \(outcome)")
+        }
+        XCTAssertFalse(message.isEmpty)
+        XCTAssertEqual(harness.appState.errorMessage, message)
+        XCTAssertFalse(harness.controller.hasLiveVoiceSession)
+        XCTAssertEqual(harness.capture.startCount, 0)
+
+        // The phone open contract: consumed (router-friendly) but Voice is
+        // never presented and auto-listen is never armed.
+        let opened = await harness.appState.openVoiceConversation(
+            PendingVoiceIntent(profile: nil, startsFreshConversation: false, source: .composer)
+        )
+        XCTAssertTrue(opened, "the request is consumed with the error surfaced")
+        XCTAssertEqual(harness.appState.errorMessage, message)
+        XCTAssertFalse(harness.appState.showVoiceSheet, "a rejected preparation must not present Voice")
+        XCTAssertFalse(harness.appState.consumeVoiceSheetAutoListen())
+        XCTAssertEqual(harness.capture.startCount, 0, "the microphone is never acquired")
+    }
+
+    /// A non-fresh request with NO session (session creation is a no-op
+    /// without a client here) must fail instead of presenting a dead sheet.
+    func testMissingSessionFailsPreparation() async {
+        let harness = makeHarness()
+        XCTAssertNil(harness.appState.activeSessionId)
+
+        let outcome = await harness.appState.prepareVoiceConversation(
+            profile: nil,
+            startsFreshConversation: false
+        )
+
+        guard case .failed(let message) = outcome else {
+            return XCTFail("missing-session preparation must fail, got \(outcome)")
+        }
+        XCTAssertEqual(message, "Hermes could not prepare a voice conversation.")
+        XCTAssertEqual(harness.appState.errorMessage, message)
+        XCTAssertFalse(harness.controller.hasLiveVoiceSession)
+        XCTAssertEqual(harness.capture.startCount, 0)
+    }
+
+    /// Fresh-session creation failure is likewise a .failed rejection.
+    func testFreshSessionCreationFailureFailsPreparation() async {
+        let harness = makeHarness()
+        XCTAssertNil(harness.appState.activeSessionId)
+
+        let outcome = await harness.appState.prepareVoiceConversation(
+            profile: nil,
+            startsFreshConversation: true
+        )
+
+        guard case .failed(let message) = outcome else {
+            return XCTFail("failed fresh creation must be a .failed rejection, got \(outcome)")
+        }
+        XCTAssertEqual(message, "Hermes could not create the requested voice conversation.")
+        XCTAssertFalse(harness.controller.hasLiveVoiceSession)
+        XCTAssertEqual(harness.capture.startCount, 0)
+    }
+}
+
+@MainActor
+final class CarPlayVoiceSurfaceGateTests: XCTestCase {
+    /// The original privacy case: CarPlay-only Voice listening while the
+    /// phone is foreground with its Voice sheet closed. When CarPlay
+    /// disconnects, a foreground phone scene must NOT count as an active
+    /// Voice surface — capture must be released with no Voice controls
+    /// anywhere.
+    func testCarPlayDisconnectWithForegroundPhoneButClosedSheetReleasesVoice() async {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        // Phone foreground (fresh AppState default), Voice sheet closed,
+        // CarPlay listening.
+        harness.appState.activeSessionId = "session-1"
+        harness.controller.beginVoiceTurn(sessionID: "session-1")
+        await harness.controller.startListening()
+        harness.coordinator.handleConnect(harness.spy)
+        XCTAssertTrue(harness.controller.hasLiveVoiceSession)
+        let startsBefore = harness.capture.startCount
+
+        harness.coordinator.handleDisconnect()
+
+        XCTAssertFalse(
+            harness.controller.hasLiveVoiceSession,
+            "no Voice surface remains: the runtime must be released"
+        )
+        XCTAssertGreaterThanOrEqual(
+            harness.capture.stopCount, 1,
+            "capture is stopped on the CarPlay-only disconnect"
+        )
+        XCTAssertEqual(harness.capture.startCount, startsBefore, "capture is never restarted")
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+    }
+
+    /// Ordinary phone Voice must still open and listen after the predicate
+    /// change: the gate is false while the sheet is closed, presenting the
+    /// sheet re-asserts it, and the sheet's auto-listen reaches the
+    /// microphone.
+    func testPhoneVoiceOpenReArmsTheGateAndListens() async {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        harness.appState.activeSessionId = "session-1"
+        // Background/foreground cycle with the sheet closed: under the new
+        // predicate the gate ends false (no Voice surface is presenting).
+        harness.appState.handleScenePhase(.background)
+        harness.appState.handleScenePhase(.active)
+
+        await harness.controller.startListening()
+        XCTAssertEqual(
+            harness.controller.state, .idle,
+            "listening is gated while no Voice surface presents"
+        )
+
+        // The user taps Voice: prepare arms the conversation, the sheet
+        // presents, the gate is re-asserted, and listen reaches capture.
+        let opened = await harness.appState.openVoiceConversation(
+            PendingVoiceIntent(profile: nil, startsFreshConversation: false, source: .composer)
+        )
+        XCTAssertTrue(opened)
+        XCTAssertTrue(harness.appState.showVoiceSheet)
+
+        await harness.controller.startListening()
+        XCTAssertEqual(harness.controller.state, .listening, "the re-asserted gate lets the sheet's listen work")
+        XCTAssertEqual(harness.capture.startCount, 1)
+    }
+
+    /// Sheet matrix for the CarPlay disconnect boundary, phone foreground:
+    /// sheet open → the phone Voice surface survives the disconnect; sheet
+    /// closed → the runtime is released.
+    func testPhoneForegroundDisconnectMatrix() async {
+        // Sheet OPEN: the phone still presents Voice.
+        let openHarness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = openHarness.defaults, suite = openHarness.defaultsSuiteName] in
+            openHarness.defaults.removePersistentDomain(forName: openHarness.defaultsSuiteName)
+        }
+        openHarness.openVoice(session: "session-1")
+        await openHarness.controller.startListening()
+        openHarness.coordinator.handleConnect(openHarness.spy)
+        openHarness.coordinator.handleDisconnect()
+        XCTAssertTrue(openHarness.controller.hasLiveVoiceSession, "the phone sheet keeps Voice alive")
+        XCTAssertFalse(openHarness.controller.isRuntimeSuspended)
+        XCTAssertEqual(openHarness.controller.state, .listening)
+
+        // Sheet CLOSED: nothing presents Voice after the disconnect.
+        let closedHarness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = closedHarness.defaults, suite = closedHarness.defaultsSuiteName] in
+            closedHarness.defaults.removePersistentDomain(forName: closedHarness.defaultsSuiteName)
+        }
+        closedHarness.appState.activeSessionId = "session-1"
+        closedHarness.controller.beginVoiceTurn(sessionID: "session-1")
+        await closedHarness.controller.startListening()
+        closedHarness.coordinator.handleConnect(closedHarness.spy)
+        closedHarness.coordinator.handleDisconnect()
+        XCTAssertFalse(closedHarness.controller.hasLiveVoiceSession, "nothing presents Voice: runtime released")
     }
 }
 

--- a/ConduitTests/CarPlayVoiceTests.swift
+++ b/ConduitTests/CarPlayVoiceTests.swift
@@ -1,0 +1,1243 @@
+//
+//  CarPlayVoiceTests.swift
+//  Conduit
+//
+//  CarPlay Voice V1: scene manifest regression, state mapping, template
+//  shape, duplicate-suppression, same-instance guarantees, surface-activity
+//  lifecycle (phone background vs CarPlay), attach-without-restart, the
+//  authoritative End teardown, re-listen with Continuous Conversation OFF,
+//  unavailability fail-closed behavior, and stale-generation fencing.
+//
+//  No CarPlay hardware is involved: the coordinator is exercised through the
+//  CarPlayInterfacing seam and a state-activator recorder; only plain
+//  CarPlay value/container objects are constructed.
+//
+
+import AVFAudio
+import CarPlay
+import XCTest
+@testable import Conduit
+
+// MARK: - Scene manifest regression
+
+@MainActor
+final class CarPlaySceneManifestTests: XCTestCase {
+    private var sceneManifest: [String: Any] {
+        Bundle.main.infoDictionary?["UIApplicationSceneManifest"] as? [String: Any] ?? [:]
+    }
+
+    func testSupportsMultipleScenesEnabledForPhoneAndCarPlayCoexistence() {
+        // UIKit creates the phone UIWindow scene AND the connected
+        // CPTemplateApplicationScene concurrently, so multiple-scene support
+        // must be enabled. The foreground role stays single-window through
+        // SwiftUI's singleton `Window` scene (not WindowGroup), so this is
+        // never an iPad multi-window product. These plist assertions pin the
+        // supported CONFIGURATION only — runtime coexistence additionally
+        // needs the CarPlay Simulator / a vehicle and stays on the physical
+        // checklist.
+        XCTAssertEqual(sceneManifest["UIApplicationSupportsMultipleScenes"] as? Bool, true)
+    }
+
+    func testCarPlaySceneConfigurationReferencesTemplateApplicationSceneDelegate() {
+        let configurations = sceneManifest["UISceneConfigurations"] as? [String: Any]
+        let carPlayConfigs = configurations?["CPTemplateApplicationSceneSessionRoleApplication"] as? [[String: Any]]
+        XCTAssertEqual(carPlayConfigs?.count, 1, "exactly one CarPlay scene configuration")
+        let config = carPlayConfigs?.first
+        XCTAssertEqual(config?["UISceneConfigurationName"] as? String, "CarPlayVoice")
+        XCTAssertEqual(
+            config?["UISceneClassName"] as? String, "CPTemplateApplicationScene",
+            "the CarPlay role pins Apple's template-application scene class explicitly"
+        )
+        let delegateName = config?["UISceneDelegateClassName"] as? String
+        XCTAssertTrue(
+            delegateName?.hasSuffix(".CarPlayVoiceSceneDelegate") == true,
+            "the delegate class name must use the product module namespace"
+        )
+        let delegateClass = delegateName.flatMap(NSClassFromString)
+        XCTAssertTrue(
+            delegateClass === CarPlayVoiceSceneDelegate.self,
+            "the manifest-declared delegate must resolve to CarPlayVoiceSceneDelegate"
+        )
+    }
+
+    func testNoApplicationRoleSceneConfigurationIsDeclared() {
+        // The phone scene stays on the SwiftUI default configuration: adding
+        // one would change foreground scene behavior beyond the CarPlay role.
+        let configurations = sceneManifest["UISceneConfigurations"] as? [String: Any]
+        XCTAssertNil(configurations?["UIApplicationSceneSessionRoleApplication"])
+        XCTAssertNil(configurations?["UISceneSessionRoleApplication"])
+    }
+}
+
+// MARK: - Controller state → CarPlay state mapping
+
+final class CarPlayVoiceStateMappingTests: XCTestCase {
+    func testAllControllerStatesMapAsSpecified() {
+        XCTAssertEqual(CarPlayVoiceState.map(.idle), .ready)
+        XCTAssertEqual(CarPlayVoiceState.map(.listening), .listening)
+        XCTAssertEqual(CarPlayVoiceState.map(.transcribing), .processing)
+        XCTAssertEqual(CarPlayVoiceState.map(.thinking), .processing)
+        XCTAssertEqual(CarPlayVoiceState.map(.speaking), .responding)
+        XCTAssertEqual(CarPlayVoiceState.map(.muted), .responding)
+        XCTAssertEqual(CarPlayVoiceState.map(.failed("anything")), .error)
+    }
+
+    func testExactlyFiveStatesWithStableIdentifiersAndSafeTitles() {
+        XCTAssertEqual(CarPlayVoiceState.allCases.count, 5)
+        XCTAssertEqual(
+            CarPlayVoiceState.allCases.map(\.identifier),
+            ["ready", "listening", "processing", "responding", "error"]
+        )
+        for state in CarPlayVoiceState.allCases {
+            XCTAssertFalse(state.titleVariants.isEmpty)
+            for title in state.titleVariants {
+                // No transcript content, errors, or verbose strings leak:
+                // titles are the fixed, short driver-safe strings.
+                XCTAssertLessThan(title.count, 40)
+            }
+        }
+        XCTAssertEqual(CarPlayVoiceState.ready.titleVariants, ["Ready"])
+        XCTAssertEqual(CarPlayVoiceState.listening.titleVariants, ["Listening…"])
+        XCTAssertEqual(CarPlayVoiceState.processing.titleVariants, ["Thinking…"])
+        XCTAssertEqual(CarPlayVoiceState.responding.titleVariants, ["Responding…"])
+        XCTAssertEqual(CarPlayVoiceState.error.titleVariants, ["Voice unavailable"])
+    }
+
+    func testFailureMessageIsDroppedByTheMapping() {
+        // `.failed` carries internals (provider errors, etc.) that must never
+        // reach the CarPlay display.
+        let mapped = CarPlayVoiceState.map(.failed("provider websocket exploded with secret details"))
+        XCTAssertEqual(mapped, .error)
+        XCTAssertFalse(
+            CarPlayVoiceState.error.titleVariants.contains { $0.contains("provider") },
+            "the error state titles must not carry failure internals"
+        )
+    }
+}
+
+// MARK: - Duplicate suppression
+
+final class CarPlayVoiceStateActivationTests: XCTestCase {
+    func testDuplicateTransitionsAreSuppressed() {
+        XCTAssertNil(CarPlayVoiceStateActivation.activationTarget(lastActivated: .listening, newState: .listening))
+        XCTAssertEqual(
+            CarPlayVoiceStateActivation.activationTarget(lastActivated: .listening, newState: .processing),
+            .processing
+        )
+        XCTAssertEqual(CarPlayVoiceStateActivation.activationTarget(lastActivated: nil, newState: .ready), .ready)
+    }
+
+    func testMutedAndSpeakingCollapseIntoOneRespondingActivation() {
+        XCTAssertNil(
+            CarPlayVoiceStateActivation.activationTarget(lastActivated: .responding, newState: .responding),
+            ".muted ↔ .speaking oscillation must not spam state activation"
+        )
+    }
+}
+
+// MARK: - Template shape
+
+@MainActor
+final class CarPlayVoiceTemplateFactoryTests: XCTestCase {
+    func testTemplateHasAtMostFiveStatesWithTheExpectedIdentifiers() {
+        let template = CarPlayVoiceTemplateFactory.makeTemplate(
+            handlers: CarPlayVoiceActionHandlers(startListening: {}, endConversation: {})
+        )
+        XCTAssertLessThanOrEqual(template.voiceControlStates.count, 5, "the template's documented maximum")
+        XCTAssertEqual(
+            template.voiceControlStates.map(\.identifier),
+            ["ready", "listening", "processing", "responding", "error"]
+        )
+    }
+
+    func testStateTitlesAreDriverSafe() {
+        let template = CarPlayVoiceTemplateFactory.makeTemplate(
+            handlers: CarPlayVoiceActionHandlers(startListening: {}, endConversation: {})
+        )
+        for state in template.voiceControlStates {
+            for title in state.titleVariants ?? [] {
+                XCTAssertLessThanOrEqual(title.count, 40)
+            }
+        }
+    }
+
+    func testActionButtonsAreMinimalAndStateAppropriate() throws {
+        guard #available(iOS 26.4, *) else {
+            throw XCTSkip("CarPlay action buttons require iOS 26.4")
+        }
+        let template = CarPlayVoiceTemplateFactory.makeTemplate(
+            handlers: CarPlayVoiceActionHandlers(startListening: {}, endConversation: {})
+        )
+        let buttonsByID = Dictionary(uniqueKeysWithValues: template.voiceControlStates.map { (
+            $0.identifier,
+            $0.actionButtons ?? []
+        ) })
+        XCTAssertEqual(buttonsByID.values.map(\.count).max() ?? 0, 1, "exactly one control per state")
+        XCTAssertEqual(buttonsByID["ready"]?.count, 1, "Ready offers Listen")
+        XCTAssertEqual(buttonsByID["listening"]?.count, 1, "an active turn offers End")
+        XCTAssertEqual(buttonsByID["processing"]?.count, 1)
+        XCTAssertEqual(buttonsByID["responding"]?.count, 1)
+        XCTAssertEqual(buttonsByID["error"]?.count, 1, "Error offers Listen to retry")
+    }
+}
+
+// MARK: - Process-wide AppState registry (same-instance invariant)
+
+@MainActor
+final class AppStateRuntimeRegistryTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        AppStateRuntimeRegistry.shared.resetForTesting()
+    }
+
+    override func tearDown() {
+        AppStateRuntimeRegistry.shared.resetForTesting()
+        super.tearDown()
+    }
+
+    func testRegistryReturnsOneInstanceAcrossAccesses() {
+        let first = AppStateRuntimeRegistry.shared.appState
+        let second = AppStateRuntimeRegistry.shared.appState
+        XCTAssertTrue(first === second, "the process has exactly one AppState")
+    }
+
+    func testCarPlayFirstLaunchOrderBindsTheSameInstanceAsThePhoneSurface() {
+        // Simulated ordering: the CarPlay scene connects before any phone
+        // scene renders, so the registry creates the instance; the SwiftUI
+        // @StateObject autoclosure then adopts the same one.
+        let carPlayResolved = AppStateRuntimeRegistry.shared.appState
+        let phoneAdopted = AppStateRuntimeRegistry.shared.appState
+        XCTAssertTrue(carPlayResolved === phoneAdopted)
+    }
+
+    func testCarPlayCoordinatorBindsTheRegistryInstance() {
+        let spy = InterfacingSpy()
+        let coordinator = CarPlayVoiceCoordinator()
+        coordinator.appStateProvider = { AppStateRuntimeRegistry.shared.appState }
+        coordinator.autoEstablishOnConnect = false
+        coordinator.handleConnect(spy)
+        XCTAssertTrue(coordinator.lastBoundAppState === AppStateRuntimeRegistry.shared.appState)
+        coordinator.handleDisconnect()
+    }
+}
+
+// MARK: - Presentation drain helper
+
+@MainActor
+extension CarPlayVoiceCoordinator {
+    /// The install completion reaches presentation through a MainActor Task
+    /// hop; this bounded drain lets tests await that hop deterministically.
+    func waitForPresentation(budget: Int = 50) async {
+        for _ in 0..<budget where !isTemplatePresented {
+            await Task.yield()
+        }
+    }
+}
+
+// MARK: - Interfacing seam
+
+@MainActor
+final class InterfacingSpy: CarPlayInterfacing {
+    private(set) var setRootTemplateCount = 0
+    private(set) var installedTemplates: [CPTemplate] = []
+    /// When false, `setRootTemplate` completions are PARKED instead of
+    /// invoked; tests flush them via `completeParkedInstall` to control the
+    /// presentation timing.
+    var completesImmediately = true
+    private var parkedCompletions: [((Bool, (any Error)?) -> Void)?] = []
+
+    func setRootTemplate(
+        _ rootTemplate: CPTemplate,
+        animated: Bool,
+        completion: ((Bool, (any Error)?) -> Void)?
+    ) {
+        setRootTemplateCount += 1
+        installedTemplates.append(rootTemplate)
+        if completesImmediately {
+            completion?(true, nil)
+        } else {
+            parkedCompletions.append(completion)
+        }
+    }
+
+    var parkedInstallCount: Int { parkedCompletions.count }
+
+    func completeParkedInstall(success: Bool = true, error: (any Error)? = nil) {
+        let completions = parkedCompletions
+        parkedCompletions.removeAll()
+        completions.forEach { $0?(success, error) }
+    }
+}
+
+// MARK: - Coordinator + AppState lifecycle
+
+@MainActor
+final class CarPlayVoiceCoordinatorTests: XCTestCase {
+    @MainActor
+    struct Harness {
+        let appState: AppState
+        let controller: VoiceConversationController
+        let capture: FakeCapture
+        let gateway: FakeGateway
+        let spy: InterfacingSpy
+        let coordinator: CarPlayVoiceCoordinator
+        let defaults: UserDefaults
+        let defaultsSuiteName: String
+        let activatorBox: CarPlayVoiceCoordinatorTests.ActivationRecorder
+
+        var activations: [CarPlayVoiceState] { activatorBox.states }
+
+        func openVoice(session: String) {
+            appState.activeSessionId = session
+            appState.showVoiceSheet = true
+            controller.beginVoiceTurn(sessionID: session)
+            appState.voiceControllerSessionProfile = appState.activeProfile
+        }
+    }
+
+    final class ActivationRecorder {
+        var states: [CarPlayVoiceState] = []
+    }
+
+    private func makeHarness(
+        connected: Bool = true,
+        continuousConversation: Bool = true
+    ) -> Harness {
+        let harness = Self.makeSharedHarness(
+            connected: connected,
+            continuousConversation: continuousConversation
+        )
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        return harness
+    }
+
+    /// Harness factory shared with other test classes. Cleanup of the
+    /// UserDefaults suite is the CALLER's responsibility (the instance
+    /// wrapper registers an XCTest teardown).
+    static func makeSharedHarness(
+        connected: Bool = true,
+        continuousConversation: Bool = true
+    ) -> Harness {
+        let suite = "CarPlayVoiceTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Failed to create test UserDefaults suite")
+        }
+        defaults.set("default", forKey: "conduit.activeProfile")
+        defaults.set(true, forKey: "conduit.voice.enabled.v1.https://example.com.default")
+        if !continuousConversation {
+            var preferences = VoiceProfilePreferences()
+            preferences.continuousConversation = false
+            if let data = try? JSONEncoder().encode(preferences) {
+                defaults.set(data, forKey: "conduit.voice.preferences.v1.https://example.com.default")
+            }
+        }
+
+        let appState = AppState(defaults: defaults, loadSavedConnection: false)
+        appState.voiceCapabilityRequesterForTesting = ImmediateVoiceConfigRequester(mode: .fullSupport)
+        if connected {
+            appState.connection = HermesConnection(baseUrl: "https://example.com", ticket: "test-ticket")
+            appState.isConnected = true
+        }
+        appState.installVoiceCapabilityStateForTesting(
+            bridge: DashboardTicketBridge(baseURL: "https://example.com"),
+            snapshot: VoiceCapabilitySnapshot(
+                isGatewayConnected: true,
+                supportsTranscription: true,
+                supportsSpeech: true,
+                unavailableReason: nil
+            ),
+            isVoiceEnabled: true
+        )
+
+        let capture = FakeCapture(permissionGranted: true)
+        let gateway = FakeGateway(transcript: "Question")
+        let controller = VoiceConversationController(
+            capture: capture,
+            playback: FakePlayback(),
+            gateway: gateway,
+            routePolicyProvider: { .fullDuplex },
+            submit: { _ in true },
+            interrupt: { true },
+            onEndConversation: { [weak appState] in appState?.closeVoiceConversation() }
+        )
+        appState.voiceConversationController = controller
+
+        let spy = InterfacingSpy()
+        let coordinator = CarPlayVoiceCoordinator()
+        let recorder = CarPlayVoiceCoordinatorTests.ActivationRecorder()
+        coordinator.appStateProvider = { appState }
+        coordinator.autoEstablishOnConnect = false
+        coordinator.stateActivator = { _, state in recorder.states.append(state) }
+
+        return Harness(
+            appState: appState,
+            controller: controller,
+            capture: capture,
+            gateway: gateway,
+            spy: spy,
+            coordinator: coordinator,
+            defaults: defaults,
+            defaultsSuiteName: suite,
+            activatorBox: recorder
+        )
+    }
+
+    // MARK: connect
+
+    func testConnectInstallsRootTemplateImmediatelyAndCompletesPresentation() async {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        XCTAssertFalse(harness.coordinator.isConnected)
+
+        harness.coordinator.handleConnect(harness.spy)
+
+        XCTAssertEqual(harness.spy.setRootTemplateCount, 1, "the root template installs before the callback returns")
+        XCTAssertTrue(harness.spy.installedTemplates.first is CPVoiceControlTemplate)
+        XCTAssertTrue(harness.coordinator.isConnected)
+        XCTAssertTrue(harness.appState.isCarPlayVoiceSurfaceActive, "CarPlay registers as an active Voice surface")
+        await harness.coordinator.waitForPresentation()
+        XCTAssertTrue(harness.coordinator.isTemplatePresented, "the completion marks presentation")
+        XCTAssertTrue(harness.activations.isEmpty, "the default Ready state is shown by presentation itself")
+        XCTAssertEqual(harness.coordinator.lastActivatedState, .ready, "dedupe is primed against the default")
+    }
+
+    func testCarPlayFirstLaunchUsesTheRegistryAppStateWithoutAnyPhoneView() {
+        AppStateRuntimeRegistry.shared.resetForTesting()
+        defer { AppStateRuntimeRegistry.shared.resetForTesting() }
+
+        let spy = InterfacingSpy()
+        let coordinator = CarPlayVoiceCoordinator()
+        coordinator.appStateProvider = { AppStateRuntimeRegistry.shared.appState }
+        coordinator.autoEstablishOnConnect = false
+
+        // The CarPlay scene connects with NO phone RootView having run.
+        coordinator.handleConnect(spy)
+
+        let adoptedBySwiftUI = AppStateRuntimeRegistry.shared.appState
+        XCTAssertTrue(
+            coordinator.lastBoundAppState === adoptedBySwiftUI,
+            "the CarPlay-created AppState is the exact instance the phone surface adopts"
+        )
+    }
+
+    // MARK: shared conversation / no second stack
+
+    func testLiveVoiceConversationAttachesWithoutRestartOrTranscriptLoss() async {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        harness.openVoice(session: "session-1")
+        // Drive a real phone turn to audible playback (user asked, Hermes
+        // answers) exactly like the suspension fixture does.
+        await harness.controller.startListening()
+        let start = Date()
+        harness.controller.ingestAudioLevel(0.1, at: start)
+        harness.controller.ingestAudioLevel(0, at: start.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 250_000_000)
+        XCTAssertEqual(harness.controller.state, .thinking)
+        harness.controller.receiveAssistantEvent(.started(sessionID: "session-1"))
+        harness.controller.receiveAssistantEvent(.delta(sessionID: "session-1", text: "Answer."))
+        try? await Task.sleep(nanoseconds: 250_000_000)
+        XCTAssertEqual(harness.controller.state, .speaking)
+        let sheetBefore = harness.appState.showVoiceSheet
+        let autoListenBefore = harness.appState.voiceSheetShouldAutoListen
+        let transcriptBefore = harness.controller.conversationTranscript
+
+        // CarPlay connects mid-turn: attach only.
+        harness.coordinator.handleConnect(harness.spy)
+        await harness.coordinator.establishVoice(generation: harness.coordinator.connectionGeneration)
+        await harness.coordinator.waitForPresentation()
+
+        XCTAssertTrue(harness.controller.hasLiveVoiceSession, "the live conversation is preserved")
+        XCTAssertTrue(harness.controller.isGatewayAttached, "the in-place gateway is retained")
+        XCTAssertEqual(
+            harness.controller.conversationTranscript, transcriptBefore,
+            "transcript survives the attach untouched"
+        )
+        XCTAssertEqual(harness.appState.showVoiceSheet, sheetBefore, "CarPlay never mutates phone presentation flags")
+        XCTAssertEqual(harness.appState.voiceSheetShouldAutoListen, autoListenBefore, "attach never arms a hot mic")
+        XCTAssertEqual(harness.controller.state, .speaking, "no restart of the in-flight turn")
+        XCTAssertEqual(harness.activations.last, .responding, "the mid-turn state displays without any restart")
+    }
+
+    func testCarPlayConnectWithNoLiveVoicePreparesThroughTheSharedPathAndStartsListening() async {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        harness.appState.activeSessionId = "existing-session"
+        harness.coordinator.handleConnect(harness.spy)
+        let generation = harness.coordinator.connectionGeneration
+
+        await harness.coordinator.establishVoice(generation: generation)
+        await harness.coordinator.waitForPresentation()
+
+        XCTAssertTrue(harness.controller.hasLiveVoiceSession, "the shared prepare path armed the conversation")
+        XCTAssertTrue(harness.controller.isGatewayAttached)
+        XCTAssertEqual(harness.appState.activeSessionId, "existing-session")
+        XCTAssertEqual(harness.controller.state, .listening, "the launcher tap is the listen intent")
+        XCTAssertFalse(harness.appState.showVoiceSheet, "CarPlay open does not present the phone sheet")
+        XCTAssertEqual(harness.activations.last, .listening)
+    }
+
+    func testCarPlayConnectContinuesTheCurrentConversationInsteadOfCreatingANewSession() async {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        harness.appState.activeSessionId = "existing-session"
+        harness.coordinator.handleConnect(harness.spy)
+
+        await harness.coordinator.establishVoice(generation: harness.coordinator.connectionGeneration)
+
+        XCTAssertEqual(
+            harness.appState.activeSessionId, "existing-session",
+            "an existing session continues; no new session is created for CarPlay"
+        )
+    }
+
+    // MARK: phone background vs CarPlay
+
+    func testPhoneBackgroundWithCarPlayActiveKeepsVoiceLive() async {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        harness.openVoice(session: "session-1")
+        await harness.controller.startListening()
+        harness.appState.setCarPlayVoiceSurfaceActive(true)
+
+        harness.appState.handleScenePhase(.background)
+
+        XCTAssertTrue(harness.appState.hasActiveVoiceSurface)
+        XCTAssertFalse(harness.controller.isRuntimeSuspended, "Voice stays live for CarPlay")
+        XCTAssertTrue(harness.controller.hasLiveVoiceSession)
+        XCTAssertNil(harness.appState.suspendedVoiceConversation, "no restoration descriptor is recorded")
+        XCTAssertEqual(harness.controller.state, .listening)
+    }
+
+    func testPhoneBackgroundWithoutCarPlayStillSuspends() async {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        harness.openVoice(session: "session-1")
+        await harness.controller.startListening()
+
+        harness.appState.handleScenePhase(.background)
+
+        XCTAssertTrue(harness.controller.isRuntimeSuspended, "the PR #161 path is unchanged without CarPlay")
+        XCTAssertEqual(harness.appState.suspendedVoiceConversation?.sessionID, "session-1")
+    }
+
+    func testCarPlayDisconnectWithActivePhoneVoiceDoesNotTouchIt() async {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        harness.openVoice(session: "session-1")
+        await harness.controller.startListening()
+        // Phone foreground is the default fresh-AppState state; CarPlay
+        // connected and then disconnected while the phone presents Voice.
+        harness.coordinator.handleConnect(harness.spy)
+        XCTAssertTrue(harness.appState.hasActiveVoiceSurface)
+
+        harness.coordinator.handleDisconnect()
+
+        XCTAssertFalse(harness.appState.isCarPlayVoiceSurfaceActive)
+        XCTAssertTrue(harness.controller.hasLiveVoiceSession, "the phone Voice surface still presents the conversation")
+        XCTAssertFalse(harness.controller.isRuntimeSuspended)
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+        XCTAssertEqual(harness.controller.state, .listening)
+    }
+
+    func testCarPlayOnlyDisconnectWithPhoneInactiveSuspendsAndRecordsDescriptor() async {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        harness.openVoice(session: "session-1")
+        await harness.controller.startListening()
+        harness.coordinator.handleConnect(harness.spy)
+        // The phone goes to the background; CarPlay is the only remaining
+        // surface, so the suspension is skipped and Voice stays live.
+        harness.appState.handleScenePhase(.background)
+        XCTAssertTrue(harness.controller.hasLiveVoiceSession, "CarPlay kept Voice live")
+        XCTAssertFalse(harness.controller.isRuntimeSuspended)
+
+        harness.coordinator.handleDisconnect()
+
+        XCTAssertTrue(harness.controller.isRuntimeSuspended, "no Voice surface remains: runtime released")
+        XCTAssertTrue(harness.controller.hasLiveVoiceSession, "the logical conversation is preserved for restore")
+        XCTAssertEqual(harness.appState.suspendedVoiceConversation?.sessionID, "session-1")
+        XCTAssertFalse(harness.appState.consumeVoiceSheetAutoListen())
+    }
+
+    func testCarPlayOnlyDisconnectWithClosedPhoneSheetStopsTheRuntime() async {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        // The conversation lives only on CarPlay: the phone sheet is closed.
+        harness.appState.activeSessionId = "session-1"
+        harness.controller.beginVoiceTurn(sessionID: "session-1")
+        await harness.controller.startListening()
+        harness.coordinator.handleConnect(harness.spy)
+        harness.appState.handleScenePhase(.background)
+        XCTAssertTrue(harness.controller.hasLiveVoiceSession, "CarPlay kept Voice live")
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+
+        harness.coordinator.handleDisconnect()
+
+        XCTAssertFalse(harness.controller.hasLiveVoiceSession, "a CarPlay-only disconnect is release, not Close")
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+    }
+
+    // MARK: controls
+
+    func testExplicitEndConvergesOnTheAuthoritativeCloseTeardown() {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        harness.openVoice(session: "session-1")
+        harness.coordinator.handleConnect(harness.spy)
+
+        harness.coordinator.endConversation()
+
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+        XCTAssertFalse(harness.appState.voiceSheetShouldAutoListen)
+        XCTAssertFalse(harness.controller.hasLiveVoiceSession, "Close tears the session down")
+        XCTAssertEqual(harness.controller.state, .idle)
+        XCTAssertFalse(harness.appState.showVoiceSheet)
+    }
+
+    func testContinuousConversationOffCanReListenThroughCarPlayWithoutChangingThePreference() async {
+        let harness = makeHarness(continuousConversation: false)
+        harness.appState.activeSessionId = "existing-session"
+        harness.coordinator.handleConnect(harness.spy)
+        await harness.coordinator.establishVoice(generation: harness.coordinator.connectionGeneration)
+        await harness.coordinator.waitForPresentation()
+        XCTAssertEqual(harness.controller.state, .listening)
+        let preferenceBefore = harness.appState.continuousConversationEnabled
+        // Simulate the continuous-OFF end-of-turn settle (the controller's
+        // own turn-end logic is covered by its suite): the shared session is
+        // logically open and settled, so CarPlay returns to Ready.
+        harness.controller.suspendRuntimeForLifecycle()
+        XCTAssertEqual(harness.activations.last, .ready, "Ready offers the Listen control again")
+
+        await harness.coordinator.performStartListeningTurn(generation: harness.coordinator.connectionGeneration)
+
+        XCTAssertEqual(harness.controller.state, .listening, "the driver can start another listening turn")
+        XCTAssertFalse(harness.controller.isRuntimeSuspended, "the re-listen re-arms the settled runtime")
+        XCTAssertEqual(
+            harness.appState.continuousConversationEnabled, preferenceBefore,
+            "re-listening never overrides the saved Continuous Conversation preference"
+        )
+    }
+
+    // MARK: unavailability
+
+    func testVoiceUnavailableSettlesIntoErrorStateWithoutMicrophone() async {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness(connected: false)
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        harness.coordinator.handleConnect(harness.spy)
+        let generation = harness.coordinator.connectionGeneration
+
+        await harness.coordinator.establishVoice(generation: generation)
+        await harness.coordinator.waitForPresentation()
+
+        XCTAssertEqual(harness.activations.last, .error, "unavailable Hermes settles into the error state")
+        XCTAssertFalse(harness.controller.hasLiveVoiceSession, "no Voice conversation was acquired")
+        XCTAssertEqual(harness.capture.startCount, 0, "the microphone is never acquired")
+        XCTAssertTrue(harness.coordinator.isConnected, "the CarPlay scene stays stable")
+    }
+
+    // MARK: stale-generation fencing
+
+    func testStaleDisconnectCannotResurrectVoice() async {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        harness.coordinator.handleConnect(harness.spy)
+        let staleGeneration = harness.coordinator.connectionGeneration
+
+        harness.coordinator.handleDisconnect()
+        XCTAssertFalse(harness.controller.hasLiveVoiceSession)
+        XCTAssertEqual(harness.spy.setRootTemplateCount, 1, "the dead interface controller is not touched again")
+
+        // The connect-time establishment completes AFTER the disconnect: the
+        // rotated generation must make it a silent no-op.
+        await harness.coordinator.establishVoice(generation: staleGeneration)
+
+        XCTAssertFalse(harness.controller.hasLiveVoiceSession, "a stale completion cannot reopen Voice")
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+        XCTAssertFalse(harness.coordinator.isConnected)
+    }
+
+    func testStaleReconnectCannotMutateTheNewConnection() async {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        // connect A → disconnect → reconnect B
+        harness.coordinator.handleConnect(harness.spy)
+        let staleGeneration = harness.coordinator.connectionGeneration
+        harness.coordinator.handleDisconnect()
+        harness.coordinator.handleConnect(harness.spy)
+        XCTAssertGreaterThan(harness.coordinator.connectionGeneration, staleGeneration)
+
+        // Stale async work from connection A completes under B's session.
+        await harness.coordinator.performStartListeningTurn(generation: staleGeneration)
+
+        XCTAssertEqual(harness.controller.state, .idle, "stale A work must not drive B's Voice")
+        XCTAssertFalse(harness.controller.hasLiveVoiceSession)
+        XCTAssertEqual(harness.spy.setRootTemplateCount, 2, "B's template is installed exactly once")
+    }
+
+    // MARK: surface reporting
+
+    func testDisconnectCancelsStateObservation() async {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        harness.coordinator.handleConnect(harness.spy)
+        harness.coordinator.handleDisconnect()
+        XCTAssertTrue(harness.activations.isEmpty, "nothing is forwarded without a bound interface")
+
+        await harness.controller.startListening()
+
+        XCTAssertTrue(harness.activations.isEmpty, "no CarPlay state is forwarded after disconnect")
+    }
+}
+
+// MARK: - Review-driven regressions (gate re-assert, stale prepare, attach)
+
+@MainActor
+final class CarPlayVoiceLifecycleRegressionTests: XCTestCase {
+    /// The reconnect flow every CarPlay driver hits: Voice live on CarPlay,
+    /// the phone locks, the car disconnects (runtime released, gate false),
+    /// then wireless CarPlay re-associates while the phone is still locked.
+    /// The Listen button must reach the microphone — no scene-phase event
+    /// fires while locked, so the surface activation itself must re-assert
+    /// the controller's gate.
+    func testReconnectAfterCarPlayOnlyDisconnectReArmsTheListenPath() async {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        harness.appState.activeSessionId = "session-1"
+        harness.controller.beginVoiceTurn(sessionID: "session-1")
+        await harness.controller.startListening()
+
+        harness.coordinator.handleConnect(harness.spy)
+        harness.appState.handleScenePhase(.background)
+        XCTAssertTrue(harness.controller.hasLiveVoiceSession, "CarPlay keeps Voice live across the phone lock")
+
+        harness.coordinator.handleDisconnect()
+        // No sheet presentation survives (the conversation lived on CarPlay),
+        // so the release is a full stop; the reconnect re-prepares cleanly.
+        XCTAssertFalse(harness.controller.hasLiveVoiceSession, "CarPlay-only disconnect releases the runtime")
+        XCTAssertFalse(harness.appState.hasActiveVoiceSurface)
+
+        // Wireless CarPlay re-associates; the phone is still locked.
+        harness.coordinator.handleConnect(harness.spy)
+        await harness.coordinator.establishVoice(generation: harness.coordinator.connectionGeneration)
+        await harness.coordinator.performStartListeningTurn(generation: harness.coordinator.connectionGeneration)
+        await harness.coordinator.waitForPresentation()
+
+        XCTAssertEqual(harness.controller.state, .listening, "the re-asserted gate lets Listen reach the microphone")
+        XCTAssertFalse(harness.controller.isRuntimeSuspended, "the re-listen re-arms the suspended runtime")
+        XCTAssertEqual(harness.activations.last, .listening)
+    }
+
+    func testStalePrepareCompletionWithActivePhoneSurfaceKeepsTheConversation() async {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        harness.appState.activeSessionId = "session-1"
+        harness.controller.beginVoiceTurn(sessionID: "session-1")
+        await harness.controller.startListening()
+
+        // A prepare captured under a DIFFERENT generation completes while the
+        // phone surface is active: the conversation is not torn down — the
+        // phone still legitimately presents it.
+        await harness.coordinator.completeVoiceEstablishment(
+            generation: harness.coordinator.connectionGeneration &+ 1,
+            outcome: .handled
+        )
+
+        XCTAssertTrue(harness.controller.hasLiveVoiceSession, "the phone surface keeps the conversation")
+        XCTAssertEqual(harness.controller.state, .listening)
+        XCTAssertNil(harness.appState.suspendedVoiceConversation)
+    }
+
+    func testStalePrepareCompletionWithNoActiveSurfaceDoesNotOrphanAnArmedSession() async {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        harness.openVoice(session: "session-1")
+        await harness.controller.startListening()
+        harness.appState.handleScenePhase(.background)
+        XCTAssertTrue(harness.controller.isRuntimeSuspended)
+
+        // A prepare completing after the surface disappeared must apply the
+        // no-surface release contract instead of leaving the session armed.
+        await harness.coordinator.completeVoiceEstablishment(
+            generation: harness.coordinator.connectionGeneration &+ 1,
+            outcome: .handled
+        )
+
+        XCTAssertTrue(harness.controller.isRuntimeSuspended, "the session stays released, not resurrected-armed")
+        XCTAssertEqual(harness.appState.suspendedVoiceConversation?.sessionID, "session-1", "still restorable")
+        XCTAssertEqual(harness.capture.startCount, 1, "no capture was (re)started by the stale completion")
+    }
+
+    func testFailedAttachSettlesIntoErrorStateAndKeepsThePhoneRestorePath() async {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        harness.openVoice(session: "session-1")
+        await harness.controller.startListening()
+        // The phone backgrounds without CarPlay: the runtime suspends and the
+        // restoration descriptor is recorded.
+        harness.appState.handleScenePhase(.background)
+        XCTAssertNotNil(harness.appState.suspendedVoiceConversation)
+        // Capabilities collapse while backgrounded: the attach re-arm must
+        // fail, and when it does the descriptor must survive.
+        harness.appState.installVoiceCapabilityStateForTesting(
+            bridge: DashboardTicketBridge(baseURL: "https://example.com"),
+            snapshot: VoiceCapabilitySnapshot(
+                isGatewayConnected: true,
+                supportsTranscription: false,
+                supportsSpeech: false,
+                unavailableReason: "no providers"
+            ),
+            isVoiceEnabled: false
+        )
+        harness.controller.setGateway(nil)
+
+        harness.coordinator.handleConnect(harness.spy)
+        await harness.coordinator.establishVoice(generation: harness.coordinator.connectionGeneration)
+        await harness.coordinator.waitForPresentation()
+
+        XCTAssertEqual(harness.activations.last, .error, "a failed attach settles into the error state")
+        XCTAssertNotNil(
+            harness.appState.suspendedVoiceConversation,
+            "a failed attach must not discard the phone-restoration descriptor"
+        )
+        XCTAssertEqual(harness.capture.startCount, 1, "the microphone is never acquired by the failed attach")
+    }
+}
+
+// MARK: - Presentation-gated state activation
+
+@MainActor
+final class CarPlayVoicePresentationGatingTests: XCTestCase {
+    private func makeSpeakingHarness() async -> CarPlayVoiceCoordinatorTests.Harness {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        harness.openVoice(session: "session-1")
+        await harness.controller.startListening()
+        let start = Date()
+        harness.controller.ingestAudioLevel(0.1, at: start)
+        harness.controller.ingestAudioLevel(0, at: start.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 250_000_000)
+        harness.controller.receiveAssistantEvent(.started(sessionID: "session-1"))
+        harness.controller.receiveAssistantEvent(.delta(sessionID: "session-1", text: "Answer."))
+        try? await Task.sleep(nanoseconds: 250_000_000)
+        XCTAssertEqual(harness.controller.state, .speaking)
+        return harness
+    }
+
+    /// Reproduces the frozen-Ready bug: an existing Voice conversation is
+    /// mid-response when CarPlay connects. The observer fires before the
+    /// root template is presented, so NOTHING may be activated yet; the
+    /// retained .responding activates exactly once on presentation success.
+    func testConnectWhileSpeakingActivatesOnlyAfterPresentation() async {
+        let harness = await makeSpeakingHarness()
+        harness.spy.completesImmediately = false
+
+        harness.coordinator.handleConnect(harness.spy)
+        await harness.coordinator.establishVoice(generation: harness.coordinator.connectionGeneration)
+
+        XCTAssertFalse(harness.coordinator.isTemplatePresented)
+        XCTAssertEqual(harness.activations, [], "pre-presentation activation is a documented no-op")
+        XCTAssertEqual(
+            harness.coordinator.pendingPresentationState, .responding,
+            "the latest desired state is retained, not lost"
+        )
+
+        harness.spy.completeParkedInstall()
+        await harness.coordinator.waitForPresentation()
+
+        XCTAssertTrue(harness.coordinator.isTemplatePresented)
+        XCTAssertEqual(harness.activations, [.responding], "responding activates exactly once on presentation")
+        XCTAssertNil(harness.coordinator.pendingPresentationState)
+
+        // Post-presentation dedupe: a mute oscillation maps to responding and
+        // must not re-activate.
+        harness.controller.setOutputMuted(true)
+        XCTAssertEqual(harness.activations, [.responding])
+    }
+
+    /// A parked install completion from connection A must never mark
+    /// connection B's template presented or activate through it.
+    func testStaleTemplateCompletionCannotPresentTheNewConnection() async {
+        let harness = await makeSpeakingHarness()
+        harness.spy.completesImmediately = false
+
+        // Connect A (install parked), disconnect, connect B (install parked).
+        harness.coordinator.handleConnect(harness.spy)
+        let spyA = harness.spy
+        harness.coordinator.handleDisconnect()
+        let spyB = InterfacingSpy()
+        spyB.completesImmediately = false
+        harness.coordinator.handleConnect(spyB)
+        XCTAssertEqual(spyB.parkedInstallCount, 1)
+        XCTAssertFalse(harness.coordinator.isTemplatePresented)
+
+        // A's late completion fires: fenced out of B.
+        spyA.completeParkedInstall()
+        await harness.coordinator.waitForPresentation()
+
+        XCTAssertFalse(
+            harness.coordinator.isTemplatePresented,
+            "a stale completion cannot present the new connection's template"
+        )
+        XCTAssertEqual(harness.activations, [], "and cannot activate through it")
+
+        // B's own completion presents normally.
+        spyB.completeParkedInstall()
+        await harness.coordinator.waitForPresentation()
+        XCTAssertTrue(harness.coordinator.isTemplatePresented)
+        XCTAssertEqual(harness.activations.last, .responding)
+    }
+
+    /// A failed install keeps the template unpresented: the desired state
+    /// stays retained (a later successful presentation will activate it) and
+    /// nothing is forwarded in the meantime.
+    func testPresentationFailureKeepsTemplateUnpresentedAndRetainsDesiredState() {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        harness.spy.completesImmediately = false
+        harness.coordinator.handleConnect(harness.spy)
+        XCTAssertEqual(harness.coordinator.pendingPresentationState, .ready)
+
+        harness.coordinator.handleControllerState(.listening)
+        harness.spy.completeParkedInstall(success: false, error: URLError(.badURL))
+
+        XCTAssertFalse(harness.coordinator.isTemplatePresented)
+        XCTAssertEqual(harness.activations, [])
+        XCTAssertEqual(
+            harness.coordinator.pendingPresentationState, .listening,
+            "the desired state is retained across the failed presentation"
+        )
+    }
+}
+
+// MARK: - Single-window claim (multi-scene for CarPlay only)
+
+@MainActor
+final class ConduitWindowClaimKeeperTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        ConduitWindowClaimKeeper.resetForTesting()
+    }
+
+    override func tearDown() {
+        ConduitWindowClaimKeeper.resetForTesting()
+        super.tearDown()
+    }
+
+    func testFirstWindowClaimsAndLaterWindowsAreRejected() {
+        XCTAssertTrue(ConduitWindowClaimKeeper.claimPrimaryWindow(), "the first window becomes primary")
+        XCTAssertFalse(
+            ConduitWindowClaimKeeper.claimPrimaryWindow(),
+            "a second foreground Conduit window dismisses itself"
+        )
+        XCTAssertFalse(ConduitWindowClaimKeeper.claimPrimaryWindow())
+    }
+
+    func testClosingThePrimaryWindowReleasesTheClaim() {
+        XCTAssertTrue(ConduitWindowClaimKeeper.claimPrimaryWindow())
+        ConduitWindowClaimKeeper.releaseClaim()
+        XCTAssertTrue(
+            ConduitWindowClaimKeeper.claimPrimaryWindow(),
+            "the next window to appear may become primary"
+        )
+    }
+}
+
+// MARK: - Phone-open attach to a live (CarPlay-owned) Voice session
+
+@MainActor
+final class CarPlayVoicePhoneAttachTests: XCTestCase {
+    /// CarPlay owns a live conversation with transcript content; the phone
+    /// sheet is NOT presented. Tapping the composer Voice control
+    /// (startsFreshConversation == false) must ATTACH: same controller, same
+    /// session, transcript untouched, assistant ownership preserved, sheet
+    /// presented — no beginVoiceTurn reset and no "stop the current
+    /// response" rejection.
+    func testPhoneOpenAttachesToCarPlayOwnedLiveSessionWithoutReset() async {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        harness.appState.activeSessionId = "session-S"
+        harness.controller.beginVoiceTurn(sessionID: "session-S")
+        await harness.controller.startListening()
+        let start = Date()
+        harness.controller.ingestAudioLevel(0.1, at: start)
+        harness.controller.ingestAudioLevel(0, at: start.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 250_000_000)
+        harness.controller.receiveAssistantEvent(.started(sessionID: "session-S"))
+        harness.controller.receiveAssistantEvent(.delta(sessionID: "session-S", text: "Answer."))
+        try? await Task.sleep(nanoseconds: 250_000_000)
+        XCTAssertTrue(harness.controller.hasLiveVoiceSession)
+        XCTAssertFalse(harness.controller.conversationTranscript.isEmpty)
+        let transcriptBefore = harness.controller.conversationTranscript
+
+        harness.coordinator.handleConnect(harness.spy)
+        await harness.coordinator.establishVoice(generation: harness.coordinator.connectionGeneration)
+
+        let opened = await harness.appState.openVoiceConversation(
+            PendingVoiceIntent(profile: nil, startsFreshConversation: false, source: .composer)
+        )
+
+        XCTAssertTrue(opened)
+        XCTAssertTrue(harness.appState.showVoiceSheet, "the phone sheet presents the attached conversation")
+        XCTAssertEqual(harness.appState.activeSessionId, "session-S", "same session, not a new one")
+        XCTAssertEqual(
+            harness.controller.conversationTranscript, transcriptBefore,
+            "the shared transcript survives the phone attach"
+        )
+        XCTAssertNil(harness.appState.errorMessage, "no spurious rejection on attach")
+
+        // Assistant ownership survived: deltas for the same session still
+        // append to the preserved transcript.
+        harness.controller.receiveAssistantEvent(.delta(sessionID: "session-S", text: " More."))
+        let expectedLastText = (transcriptBefore.last?.text ?? "") + " More."
+        XCTAssertEqual(
+            harness.controller.conversationTranscript.last?.text,
+            expectedLastText,
+            "assistant stream ownership is still armed for session-S"
+        )
+    }
+
+    /// The same continuation while an assistant turn is IN FLIGHT: phone
+    /// presentation attaches instead of rejecting with "Stop the current
+    /// response" merely because the live session already owns the turn.
+    func testPhoneOpenAttachesWhileAssistantTurnIsInFlight() async {
+        let harness = CarPlayVoiceCoordinatorTests.makeSharedHarness()
+        addTeardownBlock { [defaults = harness.defaults, suite = harness.defaultsSuiteName] in
+            defaults.removePersistentDomain(forName: suite)
+        }
+        // The phone sheet is closed; the live Voice conversation is owned by
+        // the CarPlay surface.
+        harness.appState.activeSessionId = "session-S"
+        harness.controller.beginVoiceTurn(sessionID: "session-S")
+        await harness.controller.startListening()
+        let start = Date()
+        harness.controller.ingestAudioLevel(0.1, at: start)
+        harness.controller.ingestAudioLevel(0, at: start.addingTimeInterval(1.3))
+        try? await Task.sleep(nanoseconds: 250_000_000)
+        XCTAssertEqual(harness.controller.state, .thinking, "an assistant turn is in flight")
+        let transcriptBefore = harness.controller.conversationTranscript
+
+        harness.coordinator.handleConnect(harness.spy)
+
+        let opened = await harness.appState.openVoiceConversation(
+            PendingVoiceIntent(profile: nil, startsFreshConversation: false, source: .composer)
+        )
+
+        XCTAssertTrue(opened)
+        XCTAssertTrue(harness.appState.showVoiceSheet)
+        XCTAssertEqual(harness.appState.activeSessionId, "session-S")
+        XCTAssertEqual(
+            harness.controller.conversationTranscript, transcriptBefore,
+            "the in-flight turn's transcript is untouched by the attach"
+        )
+        XCTAssertNil(
+            harness.appState.errorMessage,
+            "attaching to the live session must not emit the turn-running rejection"
+        )
+    }
+}
+
+// MARK: - Route policy regression (CarPlay stays conservative)
+
+final class CarPlayVoiceRoutePolicyTests: XCTestCase {
+    private func port(_ type: AVAudioSession.Port, name: String) -> VoiceAudioRoutePort {
+        VoiceAudioRoutePort(type: type, name: name)
+    }
+
+    func testCarPlayAudioOutputIsSpeakerSafeHalfDuplex() {
+        let policy = VoiceBargeInRoutePolicy.resolve(
+            outputs: [port(.carAudio, name: "Chevy Bolt")],
+            inputs: []
+        )
+        XCTAssertEqual(policy, .speakerSafeHalfDuplex, "the conservative half-duplex policy is preserved for CarPlay")
+    }
+
+    func testCarPlayRouteWithCarMicrophoneStaysHalfDuplex() {
+        // Even when the car exposes its own microphone input, capture and
+        // playback do not form an Apple-managed full-duplex pairing.
+        let policy = VoiceBargeInRoutePolicy.resolve(
+            outputs: [port(.carAudio, name: "Chevy Bolt")],
+            inputs: [port(.carAudio, name: "Chevy Bolt")]
+        )
+        XCTAssertEqual(policy, .speakerSafeHalfDuplex)
+    }
+
+    func testKnownRoutesKeepTheirExistingClassifications() {
+        XCTAssertEqual(
+            VoiceBargeInRoutePolicy.resolve(outputs: [port(.builtInSpeaker, name: "Speaker")], inputs: []),
+            .speakerSafeHalfDuplex,
+            "speaker"
+        )
+        XCTAssertEqual(
+            VoiceBargeInRoutePolicy.resolve(outputs: [port(.builtInReceiver, name: "Receiver")], inputs: []),
+            .speakerSafeHalfDuplex,
+            "receiver"
+        )
+        XCTAssertEqual(
+            VoiceBargeInRoutePolicy.resolve(
+                outputs: [port(.bluetoothHFP, name: "AirPods Pro")],
+                inputs: [port(.bluetoothHFP, name: "AirPods Pro")]
+            ),
+            .fullDuplex,
+            "paired Bluetooth headset"
+        )
+        XCTAssertEqual(
+            VoiceBargeInRoutePolicy.resolve(outputs: [port(.headphones, name: "Wired")], inputs: []),
+            .fullDuplex,
+            "wired headset"
+        )
+    }
+}
+
+// MARK: - Fakes (file-local copies of the established voice doubles)
+
+@MainActor
+private final class ImmediateVoiceConfigRequester: VoiceConfigurationRequesting {
+    enum Mode { case failing, fullSupport }
+
+    private let mode: Mode
+
+    init(mode: Mode = .failing) { self.mode = mode }
+
+    func requestJSON(path: String, method: String, body: [String: Any]?) async throws -> [String: Any] {
+        switch mode {
+        case .failing:
+            throw URLError(.notConnectedToInternet)
+        case .fullSupport:
+            if path.hasSuffix("/api/config") {
+                return ["stt": ["enabled": true], "tts": ["provider": "edge"]]
+            }
+            if path.hasSuffix("/api/tools/toolsets/tts/config") {
+                return ["providers": [[
+                    "name": "Microsoft Edge TTS",
+                    "tts_provider": "edge",
+                    "status": "ready",
+                    "is_active": true,
+                ]]]
+            }
+            throw URLError(.notConnectedToInternet)
+        }
+    }
+}
+
+@MainActor
+final class FakeCapture: AudioCaptureService {
+    let events: AsyncStream<VoiceCaptureEvent>
+    var captureGeneration: UInt64 = 0
+    private var continuation: AsyncStream<VoiceCaptureEvent>.Continuation?
+    private let permissionGranted: Bool
+    private(set) var startCount = 0
+    private(set) var stopCount = 0
+    private(set) var resumeCount = 0
+
+    init(permissionGranted: Bool) {
+        self.permissionGranted = permissionGranted
+        var captured: AsyncStream<VoiceCaptureEvent>.Continuation?
+        events = AsyncStream { captured = $0 }
+        continuation = captured
+    }
+    func requestPermission() async -> Bool { permissionGranted }
+    func startListening(includePreRoll: Bool) throws {
+        startCount += 1
+        captureGeneration &+= 1
+    }
+    func beginBargeInMonitoring() throws {}
+    func pause() { captureGeneration &+= 1 }
+    func resume() throws {
+        resumeCount += 1
+        captureGeneration &+= 1
+    }
+    func finishUtterance() throws -> VoiceCapturedAudio {
+        VoiceCapturedAudio(wavData: Data([1]), pcm16Data: Data([1, 0]), sampleRate: 16_000, duration: 0.01)
+    }
+    func stop() {
+        stopCount += 1
+        captureGeneration &+= 1
+    }
+    func emit(level: Float, at date: Date = Date()) {
+        continuation?.yield(.level(level, date: date, generation: captureGeneration))
+    }
+}
+
+@MainActor
+private final class FakePlayback: SpeechPlaybackService {
+    var isPlaying = false
+    var ownershipIntent: VoiceAudioIntent = .standalonePlayback
+    func start(sampleRate: Double) throws { isPlaying = true }
+    func enqueuePCM16(_ data: Data, sampleRate: Double) throws -> Int { data.count - (data.count % 2) }
+    func playEncodedAudioData(_ data: Data) throws { isPlaying = true }
+    func finish() throws {}
+    func drain() async { isPlaying = false }
+    func stop() { isPlaying = false }
+}
+
+@MainActor
+final class FakeGateway: VoiceGatewayService {
+    let profile = "default"
+    var transcript: String
+    private(set) var transcriptionCount = 0
+    init(transcript: String) { self.transcript = transcript }
+    func transcribe(_ audio: VoiceCapturedAudio) async throws -> String {
+        transcriptionCount += 1
+        return transcript
+    }
+    func openSpeechStream(
+        onStart: @escaping @MainActor (Double) throws -> Void,
+        onPCM16: @escaping @MainActor (Data, Double) throws -> Void,
+        onEncodedAudio: @escaping @MainActor (Data) throws -> Void
+    ) async throws -> VoiceSpeechStream {
+        try onStart(24_000)
+        return FakeSpeechStream()
+    }
+}
+
+@MainActor
+private final class FakeSpeechStream: VoiceSpeechStream {
+    func append(_ text: String) async throws {}
+    func finish() async throws -> Bool { false }
+    func cancel() {}
+}


### PR DESCRIPTION
## Summary

Implements the first end-to-end CarPlay Voice experience: launching Conduit from CarPlay presents a native `CPVoiceControlTemplate` backed by the **same** Hermes connection, AppState, VoiceConversationController, audio ownership, lifecycle rules, and session identity the iPhone Voice UI uses. No second Voice stack, no separate Hermes client, no CarPlay-specific backend, no duplicate AppState.

> CarPlay is another presentation/lifecycle surface over the existing Voice architecture.

**Base:** current `main` — includes PR #161 (background suspension) and PR #164 (CarPlay Voice entitlement; provisioning is already proven and untouched here).

## Architecture

### 1. Native CarPlay scene with genuine phone + CarPlay coexistence

`Info.plist` sets **`UIApplicationSupportsMultipleScenes = true`** — Apple's contract for this flag is that UIKit creates no more than one scene of ANY kind, and this architecture requires the phone UIWindow scene and the connected `CPTemplateApplicationScene` to exist simultaneously. The CarPlay role pins `UISceneClassName = CPTemplateApplicationScene` explicitly (canonical manifest shape). The foreground role stays SwiftUI-managed with **no application-role configuration declared**.

Because `WindowGroup` would expose user-creatable duplicate iPad windows under multi-scene support, and SwiftUI's singleton `Window` scene is **iOS-unavailable** (macOS 13+/visionOS only — verified in the iOS 26 SDK and docs; the deployment floor is iOS 17), the phone keeps `WindowGroup` and duplicate iPad windows **dismiss themselves** via a process-scoped first-window claim guard in `RootView` (`ConduitWindowClaimKeeper`; only the primary window drives `handleScenePhase`, so a transient duplicate's lifecycle can never suspend a conversation the primary presents). Manifest facts are pinned by `CarPlaySceneManifestTests`; these plist assertions pin the supported CONFIGURATION — runtime coexistence needs the CarPlay Simulator / a vehicle and stays on the physical checklist (CarPlay Simulator is not installed on the build Mac).

`CarPlayVoiceSceneDelegate` is deliberately thin (documented main-thread contract, `MainActor.assumeIsolated`): it forwards `didConnect`/`didDisconnect` to the coordinator.

### 2. Same-AppState invariant (CarPlay-first launch)

`AppStateRuntimeRegistry` (MainActor) is the process-wide home of the single `AppState`. `ConduitApp` adopts it (`@StateObject private var appState = AppStateRuntimeRegistry.shared.appState`) and the CarPlay scene resolves the same instance — **whoever needs it first creates it**. `AppState.init` already performs the authoritative cold-launch bootstrap (saved-connection restore), so a CarPlay-first launch establishes connection readiness without any phone view running. The registry is a reference/lifecycle seam only; it owns zero business logic. `AppStateRuntimeRegistryTests` pin one-instance-across-accesses, the CarPlay-first ordering, and the coordinator binding.

The coordinator also converges disconnect/controls on the **bound** instance (`lastBoundAppState`), so a swapped provider seam can never split surface bookkeeping across two AppStates.

### 3. Voice lifecycle generalizes to presentation surfaces

`AppState` gains `isCarPlayVoiceSurfaceActive` and the derived rule

```text
Voice may own live foreground audio
iff at least one legitimate Voice presentation surface is active
        (hasActiveVoiceSurface = isSceneActive || isCarPlayVoiceSurfaceActive)
```

- `.active` / `.background` feed the controller's surface gate with `hasActiveVoiceSurface` — the phone never *fakes* `.active`; `isSceneActive` still governs all phone-specific transport/chat reconciliation (unchanged).
- `.background` **skips** the PR #161 suspension while CarPlay presents: Voice stays live for the driver (no restoration descriptor is consumed — there is nothing to restore).
- CarPlay disconnect: if the phone scene is active, Voice is untouched; with no surface left, `handleCarPlayVoiceSurfaceRemoved()` routes through the **same** `suspendVoiceConversationForBackground()` contract (sheet-open → suspend + restoration descriptor; sheet-closed → full stop). A disconnect is release, not spoken Goodbye (which remains Close).
- Surface **activation** re-asserts the controller gate (`handleCarPlayVoiceSurfaceActivated`) — no scene-phase event fires while the phone is locked, so the reconnect-with-phone-locked flow (`testReconnectAfterCarPlayOnlyDisconnectReArmsTheListenPath`) re-arms Listen through the activation itself.

### 4. One logical conversation: prepare vs present

`openVoiceConversation` is split:

- `prepareVoiceConversation(profile:startsFreshConversation:)` — the logical acquisition (profile switch, capability refresh, session continuation/creation, gateway install, suspension supersede). Returns `.deferred` ("not connected, stay pending" — preserves the pending-intent `false` contract) or `.handled`.
- The phone flow additionally presents the sheet (`showVoiceSheet`, auto-listen), exactly as before.

Attaching is a **generic** helper, `attachToLiveVoiceConversation()`, used by both surfaces: re-asserts the presentation-surface gate, re-arms the gateway only when detached, and retires the restoration descriptor **only after** the attach succeeds. `prepareVoiceConversation` attaches to an already-live session **before** the generic turn-running rejection when `startsFreshConversation == false` — so the phone composer Voice attaching to a CarPlay-owned conversation preserves the transcript, session identity, and assistant ownership (no `beginVoiceTurn` reset, no session churn, no in-flight-turn cancellation), and the same continuation works while an assistant turn is in flight. A failed re-arm surfaces a `.failed` outcome instead of presenting a dead sheet. Fresh requests (Siri/wake/new-conversation) keep their existing cancel-and-create behavior. `PendingVoiceIntent.Source.carPlay` was deliberately **not** added: CarPlay does not route through the intent store, so it can never inherit Siri's external-launch deadline semantics.

### 5. CarPlay surface: five states, deduped, presentation-gated

`CarPlayVoiceState` = ready / listening / processing / responding / error with the specified controller mapping (`.failed(message)` drops the message — no internals on the display). `CarPlayVoiceStateActivation` suppresses duplicates (`.speaking` ↔ `.muted` collapse), and the coordinator observes only the controller's published `state` — microphone-level events never reach CarPlay. iOS 26.4 `CPVoiceControlState.actionButtons` add exactly one control per state: **Listen** at Ready/Error, **End** while active.

Activation is **presentation-gated**: `activateVoiceControlState` is a documented no-op before the template is presented, and an early activation would poison duplicate suppression (the ignored pre-presentation activation primes the dedupe, freezing the surface on Ready — e.g. connecting while a response is mid-playback). The latest desired state is therefore retained while the template is unpresented; the generation-fenced `setRootTemplate` completion marks presentation exactly once (stale completions from a superseded connection cannot present the new one), activates the retained state if it differs from the default, and only then resumes normal dedupe.

### 6. Controls

End → `AppState.closeVoiceConversation()` (the authoritative teardown — spoken Goodbye semantics untouched). Ready/Error **Listen** → the shared prepare/attach path + `controller.startListening()`; it never mutates the saved Continuous Conversation preference (pinned by test, with the preference persisted as `false`).

### 7. Stale-completion fencing

`connectionGeneration` rotates on every connect/disconnect. Establish/listen continuations (`completeVoiceEstablishment`, `completeListenTurn`) split out so the fence is deterministic: a prepare that was in flight across a disconnect applies the no-surface release contract instead of orphaning an armed session. Regression tests cover stale-establish, stale-reconnect, stale-completion-with-active-phone (conversation preserved), and stale-completion-with-no-surface (released, still restorable).

### 8. Audio

`VoiceAudioSessionCoordinator` remains the single `AVAudioSession` authority — no CarPlay-specific session code. Inspection result: the conversation policy (`.playAndRecord`/`.voiceChat`) already satisfies Apple's CarPlay voice guidance, and `defaultToSpeaker` is a no-op on accessory (car) routes, so **no route-specific mode adjustment is made**. The conservative half-duplex barge-in policy is preserved and now pinned for CarPlay routes (`carAudio` output stays `speakerSafeHalfDuplex` even with a car microphone present), alongside speaker/receiver/Bluetooth regression pins.

## Resolution round (review findings on the first head)

Three deterministic findings on `bbdd585` were fixed in `9061b33` (the current head):

1. **`.handled` now means logical Voice preparation SUCCEEDED.** Every rejection that leaves no usable Voice conversation armed (requested profile unselectable, non-fresh request while a non-Voice turn is running, Voice/STT/TTS capability unavailable, fresh-session creation failure, missing session or gateway) returns `.failed(message)`; the open contract stays router-friendly (`openVoiceConversation` returns true/consumed for `.failed`) but **never presents the Voice sheet and never arms auto-listen**. `.deferred` keeps the not-connected-yet pending contract; Siri fresh-conversation behavior is unchanged.
2. **A foreground phone scene is a Voice surface only while the Voice sheet is presenting**: `hasActiveVoiceSurface = (isSceneActive && showVoiceSheet) || isCarPlayVoiceSurfaceActive`. This closes the privacy case (CarPlay-only listening + foreground phone with the sheet closed + CarPlay disconnect → capture released instead of live audio with no controls) and keeps every legitimate flow working: presenting the sheet re-asserts the gate before auto-listen (`reassertVoiceSurfaceGate()`), sheet-open phone Voice survives a CarPlay disconnect, and the sheet-closed disconnect releases the runtime. Only the primary window drives `handleScenePhase`.
3. **The duplicate iPad window dismisses itself with environment-scoped `dismissWindow()`** — ID-scoped dismissal targets the whole WindowGroup and would have closed the primary window. A source-contract test pins the environment-scoped form; UIKit/iPad runtime behavior stays on the physical checklist (CarPlay Simulator is not installed on the build Mac).

Regression coverage added: prepare-outcome semantics (capability unavailable, missing session, fresh-session failure → `.failed`, no sheet, no auto-listen, no microphone), the surface-gate matrix (sheet open/closed × CarPlay disconnect), the phone re-listen after a closed-sheet background/foreground cycle, and the dismissal source contract.

## Test results (Mac build machine, Xcode 26.6)

- New `CarPlayVoiceTests`: **51/51 passed** — scene manifest (coexistence config), mapping, dedupe, template shape, registry identity, connect/establish, live-attach-without-restart, presentation gating (speak-before-presentation, stale completion vs new connection, presentation failure), phone-open attach (idle + in-flight turn), phone-background × CarPlay matrix, End convergence, Continuous-OFF re-listen, unavailable fail-closed (no microphone), stale-generation fencing, gate re-assert reconnect flow, failed-attach descriptor preservation, route pins, single-window claim.
- Full `ConduitTests`: **2341/2341 passed, 0 failures, exit 0** (includes VoiceConversationControllerTests, VoiceBackgroundSuspensionTests, Continuous Conversation tests, spoken Stop/End tests, PendingVoiceIntentLifecycleTests, VoiceAudioSessionCoordinatorTests, VoiceBargeInRoutePolicyTests).
- Signed Release device archive with the repo's existing manual signing: `ARCHIVE_EXIT=0`; signed entitlements carry `com.apple.developer.carplay-voice-based-conversation = true` (provisioning from PR #164 intact).
- CarPlay Simulator is not installed on the build Mac; runtime scene-coexistence and vehicle verification are deferred with the TestFlight checklist (below) — the plist/UI-test suite proves configuration and launch, not on-the-road coexistence.

## Review

Three-model review gate: 3× REQUEST CHANGES → all findings fixed. The convergent BLOCKER (CarPlay reconnect while the phone is locked never re-asserted the controller gate → Listen silently no-oped) is fixed by `handleCarPlayVoiceSurfaceActivated` with the reconnect regression test; the second BLOCKER-adjacent gap (a prepare in flight across a disconnect could orphan an armed session) is fixed by the fence's no-surface release contract with two dedicated tests. WARNINGs fixed: attach no longer discards the restoration descriptor when the gateway re-arm fails; disconnect/controls converge on the bound AppState; the root template installs before registry resolution; explicit Combine sink cancellation; `setRootTemplate` failures are logged; registry tests no longer spawn async Voice work.

## Scope guard (not in this PR)

No fillers, wake word, CarPlay transcript/history, settings UI, contacts, navigation, communication-entitlement usage, tool-result buttons, iOS-27-only features, or unrelated Voice cleanup. No provisioning changes.

## Physical TestFlight checklist (deferred, accumulates with the next shipped build)

Phone Voice: normal conversation; lock/unlock restoration; mic cold after restoration; network loss while backgrounded; AirPods; speaker; real Siri/phone interruption; spoken Goodbye no-resurrection.
CarPlay: app appears in the CarPlay launcher; cold CarPlay-first launch; wired/wireless connect; vehicle microphone input; assistant audio output; Listening/Processing/Responding transitions; Stop/Goodbye; Continuous Conversation ON/OFF; phone lock while the CarPlay conversation continues; disconnect/reconnect; phone ↔ CarPlay ownership transition.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CarPlay support for voice conversations with driver-friendly states and connection lifecycle handling.
  * Added Listen and End actions where supported.
  * Preserved active conversations when switching between phone and CarPlay.
  * Added shared voice-session management and CarPlay-first startup support.
  * Added safeguards for managing multiple phone windows.
  * Improved voice-surface gating and failure handling to prevent unintended listening.

* **Tests**
  * Added comprehensive CarPlay, lifecycle, routing, template, and shared-session coverage.

* **Documentation**
  * Clarified voice presentation-surface behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->